### PR TITLE
install: warn instead of failing when checksums.txt is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -265,9 +265,10 @@ function getExpectedChecksum(archiveName, checksumsDir) {
   const checksumsPath = path.join(dir, "checksums.txt");
 
   if (!fs.existsSync(checksumsPath)) {
-    throw new Error(
-      "[SECURITY] checksums.txt not found; refusing to install an unverified binary."
+    console.error(
+      "[WARN] checksums.txt not found, skipping checksum verification"
     );
+    return null;
   }
 
   const content = fs.readFileSync(checksumsPath, "utf8");
@@ -285,11 +286,7 @@ function getExpectedChecksum(archiveName, checksumsDir) {
 }
 
 function verifyChecksum(archivePath, expectedHash) {
-  if (typeof expectedHash !== "string" || expectedHash.length === 0) {
-    throw new Error(
-      "[SECURITY] missing expected checksum; refusing to install an unverified binary."
-    );
-  }
+  if (expectedHash === null) return;
 
   // Stream the file to avoid loading the entire archive into memory.
   // Archives can be 10-100MB; streaming keeps RSS constant.

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -52,17 +52,11 @@ describe("getExpectedChecksum", () => {
     );
   });
 
-  it("throws [SECURITY] when checksums.txt does not exist (fail-closed)", () => {
+  it("returns null when checksums.txt does not exist", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "checksum-test-"));
     // No checksums.txt in dir
-    assert.throws(
-      () => getExpectedChecksum("anything.tar.gz", dir),
-      (err) => {
-        assert.match(err.message, /^\[SECURITY\]/);
-        assert.match(err.message, /checksums\.txt not found/);
-        return true;
-      }
-    );
+    const result = getExpectedChecksum("anything.tar.gz", dir);
+    assert.equal(result, null);
   });
 
   it("skips malformed lines and still finds valid entry", () => {
@@ -130,19 +124,6 @@ describe("verifyChecksum", () => {
         return true;
       }
     );
-  });
-
-  it("verifyChecksum throws [SECURITY] on null/empty expectedHash (fail-closed)", () => {
-    const filePath = makeTmpFile("content");
-    for (const expectedHash of [null, ""]) {
-      assert.throws(
-        () => verifyChecksum(filePath, expectedHash),
-        (err) => {
-          assert.match(err.message, /^\[SECURITY\]/);
-          return true;
-        }
-      );
-    }
   });
 });
 


### PR DESCRIPTION
Restores the prior warn-and-skip behavior for a missing `checksums.txt` during npm install.

## Change
- `getExpectedChecksum` — logs `[WARN] checksums.txt not found, skipping checksum verification` and returns `null` (instead of throwing `[SECURITY]`).
- `verifyChecksum` — skips verification when there is no expected hash (instead of throwing).
- Tests updated to match.

Reverts commit `ec6fdc9b` (#1503).

## Note
This re-opens the posture #1503 closed: installs will proceed with an **unverified binary** when `checksums.txt` is absent.

All 32 tests in `scripts/install.test.js` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installations now continue when the checksum file is missing, instead of failing with an error.
  * If checksum data can’t be found, the installer skips checksum verification and logs a warning.
  * Existing checksum mismatch handling remains unchanged.  
* **Chores**
  * Bumped package version to **1.0.63**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->