### PR TITLE
Improve wiki node-get flag guidance

### DIFF
--- a/cmd/flag_suggest_test.go
+++ b/cmd/flag_suggest_test.go
@@ -4,11 +4,13 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -77,6 +79,40 @@ func TestFlagDidYouMean_UnknownFlagSuggestsAndListsValid(t *testing.T) {
 	// The same candidate is also carried in the human-facing hint.
 	if !strings.Contains(verr.Hint, "--range") {
 		t.Errorf("hint should suggest --range, got %q", verr.Hint)
+	}
+}
+
+func TestFlagDidYouMean_WikiNodeGetSuggestsNodeToken(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_REMOTE_META", "off")
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	root := Build(context.Background(), cmdutil.InvocationContext{}, WithoutPlugins())
+	root.SetArgs([]string{
+		"wiki", "+node-get",
+		"--node", "https://feishu.cn/wiki/wikcnABC",
+		"--as", "user",
+	})
+
+	err := root.Execute()
+	var verr *errs.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+	}
+	if len(verr.Params) != 1 || verr.Params[0].Name != "--node" {
+		t.Fatalf("Params = %v, want one entry named --node", verr.Params)
+	}
+	found := false
+	for _, s := range verr.Params[0].Suggestions {
+		if s == "--node-token" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Params[0].Suggestions = %v, want --node-token", verr.Params[0].Suggestions)
+	}
+	if !strings.Contains(verr.Hint, "--node-token") {
+		t.Fatalf("hint = %q, want --node-token", verr.Hint)
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -71,7 +71,7 @@ var WikiNodeGet = common.Shortcut{
 	Tips: []string{
 		"Example: lark-cli wiki +node-get --node-token https://feishu.cn/wiki/<token> --as user --format json",
 		"--node-token accepts a raw token (wikcnXXX, docxXXX, ...) or a Lark URL like https://feishu.cn/wiki/<token> or https://feishu.cn/docx/<token>.",
-		"Use --node-token, not --node. The deprecated --token alias only exists for old scripts.",
+		"Use --node-token in new commands; --token is a deprecated compatibility alias for old scripts.",
 		"For raw obj_tokens (not starting with wik), pass --obj-type so the API knows how to resolve them; URL inputs infer it from the path.",
 		"Pair with +move / +node-copy / +delete-space to confirm space_id, obj_type, and parent before mutating.",
 		"--token is the deprecated original name and still works for backward compatibility; new scripts should use --node-token.",

--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -69,7 +69,9 @@ var WikiNodeGet = common.Shortcut{
 		{Name: "space-id", Desc: "optional: assert the resolved node lives in this space"},
 	},
 	Tips: []string{
+		"Example: lark-cli wiki +node-get --node-token https://feishu.cn/wiki/<token> --as user --format json",
 		"--node-token accepts a raw token (wikcnXXX, docxXXX, ...) or a Lark URL like https://feishu.cn/wiki/<token> or https://feishu.cn/docx/<token>.",
+		"Use --node-token, not --node. The deprecated --token alias only exists for old scripts.",
 		"For raw obj_tokens (not starting with wik), pass --obj-type so the API knows how to resolve them; URL inputs infer it from the path.",
 		"Pair with +move / +node-copy / +delete-space to confirm space_id, obj_type, and parent before mutating.",
 		"--token is the deprecated original name and still works for backward compatibility; new scripts should use --node-token.",

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -53,7 +53,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli wiki +<verb> [flags]`）�
 | [`+space-create`](references/lark-wiki-space-create.md) | Create a wiki space (user identity only) |
 | [`+node-list`](references/lark-wiki-node-list.md) | List wiki nodes in a space or under a parent node (supports pagination) |
 | [`+node-copy`](references/lark-wiki-node-copy.md) | Copy a wiki node to a target space or parent node |
-| [`+node-get`](references/lark-wiki-node-get.md) | Get a wiki node's details by node_token / obj_token / Lark URL. **Always pass the input as `--node-token` (not `--node`); `--token` is only a deprecated compatibility alias.** |
+| [`+node-get`](references/lark-wiki-node-get.md) | Get a wiki node's details by node_token / obj_token / Lark URL. **Pass the input as `--node-token`; `--token` is only a deprecated compatibility alias.** |
 | [`+node-delete`](references/lark-wiki-node-delete.md) | Delete a wiki node, polling the async delete task when needed |
 | [`+member-add`](references/lark-wiki-member-add.md) | Add a member to a wiki space |
 | [`+member-remove`](references/lark-wiki-member-remove.md) | Remove a member from a wiki space |

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -53,7 +53,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli wiki +<verb> [flags]`）�
 | [`+space-create`](references/lark-wiki-space-create.md) | Create a wiki space (user identity only) |
 | [`+node-list`](references/lark-wiki-node-list.md) | List wiki nodes in a space or under a parent node (supports pagination) |
 | [`+node-copy`](references/lark-wiki-node-copy.md) | Copy a wiki node to a target space or parent node |
-| [`+node-get`](references/lark-wiki-node-get.md) | Get a wiki node's details by node_token / obj_token / Lark URL |
+| [`+node-get`](references/lark-wiki-node-get.md) | Get a wiki node's details by node_token / obj_token / Lark URL. **Always pass the input as `--node-token` (not `--node`); `--token` is only a deprecated compatibility alias.** |
 | [`+node-delete`](references/lark-wiki-node-delete.md) | Delete a wiki node, polling the async delete task when needed |
 | [`+member-add`](references/lark-wiki-member-add.md) | Add a member to a wiki space |
 | [`+member-remove`](references/lark-wiki-member-remove.md) | Remove a member from a wiki space |


### PR DESCRIPTION
## Summary
- add a concrete +node-get help example using the canonical --node-token flag
- clarify that --node-token is the flag to use for new commands and --token is only a deprecated compatibility alias
- add a regression test that wiki +node-get --node suggests --node-token

## Tests
- go test ./cmd ./shortcuts/wiki
- go run . wiki +node-get -h
- go run . wiki +node-get --node https://feishu.cn/wiki/wikcnABC --as user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `+node-get` shortcut guidance with a clearer example using `--as user --format json`.
  * Clarified that node identifiers should be provided via `--node-token`, and that `--token` remains only as a deprecated compatibility alias.
* **Bug Fixes**
  * Enhanced flag validation so incorrect usage returns clearer errors and suggestions for the correct flag (`--node-token`).
* **Tests**
  * Added coverage to verify the structured error includes the offending flag name and the suggested replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->