### PR TITLE
fix: parse drive url tokens from path only

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -1259,12 +1260,16 @@ func executeSlidesComment(runtime *common.RuntimeContext, docRef commentDocRef) 
 }
 
 func extractURLToken(raw, marker string) (string, bool) {
-	idx := strings.Index(raw, marker)
-	if idx < 0 {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme == "" || u.Host == "" {
 		return "", false
 	}
-	token := raw[idx+len(marker):]
-	if end := strings.IndexAny(token, "/?#"); end >= 0 {
+	path := u.Path
+	if !strings.HasPrefix(path, marker) {
+		return "", false
+	}
+	token := path[len(marker):]
+	if end := strings.IndexByte(token, '/'); end >= 0 {
 		token = token[:end]
 	}
 	token = strings.TrimSpace(token)

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -187,6 +187,21 @@ func TestParseCommentDocRef(t *testing.T) {
 			input:   "https://example.com/not-a-doc",
 			wantErr: "unsupported --doc input",
 		},
+		{
+			name:    "marker inside query does not infer type",
+			input:   "https://example.larksuite.com/not-a-doc?next=/slides/pres_123",
+			wantErr: "unsupported --doc input",
+		},
+		{
+			name:    "marker mid path does not infer type",
+			input:   "https://example.larksuite.com/space/wiki/wikcn123",
+			wantErr: "unsupported --doc input",
+		},
+		{
+			name:    "non-url path with marker does not infer type",
+			input:   "tmp/wiki/wikcn123",
+			wantErr: "unsupported --doc input",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2085,6 +2100,19 @@ func TestExtractURLTokenEmptyAfterMarker(t *testing.T) {
 	_, ok := extractURLToken("https://example.com/sheets/", "/sheets/")
 	if ok {
 		t.Fatal("expected false for empty token after marker")
+	}
+}
+
+func TestExtractURLTokenIgnoresMarkersOutsideURLPathPrefix(t *testing.T) {
+	t.Parallel()
+	for _, input := range []string{
+		"https://example.com/not-a-doc?next=/sheets/shtToken",
+		"https://example.com/docx/sheets/shtToken",
+		"tmp/sheets/shtToken",
+	} {
+		if got, ok := extractURLToken(input, "/sheets/"); ok {
+			t.Fatalf("extractURLToken(%q) = %q, true; want false", input, got)
+		}
 	}
 }
 

--- a/shortcuts/drive/drive_apply_permission.go
+++ b/shortcuts/drive/drive_apply_permission.go
@@ -21,8 +21,8 @@ var permApplyTypes = []string{
 }
 
 // permApplyURLMarkers maps document URL path markers to the `type` value the
-// apply-permission endpoint expects. Markers are disjoint strings (each begins
-// with "/" and ends with "/"), so a simple substring scan disambiguates them.
+// apply-permission endpoint expects. Markers are checked against the parsed URL
+// path, not the raw input, so query strings and fragments cannot spoof a type.
 var permApplyURLMarkers = []struct {
 	Marker string
 	Type   string

--- a/shortcuts/drive/drive_apply_permission_test.go
+++ b/shortcuts/drive/drive_apply_permission_test.go
@@ -86,6 +86,19 @@ func TestResolvePermApplyTarget_UnrecognizedURL(t *testing.T) {
 	}
 }
 
+func TestResolvePermApplyTarget_IgnoresMarkersOutsideURLPathPrefix(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"https://example.feishu.cn/unknown/xyz?next=/docx/doxTok123",
+		"https://example.feishu.cn/space/docx/doxTok123",
+	} {
+		_, _, err := resolvePermApplyTarget(raw, "")
+		if err == nil || !strings.Contains(err.Error(), "could not infer token") {
+			t.Fatalf("resolvePermApplyTarget(%q) error = %v, want infer error", raw, err)
+		}
+	}
+}
+
 func TestResolvePermApplyTarget_Empty(t *testing.T) {
 	t.Parallel()
 	_, _, err := resolvePermApplyTarget("   ", "docx")


### PR DESCRIPTION
## Summary
Drive URL token inference now parses the URL path rather than scanning raw input, so query strings and non-URL paths cannot spoof supported Drive resource markers.

## Changes
- Parse Drive shortcut URL tokens from parsed URL paths with an explicit scheme/host check.
- Update the apply-permission marker comment to match the path-based behavior.
- Add regression tests for add-comment and apply-permission query, mid-path, and non-URL marker cases.

## Test Plan
- [x] Unit tests pass: env GOCACHE=/private/tmp/cli-gocache go test ./shortcuts/drive
- [ ] Manual local verification confirms the lark-cli <domain> <command> flow works as expected

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling for drive comments and permission actions so document types and tokens are only detected from the actual URL path.
  * Prevents query strings, fragments, or unrelated path segments from being mistaken for valid document markers.
  * Added coverage to ensure invalid or spoofed inputs continue to return clear “unsupported input” or “could not infer token” errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->