### PR TITLE
Improve agent-facing error guidance for drive, markdown, and wiki

### DIFF
--- a/cmd/root_integration_test.go
+++ b/cmd/root_integration_test.go
@@ -103,6 +103,10 @@ func parseTypedEnvelope(t *testing.T, stderr *bytes.Buffer) typedErrorEnvelope {
 }
 
 func buildStrictModeIntegrationRootCmd(t *testing.T, f *cmdutil.Factory) *cobra.Command {
+	return buildStrictModeIntegrationRootCmdWithSetup(t, f, nil)
+}
+
+func buildStrictModeIntegrationRootCmdWithSetup(t *testing.T, f *cmdutil.Factory, setup func(*cobra.Command)) *cobra.Command {
 	t.Helper()
 	rootCmd := &cobra.Command{Use: "lark-cli"}
 	rootCmd.SilenceErrors = true
@@ -115,6 +119,9 @@ func buildStrictModeIntegrationRootCmd(t *testing.T, f *cmdutil.Factory) *cobra.
 	rootCmd.AddCommand(api.NewCmdApi(f, nil))
 	service.RegisterServiceCommands(rootCmd, f)
 	shortcuts.RegisterShortcuts(rootCmd, f)
+	if setup != nil {
+		setup(rootCmd)
+	}
 	if mode := f.ResolveStrictMode(context.Background()); mode.IsActive() {
 		pruneForStrictMode(rootCmd, mode)
 	}
@@ -355,10 +362,16 @@ func TestIntegration_StrictModeBot_ProfileOverride_ServiceExplicitUserReturnsEnv
 
 func TestIntegration_StrictModeUser_ProfileOverride_ServiceBotOnlyMethodReturnsEnvelope(t *testing.T) {
 	f, stdout, stderr := newStrictModeDefaultFactory(t, "target", core.StrictModeUser)
-	rootCmd := buildStrictModeIntegrationRootCmd(t, f)
+	rootCmd := buildStrictModeIntegrationRootCmdWithSetup(t, f, func(rootCmd *cobra.Command) {
+		fixture := &cobra.Command{Use: "strict-fixture"}
+		botOnly := &cobra.Command{Use: "bot-only", RunE: func(*cobra.Command, []string) error { return nil }}
+		cmdutil.SetSupportedIdentities(botOnly, []string{"bot"})
+		fixture.AddCommand(botOnly)
+		rootCmd.AddCommand(fixture)
+	})
 
 	code := executeRootIntegration(t, f, rootCmd, []string{
-		"im", "images", "create", "--data", `{"image_type":"message","image":"x"}`, "--dry-run",
+		"strict-fixture", "bot-only",
 	})
 
 	if code != output.ExitValidation {

--- a/cmd/root_integration_test.go
+++ b/cmd/root_integration_test.go
@@ -103,10 +103,6 @@ func parseTypedEnvelope(t *testing.T, stderr *bytes.Buffer) typedErrorEnvelope {
 }
 
 func buildStrictModeIntegrationRootCmd(t *testing.T, f *cmdutil.Factory) *cobra.Command {
-	return buildStrictModeIntegrationRootCmdWithSetup(t, f, nil)
-}
-
-func buildStrictModeIntegrationRootCmdWithSetup(t *testing.T, f *cmdutil.Factory, setup func(*cobra.Command)) *cobra.Command {
 	t.Helper()
 	rootCmd := &cobra.Command{Use: "lark-cli"}
 	rootCmd.SilenceErrors = true
@@ -119,9 +115,6 @@ func buildStrictModeIntegrationRootCmdWithSetup(t *testing.T, f *cmdutil.Factory
 	rootCmd.AddCommand(api.NewCmdApi(f, nil))
 	service.RegisterServiceCommands(rootCmd, f)
 	shortcuts.RegisterShortcuts(rootCmd, f)
-	if setup != nil {
-		setup(rootCmd)
-	}
 	if mode := f.ResolveStrictMode(context.Background()); mode.IsActive() {
 		pruneForStrictMode(rootCmd, mode)
 	}
@@ -362,16 +355,10 @@ func TestIntegration_StrictModeBot_ProfileOverride_ServiceExplicitUserReturnsEnv
 
 func TestIntegration_StrictModeUser_ProfileOverride_ServiceBotOnlyMethodReturnsEnvelope(t *testing.T) {
 	f, stdout, stderr := newStrictModeDefaultFactory(t, "target", core.StrictModeUser)
-	rootCmd := buildStrictModeIntegrationRootCmdWithSetup(t, f, func(rootCmd *cobra.Command) {
-		fixture := &cobra.Command{Use: "strict-fixture"}
-		botOnly := &cobra.Command{Use: "bot-only", RunE: func(*cobra.Command, []string) error { return nil }}
-		cmdutil.SetSupportedIdentities(botOnly, []string{"bot"})
-		fixture.AddCommand(botOnly)
-		rootCmd.AddCommand(fixture)
-	})
+	rootCmd := buildStrictModeIntegrationRootCmd(t, f)
 
 	code := executeRootIntegration(t, f, rootCmd, []string{
-		"strict-fixture", "bot-only",
+		"im", "images", "create", "--data", `{"image_type":"message","image":"x"}`, "--dry-run",
 	})
 
 	if code != output.ExitValidation {

--- a/internal/errclass/codemeta_drive.go
+++ b/internal/errclass/codemeta_drive.go
@@ -10,20 +10,22 @@ import "github.com/larksuite/cli/errs"
 // ambiguous codes fall back to CategoryAPI via BuildAPIError.
 // BuildAPIError consumes this map via mergeCodeMeta + LookupCodeMeta.
 var driveCodeMeta = map[int]CodeMeta{
-	1061001:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive "unknown error"
-	1061002:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // params error
-	1061004:  {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // forbidden
-	1061007:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // file has been deleted
-	1061043:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},                // file size beyond limit
-	1061044:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // parent folder does not exist (upload)
-	1062009:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // actual size inconsistent with declared size
-	1063001:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // secure label invalid parameter
-	1063002:  {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // secure label permission denied
-	1063013:  {Category: errs.CategoryValidation, Subtype: errs.SubtypeFailedPrecondition},    // secure label downgrade requires approval
-	1069302:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // comment endpoint "Invalid or missing parameters"
-	99992402: {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // platform field validation failed
-	9499:     {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // invalid parameter type in JSON field
-	2200:     {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive tenant/internal errors
+	1061001:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive "unknown error"
+	1061002:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // params error
+	1061004:   {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // forbidden
+	1061007:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // file has been deleted
+	1061043:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},                // file size beyond limit
+	1061044:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // parent folder does not exist (upload)
+	1061101:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},                // file quota exceeded
+	1062009:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // actual size inconsistent with declared size
+	1063001:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // secure label invalid parameter
+	1063002:   {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // secure label permission denied
+	1063013:   {Category: errs.CategoryValidation, Subtype: errs.SubtypeFailedPrecondition},    // secure label downgrade requires approval
+	1069302:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // comment endpoint "Invalid or missing parameters"
+	99992402:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // platform field validation failed
+	9499:      {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // invalid parameter type in JSON field
+	2200:      {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive tenant/internal errors
+	233523001: {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive/docs transient server error
 }
 
 func init() { mergeCodeMeta(driveCodeMeta, "drive") }

--- a/internal/errclass/codemeta_test.go
+++ b/internal/errclass/codemeta_test.go
@@ -114,8 +114,35 @@ func TestLookupCodeMeta_DrivePushCodes(t *testing.T) {
 		{1061004, errs.CategoryAuthorization, errs.SubtypePermissionDenied, false},
 		{1061007, errs.CategoryAPI, errs.SubtypeNotFound, false},
 		{1061043, errs.CategoryAPI, errs.SubtypeQuotaExceeded, false},
+		{1061101, errs.CategoryAPI, errs.SubtypeQuotaExceeded, false},
 		{1062009, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 		{2200, errs.CategoryAPI, errs.SubtypeServerError, true},
+		{233523001, errs.CategoryAPI, errs.SubtypeServerError, true},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d", tc.code), func(t *testing.T) {
+			got, ok := LookupCodeMeta(tc.code)
+			if !ok {
+				t.Fatalf("LookupCodeMeta(%d) ok=false, want true", tc.code)
+			}
+			if got.Category != tc.wantCat || got.Subtype != tc.wantSubtype || got.Retryable != tc.wantRetry {
+				t.Fatalf("LookupCodeMeta(%d) = %+v, want Category=%v Subtype=%v Retryable=%v",
+					tc.code, got, tc.wantCat, tc.wantSubtype, tc.wantRetry)
+			}
+		})
+	}
+}
+
+func TestLookupCodeMeta_WikiCodes(t *testing.T) {
+	cases := []struct {
+		code        int
+		wantCat     errs.Category
+		wantSubtype errs.Subtype
+		wantRetry   bool
+	}{
+		{131002, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
+		{131005, errs.CategoryAPI, errs.SubtypeNotFound, false},
+		{131006, errs.CategoryAuthorization, errs.SubtypePermissionDenied, false},
 	}
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%d", tc.code), func(t *testing.T) {

--- a/internal/errclass/codemeta_wiki.go
+++ b/internal/errclass/codemeta_wiki.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package errclass
+
+import "github.com/larksuite/cli/errs"
+
+// wikiCodeMeta holds wiki-service Lark code -> CodeMeta mappings observed from
+// wiki shortcut failure telemetry. Keep these to wiki-wide meanings only; add
+// command-specific recovery guidance at the shortcut layer.
+var wikiCodeMeta = map[int]CodeMeta{
+	131002: {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},          // param err: space_id is not int / invalid page_token
+	131005: {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                   // wiki node / space not found
+	131006: {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied}, // wiki space/node read permission denied
+}
+
+func init() { mergeCodeMeta(wikiCodeMeta, "wiki") }

--- a/shortcuts/drive/drive_pull.go
+++ b/shortcuts/drive/drive_pull.go
@@ -47,7 +47,6 @@ type drivePullItem struct {
 	Code       int    `json:"code,omitempty"`
 	Subtype    string `json:"subtype,omitempty"`
 	Retryable  *bool  `json:"retryable,omitempty"`
-	Terminal   bool   `json:"-"`
 }
 
 type drivePullTarget struct {
@@ -185,6 +184,7 @@ var DrivePull = common.Shortcut{
 
 		var downloaded, skipped, failed, deletedLocal int
 		downloadFailed := 0
+		aborted := false
 		items := make([]drivePullItem, 0)
 
 		// Deterministic iteration order for output stability.
@@ -195,7 +195,7 @@ var DrivePull = common.Shortcut{
 		sort.Strings(downloadablePaths)
 
 		for _, rel := range downloadablePaths {
-			if drivePullHasTerminalFailure(items) {
+			if aborted {
 				break
 			}
 			targetFile := remoteFiles[rel]
@@ -233,6 +233,7 @@ var DrivePull = common.Shortcut{
 				failed++
 				downloadFailed++
 				if terminal {
+					aborted = true
 					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +pull after terminal %s failure: %v\n", item.Phase, err)
 					break
 				}
@@ -299,7 +300,7 @@ var DrivePull = common.Shortcut{
 				"skipped":       skipped,
 				"failed":        failed,
 				"deleted_local": deletedLocal,
-				"aborted":       drivePullHasTerminalFailure(items),
+				"aborted":       aborted,
 			},
 			"items": items,
 		}
@@ -344,18 +345,8 @@ func drivePullFailedItem(relPath, fileToken, sourceID, action, phase string, err
 		Code:       decision.Code,
 		Subtype:    decision.Subtype,
 		Retryable:  driveBoolPtr(decision.Retryable),
-		Terminal:   decision.Terminal,
 	}
 	return item, decision.Terminal
-}
-
-func drivePullHasTerminalFailure(items []drivePullItem) bool {
-	for _, item := range items {
-		if item.Terminal {
-			return true
-		}
-	}
-	return false
 }
 
 // drivePullDownload streams one Drive file into the local mirror target and

--- a/shortcuts/drive/drive_pull.go
+++ b/shortcuts/drive/drive_pull.go
@@ -47,6 +47,7 @@ type drivePullItem struct {
 	Code       int    `json:"code,omitempty"`
 	Subtype    string `json:"subtype,omitempty"`
 	Retryable  *bool  `json:"retryable,omitempty"`
+	Terminal   bool   `json:"-"`
 }
 
 type drivePullTarget struct {
@@ -343,13 +344,14 @@ func drivePullFailedItem(relPath, fileToken, sourceID, action, phase string, err
 		Code:       decision.Code,
 		Subtype:    decision.Subtype,
 		Retryable:  driveBoolPtr(decision.Retryable),
+		Terminal:   decision.Terminal,
 	}
 	return item, decision.Terminal
 }
 
 func drivePullHasTerminalFailure(items []drivePullItem) bool {
 	for _, item := range items {
-		if driveTerminalBatchErrorClass(item.ErrorClass) {
+		if item.Terminal {
 			return true
 		}
 	}

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -41,6 +41,7 @@ type drivePushItem struct {
 	Code       int    `json:"code,omitempty"`
 	Subtype    string `json:"subtype,omitempty"`
 	Retryable  *bool  `json:"retryable,omitempty"`
+	Terminal   bool   `json:"-"`
 }
 
 type driveBatchFailureDecision struct {
@@ -579,6 +580,7 @@ func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int
 		Code:       decision.Code,
 		Subtype:    decision.Subtype,
 		Retryable:  driveBoolPtr(decision.Retryable),
+		Terminal:   decision.Terminal,
 	}
 	return item, decision.Terminal
 }
@@ -644,20 +646,11 @@ func drivePushIsAlreadyDeleted(err error) bool {
 
 func drivePushHasTerminalFailure(items []drivePushItem) bool {
 	for _, item := range items {
-		if driveTerminalBatchErrorClass(item.ErrorClass) {
+		if item.Terminal {
 			return true
 		}
 	}
 	return false
-}
-
-func driveTerminalBatchErrorClass(errorClass string) bool {
-	switch errorClass {
-	case "app_scope_missing", "user_scope_missing", "permission_denied", "invalid_api_parameters", "rate_limited", "server_error", "parent_node_missing":
-		return true
-	default:
-		return false
-	}
 }
 
 func drivePushRemoteViews(entries []driveRemoteEntry, duplicateRemote string) (map[string]driveRemoteEntry, map[string]driveRemoteEntry, map[string][]driveRemoteEntry, error) {

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -41,7 +41,6 @@ type drivePushItem struct {
 	Code       int    `json:"code,omitempty"`
 	Subtype    string `json:"subtype,omitempty"`
 	Retryable  *bool  `json:"retryable,omitempty"`
-	Terminal   bool   `json:"-"`
 }
 
 type driveBatchFailureDecision struct {
@@ -243,6 +242,7 @@ var DrivePush = common.Shortcut{
 		// locally and now on Drive too), which is the worst-of-both-worlds
 		// outcome the review flagged.
 		uploadFailed := false
+		aborted := false
 
 		// folderCache holds rel_path → folder_token. Seeded from the remote
 		// listing (so we don't recreate folders that already exist) and
@@ -269,6 +269,7 @@ var DrivePush = common.Shortcut{
 				failed++
 				uploadFailed = true
 				if terminal {
+					aborted = true
 					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, ensureErr)
 					break
 				}
@@ -287,7 +288,7 @@ var DrivePush = common.Shortcut{
 
 		for _, rel := range localPaths {
 			localFile := localFiles[rel]
-			if uploadFailed && drivePushHasTerminalFailure(items) {
+			if uploadFailed && aborted {
 				break
 			}
 
@@ -304,6 +305,7 @@ var DrivePush = common.Shortcut{
 					failed++
 					uploadFailed = true
 					if terminal {
+						aborted = true
 						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, parentErr)
 						break
 					}
@@ -335,6 +337,7 @@ var DrivePush = common.Shortcut{
 					failed++
 					uploadFailed = true
 					if terminal {
+						aborted = true
 						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, upErr)
 						break
 					}
@@ -353,6 +356,7 @@ var DrivePush = common.Shortcut{
 				failed++
 				uploadFailed = true
 				if terminal {
+					aborted = true
 					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, ensureErr)
 					break
 				}
@@ -365,6 +369,7 @@ var DrivePush = common.Shortcut{
 				failed++
 				uploadFailed = true
 				if terminal {
+					aborted = true
 					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, upErr)
 					break
 				}
@@ -418,6 +423,7 @@ var DrivePush = common.Shortcut{
 						items = append(items, item)
 						failed++
 						if terminal {
+							aborted = true
 							fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, err)
 							abortDelete = true
 							break
@@ -436,7 +442,7 @@ var DrivePush = common.Shortcut{
 				"skipped":        skipped,
 				"failed":         failed,
 				"deleted_remote": deletedRemote,
-				"aborted":        drivePushHasTerminalFailure(items),
+				"aborted":        aborted,
 			},
 			"items": items,
 		}
@@ -580,7 +586,6 @@ func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int
 		Code:       decision.Code,
 		Subtype:    decision.Subtype,
 		Retryable:  driveBoolPtr(decision.Retryable),
-		Terminal:   decision.Terminal,
 	}
 	return item, decision.Terminal
 }
@@ -642,15 +647,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 func drivePushIsAlreadyDeleted(err error) bool {
 	problem, ok := errs.ProblemOf(err)
 	return ok && problem.Code == 1061007
-}
-
-func drivePushHasTerminalFailure(items []drivePushItem) bool {
-	for _, item := range items {
-		if item.Terminal {
-			return true
-		}
-	}
-	return false
 }
 
 func drivePushRemoteViews(entries []driveRemoteEntry, duplicateRemote string) (map[string]driveRemoteEntry, map[string]driveRemoteEntry, map[string][]driveRemoteEntry, error) {

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -35,6 +35,7 @@ type drivePushItem struct {
 	Version    string `json:"version,omitempty"`
 	SizeBytes  int64  `json:"size_bytes,omitempty"`
 	Error      string `json:"error,omitempty"`
+	Hint       string `json:"hint,omitempty"`
 	Phase      string `json:"phase,omitempty"`
 	ErrorClass string `json:"error_class,omitempty"`
 	Code       int    `json:"code,omitempty"`
@@ -48,6 +49,7 @@ type driveBatchFailureDecision struct {
 	Subtype   string
 	Retryable bool
 	Terminal  bool
+	Hint      string
 }
 
 // DrivePush is a one-way, file-level mirror from a local directory onto a
@@ -407,6 +409,10 @@ var DrivePush = common.Shortcut{
 						continue
 					}
 					if err := drivePushDeleteFile(ctx, runtime, entry.FileToken); err != nil {
+						if drivePushIsAlreadyDeleted(err) {
+							items = append(items, drivePushItem{RelPath: rel, FileToken: entry.FileToken, Action: "already_deleted"})
+							continue
+						}
 						item, terminal := drivePushFailedItem(rel, entry.FileToken, "delete_failed", "delete", 0, err)
 						items = append(items, item)
 						failed++
@@ -567,6 +573,7 @@ func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int
 		Action:     action,
 		SizeBytes:  sizeBytes,
 		Error:      err.Error(),
+		Hint:       decision.Hint,
 		Phase:      phase,
 		ErrorClass: decision.Class,
 		Code:       decision.Code,
@@ -613,6 +620,10 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 		decision.Class = "file_size_limit"
 	case problem.Code == 1062009:
 		decision.Class = "upload_size_mismatch"
+	case problem.Code == 1061044:
+		decision.Class = "parent_node_missing"
+		decision.Terminal = true
+		decision.Hint = "The destination parent folder no longer exists or is not visible. Verify --folder-token, folder permissions, and whether a parent directory was deleted during push before retrying."
 	case problem.Subtype == errs.SubtypeNotFound || problem.Code == 1061007:
 		decision.Class = "remote_not_found"
 	case problem.Subtype == errs.SubtypeServerError || problem.Code == 1061001 || problem.Code == 2200:
@@ -626,6 +637,11 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	return decision
 }
 
+func drivePushIsAlreadyDeleted(err error) bool {
+	problem, ok := errs.ProblemOf(err)
+	return ok && problem.Code == 1061007
+}
+
 func drivePushHasTerminalFailure(items []drivePushItem) bool {
 	for _, item := range items {
 		if driveTerminalBatchErrorClass(item.ErrorClass) {
@@ -637,7 +653,7 @@ func drivePushHasTerminalFailure(items []drivePushItem) bool {
 
 func driveTerminalBatchErrorClass(errorClass string) bool {
 	switch errorClass {
-	case "app_scope_missing", "user_scope_missing", "permission_denied", "invalid_api_parameters", "rate_limited", "server_error":
+	case "app_scope_missing", "user_scope_missing", "permission_denied", "invalid_api_parameters", "rate_limited", "server_error", "parent_node_missing":
 		return true
 	default:
 		return false

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -732,6 +732,65 @@ func TestDrivePushDeleteRemoteAbortsAfterTerminalFailure(t *testing.T) {
 	}
 }
 
+func TestDrivePushDeleteRemoteTreatsAlreadyDeletedAsNoop(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"files": []interface{}{
+					map[string]interface{}{"token": "tok_orphan", "name": "orphan.txt", "type": "file"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/drive/v1/files/tok_orphan",
+		Body: map[string]interface{}{
+			"code": 1061007,
+			"msg":  "file has been delete.",
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--delete-remote",
+		"--yes",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("already-deleted remote should be an idempotent success, got: %v\nstdout: %s", err, stdout.String())
+	}
+
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["failed"]; got != float64(0) {
+		t.Fatalf("summary.failed = %v, want 0", got)
+	}
+	if got := summary["deleted_remote"]; got != float64(0) {
+		t.Fatalf("summary.deleted_remote = %v, want 0 because CLI did not delete it in this run", got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1; items=%#v", len(items), items)
+	}
+	item := items[0]
+	if item["action"] != "already_deleted" || item["file_token"] != "tok_orphan" {
+		t.Fatalf("unexpected already-deleted item: %#v", item)
+	}
+}
+
 func TestDrivePushNewestOverwritesChosenDuplicateAndDeletesSibling(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 
@@ -1133,6 +1192,78 @@ func TestDrivePushAbortsAfterUploadParamsError(t *testing.T) {
 	for _, item := range items {
 		if item["rel_path"] == "b.txt" {
 			t.Fatalf("terminal upload params error must abort before b.txt, got items=%#v", items)
+		}
+	}
+}
+
+func TestDrivePushAbortsAfterUploadParentNodeMissing(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "a.txt"), []byte("A"), 0o644); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "b.txt"), []byte("B"), 0o644); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/upload_all",
+		Body: map[string]interface{}{
+			"code": 1061044,
+			"msg":  "parent node not exist.",
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["failed"]; got != float64(1) {
+		t.Fatalf("summary.failed = %v, want 1", got)
+	}
+	if got := summary["aborted"]; got != true {
+		t.Fatalf("summary.aborted = %v, want true", got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1; items=%#v", len(items), items)
+	}
+	item := items[0]
+	if item["rel_path"] != "a.txt" || item["phase"] != "upload" || item["error_class"] != "parent_node_missing" {
+		t.Fatalf("unexpected failed item: %#v", item)
+	}
+	if item["code"] != float64(1061044) || item["subtype"] != "not_found" || item["retryable"] != false {
+		t.Fatalf("unexpected failure metadata: %#v", item)
+	}
+	if got, _ := item["hint"].(string); !strings.Contains(got, "--folder-token") || !strings.Contains(got, "parent") {
+		t.Fatalf("hint should point at the destination parent folder, got item=%#v", item)
+	}
+	for _, item := range items {
+		if item["rel_path"] == "b.txt" {
+			t.Fatalf("parent-node missing must abort before b.txt, got items=%#v", items)
 		}
 	}
 }

--- a/shortcuts/drive/drive_sync.go
+++ b/shortcuts/drive/drive_sync.go
@@ -40,6 +40,7 @@ type driveSyncItem struct {
 	Code       int    `json:"code,omitempty"`
 	Subtype    string `json:"subtype,omitempty"`
 	Retryable  *bool  `json:"retryable,omitempty"`
+	Terminal   bool   `json:"-"`
 }
 
 // DriveSync performs a two-way sync between a local directory and a Drive
@@ -573,13 +574,14 @@ func driveSyncFailedItem(relPath, fileToken, action, direction, phase string, er
 		Code:       decision.Code,
 		Subtype:    decision.Subtype,
 		Retryable:  driveBoolPtr(decision.Retryable),
+		Terminal:   decision.Terminal,
 	}
 	return item, decision.Terminal
 }
 
 func driveSyncHasTerminalFailure(items []driveSyncItem) bool {
 	for _, item := range items {
-		if driveTerminalBatchErrorClass(item.ErrorClass) {
+		if item.Terminal {
 			return true
 		}
 	}

--- a/shortcuts/drive/drive_sync.go
+++ b/shortcuts/drive/drive_sync.go
@@ -40,7 +40,6 @@ type driveSyncItem struct {
 	Code       int    `json:"code,omitempty"`
 	Subtype    string `json:"subtype,omitempty"`
 	Retryable  *bool  `json:"retryable,omitempty"`
-	Terminal   bool   `json:"-"`
 }
 
 // DriveSync performs a two-way sync between a local directory and a Drive
@@ -269,6 +268,7 @@ var DriveSync = common.Shortcut{
 
 		// --- Phase 2: Execute sync operations ---
 		var pulled, pushed, skipped, failed int
+		aborted := false
 		items := make([]driveSyncItem, 0)
 
 		// Build push infrastructure: local walk for push + remote views + folder cache.
@@ -287,16 +287,21 @@ var DriveSync = common.Shortcut{
 		// Mirror local directory structure first (same as +push), so
 		// empty local directories are not silently dropped.
 		for _, relDir := range localDirs {
-			if driveSyncHasTerminalFailure(items) {
+			if aborted {
 				break
 			}
 			if _, alreadyRemote := folderCache[relDir]; alreadyRemote {
 				continue
 			}
 			if _, ensureErr := drivePushEnsureFolder(ctx, runtime, folderToken, relDir, folderCache); ensureErr != nil {
-				item, _ := driveSyncFailedItem(relDir, "", "failed", "push", "create_folder", ensureErr)
+				item, terminal := driveSyncFailedItem(relDir, "", "failed", "push", "create_folder", ensureErr)
 				items = append(items, item)
 				failed++
+				if terminal {
+					aborted = true
+					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, ensureErr)
+					break
+				}
 				continue
 			}
 			items = append(items, driveSyncItem{RelPath: relDir, FileToken: folderCache[relDir], Action: "folder_created", Direction: "push"})
@@ -305,7 +310,7 @@ var DriveSync = common.Shortcut{
 
 		// 2a. Pull new_remote files.
 		for _, entry := range newRemote {
-			if driveSyncHasTerminalFailure(items) {
+			if aborted {
 				break
 			}
 			targetFile, ok := pullRemoteFiles[entry.RelPath]
@@ -319,6 +324,7 @@ var DriveSync = common.Shortcut{
 				items = append(items, item)
 				failed++
 				if terminal {
+					aborted = true
 					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, err)
 					break
 				}
@@ -330,7 +336,7 @@ var DriveSync = common.Shortcut{
 
 		// 2b. Push new_local files.
 		for _, entry := range newLocal {
-			if driveSyncHasTerminalFailure(items) {
+			if aborted {
 				break
 			}
 			localFile, ok := pushLocalFiles[entry.RelPath]
@@ -342,9 +348,14 @@ var DriveSync = common.Shortcut{
 			parentRel := drivePushParentRel(entry.RelPath)
 			parentToken, ensureErr := drivePushEnsureFolder(ctx, runtime, folderToken, parentRel, folderCache)
 			if ensureErr != nil {
-				item, _ := driveSyncFailedItem(entry.RelPath, "", "failed", "push", "create_folder", ensureErr)
+				item, terminal := driveSyncFailedItem(entry.RelPath, "", "failed", "push", "create_folder", ensureErr)
 				items = append(items, item)
 				failed++
+				if terminal {
+					aborted = true
+					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, ensureErr)
+					break
+				}
 				continue
 			}
 			token, _, upErr := drivePushUploadFile(ctx, runtime, localFile, "", parentToken)
@@ -353,6 +364,7 @@ var DriveSync = common.Shortcut{
 				items = append(items, item)
 				failed++
 				if terminal {
+					aborted = true
 					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, upErr)
 					break
 				}
@@ -364,7 +376,7 @@ var DriveSync = common.Shortcut{
 
 		// 2c. Resolve modified files by --on-conflict strategy.
 		for _, entry := range modified {
-			if driveSyncHasTerminalFailure(items) {
+			if aborted {
 				break
 			}
 			remoteFile := remoteFiles[entry.RelPath]
@@ -398,6 +410,7 @@ var DriveSync = common.Shortcut{
 					items = append(items, item)
 					failed++
 					if terminal {
+						aborted = true
 						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, err)
 						break
 					}
@@ -416,9 +429,14 @@ var DriveSync = common.Shortcut{
 				}
 				parentToken, parentErr := drivePushEnsureFolder(ctx, runtime, folderToken, drivePushParentRel(entry.RelPath), folderCache)
 				if parentErr != nil {
-					item, _ := driveSyncFailedItem(entry.RelPath, existingToken, "failed", "push", "create_folder", parentErr)
+					item, terminal := driveSyncFailedItem(entry.RelPath, existingToken, "failed", "push", "create_folder", parentErr)
 					items = append(items, item)
 					failed++
+					if terminal {
+						aborted = true
+						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, parentErr)
+						break
+					}
 					continue
 				}
 				token, _, upErr := drivePushUploadFile(ctx, runtime, localFile, existingToken, parentToken)
@@ -436,6 +454,7 @@ var DriveSync = common.Shortcut{
 					items = append(items, item)
 					failed++
 					if terminal {
+						aborted = true
 						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, upErr)
 						break
 					}
@@ -504,6 +523,7 @@ var DriveSync = common.Shortcut{
 					items = append(items, item)
 					failed++
 					if terminal {
+						aborted = true
 						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, downloadErr)
 						break
 					}
@@ -532,7 +552,7 @@ var DriveSync = common.Shortcut{
 				"pushed":  pushed,
 				"skipped": skipped,
 				"failed":  failed,
-				"aborted": driveSyncHasTerminalFailure(items),
+				"aborted": aborted,
 			},
 			"items": items,
 		}
@@ -574,18 +594,8 @@ func driveSyncFailedItem(relPath, fileToken, action, direction, phase string, er
 		Code:       decision.Code,
 		Subtype:    decision.Subtype,
 		Retryable:  driveBoolPtr(decision.Retryable),
-		Terminal:   decision.Terminal,
 	}
 	return item, decision.Terminal
-}
-
-func driveSyncHasTerminalFailure(items []driveSyncItem) bool {
-	for _, item := range items {
-		if item.Terminal {
-			return true
-		}
-	}
-	return false
 }
 
 // driveSyncAskConflict prompts the user for a conflict resolution strategy

--- a/shortcuts/markdown/helpers.go
+++ b/shortcuts/markdown/helpers.go
@@ -715,9 +715,15 @@ func markdownUploadProblem(err error, action string) error {
 		case 90003087:
 			appendMarkdownProblemHint(err, "The current tenant or user may not have document capabilities enabled. Ask an administrator to verify document-module access.")
 		case 1061003, 1061044:
-			appendMarkdownProblemHint(err, "Check whether the target folder or wiki node still exists, and verify the token you passed to the command.")
+			appendMarkdownProblemHint(err, "Check whether the target folder or wiki node still exists, and verify the parent token type. For Drive folders, pass --folder-token with a Drive folder token/URL; for wiki nodes, pass --wiki-token with a wiki node token/URL.")
 		case 1061004, 1062501:
 			appendMarkdownProblemHint(err, "Check whether the current identity has write access to the target folder or wiki node.")
+		case 1061101:
+			appendMarkdownProblemHint(err, "The target Drive/wiki storage quota is exhausted. Free space, choose another parent folder/wiki node, or ask an administrator to raise quota before retrying.")
+		case 233523001:
+			appendMarkdownProblemHint(err, "The upstream document service returned a transient server error. Retry later; if it repeats, keep the log_id/request_id for service-side investigation.")
+		case 99991400:
+			appendMarkdownProblemHint(err, "The upload API is rate limited. Stop immediate retries and retry later with exponential backoff.")
 		}
 	}
 	return err

--- a/shortcuts/markdown/markdown_create.go
+++ b/shortcuts/markdown/markdown_create.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -139,21 +140,32 @@ func normalizeMarkdownFolderToken(token string) (string, error) {
 	if strings.Contains(token, "://") {
 		ref, ok := common.ParseResourceURL(token)
 		if !ok {
-			return "", markdownValidationParamError("--folder-token", "--folder-token URL is unsupported; pass a Drive folder URL or raw folder token")
+			return "", markdownValidationParamError("--folder-token", "--folder-token URL is unsupported").
+				WithHint("Pass a Drive folder URL or raw folder token.")
 		}
 		if ref.Type != "folder" {
 			return "", markdownValidationParamError("--folder-token",
-				"--folder-token must identify a Drive folder; got a %s URL. Use --wiki-token for wiki nodes or pass a Drive folder URL/token.",
+				"--folder-token must identify a Drive folder; got a %s URL",
 				ref.Type,
-			)
+			).WithHint("Use --wiki-token for wiki nodes or pass a Drive folder URL/token.")
+		}
+		if err := validateMarkdownTargetTokenName(ref.Token, "--folder-token"); err != nil {
+			return "", err
 		}
 		return ref.Token, nil
 	}
+	if err := rejectMarkdownPartialToken(token, "--folder-token"); err != nil {
+		return "", err
+	}
 	switch markdownKnownResourceTokenKind(token) {
 	case "wiki":
-		return "", markdownValidationParamError("--folder-token", "--folder-token looks like a wiki node token; pass it with --wiki-token instead")
+		return "", markdownValidationParamError("--folder-token", "--folder-token looks like a wiki node token").
+			WithHint("Pass it with --wiki-token instead.")
 	case "doc", "docx", "sheet", "bitable", "mindnote", "slides", "file":
 		return "", markdownValidationParamError("--folder-token", "--folder-token must be a Drive folder token, not a %s token", markdownKnownResourceTokenKind(token))
+	}
+	if err := validateMarkdownTargetTokenName(token, "--folder-token"); err != nil {
+		return "", err
 	}
 	return token, nil
 }
@@ -163,20 +175,45 @@ func normalizeMarkdownWikiToken(token string) (string, error) {
 	if strings.Contains(token, "://") {
 		ref, ok := common.ParseResourceURL(token)
 		if !ok {
-			return "", markdownValidationParamError("--wiki-token", "--wiki-token URL is unsupported; pass a wiki node URL or raw wiki node token")
+			return "", markdownValidationParamError("--wiki-token", "--wiki-token URL is unsupported").
+				WithHint("Pass a wiki node URL or raw wiki node token.")
 		}
 		if ref.Type != "wiki" {
 			return "", markdownValidationParamError("--wiki-token",
-				"--wiki-token must identify a wiki node; got a %s URL. Resolve document URLs with `lark-cli wiki +node-get --node-token <url>` and use the returned node_token.",
+				"--wiki-token must identify a wiki node; got a %s URL",
 				ref.Type,
-			)
+			).WithHint("Resolve document URLs with `lark-cli wiki +node-get --node-token <url>` and use the returned node_token.")
+		}
+		if err := validateMarkdownTargetTokenName(ref.Token, "--wiki-token"); err != nil {
+			return "", err
 		}
 		return ref.Token, nil
+	}
+	if err := rejectMarkdownPartialToken(token, "--wiki-token"); err != nil {
+		return "", err
 	}
 	if kind := markdownKnownResourceTokenKind(token); kind != "" && kind != "wiki" {
 		return "", markdownValidationParamError("--wiki-token", "--wiki-token must be a wiki node token, not a %s token", kind)
 	}
+	if err := validateMarkdownTargetTokenName(token, "--wiki-token"); err != nil {
+		return "", err
+	}
 	return token, nil
+}
+
+func rejectMarkdownPartialToken(token, flagName string) error {
+	if strings.ContainsAny(token, "/?#") {
+		return markdownValidationParamError(flagName, "%s must be a raw token, not a path, query, or fragment", flagName).
+			WithHint("Pass a full Lark URL, or copy only the token value without path/query/fragment characters.")
+	}
+	return nil
+}
+
+func validateMarkdownTargetTokenName(token, flagName string) error {
+	if err := validate.ResourceName(token, flagName); err != nil {
+		return markdownValidationParamError(flagName, "%s", err).WithCause(err)
+	}
+	return nil
 }
 
 func markdownKnownResourceTokenKind(token string) string {

--- a/shortcuts/markdown/markdown_create.go
+++ b/shortcuts/markdown/markdown_create.go
@@ -30,27 +30,19 @@ var MarkdownCreate = common.Shortcut{
 	Tips: []string{
 		"Omit both --folder-token and --wiki-token to create the Markdown file in the caller's Drive root folder.",
 		"Use --wiki-token <wiki_node_token> to create the Markdown file under a wiki node; the shortcut maps this to parent_type=wiki automatically.",
+		"--folder-token and --wiki-token also accept full Lark URLs and normalize them to the required token.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		return validateMarkdownSpec(runtime, markdownUploadSpec{
-			FileName:    strings.TrimSpace(runtime.Str("name")),
-			FolderToken: strings.TrimSpace(runtime.Str("folder-token")),
-			WikiToken:   strings.TrimSpace(runtime.Str("wiki-token")),
-			FilePath:    strings.TrimSpace(runtime.Str("file")),
-			FileSet:     runtime.Changed("file"),
-			Content:     runtime.Str("content"),
-			ContentSet:  runtime.Changed("content"),
-		}, true)
+		spec, err := readMarkdownCreateSpec(runtime)
+		if err != nil {
+			return err
+		}
+		return validateMarkdownSpec(runtime, spec, true)
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		spec := markdownUploadSpec{
-			FileName:    strings.TrimSpace(runtime.Str("name")),
-			FolderToken: strings.TrimSpace(runtime.Str("folder-token")),
-			WikiToken:   strings.TrimSpace(runtime.Str("wiki-token")),
-			FilePath:    strings.TrimSpace(runtime.Str("file")),
-			FileSet:     runtime.Changed("file"),
-			Content:     runtime.Str("content"),
-			ContentSet:  runtime.Changed("content"),
+		spec, err := readMarkdownCreateSpec(runtime)
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
 		}
 		fileSize, err := markdownSourceSize(runtime, spec)
 		if err != nil {
@@ -71,14 +63,9 @@ var MarkdownCreate = common.Shortcut{
 		return dry
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		spec := markdownUploadSpec{
-			FileName:    strings.TrimSpace(runtime.Str("name")),
-			FolderToken: strings.TrimSpace(runtime.Str("folder-token")),
-			WikiToken:   strings.TrimSpace(runtime.Str("wiki-token")),
-			FilePath:    strings.TrimSpace(runtime.Str("file")),
-			FileSet:     runtime.Changed("file"),
-			Content:     runtime.Str("content"),
-			ContentSet:  runtime.Changed("content"),
+		spec, err := readMarkdownCreateSpec(runtime)
+		if err != nil {
+			return err
 		}
 		fileSize, err := markdownSourceSize(runtime, spec)
 		if err != nil {
@@ -114,4 +101,104 @@ var MarkdownCreate = common.Shortcut{
 		})
 		return nil
 	},
+}
+
+func readMarkdownCreateSpec(runtime *common.RuntimeContext) (markdownUploadSpec, error) {
+	spec := markdownUploadSpec{
+		FileName:    strings.TrimSpace(runtime.Str("name")),
+		FolderToken: strings.TrimSpace(runtime.Str("folder-token")),
+		WikiToken:   strings.TrimSpace(runtime.Str("wiki-token")),
+		FilePath:    strings.TrimSpace(runtime.Str("file")),
+		FileSet:     runtime.Changed("file"),
+		Content:     runtime.Str("content"),
+		ContentSet:  runtime.Changed("content"),
+	}
+	return normalizeMarkdownCreateTargetSpec(spec)
+}
+
+func normalizeMarkdownCreateTargetSpec(spec markdownUploadSpec) (markdownUploadSpec, error) {
+	if spec.FolderToken != "" {
+		token, err := normalizeMarkdownFolderToken(spec.FolderToken)
+		if err != nil {
+			return markdownUploadSpec{}, err
+		}
+		spec.FolderToken = token
+	}
+	if spec.WikiToken != "" {
+		token, err := normalizeMarkdownWikiToken(spec.WikiToken)
+		if err != nil {
+			return markdownUploadSpec{}, err
+		}
+		spec.WikiToken = token
+	}
+	return spec, nil
+}
+
+func normalizeMarkdownFolderToken(token string) (string, error) {
+	token = strings.TrimSpace(token)
+	if strings.Contains(token, "://") {
+		ref, ok := common.ParseResourceURL(token)
+		if !ok {
+			return "", markdownValidationParamError("--folder-token", "--folder-token URL is unsupported; pass a Drive folder URL or raw folder token")
+		}
+		if ref.Type != "folder" {
+			return "", markdownValidationParamError("--folder-token",
+				"--folder-token must identify a Drive folder; got a %s URL. Use --wiki-token for wiki nodes or pass a Drive folder URL/token.",
+				ref.Type,
+			)
+		}
+		return ref.Token, nil
+	}
+	switch markdownKnownResourceTokenKind(token) {
+	case "wiki":
+		return "", markdownValidationParamError("--folder-token", "--folder-token looks like a wiki node token; pass it with --wiki-token instead")
+	case "doc", "docx", "sheet", "bitable", "mindnote", "slides", "file":
+		return "", markdownValidationParamError("--folder-token", "--folder-token must be a Drive folder token, not a %s token", markdownKnownResourceTokenKind(token))
+	}
+	return token, nil
+}
+
+func normalizeMarkdownWikiToken(token string) (string, error) {
+	token = strings.TrimSpace(token)
+	if strings.Contains(token, "://") {
+		ref, ok := common.ParseResourceURL(token)
+		if !ok {
+			return "", markdownValidationParamError("--wiki-token", "--wiki-token URL is unsupported; pass a wiki node URL or raw wiki node token")
+		}
+		if ref.Type != "wiki" {
+			return "", markdownValidationParamError("--wiki-token",
+				"--wiki-token must identify a wiki node; got a %s URL. Resolve document URLs with `lark-cli wiki +node-get --node-token <url>` and use the returned node_token.",
+				ref.Type,
+			)
+		}
+		return ref.Token, nil
+	}
+	if kind := markdownKnownResourceTokenKind(token); kind != "" && kind != "wiki" {
+		return "", markdownValidationParamError("--wiki-token", "--wiki-token must be a wiki node token, not a %s token", kind)
+	}
+	return token, nil
+}
+
+func markdownKnownResourceTokenKind(token string) string {
+	lower := strings.ToLower(strings.TrimSpace(token))
+	switch {
+	case strings.HasPrefix(lower, "wik"):
+		return "wiki"
+	case strings.HasPrefix(lower, "docx"):
+		return "docx"
+	case strings.HasPrefix(lower, "doc"):
+		return "doc"
+	case strings.HasPrefix(lower, "sht"):
+		return "sheet"
+	case strings.HasPrefix(lower, "bas"):
+		return "bitable"
+	case strings.HasPrefix(lower, "mn"):
+		return "mindnote"
+	case strings.HasPrefix(lower, "sld"):
+		return "slides"
+	case strings.HasPrefix(lower, "box"), strings.HasPrefix(lower, "file"):
+		return "file"
+	default:
+		return ""
+	}
 }

--- a/shortcuts/markdown/markdown_test.go
+++ b/shortcuts/markdown/markdown_test.go
@@ -481,7 +481,14 @@ func TestMarkdownCreateRejectsWikiURLInFolderToken(t *testing.T) {
 		"--content", "# hello",
 		"--folder-token", "https://feishu.cn/wiki/wikcnWrongFlag",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "Use --wiki-token") {
+	if err == nil {
+		t.Fatalf("expected folder-token URL type error, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false for %T: %v", err, err)
+	}
+	if !strings.Contains(p.Message, "must identify a Drive folder") || !strings.Contains(p.Hint, "Use --wiki-token") {
 		t.Fatalf("expected folder-token URL type error, got %v", err)
 	}
 }
@@ -495,7 +502,14 @@ func TestMarkdownCreateRejectsDocURLInWikiToken(t *testing.T) {
 		"--content", "# hello",
 		"--wiki-token", "https://feishu.cn/docx/docxWrongFlag",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "must identify a wiki node") {
+	if err == nil {
+		t.Fatalf("expected wiki-token URL type error, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false for %T: %v", err, err)
+	}
+	if !strings.Contains(p.Message, "must identify a wiki node") || !strings.Contains(p.Hint, "+node-get") {
 		t.Fatalf("expected wiki-token URL type error, got %v", err)
 	}
 }

--- a/shortcuts/markdown/markdown_test.go
+++ b/shortcuts/markdown/markdown_test.go
@@ -446,6 +446,84 @@ func TestMarkdownCreateDryRunWithWikiToken(t *testing.T) {
 	}
 }
 
+func TestMarkdownCreateDryRunNormalizesFolderURL(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, markdownTestConfig())
+
+	err := mountAndRunMarkdown(t, MarkdownCreate, []string{
+		"+create",
+		"--name", "README.md",
+		"--content", "# hello",
+		"--folder-token", "https://feishu.cn/drive/folder/fldcnMarkdownTarget",
+		"--dry-run",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, `"parent_type": "explorer"`) {
+		t.Fatalf("dry-run missing explorer parent_type: %s", out)
+	}
+	if !strings.Contains(out, `"parent_node": "fldcnMarkdownTarget"`) {
+		t.Fatalf("dry-run did not normalize folder URL to token: %s", out)
+	}
+	if strings.Contains(out, "https://feishu.cn/drive/folder/") {
+		t.Fatalf("dry-run leaked raw folder URL instead of token: %s", out)
+	}
+}
+
+func TestMarkdownCreateRejectsWikiURLInFolderToken(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, markdownTestConfig())
+
+	err := mountAndRunMarkdown(t, MarkdownCreate, []string{
+		"+create",
+		"--name", "README.md",
+		"--content", "# hello",
+		"--folder-token", "https://feishu.cn/wiki/wikcnWrongFlag",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "Use --wiki-token") {
+		t.Fatalf("expected folder-token URL type error, got %v", err)
+	}
+}
+
+func TestMarkdownCreateRejectsDocURLInWikiToken(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, markdownTestConfig())
+
+	err := mountAndRunMarkdown(t, MarkdownCreate, []string{
+		"+create",
+		"--name", "README.md",
+		"--content", "# hello",
+		"--wiki-token", "https://feishu.cn/docx/docxWrongFlag",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "must identify a wiki node") {
+		t.Fatalf("expected wiki-token URL type error, got %v", err)
+	}
+}
+
+func TestMarkdownUploadProblemAddsQuotaAndServerHints(t *testing.T) {
+	t.Parallel()
+
+	quotaErr := errs.NewAPIError(errs.SubtypeQuotaExceeded, "file quota exceeded").WithCode(1061101)
+	got := markdownUploadProblem(quotaErr, markdownUploadAllAction)
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf(quotaErr) ok=false")
+	}
+	if !strings.Contains(p.Hint, "storage quota is exhausted") {
+		t.Fatalf("quota hint = %q", p.Hint)
+	}
+
+	serverErr := errs.NewAPIError(errs.SubtypeServerError, "NA").WithCode(233523001).WithRetryable()
+	got = markdownUploadProblem(serverErr, markdownUploadAllAction)
+	p, ok = errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf(serverErr) ok=false")
+	}
+	if !p.Retryable || !strings.Contains(p.Hint, "transient server error") {
+		t.Fatalf("server retryable=%v hint=%q", p.Retryable, p.Hint)
+	}
+}
+
 func TestMarkdownCreateDryRunReportsSourceFileError(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, markdownTestConfig())
 

--- a/shortcuts/markdown/markdown_test.go
+++ b/shortcuts/markdown/markdown_test.go
@@ -514,6 +514,81 @@ func TestMarkdownCreateRejectsDocURLInWikiToken(t *testing.T) {
 	}
 }
 
+func TestNormalizeMarkdownTargetTokensRejectAmbiguousInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		run      func() (string, error)
+		wantMsg  string
+		wantHint string
+	}{
+		{
+			name:     "wiki token passed as folder token",
+			run:      func() (string, error) { return normalizeMarkdownFolderToken("wik_placeholder_wrong") },
+			wantMsg:  "--folder-token looks like a wiki node token",
+			wantHint: "--wiki-token",
+		},
+		{
+			name:     "folder token path fragment",
+			run:      func() (string, error) { return normalizeMarkdownFolderToken("folder_token/child") },
+			wantMsg:  "--folder-token must be a raw token",
+			wantHint: "full Lark URL",
+		},
+		{
+			name:     "doc token passed as wiki token",
+			run:      func() (string, error) { return normalizeMarkdownWikiToken("docx_placeholder_wrong") },
+			wantMsg:  "--wiki-token must be a wiki node token",
+			wantHint: "",
+		},
+		{
+			name:     "wiki token query fragment",
+			run:      func() (string, error) { return normalizeMarkdownWikiToken("wik_placeholder?from=copy") },
+			wantMsg:  "--wiki-token must be a raw token",
+			wantHint: "path/query/fragment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.run()
+			if err == nil {
+				t.Fatalf("expected validation error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("ProblemOf() ok=false for %T: %v", err, err)
+			}
+			if !strings.Contains(p.Message, tt.wantMsg) {
+				t.Fatalf("message = %q, want substring %q", p.Message, tt.wantMsg)
+			}
+			if tt.wantHint != "" && !strings.Contains(p.Hint, tt.wantHint) {
+				t.Fatalf("hint = %q, want substring %q", p.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestNormalizeMarkdownTargetTokensAcceptRawTokens(t *testing.T) {
+	t.Parallel()
+
+	folderToken, err := normalizeMarkdownFolderToken("folder_token_raw")
+	if err != nil {
+		t.Fatalf("normalizeMarkdownFolderToken() error = %v", err)
+	}
+	if folderToken != "folder_token_raw" {
+		t.Fatalf("folder token = %q", folderToken)
+	}
+
+	wikiToken, err := normalizeMarkdownWikiToken("wik_placeholder_raw")
+	if err != nil {
+		t.Fatalf("normalizeMarkdownWikiToken() error = %v", err)
+	}
+	if wikiToken != "wik_placeholder_raw" {
+		t.Fatalf("wiki token = %q", wikiToken)
+	}
+}
+
 func TestMarkdownUploadProblemAddsQuotaAndServerHints(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/wiki/wiki_helpers.go
+++ b/shortcuts/wiki/wiki_helpers.go
@@ -6,6 +6,7 @@ package wiki
 import (
 	"strings"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -25,4 +26,18 @@ func wikiNodeURL(brand core.LarkBrand, node *wikiNodeRecord) string {
 		return u
 	}
 	return common.BuildResourceURL(brand, "wiki", node.NodeToken)
+}
+
+func appendWikiProblemHint(err error, hint string) error {
+	if strings.TrimSpace(hint) == "" {
+		return err
+	}
+	if p, ok := errs.ProblemOf(err); ok {
+		if strings.TrimSpace(p.Hint) != "" {
+			p.Hint = p.Hint + "\n" + hint
+		} else {
+			p.Hint = hint
+		}
+	}
+	return err
 }

--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -5,6 +5,7 @@ package wiki
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -138,7 +139,21 @@ func TestWikiNodeListRejectsNonNumericSpaceID(t *testing.T) {
 	err := mountAndRunWiki(t, WikiNodeList, []string{
 		"+node-list", "--space-id", "wikcnABC", "--as", "user",
 	}, factory, nil)
-	if err == nil || !strings.Contains(err.Error(), "--space-id must be a numeric wiki space_id") {
+	if err == nil {
+		t.Fatalf("expected numeric space_id validation error, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false for %T: %v", err, err)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--space-id" {
+		t.Fatalf("problem = %#v param=%q, want validation/invalid_argument/--space-id", p, validationErr.Param)
+	}
+	if !strings.Contains(p.Message, "--space-id must be a numeric wiki space_id") || !strings.Contains(p.Hint, "+space-list") {
 		t.Fatalf("expected numeric space_id validation error, got %v", err)
 	}
 }
@@ -153,7 +168,21 @@ func TestWikiNodeListRejectsDocumentURLAsParentNodeToken(t *testing.T) {
 		"--parent-node-token", "https://feishu.cn/docx/docxABC",
 		"--as", "user",
 	}, factory, nil)
-	if err == nil || !strings.Contains(err.Error(), "must identify a wiki node") {
+	if err == nil {
+		t.Fatalf("expected parent-node-token URL type validation error, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false for %T: %v", err, err)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--parent-node-token" {
+		t.Fatalf("problem = %#v param=%q, want validation/invalid_argument/--parent-node-token", p, validationErr.Param)
+	}
+	if !strings.Contains(p.Message, "must identify a wiki node") || !strings.Contains(p.Hint, "+node-get") {
 		t.Fatalf("expected parent-node-token URL type validation error, got %v", err)
 	}
 }

--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -130,6 +131,59 @@ func TestWikiNodeListRequiresSpaceID(t *testing.T) {
 	}
 }
 
+func TestWikiNodeListRejectsNonNumericSpaceID(t *testing.T) {
+	t.Parallel()
+
+	factory, _, _, _ := cmdutil.TestFactory(t, wikiTestConfig())
+	err := mountAndRunWiki(t, WikiNodeList, []string{
+		"+node-list", "--space-id", "wikcnABC", "--as", "user",
+	}, factory, nil)
+	if err == nil || !strings.Contains(err.Error(), "--space-id must be a numeric wiki space_id") {
+		t.Fatalf("expected numeric space_id validation error, got %v", err)
+	}
+}
+
+func TestWikiNodeListRejectsDocumentURLAsParentNodeToken(t *testing.T) {
+	t.Parallel()
+
+	factory, _, _, _ := cmdutil.TestFactory(t, wikiTestConfig())
+	err := mountAndRunWiki(t, WikiNodeList, []string{
+		"+node-list",
+		"--space-id", "7211568716812369922",
+		"--parent-node-token", "https://feishu.cn/docx/docxABC",
+		"--as", "user",
+	}, factory, nil)
+	if err == nil || !strings.Contains(err.Error(), "must identify a wiki node") {
+		t.Fatalf("expected parent-node-token URL type validation error, got %v", err)
+	}
+}
+
+func TestWikiNodeListNormalizesWikiURLParentNodeToken(t *testing.T) {
+	t.Parallel()
+
+	token, err := normalizeWikiNodeListParentToken("https://feishu.cn/wiki/wikcnPARENT?from=copy")
+	if err != nil {
+		t.Fatalf("normalizeWikiNodeListParentToken() error = %v", err)
+	}
+	if token != "wikcnPARENT" {
+		t.Fatalf("token = %q, want wikcnPARENT", token)
+	}
+}
+
+func TestWikiNodeListProblemAddsActionableHint(t *testing.T) {
+	t.Parallel()
+
+	err := errs.NewAPIError(errs.SubtypeInvalidParameters, "param err: invalid page_token").WithCode(131002)
+	got := wikiNodeListProblem(err, nil)
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false")
+	}
+	if !strings.Contains(p.Hint, "page token is invalid or stale") {
+		t.Fatalf("hint = %q, want invalid page token guidance", p.Hint)
+	}
+}
+
 func TestWikiNodeListReturnsNodesForSpace(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 
@@ -137,14 +191,14 @@ func TestWikiNodeListReturnsNodesForSpace(t *testing.T) {
 
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/space_123/nodes",
+		URL:    "/open-apis/wiki/v2/spaces/7211568716812369922/nodes",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
 				"has_more": false,
 				"items": []interface{}{
 					map[string]interface{}{
-						"space_id":          "space_123",
+						"space_id":          "7211568716812369922",
 						"node_token":        "wik_node_1",
 						"obj_token":         "docx_1",
 						"obj_type":          "docx",
@@ -154,7 +208,7 @@ func TestWikiNodeListReturnsNodesForSpace(t *testing.T) {
 						"has_child":         true,
 					},
 					map[string]interface{}{
-						"space_id":          "space_123",
+						"space_id":          "7211568716812369922",
 						"node_token":        "wik_node_2",
 						"obj_token":         "docx_2",
 						"obj_type":          "docx",
@@ -170,7 +224,7 @@ func TestWikiNodeListReturnsNodesForSpace(t *testing.T) {
 	})
 
 	err := mountAndRunWiki(t, WikiNodeList, []string{
-		"+node-list", "--space-id", "space_123", "--as", "bot",
+		"+node-list", "--space-id", "7211568716812369922", "--as", "bot",
 	}, factory, stdout)
 	if err != nil {
 		t.Fatalf("mountAndRunWiki() error = %v", err)
@@ -211,14 +265,14 @@ func TestWikiNodeListPassesParentNodeToken(t *testing.T) {
 
 	stub := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/space_123/nodes?page_size=50&parent_node_token=wik_parent",
+		URL:    "/open-apis/wiki/v2/spaces/7211568716812369922/nodes?page_size=50&parent_node_token=wik_parent",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
 				"has_more": false,
 				"items": []interface{}{
 					map[string]interface{}{
-						"space_id":          "space_123",
+						"space_id":          "7211568716812369922",
 						"node_token":        "wik_child",
 						"obj_token":         "docx_child",
 						"obj_type":          "docx",
@@ -235,7 +289,7 @@ func TestWikiNodeListPassesParentNodeToken(t *testing.T) {
 	reg.Register(stub)
 
 	err := mountAndRunWiki(t, WikiNodeList, []string{
-		"+node-list", "--space-id", "space_123", "--parent-node-token", "wik_parent", "--as", "bot",
+		"+node-list", "--space-id", "7211568716812369922", "--parent-node-token", "wik_parent", "--as", "bot",
 	}, factory, stdout)
 	if err != nil {
 		t.Fatalf("mountAndRunWiki() error = %v", err)
@@ -286,7 +340,7 @@ func TestWikiNodeListResolvesMyLibraryForUser(t *testing.T) {
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
 				"space": map[string]interface{}{
-					"space_id":   "space_personal_42",
+					"space_id":   "7211568716812369923",
 					"name":       "My Library",
 					"space_type": "my_library",
 				},
@@ -296,14 +350,14 @@ func TestWikiNodeListResolvesMyLibraryForUser(t *testing.T) {
 	// Step 2: list nodes in the resolved space.
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/space_personal_42/nodes",
+		URL:    "/open-apis/wiki/v2/spaces/7211568716812369923/nodes",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
 				"has_more": false,
 				"items": []interface{}{
 					map[string]interface{}{
-						"space_id":   "space_personal_42",
+						"space_id":   "7211568716812369923",
 						"node_token": "wik_personal_1",
 						"title":      "Personal Note",
 					},
@@ -334,8 +388,8 @@ func TestWikiNodeListResolvesMyLibraryForUser(t *testing.T) {
 	if envelope.Meta.Count != 1 {
 		t.Fatalf("meta.count = %v, want 1", envelope.Meta.Count)
 	}
-	if envelope.Data.Nodes[0]["space_id"] != "space_personal_42" {
-		t.Fatalf("nodes[0].space_id = %v, want space_personal_42", envelope.Data.Nodes[0]["space_id"])
+	if envelope.Data.Nodes[0]["space_id"] != "7211568716812369923" {
+		t.Fatalf("nodes[0].space_id = %v, want 7211568716812369923", envelope.Data.Nodes[0]["space_id"])
 	}
 }
 
@@ -758,21 +812,21 @@ func TestWikiNodeListDefaultIsSinglePage(t *testing.T) {
 	// test pins down the "default = single page" contract.
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/space_123/nodes",
+		URL:    "/open-apis/wiki/v2/spaces/7211568716812369922/nodes",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
 				"has_more":   true,
 				"page_token": "tok_next",
 				"items": []interface{}{
-					map[string]interface{}{"space_id": "space_123", "node_token": "wik_1", "title": "First"},
+					map[string]interface{}{"space_id": "7211568716812369922", "node_token": "wik_1", "title": "First"},
 				},
 			},
 		},
 	})
 
 	err := mountAndRunWiki(t, WikiNodeList, []string{
-		"+node-list", "--space-id", "space_123", "--as", "bot",
+		"+node-list", "--space-id", "7211568716812369922", "--as", "bot",
 	}, factory, stdout)
 	if err != nil {
 		t.Fatalf("mountAndRunWiki() error = %v", err)
@@ -802,14 +856,14 @@ func TestWikiNodeListPrettyFormatRendersFields(t *testing.T) {
 	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/space_123/nodes",
+		URL:    "/open-apis/wiki/v2/spaces/7211568716812369922/nodes",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
 				"has_more": false,
 				"items": []interface{}{
 					map[string]interface{}{
-						"space_id":   "space_123",
+						"space_id":   "7211568716812369922",
 						"node_token": "wik_1",
 						"obj_type":   "docx",
 						"obj_token":  "docx_1",
@@ -822,7 +876,7 @@ func TestWikiNodeListPrettyFormatRendersFields(t *testing.T) {
 	})
 
 	err := mountAndRunWiki(t, WikiNodeList, []string{
-		"+node-list", "--space-id", "space_123", "--format", "pretty", "--as", "bot",
+		"+node-list", "--space-id", "7211568716812369922", "--format", "pretty", "--as", "bot",
 	}, factory, stdout)
 	if err != nil {
 		t.Fatalf("mountAndRunWiki() error = %v", err)

--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -199,6 +199,66 @@ func TestWikiNodeListNormalizesWikiURLParentNodeToken(t *testing.T) {
 	}
 }
 
+func TestWikiNodeListRejectsAmbiguousSpaceAndParentTokens(t *testing.T) {
+	t.Parallel()
+
+	if err := validateWikiNodeListSpaceID("https://example.invalid/wiki/space"); err == nil {
+		t.Fatalf("expected URL space-id validation error")
+	} else {
+		p, ok := errs.ProblemOf(err)
+		if !ok {
+			t.Fatalf("ProblemOf() ok=false for %T: %v", err, err)
+		}
+		if !strings.Contains(p.Message, "not a URL or path") || !strings.Contains(p.Hint, "+space-list") {
+			t.Fatalf("problem = %#v, want URL/path message and +space-list hint", p)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		wantMsg string
+	}{
+		{
+			name:    "partial wiki path",
+			input:   "wik_placeholder/child",
+			wantMsg: "raw wiki node token",
+		},
+		{
+			name:    "document token",
+			input:   "docx_placeholder_parent",
+			wantMsg: "must be a wiki node token",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := normalizeWikiNodeListParentToken(tt.input)
+			if err == nil {
+				t.Fatalf("expected parent token validation error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("ProblemOf() ok=false for %T: %v", err, err)
+			}
+			if !strings.Contains(p.Message, tt.wantMsg) {
+				t.Fatalf("message = %q, want substring %q", p.Message, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestWikiNodeListAcceptsEmptyParentToken(t *testing.T) {
+	t.Parallel()
+
+	token, err := normalizeWikiNodeListParentToken("")
+	if err != nil {
+		t.Fatalf("normalizeWikiNodeListParentToken(empty) error = %v", err)
+	}
+	if token != "" {
+		t.Fatalf("token = %q, want empty", token)
+	}
+}
+
 func TestWikiNodeListProblemAddsActionableHint(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/wiki/wiki_node_list.go
+++ b/shortcuts/wiki/wiki_node_list.go
@@ -48,27 +48,19 @@ var WikiNodeList = common.Shortcut{
 		"--space-id my_library is a per-user alias and is only valid with --as user.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		spaceID := strings.TrimSpace(runtime.Str("space-id"))
-		// my_library is a per-user personal-library alias; it has no meaning
-		// for a tenant_access_token (--as bot), so reject early with a clear
-		// hint instead of deferring to API-time errors. Matches the contract
-		// used by +node-create and +move.
-		if runtime.As().IsBot() && spaceID == wikiMyLibrarySpaceID {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "bot identity does not support --space-id my_library; use an explicit --space-id").WithParam("--space-id")
-		}
-		if err := validateOptionalResourceName(spaceID, "--space-id"); err != nil {
-			return err
-		}
-		if err := validateOptionalResourceName(strings.TrimSpace(runtime.Str("parent-node-token")), "--parent-node-token"); err != nil {
+		if _, err := readWikiNodeListSpec(runtime); err != nil {
 			return err
 		}
 		return validateWikiListPagination(runtime, wikiNodeListMaxPageSize)
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		spaceID := strings.TrimSpace(runtime.Str("space-id"))
+		spec, err := readWikiNodeListSpec(runtime)
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
 		params := map[string]interface{}{"page_size": runtime.Int("page-size")}
-		if pt := strings.TrimSpace(runtime.Str("parent-node-token")); pt != "" {
-			params["parent_node_token"] = pt
+		if spec.ParentNodeToken != "" {
+			params["parent_node_token"] = spec.ParentNodeToken
 		}
 		if pt := strings.TrimSpace(runtime.Str("page-token")); pt != "" {
 			params["page_token"] = pt
@@ -80,7 +72,7 @@ var WikiNodeList = common.Shortcut{
 		// When the caller passes my_library, +node-list must first resolve it
 		// to the real per-user space_id before listing nodes, mirroring the
 		// two-step orchestration used by +node-create.
-		if spaceID == wikiMyLibrarySpaceID {
+		if spec.SpaceID == wikiMyLibrarySpaceID {
 			return d.
 				Desc("2-step orchestration: resolve my_library -> list nodes").
 				GET("/open-apis/wiki/v2/spaces/my_library").
@@ -91,13 +83,17 @@ var WikiNodeList = common.Shortcut{
 				Set("space_id", "<resolved_space_id>")
 		}
 		return d.
-			GET(fmt.Sprintf("/open-apis/wiki/v2/spaces/%s/nodes", validate.EncodePathSegment(spaceID))).
+			GET(fmt.Sprintf("/open-apis/wiki/v2/spaces/%s/nodes", validate.EncodePathSegment(spec.SpaceID))).
 			Params(params).
-			Set("space_id", spaceID)
+			Set("space_id", spec.SpaceID)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		warnIfConflictingPagingFlags(runtime)
-		spaceID := strings.TrimSpace(runtime.Str("space-id"))
+		spec, err := readWikiNodeListSpec(runtime)
+		if err != nil {
+			return err
+		}
+		spaceID := spec.SpaceID
 
 		// Resolve the my_library alias to the per-user real space_id before
 		// listing, so the subsequent request hits a concrete space endpoint.
@@ -110,7 +106,7 @@ var WikiNodeList = common.Shortcut{
 			spaceID = resolved
 		}
 
-		nodes, hasMore, nextToken, err := fetchWikiNodes(runtime, spaceID)
+		nodes, hasMore, nextToken, err := fetchWikiNodes(runtime, spaceID, spec.ParentNodeToken)
 		if err != nil {
 			return err
 		}
@@ -127,10 +123,104 @@ var WikiNodeList = common.Shortcut{
 	},
 }
 
-func fetchWikiNodes(runtime *common.RuntimeContext, spaceID string) ([]map[string]interface{}, bool, string, error) {
+type wikiNodeListSpec struct {
+	SpaceID         string
+	ParentNodeToken string
+}
+
+func readWikiNodeListSpec(runtime *common.RuntimeContext) (wikiNodeListSpec, error) {
+	spaceID := strings.TrimSpace(runtime.Str("space-id"))
+	// my_library is a per-user personal-library alias; it has no meaning
+	// for a tenant_access_token (--as bot), so reject early with a clear
+	// hint instead of deferring to API-time errors. Matches the contract
+	// used by +node-create and +move.
+	if runtime.As().IsBot() && spaceID == wikiMyLibrarySpaceID {
+		return wikiNodeListSpec{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "bot identity does not support --space-id my_library; use an explicit numeric --space-id").WithParam("--space-id")
+	}
+	if err := validateWikiNodeListSpaceID(spaceID); err != nil {
+		return wikiNodeListSpec{}, err
+	}
+
+	parentNodeToken, err := normalizeWikiNodeListParentToken(strings.TrimSpace(runtime.Str("parent-node-token")))
+	if err != nil {
+		return wikiNodeListSpec{}, err
+	}
+	return wikiNodeListSpec{SpaceID: spaceID, ParentNodeToken: parentNodeToken}, nil
+}
+
+func validateWikiNodeListSpaceID(spaceID string) error {
+	if spaceID == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--space-id is required").WithParam("--space-id")
+	}
+	if spaceID == wikiMyLibrarySpaceID {
+		return nil
+	}
+	if strings.Contains(spaceID, "://") || strings.ContainsAny(spaceID, "/?#") {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--space-id must be a numeric wiki space_id, not a URL or path; run `lark-cli wiki +space-list --as user` to discover space IDs",
+		).WithParam("--space-id")
+	}
+	if !isDecimalWikiSpaceID(spaceID) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--space-id must be a numeric wiki space_id; do not pass a wiki node token, document token, or title",
+		).WithParam("--space-id").WithHint("Run `lark-cli wiki +space-list --as user` to list accessible wiki spaces, then pass the numeric `space_id`.")
+	}
+	if err := validateOptionalResourceName(spaceID, "--space-id"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isDecimalWikiSpaceID(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeWikiNodeListParentToken(parentNodeToken string) (string, error) {
+	if parentNodeToken == "" {
+		return "", nil
+	}
+	if strings.Contains(parentNodeToken, "://") {
+		ref, ok := common.ParseResourceURL(parentNodeToken)
+		if !ok {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--parent-node-token URL is unsupported; pass a raw wiki node token from `wiki +node-get` or `wiki +node-list`",
+			).WithParam("--parent-node-token")
+		}
+		if ref.Type != "wiki" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--parent-node-token must identify a wiki node; got a %s URL. Resolve the document URL with `lark-cli wiki +node-get --node-token <url>` and use its `node_token`.",
+				ref.Type,
+			).WithParam("--parent-node-token")
+		}
+		parentNodeToken = ref.Token
+	}
+	if strings.ContainsAny(parentNodeToken, "/?#") {
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--parent-node-token must be a raw wiki node token, not a partial URL or path",
+		).WithParam("--parent-node-token")
+	}
+	if !looksLikeWikiNodeToken(parentNodeToken) {
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--parent-node-token must be a wiki node token; do not pass a docx/sheet/base/file token",
+		).WithParam("--parent-node-token").WithHint("Run `lark-cli wiki +node-get --node-token <url-or-token>` to resolve a document URL or obj_token to the wiki `node_token` first.")
+	}
+	if err := validateOptionalResourceName(parentNodeToken, "--parent-node-token"); err != nil {
+		return "", err
+	}
+	return parentNodeToken, nil
+}
+
+func fetchWikiNodes(runtime *common.RuntimeContext, spaceID, parentNodeToken string) ([]map[string]interface{}, bool, string, error) {
 	pageSize := runtime.Int("page-size")
 	startToken := strings.TrimSpace(runtime.Str("page-token"))
-	parentNodeToken := strings.TrimSpace(runtime.Str("parent-node-token"))
 	auto := wikiListShouldAutoPaginate(runtime)
 	pageLimit := runtime.Int("page-limit")
 
@@ -153,7 +243,7 @@ func fetchWikiNodes(runtime *common.RuntimeContext, spaceID string) ([]map[strin
 		}
 		data, err := runtime.CallAPITyped("GET", apiPath, params, nil)
 		if err != nil {
-			return nil, false, "", err
+			return nil, false, "", wikiNodeListProblem(err, runtime)
 		}
 		items, _ := data["items"].([]interface{})
 		for _, item := range items {
@@ -175,6 +265,36 @@ func fetchWikiNodes(runtime *common.RuntimeContext, spaceID string) ([]map[strin
 		pageToken = lastPageToken
 	}
 	return nodes, lastHasMore, lastPageToken, nil
+}
+
+func wikiNodeListProblem(err error, runtime *common.RuntimeContext) error {
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		return err
+	}
+	switch p.Code {
+	case 131002:
+		msg := strings.ToLower(p.Message)
+		switch {
+		case strings.Contains(msg, "page_token"):
+			appendWikiProblemHint(err, "The page token is invalid or stale. Use only the `page_token` returned by the immediately preceding `wiki +node-list` response, or omit --page-token and start over.")
+		case strings.Contains(msg, "space_id"):
+			appendWikiProblemHint(err, "The --space-id value must be the numeric wiki space_id from `wiki +space-list`; do not pass a wiki URL, node token, document token, or title.")
+		default:
+			appendWikiProblemHint(err, "Check the wiki +node-list flags. Fix the parameter before retrying; this is not a transient error.")
+		}
+	case 131005:
+		appendWikiProblemHint(err, "The target wiki space or parent node was not found. Re-discover the space with `wiki +space-list` and the parent with `wiki +node-list`/`wiki +node-get`; do not retry the same stale token.")
+	case 131006:
+		if runtime != nil && runtime.As().IsBot() {
+			appendWikiProblemHint(err, "The bot/app identity cannot read this wiki space or node. Grant the app the required wiki scope and ensure the app or bot has access to the target knowledge space.")
+		} else {
+			appendWikiProblemHint(err, "The current user cannot read this wiki space or node. Switch to a user with access or ask the space owner to grant read permission.")
+		}
+	case 99991400:
+		appendWikiProblemHint(err, "Rate limited by the wiki API. Stop immediate retries and retry later with exponential backoff or a smaller --page-limit.")
+	}
+	return err
 }
 
 func wikiNodeListItem(m map[string]interface{}) map[string]interface{} {

--- a/shortcuts/wiki/wiki_node_list.go
+++ b/shortcuts/wiki/wiki_node_list.go
@@ -157,8 +157,8 @@ func validateWikiNodeListSpaceID(spaceID string) error {
 	}
 	if strings.Contains(spaceID, "://") || strings.ContainsAny(spaceID, "/?#") {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument,
-			"--space-id must be a numeric wiki space_id, not a URL or path; run `lark-cli wiki +space-list --as user` to discover space IDs",
-		).WithParam("--space-id")
+			"--space-id must be a numeric wiki space_id, not a URL or path",
+		).WithParam("--space-id").WithHint("Run `lark-cli wiki +space-list --as user` to discover space IDs.")
 	}
 	if !isDecimalWikiSpaceID(spaceID) {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument,
@@ -191,14 +191,14 @@ func normalizeWikiNodeListParentToken(parentNodeToken string) (string, error) {
 		ref, ok := common.ParseResourceURL(parentNodeToken)
 		if !ok {
 			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
-				"--parent-node-token URL is unsupported; pass a raw wiki node token from `wiki +node-get` or `wiki +node-list`",
-			).WithParam("--parent-node-token")
+				"--parent-node-token URL is unsupported",
+			).WithParam("--parent-node-token").WithHint("Pass a raw wiki node token from `wiki +node-get` or `wiki +node-list`.")
 		}
 		if ref.Type != "wiki" {
 			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
-				"--parent-node-token must identify a wiki node; got a %s URL. Resolve the document URL with `lark-cli wiki +node-get --node-token <url>` and use its `node_token`.",
+				"--parent-node-token must identify a wiki node; got a %s URL",
 				ref.Type,
-			).WithParam("--parent-node-token")
+			).WithParam("--parent-node-token").WithHint("Resolve the document URL with `lark-cli wiki +node-get --node-token <url>` and use its `node_token`.")
 		}
 		parentNodeToken = ref.Token
 	}

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -15,6 +15,7 @@
 | `summary.skipped` | 因 `--if-exists=skip` 或 `--if-exists=smart` 命中“无需传输”而跳过的文件数 |
 | `summary.failed` | 上传 / 覆盖 / 建目录 / 删除失败的条目数；**只要不为 0，命令就以非零状态退出**（结构化 `items[]` 仍在 stdout 上） |
 | `summary.deleted_remote` | 启用 `--delete-remote --yes` 时删除的云端文件数 |
+| `summary.aborted` | 命中终止性错误并停止后续批处理时为 `true` |
 | `items[]` | 每个条目的明细（`rel_path` / `file_token` / `action` / 覆盖时的 `version` / `size_bytes` / 失败时的 `error` / `hint` / `phase` / `error_class` / `code` / `subtype` / `retryable`） |
 
 `items[].action` 取值：`uploaded` / `overwritten` / `skipped` / `folder_created` / `deleted_remote` / `already_deleted` / `failed` / `delete_failed`。
@@ -122,7 +123,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
     {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
-    {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "..."}
+    {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "...", "hint": "...", "phase": "delete", "error_class": "...", "code": 0, "subtype": "...", "retryable": false}
   ]
 }
 ```

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -15,9 +15,9 @@
 | `summary.skipped` | 因 `--if-exists=skip` 或 `--if-exists=smart` 命中“无需传输”而跳过的文件数 |
 | `summary.failed` | 上传 / 覆盖 / 建目录 / 删除失败的条目数；**只要不为 0，命令就以非零状态退出**（结构化 `items[]` 仍在 stdout 上） |
 | `summary.deleted_remote` | 启用 `--delete-remote --yes` 时删除的云端文件数 |
-| `items[]` | 每个条目的明细（`rel_path` / `file_token` / `action` / 覆盖时的 `version` / `size_bytes` / 失败时的 `error`） |
+| `items[]` | 每个条目的明细（`rel_path` / `file_token` / `action` / 覆盖时的 `version` / `size_bytes` / 失败时的 `error` / `hint` / `phase` / `error_class` / `code` / `subtype` / `retryable`） |
 
-`items[].action` 取值：`uploaded` / `overwritten` / `skipped` / `folder_created` / `deleted_remote` / `failed` / `delete_failed`。
+`items[].action` 取值：`uploaded` / `overwritten` / `skipped` / `folder_created` / `deleted_remote` / `already_deleted` / `failed` / `delete_failed`。
 
 > 本地目录（包括空目录）会被镜像到 Drive；新建的子目录会以 `action: "folder_created"` 出现在 `items[]` 里，但**不计入** `summary.uploaded`（该字段只数文件）。已存在的远端目录复用其 token，不会重复 `create_folder`，也不会出现在 `items[]` 里。
 
@@ -95,6 +95,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 - `--delete-remote`（无 `--yes`）→ Validate 直接报错：`--delete-remote requires --yes`，不会发起任何列表 / 上传 / 删除请求。
 - `--delete-remote --yes` → Validate 阶段还会**动态做一次** `space:document:delete` 的 scope 预检：缺这条 scope 时整次运行立刻失败、不发任何上传请求，避免出现"上传都成功了，但删除阶段才报 missing_scope"的半同步状态。
 - `--delete-remote --yes`（且 scope 已授权）→ 正常执行：先把本地文件 push 上去，再扫一遍远端 `type=file` 列表，把不在本地清单里的逐个删除。**任何上传 / 覆盖 / 建目录失败时，整段 `--delete-remote` 阶段会被跳过**（stderr 上有提示），命令以非零状态退出，远端不会被破坏。
+- 删除阶段如果服务端返回 `1061007 file has been delete`，说明目标远端文件在本次 DELETE 前已经不存在；这已经满足 `--delete-remote` 的目标状态，输出会记为 `action: "already_deleted"`，不计入 `summary.failed`，也不计入 `summary.deleted_remote`。
 - 远端同名冲突且使用默认 `fail`，或冲突里混有 folder / 其他非 `type=file` 对象 → 在上传阶段前失败，删除阶段不会运行。
 - 不传 `--delete-remote` → `summary.deleted_remote` 永远是 0；命令对远端"多余"文件视而不见。
 - 在线文档（docx / sheet / bitable / ...）和快捷方式即使本地完全没有同名文件，也**不会**进入删除候选，因为它们从来不进 `summary.uploaded` 的对齐域。
@@ -110,21 +111,45 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     "uploaded": 0,
     "skipped": 0,
     "failed": 0,
-    "deleted_remote": 0
+    "deleted_remote": 0,
+    "aborted": false
   },
   "items": [
     {"rel_path": "...", "file_token": "...", "action": "folder_created"},
     {"rel_path": "...", "file_token": "...", "action": "uploaded",       "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "overwritten",    "version": "...", "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "skipped",        "size_bytes": 0},
-    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "..."},
+    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
+    {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
     {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "..."}
   ]
 }
 ```
 
 `rel_path` 始终用 `/` 作为分隔符（跨平台一致）。
+
+## 失败处理与 agent 行为
+
+`+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
+
+常见终止性错误：
+
+| `error_class` | 常见 `code` | 含义 | Agent 应对 |
+|---|---:|---|---|
+| `app_scope_missing` | `99991672` | 应用身份缺少 Drive / 文件夹相关 scope | 停止重试，引导开通错误里列出的应用身份权限，例如 `space:folder:create` 或 `drive:drive` |
+| `user_scope_missing` | `99991679` | 用户身份缺少授权 | 停止重试，走 `lark-cli auth login --scope ...` 补错误里列出的 scope |
+| `permission_denied` | `1061004` / HTTP 403 | 当前身份无权操作目标资源 | 停止重试，检查目标文件夹权限、身份类型（user / bot）和资源可见性 |
+| `invalid_api_parameters` | `1061002` | API 参数被服务端拒绝 | 停止重试，检查 `--folder-token`、覆盖模式、`file_token`、文件名和上传参数；不要对同一参数组合批量重试 |
+| `parent_node_missing` | `1061044` | 上传 / 建目录使用的父文件夹不存在或当前身份不可见 | 停止重试，检查 `--folder-token` 是否仍存在、是否有权限、父目录是否在 push 过程中被删除；不要继续上传同一目录树 |
+| `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
+| `server_error` | `1061001` / `2200` | Drive 服务端异常 | 停止当前批次，稍后重试；保留 `log_id` 便于排查 |
+
+非终止但需要解释的状态：
+
+- `file_size_limit` / `1061043`：文件超过 Drive 上传限制。不要继续尝试同一文件；改拆分或换存储方式。
+- `upload_size_mismatch` / `1062009`：本地文件在上传过程中发生变化，或声明大小与实际读取大小不一致。重新扫描本地文件后再 push。
+- `remote_not_found` / `1061007`：一般表示远端文件已不存在。删除阶段的 `1061007` 会被视为 `already_deleted` 成功项；其他阶段需重新列表确认远端状态。
 
 ## 性能注意
 

--- a/skills/lark-markdown/SKILL.md
+++ b/skills/lark-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark-markdown
-version: 1.2.1
+version: 1.2.2
 description: "飞书 Markdown：查看、创建、上传、编辑和比较 Markdown 文件。当用户需要创建或编辑 Markdown 文件、读取、修改、局部 patch 或比较差异时使用。不负责将 Markdown 导入为飞书在线文档，也不负责文件搜索、权限、评论、移动、删除等云空间管理操作。"
 metadata:
   requires:
@@ -25,7 +25,8 @@ metadata:
 - 用户要先拿 Markdown 文件的历史版本号，再做比较/下载/回滚，先用 [`lark-drive`](../lark-drive/SKILL.md) 的 `lark-cli drive +version-history`
 - 用户要把本地 Markdown **导入成在线新版文档（docx）**，不要用本 skill，改用 [`lark-drive`](../lark-drive/SKILL.md) 的 `lark-cli drive +import --type docx`
 - 用户要对 Markdown 文件做**rename / move / delete / 搜索 / 权限 / 评论**等云空间（云盘/云存储）操作，不要留在本 skill，切到 [`lark-drive`](../lark-drive/SKILL.md)
-- `markdown +create` / `+overwrite` 命中 `missing scope`、`permission denied`、`not found`、`version limit` 时，默认停止重试并按报错 hint 处理；只有 `rate limit` 或临时网络错误才做有限重试。
+- `markdown +create` / `+overwrite` 命中 `missing scope`、`permission denied`、`not found`、`quota_exceeded`、`version limit` 时，默认停止重试并按报错 hint 处理；只有 `rate_limit`、`server_error` 或临时网络错误才做有限退避重试。
+- `markdown +create` 的目标参数不要猜：Drive 文件夹用 `--folder-token`，Wiki 节点用 `--wiki-token`。如果用户给的是 URL，可以直接传完整 URL；CLI 会归一成 token。不要把 doc/sheet/wiki URL 放进 `--folder-token` 试错。
 
 ## 核心边界
 

--- a/skills/lark-markdown/references/lark-markdown-create.md
+++ b/skills/lark-markdown/references/lark-markdown-create.md
@@ -32,9 +32,19 @@ lark-cli markdown +create \
   --folder-token fldcn_xxx \
   --file ./README.md
 
+# 创建到指定文件夹（可直接传 Drive folder URL）
+lark-cli markdown +create \
+  --folder-token "https://feishu.cn/drive/folder/fldcn_xxx" \
+  --file ./README.md
+
 # 创建到指定 wiki 节点
 lark-cli markdown +create \
   --wiki-token wikcn_xxx \
+  --file ./README.md
+
+# 创建到指定 wiki 节点（可直接传 wiki URL）
+lark-cli markdown +create \
+  --wiki-token "https://feishu.cn/wiki/wikcn_xxx" \
   --file ./README.md
 
 # 预览底层请求
@@ -48,8 +58,8 @@ lark-cli markdown +create \
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--folder-token` | 否 | 目标 Drive 文件夹 token；与 `--wiki-token` 互斥；省略时创建到根目录 |
-| `--wiki-token` | 否 | 目标 wiki 节点 token；与 `--folder-token` 互斥；传入后自动映射为 `parent_type=wiki` |
+| `--folder-token` | 否 | 目标 Drive 文件夹 token 或 Drive folder URL；与 `--wiki-token` 互斥；省略时创建到根目录 |
+| `--wiki-token` | 否 | 目标 wiki 节点 token 或 wiki URL；与 `--folder-token` 互斥；传入后自动映射为 `parent_type=wiki` |
 | `--name` | 条件必填 | 文件名，**必须显式带 `.md` 后缀**；使用 `--content` 时必填；使用 `--file` 时可省略，默认取本地文件名 |
 | `--content` | 条件必填 | Markdown 内容；与 `--file` 互斥；支持直接传字符串、`@file`、`-`（stdin） |
 | `--file` | 条件必填 | 本地 `.md` 文件路径；与 `--content` 互斥 |
@@ -58,6 +68,8 @@ lark-cli markdown +create \
 
 - `--content` 与 `--file` 必须二选一
 - `--folder-token` 与 `--wiki-token` 互斥
+- `--folder-token` 只能是 Drive 文件夹；不要传 wiki/doc/sheet/base/file token 或 URL
+- `--wiki-token` 只能是 Wiki 节点；如果只有 docx/sheet/base 等文档 URL，先用 `lark-cli wiki +node-get --node-token <url>` 解析出 `node_token`
 - `--name` 必须带 `.md` 后缀
 - `--file` 指向的本地文件名也必须带 `.md` 后缀
 - 传 `--wiki-token` 时，返回值中不会附带 `/file/<token>` URL，因为 wiki 承载文件没有稳定的独立 file URL
@@ -87,6 +99,14 @@ lark-cli markdown +create \
 > `permission_grant.perm = full_access` 表示该资源已授予“可管理权限”。
 >
 > **不要擅自执行 owner 转移。** 如果用户需要把 owner 转给自己，必须单独确认。
+
+## 失败处理
+
+- `not_found` / `1061044`：父目录或 wiki 节点不存在，或 token 类型放错参数。修正 `--folder-token` / `--wiki-token` 后再试，不要重复提交同一参数。
+- `quota_exceeded` / `1061101`：目标存储空间配额已满。释放空间、换父目录/节点或请管理员扩容后再试。
+- `permission_denied` / `missing_scope`：区分身份处理。`--as user` 看用户授权和目标 ACL；`--as bot` 看应用 scope 与目标目录/节点 ACL。
+- `rate_limit`：停止立即重试，使用退避。
+- `server_error` / `233523001`：可以稍后有限重试；若重复出现，保留 `log_id` / request id 给服务端排查。
 
 ## 参考
 

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark-wiki
-version: 1.0.1
+version: 1.0.2
 description: "飞书知识库：管理知识空间、空间成员和文档节点。创建和查询知识空间、查看和管理空间成员、管理节点层级结构、在知识库中组织文档和快捷方式。当用户需要在知识库中查找或创建文档、浏览知识空间结构、查看或管理空间成员、移动或复制节点时使用。当用户给出 doubao.com 的 /wiki/ URL/token 时，也应直接使用本 skill，不要因为域名不是飞书而回退到 WebFetch；路由依据是 URL 路径模式和 token，而不是域名。不负责：上传文件到知识库节点下（走 lark-drive）、编辑文档/表格/Base 内容（走 lark-doc / lark-sheets / lark-base）。"
 metadata:
   requires:
@@ -34,6 +34,8 @@ metadata:
   - 用户明确选定后再执行 `lark-cli wiki +delete-space --space-id <ID> --yes`（高风险写操作，必须显式 `--yes`）。
   - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki spaces get_node` 解析出 `data.node.space_id` 再传。
 - 用户要在知识库中创建新节点，优先使用 `lark-cli wiki +node-create`。
+- 用户要列出 Wiki 节点：先用 `wiki +space-list --as user` 拿数字 `space_id`，再用 `wiki +node-list --space-id <space_id>`。不要把 wiki URL、node token、doc token、名称直接当 `--space-id`。钻子节点时 `--parent-node-token` 必须是 wiki node token；如果用户给的是 docx/sheet/base URL，先用 `wiki +node-get --node-token <url>` 解析出 `node_token`。
+- `wiki +node-list` 命中 `invalid_parameters`、`not_found`、`permission_denied` 时，不要重复调用同一参数；按 hint 修 `space_id` / `parent_node_token` / 权限。只有 `rate_limit` 才做退避重试。
 - 用户说“给知识库添加成员/管理员”：先把目标解析成“用户 / 群 / 部门 / 应用”四类之一，再决定 `--member-type`，不要先调 `wiki +member-add` 再根据报错反推类型。
 - 用户说“部门 + bot”：这是已知不支持路径。不要继续尝试 `wiki +member-add --as bot`；直接提示必须改成 `--as user`，或明确告知当前要求无法完成。
 - 用户说“用户 / 群 / 应用 + 添加成员”：先解析对应 ID，再执行 `wiki +member-add`。

--- a/skills/lark-wiki/references/lark-wiki-node-list.md
+++ b/skills/lark-wiki/references/lark-wiki-node-list.md
@@ -11,6 +11,9 @@ lark-cli wiki +node-list --space-id <SPACE_ID>
 # Drill into a sub-directory (still single page by default)
 lark-cli wiki +node-list --space-id <SPACE_ID> --parent-node-token <NODE_TOKEN>
 
+# Drill with a wiki URL (CLI normalizes /wiki/<token> to node_token)
+lark-cli wiki +node-list --space-id <SPACE_ID> --parent-node-token "https://feishu.cn/wiki/wikcn_xxx"
+
 # Personal document library (user identity only)
 lark-cli wiki +node-list --space-id my_library --as user
 
@@ -31,8 +34,8 @@ lark-cli wiki +node-list --space-id <SPACE_ID> --format pretty
 
 | Flag | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `--space-id` | string | **Yes** | — | Wiki space ID. Use `my_library` for personal document library (user only) |
-| `--parent-node-token` | string | No | — | Parent node token; omit to list the space root |
+| `--space-id` | string | **Yes** | — | Numeric wiki space ID. Use `my_library` for personal document library (user only) |
+| `--parent-node-token` | string | No | — | Parent wiki node token, or a `/wiki/<token>` URL; omit to list the space root |
 | `--page-size` | int | No | 50 | Page size, 1-50 |
 | `--page-token` | string | No | — | Page cursor; implies single-page fetch (no auto-pagination) |
 | `--page-all` | bool | No | `false` | Automatically paginate through all pages (capped by `--page-limit`) |
@@ -82,6 +85,10 @@ lark-cli wiki +node-list --space-id 6946843325487912356 --parent-node-token wikc
 ## Notes
 
 - `--space-id my_library` is a per-user alias and only valid with `--as user`. The shortcut will refuse `--as bot` with `my_library` upfront.
+- `--space-id` is a numeric wiki `space_id`. Do not pass a wiki URL, wiki node token, document token, or title. Use `lark-cli wiki +space-list --as user` to discover it.
+- `--parent-node-token` must resolve to a wiki node token. If you have a docx/sheet/base/file URL, first run `lark-cli wiki +node-get --node-token <url>` and use the returned `node_token`.
+- Treat `invalid_parameters` (`space_id is not int`, `invalid page_token`), `not_found` (`node not found by parent node token`), and `permission_denied` as terminal for the current arguments. Fix the argument or permission before retrying.
+- For `rate_limit`, stop immediate retries and retry later with exponential backoff or a smaller `--page-limit`.
 
 ## Required Scope
 


### PR DESCRIPTION
## Summary
- improve agent-facing error guidance for high-noise Drive, Markdown, and Wiki shortcut failures
- classify Drive upload/delete and Wiki list failures into more precise terminal/retryable categories with actionable hints
- add target URL/token normalization and local validation for `markdown +create` and `wiki +node-list`
- update skill docs so agents stop retrying terminal errors and fix parameters/permissions instead

## Context
Failure telemetry showed several repeated agent error patterns:
- `drive +push`: missing parent folders and delete-remote already-deleted responses caused noisy hard failures
- `markdown +create`: agents mixed folder/wiki/document tokens, retried quota/not-found/server failures without enough guidance
- `wiki +node-list`: agents passed wiki URLs, node tokens, document tokens, or stale page tokens where numeric `space_id` / wiki `node_token` were required

This PR turns those cases into clearer CLI behavior:
- terminal parameter/resource/permission failures get explicit recovery hints
- retryable rate-limit/server failures remain retryable and recommend backoff
- obvious token/URL mismatches are rejected before calling OpenAPI

## Tests
- `go test ./shortcuts/drive ./internal/errclass`
- `go test ./shortcuts/drive ./internal/errclass ./internal/qualitygate/skillscan ./internal/skillcontent`
- `go test ./shortcuts/wiki ./shortcuts/markdown ./internal/errclass ./internal/qualitygate/skillscan ./internal/skillcontent`

## Notes
- A broader run of `go test ./internal/qualitygate/... ./internal/skillcontent/... ./shortcuts/drive ./internal/errclass` still fails in `internal/qualitygate/cmd/manifest-export` because the existing command index test cannot find `drive file.comments create_v2`; the affected packages above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `drive push`, `drive pull`, and `drive sync` now stop immediately on terminal errors and report `aborted` in the summary.
  * `markdown +create` and wiki/markdown targeting now accept supported folder/wiki URLs and normalize them automatically.
* **Bug Fixes**
  * Treats Drive “already deleted” responses (`1061007`) as idempotent success (`action: already_deleted`) during `--delete-remote`.
  * Improves handling when destination parents are missing during Drive upload (adds per-item hints and aborts the run).
  * Enhances wiki `+node-list` parsing, validation, and error hints (space IDs and parent-node tokens), including stale/invalid cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->