### PR TITLE
fix: trim sheet comment block ids

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -962,11 +962,14 @@ func firstPresentValue(m map[string]interface{}, keys ...string) interface{} {
 // Column is converted from letter to 0-based index (A=0), row from 1-based to 0-based.
 func parseSheetCellRef(input string) (*sheetAnchor, error) {
 	parts := strings.SplitN(input, "!", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	if len(parts) != 2 {
 		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--block-id for sheet must be <sheetId>!<cell> (e.g. a281f9!D6), got %q", input).WithParam("--block-id")
 	}
-	sheetID := parts[0]
+	sheetID := strings.TrimSpace(parts[0])
 	cell := strings.TrimSpace(parts[1])
+	if sheetID == "" || cell == "" {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--block-id for sheet must be <sheetId>!<cell> (e.g. a281f9!D6), got %q", input).WithParam("--block-id")
+	}
 
 	// Parse cell reference like "D6" into col letter + row number.
 	i := 0

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -797,6 +797,7 @@ func TestParseSheetCellRef(t *testing.T) {
 		{"AA1", "s1!AA1", "s1", 26, 0},
 		{"lowercase", "s1!d6", "s1", 3, 5},
 		{"B10", "sheet1!B10", "sheet1", 1, 9},
+		{"trims spaces", " s1 ! D6 ", "s1", 3, 5},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -814,7 +815,7 @@ func TestParseSheetCellRef(t *testing.T) {
 
 func TestParseSheetCellRefInvalid(t *testing.T) {
 	t.Parallel()
-	cases := []string{"", "noExclamation", "s1!", "!A1", "s1!123", "s1!A"}
+	cases := []string{"", "noExclamation", "s1!", "!A1", "   !A1", "s1!123", "s1!A"}
 	for _, input := range cases {
 		t.Run(input, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary
Trim sheet comment block-id parts before validation so whitespace around the `!` separator does not leak into the API request, and whitespace-only sheet IDs are rejected before execution.

## Changes
- Trim the sheet ID and cell portions in `parseSheetCellRef` before validating them.
- Add regression coverage for spaced sheet comment block IDs and blank sheet IDs.

## Test Plan
- [x] Unit tests pass: `env GOCACHE=/private/tmp/lark-cli-gocache go test ./shortcuts/drive`
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sheet-and-cell references with extra whitespace, so valid inputs are recognized more reliably.
  * Tightened validation for malformed references that are missing a valid sheet identifier.
* **Tests**
  * Expanded coverage for whitespace-trimmed references and invalid edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->