### PR TITLE
install: warn instead of failing when checksums.txt is missing

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -265,9 +265,10 @@ function getExpectedChecksum(archiveName, checksumsDir) {
   const checksumsPath = path.join(dir, "checksums.txt");
 
   if (!fs.existsSync(checksumsPath)) {
-    throw new Error(
-      "[SECURITY] checksums.txt not found; refusing to install an unverified binary."
+    console.error(
+      "[WARN] checksums.txt not found, skipping checksum verification"
     );
+    return null;
   }
 
   const content = fs.readFileSync(checksumsPath, "utf8");
@@ -285,11 +286,7 @@ function getExpectedChecksum(archiveName, checksumsDir) {
 }
 
 function verifyChecksum(archivePath, expectedHash) {
-  if (typeof expectedHash !== "string" || expectedHash.length === 0) {
-    throw new Error(
-      "[SECURITY] missing expected checksum; refusing to install an unverified binary."
-    );
-  }
+  if (expectedHash === null) return;
 
   // Stream the file to avoid loading the entire archive into memory.
   // Archives can be 10-100MB; streaming keeps RSS constant.

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -52,17 +52,11 @@ describe("getExpectedChecksum", () => {
     );
   });
 
-  it("throws [SECURITY] when checksums.txt does not exist (fail-closed)", () => {
+  it("returns null when checksums.txt does not exist", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "checksum-test-"));
     // No checksums.txt in dir
-    assert.throws(
-      () => getExpectedChecksum("anything.tar.gz", dir),
-      (err) => {
-        assert.match(err.message, /^\[SECURITY\]/);
-        assert.match(err.message, /checksums\.txt not found/);
-        return true;
-      }
-    );
+    const result = getExpectedChecksum("anything.tar.gz", dir);
+    assert.equal(result, null);
   });
 
   it("skips malformed lines and still finds valid entry", () => {
@@ -130,19 +124,6 @@ describe("verifyChecksum", () => {
         return true;
       }
     );
-  });
-
-  it("verifyChecksum throws [SECURITY] on null/empty expectedHash (fail-closed)", () => {
-    const filePath = makeTmpFile("content");
-    for (const expectedHash of [null, ""]) {
-      assert.throws(
-        () => verifyChecksum(filePath, expectedHash),
-        (err) => {
-          assert.match(err.message, /^\[SECURITY\]/);
-          return true;
-        }
-      );
-    }
   });
 });
 


### PR DESCRIPTION
Reverts #1503 (commit `ec6fdc9b`).

## What this reverts
PR #1503 made the npm install script **fail closed** when `checksums.txt` was missing: `getExpectedChecksum` threw `[SECURITY] checksums.txt not found` and `verifyChecksum` threw on a null/empty expected hash.

This restores the prior behavior:
- `getExpectedChecksum` — logs `[WARN] checksums.txt not found, skipping checksum verification` and returns `null`.
- `verifyChecksum` — skips verification when `expectedHash === null`.
- Tests reverted to match.

## Note
This re-opens the security posture #1503 closed: installs will proceed with an **unverified binary** when `checksums.txt` is absent.

All 32 tests in `scripts/install.test.js` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install behavior when checksum metadata is unavailable: installation now continues with a warning instead of stopping with a security error.
  * Checksum verification is skipped when no expected checksum can be determined, avoiding failed installs in that case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->