### PR TITLE
chore: release v1.0.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.61] - 2026-06-30
+
+### Features
+
+- **apps**: Add `db`, `file`, `openapi-key` and observability shortcuts (#1596)
+- **identity**: Add `whoami` command showing effective identity (#1666)
+- **docs**: Add reference map flags (#1547)
+
+### Bug Fixes
+
+- **identity**: Correct identity diagnosis under external credential providers (#1693)
+- **cli**: Harden git credential error handling (#1676)
+
+### Documentation
+
+- **doc**: Guide document copy skill usage (#1673)
+- **doc**: Fix lark-doc media token examples (#1662)
+
 ## [v1.0.60] - 2026-06-29
 
 ### Features
@@ -1299,6 +1317,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.61]: https://github.com/larksuite/cli/releases/tag/v1.0.61
 [v1.0.60]: https://github.com/larksuite/cli/releases/tag/v1.0.60
 [v1.0.59]: https://github.com/larksuite/cli/releases/tag/v1.0.59
 [v1.0.58]: https://github.com/larksuite/cli/releases/tag/v1.0.58

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
Release v1.0.61.

Bumps `package.json` to 1.0.61 and adds the changelog entry for the 7 commits since v1.0.60.

### Features
- **apps**: add `db`, `file`, `openapi-key` and observability shortcuts (#1596)
- **identity**: add `whoami` command showing effective identity (#1666)
- **docs**: add reference map flags (#1547)

### Bug Fixes
- **identity**: correct identity diagnosis under external credential providers (#1693)
- **cli**: harden git credential error handling (#1676)

### Documentation
- **doc**: guide document copy skill usage (#1673)
- **doc**: fix lark-doc media token examples (#1662)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.0.61, including new entries for features, bug fixes, and documentation updates.
* **Chores**
  * Bumped the package version to 1.0.61.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->