### PR TITLE
Retry E2E retryable service errors by default

### DIFF
--- a/tests/cli_e2e/core.go
+++ b/tests/cli_e2e/core.go
@@ -26,6 +26,13 @@ const projectRootMarkerDir = "tests"
 const cliBinaryName = "lark-cli"
 const CleanupTimeout = 30 * time.Second
 
+var (
+	defaultRetryAttempts        = 4
+	defaultRetryInitialDelay    = 1 * time.Second
+	defaultRetryMaxDelay        = 6 * time.Second
+	defaultRetryBackoffMultiple = 2
+)
+
 func SkipWithoutUserToken(t *testing.T) {
 	t.Helper()
 	if os.Getenv("LARKSUITE_CLI_USER_ACCESS_TOKEN") != "" {
@@ -112,7 +119,16 @@ type RetryOptions struct {
 }
 
 // RunCmd executes lark-cli and captures stdout/stderr/exit code.
+// Service errors that return {"error":{"retryable":true}} are retried with
+// bounded exponential backoff so individual tests do not need to remember
+// RunCmdWithRetry for normal transient server contention.
 func RunCmd(ctx context.Context, req Request) (*Result, error) {
+	return RunCmdWithRetry(ctx, req, RetryOptions{
+		ShouldRetry: ResultHasRetryableError,
+	})
+}
+
+func runCmdOnce(ctx context.Context, req Request) (*Result, error) {
 	binaryPath, err := ResolveBinaryPath(req)
 	if err != nil {
 		return nil, err
@@ -186,16 +202,16 @@ func buildCommandEnv(req Request) []string {
 // RunCmdWithRetry reruns a command when the result matches the configured retry condition.
 func RunCmdWithRetry(ctx context.Context, req Request, opts RetryOptions) (*Result, error) {
 	if opts.Attempts <= 0 {
-		opts.Attempts = 4
+		opts.Attempts = defaultRetryAttempts
 	}
 	if opts.InitialDelay <= 0 {
-		opts.InitialDelay = 1 * time.Second
+		opts.InitialDelay = defaultRetryInitialDelay
 	}
 	if opts.MaxDelay <= 0 {
-		opts.MaxDelay = 6 * time.Second
+		opts.MaxDelay = defaultRetryMaxDelay
 	}
 	if opts.BackoffMultiple <= 1 {
-		opts.BackoffMultiple = 2
+		opts.BackoffMultiple = defaultRetryBackoffMultiple
 	}
 	if opts.ShouldRetry == nil {
 		opts.ShouldRetry = func(result *Result) bool {
@@ -206,7 +222,7 @@ func RunCmdWithRetry(ctx context.Context, req Request, opts RetryOptions) (*Resu
 	delay := opts.InitialDelay
 	var lastResult *Result
 	for attempt := 1; attempt <= opts.Attempts; attempt++ {
-		result, err := RunCmd(ctx, req)
+		result, err := runCmdOnce(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -232,6 +248,23 @@ func RunCmdWithRetry(ctx context.Context, req Request, opts RetryOptions) (*Resu
 	}
 
 	return lastResult, nil
+}
+
+// ResultHasRetryableError reports whether lark-cli returned a structured
+// service error with error.retryable=true in either output stream.
+func ResultHasRetryableError(result *Result) bool {
+	if result == nil {
+		return false
+	}
+	return rawHasRetryableError(result.Stdout) || rawHasRetryableError(result.Stderr)
+}
+
+func rawHasRetryableError(raw string) bool {
+	payload := extractJSONPayload(raw)
+	if payload == "" {
+		return false
+	}
+	return gjson.Get(payload, "error.retryable").Bool()
 }
 
 // GenerateSuffix returns a high-entropy UTC timestamp suffix suitable for remote test resource names.
@@ -271,26 +304,11 @@ func isCleanupSuppressedResult(result *Result) bool {
 		return false
 	}
 
-	raw := strings.TrimSpace(result.Stdout)
-	if raw == "" {
-		raw = strings.TrimSpace(result.Stderr)
+	payload := extractJSONPayload(result.Stdout)
+	if payload == "" {
+		payload = extractJSONPayload(result.Stderr)
 	}
-	if raw == "" {
-		return false
-	}
-
-	start := strings.LastIndex(raw, "\n{")
-	if start >= 0 {
-		start++
-	} else {
-		start = strings.Index(raw, "{")
-	}
-	if start < 0 {
-		return false
-	}
-
-	payload := raw[start:]
-	if !gjson.Valid(payload) {
+	if payload == "" {
 		return false
 	}
 
@@ -304,6 +322,32 @@ func isCleanupSuppressedResult(result *Result) bool {
 	}
 
 	return errType == "api_error" && (errCode == 800004135 || strings.Contains(errMessage, " limited"))
+}
+
+func extractJSONPayload(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if gjson.Valid(raw) {
+		return raw
+	}
+
+	start := strings.LastIndex(raw, "\n{")
+	if start >= 0 {
+		start++
+	} else {
+		start = strings.Index(raw, "{")
+	}
+	if start < 0 {
+		return ""
+	}
+
+	payload := raw[start:]
+	if !gjson.Valid(payload) {
+		return ""
+	}
+	return payload
 }
 
 // ResolveBinaryPath finds the CLI binary path using request, env, then PATH.

--- a/tests/cli_e2e/core_test.go
+++ b/tests/cli_e2e/core_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,6 +224,65 @@ func TestRunCmd(t *testing.T) {
 		assert.NotContains(t, env, "LARKSUITE_CLI_APP_ID=cli_app_test")
 		assert.NotContains(t, env, "LARKSUITE_CLI_USER_ACCESS_TOKEN=uat_test")
 	})
+
+	t.Run("retries structured retryable service errors by default", func(t *testing.T) {
+		useFastDefaultRetry(t)
+
+		fake := newFakeCLI(t)
+		statePath := filepath.Join(t.TempDir(), "retry-count")
+		result, err := RunCmd(context.Background(), Request{
+			BinaryPath: fake.BinaryPath,
+			Args:       []string{"fail-once-retryable", statePath},
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+
+		countBytes, err := os.ReadFile(statePath)
+		require.NoError(t, err)
+		assert.Equal(t, "2\n", string(countBytes))
+	})
+
+	t.Run("does not retry non-retryable service errors by default", func(t *testing.T) {
+		useFastDefaultRetry(t)
+
+		fake := newFakeCLI(t)
+		statePath := filepath.Join(t.TempDir(), "retry-count")
+		result, err := RunCmd(context.Background(), Request{
+			BinaryPath: fake.BinaryPath,
+			Args:       []string{"always-non-retryable", statePath},
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 1)
+
+		countBytes, err := os.ReadFile(statePath)
+		require.NoError(t, err)
+		assert.Equal(t, "1\n", string(countBytes))
+	})
+}
+
+func TestRunCmdWithRetry(t *testing.T) {
+	t.Run("does not include RunCmd default retry as a nested retry", func(t *testing.T) {
+		useFastDefaultRetry(t)
+
+		fake := newFakeCLI(t)
+		statePath := filepath.Join(t.TempDir(), "retry-count")
+		result, err := RunCmdWithRetry(context.Background(), Request{
+			BinaryPath: fake.BinaryPath,
+			Args:       []string{"fail-once-retryable", statePath},
+		}, RetryOptions{
+			Attempts:     1,
+			InitialDelay: time.Millisecond,
+			MaxDelay:     time.Millisecond,
+			ShouldRetry:  ResultHasRetryableError,
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 1)
+
+		countBytes, err := os.ReadFile(statePath)
+		require.NoError(t, err)
+		assert.Equal(t, "1\n", string(countBytes))
+	})
 }
 
 type fakeCLI struct {
@@ -260,6 +320,35 @@ if [ "$1" = "emit-stdin" ]; then
   exit 0
 fi
 
+if [ "$1" = "fail-once-retryable" ]; then
+  state="$2"
+  count=0
+  if [ -f "$state" ]; then
+    count="$(cat "$state")"
+  fi
+  count=$((count + 1))
+  echo "$count" > "$state"
+  if [ "$count" -eq 1 ]; then
+    echo "Deleting folder fake..." >&2
+    echo '{"ok":false,"error":{"type":"api","code":1061045,"message":"resource contention occurred, please retry.","retryable":true}}' >&2
+    exit 1
+  fi
+  echo '{"ok":true}'
+  exit 0
+fi
+
+if [ "$1" = "always-non-retryable" ]; then
+  state="$2"
+  count=0
+  if [ -f "$state" ]; then
+    count="$(cat "$state")"
+  fi
+  count=$((count + 1))
+  echo "$count" > "$state"
+  echo '{"ok":false,"error":{"type":"api","code":123,"message":"validation failed","retryable":false}}' >&2
+  exit 1
+fi
+
 exit_code=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -289,6 +378,19 @@ exit "$exit_code"
 	return fakeCLI{
 		BinaryPath: binaryPath,
 	}
+}
+
+func useFastDefaultRetry(t *testing.T) {
+	t.Helper()
+
+	oldInitialDelay := defaultRetryInitialDelay
+	oldMaxDelay := defaultRetryMaxDelay
+	defaultRetryInitialDelay = time.Millisecond
+	defaultRetryMaxDelay = time.Millisecond
+	t.Cleanup(func() {
+		defaultRetryInitialDelay = oldInitialDelay
+		defaultRetryMaxDelay = oldMaxDelay
+	})
 }
 
 func assertSamePath(t *testing.T, want string, got string) {


### PR DESCRIPTION
## What changed

- Make the CLI E2E `RunCmd` helper automatically retry structured service errors when the CLI returns `error.retryable: true`.
- Split the actual process execution into `runCmdOnce` so `RunCmdWithRetry` remains a custom retry entrypoint and does not nest the default `RunCmd` retry policy.
- Share JSON payload extraction between retryable-error detection and cleanup-error suppression, covering stderr that contains progress text before the JSON envelope.
- Add fake CLI coverage for retryable errors, non-retryable errors, and the no-nested-retry contract.

## Why

Live E2E ownership is now distributed across feature owners. Transient server contention, such as Drive delete returning `1061045` with `retryable: true`, should be handled by the framework by default instead of depending on every test author remembering to call `RunCmdWithRetry`.
