### PR TITLE
chore: release v1.0.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.66] - 2026-07-07
+
+### Features
+
+- support semantic recurring calendar operations (#1723)
+- minute wait (#1768)
+
+### Bug Fixes
+
+- guide drive import concurrency conflicts (#1751)
+- **calendar**: guide approval room booking fallback (#1637)
+- support pnpm global installs in self-update (#1705)
+- resolve schema against runtime metadata in plugin builds; gate cache overlay by version (#1764)
+
+### Documentation
+
+- tighten doc creation validation workflow (#1759)
+- clarify success envelope contract — judge success by ok, not code (#1730)
+
+### Refactoring
+
+- **envvars**: consolidate agent env value access (#1757)
+
+### Misc
+
+- Improve agent-facing error guidance for drive, markdown, and wiki (#1779)
+
 ## [v1.0.65] - 2026-07-03
 
 ### Features
@@ -1371,6 +1398,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.66]: https://github.com/larksuite/cli/releases/tag/v1.0.66
 [v1.0.65]: https://github.com/larksuite/cli/releases/tag/v1.0.65
 [v1.0.64]: https://github.com/larksuite/cli/releases/tag/v1.0.64
 [v1.0.62]: https://github.com/larksuite/cli/releases/tag/v1.0.62

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.65` |
| Release version | `1.0.66` |
| Tag | `v1.0.66` |
| Branch | `release/v1.0.66` |
| Date | `2026-07-07` |

## Changes

- fix: guide drive import concurrency conflicts (#1751)
- feat: support semantic recurring calendar operations (#1723)
- fix(calendar): guide approval room booking fallback (#1637)
- docs: tighten doc creation validation workflow (#1759)
- docs: clarify success envelope contract — judge success by ok, not code (#1730)
- fix: support pnpm global installs in self-update (#1705)
- refactor(envvars): consolidate agent env value access (#1757)
- fix: resolve schema against runtime metadata in plugin builds; gate cache overlay by version (#1764)
- feat: minute wait (#1768)
- Improve agent-facing error guidance for drive, markdown, and wiki (#1779)

## Files Changed

- `package.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release entry for version 1.0.66 with updated release notes.
  * Added the matching release tag reference in the changelog.
* **Chores**
  * Bumped the package version from 1.0.65 to 1.0.66.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->