### PR TITLE
fix: support pnpm self-update

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -230,7 +230,7 @@ func doManualUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest stri
 	fmt.Fprintf(io.ErrOut, "To update manually, download the latest release:\n")
 	fmt.Fprintf(io.ErrOut, "  Release:   %s\n", releaseURL(latest))
 	fmt.Fprintf(io.ErrOut, "  Changelog: %s\n", changelogURL())
-	fmt.Fprintf(io.ErrOut, manualInstallHint(detect.Method, latest))
+	fmt.Fprint(io.ErrOut, manualInstallHint(detect.Method, latest))
 	emitSkillsTextHints(io, skillsResult)
 	return nil
 }
@@ -286,7 +286,7 @@ func doPackageManagerUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, lat
 	if err := updater.VerifyBinary(latest); err != nil {
 		restore()
 		msg := fmt.Sprintf("new binary verification failed: %s", err)
-		hint := verificationFailureHint(updater, latest, reinstallCommand(manager, latest))
+		hint := verificationFailureHint(updater, latest, manager)
 		if opts.JSON {
 			output.PrintJson(io.Out, map[string]interface{}{
 				"ok":    false,
@@ -322,22 +322,29 @@ func doPackageManagerUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, lat
 	return nil
 }
 
-func packageManagerPermissionHint(manager, output string) string {
+func packageManagerPermissionHint(manager, combinedOutput string) string {
 	if manager == "npm" {
-		return permissionHint(output)
+		return permissionHint(combinedOutput)
 	}
-	if manager == "pnpm" && strings.Contains(output, "EACCES") && !isWindows() {
+	if manager == "pnpm" && strings.Contains(combinedOutput, "EACCES") && !isWindows() {
 		return "Permission denied. Check pnpm global directory permissions or run: pnpm setup"
 	}
 	return ""
 }
 
 func manualInstallHint(method selfupdate.InstallMethod, latest string) string {
-	manager := "npm"
-	if method == selfupdate.InstallPnpm {
-		manager = "pnpm"
+	switch method {
+	case selfupdate.InstallNpm:
+		return packageManagerInstallHint("npm", latest)
+	case selfupdate.InstallPnpm:
+		return packageManagerInstallHint("pnpm", latest)
+	default:
+		return ""
 	}
-	return fmt.Sprintf("\nOr install via %s (note: skills will not be synced):\n  %s\n  npx skills add larksuite/cli -y -g   # sync skills separately\n", manager, reinstallCommand(manager, latest))
+}
+
+func packageManagerInstallHint(manager, latest string) string {
+	return fmt.Sprintf("\nOr install via %s (note: skills will not be synced):\n  %s\n  %s   # sync skills separately\n", manager, reinstallCommand(manager, latest), skillsSyncCommand(manager))
 }
 
 func permissionHint(npmOutput string) string {
@@ -347,11 +354,11 @@ func permissionHint(npmOutput string) string {
 	return ""
 }
 
-func verificationFailureHint(updater *selfupdate.Updater, latest, reinstall string) string {
+func verificationFailureHint(updater *selfupdate.Updater, latest, manager string) string {
 	if updater.CanRestorePreviousVersion() {
 		return "the previous version has been restored"
 	}
-	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): %s && npx skills add larksuite/cli -y -g, or download %s", reinstall, releaseURL(latest))
+	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): %s && %s, or download %s", reinstallCommand(manager, latest), skillsSyncCommand(manager), releaseURL(latest))
 }
 
 func reinstallCommand(manager, latest string) string {
@@ -361,6 +368,13 @@ func reinstallCommand(manager, latest string) string {
 	default:
 		return fmt.Sprintf("npm install -g %s@%s", selfupdate.NpmPackage, latest)
 	}
+}
+
+func skillsSyncCommand(manager string) string {
+	if manager == "pnpm" {
+		return "pnpm dlx skills add larksuite/cli -y -g"
+	}
+	return "npx skills add larksuite/cli -y -g"
 }
 
 func runSkillsAndState(updater *selfupdate.Updater, io *cmdutil.IOStreams, stateVersion string, force bool) *skillscheck.SyncResult {

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -103,6 +103,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 Detects the installation method automatically:
   - npm install: runs npm install -g @larksuite/cli@<version>
+  - pnpm install: runs pnpm add -g @larksuite/cli@<version>
   - manual/other: shows GitHub Releases download URL
 
 Use --json for structured output (for AI agents and scripts).
@@ -163,6 +164,9 @@ func updateRun(opts *UpdateOptions) error {
 	// 6. Execute update
 	if !detect.CanAutoUpdate() {
 		return doManualUpdate(opts, io, cur, latest, detect, updater)
+	}
+	if detect.Method == selfupdate.InstallPnpm {
+		return doPnpmUpdate(opts, io, cur, latest, updater)
 	}
 	return doNpmUpdate(opts, io, cur, latest, updater)
 }
@@ -226,12 +230,20 @@ func doManualUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest stri
 	fmt.Fprintf(io.ErrOut, "To update manually, download the latest release:\n")
 	fmt.Fprintf(io.ErrOut, "  Release:   %s\n", releaseURL(latest))
 	fmt.Fprintf(io.ErrOut, "  Changelog: %s\n", changelogURL())
-	fmt.Fprintf(io.ErrOut, "\nOr install via npm (note: skills will not be synced):\n  npm install -g %s@%s\n  npx skills add larksuite/cli -y -g   # sync skills separately\n", selfupdate.NpmPackage, latest)
+	fmt.Fprintf(io.ErrOut, manualInstallHint(detect.Method, latest))
 	emitSkillsTextHints(io, skillsResult)
 	return nil
 }
 
 func doNpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string, updater *selfupdate.Updater) error {
+	return doPackageManagerUpdate(opts, io, cur, latest, updater, "npm", "npm install", updater.RunNpmInstall)
+}
+
+func doPnpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string, updater *selfupdate.Updater) error {
+	return doPackageManagerUpdate(opts, io, cur, latest, updater, "pnpm", "pnpm add", updater.RunPnpmInstall)
+}
+
+func doPackageManagerUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string, updater *selfupdate.Updater, manager, action string, install func(string) *selfupdate.NpmResult) error {
 	restore, err := updater.PrepareSelfReplace()
 	if err != nil {
 		return reportError(opts, io, "update_error",
@@ -239,31 +251,31 @@ func doNpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string,
 	}
 
 	if !opts.JSON {
-		fmt.Fprintf(io.ErrOut, "Updating lark-cli %s %s %s via npm ...\n", cur, symArrow(), latest)
+		fmt.Fprintf(io.ErrOut, "Updating lark-cli %s %s %s via %s ...\n", cur, symArrow(), latest, manager)
 	}
 
-	npmResult := updater.RunNpmInstall(latest)
-	if npmResult.Err != nil {
+	installResult := install(latest)
+	if installResult.Err != nil {
 		restore()
-		combined := npmResult.CombinedOutput()
+		combined := installResult.CombinedOutput()
 		if opts.JSON {
 			output.PrintJson(io.Out, map[string]interface{}{
 				"ok": false, "error": map[string]interface{}{
-					"type": "update_error", "message": fmt.Sprintf("npm install failed: %s", npmResult.Err),
+					"type": "update_error", "message": fmt.Sprintf("%s failed: %s", action, installResult.Err),
 					"detail": selfupdate.Truncate(combined, maxNpmOutput),
-					"hint":   permissionHint(combined),
+					"hint":   packageManagerPermissionHint(manager, combined),
 				},
 			})
 			return output.ErrBare(output.ExitAPI)
 		}
-		if npmResult.Stdout.Len() > 0 {
-			fmt.Fprint(io.ErrOut, npmResult.Stdout.String())
+		if installResult.Stdout.Len() > 0 {
+			fmt.Fprint(io.ErrOut, installResult.Stdout.String())
 		}
-		if npmResult.Stderr.Len() > 0 {
-			fmt.Fprint(io.ErrOut, npmResult.Stderr.String())
+		if installResult.Stderr.Len() > 0 {
+			fmt.Fprint(io.ErrOut, installResult.Stderr.String())
 		}
-		fmt.Fprintf(io.ErrOut, "\n%s Update failed: %s\n", symFail(), npmResult.Err)
-		if hint := permissionHint(combined); hint != "" {
+		fmt.Fprintf(io.ErrOut, "\n%s Update failed: %s\n", symFail(), installResult.Err)
+		if hint := packageManagerPermissionHint(manager, combined); hint != "" {
 			fmt.Fprintf(io.ErrOut, "  %s\n", hint)
 		}
 		return output.ErrBare(output.ExitAPI)
@@ -274,7 +286,7 @@ func doNpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string,
 	if err := updater.VerifyBinary(latest); err != nil {
 		restore()
 		msg := fmt.Sprintf("new binary verification failed: %s", err)
-		hint := verificationFailureHint(updater, latest)
+		hint := verificationFailureHint(updater, latest, reinstallCommand(manager, latest))
 		if opts.JSON {
 			output.PrintJson(io.Out, map[string]interface{}{
 				"ok":    false,
@@ -310,6 +322,24 @@ func doNpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string,
 	return nil
 }
 
+func packageManagerPermissionHint(manager, output string) string {
+	if manager == "npm" {
+		return permissionHint(output)
+	}
+	if manager == "pnpm" && strings.Contains(output, "EACCES") && !isWindows() {
+		return "Permission denied. Check pnpm global directory permissions or run: pnpm setup"
+	}
+	return ""
+}
+
+func manualInstallHint(method selfupdate.InstallMethod, latest string) string {
+	manager := "npm"
+	if method == selfupdate.InstallPnpm {
+		manager = "pnpm"
+	}
+	return fmt.Sprintf("\nOr install via %s (note: skills will not be synced):\n  %s\n  npx skills add larksuite/cli -y -g   # sync skills separately\n", manager, reinstallCommand(manager, latest))
+}
+
 func permissionHint(npmOutput string) string {
 	if strings.Contains(npmOutput, "EACCES") && !isWindows() {
 		return "Permission denied. Try: sudo lark-cli update, or adjust your npm global prefix: https://docs.npmjs.com/resolving-eacces-permissions-errors"
@@ -317,11 +347,20 @@ func permissionHint(npmOutput string) string {
 	return ""
 }
 
-func verificationFailureHint(updater *selfupdate.Updater, latest string) string {
+func verificationFailureHint(updater *selfupdate.Updater, latest, reinstall string) string {
 	if updater.CanRestorePreviousVersion() {
 		return "the previous version has been restored"
 	}
-	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): npm install -g %s@%s && npx skills add larksuite/cli -y -g, or download %s", selfupdate.NpmPackage, latest, releaseURL(latest))
+	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): %s && npx skills add larksuite/cli -y -g, or download %s", reinstall, releaseURL(latest))
+}
+
+func reinstallCommand(manager, latest string) string {
+	switch manager {
+	case "pnpm":
+		return fmt.Sprintf("pnpm add -g %s@%s", selfupdate.NpmPackage, latest)
+	default:
+		return fmt.Sprintf("npm install -g %s@%s", selfupdate.NpmPackage, latest)
+	}
 }
 
 func runSkillsAndState(updater *selfupdate.Updater, io *cmdutil.IOStreams, stateVersion string, force bool) *skillscheck.SyncResult {

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -228,6 +228,9 @@ func TestUpdateManual_Human(t *testing.T) {
 	if !strings.Contains(out, "releases/tag/v2.0.0") {
 		t.Errorf("expected version-pinned URL in stderr, got: %s", out)
 	}
+	if strings.Contains(out, "npm install -g") || strings.Contains(out, "pnpm add -g") {
+		t.Errorf("manual install should not suggest a package manager command, got: %s", out)
+	}
 }
 
 func TestUpdateNpm_JSON(t *testing.T) {
@@ -353,6 +356,45 @@ func TestUpdatePnpm_Human(t *testing.T) {
 	}
 	if !strings.Contains(out, "Successfully updated") {
 		t.Errorf("expected success message in stderr, got: %s", out)
+	}
+}
+
+func TestUpdatePnpmFail_JSON(t *testing.T) {
+	f, stdout, _ := newTestFactory(t)
+	cmd := NewCmdUpdate(f)
+	cmd.SetArgs([]string{"--json"})
+
+	origFetch := fetchLatest
+	fetchLatest = func() (string, error) { return "2.0.0", nil }
+	defer func() { fetchLatest = origFetch }()
+	origVersion := currentVersion
+	currentVersion = func() string { return "1.0.0" }
+	defer func() { currentVersion = origVersion }()
+
+	mockDetectAndPnpm(t,
+		selfupdate.DetectResult{Method: selfupdate.InstallPnpm, ResolvedPath: "/node_modules/.pnpm/@larksuite+cli@1.0.0/node_modules/@larksuite/cli/bin/lark-cli", PnpmAvailable: true},
+		func(version string) *selfupdate.NpmResult {
+			r := &selfupdate.NpmResult{}
+			r.Stderr.WriteString("EACCES: permission denied")
+			r.Err = errors.New("pnpm add failed")
+			return r
+		},
+	)
+
+	err := cmd.Execute()
+	var bareErr *output.BareError
+	if !errors.As(err, &bareErr) {
+		t.Fatalf("expected bare error, got %T: %v", err, err)
+	}
+	if bareErr.Code != output.ExitAPI {
+		t.Fatalf("bare exit code = %d, want %d", bareErr.Code, output.ExitAPI)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "pnpm add failed") {
+		t.Errorf("expected pnpm add failure in JSON output, got: %s", out)
+	}
+	if !strings.Contains(out, "pnpm setup") {
+		t.Errorf("expected pnpm permission hint in JSON output, got: %s", out)
 	}
 }
 
@@ -693,6 +735,60 @@ func TestUpdateNpmVerifyFail_JSON_NoRestoreHintWhenBackupUnavailable(t *testing.
 	}
 }
 
+func TestUpdatePnpmVerifyFail_JSON_NoRestoreHintWhenBackupUnavailable(t *testing.T) {
+	f, stdout, _ := newTestFactory(t)
+	cmd := NewCmdUpdate(f)
+	cmd.SetArgs([]string{"--json"})
+
+	origFetch := fetchLatest
+	fetchLatest = func() (string, error) { return "2.0.0", nil }
+	defer func() { fetchLatest = origFetch }()
+	origVersion := currentVersion
+	currentVersion = func() string { return "1.0.0" }
+	defer func() { currentVersion = origVersion }()
+
+	origNew := newUpdater
+	newUpdater = func() *selfupdate.Updater {
+		u := selfupdate.New()
+		u.DetectOverride = func() selfupdate.DetectResult {
+			return selfupdate.DetectResult{Method: selfupdate.InstallPnpm, ResolvedPath: "/node_modules/.pnpm/@larksuite+cli@1.0.0/node_modules/@larksuite/cli/bin/lark-cli", PnpmAvailable: true}
+		}
+		u.PnpmInstallOverride = func(version string) *selfupdate.NpmResult { return &selfupdate.NpmResult{} }
+		u.VerifyOverride = func(string) error { return errors.New("bad binary") }
+		u.RestoreAvailableOverride = func() bool { return false }
+		u.SkillsIndexFetchOverride = func() *selfupdate.NpmResult {
+			t.Fatal("skills sync should not run when binary verification fails")
+			return nil
+		}
+		u.SkillsCommandOverride = func(args ...string) *selfupdate.NpmResult {
+			t.Fatal("skills sync should not run when binary verification fails")
+			return nil
+		}
+		return u
+	}
+	defer func() { newUpdater = origNew }()
+
+	err := cmd.Execute()
+	var bareErr *output.BareError
+	if !errors.As(err, &bareErr) {
+		t.Fatalf("expected *output.BareError, got %T: %v", err, err)
+	}
+	if bareErr.Code != output.ExitAPI {
+		t.Fatalf("expected ExitAPI (%d), got %d", output.ExitAPI, bareErr.Code)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "pnpm add -g @larksuite/cli@2.0.0") {
+		t.Errorf("expected pnpm reinstall command in hint, got: %s", out)
+	}
+	if !strings.Contains(out, "pnpm dlx skills add larksuite/cli -y -g") {
+		t.Errorf("expected pnpm skills sync command in hint, got: %s", out)
+	}
+	if strings.Contains(out, "npm install -g") || strings.Contains(out, "npx skills add") {
+		t.Errorf("pnpm verification failure should not suggest npm/npx, got: %s", out)
+	}
+}
+
 func TestUpdateCheck_JSON_Npm(t *testing.T) {
 	f, stdout, _ := newTestFactory(t)
 	cmd := NewCmdUpdate(f)
@@ -907,18 +1003,47 @@ func TestPermissionHint(t *testing.T) {
 	}
 }
 
+func TestPackageManagerPermissionHintPnpm(t *testing.T) {
+	origOS := currentOS
+	defer func() { currentOS = origOS }()
+
+	currentOS = "linux"
+	hint := packageManagerPermissionHint("pnpm", "EACCES: permission denied")
+	if !strings.Contains(hint, "pnpm setup") {
+		t.Fatalf("pnpm permission hint = %q, want pnpm setup guidance", hint)
+	}
+
+	currentOS = "windows"
+	if got := packageManagerPermissionHint("pnpm", "EACCES: permission denied"); got != "" {
+		t.Fatalf("pnpm permission hint on Windows = %q, want empty", got)
+	}
+}
+
 func TestManualInstallHintUsesDetectedPackageManager(t *testing.T) {
 	pnpmHint := manualInstallHint(selfupdate.InstallPnpm, "2.0.0")
 	if !strings.Contains(pnpmHint, "pnpm add -g @larksuite/cli@2.0.0") {
 		t.Fatalf("pnpm manual hint = %q, want pnpm add command", pnpmHint)
 	}
-	if strings.Contains(pnpmHint, "npm install -g") {
-		t.Fatalf("pnpm manual hint should not suggest npm install: %q", pnpmHint)
+	if !strings.Contains(pnpmHint, "pnpm dlx skills add larksuite/cli -y -g") {
+		t.Fatalf("pnpm manual hint = %q, want pnpm dlx skills command", pnpmHint)
+	}
+	if strings.Contains(pnpmHint, "npm install -g") || strings.Contains(pnpmHint, "npx skills add") {
+		t.Fatalf("pnpm manual hint should not suggest npm/npx: %q", pnpmHint)
 	}
 
 	npmHint := manualInstallHint(selfupdate.InstallNpm, "2.0.0")
 	if !strings.Contains(npmHint, "npm install -g @larksuite/cli@2.0.0") {
 		t.Fatalf("npm manual hint = %q, want npm install command", npmHint)
+	}
+	if !strings.Contains(npmHint, "npx skills add larksuite/cli -y -g") {
+		t.Fatalf("npm manual hint = %q, want npx skills command", npmHint)
+	}
+	if strings.Contains(npmHint, "pnpm dlx") {
+		t.Fatalf("npm manual hint should not suggest pnpm: %q", npmHint)
+	}
+
+	if manualHint := manualInstallHint(selfupdate.InstallManual, "2.0.0"); manualHint != "" {
+		t.Fatalf("manual install hint = %q, want empty package-manager hint", manualHint)
 	}
 }
 

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -57,6 +57,26 @@ func mockDetectAndNpm(t *testing.T, result selfupdate.DetectResult, npmFn func(s
 	t.Cleanup(func() { newUpdater = origNew })
 }
 
+func mockDetectAndPnpm(t *testing.T, result selfupdate.DetectResult, pnpmFn func(string) *selfupdate.NpmResult) {
+	t.Helper()
+	origNew := newUpdater
+	newUpdater = func() *selfupdate.Updater {
+		u := selfupdate.New()
+		u.DetectOverride = func() selfupdate.DetectResult { return result }
+		u.NpmInstallOverride = func(version string) *selfupdate.NpmResult {
+			r := &selfupdate.NpmResult{}
+			r.Err = fmt.Errorf("npm should not run for pnpm install")
+			return r
+		}
+		u.PnpmInstallOverride = pnpmFn
+		u.VerifyOverride = func(string) error { return nil }
+		u.SkillsIndexFetchOverride = successfulSkillsIndexFetch()
+		u.SkillsCommandOverride = successfulSkillsCommand()
+		return u
+	}
+	t.Cleanup(func() { newUpdater = origNew })
+}
+
 func successfulSkillsIndexFetch() func() *selfupdate.NpmResult {
 	return func() *selfupdate.NpmResult {
 		r := &selfupdate.NpmResult{}
@@ -263,6 +283,74 @@ func TestUpdateNpm_Human(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	out := stderr.String()
+	if !strings.Contains(out, "Successfully updated") {
+		t.Errorf("expected success message in stderr, got: %s", out)
+	}
+}
+
+func TestUpdatePnpm_JSON(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _ := newTestFactory(t)
+	cmd := NewCmdUpdate(f)
+	cmd.SetArgs([]string{"--json"})
+
+	origFetch := fetchLatest
+	fetchLatest = func() (string, error) { return "2.0.0", nil }
+	defer func() { fetchLatest = origFetch }()
+	origVersion := currentVersion
+	currentVersion = func() string { return "1.0.0" }
+	defer func() { currentVersion = origVersion }()
+
+	calledVersion := ""
+	mockDetectAndPnpm(t,
+		selfupdate.DetectResult{Method: selfupdate.InstallPnpm, ResolvedPath: "/node_modules/.pnpm/@larksuite+cli@1.0.0/node_modules/@larksuite/cli/bin/lark-cli", PnpmAvailable: true},
+		func(version string) *selfupdate.NpmResult {
+			calledVersion = version
+			return &selfupdate.NpmResult{}
+		},
+	)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calledVersion != "2.0.0" {
+		t.Fatalf("pnpm install called with version %q, want 2.0.0", calledVersion)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"action": "updated"`) {
+		t.Errorf("expected updated in output, got: %s", out)
+	}
+}
+
+func TestUpdatePnpm_Human(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, _, stderr := newTestFactory(t)
+	cmd := NewCmdUpdate(f)
+	cmd.SetArgs([]string{})
+
+	origFetch := fetchLatest
+	fetchLatest = func() (string, error) { return "2.0.0", nil }
+	defer func() { fetchLatest = origFetch }()
+	origVersion := currentVersion
+	currentVersion = func() string { return "1.0.0" }
+	defer func() { currentVersion = origVersion }()
+
+	mockDetectAndPnpm(t,
+		selfupdate.DetectResult{Method: selfupdate.InstallPnpm, ResolvedPath: "/node_modules/.pnpm/@larksuite+cli@1.0.0/node_modules/@larksuite/cli/bin/lark-cli", PnpmAvailable: true},
+		func(version string) *selfupdate.NpmResult { return &selfupdate.NpmResult{} },
+	)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "via pnpm") {
+		t.Errorf("expected pnpm update path in stderr, got: %s", out)
+	}
 	if !strings.Contains(out, "Successfully updated") {
 		t.Errorf("expected success message in stderr, got: %s", out)
 	}
@@ -637,6 +725,32 @@ func TestUpdateCheck_JSON_Npm(t *testing.T) {
 	}
 }
 
+func TestUpdateCheck_JSON_Pnpm(t *testing.T) {
+	f, stdout, _ := newTestFactory(t)
+	cmd := NewCmdUpdate(f)
+	cmd.SetArgs([]string{"--json", "--check"})
+
+	origFetch := fetchLatest
+	fetchLatest = func() (string, error) { return "2.0.0", nil }
+	defer func() { fetchLatest = origFetch }()
+	origVersion := currentVersion
+	currentVersion = func() string { return "1.0.0" }
+	defer func() { currentVersion = origVersion }()
+	mockDetect(t, selfupdate.DetectResult{Method: selfupdate.InstallPnpm, ResolvedPath: "/node_modules/.pnpm/@larksuite+cli@1.0.0/node_modules/@larksuite/cli/bin/lark-cli", PnpmAvailable: true})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"action": "update_available"`) {
+		t.Errorf("expected update_available action, got: %s", out)
+	}
+	if !strings.Contains(out, `"auto_update": true`) {
+		t.Errorf("expected auto_update:true for pnpm, got: %s", out)
+	}
+}
+
 func TestUpdateCheck_Human_Npm(t *testing.T) {
 	f, _, stderr := newTestFactory(t)
 	cmd := NewCmdUpdate(f)
@@ -689,6 +803,36 @@ func TestUpdateCheck_Human_Manual(t *testing.T) {
 	}
 	if strings.Contains(out, "lark-cli update` to install") {
 		t.Errorf("should NOT suggest 'lark-cli update' for manual install, got: %s", out)
+	}
+}
+
+func TestUpdatePnpmNotFound_FallsBackToManual(t *testing.T) {
+	f, stdout, _ := newTestFactory(t)
+	cmd := NewCmdUpdate(f)
+	cmd.SetArgs([]string{"--json"})
+
+	origFetch := fetchLatest
+	fetchLatest = func() (string, error) { return "2.0.0", nil }
+	defer func() { fetchLatest = origFetch }()
+	origVersion := currentVersion
+	currentVersion = func() string { return "1.0.0" }
+	defer func() { currentVersion = origVersion }()
+	mockDetect(t, selfupdate.DetectResult{
+		Method:        selfupdate.InstallPnpm,
+		ResolvedPath:  "/node_modules/.pnpm/@larksuite+cli@1.0.0/node_modules/@larksuite/cli/bin/lark-cli",
+		PnpmAvailable: false,
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"action": "manual_required"`) {
+		t.Errorf("expected manual_required when pnpm not found, got: %s", out)
+	}
+	if !strings.Contains(out, "pnpm is not available") {
+		t.Errorf("expected 'pnpm is not available' reason when pnpm detected but missing, got: %s", out)
 	}
 }
 
@@ -760,6 +904,21 @@ func TestPermissionHint(t *testing.T) {
 	currentOS = "linux"
 	if got := permissionHint("some other error"); got != "" {
 		t.Errorf("expected empty hint for non-EACCES, got: %s", got)
+	}
+}
+
+func TestManualInstallHintUsesDetectedPackageManager(t *testing.T) {
+	pnpmHint := manualInstallHint(selfupdate.InstallPnpm, "2.0.0")
+	if !strings.Contains(pnpmHint, "pnpm add -g @larksuite/cli@2.0.0") {
+		t.Fatalf("pnpm manual hint = %q, want pnpm add command", pnpmHint)
+	}
+	if strings.Contains(pnpmHint, "npm install -g") {
+		t.Fatalf("pnpm manual hint should not suggest npm install: %q", pnpmHint)
+	}
+
+	npmHint := manualInstallHint(selfupdate.InstallNpm, "2.0.0")
+	if !strings.Contains(npmHint, "npm install -g @larksuite/cli@2.0.0") {
+		t.Fatalf("npm manual hint = %q, want npm install command", npmHint)
 	}
 }
 

--- a/internal/selfupdate/updater.go
+++ b/internal/selfupdate/updater.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
-// Package selfupdate handles installation detection, npm-based updates,
+// Package selfupdate handles installation detection, package-manager updates,
 // skills updates, and platform-specific binary replacement for the CLI
 // self-update flow.
 package selfupdate
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ type InstallMethod int
 
 const (
 	InstallNpm InstallMethod = iota
+	InstallPnpm
 	InstallManual
 )
 
@@ -44,6 +46,7 @@ const (
 	skillsUpdateTimeout    = 2 * time.Minute
 	skillsIndexMaxBodySize = 1 << 20
 	verifyTimeout          = 10 * time.Second
+	shimReadLimit          = 64 << 10
 )
 
 var (
@@ -53,14 +56,22 @@ var (
 
 // DetectResult holds installation detection results.
 type DetectResult struct {
-	Method       InstallMethod
-	ResolvedPath string
-	NpmAvailable bool
+	Method        InstallMethod
+	ResolvedPath  string
+	NpmAvailable  bool
+	PnpmAvailable bool
 }
 
 // CanAutoUpdate returns true if the CLI can update itself automatically.
 func (d DetectResult) CanAutoUpdate() bool {
-	return d.Method == InstallNpm && d.NpmAvailable
+	switch d.Method {
+	case InstallNpm:
+		return d.NpmAvailable
+	case InstallPnpm:
+		return d.PnpmAvailable
+	default:
+		return false
+	}
 }
 
 // ManualReason returns a human-readable explanation of why auto-update is unavailable.
@@ -68,7 +79,10 @@ func (d DetectResult) ManualReason() string {
 	if d.Method == InstallNpm && !d.NpmAvailable {
 		return "installed via npm, but npm is not available in PATH"
 	}
-	return "not installed via npm"
+	if d.Method == InstallPnpm && !d.PnpmAvailable {
+		return "installed via pnpm, but pnpm is not available in PATH"
+	}
+	return "not installed via npm or pnpm"
 }
 
 // NpmResult holds the result of an npm install or skills update execution.
@@ -92,6 +106,7 @@ func (r *NpmResult) CombinedOutput() string {
 type Updater struct {
 	DetectOverride           func() DetectResult
 	NpmInstallOverride       func(version string) *NpmResult
+	PnpmInstallOverride      func(version string) *NpmResult
 	SkillsIndexFetchOverride func() *NpmResult
 	SkillsCommandOverride    func(args ...string) *NpmResult
 	VerifyOverride           func(expectedVersion string) error
@@ -121,23 +136,65 @@ func (u *Updater) DetectInstallMethod() DetectResult {
 		return DetectResult{Method: InstallManual, ResolvedPath: exe}
 	}
 
-	method := InstallManual
-	if strings.Contains(resolved, "node_modules") {
-		method = InstallNpm
+	method := detectInstallMethod(resolved)
+	if method == InstallManual {
+		method = detectShimInstallMethod(resolved)
 	}
 
 	npmAvailable := false
+	pnpmAvailable := false
 	if method == InstallNpm {
 		if _, err := exec.LookPath("npm"); err == nil {
 			npmAvailable = true
 		}
+	} else if method == InstallPnpm {
+		if _, err := exec.LookPath("pnpm"); err == nil {
+			pnpmAvailable = true
+		}
 	}
 
 	return DetectResult{
-		Method:       method,
-		ResolvedPath: resolved,
-		NpmAvailable: npmAvailable,
+		Method:        method,
+		ResolvedPath:  resolved,
+		NpmAvailable:  npmAvailable,
+		PnpmAvailable: pnpmAvailable,
 	}
+}
+
+func detectInstallMethod(resolved string) InstallMethod {
+	normalized := normalizePathText(resolved)
+	normalized = "/" + strings.Trim(normalized, "/") + "/"
+	if strings.Contains(normalized, "/node_modules/.pnpm/") {
+		return InstallPnpm
+	}
+	if strings.Contains(normalized, "/node_modules/") {
+		return InstallNpm
+	}
+	return InstallManual
+}
+
+func detectShimInstallMethod(resolved string) InstallMethod {
+	file, err := vfs.Open(resolved)
+	if err != nil {
+		return InstallManual
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, shimReadLimit))
+	if err != nil {
+		return InstallManual
+	}
+	content := normalizePathText(string(data))
+	if strings.Contains(content, "cmd-shim-target=") &&
+		strings.Contains(content, "/global/") &&
+		strings.Contains(content, "/node_modules/@larksuite/cli/") {
+		return InstallPnpm
+	}
+	return InstallManual
+}
+
+func normalizePathText(s string) string {
+	return strings.ReplaceAll(filepath.ToSlash(s), "\\", "/")
 }
 
 // RunNpmInstall executes npm install -g @larksuite/cli@<version>.
@@ -159,6 +216,29 @@ func (u *Updater) RunNpmInstall(version string) *NpmResult {
 	r.Err = cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		r.Err = fmt.Errorf("npm install timed out after %s", npmInstallTimeout)
+	}
+	return r
+}
+
+// RunPnpmInstall executes pnpm add -g @larksuite/cli@<version>.
+func (u *Updater) RunPnpmInstall(version string) *NpmResult {
+	if u.PnpmInstallOverride != nil {
+		return u.PnpmInstallOverride(version)
+	}
+	r := &NpmResult{}
+	pnpmPath, err := exec.LookPath("pnpm")
+	if err != nil {
+		r.Err = fmt.Errorf("pnpm not found in PATH: %w", err)
+		return r
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), npmInstallTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, pnpmPath, "add", "-g", NpmPackage+"@"+version)
+	cmd.Stdout = &r.Stdout
+	cmd.Stderr = &r.Stderr
+	r.Err = cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		r.Err = fmt.Errorf("pnpm add timed out after %s", npmInstallTimeout)
 	}
 	return r
 }

--- a/internal/selfupdate/updater.go
+++ b/internal/selfupdate/updater.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/transport"
 	"github.com/larksuite/cli/internal/vfs"
 )
@@ -167,6 +168,10 @@ func detectInstallMethod(resolved string) InstallMethod {
 	if strings.Contains(normalized, "/node_modules/.pnpm/") {
 		return InstallPnpm
 	}
+	if strings.Contains(normalized, "/global/") &&
+		strings.Contains(normalized, "/node_modules/@larksuite/cli/") {
+		return InstallPnpm
+	}
 	if strings.Contains(normalized, "/node_modules/") {
 		return InstallNpm
 	}
@@ -228,7 +233,9 @@ func (u *Updater) RunPnpmInstall(version string) *NpmResult {
 	r := &NpmResult{}
 	pnpmPath, err := exec.LookPath("pnpm")
 	if err != nil {
-		r.Err = fmt.Errorf("pnpm not found in PATH: %w", err)
+		r.Err = errs.NewValidationError(errs.SubtypeFailedPrecondition, "pnpm not found in PATH: %s", err).
+			WithHint("install pnpm or update manually from GitHub Releases").
+			WithCause(err)
 		return r
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), npmInstallTimeout)
@@ -238,7 +245,8 @@ func (u *Updater) RunPnpmInstall(version string) *NpmResult {
 	cmd.Stderr = &r.Stderr
 	r.Err = cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
-		r.Err = fmt.Errorf("pnpm add timed out after %s", npmInstallTimeout)
+		r.Err = errs.NewNetworkError(errs.SubtypeNetworkTimeout, "pnpm add timed out after %s", npmInstallTimeout).
+			WithCause(context.DeadlineExceeded)
 	}
 	return r
 }

--- a/internal/selfupdate/updater_test.go
+++ b/internal/selfupdate/updater_test.go
@@ -12,11 +12,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/vfs"
 )
 
@@ -174,6 +176,39 @@ func TestDetectInstallMethodPnpmShim(t *testing.T) {
 	}
 }
 
+func TestDetectInstallMethodPnpmGlobalTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX-style pnpm global target")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "global", "v11", "f111-19f1c1c585b", "node_modules", "@larksuite", "cli", "scripts", "run.js")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/usr/bin/env node\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pathDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pathDir, "pnpm"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", pathDir)
+
+	oldFS := vfs.DefaultFS
+	t.Cleanup(func() { vfs.DefaultFS = oldFS })
+	vfs.DefaultFS = executableTestFS{exe: bin}
+
+	got := New().DetectInstallMethod()
+	if got.Method != InstallPnpm {
+		t.Fatalf("Method = %v, want InstallPnpm (path: %s)", got.Method, got.ResolvedPath)
+	}
+	if !got.PnpmAvailable {
+		t.Fatal("PnpmAvailable = false, want true")
+	}
+}
+
 func TestDetectInstallMethodNpm(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses POSIX-style npm global path")
@@ -215,7 +250,7 @@ func TestRunPnpmInstallUsesExpectedArgs(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "pnpm")
 	logPath := filepath.Join(dir, "pnpm.log")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \""+logPath+"\"\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nfor arg do printf '%s\\n' \"$arg\"; done >> \""+logPath+"\"\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir)
@@ -228,8 +263,27 @@ func TestRunPnpmInstallUsesExpectedArgs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := strings.TrimSpace(string(raw)), "add -g @larksuite/cli@2.0.0"; got != want {
+	if got, want := strings.Split(strings.TrimSpace(string(raw)), "\n"), []string{"add", "-g", "@larksuite/cli@2.0.0"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
+func TestRunPnpmInstallMissingBinaryUsesTypedError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	result := New().RunPnpmInstall("2.0.0")
+	if result.Err == nil {
+		t.Fatal("RunPnpmInstall() err = nil, want typed error")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(result.Err, &validationErr) {
+		t.Fatalf("RunPnpmInstall() err type = %T, want *errs.ValidationError", result.Err)
+	}
+	if validationErr.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("Subtype = %q, want %q", validationErr.Subtype, errs.SubtypeFailedPrecondition)
+	}
+	if errors.Unwrap(result.Err) == nil {
+		t.Fatal("RunPnpmInstall() error should preserve the underlying LookPath cause")
 	}
 }
 

--- a/internal/selfupdate/updater_test.go
+++ b/internal/selfupdate/updater_test.go
@@ -75,6 +75,164 @@ func TestCleanupStaleFiles_NoPanic(t *testing.T) {
 	u.CleanupStaleFiles()
 }
 
+func TestDetectInstallMethodPnpm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX-style pnpm global path")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "Library", "pnpm", "global", "5", "node_modules", ".pnpm", "@larksuite+cli@1.0.44", "node_modules", "@larksuite", "cli", "bin", "lark-cli")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pathDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pathDir, "pnpm"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", pathDir)
+
+	oldFS := vfs.DefaultFS
+	t.Cleanup(func() { vfs.DefaultFS = oldFS })
+	vfs.DefaultFS = executableTestFS{exe: bin}
+
+	got := New().DetectInstallMethod()
+	if got.Method != InstallPnpm {
+		t.Fatalf("Method = %v, want InstallPnpm (path: %s)", got.Method, got.ResolvedPath)
+	}
+	if !got.PnpmAvailable {
+		t.Fatal("PnpmAvailable = false, want true")
+	}
+}
+
+func TestDetectInstallMethodPnpmUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX-style pnpm global path")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "Library", "pnpm", "global", "5", "node_modules", ".pnpm", "@larksuite+cli@1.0.44", "node_modules", "@larksuite", "cli", "bin", "lark-cli")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	oldFS := vfs.DefaultFS
+	t.Cleanup(func() { vfs.DefaultFS = oldFS })
+	vfs.DefaultFS = executableTestFS{exe: bin}
+
+	got := New().DetectInstallMethod()
+	if got.Method != InstallPnpm {
+		t.Fatalf("Method = %v, want InstallPnpm (path: %s)", got.Method, got.ResolvedPath)
+	}
+	if got.PnpmAvailable {
+		t.Fatal("PnpmAvailable = true, want false")
+	}
+	if got.ManualReason() != "installed via pnpm, but pnpm is not available in PATH" {
+		t.Fatalf("ManualReason() = %q, want pnpm unavailable reason", got.ManualReason())
+	}
+}
+
+func TestDetectInstallMethodPnpmShim(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX-style pnpm shim")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin", "lark-cli")
+	target := filepath.Join(dir, "global", "v11", "f111-19f1c1c585b", "node_modules", "@larksuite", "cli", "scripts", "run.js")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shim := "#!/bin/sh\nexec node \"" + target + "\" \"$@\"\n# cmd-shim-target=" + target + "\n"
+	if err := os.WriteFile(bin, []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pathDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pathDir, "pnpm"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", pathDir)
+
+	oldFS := vfs.DefaultFS
+	t.Cleanup(func() { vfs.DefaultFS = oldFS })
+	vfs.DefaultFS = executableTestFS{exe: bin}
+
+	got := New().DetectInstallMethod()
+	if got.Method != InstallPnpm {
+		t.Fatalf("Method = %v, want InstallPnpm (path: %s)", got.Method, got.ResolvedPath)
+	}
+	if !got.PnpmAvailable {
+		t.Fatal("PnpmAvailable = false, want true")
+	}
+}
+
+func TestDetectInstallMethodNpm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX-style npm global path")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "lib", "node_modules", "@larksuite", "cli", "bin", "lark-cli")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pathDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pathDir, "npm"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", pathDir)
+
+	oldFS := vfs.DefaultFS
+	t.Cleanup(func() { vfs.DefaultFS = oldFS })
+	vfs.DefaultFS = executableTestFS{exe: bin}
+
+	got := New().DetectInstallMethod()
+	if got.Method != InstallNpm {
+		t.Fatalf("Method = %v, want InstallNpm (path: %s)", got.Method, got.ResolvedPath)
+	}
+	if !got.NpmAvailable {
+		t.Fatal("NpmAvailable = false, want true")
+	}
+}
+
+func TestRunPnpmInstallUsesExpectedArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell script")
+	}
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "pnpm")
+	logPath := filepath.Join(dir, "pnpm.log")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \""+logPath+"\"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	result := New().RunPnpmInstall("2.0.0")
+	if result.Err != nil {
+		t.Fatalf("RunPnpmInstall() err = %v, want nil", result.Err)
+	}
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(string(raw)), "add -g @larksuite/cli@2.0.0"; got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
 func TestVerifyBinaryLookPath(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Summary
Fixes #1681 by recognizing pnpm-managed installations in `lark-cli update` and using pnpm for automatic self-update instead of falling back to manual/npm-only update guidance.

## Changes
- Added pnpm as a first-class self-update install method, including detection for `.pnpm` global paths and pnpm command shims.
- Tracked pnpm availability separately from npm availability so `--check` and update decisions report the correct `auto_update` state.
- Added `RunPnpmInstall`, which runs `pnpm add -g @larksuite/cli@<version>` when the CLI was installed through pnpm.
- Generalized the existing npm update flow so npm and pnpm both preserve self-replace preparation, rollback, binary verification, skills sync, JSON envelopes, and human-readable output.
- Updated help text, manual fallback guidance, permission hints, and verification failure reinstall hints to show pnpm-specific commands when pnpm is the detected installer.
- Added focused unit coverage for pnpm path detection, missing-pnpm fallback, pnpm shim detection, pnpm install invocation, JSON/human update output, `--check`, and manual install hints.

## Test Plan
- [x] `go test ./internal/selfupdate ./cmd/update`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go mod tidy` followed by `git diff -- go.mod go.sum` with no diff
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main` (`0 issues`; existing config warning only)
- [x] `make script-test`
- [x] `make examples-build`
- [x] Dry-run/local E2E subset: `go test -v -count=1 ./tests/cli_e2e/... -run 'DryRun|StdinRegression|ResolveBinaryPath|BuildArgs|SkipWithoutUserToken|EventConsumeUnknownKeyRegression|EventSubscribeInvalidRouteRegression|GitCredentialListLocal|GitCredentialRemoveLocal'`
- [ ] `make unit-test` was attempted. It did not complete green for environment/unrelated reasons outside this change:
  - `internal/event/consume` failed once with `dial tcp 127.0.0.1:<port>: connect: can't assign requested address`; rerunning `go test -race -gcflags="all=-N -l" -count=1 ./internal/event/consume` passed.
  - `shortcuts/minutes` fails because this machine resolves `example.com` to `198.18.4.33`, so URL safety rejects fixture download URLs as local/internal. Confirmed with `dscacheutil -q host -a name example.com` and Python `socket.getaddrinfo('example.com', 443)`.
- [ ] `make integration-test` was attempted. The build step succeeded and dry-run/local tests passed, but live E2E is blocked by the current test credentials/scopes, including missing `base:app:create`, `drive:drive`, `space:folder:create`, `wiki:*`, and user IM scopes such as `im:chat:create_by_user` / `im:feed.shortcut:*`.

## Related Issues
- Fixes #1681


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The update command now supports pnpm-based installations alongside npm, with auto-update and manual-update guidance tailored to the detected package manager.
  * Update messages and verification prompts now show package-manager-specific install and reinstall commands (including pnpm-specific skills-sync and permission guidance).

* **Bug Fixes**
  * Improved update detection for pnpm installs, including shim-based setups and cases where pnpm is missing from the environment.
  * Failure and permission messaging is now more accurate and manager-aware (including Linux vs Windows behavior), with clearer manual fallback when auto-update isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->