### PR TITLE
Soften Drive cleanup visibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,12 +263,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
+      - name: Resolve CLI E2E scope
+        id: e2e_scope
+        run: scripts/e2e_scope.sh
       - name: Build lark-cli
         run: make build
       - name: Run dry-run E2E tests
@@ -277,7 +282,19 @@ jobs:
           LARKSUITE_CLI_APP_ID: dry-run
           LARKSUITE_CLI_APP_SECRET: dry-run
           LARKSUITE_CLI_BRAND: feishu
-        run: go test -v -count=1 -timeout=5m ./tests/cli_e2e/... -run 'DryRun|Regression'
+        run: |
+          if [ "${{ steps.e2e_scope.outputs.mode }}" = "skip" ]; then
+            echo "No dry-run CLI E2E needed: ${{ steps.e2e_scope.outputs.reason }}"
+            exit 0
+          fi
+          packages="${{ steps.e2e_scope.outputs.dry_packages }}"
+          if [ -z "$packages" ]; then
+            echo "::error::No dry-run CLI E2E packages resolved for mode ${{ steps.e2e_scope.outputs.mode }}"
+            exit 1
+          fi
+          echo "Dry-run CLI E2E scope: ${{ steps.e2e_scope.outputs.mode }} (${{ steps.e2e_scope.outputs.reason }})"
+          echo "Dry-run CLI E2E packages: $packages"
+          go test -v -count=1 -timeout=5m $packages -run 'DryRun|Regression'
 
   e2e-live:
     needs: [unit-test, lint, script-test, deterministic-gate]
@@ -292,15 +309,21 @@ jobs:
       TEST_USER_ACCESS_TOKEN: ${{ secrets.TEST_USER_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
+      - name: Resolve CLI E2E scope
+        id: e2e_scope
+        run: scripts/e2e_scope.sh
       - name: Build lark-cli
         run: make build
       - name: Configure bot credentials
+        if: ${{ steps.e2e_scope.outputs.mode != 'skip' }}
         run: |
           if [ -z "$TEST_BOT1_APP_ID" ] || [ -z "$TEST_BOT1_APP_SECRET" ]; then
             echo "::error::Missing required secrets: TEST_BOT1_APP_ID / TEST_BOT1_APP_SECRET"
@@ -311,15 +334,20 @@ jobs:
         env:
           LARK_CLI_BIN: ${{ github.workspace }}/lark-cli
         run: |
-          packages=$(go list ./tests/cli_e2e/... | grep -v '^github.com/larksuite/cli/tests/cli_e2e$' | grep -v '/demo$')
+          if [ "${{ steps.e2e_scope.outputs.mode }}" = "skip" ]; then
+            echo "No live CLI E2E needed: ${{ steps.e2e_scope.outputs.reason }}"
+            exit 0
+          fi
+          packages="${{ steps.e2e_scope.outputs.live_packages }}"
           if [ -z "$packages" ]; then
-            echo "No CLI E2E packages to test after exclusions."
+            echo "::error::No live CLI E2E packages resolved for mode ${{ steps.e2e_scope.outputs.mode }}"
             exit 1
           fi
-          packages_arg=$(printf '%s\n' "$packages" | paste -sd' ' -)
-          go run gotest.tools/gotestsum@v1.12.3 --rerun-fails=2 --rerun-fails-max-failures=20 --packages="$packages_arg" --format testname --junitfile cli-e2e-report.xml -- -count=1 -v
+          echo "Live CLI E2E scope: ${{ steps.e2e_scope.outputs.mode }} (${{ steps.e2e_scope.outputs.reason }})"
+          echo "Live CLI E2E packages: $packages"
+          go run gotest.tools/gotestsum@v1.12.3 --rerun-fails=2 --rerun-fails-max-failures=20 --packages="$packages" --format testname --junitfile cli-e2e-report.xml -- -count=1 -v
       - name: Publish CLI E2E test report
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.e2e_scope.outputs.mode != 'skip' }}
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: CLI E2E Tests

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ fmt-check:
 
 script-test:
 	bash scripts/resolve-changed-from.test.sh
+	bash scripts/e2e_scope.test.sh
 	bash scripts/ci-workflow.test.sh
 	bash scripts/semantic-review-workflow.test.sh
 	$(NODE) --test scripts/semantic-review-verify-artifact.test.js scripts/pr-quality-summary.test.js scripts/semantic-review-publish.test.js scripts/ci-quality-summary-publish.test.js

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -215,6 +215,35 @@ if ! grep -Fq "if: \${{ $fork_safe_guard }}" <<<"$section"; then
   exit 1
 fi
 
+if ! grep -Fq "name: Resolve CLI E2E scope" <<<"$dry_run_section" ||
+   ! grep -Fq "id: e2e_scope" <<<"$dry_run_section" ||
+   ! grep -Fq "run: scripts/e2e_scope.sh" <<<"$dry_run_section"; then
+  echo "e2e-dry-run should resolve changed-file CLI E2E scope before running tests"
+  exit 1
+fi
+
+if ! grep -Fq "steps.e2e_scope.outputs.dry_packages" <<<"$dry_run_section"; then
+  echo "e2e-dry-run should use resolved dry_packages instead of always running the full suite"
+  exit 1
+fi
+
+if ! grep -Fq "No dry-run CLI E2E needed" <<<"$dry_run_section"; then
+  echo "e2e-dry-run should explicitly skip when scope mode is skip"
+  exit 1
+fi
+
+if ! grep -Fq "name: Resolve CLI E2E scope" <<<"$section" ||
+   ! grep -Fq "id: e2e_scope" <<<"$section" ||
+   ! grep -Fq "run: scripts/e2e_scope.sh" <<<"$section"; then
+  echo "e2e-live should resolve changed-file CLI E2E scope before credentials and tests"
+  exit 1
+fi
+
+if ! grep -Fq "steps.e2e_scope.outputs.live_packages" <<<"$section"; then
+  echo "e2e-live should use resolved live_packages instead of always running the full suite"
+  exit 1
+fi
+
 if ! grep -Fq "permissions:" <<<"$section" ||
    ! grep -Fq "contents: read" <<<"$section" ||
    ! grep -Fq "checks: write" <<<"$section"; then
@@ -237,13 +266,23 @@ if ! grep -Fq "::error::Missing required secrets: TEST_BOT1_APP_ID / TEST_BOT1_A
   exit 1
 fi
 
+if ! awk '
+  /^      - name: Configure bot credentials/ { in_step = 1 }
+  in_step && /if: \$\{\{ steps\.e2e_scope\.outputs\.mode != '\''skip'\'' \}\}/ { found = 1 }
+  in_step && /^      - name:/ && !/Configure bot credentials/ { in_step = 0 }
+  END { exit found ? 0 : 1 }
+' <<<"$section"; then
+  echo "e2e-live should only configure bot credentials when scope mode is not skip"
+  exit 1
+fi
+
 if grep -Fq "steps.live_e2e_credentials.outputs.configured" <<<"$section"; then
   echo "e2e-live build, configure, test, and report steps should not be gated by a skip-state output"
   exit 1
 fi
 
-if ! grep -Fq "if: \${{ !cancelled() }}" <<<"$section"; then
-  echo "e2e-live report step should run after attempted live tests unless the workflow is cancelled"
+if ! grep -Fq "if: \${{ !cancelled() && steps.e2e_scope.outputs.mode != 'skip' }}" <<<"$section"; then
+  echo "e2e-live report step should run after attempted live tests unless the workflow is cancelled or scope is skip"
   exit 1
 fi
 

--- a/scripts/e2e_scope.sh
+++ b/scripts/e2e_scope.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+ROOT="${E2E_SCOPE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$ROOT"
+
+module_path="$(go list -m)"
+e2e_prefix="${module_path}/tests/cli_e2e"
+
+all_live_packages() {
+  go list ./tests/cli_e2e/... |
+    grep -v "^${e2e_prefix}$" |
+    grep -v '/demo$'
+}
+
+domain_exists() {
+  local domain="$1"
+  go list "./tests/cli_e2e/${domain}" >/dev/null 2>&1
+}
+
+append_unique_line() {
+  local value="$1"
+  local current="$2"
+  if [ -z "$value" ]; then
+    printf '%s' "$current"
+    return
+  fi
+  if printf '%s\n' "$current" | grep -Fxq "$value"; then
+    printf '%s' "$current"
+    return
+  fi
+  if [ -z "$current" ]; then
+    printf '%s' "$value"
+  else
+    printf '%s\n%s' "$current" "$value"
+  fi
+}
+
+domains=""
+force_full_reason=""
+matched_relevant=false
+
+add_domain() {
+  local domain="$1"
+  case "$domain" in
+    doc|docs|lark-doc)
+      domains="$(append_unique_line doc "$domains")"
+      domains="$(append_unique_line docs "$domains")"
+      ;;
+    drive|lark-drive)
+      domains="$(append_unique_line drive "$domains")"
+      ;;
+    sheets|lark-sheets)
+      domains="$(append_unique_line sheets "$domains")"
+      ;;
+    wiki|lark-wiki)
+      domains="$(append_unique_line wiki "$domains")"
+      ;;
+    base|lark-base)
+      domains="$(append_unique_line base "$domains")"
+      ;;
+    im|lark-im)
+      domains="$(append_unique_line im "$domains")"
+      ;;
+    vc|lark-vc)
+      domains="$(append_unique_line vc "$domains")"
+      ;;
+    calendar|lark-calendar)
+      domains="$(append_unique_line calendar "$domains")"
+      ;;
+    task|lark-task)
+      domains="$(append_unique_line task "$domains")"
+      ;;
+    contact|lark-contact)
+      domains="$(append_unique_line contact "$domains")"
+      ;;
+    mail|lark-mail)
+      domains="$(append_unique_line mail "$domains")"
+      ;;
+    minutes|lark-minutes)
+      domains="$(append_unique_line minutes "$domains")"
+      ;;
+    okr|lark-okr)
+      domains="$(append_unique_line okr "$domains")"
+      ;;
+    slides|lark-slides)
+      domains="$(append_unique_line slides "$domains")"
+      ;;
+    apps|lark-apps)
+      domains="$(append_unique_line apps "$domains")"
+      ;;
+    markdown|lark-markdown)
+      domains="$(append_unique_line markdown "$domains")"
+      ;;
+    note|lark-note)
+      domains="$(append_unique_line note "$domains")"
+      ;;
+    event|lark-event)
+      domains="$(append_unique_line event "$domains")"
+      ;;
+    config)
+      domains="$(append_unique_line config "$domains")"
+      ;;
+    *)
+      force_full_reason="unmapped domain path: ${domain}"
+      ;;
+  esac
+}
+
+mark_full() {
+  if [ -z "$force_full_reason" ]; then
+    force_full_reason="$1"
+  fi
+}
+
+is_docs_only_path() {
+  case "$1" in
+    README*|CHANGELOG*|LICENSE|CLA.md|docs/*|.changeset/*|*.md|*.mdx|*.txt|*.rst)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+classify_path() {
+  local path="${1#./}"
+  [ -z "$path" ] && return
+
+  case "$path" in
+    tests/cli_e2e/*/*)
+      local rest="${path#tests/cli_e2e/}"
+      local domain="${rest%%/*}"
+      if [ "$domain" = "demo" ]; then
+        return
+      fi
+      if domain_exists "$domain"; then
+        matched_relevant=true
+        add_domain "$domain"
+        return
+      fi
+      if is_docs_only_path "$path"; then
+        return
+      fi
+      mark_full "unknown CLI E2E domain path: ${path}"
+      return
+      ;;
+    tests/cli_e2e/*)
+      mark_full "shared CLI E2E harness changed: ${path}"
+      return
+      ;;
+    shortcuts/common/*|cmd/*|internal/*|pkg/*|extension/*|registry/*|go.mod|go.sum|Makefile|.github/workflows/*|scripts/*)
+      mark_full "shared/runtime path changed: ${path}"
+      return
+      ;;
+    shortcuts/*/*)
+      local rest="${path#shortcuts/}"
+      matched_relevant=true
+      add_domain "${rest%%/*}"
+      return
+      ;;
+    skills/lark-*/*)
+      local rest="${path#skills/}"
+      matched_relevant=true
+      add_domain "${rest%%/*}"
+      return
+      ;;
+  esac
+
+  if is_docs_only_path "$path"; then
+    return
+  fi
+
+  mark_full "unclassified path changed: ${path}"
+}
+
+changed_files() {
+  if [ -n "${E2E_SCOPE_CHANGED_FILES:-}" ]; then
+    cat "$E2E_SCOPE_CHANGED_FILES"
+    return
+  fi
+
+  if [ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]; then
+    return 1
+  fi
+
+  local base_ref="${GITHUB_BASE_REF:-main}"
+  if git rev-parse --verify "origin/${base_ref}" >/dev/null 2>&1; then
+    git diff --name-only "origin/${base_ref}...HEAD"
+    return
+  fi
+
+  return 1
+}
+
+if ! files="$(changed_files)"; then
+  mode="full"
+  reason="non-pull_request run or unavailable diff"
+  domains="all"
+  packages="$(all_live_packages | paste -sd' ' -)"
+else
+  while IFS= read -r file; do
+    classify_path "$file"
+  done <<<"$files"
+
+  if [ -n "$force_full_reason" ]; then
+    mode="full"
+    reason="$force_full_reason"
+    domains="all"
+    packages="$(all_live_packages | paste -sd' ' -)"
+  elif [ -n "$domains" ] && [ "$matched_relevant" = true ]; then
+    mode="subset"
+    reason="business domain scoped changes"
+    domains="$(printf '%s\n' "$domains" | sort -u)"
+    packages="$(
+      for domain in $domains; do
+        if domain_exists "$domain"; then
+          printf '%s/tests/cli_e2e/%s\n' "$module_path" "$domain"
+        fi
+      done | sort -u | paste -sd' ' -
+    )"
+  else
+    mode="skip"
+    reason="docs-only or no live CLI E2E impact"
+    domains=""
+    packages=""
+  fi
+fi
+
+domains_line="$(printf '%s\n' "$domains" | paste -sd',' -)"
+
+emit() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+emit mode "$mode"
+emit reason "$reason"
+emit domains "$domains_line"
+emit dry_packages "$packages"
+emit live_packages "$packages"

--- a/scripts/e2e_scope.test.sh
+++ b/scripts/e2e_scope.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+script="scripts/e2e_scope.sh"
+
+run_scope() {
+  local file="$1"
+  E2E_SCOPE_CHANGED_FILES="$file" "$script"
+}
+
+write_changes() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+field() {
+  local key="$1"
+  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }'
+}
+
+assert_field() {
+  local output="$1"
+  local key="$2"
+  local want="$3"
+  local got
+  got="$(printf '%s\n' "$output" | field "$key")"
+  if [ "$got" != "$want" ]; then
+    printf 'expected %s=%s, got %s\nfull output:\n%s\n' "$key" "$want" "$got" "$output" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    printf 'expected output to contain %s\nfull output:\n%s\n' "$needle" "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if grep -Fq "$needle" <<<"$haystack"; then
+    printf 'expected output not to contain %s\nfull output:\n%s\n' "$needle" "$haystack" >&2
+    exit 1
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+changes="$tmpdir/changes.txt"
+
+write_changes "$changes" "shortcuts/im/messages/send.go"
+output="$(run_scope "$changes")"
+assert_field "$output" mode subset
+assert_field "$output" domains im
+assert_contains "$output" "github.com/larksuite/cli/tests/cli_e2e/im"
+assert_not_contains "$output" "github.com/larksuite/cli/tests/cli_e2e/drive"
+
+write_changes "$changes" "shortcuts/doc/update.go"
+output="$(run_scope "$changes")"
+assert_field "$output" mode subset
+assert_field "$output" domains doc,docs
+assert_contains "$output" "github.com/larksuite/cli/tests/cli_e2e/doc"
+assert_contains "$output" "github.com/larksuite/cli/tests/cli_e2e/docs"
+
+write_changes "$changes" "tests/cli_e2e/drive/helpers.go"
+output="$(run_scope "$changes")"
+assert_field "$output" mode subset
+assert_field "$output" domains drive
+assert_contains "$output" "github.com/larksuite/cli/tests/cli_e2e/drive"
+
+write_changes "$changes" "tests/cli_e2e/core.go"
+output="$(run_scope "$changes")"
+assert_field "$output" mode full
+assert_field "$output" domains all
+assert_contains "$output" "shared CLI E2E harness changed"
+
+write_changes "$changes" "cmd/root.go"
+output="$(run_scope "$changes")"
+assert_field "$output" mode full
+assert_field "$output" domains all
+assert_contains "$output" "shared/runtime path changed"
+
+write_changes "$changes" "docs/usage.md" "README.md"
+output="$(run_scope "$changes")"
+assert_field "$output" mode skip
+assert_field "$output" domains ""
+assert_field "$output" live_packages ""
+
+write_changes "$changes" "skills/lark-sheets/SKILL.md"
+output="$(run_scope "$changes")"
+assert_field "$output" mode subset
+assert_field "$output" domains sheets
+assert_contains "$output" "github.com/larksuite/cli/tests/cli_e2e/sheets"

--- a/tests/cli_e2e/core.go
+++ b/tests/cli_e2e/core.go
@@ -24,7 +24,7 @@ import (
 const EnvBinaryPath = "LARK_CLI_BIN"
 const projectRootMarkerDir = "tests"
 const cliBinaryName = "lark-cli"
-const CleanupTimeout = 30 * time.Second
+const CleanupTimeout = 90 * time.Second
 
 func SkipWithoutUserToken(t *testing.T) {
 	t.Helper()
@@ -100,6 +100,39 @@ type Result struct {
 	Stdout     string
 	Stderr     string
 	RunErr     error
+}
+
+type cleanupWarningError struct {
+	err error
+}
+
+func (e *cleanupWarningError) Error() string {
+	return e.err.Error()
+}
+
+func (e *cleanupWarningError) Unwrap() error {
+	return e.err
+}
+
+// CleanupWarning marks a cleanup verification issue as non-fatal after the
+// destructive cleanup command itself has already succeeded.
+func CleanupWarning(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &cleanupWarningError{err: err}
+}
+
+// CleanupWarningf formats and marks a cleanup warning.
+func CleanupWarningf(format string, args ...any) error {
+	return CleanupWarning(fmt.Errorf(format, args...))
+}
+
+// IsCleanupWarning reports whether err should be logged without failing the
+// parent test.
+func IsCleanupWarning(err error) bool {
+	var warning *cleanupWarningError
+	return errors.As(err, &warning)
 }
 
 // RetryOptions configures retry behavior for flaky external API calls.
@@ -251,6 +284,10 @@ func ReportCleanupFailure(parentT *testing.T, prefix string, result *Result, err
 	parentT.Helper()
 
 	if err != nil {
+		if IsCleanupWarning(err) {
+			parentT.Logf("%s: %v", prefix, err)
+			return
+		}
 		parentT.Errorf("%s: %v", prefix, err)
 		return
 	}

--- a/tests/cli_e2e/drive/helpers.go
+++ b/tests/cli_e2e/drive/helpers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+var driveDeleteVisibilityTimeout = 60 * time.Second
+
 // CreateDriveFolder creates a Drive folder, optionally under a parent folder, and
 // deletes it during parent cleanup.
 func CreateDriveFolder(t *testing.T, parentT *testing.T, ctx context.Context, name string, defaultAs string, parentFolderToken string) string {
@@ -83,13 +85,13 @@ func DeleteDriveResourceAndVerify(ctx context.Context, token, docType, defaultAs
 		return deleteResult, fmt.Errorf("drive resource %s/%s still exists after delete failed: exit=%d stdout=%s stderr=%s", docType, token, deleteResult.ExitCode, deleteResult.Stdout, deleteResult.Stderr)
 	}
 	if err := WaitDriveResourceDeleted(ctx, token, docType, defaultAs); err != nil {
-		return deleteResult, err
+		return deleteResult, clie2e.CleanupWarningf("drive resource %s/%s still visible after accepted delete: %w", docType, token, err)
 	}
 	return deleteResult, nil
 }
 
 func WaitDriveResourceDeleted(ctx context.Context, token, docType, defaultAs string) error {
-	deadline := time.NewTimer(20 * time.Second)
+	deadline := time.NewTimer(driveDeleteVisibilityTimeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -107,7 +109,7 @@ func WaitDriveResourceDeleted(ctx context.Context, token, docType, defaultAs str
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-deadline.C:
-			return fmt.Errorf("drive resource %s/%s still exists after delete", docType, token)
+			return fmt.Errorf("drive resource %s/%s still exists %s after delete", docType, token, driveDeleteVisibilityTimeout)
 		case <-ticker.C:
 		}
 	}

--- a/tests/cli_e2e/drive/helpers_test.go
+++ b/tests/cli_e2e/drive/helpers_test.go
@@ -5,8 +5,13 @@ package drive
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,4 +20,63 @@ func createDriveFolder(t *testing.T, parentT *testing.T, ctx context.Context, na
 	folderToken := CreateDriveFolder(t, parentT, ctx, name, "bot", parentFolderToken)
 	require.NotEmpty(t, folderToken)
 	return folderToken
+}
+
+func TestDeleteDriveResourceAndVerify(t *testing.T) {
+	t.Run("successful delete with stale meta returns cleanup warning", func(t *testing.T) {
+		fake := mustWriteDriveCleanupFakeCLI(t)
+		t.Setenv(clie2e.EnvBinaryPath, fake)
+
+		oldTimeout := driveDeleteVisibilityTimeout
+		driveDeleteVisibilityTimeout = 10 * time.Millisecond
+		t.Cleanup(func() {
+			driveDeleteVisibilityTimeout = oldTimeout
+		})
+
+		result, err := DeleteDriveResourceAndVerify(context.Background(), "fld_stale", "folder", "bot")
+		require.NotNil(t, result)
+		assert.Equal(t, 0, result.ExitCode)
+		require.Error(t, err)
+		assert.True(t, clie2e.IsCleanupWarning(err), "err: %v", err)
+	})
+
+	t.Run("failed delete with existing meta remains fatal", func(t *testing.T) {
+		fake := mustWriteDriveCleanupFakeCLI(t)
+		t.Setenv(clie2e.EnvBinaryPath, fake)
+		t.Setenv("FAKE_DRIVE_DELETE_EXIT", "1")
+
+		result, err := DeleteDriveResourceAndVerify(context.Background(), "fld_existing", "folder", "bot")
+		require.NotNil(t, result)
+		assert.Equal(t, 1, result.ExitCode)
+		require.Error(t, err)
+		assert.False(t, clie2e.IsCleanupWarning(err), "err: %v", err)
+		assert.Contains(t, err.Error(), "still exists after delete failed")
+	})
+}
+
+func mustWriteDriveCleanupFakeCLI(t *testing.T) string {
+	t.Helper()
+
+	script := `#!/bin/sh
+if [ "$1" = "drive" ] && [ "$2" = "+delete" ]; then
+  if [ "${FAKE_DRIVE_DELETE_EXIT:-0}" != "0" ]; then
+    echo '{"ok":false,"error":{"type":"api","message":"delete failed"}}' >&2
+    exit "$FAKE_DRIVE_DELETE_EXIT"
+  fi
+  echo '{"ok":true}'
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "post" ] && [ "$3" = "/open-apis/drive/v1/metas/batch_query" ]; then
+  echo '{"ok":true,"data":{"metas":[{"url":"https://example.com/still-visible"}]}}'
+  exit 0
+fi
+
+echo "unexpected fake CLI args: $*" >&2
+exit 2
+`
+
+	binaryPath := filepath.Join(t.TempDir(), "fake-lark-cli")
+	require.NoError(t, os.WriteFile(binaryPath, []byte(script), 0o755))
+	return binaryPath
 }


### PR DESCRIPTION
## What changed

- Treat Drive cleanup visibility lag differently from delete failures: if `drive +delete` succeeds but meta remains visible after the post-delete wait, report a cleanup warning instead of failing the business E2E.
- Keep failed delete commands fatal when the resource still exists.
- Extend cleanup context to 90s and Drive delete visibility polling to 60s.
- Add `scripts/e2e_scope.sh` so CI resolves CLI E2E scope from changed files as `subset`, `full`, or `skip`.
- Wire both dry-run and live CLI E2E jobs to use resolved `dry_packages` / `live_packages` instead of always running every domain package.
- Add script-level coverage for domain subset, doc/docs expansion, shared-harness full fallback, runtime full fallback, docs-only skip, and skill-domain mapping.

## Why

Drive delete can be accepted by the server while metadata remains visible briefly because of eventual consistency. Teardown should not fail otherwise-passed business workflows, such as `TestDocs_UpdateWorkflow`, when the destructive cleanup command has already succeeded.

Live E2E should also stay focused on the business domains touched by a PR. Domain-specific changes now run only matching `tests/cli_e2e/<domain>` packages, while shared/runtime/workflow changes conservatively fall back to full coverage and docs-only changes skip CLI E2E.

## Validation

- `make script-test`
- `bash scripts/e2e_scope.test.sh`
- `bash scripts/ci-workflow.test.sh`
- `go test ./tests/cli_e2e ./tests/cli_e2e/drive -run TestDeleteDriveResourceAndVerify -count=1`