### PR TITLE
docs(im): add cloud draft skill entry

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -189,6 +189,10 @@ lark-cli im <resource> <method> [flags] # 调用 API
   - `delete` — Delete a feed group. Identity: `user` only (`user_access_token`).[Must-read](references/lark-im-feed-groups.md)
   - `update` — Update a feed group. Identity: `user` only (`user_access_token`).[Must-read](references/lark-im-feed-groups.md)
 
+### draft
+
+  - `create` — 写入草稿。Identity: `user` only (`user_access_token`); `scene` enum: use `1` (`CHAT_INPUT`) for the main chat input and provide `chat_id`, use `2` (`MSG_THREAD`) for the thread/reply input and provide `thread_id`, and do not choose `0` (`UNKNOWN`) unless the task explicitly asks for the unknown scene.
+
 ## 权限表
 
 | 方法 | 所需 scope |
@@ -229,3 +233,4 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `feed.groups.create` | `im:feed_group_v1:write` |
 | `feed.groups.delete` | `im:feed_group_v1:write` |
 | `feed.groups.update` | `im:feed_group_v1:write` |
+| `draft.create` | `im:message.draft_write_as_user` |


### PR DESCRIPTION
## Summary

Add Cloud Draft command entry to the Lark IM skill documentation.

## Changes

- Document `im draft create` under the IM draft section.
- Add identity/token requirements for `draft.create`.
- Add the required scope `im:message.draft_write_as_user`.

## Test Plan

- Verified the command is generated from registry metadata.
- Verified locally:
  - `./lark-cli schema im.draft.create`
  - `./lark-cli im draft create --as user --dry-run ...`
  - Real call returned `ok=true` and `code=0`.
- Joined gray group and verified cloud draft display in Feishu client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the IM API resource list to include draft support.
  * Added guidance for creating drafts with user access and the required permission scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->