### PR TITLE
feat(base): add unsupported capability boundaries section to lark-base skill

### DIFF
--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -33,6 +33,17 @@ metadata:
 - 用户要把 Excel / CSV / `.base` 导入成 Base 时，先转 `lark-cli drive +import --type bitable`，导入完成后再回到 Base 命令。
 - 认证、初始化、scope、身份切换、权限不足恢复属于 `lark-shared`；Base 文档只保留会影响 Base 路径选择的权限规则。
 
+### 未支持能力边界
+
+遇到 Base UI 上可能存在、但 `lark-cli base --help`、本 skill 或 reference 没有明确支持的能力时，先停止探索并说明 CLI 当前不支持；不要 grep 源码、读 registry metadata、启动研究子任务、跨 skill 搜索，或用 `lark-cli api` 猜测未文档化写参数。常见高风险边界：
+
+- 子记录、层级记录、树形记录、`parent_record_id` 写入：当前 `+record-*` 只支持普通记录创建/更新/删除，不要用普通 link 字段擅自模拟"子记录"。可说明暂不支持，并询问是否改为新增普通记录或关联记录。
+- 视图行高、密度、TableManager 行高设置：当前 `+view-*` 支持 filter/sort/group/card/timebar/visible-fields 等已列出的配置；没有行高/密度写命令。不要用裸 API 猜 `row_height`、`record_height`、`line_height` 等字段。
+- 自动编号"将修改用于已有编号 / 重新编号已有记录"开关：当前字段 JSON 只支持自动编号规则本身；没有已验证的重算已有编号开关。不要猜 `apply_existing`、`reformat_existing`、`renumber` 等参数或切换到旧版 bitable 裸接口。
+- 分享视图、分享仪表盘、记录分享链接、Base workspace 链接等"Token 与链接"表里声明暂不支持直接访问的链接：不要换身份或裸调绕过，按表中替代路径处理。
+
+如果用户请求的是已支持的字段、记录、表、视图配置，继续按"快速路由"执行；不要因为上面的边界拒绝正常 CRUD。
+
 ## 先获取 Base Token 和所需 ID
 
 进入任何需要目标 Base 的 shortcut 前，必须先拿到可用的 `base_token`，以及当前任务需要的 `table_id` / `view_id` / `record_id` / `form_id` / `dashboard_id` / `workflow_id` 等真实 ID；不要把完整 URL、wiki token、workspace token 或孤立 raw token 直接当作 `--base-token`。


### PR DESCRIPTION
## Summary

Adds a new `### 未支持能力边界` (Unsupported Capability Boundaries) subsection to the `## 使用边界` section of `skills/lark-base/SKILL.md`. This section explicitly documents high-risk capability boundaries that the current `lark-cli base` commands do not support, preventing the agent from exploring, guessing, or attempting workarounds for unsupported features.

## Changes

- `skills/lark-base/SKILL.md`: Added `### 未支持能力边界` subsection under `## 使用边界` documenting four categories of unsupported capabilities:
  - Sub-records / hierarchical records / `parent_record_id` writes
  - View row height, density, and TableManager row height settings
  - Auto-number "apply to existing records / renumber" toggle
  - Share view, share dashboard, record share links, and Base workspace links declared as unsupported in the token table

## Test Plan

- `git diff --check`: passed (no whitespace errors)
- Manual review: new section is correctly placed as a subsection of `## 使用边界`, before `## 先获取 Base Token 和所需 ID`, preserving the existing document structure of the GitHub target file

## Related Issues

Auto research task: 01KVSHSA80CGWG6QVWPR7TDR1N


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clear “unsupported capabilities” section for Base/UI guidance.
  * Clarified which undocumented features should not be assumed or explored, including hierarchical records, row density settings, auto-number reformatting options, and certain share/link access paths.
  * Reinforced that supported field, record, table, and view configurations should continue to use the normal workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->