### PR TITLE
fix(approval): reject unsupported instance form controls

### DIFF
--- a/cmd/service/approval_preflight.go
+++ b/cmd/service/approval_preflight.go
@@ -70,7 +70,7 @@ func validateApprovalInstanceCreateData(schemaPath string, data any) error {
 	return errs.NewValidationError(errs.SubtypeInvalidArgument,
 		"approval instances create does not support form control type(s): %s",
 		strings.Join(parts, ", ")).
-		WithParam("form").
+		WithParam("--data").
 		WithHint("remove unsupported controls from --data.form or create the approval in the Lark/Feishu client")
 }
 

--- a/cmd/service/approval_preflight.go
+++ b/cmd/service/approval_preflight.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+)
+
+var unsupportedApprovalInstanceControlTypes = map[string]struct{}{
+	"text":                        {},
+	"mutableGroup":                {},
+	"account":                     {},
+	"serialNumber":                {},
+	"tripGroup":                   {},
+	"apaascorehrOnboardingGroup":  {},
+	"apaascorehrRegularateGroup":  {},
+	"remedyGroupV2":               {},
+	"apaascorehrJobAdjustGroup":   {},
+	"apaascorehrOffboardingGroup": {},
+}
+
+type unsupportedApprovalControl struct {
+	ID   string
+	Type string
+}
+
+func validateApprovalInstanceCreateData(schemaPath string, data any) error {
+	if schemaPath != "approval.instances.create" {
+		return nil
+	}
+	body, ok := data.(map[string]any)
+	if !ok {
+		return nil
+	}
+	rawForm, ok := body["form"].(string)
+	if !ok || strings.TrimSpace(rawForm) == "" {
+		return nil
+	}
+
+	var controls []any
+	if err := json.Unmarshal([]byte(rawForm), &controls); err != nil {
+		return nil
+	}
+	var unsupported []unsupportedApprovalControl
+	collectUnsupportedApprovalControls(controls, &unsupported)
+	if len(unsupported) == 0 {
+		return nil
+	}
+
+	sort.Slice(unsupported, func(i, j int) bool {
+		if unsupported[i].Type == unsupported[j].Type {
+			return unsupported[i].ID < unsupported[j].ID
+		}
+		return unsupported[i].Type < unsupported[j].Type
+	})
+	parts := make([]string, 0, len(unsupported))
+	for _, item := range unsupported {
+		if item.ID == "" {
+			parts = append(parts, item.Type)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s(%s)", item.Type, item.ID))
+	}
+	return errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"approval instances create does not support form control type(s): %s",
+		strings.Join(parts, ", ")).
+		WithParam("form").
+		WithHint("remove unsupported controls from --data.form or create the approval in the Lark/Feishu client")
+}
+
+func collectUnsupportedApprovalControls(value any, out *[]unsupportedApprovalControl) {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			collectUnsupportedApprovalControls(item, out)
+		}
+	case map[string]any:
+		controlType, _ := typed["type"].(string)
+		if _, unsupported := unsupportedApprovalInstanceControlTypes[controlType]; unsupported {
+			id, _ := typed["id"].(string)
+			*out = append(*out, unsupportedApprovalControl{ID: id, Type: controlType})
+		}
+		for _, nested := range typed {
+			collectUnsupportedApprovalControls(nested, out)
+		}
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -658,6 +658,9 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		if err != nil {
 			return client.RawApiRequest{}, nil, err
 		}
+		if err := validateApprovalInstanceCreateData(opts.SchemaPath, data); err != nil {
+			return client.RawApiRequest{}, nil, err
+		}
 		request.Data = data
 		if opts.Output != "" {
 			request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileDownload())

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -389,6 +389,45 @@ func TestServiceMethod_InvalidDataJSON(t *testing.T) {
 	}
 }
 
+func TestServiceMethod_ApprovalInstanceCreateRejectsUnsupportedAccountControl(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	spec := meta.ServiceFromMap(map[string]interface{}{
+		"name": "approval", "servicePath": "/open-apis/approval/v4",
+	})
+	method := meta.FromMap(map[string]interface{}{
+		"path": "instances", "httpMethod": "POST", "parameters": map[string]interface{}{},
+	})
+	cmd := NewCmdServiceMethod(f, spec, method, "create", "instances", nil)
+	cmd.SetArgs([]string{
+		"--data", `{"approval_code":"code","form":"[{\"id\":\"payee\",\"type\":\"account\",\"value\":{\"account_id\":\"acct_1\"}}]"}`,
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unsupported approval account control")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %+v, want validation/invalid_argument", problem)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	if validationErr.Param != "form" {
+		t.Fatalf("param = %q, want form", validationErr.Param)
+	}
+	for _, want := range []string{"account", "payee"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got: %v", want, err)
+		}
+	}
+}
+
 func TestServiceMethod_ParamsAndDataBothStdinConflict(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
 	spec := meta.ServiceFromMap(map[string]interface{}{

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -418,10 +418,49 @@ func TestServiceMethod_ApprovalInstanceCreateRejectsUnsupportedAccountControl(t 
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected ValidationError, got %T", err)
 	}
-	if validationErr.Param != "form" {
-		t.Fatalf("param = %q, want form", validationErr.Param)
+	if validationErr.Param != "--data" {
+		t.Fatalf("param = %q, want --data", validationErr.Param)
 	}
 	for _, want := range []string{"account", "payee"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got: %v", want, err)
+		}
+	}
+}
+
+func TestServiceMethod_ApprovalInstanceCreateRejectsNestedUnsupportedControl(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	spec := meta.ServiceFromMap(map[string]interface{}{
+		"name": "approval", "servicePath": "/open-apis/approval/v4",
+	})
+	method := meta.FromMap(map[string]interface{}{
+		"path": "instances", "httpMethod": "POST", "parameters": map[string]interface{}{},
+	})
+	cmd := NewCmdServiceMethod(f, spec, method, "create", "instances", nil)
+	cmd.SetArgs([]string{
+		"--data", `{"approval_code":"code","form":"[{\"id\":\"group\",\"type\":\"fieldList\",\"value\":[[{\"id\":\"nested_payee\",\"type\":\"account\",\"value\":{\"account_id\":\"acct_1\"}}]]}]"}`,
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nested unsupported approval control")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %+v, want validation/invalid_argument", problem)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	if validationErr.Param != "--data" {
+		t.Fatalf("param = %q, want --data", validationErr.Param)
+	}
+	for _, want := range []string{"account", "nested_payee"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected error to mention %q, got: %v", want, err)
 		}

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -389,81 +389,63 @@ func TestServiceMethod_InvalidDataJSON(t *testing.T) {
 	}
 }
 
-func TestServiceMethod_ApprovalInstanceCreateRejectsUnsupportedAccountControl(t *testing.T) {
-	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := meta.ServiceFromMap(map[string]interface{}{
-		"name": "approval", "servicePath": "/open-apis/approval/v4",
-	})
-	method := meta.FromMap(map[string]interface{}{
-		"path": "instances", "httpMethod": "POST", "parameters": map[string]interface{}{},
-	})
-	cmd := NewCmdServiceMethod(f, spec, method, "create", "instances", nil)
-	cmd.SetArgs([]string{
-		"--data", `{"approval_code":"code","form":"[{\"id\":\"payee\",\"type\":\"account\",\"value\":{\"account_id\":\"acct_1\"}}]"}`,
-		"--dry-run",
-	})
+func TestServiceMethod_ApprovalInstanceCreateRejectsUnsupportedControls(t *testing.T) {
+	cases := []struct {
+		name        string
+		data        string
+		wantSubstrs []string
+	}{
+		{
+			name:        "top-level account control",
+			data:        `{"approval_code":"code","form":"[{\"id\":\"payee\",\"type\":\"account\",\"value\":{\"account_id\":\"acct_1\"}}]"}`,
+			wantSubstrs: []string{"account", "payee"},
+		},
+		{
+			name:        "nested account control",
+			data:        `{"approval_code":"code","form":"[{\"id\":\"group\",\"type\":\"fieldList\",\"value\":[[{\"id\":\"nested_payee\",\"type\":\"account\",\"value\":{\"account_id\":\"acct_1\"}}]]}]"}`,
+			wantSubstrs: []string{"account", "nested_payee"},
+		},
+	}
 
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for unsupported approval account control")
-	}
-	problem, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected typed error, got %T: %v", err, err)
-	}
-	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
-		t.Fatalf("problem = %+v, want validation/invalid_argument", problem)
-	}
-	var validationErr *errs.ValidationError
-	if !errors.As(err, &validationErr) {
-		t.Fatalf("expected ValidationError, got %T", err)
-	}
-	if validationErr.Param != "--data" {
-		t.Fatalf("param = %q, want --data", validationErr.Param)
-	}
-	for _, want := range []string{"account", "payee"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("expected error to mention %q, got: %v", want, err)
-		}
-	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+			spec := meta.ServiceFromMap(map[string]interface{}{
+				"name": "approval", "servicePath": "/open-apis/approval/v4",
+			})
+			method := meta.FromMap(map[string]interface{}{
+				"path": "instances", "httpMethod": "POST", "parameters": map[string]interface{}{},
+			})
+			cmd := NewCmdServiceMethod(f, spec, method, "create", "instances", nil)
+			cmd.SetArgs([]string{
+				"--data", tc.data,
+				"--dry-run",
+			})
 
-func TestServiceMethod_ApprovalInstanceCreateRejectsNestedUnsupportedControl(t *testing.T) {
-	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := meta.ServiceFromMap(map[string]interface{}{
-		"name": "approval", "servicePath": "/open-apis/approval/v4",
-	})
-	method := meta.FromMap(map[string]interface{}{
-		"path": "instances", "httpMethod": "POST", "parameters": map[string]interface{}{},
-	})
-	cmd := NewCmdServiceMethod(f, spec, method, "create", "instances", nil)
-	cmd.SetArgs([]string{
-		"--data", `{"approval_code":"code","form":"[{\"id\":\"group\",\"type\":\"fieldList\",\"value\":[[{\"id\":\"nested_payee\",\"type\":\"account\",\"value\":{\"account_id\":\"acct_1\"}}]]}]"}`,
-		"--dry-run",
-	})
-
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for nested unsupported approval control")
-	}
-	problem, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected typed error, got %T: %v", err, err)
-	}
-	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
-		t.Fatalf("problem = %+v, want validation/invalid_argument", problem)
-	}
-	var validationErr *errs.ValidationError
-	if !errors.As(err, &validationErr) {
-		t.Fatalf("expected ValidationError, got %T", err)
-	}
-	if validationErr.Param != "--data" {
-		t.Fatalf("param = %q, want --data", validationErr.Param)
-	}
-	for _, want := range []string{"account", "nested_payee"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("expected error to mention %q, got: %v", want, err)
-		}
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error for unsupported approval control")
+			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed error, got %T: %v", err, err)
+			}
+			if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem = %+v, want validation/invalid_argument", problem)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("expected ValidationError, got %T", err)
+			}
+			if validationErr.Param != "--data" {
+				t.Fatalf("param = %q, want --data", validationErr.Param)
+			}
+			for _, want := range tc.wantSubstrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("expected error to mention %q, got: %v", want, err)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Reject unsupported approval instance form controls before sending `approval instances create` requests. This turns documented unsupported controls such as `account` into an actionable typed validation error instead of allowing ambiguous instance creation.

## Changes
- Add a focused preflight check for `approval.instances.create` request bodies.
- Detect unsupported controls in `--data.form`, including nested controls, and include the control type/id in the validation message.
- Add a regression test for an `account` form control.

## Test Plan
- [x] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected (not run against a live approval instance; covered by dry-run/unit preflight tests)

Validation run:
- `go test ./cmd/service -run TestServiceMethod_ApprovalInstanceCreateRejectsUnsupportedAccountControl -count=1`
- `go test ./cmd/service -count=1`
- `go test ./cmd/service ./errs -count=1`
- `go vet ./cmd/service ./errs`
- `git diff --check`

## Related Issues
- Fixes #1672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for `approval instances create` to reject unsupported form control `type` values, including deeply nested controls.
  * When using `--data` (non-`--file`), validation now fails early with a clear `--data`-scoped validation error that identifies the offending control(s) (optionally including their IDs).
* **Tests**
  * Added coverage to confirm both top-level and nested unsupported controls are rejected in `--dry-run`, with the expected validation category/subtype and error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->