### PR TITLE
Add mail attachment download URL usage hint

### DIFF
--- a/cmd/service/response_transform_test.go
+++ b/cmd/service/response_transform_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/vfs/localfileio"
+)
+
+func serviceTransformTestResp(body string) *larkcore.ApiResp {
+	return &larkcore.ApiResp{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		RawBody: []byte(body),
+	}
+}
+
+func decodeServiceTransformOutput(t *testing.T, out *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	var got map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out.String())
+	}
+	return got
+}
+
+func TestServiceResponseTransformInjectsMailAttachmentDownloadURLHint(t *testing.T) {
+	body := `{"code":0,"msg":"ok","data":{"download_urls":[{"attachment_id":"att_1","download_url":"https://example.com/a"}]}}`
+	resp := serviceTransformTestResp(body)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := client.HandleResponse(resp, client.ResponseOptions{
+		Out:       &out,
+		ErrOut:    &errOut,
+		FileIO:    &localfileio.LocalFileIO{},
+		Transform: serviceResponseTransform(mailAttachmentDownloadURLSchemaPath),
+	})
+	if err != nil {
+		t.Fatalf("HandleResponse failed: %v", err)
+	}
+
+	got := decodeServiceTransformOutput(t, &out)
+	data, ok := got["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data = %T, want object; output: %s", got["data"], out.String())
+	}
+	if data["download_url_usage_hint"] != mailAttachmentDownloadURLUsageHint {
+		t.Fatalf("download_url_usage_hint = %v, want fixed hint", data["download_url_usage_hint"])
+	}
+}
+
+func TestServiceResponseTransformSkipsNonTargetSchemaPath(t *testing.T) {
+	body := `{"code":0,"msg":"ok","data":{"download_urls":[{"attachment_id":"att_1","download_url":"https://example.com/a"}]}}`
+	resp := serviceTransformTestResp(body)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := client.HandleResponse(resp, client.ResponseOptions{
+		Out:       &out,
+		ErrOut:    &errOut,
+		FileIO:    &localfileio.LocalFileIO{},
+		Transform: serviceResponseTransform("mail.user_mailbox.template.attachments.download_url"),
+	})
+	if err != nil {
+		t.Fatalf("HandleResponse failed: %v", err)
+	}
+
+	got := decodeServiceTransformOutput(t, &out)
+	data, ok := got["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data = %T, want object; output: %s", got["data"], out.String())
+	}
+	if _, exists := data["download_url_usage_hint"]; exists {
+		t.Fatalf("non-target response got hint: %s", out.String())
+	}
+}
+
+func TestServiceResponseTransformHintVisibleToJQ(t *testing.T) {
+	body := `{"code":0,"msg":"ok","data":{"download_urls":[]}}`
+	resp := serviceTransformTestResp(body)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := client.HandleResponse(resp, client.ResponseOptions{
+		JqExpr:    ".data.download_url_usage_hint",
+		Out:       &out,
+		ErrOut:    &errOut,
+		FileIO:    &localfileio.LocalFileIO{},
+		Transform: serviceResponseTransform(mailAttachmentDownloadURLSchemaPath),
+	})
+	if err != nil {
+		t.Fatalf("HandleResponse failed: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != mailAttachmentDownloadURLUsageHint {
+		t.Fatalf("jq output = %q, want hint", out.String())
+	}
+}
+
+func TestServiceResponseTransformDoesNotInjectBusinessError(t *testing.T) {
+	body := `{"code":99991400,"msg":"invalid token","data":{"download_urls":[]}}`
+	resp := serviceTransformTestResp(body)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := client.HandleResponse(resp, client.ResponseOptions{
+		Out:       &out,
+		ErrOut:    &errOut,
+		FileIO:    &localfileio.LocalFileIO{},
+		Transform: serviceResponseTransform(mailAttachmentDownloadURLSchemaPath),
+	})
+	if err == nil {
+		t.Fatal("expected business error")
+	}
+	if strings.Contains(out.String(), "download_url_usage_hint") {
+		t.Fatalf("business error response emitted hint: %s", out.String())
+	}
+}
+
+func TestInjectMailAttachmentDownloadURLHintPreservesServerValue(t *testing.T) {
+	result := map[string]interface{}{
+		"data": map[string]interface{}{
+			"download_url_usage_hint": "server-provided",
+		},
+	}
+
+	got := injectMailAttachmentDownloadURLHint(result)
+	data := got.(map[string]interface{})["data"].(map[string]interface{})
+	if data["download_url_usage_hint"] != "server-provided" {
+		t.Fatalf("server-provided hint was overwritten: %v", data["download_url_usage_hint"])
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -28,6 +28,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const mailAttachmentDownloadURLSchemaPath = "mail.user_mailbox.message.attachments.download_url"
+
+const mailAttachmentDownloadURLUsageHint = "Generate it only when the user is ready to download. Do not send or store it as a long-lived clickable link. download_url is a short-lived pre-signed URL, usually valid for about 2 hours or less and may expire earlier."
+
 // RegisterServiceCommands registers all service commands from from_meta specs.
 func RegisterServiceCommands(parent *cobra.Command, f *cmdutil.Factory) {
 	RegisterServiceCommandsWithContext(context.Background(), parent, f)
@@ -449,7 +453,31 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		CommandPath: opts.Cmd.CommandPath(),
 		Identity:    opts.As,
 		CheckError:  checkErr,
+		Transform:   serviceResponseTransform(opts.SchemaPath),
 	})
+}
+
+func serviceResponseTransform(schemaPath string) func(interface{}) interface{} {
+	if schemaPath != mailAttachmentDownloadURLSchemaPath {
+		return nil
+	}
+	return injectMailAttachmentDownloadURLHint
+}
+
+func injectMailAttachmentDownloadURLHint(result interface{}) interface{} {
+	root, ok := result.(map[string]interface{})
+	if !ok {
+		return result
+	}
+	data, ok := root["data"].(map[string]interface{})
+	if !ok {
+		return result
+	}
+	if _, exists := data["download_url_usage_hint"]; exists {
+		return result
+	}
+	data["download_url_usage_hint"] = mailAttachmentDownloadURLUsageHint
+	return result
 }
 
 // checkServiceScopes pre-checks user scopes before making the API call.

--- a/internal/client/response.go
+++ b/internal/client/response.go
@@ -39,6 +39,9 @@ type ResponseOptions struct {
 	// CheckError is called on parsed JSON results. Nil defaults to (*APIClient).CheckResponse
 	// with the Identity field (or AsUser when unset).
 	CheckError func(result interface{}, identity core.Identity) error
+	// Transform can enrich successful JSON results before safety scanning,
+	// jq filtering, or formatted output. It is not called for business errors.
+	Transform func(result interface{}) interface{}
 }
 
 // httpStatusError classifies an HTTP error response by status when the body
@@ -108,6 +111,9 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 		// successful result. Classify by HTTP status so it is never swallowed.
 		if resp.StatusCode >= 400 {
 			return httpStatusError(resp.StatusCode, resp.RawBody)
+		}
+		if opts.Transform != nil {
+			result = opts.Transform(result)
 		}
 		if opts.OutputPath != "" {
 			// File downloads keep the existing raw-response scan path because the

--- a/skills/lark-mail/references/lark-mail-message.md
+++ b/skills/lark-mail/references/lark-mail-message.md
@@ -194,6 +194,7 @@ lark-cli mail user_mailbox.message.attachments download_url \
 ```
 
 普通附件和内嵌图片使用同一个 `user_mailbox.message.attachments download_url` 原生 API（无 shortcut 封装），传入 `attachments[].id` 即可。
+`download_url` 是短时效预签名 URL，应在用户准备下载时再生成；不要把它作为长期可点击链接发送、保存或转发。Generate it only when the user is ready to download. Do not send or store it as a long-lived clickable link. download_url is a short-lived pre-signed URL, usually valid for about 2 hours or less and may expire earlier.
 
 ## 日程邀请邮件
 
@@ -229,5 +230,5 @@ lark-cli mail user_mailbox.message.attachments download_url \
 - `lark-cli mail +thread` — 读取会话中所有邮件
 - `lark-cli mail +reply` — 回复邮件
 - `lark-cli mail +forward` — 转发邮件
-- `lark-cli mail user_mailbox.message.attachments download_url` — 按需获取邮件附件/图片下载 URL
+- `lark-cli mail user_mailbox.message.attachments download_url` — 用户准备下载时按需获取邮件附件/图片短时效下载 URL，不要长期保存或转发为可点击链接
 - `lark-cli mail user_mailbox.messages list` — 列出收件箱邮件（获取 `message_id`）

--- a/skills/lark-mail/references/lark-mail-messages.md
+++ b/skills/lark-mail/references/lark-mail-messages.md
@@ -78,6 +78,7 @@ lark-cli mail +messages --message-ids <id1>,<id2> --dry-run
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +messages` 仅返回附件元数据。如后续步骤需要下载 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
+- `download_url` 是短时效预签名 URL，应在用户准备下载时再生成；不要把它作为长期可点击链接发送、保存或转发。Generate it only when the user is ready to download. Do not send or store it as a long-lived clickable link. download_url is a short-lived pre-signed URL, usually valid for about 2 hours or less and may expire earlier.
 
 ## 典型场景
 
@@ -105,4 +106,4 @@ lark-cli mail +messages --message-ids <id1>,<id2> --html=false --format json
 - `lark-cli mail +thread` — 读取会话中所有邮件
 - `lark-cli mail +reply` — 回复邮件
 - `lark-cli mail +forward` — 转发邮件
-- `lark-cli mail user_mailbox.message.attachments download_url` — 按需获取邮件附件/图片下载 URL
+- `lark-cli mail user_mailbox.message.attachments download_url` — 用户准备下载时按需获取邮件附件/图片短时效下载 URL，不要长期保存或转发为可点击链接

--- a/skills/lark-mail/references/lark-mail-thread.md
+++ b/skills/lark-mail/references/lark-mail-thread.md
@@ -71,6 +71,7 @@ lark-cli mail +thread --thread-id <thread-id> --dry-run
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +thread` 不再在读取会话时获取附件/图片下载 URL。如后续步骤需要 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
+- `download_url` 是短时效预签名 URL，应在用户准备下载时再生成；不要把它作为长期可点击链接发送、保存或转发。Generate it only when the user is ready to download. Do not send or store it as a long-lived clickable link. download_url is a short-lived pre-signed URL, usually valid for about 2 hours or less and may expire earlier.
 - 查看某条邮件的原始 HTML：
 
 ```bash
@@ -107,5 +108,5 @@ lark-cli mail +reply --message-id <last_message_id> --body "..."
 - `lark-cli mail +message` — 读取单封邮件
 - `lark-cli mail +reply` — 回复邮件
 - `lark-cli mail +forward` — 转发邮件
-- `lark-cli mail user_mailbox.message.attachments download_url` — 按需获取邮件附件/图片下载 URL
+- `lark-cli mail user_mailbox.message.attachments download_url` — 用户准备下载时按需获取邮件附件/图片短时效下载 URL，不要长期保存或转发为可点击链接
 - `lark-cli mail user_mailbox.messages list` — 列出收件箱邮件（获取 `thread_id`）


### PR DESCRIPTION
This updates mail attachment download handling to include a short-lived URL usage hint in successful responses.

- Adds response metadata for generated download URLs.
- Covers the response transformation path with tests.
- Refreshes the related mail command references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download responses now include a helpful usage hint for mail attachment links when applicable.

* **Bug Fixes**
  * Prevents the hint from appearing for unrelated responses or business errors.
  * Preserves any existing server-provided hint value.

* **Documentation**
  * Clarified that download links are short-lived and should be generated only when needed for immediate download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->