### PR TITLE
feat: support isv block references in docs xml

### DIFF
--- a/internal/cmdutil/factory_default_test.go
+++ b/internal/cmdutil/factory_default_test.go
@@ -28,7 +28,13 @@ func (p *countingFileIOProvider) ResolveFileIO(context.Context) fileio.FileIO {
 	return &localfileio.LocalFileIO{}
 }
 
+func disableRemoteMetaForFactoryTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_REMOTE_META", "off")
+}
+
 func TestNewDefault_InvocationProfileUsedByStrictModeAndConfig(t *testing.T) {
+	disableRemoteMetaForFactoryTest(t)
 	t.Setenv(envvars.CliAppID, "")
 	t.Setenv(envvars.CliAppSecret, "")
 	t.Setenv(envvars.CliUserAccessToken, "")
@@ -77,6 +83,7 @@ func TestNewDefault_InvocationProfileUsedByStrictModeAndConfig(t *testing.T) {
 }
 
 func TestNewDefault_InvocationProfileMissingSticksAcrossEarlyStrictMode(t *testing.T) {
+	disableRemoteMetaForFactoryTest(t)
 	t.Setenv(envvars.CliAppID, "")
 	t.Setenv(envvars.CliAppSecret, "")
 	t.Setenv(envvars.CliUserAccessToken, "")
@@ -118,6 +125,7 @@ func TestNewDefault_InvocationProfileMissingSticksAcrossEarlyStrictMode(t *testi
 }
 
 func TestNewDefault_ResolveAs_UsesDefaultAsFromEnvAccount(t *testing.T) {
+	disableRemoteMetaForFactoryTest(t)
 	t.Setenv(envvars.CliAppID, "env-app")
 	t.Setenv(envvars.CliAppSecret, "env-secret")
 	t.Setenv(envvars.CliDefaultAs, "user")
@@ -138,6 +146,7 @@ func TestNewDefault_ResolveAs_UsesDefaultAsFromEnvAccount(t *testing.T) {
 }
 
 func TestNewDefault_ConfigReturnsCliConfigCopyOfCredentialAccount(t *testing.T) {
+	disableRemoteMetaForFactoryTest(t)
 	t.Setenv(envvars.CliAppID, "env-app")
 	t.Setenv(envvars.CliAppSecret, "env-secret")
 	t.Setenv(envvars.CliDefaultAs, "")
@@ -163,6 +172,7 @@ func TestNewDefault_ConfigReturnsCliConfigCopyOfCredentialAccount(t *testing.T) 
 }
 
 func TestNewDefault_ConfigUsesRuntimePlaceholderForTokenOnlyEnvAccount(t *testing.T) {
+	disableRemoteMetaForFactoryTest(t)
 	t.Setenv(envvars.CliAppID, "env-app")
 	t.Setenv(envvars.CliAppSecret, "")
 	t.Setenv(envvars.CliDefaultAs, "")

--- a/shortcuts/doc/doc_errors_test.go
+++ b/shortcuts/doc/doc_errors_test.go
@@ -64,15 +64,19 @@ func assertValidationContract(t *testing.T, err error, wantSubtype errs.Subtype,
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
 	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf() ok = false for %T (%v)", err, err)
+	}
+	if problem.Category != errs.CategoryValidation {
+		t.Errorf("category = %q, want %q", problem.Category, errs.CategoryValidation)
+	}
+	if problem.Subtype != wantSubtype {
+		t.Errorf("subtype = %q, want %q", problem.Subtype, wantSubtype)
+	}
 	var ve *errs.ValidationError
 	if !errors.As(err, &ve) {
 		t.Fatalf("error type = %T, want *errs.ValidationError (%v)", err, err)
-	}
-	if ve.Category != errs.CategoryValidation {
-		t.Errorf("category = %q, want %q", ve.Category, errs.CategoryValidation)
-	}
-	if ve.Subtype != wantSubtype {
-		t.Errorf("subtype = %q, want %q", ve.Subtype, wantSubtype)
 	}
 	if ve.Param != wantParam {
 		t.Errorf("param = %q, want %q", ve.Param, wantParam)

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -14,7 +14,7 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-const docsFetchExtraParam = `{"enable_user_cite_reference_map":true,"return_html5_block_data":true}`
+const docsFetchExtraParam = `{"enable_user_cite_reference_map":true,"return_html5_block_data":true,"return_isv_block_data":true}`
 
 // v2FetchFlags returns the flag definitions for the v2 (OpenAPI) fetch path.
 func v2FetchFlags() []common.Flag {
@@ -72,6 +72,9 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 		return err
 	}
 	if err := processHTML5BlockReferenceMapForFetch(runtime, effectiveFetchFormat(runtime), ref.Token, data); err != nil {
+		return err
+	}
+	if err := processISVBlockReferenceMapForFetch(runtime, effectiveFetchFormat(runtime), ref.Token, data); err != nil {
 		return err
 	}
 	if warning := addFetchDetailDowngradeWarning(runtime, data); warning != "" && runtime.Format == "pretty" {

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -572,11 +572,14 @@ func TestBuildFetchBodyIncludesFetchExtraParamByDefault(t *testing.T) {
 	if got["return_html5_block_data"] != true {
 		t.Fatalf("return_html5_block_data = %#v, want true in %#v", got["return_html5_block_data"], got)
 	}
+	if got["return_isv_block_data"] != true {
+		t.Fatalf("return_isv_block_data = %#v, want true in %#v", got["return_isv_block_data"], got)
+	}
 	if _, ok := got["reference_map_mode"]; ok {
 		t.Fatalf("extra_param should not use legacy reference_map_mode: %#v", got)
 	}
-	if len(got) != 2 {
-		t.Fatalf("extra_param should only contain fetch reference_map and html5 data toggles: %#v", got)
+	if len(got) != 3 {
+		t.Fatalf("extra_param should only contain fetch reference_map, html5 data, and isv data toggles: %#v", got)
 	}
 }
 

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -152,9 +152,44 @@ func executeUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
+	if err := ensureDocsUpdateResultSucceeded(data); err != nil {
+		return err
+	}
 
 	runtime.OutRaw(data, nil)
 	return nil
+}
+
+func ensureDocsUpdateResultSucceeded(data map[string]interface{}) error {
+	result, _ := data["result"].(string)
+	if !strings.EqualFold(strings.TrimSpace(result), "failed") {
+		return nil
+	}
+	return errs.NewAPIError(errs.SubtypeServerError, "docs update result=failed: %s", docsUpdateFailureDetail(data))
+}
+
+func docsUpdateFailureDetail(data map[string]interface{}) string {
+	for _, key := range []string{"warnings", "error", "message", "msg"} {
+		if detail := docsUpdateFailureValue(data[key]); detail != "" {
+			return fmt.Sprintf("%s=%s", key, detail)
+		}
+	}
+	return "backend accepted the request but did not apply the operation"
+}
+
+func docsUpdateFailureValue(value interface{}) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		raw, err := json.Marshal(typed)
+		if err == nil {
+			return string(raw)
+		}
+		return fmt.Sprint(typed)
+	}
 }
 
 func buildUpdateBody(runtime *common.RuntimeContext) map[string]interface{} {

--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -31,11 +31,17 @@ const (
 	whiteboardTag      = "whiteboard"
 	whiteboardTypeAttr = "type"
 	whiteboardPathAttr = "path"
+
+	isvBlockTag       = "isv-block"
+	isvBlockTypeAttr  = "type"
+	isvBlockRefPrefix = "isv"
 )
 
 var (
 	html5BlockStartTagPattern = regexp.MustCompile(`(?is)<html5-block\b[^>]*>`)
 	html5BlockElementPattern  = regexp.MustCompile(`(?is)<html5-block\b[^>]*>(.*?)</html5-block>`)
+	isvBlockStartTagPattern   = regexp.MustCompile(`(?is)<isv-block\b[^>]*>`)
+	isvBlockElementPattern    = regexp.MustCompile(`(?is)<isv-block\b[^>]*>(.*?)</isv-block>`)
 	html5BlockSafeNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 	whiteboardElementPattern  = regexp.MustCompile(`(?is)<whiteboard\b[^>]*(?:/>|>.*?</whiteboard>)`)
 )
@@ -137,6 +143,19 @@ func prepareDocsV2WriteInput(runtime *common.RuntimeContext, input docsV2WriteIn
 		return docsV2WriteInput{}, err
 	}
 	refMap = mergeHTML5ReferenceMap(refMap, html5RefMap)
+
+	isvRefMap, err := isvReferenceMapFromObject(refMap)
+	if err != nil {
+		return docsV2WriteInput{}, err
+	}
+	content, isvRefMap, err = prepareISVBlockWriteContent(runtime, runtime.Str("doc-format"), content, isvRefMap)
+	if err != nil {
+		return docsV2WriteInput{}, err
+	}
+	if err := resolveISVReferenceMapPaths(runtime, isvRefMap); err != nil {
+		return docsV2WriteInput{}, err
+	}
+	refMap = mergeISVReferenceMap(refMap, isvRefMap)
 	return docsV2WriteInput{
 		Content:      content,
 		ReferenceMap: refMap,
@@ -517,6 +536,119 @@ func validateHTML5BlockWriteElementBodies(format string, content string) error {
 	return validateErr
 }
 
+func prepareISVBlockWriteContent(runtime *common.RuntimeContext, format string, content string, refMap html5BlockReferenceMap) (string, html5BlockReferenceMap, error) {
+	if !strings.Contains(content, "<isv-block") {
+		return content, compactReferenceMap(refMap), nil
+	}
+	if err := validateISVBlockWriteElementBodies(format, content); err != nil {
+		return "", nil, err
+	}
+
+	refMap = cloneReferenceMap(refMap)
+	if refMap == nil {
+		refMap = html5BlockReferenceMap{}
+	}
+	ensureReferenceGroup(refMap, isvBlockTag)
+	nextRef := nextISVBlockRef(refMap)
+
+	rewrite := func(segment string) (string, error) {
+		return rewriteISVBlockStartTags(segment, func(raw string) (string, error) {
+			tag, err := parseISVBlockStartTag(raw)
+			if err != nil {
+				return "", common.ValidationErrorf("invalid isv-block type tag for reference_map.isv-block.<ref>: %v", err).WithParam("isv-block")
+			}
+			if !tag.hasAttr(isvBlockTypeAttr) {
+				return "", common.ValidationErrorf("isv-block requires type attribute before using path or reference_map.isv-block.<ref>").WithParam("type")
+			}
+			if tag.hasAttr(html5BlockDataAttr) {
+				return "", common.ValidationErrorf("isv-block type data is reserved for SDK internals; use data-ref with reference_map.isv-block.<ref> or path=\"@relative.data\"").WithParam("isv-block")
+			}
+
+			pathValue, hasPath := tag.attr(html5BlockPathAttr)
+			dataRef, hasDataRef := tag.attr(html5BlockDataRefAttr)
+			if hasPath && hasDataRef {
+				return "", common.ValidationErrorf("isv-block type cannot contain both path and data-ref; use either path or reference_map.isv-block.<ref>").WithParam("isv-block")
+			}
+			if hasDataRef {
+				ref := strings.TrimSpace(dataRef)
+				if ref == "" {
+					return "", common.ValidationErrorf("isv-block type data-ref cannot be empty; expected reference_map.isv-block.<ref>").WithParam("data-ref")
+				}
+				if _, ok := refMap[isvBlockTag][ref]; !ok {
+					return "", common.ValidationErrorf("reference_map.%s.%s is required for isv-block type data-ref", isvBlockTag, ref).WithParam("reference_map")
+				}
+				return tag.renderTag(isvBlockTag, false), nil
+			}
+			if !hasPath {
+				return "", common.ValidationErrorf("isv-block type requires path=\"@relative.data\" or data-ref with reference_map.isv-block.<ref>").WithParam("isv-block")
+			}
+
+			data, err := readISVBlockPath(runtime, pathValue, "isv-block type path")
+			if err != nil {
+				return "", err
+			}
+			ref := nextRef()
+			refMap[isvBlockTag][ref] = html5BlockReferenceEntry{Data: data}
+			tag.removeAttrs(html5BlockPathAttr, html5BlockDataRefAttr, html5BlockDataAttr)
+			tag.Attrs = append(tag.Attrs, html5BlockAttr{Name: html5BlockDataRefAttr, Value: ref})
+			return tag.renderTag(isvBlockTag, false), nil
+		})
+	}
+
+	var (
+		out string
+		err error
+	)
+	if strings.TrimSpace(format) == "markdown" {
+		out = applyOutsideCodeFences(content, func(segment string) string {
+			if err != nil {
+				return segment
+			}
+			outSegment, rewriteErr := rewrite(segment)
+			if rewriteErr != nil {
+				err = rewriteErr
+				return segment
+			}
+			return outSegment
+		})
+	} else {
+		out, err = rewrite(content)
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	return out, compactReferenceMap(refMap), nil
+}
+
+func validateISVBlockWriteElementBodies(format string, content string) error {
+	validateSegment := func(segment string) error {
+		matches := isvBlockElementPattern.FindAllStringSubmatchIndex(segment, -1)
+		for _, match := range matches {
+			if len(match) < 4 || match[2] < 0 || match[3] < 0 {
+				continue
+			}
+			if strings.TrimSpace(segment[match[2]:match[3]]) != "" {
+				return common.ValidationErrorf("isv-block type content must be loaded from path=\"@relative.data\" or reference_map.isv-block.<ref>; remove content between <isv-block> and </isv-block>").WithParam("isv-block")
+			}
+		}
+		return nil
+	}
+
+	if strings.TrimSpace(format) != "markdown" {
+		return validateSegment(content)
+	}
+
+	var validateErr error
+	_ = applyOutsideCodeFences(content, func(segment string) string {
+		if validateErr != nil {
+			return segment
+		}
+		validateErr = validateSegment(segment)
+		return segment
+	})
+	return validateErr
+}
+
 func processHTML5BlockReferenceMapForFetch(runtime *common.RuntimeContext, format string, docToken string, data map[string]interface{}) error {
 	doc, _ := data["document"].(map[string]interface{})
 	if doc == nil {
@@ -560,6 +692,53 @@ func processHTML5BlockReferenceMapForFetch(runtime *common.RuntimeContext, forma
 	return nil
 }
 
+func processISVBlockReferenceMapForFetch(runtime *common.RuntimeContext, format string, docToken string, data map[string]interface{}) error {
+	doc, _ := data["document"].(map[string]interface{})
+	if doc == nil {
+		return nil
+	}
+	content, _ := doc["content"].(string)
+	if !hasProcessableISVBlock(format, content) {
+		return nil
+	}
+
+	refMap, err := referenceMapFromDocumentForBlock(doc, isvBlockTag)
+	if err != nil {
+		return err
+	}
+	group := refMap[isvBlockTag]
+	if group == nil {
+		return common.ValidationErrorf("document.reference_map.%s is required for fetched isv-block type content", isvBlockTag).WithParam("reference_map")
+	}
+
+	if err := validateFetchedISVBlockRefs(format, content, refMap); err != nil {
+		return err
+	}
+
+	changed := false
+	for ref, entry := range group {
+		if entry.Data == "" || len([]byte(entry.Data)) <= html5BlockReferenceMaxRaw {
+			continue
+		}
+		revisionID, err := documentRevisionIDForResourcePath(doc)
+		if err != nil {
+			return err
+		}
+		relPath, err := writeISVBlockReferenceFile(runtime, docToken, revisionID, ref, entry.Data)
+		if err != nil {
+			return err
+		}
+		entry.Data = ""
+		entry.Path = "@" + filepath.ToSlash(relPath)
+		group[ref] = entry
+		changed = true
+	}
+	if changed {
+		doc["reference_map"] = refMap
+	}
+	return nil
+}
+
 func referenceMapFromDocument(doc map[string]interface{}) (html5BlockReferenceMap, error) {
 	raw, ok := doc["reference_map"]
 	if !ok || raw == nil {
@@ -571,6 +750,21 @@ func referenceMapFromDocument(doc map[string]interface{}) (html5BlockReferenceMa
 	}
 	if len(refMap) == 0 {
 		return nil, common.ValidationErrorf("document.reference_map is required for fetched html5-block content").WithParam("reference_map")
+	}
+	return refMap, nil
+}
+
+func referenceMapFromDocumentForBlock(doc map[string]interface{}, blockTag string) (html5BlockReferenceMap, error) {
+	raw, ok := doc["reference_map"]
+	if !ok || raw == nil {
+		return nil, common.ValidationErrorf("document.reference_map.%s is required for fetched %s content", blockTag, blockTag).WithParam("reference_map")
+	}
+	refMap, err := referenceMapFromValue(raw, "document.reference_map")
+	if err != nil {
+		return nil, err
+	}
+	if len(refMap) == 0 {
+		return nil, common.ValidationErrorf("document.reference_map.%s is required for fetched %s content", blockTag, blockTag).WithParam("reference_map")
 	}
 	return refMap, nil
 }
@@ -620,6 +814,43 @@ func validateFetchedHTML5BlockRefs(format string, content string, refMap html5Bl
 	return validateErr
 }
 
+func validateFetchedISVBlockRefs(format string, content string, refMap html5BlockReferenceMap) error {
+	validateSegment := func(segment string) error {
+		_, err := rewriteISVBlockStartTags(segment, func(raw string) (string, error) {
+			tag, parseErr := parseISVBlockStartTag(raw)
+			if parseErr != nil {
+				return raw, common.ValidationErrorf("invalid isv-block type tag in fetched content for reference_map.isv-block.<ref>: %v", parseErr).WithParam("isv-block")
+			}
+			if !tag.hasAttr(isvBlockTypeAttr) {
+				return raw, common.ValidationErrorf("fetched isv-block is missing type; cannot resolve reference_map.isv-block.<ref>").WithParam("type")
+			}
+			ref, ok := tag.attr(html5BlockDataRefAttr)
+			if !ok || strings.TrimSpace(ref) == "" {
+				return raw, common.ValidationErrorf("fetched isv-block type is missing data-ref; cannot resolve reference_map.isv-block.<ref>").WithParam("isv-block")
+			}
+			ref = strings.TrimSpace(ref)
+			if _, ok := refMap[isvBlockTag][ref]; !ok {
+				return raw, common.ValidationErrorf("document.reference_map.%s.%s is missing; cannot resolve isv-block type. Re-run fetch or check that the upstream document.reference_map field includes this ref.", isvBlockTag, ref).WithParam("reference_map")
+			}
+			return raw, nil
+		})
+		return err
+	}
+
+	if strings.TrimSpace(format) != "markdown" {
+		return validateSegment(content)
+	}
+	var validateErr error
+	_ = applyOutsideCodeFences(content, func(segment string) string {
+		if validateErr != nil {
+			return segment
+		}
+		validateErr = validateSegment(segment)
+		return segment
+	})
+	return validateErr
+}
+
 func resolveReferenceMapPaths(runtime *common.RuntimeContext, refMap html5BlockReferenceMap) error {
 	for typ, group := range refMap {
 		for ref, entry := range group {
@@ -637,6 +868,26 @@ func resolveReferenceMapPaths(runtime *common.RuntimeContext, refMap html5BlockR
 			entry.Path = ""
 			group[ref] = entry
 		}
+	}
+	return nil
+}
+
+func resolveISVReferenceMapPaths(runtime *common.RuntimeContext, refMap html5BlockReferenceMap) error {
+	group := refMap[isvBlockTag]
+	for ref, entry := range group {
+		if strings.TrimSpace(entry.Path) == "" {
+			continue
+		}
+		if entry.Data != "" {
+			return common.ValidationErrorf("reference_map.%s.%s must use either data or path, not both, for isv-block type", isvBlockTag, ref).WithParam("reference_map")
+		}
+		data, err := readISVBlockPath(runtime, entry.Path, fmt.Sprintf("reference_map.%s.%s.path for isv-block type", isvBlockTag, ref))
+		if err != nil {
+			return err
+		}
+		entry.Data = data
+		entry.Path = ""
+		group[ref] = entry
 	}
 	return nil
 }
@@ -664,6 +915,29 @@ func readHTML5BlockPath(runtime *common.RuntimeContext, pathValue string, label 
 	return string(data), nil
 }
 
+func readISVBlockPath(runtime *common.RuntimeContext, pathValue string, label string) (string, error) {
+	pathRaw := strings.TrimSpace(pathValue)
+	if !strings.HasPrefix(pathRaw, "@") {
+		return "", common.ValidationErrorf("%s %q must start with @, for example @payload.data; use reference_map.isv-block.<ref>.data for inline data", label, pathValue).WithParam("path")
+	}
+	relPath := strings.TrimSpace(strings.TrimPrefix(pathRaw, "@"))
+	if relPath == "" {
+		return "", common.ValidationErrorf("%s cannot be empty after @; expected reference_map.isv-block.<ref>.data or path=\"@relative.data\"", label).WithParam("path")
+	}
+	clean := filepath.Clean(relPath)
+	if filepath.IsAbs(clean) || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", common.ValidationErrorf("%s %q must be a relative path within the current working directory for reference_map.isv-block.<ref>", label, pathValue).WithParam("path")
+	}
+	if strings.ToLower(filepath.Ext(clean)) != ".data" {
+		return "", common.ValidationErrorf("%s %q must point to a .data file for reference_map.isv-block.<ref>", label, pathValue).WithParam("path")
+	}
+	data, err := cmdutil.ReadInputFile(runtime.FileIO(), clean)
+	if err != nil {
+		return "", common.ValidationErrorf("%s %q cannot be read from the current working directory; check that the file exists relative to where lark-cli is running and matches reference_map.isv-block.<ref>: %v", label, clean, err).WithParam("path").WithCause(err)
+	}
+	return string(data), nil
+}
+
 func hasProcessableHTML5Block(format string, content string) bool {
 	if !strings.Contains(content, "<html5-block") {
 		return false
@@ -674,6 +948,23 @@ func hasProcessableHTML5Block(format string, content string) bool {
 	found := false
 	_ = applyOutsideCodeFences(content, func(segment string) string {
 		if strings.Contains(segment, "<html5-block") {
+			found = true
+		}
+		return segment
+	})
+	return found
+}
+
+func hasProcessableISVBlock(format string, content string) bool {
+	if !strings.Contains(content, "<isv-block") {
+		return false
+	}
+	if strings.TrimSpace(format) != "markdown" {
+		return true
+	}
+	found := false
+	_ = applyOutsideCodeFences(content, func(segment string) string {
+		if strings.Contains(segment, "<isv-block") {
 			found = true
 		}
 		return segment
@@ -756,6 +1047,17 @@ func html5ReferenceMapFromObject(refMap map[string]interface{}) (html5BlockRefer
 	return referenceMapFromValue(map[string]interface{}{html5BlockTag: group}, "reference_map."+html5BlockTag)
 }
 
+func isvReferenceMapFromObject(refMap map[string]interface{}) (html5BlockReferenceMap, error) {
+	if len(refMap) == 0 {
+		return nil, nil
+	}
+	group, ok := refMap[isvBlockTag]
+	if !ok || group == nil {
+		return nil, nil
+	}
+	return referenceMapFromValue(map[string]interface{}{isvBlockTag: group}, "reference_map."+isvBlockTag)
+}
+
 func mergeHTML5ReferenceMap(refMap map[string]interface{}, html5RefMap html5BlockReferenceMap) map[string]interface{} {
 	group := html5RefMap[html5BlockTag]
 	if len(group) == 0 {
@@ -765,6 +1067,18 @@ func mergeHTML5ReferenceMap(refMap map[string]interface{}, html5RefMap html5Bloc
 		refMap = map[string]interface{}{}
 	}
 	refMap[html5BlockTag] = group
+	return refMap
+}
+
+func mergeISVReferenceMap(refMap map[string]interface{}, isvRefMap html5BlockReferenceMap) map[string]interface{} {
+	group := isvRefMap[isvBlockTag]
+	if len(group) == 0 {
+		return refMap
+	}
+	if refMap == nil {
+		refMap = map[string]interface{}{}
+	}
+	refMap[isvBlockTag] = group
 	return refMap
 }
 
@@ -804,6 +1118,19 @@ func nextHTML5BlockRef(refMap html5BlockReferenceMap) func() string {
 	}
 }
 
+func nextISVBlockRef(refMap html5BlockReferenceMap) func() string {
+	next := 1
+	return func() string {
+		for {
+			ref := fmt.Sprintf("%s_%d", isvBlockRefPrefix, next)
+			next++
+			if _, exists := refMap[isvBlockTag][ref]; !exists {
+				return ref
+			}
+		}
+	}
+}
+
 func writeHTML5BlockReferenceFile(runtime *common.RuntimeContext, docToken string, ref string, html string) (string, error) {
 	if !isSafeHTML5BlockResourceName(docToken) {
 		return "", common.ValidationErrorf("document_id %q cannot be used as a resource directory name", docToken).WithParam("document_id")
@@ -824,6 +1151,68 @@ func writeHTML5BlockReferenceFile(runtime *common.RuntimeContext, docToken strin
 		return "", errs.NewInternalError(errs.SubtypeFileIO, "cannot write html5-block reference file %q: %v", relPath, err).WithCause(err)
 	}
 	return relPath, nil
+}
+
+func writeISVBlockReferenceFile(runtime *common.RuntimeContext, docToken string, revisionID string, ref string, data string) (string, error) {
+	if !isSafeHTML5BlockResourceName(docToken) {
+		return "", common.ValidationErrorf("document_id %q cannot be used as a resource directory name for isv-block type reference_map.isv-block.<ref>", docToken).WithParam("document_id")
+	}
+	if !isSafeHTML5BlockResourceName(revisionID) {
+		return "", common.ValidationErrorf("document revision_id %q cannot be used as a resource directory name for isv-block type reference_map.isv-block.<ref>", revisionID).WithParam("revision_id")
+	}
+	if !isSafeHTML5BlockResourceName(ref) {
+		return "", common.ValidationErrorf("isv-block type data-ref %q cannot be used as a file name for reference_map.isv-block.<ref>", ref).WithParam("data-ref")
+	}
+	relPath := filepath.Join(html5BlockReferenceRoot, docToken, "rev_"+revisionID, isvBlockTag, ref+".data")
+	raw := []byte(data)
+	_, err := runtime.FileIO().Save(relPath, fileio.SaveOptions{
+		ContentType:   "application/octet-stream",
+		ContentLength: int64(len(raw)),
+	}, bytes.NewReader(raw))
+	if err != nil {
+		if errors.Is(err, fileio.ErrPathValidation) {
+			return "", common.ValidationErrorf("cannot write isv-block type reference_map.isv-block.<ref> file %q: %v", relPath, err).WithParam("reference_map").WithCause(err)
+		}
+		return "", errs.NewInternalError(errs.SubtypeFileIO, "cannot write isv-block reference file %q: %v", relPath, err).WithCause(err)
+	}
+	return relPath, nil
+}
+
+func documentRevisionIDForResourcePath(doc map[string]interface{}) (string, error) {
+	switch v := doc["revision_id"].(type) {
+	case float64:
+		if v < 0 || v != float64(int64(v)) {
+			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
+		}
+		return fmt.Sprintf("%d", int64(v)), nil
+	case int:
+		if v < 0 {
+			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
+		}
+		return fmt.Sprintf("%d", v), nil
+	case int64:
+		if v < 0 {
+			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
+		}
+		return fmt.Sprintf("%d", v), nil
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id").WithCause(err)
+		}
+		if n < 0 {
+			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
+		}
+		return fmt.Sprintf("%d", n), nil
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" || !html5BlockSafeNamePattern.MatchString(trimmed) {
+			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
+		}
+		return trimmed, nil
+	default:
+		return "", common.ValidationErrorf("document.revision_id is required for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
+	}
 }
 
 func isSafeHTML5BlockResourceName(name string) bool {
@@ -849,7 +1238,34 @@ func rewriteHTML5BlockStartTags(content string, fn func(raw string) (string, err
 	return out, nil
 }
 
+func rewriteISVBlockStartTags(content string, fn func(raw string) (string, error)) (string, error) {
+	var rewriteErr error
+	out := isvBlockStartTagPattern.ReplaceAllStringFunc(content, func(raw string) string {
+		if rewriteErr != nil {
+			return raw
+		}
+		rewritten, err := fn(raw)
+		if err != nil {
+			rewriteErr = err
+			return raw
+		}
+		return rewritten
+	})
+	if rewriteErr != nil {
+		return "", rewriteErr
+	}
+	return out, nil
+}
+
 func parseHTML5BlockStartTag(raw string) (html5BlockStartTag, error) {
+	return parseBlockStartTag(raw, html5BlockTag)
+}
+
+func parseISVBlockStartTag(raw string) (html5BlockStartTag, error) {
+	return parseBlockStartTag(raw, isvBlockTag)
+}
+
+func parseBlockStartTag(raw string, expectedTag string) (html5BlockStartTag, error) {
 	trimmed := strings.TrimSpace(raw)
 	selfClosing := strings.HasSuffix(trimmed, "/>")
 	decoder := xml.NewDecoder(strings.NewReader(raw))
@@ -865,8 +1281,8 @@ func parseHTML5BlockStartTag(raw string) (html5BlockStartTag, error) {
 		if !ok {
 			continue
 		}
-		if start.Name.Local != html5BlockTag {
-			return html5BlockStartTag{}, fmt.Errorf("expected <%s>, got <%s>", html5BlockTag, start.Name.Local) //nolint:forbidigo // intermediate parse helper; callers wrap with typed validation errors.
+		if start.Name.Local != expectedTag {
+			return html5BlockStartTag{}, fmt.Errorf("expected <%s>, got <%s>", expectedTag, start.Name.Local) //nolint:forbidigo // intermediate parse helper; callers wrap with typed validation errors.
 		}
 		attrs := make([]html5BlockAttr, 0, len(start.Attr))
 		for _, attr := range start.Attr {
@@ -969,9 +1385,13 @@ func (t *whiteboardStartTag) setAttr(name string, value string) {
 }
 
 func (t html5BlockStartTag) render(selfClosing bool) string {
+	return t.renderTag(html5BlockTag, selfClosing)
+}
+
+func (t html5BlockStartTag) renderTag(tag string, selfClosing bool) string {
 	var b strings.Builder
 	b.WriteByte('<')
-	b.WriteString(html5BlockTag)
+	b.WriteString(tag)
 	for _, attr := range t.Attrs {
 		b.WriteByte(' ')
 		b.WriteString(attr.Name)
@@ -986,7 +1406,7 @@ func (t html5BlockStartTag) render(selfClosing bool) string {
 	}
 	if t.SelfClosing && !selfClosing {
 		b.WriteString("</")
-		b.WriteString(html5BlockTag)
+		b.WriteString(tag)
 		b.WriteByte('>')
 	}
 	return b.String()

--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -560,6 +560,10 @@ func prepareISVBlockWriteContent(runtime *common.RuntimeContext, format string, 
 			if !tag.hasAttr(isvBlockTypeAttr) {
 				return "", common.ValidationErrorf("isv-block requires type attribute before using path or reference_map.isv-block.<ref>").WithParam("type")
 			}
+			publicType, _ := tag.attr(isvBlockTypeAttr)
+			if strings.TrimSpace(publicType) == "" {
+				return "", common.ValidationErrorf("isv-block type cannot be empty; expected a configured type before using path or reference_map.isv-block.<ref>").WithParam("type")
+			}
 			if tag.hasAttr(html5BlockDataAttr) {
 				return "", common.ValidationErrorf("isv-block type data is reserved for SDK internals; use data-ref with reference_map.isv-block.<ref> or path=\"@relative.data\"").WithParam("isv-block")
 			}
@@ -819,6 +823,10 @@ func validateFetchedISVBlockRefs(format string, content string, refMap html5Bloc
 			}
 			if !tag.hasAttr(isvBlockTypeAttr) {
 				return raw, common.ValidationErrorf("fetched isv-block is missing type; cannot resolve reference_map.isv-block.<ref>").WithParam("type")
+			}
+			publicType, _ := tag.attr(isvBlockTypeAttr)
+			if strings.TrimSpace(publicType) == "" {
+				return raw, common.ValidationErrorf("fetched isv-block type cannot be empty; cannot resolve reference_map.isv-block.<ref>").WithParam("type")
 			}
 			ref, ok := tag.attr(html5BlockDataRefAttr)
 			if !ok || strings.TrimSpace(ref) == "" {

--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -560,10 +560,6 @@ func prepareISVBlockWriteContent(runtime *common.RuntimeContext, format string, 
 			if !tag.hasAttr(isvBlockTypeAttr) {
 				return "", common.ValidationErrorf("isv-block requires type attribute before using path or reference_map.isv-block.<ref>").WithParam("type")
 			}
-			publicType, _ := tag.attr(isvBlockTypeAttr)
-			if strings.TrimSpace(publicType) == "" {
-				return "", common.ValidationErrorf("isv-block type cannot be empty; expected a configured type before using path or reference_map.isv-block.<ref>").WithParam("type")
-			}
 			if tag.hasAttr(html5BlockDataAttr) {
 				return "", common.ValidationErrorf("isv-block type data is reserved for SDK internals; use data-ref with reference_map.isv-block.<ref> or path=\"@relative.data\"").WithParam("isv-block")
 			}
@@ -823,10 +819,6 @@ func validateFetchedISVBlockRefs(format string, content string, refMap html5Bloc
 			}
 			if !tag.hasAttr(isvBlockTypeAttr) {
 				return raw, common.ValidationErrorf("fetched isv-block is missing type; cannot resolve reference_map.isv-block.<ref>").WithParam("type")
-			}
-			publicType, _ := tag.attr(isvBlockTypeAttr)
-			if strings.TrimSpace(publicType) == "" {
-				return raw, common.ValidationErrorf("fetched isv-block type cannot be empty; cannot resolve reference_map.isv-block.<ref>").WithParam("type")
 			}
 			ref, ok := tag.attr(html5BlockDataRefAttr)
 			if !ok || strings.TrimSpace(ref) == "" {

--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -720,11 +720,7 @@ func processISVBlockReferenceMapForFetch(runtime *common.RuntimeContext, format 
 		if entry.Data == "" || len([]byte(entry.Data)) <= html5BlockReferenceMaxRaw {
 			continue
 		}
-		revisionID, err := documentRevisionIDForResourcePath(doc)
-		if err != nil {
-			return err
-		}
-		relPath, err := writeISVBlockReferenceFile(runtime, docToken, revisionID, ref, entry.Data)
+		relPath, err := writeISVBlockReferenceFile(runtime, docToken, ref, entry.Data)
 		if err != nil {
 			return err
 		}
@@ -1153,17 +1149,14 @@ func writeHTML5BlockReferenceFile(runtime *common.RuntimeContext, docToken strin
 	return relPath, nil
 }
 
-func writeISVBlockReferenceFile(runtime *common.RuntimeContext, docToken string, revisionID string, ref string, data string) (string, error) {
+func writeISVBlockReferenceFile(runtime *common.RuntimeContext, docToken string, ref string, data string) (string, error) {
 	if !isSafeHTML5BlockResourceName(docToken) {
 		return "", common.ValidationErrorf("document_id %q cannot be used as a resource directory name for isv-block type reference_map.isv-block.<ref>", docToken).WithParam("document_id")
-	}
-	if !isSafeHTML5BlockResourceName(revisionID) {
-		return "", common.ValidationErrorf("document revision_id %q cannot be used as a resource directory name for isv-block type reference_map.isv-block.<ref>", revisionID).WithParam("revision_id")
 	}
 	if !isSafeHTML5BlockResourceName(ref) {
 		return "", common.ValidationErrorf("isv-block type data-ref %q cannot be used as a file name for reference_map.isv-block.<ref>", ref).WithParam("data-ref")
 	}
-	relPath := filepath.Join(html5BlockReferenceRoot, docToken, "rev_"+revisionID, isvBlockTag, ref+".data")
+	relPath := filepath.Join(html5BlockReferenceRoot, docToken, ref+".data")
 	raw := []byte(data)
 	_, err := runtime.FileIO().Save(relPath, fileio.SaveOptions{
 		ContentType:   "application/octet-stream",
@@ -1176,43 +1169,6 @@ func writeISVBlockReferenceFile(runtime *common.RuntimeContext, docToken string,
 		return "", errs.NewInternalError(errs.SubtypeFileIO, "cannot write isv-block reference file %q: %v", relPath, err).WithCause(err)
 	}
 	return relPath, nil
-}
-
-func documentRevisionIDForResourcePath(doc map[string]interface{}) (string, error) {
-	switch v := doc["revision_id"].(type) {
-	case float64:
-		if v < 0 || v != float64(int64(v)) {
-			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
-		}
-		return fmt.Sprintf("%d", int64(v)), nil
-	case int:
-		if v < 0 {
-			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
-		}
-		return fmt.Sprintf("%d", v), nil
-	case int64:
-		if v < 0 {
-			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
-		}
-		return fmt.Sprintf("%d", v), nil
-	case json.Number:
-		n, err := v.Int64()
-		if err != nil {
-			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id").WithCause(err)
-		}
-		if n < 0 {
-			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
-		}
-		return fmt.Sprintf("%d", n), nil
-	case string:
-		trimmed := strings.TrimSpace(v)
-		if trimmed == "" || !html5BlockSafeNamePattern.MatchString(trimmed) {
-			return "", common.ValidationErrorf("document.revision_id is required as an integer for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
-		}
-		return trimmed, nil
-	default:
-		return "", common.ValidationErrorf("document.revision_id is required for isv-block type reference_map.isv-block.<ref> resource paths").WithParam("revision_id")
-	}
 }
 
 func isSafeHTML5BlockResourceName(name string) bool {

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -359,7 +359,7 @@ func TestDocsFetchV2HTML5BlockLargeReferenceMapUsesPath(t *testing.T) {
 	}
 }
 
-func TestDocsFetchV2ISVBlockLargeReferenceMapUsesRevisionPath(t *testing.T) {
+func TestDocsFetchV2ISVBlockLargeReferenceMapUsesFlatDocumentPath(t *testing.T) {
 	dir := t.TempDir()
 	cmdutil.TestChdir(t, dir)
 
@@ -368,7 +368,6 @@ func TestDocsFetchV2ISVBlockLargeReferenceMapUsesRevisionPath(t *testing.T) {
 	registerDocsAIStub(reg, "POST", "/open-apis/docs_ai/v1/documents/doxcn_fetch/fetch", map[string]interface{}{
 		"document": map[string]interface{}{
 			"document_id": "doxcn_fetch",
-			"revision_id": float64(7),
 			"content":     `<docx><isv-block type="aeolus_dashboard_insight" data-ref="isv_1"></isv-block></docx>`,
 			"reference_map": map[string]interface{}{
 				"isv-block": map[string]interface{}{
@@ -389,7 +388,7 @@ func TestDocsFetchV2ISVBlockLargeReferenceMapUsesRevisionPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	written := filepath.Join(dir, html5BlockReferenceRoot, "doxcn_fetch", "rev_7", isvBlockTag, "isv_1.data")
+	written := filepath.Join(dir, html5BlockReferenceRoot, "doxcn_fetch", "isv_1.data")
 	raw, err := os.ReadFile(written)
 	if err != nil {
 		t.Fatalf("ReadFile(%s) error: %v", written, err)
@@ -412,7 +411,7 @@ func TestDocsFetchV2ISVBlockLargeReferenceMapUsesRevisionPath(t *testing.T) {
 	}
 	refMap := decodeHTML5ReferenceMap(t, doc["reference_map"])
 	entry := refMap[isvBlockTag]["isv_1"]
-	if entry.Data != "" || entry.Path != "@doc-fetch-resources/doxcn_fetch/rev_7/isv-block/isv_1.data" {
+	if entry.Data != "" || entry.Path != "@doc-fetch-resources/doxcn_fetch/isv_1.data" {
 		t.Fatalf("large isv data should be represented as path, got %#v", entry)
 	}
 }

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -359,6 +359,183 @@ func TestDocsFetchV2HTML5BlockLargeReferenceMapUsesPath(t *testing.T) {
 	}
 }
 
+func TestDocsFetchV2ISVBlockLargeReferenceMapUsesRevisionPath(t *testing.T) {
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+
+	largeData := `{"payload":"` + strings.Repeat("x", html5BlockReferenceMaxRaw+1) + `"}`
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-isv-fetch-large"))
+	registerDocsAIStub(reg, "POST", "/open-apis/docs_ai/v1/documents/doxcn_fetch/fetch", map[string]interface{}{
+		"document": map[string]interface{}{
+			"document_id": "doxcn_fetch",
+			"revision_id": float64(7),
+			"content":     `<docx><isv-block type="aeolus_dashboard_insight" data-ref="isv_1"></isv-block></docx>`,
+			"reference_map": map[string]interface{}{
+				"isv-block": map[string]interface{}{
+					"isv_1": map[string]interface{}{"data": largeData},
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--api-version", "v2",
+		"--doc", "doxcn_fetch",
+		"--format", "json",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	written := filepath.Join(dir, html5BlockReferenceRoot, "doxcn_fetch", "rev_7", isvBlockTag, "isv_1.data")
+	raw, err := os.ReadFile(written)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error: %v", written, err)
+	}
+	if string(raw) != largeData {
+		t.Fatalf("materialized isv data = %q", raw)
+	}
+	if strings.Contains(stdout.String(), largeData) {
+		t.Fatalf("large isv data should not be carried in stdout")
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	data, _ := envelope["data"].(map[string]interface{})
+	doc, _ := data["document"].(map[string]interface{})
+	if got := doc["content"].(string); strings.Contains(got, `path="@`) || !strings.Contains(got, `data-ref="isv_1"`) {
+		t.Fatalf("content should keep data-ref and not path: %s", got)
+	}
+	refMap := decodeHTML5ReferenceMap(t, doc["reference_map"])
+	entry := refMap[isvBlockTag]["isv_1"]
+	if entry.Data != "" || entry.Path != "@doc-fetch-resources/doxcn_fetch/rev_7/isv-block/isv_1.data" {
+		t.Fatalf("large isv data should be represented as path, got %#v", entry)
+	}
+}
+
+func TestDocsCreateV2ISVBlockReferenceMapFromPath(t *testing.T) {
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+	if err := os.WriteFile("insight.data", []byte(`{"dashboard":"demo"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
+	stub := registerDocsAIStub(reg, "POST", "/open-apis/docs_ai/v1/documents", map[string]interface{}{
+		"document": map[string]interface{}{
+			"document_id": "doxcn_new_doc",
+			"revision_id": float64(1),
+		},
+	})
+
+	err := runDocsCreateShortcut(t, f, stdout, []string{
+		"+create",
+		"--api-version", "v2",
+		"--content", `<isv-block type="aeolus_dashboard_insight" path="@insight.data"></isv-block>`,
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := decodeRequestBody(t, stub.CapturedBody)
+	if got := body["content"].(string); got != `<isv-block type="aeolus_dashboard_insight" data-ref="isv_1"></isv-block>` {
+		t.Fatalf("content = %q", got)
+	}
+	refMap := decodeHTML5ReferenceMap(t, body["reference_map"])
+	if got := refMap[isvBlockTag]["isv_1"].Data; got != `{"dashboard":"demo"}` {
+		t.Fatalf("reference_map isv data = %q", got)
+	}
+}
+
+func TestDocsCreateV2ISVBlockRejectsInvalidAttributes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "path and data-ref",
+			content: `<isv-block type="aeolus_dashboard_insight" path="@insight.data" data-ref="isv_1"></isv-block>`,
+			want:    "isv-block type cannot contain both path and data-ref",
+		},
+		{
+			name:    "non relative path",
+			content: `<isv-block type="aeolus_dashboard_insight" path="/tmp/insight.data"></isv-block>`,
+			want:    "isv-block type path",
+		},
+		{
+			name:    "internal data",
+			content: `<isv-block type="aeolus_dashboard_insight" data="internal"></isv-block>`,
+			want:    "isv-block type data is reserved for SDK internals",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
+			err := runDocsCreateShortcut(t, f, stdout, []string{
+				"+create",
+				"--api-version", "v2",
+				"--content", tt.content,
+				"--as", "user",
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got: %v", tt.want, err)
+			}
+			for _, required := range []string{"isv-block", "type", "reference_map.isv-block"} {
+				if !strings.Contains(err.Error(), required) {
+					t.Fatalf("error %q should contain %q", err.Error(), required)
+				}
+			}
+		})
+	}
+}
+
+func TestISVBlockMarkdownCodeFenceIsIgnored(t *testing.T) {
+	for _, fence := range []string{"```", "~~~"} {
+		t.Run(fence, func(t *testing.T) {
+			content := fence + "xml\n<isv-block type=\"aeolus_dashboard_insight\" data-ref=\"isv_1\"></isv-block>\n" + fence + "\n"
+			if hasProcessableISVBlock("markdown", content) {
+				t.Fatalf("isv-block inside markdown code fence should be ignored")
+			}
+		})
+	}
+}
+
+func TestDocsUpdateV2ISVBlockDeleteDoesNotRequireReferenceMapData(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-isv-delete"))
+	stub := registerDocsAIStub(reg, "PUT", "/open-apis/docs_ai/v1/documents/doxcn_doc", map[string]interface{}{
+		"document": map[string]interface{}{
+			"revision_id": float64(8),
+		},
+		"result": "success",
+	})
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--api-version", "v2",
+		"--doc", "doxcn_doc",
+		"--command", "block_delete",
+		"--block-id", "blk_isv",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := decodeRequestBody(t, stub.CapturedBody)
+	if _, ok := body["reference_map"]; ok {
+		t.Fatalf("block_delete should not require or send reference_map: %#v", body)
+	}
+	if got := body["command"]; got != "block_delete" {
+		t.Fatalf("command = %#v", got)
+	}
+}
+
 func TestDocsCreateV2HTML5BlockReferenceMapAdvancedInput(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
 	stub := registerDocsAIStub(reg, "POST", "/open-apis/docs_ai/v1/documents", map[string]interface{}{

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -474,12 +474,6 @@ func TestDocsCreateV2ISVBlockRejectsInvalidAttributes(t *testing.T) {
 			content: `<isv-block type="aeolus_dashboard_insight" data="internal"></isv-block>`,
 			want:    "isv-block type data is reserved for SDK internals",
 		},
-		{
-			name:         "blank type",
-			content:      `<isv-block type=" " data-ref="isv_1"></isv-block>`,
-			referenceMap: `{"isv-block":{"isv_1":{"data":"raw"}}}`,
-			want:         "isv-block type cannot be empty",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -571,22 +565,6 @@ func TestDocsUpdateV2ResultFailedReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "copy source block is not supported") {
 		t.Fatalf("error should include service warning, got: %v", err)
-	}
-}
-
-func TestDocsUpdateV2ISVBlockRejectsBlankType(t *testing.T) {
-	f, stdout, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-isv-update-blank-type"))
-	err := mountAndRunDocs(t, DocsUpdate, []string{
-		"+update",
-		"--api-version", "v2",
-		"--doc", "doxcn_doc",
-		"--command", "append",
-		"--content", `<isv-block type=" " data-ref="isv_1"></isv-block>`,
-		"--reference-map", `{"isv-block":{"isv_1":{"data":"raw"}}}`,
-		"--as", "user",
-	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "isv-block type cannot be empty") {
-		t.Fatalf("expected blank type error, got: %v", err)
 	}
 }
 

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -478,6 +478,12 @@ func TestDocsCreateV2ISVBlockRejectsInvalidAttributes(t *testing.T) {
 			want:      "isv-block type data is reserved for SDK internals",
 			wantParam: "isv-block",
 		},
+		{
+			name:      "missing type",
+			content:   `<isv-block path="@insight.data"></isv-block>`,
+			want:      "isv-block requires type attribute",
+			wantParam: "type",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -363,7 +363,7 @@ func TestDocsFetchV2ISVBlockLargeReferenceMapUsesFlatDocumentPath(t *testing.T) 
 	dir := t.TempDir()
 	cmdutil.TestChdir(t, dir)
 
-	largeData := `{"payload":"` + strings.Repeat("x", html5BlockReferenceMaxRaw+1) + `"}`
+	largeData := `{"payload":"` + strings.Repeat("x", html5BlockReferenceMaxRaw+1) + `"}` + "\n"
 	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-isv-fetch-large"))
 	registerDocsAIStub(reg, "POST", "/open-apis/docs_ai/v1/documents/doxcn_fetch/fetch", map[string]interface{}{
 		"document": map[string]interface{}{
@@ -419,7 +419,8 @@ func TestDocsFetchV2ISVBlockLargeReferenceMapUsesFlatDocumentPath(t *testing.T) 
 func TestDocsCreateV2ISVBlockReferenceMapFromPath(t *testing.T) {
 	dir := t.TempDir()
 	cmdutil.TestChdir(t, dir)
-	if err := os.WriteFile("insight.data", []byte(`{"dashboard":"demo"}`), 0o600); err != nil {
+	rawData := `{"dashboard":"demo"}` + "\n"
+	if err := os.WriteFile("insight.data", []byte(rawData), 0o600); err != nil {
 		t.Fatalf("WriteFile() error: %v", err)
 	}
 
@@ -446,16 +447,17 @@ func TestDocsCreateV2ISVBlockReferenceMapFromPath(t *testing.T) {
 		t.Fatalf("content = %q", got)
 	}
 	refMap := decodeHTML5ReferenceMap(t, body["reference_map"])
-	if got := refMap[isvBlockTag]["isv_1"].Data; got != `{"dashboard":"demo"}` {
+	if got := refMap[isvBlockTag]["isv_1"].Data; got != rawData {
 		t.Fatalf("reference_map isv data = %q", got)
 	}
 }
 
 func TestDocsCreateV2ISVBlockRejectsInvalidAttributes(t *testing.T) {
 	tests := []struct {
-		name    string
-		content string
-		want    string
+		name         string
+		content      string
+		referenceMap string
+		want         string
 	}{
 		{
 			name:    "path and data-ref",
@@ -472,16 +474,26 @@ func TestDocsCreateV2ISVBlockRejectsInvalidAttributes(t *testing.T) {
 			content: `<isv-block type="aeolus_dashboard_insight" data="internal"></isv-block>`,
 			want:    "isv-block type data is reserved for SDK internals",
 		},
+		{
+			name:         "blank type",
+			content:      `<isv-block type=" " data-ref="isv_1"></isv-block>`,
+			referenceMap: `{"isv-block":{"isv_1":{"data":"raw"}}}`,
+			want:         "isv-block type cannot be empty",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f, stdout, _, _ := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
-			err := runDocsCreateShortcut(t, f, stdout, []string{
+			args := []string{
 				"+create",
 				"--api-version", "v2",
 				"--content", tt.content,
 				"--as", "user",
-			})
+			}
+			if tt.referenceMap != "" {
+				args = append(args, "--reference-map", tt.referenceMap)
+			}
+			err := runDocsCreateShortcut(t, f, stdout, args)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("expected %q error, got: %v", tt.want, err)
 			}
@@ -532,6 +544,85 @@ func TestDocsUpdateV2ISVBlockDeleteDoesNotRequireReferenceMapData(t *testing.T) 
 	}
 	if got := body["command"]; got != "block_delete" {
 		t.Fatalf("command = %#v", got)
+	}
+}
+
+func TestDocsUpdateV2ResultFailedReturnsError(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-isv-copy-failed"))
+	registerDocsAIStub(reg, "PUT", "/open-apis/docs_ai/v1/documents/doxcn_doc", map[string]interface{}{
+		"document": map[string]interface{}{
+			"revision_id": float64(9),
+		},
+		"result":   "failed",
+		"warnings": []interface{}{"copy source block is not supported"},
+	})
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--api-version", "v2",
+		"--doc", "doxcn_doc",
+		"--command", "block_copy_insert_after",
+		"--block-id", "blk_anchor",
+		"--src-block-ids", "blk_isv",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "result=failed") {
+		t.Fatalf("expected result=failed error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "copy source block is not supported") {
+		t.Fatalf("error should include service warning, got: %v", err)
+	}
+}
+
+func TestDocsUpdateV2ISVBlockRejectsBlankType(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-isv-update-blank-type"))
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--api-version", "v2",
+		"--doc", "doxcn_doc",
+		"--command", "append",
+		"--content", `<isv-block type=" " data-ref="isv_1"></isv-block>`,
+		"--reference-map", `{"isv-block":{"isv_1":{"data":"raw"}}}`,
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "isv-block type cannot be empty") {
+		t.Fatalf("expected blank type error, got: %v", err)
+	}
+}
+
+func TestDocsUpdateV2ISVBlockReferenceMapPathPreservesTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+	rawData := "raw\n"
+	if err := os.WriteFile("insight.data", []byte(rawData), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-isv-update-newline"))
+	stub := registerDocsAIStub(reg, "PUT", "/open-apis/docs_ai/v1/documents/doxcn_doc", map[string]interface{}{
+		"document": map[string]interface{}{
+			"revision_id": float64(10),
+		},
+		"result": "success",
+	})
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--api-version", "v2",
+		"--doc", "doxcn_doc",
+		"--command", "append",
+		"--content", `<isv-block type="aeolus_dashboard_insight" data-ref="isv_1"></isv-block>`,
+		"--reference-map", `{"isv-block":{"isv_1":{"path":"@insight.data"}}}`,
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := decodeRequestBody(t, stub.CapturedBody)
+	refMap := decodeHTML5ReferenceMap(t, body["reference_map"])
+	if got := refMap[isvBlockTag]["isv_1"].Data; got != rawData {
+		t.Fatalf("reference_map isv data = %q", got)
 	}
 }
 

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -458,21 +458,25 @@ func TestDocsCreateV2ISVBlockRejectsInvalidAttributes(t *testing.T) {
 		content      string
 		referenceMap string
 		want         string
+		wantParam    string
 	}{
 		{
-			name:    "path and data-ref",
-			content: `<isv-block type="aeolus_dashboard_insight" path="@insight.data" data-ref="isv_1"></isv-block>`,
-			want:    "isv-block type cannot contain both path and data-ref",
+			name:      "path and data-ref",
+			content:   `<isv-block type="aeolus_dashboard_insight" path="@insight.data" data-ref="isv_1"></isv-block>`,
+			want:      "isv-block type cannot contain both path and data-ref",
+			wantParam: "isv-block",
 		},
 		{
-			name:    "non relative path",
-			content: `<isv-block type="aeolus_dashboard_insight" path="/tmp/insight.data"></isv-block>`,
-			want:    "isv-block type path",
+			name:      "non relative path",
+			content:   `<isv-block type="aeolus_dashboard_insight" path="/tmp/insight.data"></isv-block>`,
+			want:      "isv-block type path",
+			wantParam: "path",
 		},
 		{
-			name:    "internal data",
-			content: `<isv-block type="aeolus_dashboard_insight" data="internal"></isv-block>`,
-			want:    "isv-block type data is reserved for SDK internals",
+			name:      "internal data",
+			content:   `<isv-block type="aeolus_dashboard_insight" data="internal"></isv-block>`,
+			want:      "isv-block type data is reserved for SDK internals",
+			wantParam: "isv-block",
 		},
 	}
 	for _, tt := range tests {
@@ -491,6 +495,7 @@ func TestDocsCreateV2ISVBlockRejectsInvalidAttributes(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("expected %q error, got: %v", tt.want, err)
 			}
+			assertValidationContract(t, err, errs.SubtypeInvalidArgument, tt.wantParam)
 			for _, required := range []string{"isv-block", "type", "reference_map.isv-block"} {
 				if !strings.Contains(err.Error(), required) {
 					t.Fatalf("error %q should contain %q", err.Error(), required)
@@ -565,6 +570,16 @@ func TestDocsUpdateV2ResultFailedReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "copy source block is not supported") {
 		t.Fatalf("error should include service warning, got: %v", err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got: %T (%v)", err, err)
+	}
+	if problem.Category != errs.CategoryAPI {
+		t.Fatalf("category = %q, want %q", problem.Category, errs.CategoryAPI)
+	}
+	if problem.Subtype != errs.SubtypeServerError {
+		t.Fatalf("subtype = %q, want %q", problem.Subtype, errs.SubtypeServerError)
 	}
 }
 

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -60,7 +60,7 @@ func TestDocs_DryRunDefaultsToV2OpenAPI(t *testing.T) {
 				"--dry-run",
 			},
 			wantContains:   []string{"/open-apis/docs_ai/v1/documents/doxcnDryRunE2E/fetch"},
-			wantExtraParam: `{"enable_user_cite_reference_map":true,"return_html5_block_data":true}`,
+			wantExtraParam: `{"enable_user_cite_reference_map":true,"return_html5_block_data":true,"return_isv_block_data":true}`,
 		},
 		{
 			name: "update",


### PR DESCRIPTION
## Summary
Add lark-cli docs XML support for generic ISV blocks. Fetch now exposes configured ISV blocks as `<isv-block type="..." data-ref="...">` with data stored under `reference_map.isv-block`, while html5-block behavior remains unchanged.

## Changes
- Request ISV block data from ai_edit during `docs +fetch`.
- Serialize ISV reference data under the stable `reference_map.isv-block` group.
- Emit inline ISV data for small payloads and path-backed resources for larger payloads.
- Flatten fetched ISV resource paths to `doc-fetch-resources/{doc_token}/isv_N.data`.
- Add CLI dry-run and resource handling tests for ISV reference behavior.

## Test Plan
- [x] `go test ./shortcuts/doc`
- [x] `go build -o ./lark-cli .`
- [x] `go test ./tests/cli_e2e/docs -run 'TestDocs_DryRunDefaultsToV2OpenAPI|TestDocs_CreateTitleDryRunPrependsContent'`
- [x] E2E covered fetch, create, replace, delete, missing reference, unknown type, and Lark-brand write rejection paths.
- [x] Report gate passed for `/Users/bytedance/.ccm-harness/worktrees/lark-cli-isv-blocks/larksuite_cli/.lark-cli-e2e-test/reports/isv-timeline-20260703144947/report.md`.

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `isv-block` resource support alongside existing document block handling.
  * Docs v2 fetch now includes ISV block data in the default request payload.
* **Bug Fixes**
  * Large inline `isv-block` reference-map data is offloaded into doc-scoped `.data` files.
  * `isv-block` parsing/fetch handling is stricter (requires `type`, enforces valid attribute combinations, and ignores `isv-block` inside Markdown code fences).
  * Docs v2 update now returns an error when the API result is `failed`.
* **Tests**
  * Updated and expanded fetch/create/update and dry-run assertions for ISV defaults and `failed` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->