### PR TITLE
feat(im): guide bot-not-in-chat recovery on message send

### DIFF
--- a/shortcuts/im/im_errors.go
+++ b/shortcuts/im/im_errors.go
@@ -6,10 +6,45 @@ package im
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
 )
+
+// botNotInChatCode is Lark API error 230002 ("Bot/User can NOT be out of the
+// chat"), returned when a bot tries to post to a group chat it is not a member
+// of. The bot must be added to the chat before it can send there.
+const botNotInChatCode = 230002
+
+// enrichBotNotInChatErr augments a 230002 error from a bot-identity group send
+// with an actionable recovery hint: add the bot to the chat with user identity,
+// then retry. chatID is the target group; it is empty for P2P sends, which are
+// left unchanged because their recovery differs (there is no membership to add).
+// appID is the bot's own app ID (runtime.Config.AppID) used to fill id_list; a
+// cli_xxx placeholder is used when it is unavailable. Errors with any other code
+// (and the nil error) are returned unchanged, preserving classification.
+func enrichBotNotInChatErr(err error, chatID, appID string) error {
+	if err == nil || chatID == "" {
+		return err
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Code != botNotInChatCode {
+		return err
+	}
+	botID := appID
+	if botID == "" {
+		botID = "cli_xxx" // the bot's own app_id; see `lark-cli config` / the app console
+	}
+	hint := fmt.Sprintf(
+		"the bot is not a member of chat %s, so it cannot post there. "+
+			"Add the bot to the chat with user identity, then retry the send:\n"+
+			"lark-cli im chat.members create "+
+			"--params '{\"chat_id\":\"%s\",\"member_id_type\":\"app_id\"}' "+
+			"--data '{\"id_list\":[\"%s\"]}' --as user",
+		chatID, chatID, botID)
+	return appendIMRecoveryHint(err, hint)
+}
 
 // wrapIMNetworkErr returns err unchanged when it is already a typed errs.*
 // error (preserving its subtype / code / log_id from the runtime boundary),

--- a/shortcuts/im/im_errors_test.go
+++ b/shortcuts/im/im_errors_test.go
@@ -5,6 +5,7 @@ package im
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
@@ -65,6 +66,59 @@ func TestAppendIMRecoveryHint_RawBecomesInternal(t *testing.T) {
 
 func TestAppendIMRecoveryHint_Nil(t *testing.T) {
 	if appendIMRecoveryHint(nil, "hint") != nil {
+		t.Errorf("nil in -> nil out")
+	}
+}
+
+func TestEnrichBotNotInChatErr_AddsHintWithBotAppID(t *testing.T) {
+	apiErr := errs.NewAPIError(errs.SubtypeUnknown, "Bot/User can NOT be out of the chat.").WithCode(230002)
+	got := enrichBotNotInChatErr(apiErr, "oc_abc", "cli_app123")
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", got)
+	}
+	if p.Code != 230002 {
+		t.Errorf("code = %d, want 230002 (classification must be preserved)", p.Code)
+	}
+	for _, want := range []string{"oc_abc", "cli_app123", "chat.members create", "--as user", "member_id_type"} {
+		if !strings.Contains(p.Hint, want) {
+			t.Errorf("hint %q must contain %q", p.Hint, want)
+		}
+	}
+}
+
+func TestEnrichBotNotInChatErr_UsesPlaceholderWhenAppIDEmpty(t *testing.T) {
+	apiErr := errs.NewAPIError(errs.SubtypeUnknown, "Bot/User can NOT be out of the chat.").WithCode(230002)
+	got := enrichBotNotInChatErr(apiErr, "oc_abc", "")
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", got)
+	}
+	if !strings.Contains(p.Hint, "cli_") {
+		t.Errorf("hint %q must contain a cli_ app_id placeholder", p.Hint)
+	}
+}
+
+func TestEnrichBotNotInChatErr_PassthroughOnOtherCode(t *testing.T) {
+	apiErr := errs.NewAPIError(errs.SubtypeNotFound, "not found").WithCode(230001)
+	got := enrichBotNotInChatErr(apiErr, "oc_abc", "cli_app123")
+	p, _ := errs.ProblemOf(got)
+	if p.Hint != "" {
+		t.Errorf("non-230002 error must be unchanged, got hint %q", p.Hint)
+	}
+}
+
+func TestEnrichBotNotInChatErr_PassthroughOnEmptyChatID(t *testing.T) {
+	apiErr := errs.NewAPIError(errs.SubtypeUnknown, "Bot/User can NOT be out of the chat.").WithCode(230002)
+	got := enrichBotNotInChatErr(apiErr, "", "cli_app123")
+	p, _ := errs.ProblemOf(got)
+	if p.Hint != "" {
+		t.Errorf("empty chat-id (P2P) must be unchanged, got hint %q", p.Hint)
+	}
+}
+
+func TestEnrichBotNotInChatErr_Nil(t *testing.T) {
+	if enrichBotNotInChatErr(nil, "oc_abc", "cli_app123") != nil {
 		t.Errorf("nil in -> nil out")
 	}
 }

--- a/shortcuts/im/im_messages_send.go
+++ b/shortcuts/im/im_messages_send.go
@@ -199,6 +199,11 @@ var ImMessagesSend = common.Shortcut{
 		resData, err := runtime.DoAPIJSONTyped(http.MethodPost, "/open-apis/im/v1/messages",
 			larkcore.QueryParams{"receive_id_type": []string{receiveIdType}}, data)
 		if err != nil {
+			if runtime.IsBot() {
+				// Bot-identity group send to a chat the bot is not in fails with
+				// 230002; attach the add-bot-then-retry recovery command.
+				return enrichBotNotInChatErr(err, chatFlag, runtime.Config.AppID)
+			}
 			return err
 		}
 

--- a/skills/lark-im/references/lark-im-messages-send.md
+++ b/skills/lark-im/references/lark-im-messages-send.md
@@ -16,9 +16,27 @@ Messages sent by this tool are visible to other people. Before calling it, you *
 
 **Do not** send messages without explicit user approval.
 
-When using `--as bot`, the message is sent in the app's name, so make sure the app has already been added to the target chat.
-
 When using `--as user`, the message is sent as the authorized end user and requires the `im:message.send_as_user` and `im:message` scopes.
+
+## Precondition: The Bot Must Be In The Chat (`--as bot` + `--chat-id`)
+
+A bot **cannot** post to a group it is not a member of. Sending anyway fails with **error 230002 `Bot/User can NOT be out of the chat`** and the task cannot complete until the bot is added.
+
+**Before the first `--as bot --chat-id` send in a chat, ensure the bot is a member.** Concretely:
+
+- If you just created the group with `--as user`, add the bot right after (the authorized user must be in the group):
+
+  ```bash
+  # <bot app_id> is this app's own cli_xxx (see the app console / your config)
+  lark-cli im chat.members create \
+    --params '{"chat_id":"oc_xxx","member_id_type":"app_id"}' \
+    --data '{"id_list":["cli_xxx"]}' --as user
+  ```
+
+- If you are creating the group with `--as bot`, the creating bot is already a member — no extra step needed.
+- If you are unsure whether the bot is in the chat, either add it as above (adding an already-present bot is harmless) or check with `lark-cli im chat.members bots --params '{"chat_id":"oc_xxx"}'`.
+
+If a send still returns **230002**, do **not** treat the task as failed: add the bot with the command above, then re-run the exact same send. The CLI attaches this recovery command to the error's `hint` — follow it and retry.
 
 ## Choose The Right Content Flag
 
@@ -200,6 +218,16 @@ lark-cli im +messages-send --chat-id oc_xxx --markdown $'## Test\n\nhello' --dry
 - Using `--content` without making the JSON match the effective `--msg-type`.
 - Explicitly setting `--msg-type` to something that conflicts with `--text`, `--markdown`, or media flags.
 - Mixing `--text`, `--markdown`, or `--content` with media flags in one command.
+- Sending `--as bot` to a `--chat-id` without first ensuring the bot is a member of that chat. This fails with 230002 — see the precondition above and the table below.
+
+## Common Errors and Troubleshooting
+
+| Symptom | Root Cause | Solution |
+|---------|-----------|----------|
+| `Bot/User can NOT be out of the chat` (230002), `--as bot` + `--chat-id` | The bot is not a member of the target group | Add the bot with user identity, then retry the same send: `lark-cli im chat.members create --params '{"chat_id":"oc_xxx","member_id_type":"app_id"}' --data '{"id_list":["cli_xxx"]}' --as user` (`cli_xxx` is this app's own app_id). This is **recoverable** — do not report the task as failed without adding the bot and retrying. |
+| `Bot/User can NOT be out of the chat` (230002), `--as user` | The authorized user is not a member of the target group | Send to a chat the user belongs to, or have the user added to the group first; user membership cannot be granted by the app itself |
+| Permission denied (99991672) | Missing `im:message:send_as_bot` (bot) or `im:message.send_as_user` + `im:message` (user) scope | Enable the required scope for the app in the Open Platform console |
+| Message sends but `@mention` does not resolve | `<at>` syntax does not match the message type | Use the per-type `<at>` forms in the @Mention Format section below |
 
 ## `content` Format Reference
 


### PR DESCRIPTION
## What

Sending a message with `--as bot --chat-id` to a group the bot is **not** a member of fails with API error **230002** (`Bot/User can NOT be out of the chat`). Previously the raw error was returned with no recovery path, so callers — especially AI agents driving the CLI — treated the task as failed instead of adding the bot and retrying.

## Changes

- **`shortcuts/im/im_errors.go`**: new `enrichBotNotInChatErr` helper that, on a 230002 error from a bot-identity group send, appends an actionable recovery hint via the existing `appendIMRecoveryHint`. The hint carries the exact add-bot command (`chat.members create` with `member_id_type=app_id`, `--as user`) pre-filled with the bot's own `app_id` (`runtime.Config.AppID`), plus a "retry the send" instruction. Non-230002 errors, P2P sends (no `chat-id`), user-identity sends, and nil are passed through unchanged, preserving classification / code / log_id.
- **`shortcuts/im/im_messages_send.go`**: wire the helper into the `+messages-send` Execute error path, gated on bot identity.
- **`skills/lark-im/references/lark-im-messages-send.md`**: promote the buried "bot must be in the chat" note into an explicit **Precondition** section and a **Common Errors and Troubleshooting** table (following the `chat-create.md` convention), so the guidance is discoverable before the send.

The hint renders in the error envelope through the standard `WriteTypedErrorEnvelope` / `Problem.Hint` path (the same mechanism every other `WithHint` uses), so the recovery command appears directly in the output the caller reads.

## Tests

- `shortcuts/im/im_errors_test.go`: added coverage for the helper — hint content + preserved code, empty-app_id placeholder, pass-through on other codes / empty chat-id, and nil. Written test-first (RED → GREEN).
- `go build ./...`, `go vet ./shortcuts/im/`, `gofmt` clean, and `go test ./shortcuts/im/ ./errs/... ./internal/output/...` all pass.
