### PR TITLE
Complete mail rule reorder IDs

### DIFF
--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/meta"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/util"
+)
+
+const mailRuleReorderMethodID = "user_mailbox.rule.reorder"
+
+func isMailRuleReorder(method meta.Method) bool {
+	return method.ID == mailRuleReorderMethodID
+}
+
+func completeMailRuleReorder(ctx context.Context, ac *client.APIClient, request client.RawApiRequest) (client.RawApiRequest, error) {
+	inputIDs, err := extractRuleIDs(request.Data)
+	if err != nil {
+		return request, err
+	}
+	currentIDs, err := listMailRuleIDs(ctx, ac, request)
+	if err != nil {
+		return request, err
+	}
+	fullIDs, err := mergeRuleIDs(inputIDs, currentIDs)
+	if err != nil {
+		return request, err
+	}
+	data := cloneJSONMap(request.Data)
+	data["rule_ids"] = fullIDs
+	request.Data = data
+	return request, nil
+}
+
+func extractRuleIDs(data any) ([]string, error) {
+	body, ok := data.(map[string]any)
+	if !ok {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--data.rule_ids must be a string array").WithParam("--data.rule_ids")
+	}
+	raw, ok := body["rule_ids"]
+	if !ok {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--data.rule_ids must be a string array").WithParam("--data.rule_ids")
+	}
+
+	switch ids := raw.(type) {
+	case []string:
+		return validateRuleIDs(ids)
+	case []any:
+		out := make([]string, 0, len(ids))
+		for _, item := range ids {
+			id, ok := item.(string)
+			if !ok {
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--data.rule_ids must be a string array").WithParam("--data.rule_ids")
+			}
+			out = append(out, id)
+		}
+		return validateRuleIDs(out)
+	default:
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--data.rule_ids must be a string array").WithParam("--data.rule_ids")
+	}
+}
+
+func validateRuleIDs(ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--data.rule_ids must contain at least one rule ID").WithParam("--data.rule_ids")
+	}
+	seen := map[string]struct{}{}
+	for _, id := range ids {
+		if id == "" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--data.rule_ids must not contain empty rule IDs").WithParam("--data.rule_ids")
+		}
+		if _, ok := seen[id]; ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "duplicate rule ID in --data.rule_ids: %s", id).WithParam("--data.rule_ids")
+		}
+		seen[id] = struct{}{}
+	}
+	return ids, nil
+}
+
+func mergeRuleIDs(inputIDs, currentIDs []string) ([]string, error) {
+	inputSet := map[string]struct{}{}
+	for _, id := range inputIDs {
+		inputSet[id] = struct{}{}
+	}
+	currentSet := map[string]struct{}{}
+	for _, id := range currentIDs {
+		currentSet[id] = struct{}{}
+	}
+	for _, id := range inputIDs {
+		if _, ok := currentSet[id]; !ok {
+			return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition, "unknown rule ID in --data.rule_ids: %s", id).
+				WithParam("--data.rule_ids").
+				WithHint("run: lark-cli mail user_mailbox.rules list --params '{\"user_mailbox_id\":\"<mailbox>\"}' --as user")
+		}
+	}
+
+	nextInput := 0
+	out := make([]string, 0, len(currentIDs))
+	for _, id := range currentIDs {
+		if _, selected := inputSet[id]; selected {
+			out = append(out, inputIDs[nextInput])
+			nextInput++
+			continue
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func listMailRuleIDs(ctx context.Context, ac *client.APIClient, request client.RawApiRequest) ([]string, error) {
+	listRequest := request
+	listRequest.Method = "GET"
+	listRequest.URL = strings.TrimSuffix(request.URL, "/reorder")
+	listRequest.Params = nil
+	listRequest.Data = nil
+	listRequest.ExtraOpts = nil
+
+	resp, err := ac.DoAPI(ctx, listRequest)
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.ParseJSONResponse(resp)
+	if err != nil {
+		return nil, client.WrapJSONResponseParseError(err, resp.RawBody)
+	}
+	if apiErr := ac.CheckResponse(result, request.As); apiErr != nil {
+		return nil, apiErr
+	}
+	return extractCurrentRuleIDs(result), nil
+}
+
+func extractCurrentRuleIDs(result any) []string {
+	resultMap, _ := result.(map[string]any)
+	data, _ := resultMap["data"].(map[string]any)
+	items, _ := data["items"].([]any)
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		rule, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := rule["id"].(string)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func cloneJSONMap(data any) map[string]any {
+	src, _ := data.(map[string]any)
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func mailRuleReorderDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, format string) error {
+	if _, err := extractRuleIDs(request.Data); err != nil {
+		return err
+	}
+	dr := cmdutil.NewDryRunAPI().
+		Desc("mail rule reorder completes partial rule_ids at execution time").
+		GET(strings.TrimSuffix(request.URL, "/reorder")).
+		Desc("Step 1: list current mail rules to read the full rule ID order").
+		POST(request.URL).
+		Desc("Step 2: replace --data.rule_ids with the completed full order, then reorder")
+	if !util.IsNil(request.Data) {
+		dr.Body(map[string]any{
+			"rule_ids": "<completed from current list; selected slots keep current positions and use input order>",
+			"input":    request.Data,
+		})
+	}
+	dr.Set("as", string(request.As))
+	dr.Set("appId", config.AppID)
+	if config.UserOpenId != "" {
+		dr.Set("userOpenId", config.UserOpenId)
+	}
+	return printDryRunAPI(f.IOStreams.Out, dr, format)
+}
+
+func printDryRunAPI(w io.Writer, dr *cmdutil.DryRunAPI, format string) error {
+	fmt.Fprintln(w, "=== Dry Run ===")
+	if format == "pretty" {
+		fmt.Fprint(w, dr.Format())
+		return nil
+	}
+	output.PrintJson(w, dr)
+	return nil
+}

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func mailSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]any{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRuleReorderMethod() meta.Method {
+	return meta.FromMap(map[string]any{
+		"id":         mailRuleReorderMethodID,
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]any{
+			"user_mailbox_id": map[string]any{"type": "string", "location": "path", "required": true},
+		},
+		"requestBody": map[string]any{
+			"rule_ids": map[string]any{"type": "array", "required": true},
+		},
+	})
+}
+
+func TestMergeRuleIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		current []string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "complete input stays unchanged",
+			input:   []string{"r3", "r2", "r1"},
+			current: []string{"r1", "r2", "r3"},
+			want:    []string{"r3", "r2", "r1"},
+		},
+		{
+			name:    "partial input fills original selected slots",
+			input:   []string{"r3", "r1"},
+			current: []string{"r1", "r2", "r3", "r4"},
+			want:    []string{"r3", "r2", "r1", "r4"},
+		},
+		{
+			name:    "unknown id",
+			input:   []string{"r9"},
+			current: []string{"r1", "r2"},
+			wantErr: "unknown rule ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mergeRuleIDs(tt.input, tt.current)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("mergeRuleIDs error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("mergeRuleIDs unexpected error: %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("mergeRuleIDs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractRuleIDsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    any
+		wantErr string
+	}{
+		{name: "missing", data: map[string]any{}, wantErr: "string array"},
+		{name: "not array", data: map[string]any{"rule_ids": "r1"}, wantErr: "string array"},
+		{name: "non string", data: map[string]any{"rule_ids": []any{"r1", 2}}, wantErr: "string array"},
+		{name: "empty array", data: map[string]any{"rule_ids": []any{}}, wantErr: "at least one"},
+		{name: "empty id", data: map[string]any{"rule_ids": []any{""}}, wantErr: "must not contain empty"},
+		{name: "duplicate id", data: map[string]any{"rule_ids": []any{"r1", "r1"}}, wantErr: "duplicate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := extractRuleIDs(tt.data)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("expected ValidationError, got %T: %v", err, err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceMethod_MailRuleReorderCompletesPartialIDs(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-mail-rules", AppSecret: "test-secret-mail-rules", Brand: core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]any{
+			"code": 0,
+			"data": map[string]any{
+				"items": []any{
+					map[string]any{"id": "r1"},
+					map[string]any{"id": "r2"},
+					map[string]any{"id": "r3"},
+					map[string]any{"id": "r4"},
+				},
+			},
+		},
+	})
+	var reorderBody map[string]any
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]any{"code": 0, "data": map[string]any{"ok": true}},
+		OnMatch: func(reqBodyCapture *http.Request) {
+			_ = json.NewDecoder(reqBodyCapture.Body).Decode(&reorderBody)
+		},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["r3","r1"]}`,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gotIDs, _ := reorderBody["rule_ids"].([]any)
+	if got := stringifySlice(gotIDs); strings.Join(got, ",") != "r3,r2,r1,r4" {
+		t.Fatalf("posted rule_ids = %v, want [r3 r2 r1 r4]; stdout=%s", got, stdout.String())
+	}
+}
+
+func TestServiceMethod_MailRuleReorderDryRunShowsTwoStepPlan(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["r3","r1"]}`,
+		"--dry-run",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Step 1: list current mail rules") ||
+		!strings.Contains(out, "GET") ||
+		!strings.Contains(out, "POST") ||
+		!strings.Contains(out, "completed from current list") {
+		t.Fatalf("dry-run output missing two-step plan:\n%s", out)
+	}
+}
+
+func TestServiceMethod_MailRuleReorderDryRunValidatesRuleIDsWithoutList(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":"r1"}`,
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
+}
+
+func TestServiceMethod_MailRuleReorderListAPIFailurePassesThrough(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]any{
+			"code": 230027,
+			"msg":  "user not authorized",
+		},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["r1"]}`,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected list API error")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+}
+
+func stringifySlice(items []any) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.(string))
+	}
+	return out
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -358,6 +358,9 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	}
 
 	if opts.DryRun {
+		if isMailRuleReorder(opts.Method) {
+			return mailRuleReorderDryRun(f, request, config, opts.Format)
+		}
 		if fileMeta != nil {
 			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
 		}
@@ -373,6 +376,12 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	ac, err := f.NewAPIClientWithConfig(config)
 	if err != nil {
 		return err
+	}
+	if isMailRuleReorder(opts.Method) {
+		request, err = completeMailRuleReorder(opts.Ctx, ac, request)
+		if err != nil {
+			return err
+		}
 	}
 
 	out := f.IOStreams.Out


### PR DESCRIPTION
Completes the mail rule reorder command by expanding partial rule ID input into the full current rule order before calling the reorder endpoint.

Changes:
- Adds rule ID validation and merge logic for selected reordered IDs.
- Lists existing mail rules before submitting the reorder request.
- Adds dry-run output and tests for the rule reorder flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reordering mail rules with partial input, automatically completing the full rule order before execution.
  * Added a dry-run preview that shows the steps needed to list current rules and submit the reorder request.

* **Bug Fixes**
  * Improved validation for rule ID lists, including empty values, duplicates, and invalid payload shapes.
  * Preserved the existing order of unspecified rules while applying the requested reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->