### PR TITLE
feat(base): tighten lark-base auth fallback and local attachment lookup guidance

### DIFF
--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -32,6 +32,8 @@ metadata:
 - 本轮 Base 不依赖 `lark-cli schema`。SKILL 只保留路由、风险和复杂 JSON/DSL；简单命令由命令自身的参数、tips 和错误恢复承接。
 - 用户要把 Excel / CSV / `.base` 导入成 Base 时，先转 `lark-cli drive +import --type bitable`，导入完成后再回到 Base 命令。
 - 认证、初始化、scope、身份切换、权限不足恢复属于 `lark-shared`；Base 文档只保留会影响 Base 路径选择的权限规则。
+- 任一 Base 命令返回 `token_missing`、`need_user_authorization` 或 `current command requires scope(s)` 后，停止继续试 Base/Drive/Contact 业务命令；直接走 `lark-cli auth login --domain base --no-wait --json`，生成二维码后结束本轮等待授权。不要手写多个 scope 的空格字符串，容易触发 malformed scopes。
+- 本地附件上传前只检查用户给定的相对路径或当前目录下同名候选；文件不存在就报告缺失并停止，不要扩大到仓库外、home 目录或全盘搜索。
 
 ## 先获取 Base Token 和所需 ID
 
@@ -55,7 +57,7 @@ metadata:
 | 创建/更新字段 | `+field-create` / `+field-update` | 必读 [lark-base-field-json.md](references/lark-base-field-json.md)；公式读 [formula-field-guide.md](references/formula-field-guide.md)；lookup 读 [lookup-field-guide.md](references/lookup-field-guide.md)；命令细节读 [lark-base-field-create.md](references/lark-base-field-create.md) / [lark-base-field-update.md](references/lark-base-field-update.md) |
 | 读记录明细 | `+record-get` / `+record-list` / `+record-search` | 涉及筛选、排序、Top/Bottom N、聚合、多表关联、全局结论时读 [lark-base-data-analysis-sop.md](references/lark-base-data-analysis-sop.md) |
 | 写记录 | `+record-upsert` / `+record-batch-create` / `+record-batch-update` | 必读 [lark-base-record-upsert.md](references/lark-base-record-upsert.md) / [lark-base-record-batch-create.md](references/lark-base-record-batch-create.md) / [lark-base-record-batch-update.md](references/lark-base-record-batch-update.md) 和 [lark-base-cell-value.md](references/lark-base-cell-value.md) |
-| 附件字段 | `+record-upload-attachment` / `+record-download-attachment` / `+record-remove-attachment` | 附件不要伪造成普通 CellValue；上传走本地文件，下载/删除按 file token 或字段定位 |
+| 附件字段 | `+record-upload-attachment` / `+record-download-attachment` / `+record-remove-attachment` | 附件不要伪造成普通 CellValue；上传前按上面的本地附件边界确认文件存在，下载/删除按 file token 或字段定位 |
 | 删除记录 / 分享记录链接 / 历史 | `+record-delete` / `+record-share-link-create` / `+record-history-list` | 删除前确认 record；分享链接最多 100 条；历史读 [lark-base-record-history-list.md](references/lark-base-record-history-list.md)，只查单条记录，不做整表审计 |
 | 管理视图 | `+view-*` | `+view-set-filter` 读 [lark-base-view-set-filter.md](references/lark-base-view-set-filter.md)；其余配置先 get 现状，再按返回结构更新 |
 | 一次性聚合统计 | `+data-query` | 必读 [lark-base-data-analysis-sop.md](references/lark-base-data-analysis-sop.md) 和入口 [lark-base-data-query-guide.md](references/lark-base-data-query-guide.md)；完整 DSL 再读 [lark-base-data-query.md](references/lark-base-data-query.md) |


### PR DESCRIPTION
## Summary
Tighten the `lark-base` skill guidance so agents fall back to a single `auth login` flow on token/scope errors and constrain local attachment path lookup to explicit, in-scope candidates.

## Changes
- `skills/lark-base/SKILL.md`: Under "Usage boundaries", add two rules: (1) once any Base command returns `token_missing`, `need_user_authorization`, or `current command requires scope(s)`, stop probing more Base/Drive/Contact business commands and run `lark-cli auth login --domain base --no-wait --json` to end the round after the QR code is generated, and avoid hand-crafted space-separated scope strings that trigger malformed scopes; (2) before uploading a local attachment, only check the user-provided relative path or same-name candidates in the current directory, and stop with a not-found report instead of expanding the search to the repository parent, home directory, or the whole disk.
- `skills/lark-base/SKILL.md`: Update the attachment-field row in the quick routing table to cross-reference the new local-attachment boundary rule instead of the generic "upload from local file" wording.

## Test Plan
- `git diff --check` (clean, no whitespace errors).
- Manual review of the rendered `skills/lark-base/SKILL.md` to confirm the new bullets sit under the "Usage boundaries" section and that the quick routing table row for attachment fields still parses.

## Related Issues
Auto research task: 01KWE29JZMNK51APJWKJ63ZK68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the handling of Base command authorization and token/scope-related failures, including when to stop and re-authenticate.
  * Added stricter guidance for local file attachments: only check the intended path, report missing files immediately, and avoid searching outside the expected location.
  * Updated attachment-field guidance to ensure uploads, downloads, and deletions follow the correct attachment-specific workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->