### PR TITLE
fix(plugin): improve --help Tips with local-command hint and update semantics

### DIFF
--- a/shortcuts/apps/apps_plugin_install.go
+++ b/shortcuts/apps/apps_plugin_install.go
@@ -34,9 +34,10 @@ var AppsPluginInstall = common.Shortcut{
 	Scopes:            []string{},
 	AuthTypes:         []string{"user"},
 	Tips: []string{
-		"Example: lark-cli apps +plugin-install --name @official-plugins/ai-text-generate",
-		"Example: lark-cli apps +plugin-install --name @official-plugins/ai-text-generate --version 1.0.0",
-		"Example: lark-cli apps +plugin-install  (install all declared plugins in package.json)",
+		"Run in project root (like npm); does NOT take --app-id",
+		"Example: lark-cli apps +plugin-install --name @official-plugins/ai-text-generate  (install or update to latest)",
+		"Example: lark-cli apps +plugin-install --name @official-plugins/ai-text-generate --version 1.0.0  (install or update to specific version)",
+		"Example: lark-cli apps +plugin-install  (batch install all declared plugins from package.json actionPlugins)",
 	},
 	Flags: []common.Flag{
 		{Name: "name", Desc: "plugin key (e.g. @official-plugins/ai-text-generate); omit to install all declared plugins"},

--- a/shortcuts/apps/apps_plugin_list.go
+++ b/shortcuts/apps/apps_plugin_list.go
@@ -21,6 +21,7 @@ var AppsPluginList = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{},
 	Tips: []string{
+		"Run in project root (like npm); does NOT take --app-id",
 		"Example: lark-cli apps +plugin-list",
 		"Example: lark-cli apps +plugin-list --format pretty",
 	},

--- a/shortcuts/apps/apps_plugin_uninstall.go
+++ b/shortcuts/apps/apps_plugin_uninstall.go
@@ -22,6 +22,7 @@ var AppsPluginUninstall = common.Shortcut{
 	Risk:        "write",
 	Scopes:      []string{},
 	Tips: []string{
+		"Run in project root (like npm); does NOT take --app-id",
 		"Example: lark-cli apps +plugin-uninstall --name @official-plugins/ai-text-generate",
 	},
 	Flags: []common.Flag{


### PR DESCRIPTION
## Summary
- Add "Run in project root (like npm); does NOT take --app-id" to all three plugin command Tips, preventing agent from mistakenly passing `--app-id`
- Clarify `+plugin-install` also supports update (install or update to latest/specific version)
- Clarify batch install reads from `package.json` `actionPlugins`

## Test plan
- [x] `go build ./shortcuts/apps/` passes
- [x] `go vet ./shortcuts/apps/` no issues
- [x] Verified `--help` output for all three commands shows updated Tips