### PR TITLE
fix(update): increase npm registry fetch timeout from 5s to 15s

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -25,7 +25,7 @@ import (
 const (
 	registryURL  = "https://registry.npmjs.org/@larksuite/cli/latest"
 	cacheTTL     = 24 * time.Hour
-	fetchTimeout = 5 * time.Second
+	fetchTimeout = 15 * time.Second
 	stateFile    = "update-state.json"
 	maxBody      = 256 << 10 // 256 KB
 


### PR DESCRIPTION
## Problem

`lark-cli update --check` fails with `context deadline exceeded` when the network path to `registry.npmjs.org` has high TLS handshake latency. This is common behind TUN-mode proxies (e.g. Clash Verge TUN), VPNs, or transcontinental routes.

## Root Cause

`internal/update/update.go` uses a hardcoded 5-second HTTP client timeout for the npm registry fetch:

```go
fetchTimeout = 5 * time.Second
```

This timeout covers the entire request lifecycle (DNS + TCP + TLS + headers + body). Under TUN-mode proxies, the TLS handshake alone takes 4-6 seconds because traffic is intercepted at the virtual interface and re-routed through a proxy tunnel:

```
# Measured behind Clash TUN (US node, from China)
curl timing:
  DNS resolve:   ~0ms   (fake-ip 198.18.0.x)
  TCP connect:   ~0ms   (local TUN interface)
  TLS handshake: 4.3-5.9s  ← bottleneck
  Total:         4.7-6.3s
```

`curl` succeeds because it has no default connect timeout. Go's `http.Client.Timeout = 5s` is too tight — the TLS handshake hasn't finished before the deadline fires.

The 5s timeout also makes the failure non-deterministic: sometimes the TLS handshake completes in 4.3s and the check succeeds, sometimes it takes 5.9s and fails. This makes the bug hard to reproduce and diagnose.

## Fix

Increase `fetchTimeout` from 5s to 15s:

```go
fetchTimeout = 15 * time.Second
```

15s provides comfortable headroom for high-latency network paths while still failing fast on genuinely unreachable networks. The npm registry endpoint returns a tiny JSON payload (<1KB), so the extra timeout does not delay real failures meaningfully.

## Verification

- `go build ./internal/update/` — passes
- `go test ./internal/update/ -count=1` — passes
- Manual test with the Go test program confirms: timeout=5s fails intermittently, timeout=10s/15s succeeds consistently

## Notes

Switching Clash Verge between TUN / System Proxy / rule modes does not help — TUN is always intercepting traffic when enabled, and the TLS latency is inherent to the proxy round-trip. Setting `HTTP_PROXY`/`HTTPS_PROXY` env vars also does not help because the Go binary already uses `http.DefaultTransport` which honors proxy env vars; the issue is the timeout, not proxy detection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the timeout for registry fetches, helping reduce failed or interrupted npm update requests on slower connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->