### PR TITLE
fix: clarify --profile global flag help description

### DIFF
--- a/cmd/global_flags.go
+++ b/cmd/global_flags.go
@@ -21,7 +21,7 @@ type GlobalOptions struct {
 // applies any visibility policy encoded in opts. Pure function: no disk,
 // network, or environment reads — the caller decides HideProfile.
 func RegisterGlobalFlags(fs *pflag.FlagSet, opts *GlobalOptions) {
-	fs.StringVar(&opts.Profile, "profile", "", "use a specific profile")
+	fs.StringVar(&opts.Profile, "profile", "", "use a specific configuration profile (see 'lark-cli profile list')")
 	if opts.HideProfile {
 		_ = fs.MarkHidden("profile")
 	}


### PR DESCRIPTION
## Summary

The global `--profile` flag's help text read "use a specific profile", which explains neither what a profile is nor how to discover available profile names. This PR clarifies the usage string so users can jump straight to the right follow-up command from `--help` output.

## Changes

- Update the `--profile` usage string in `cmd/global_flags.go` to `use a specific configuration profile (see 'lark-cli profile list')`, matching the `profile` command group wording ("Manage configuration profiles") and the existing hint style in `cmd/config/show.go`

## Test Plan

- [x] `make unit-test` passed
- [x] `go build ./...` and `go vet ./...` pass
- [x] Manual local verification: `./lark-cli --help` shows `--profile string   use a specific configuration profile (see 'lark-cli profile list')`; with a single-app config the flag stays hidden in subcommand help and shell completion, and `--profile <name>` still parses — behavior unchanged

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `--profile` flag help text to give a clearer hint about how to view available profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->