### PR TITLE
feat: support whiteboard file inputs in docs XML

### DIFF
--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -259,25 +259,19 @@ func prepareWhiteboardWriteContent(runtime *common.RuntimeContext, format string
 		return rewrite(content)
 	}
 
-	var (
-		out strings.Builder
-		err error
-	)
-	out.WriteString(applyOutsideCodeFences(content, func(segment string) string {
-		if err != nil {
-			return segment
-		}
+	var rewriteErrs []error
+	out := applyOutsideCodeFences(content, func(segment string) string {
 		outSegment, rewriteErr := rewrite(segment)
 		if rewriteErr != nil {
-			err = rewriteErr
+			rewriteErrs = append(rewriteErrs, rewriteErr)
 			return segment
 		}
 		return outSegment
-	}))
-	if err != nil {
-		return "", err
+	})
+	if len(rewriteErrs) > 0 {
+		return "", aggregateWhiteboardRewriteErrors(rewriteErrs)
 	}
-	return out.String(), nil
+	return out, nil
 }
 
 func rewriteWhiteboardFileRefs(runtime *common.RuntimeContext, content string) (string, error) {
@@ -399,7 +393,10 @@ func readWhiteboardPath(runtime *common.RuntimeContext, pathValue string, typ st
 	}
 	data, err := cmdutil.ReadInputFile(runtime.FileIO(), clean)
 	if err != nil {
-		return "", common.ValidationErrorf("whiteboard %s path %q cannot be read from the current working directory; check that the file exists relative to where lark-cli is running: %v", typ, clean, err).WithParam("path").WithCause(err)
+		return "", common.ValidationErrorf("whiteboard %s path %q cannot be read from the current working directory; check that the file exists relative to where lark-cli is running: %v", typ, clean, err).
+			WithParam("path").
+			WithParams(errs.InvalidParam{Name: clean, Reason: fmt.Sprintf("whiteboard %s path cannot be read", typ)}).
+			WithCause(err)
 	}
 	return string(data), nil
 }
@@ -446,11 +443,49 @@ func whiteboardContentForType(typ string, data string) string {
 }
 
 func aggregateWhiteboardRewriteErrors(rewriteErrs []error) error {
-	messages := make([]string, 0, len(rewriteErrs))
-	for _, err := range rewriteErrs {
+	flatErrs := flattenWhiteboardRewriteErrors(rewriteErrs)
+	messages := make([]string, 0, len(flatErrs))
+	params := make([]errs.InvalidParam, 0, len(flatErrs))
+	for _, err := range flatErrs {
 		messages = append(messages, err.Error())
+		params = append(params, whiteboardInvalidParamsFromError(err)...)
 	}
-	return common.ValidationErrorf("whiteboard file input failed: %s", strings.Join(messages, "; ")).WithParam("whiteboard").WithCause(errors.Join(rewriteErrs...))
+	validationErr := common.ValidationErrorf("whiteboard file input failed: %s", strings.Join(messages, "; ")).
+		WithParam("whiteboard").
+		WithCause(errors.Join(flatErrs...))
+	if len(params) > 0 {
+		validationErr.WithParams(params...)
+	}
+	return validationErr
+}
+
+func flattenWhiteboardRewriteErrors(rewriteErrs []error) []error {
+	flatErrs := make([]error, 0, len(rewriteErrs))
+	for _, err := range rewriteErrs {
+		var validationErr *errs.ValidationError
+		if errors.As(err, &validationErr) && validationErr.Param == "whiteboard" && validationErr.Cause != nil {
+			if joined, ok := validationErr.Cause.(interface{ Unwrap() []error }); ok {
+				flatErrs = append(flatErrs, flattenWhiteboardRewriteErrors(joined.Unwrap())...)
+				continue
+			}
+		}
+		flatErrs = append(flatErrs, err)
+	}
+	return flatErrs
+}
+
+func whiteboardInvalidParamsFromError(err error) []errs.InvalidParam {
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		return nil
+	}
+	if len(validationErr.Params) > 0 {
+		return validationErr.Params
+	}
+	if validationErr.Param != "" {
+		return []errs.InvalidParam{{Name: validationErr.Param, Reason: validationErr.Message}}
+	}
+	return nil
 }
 
 func validateHTML5BlockWriteElementBodies(format string, content string) error {

--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -27,12 +27,17 @@ const (
 	html5BlockDataAttr        = "data"
 	html5BlockReferenceRoot   = "doc-fetch-resources"
 	html5BlockReferenceMaxRaw = 1024
+
+	whiteboardTag      = "whiteboard"
+	whiteboardTypeAttr = "type"
+	whiteboardPathAttr = "path"
 )
 
 var (
 	html5BlockStartTagPattern = regexp.MustCompile(`(?is)<html5-block\b[^>]*>`)
 	html5BlockElementPattern  = regexp.MustCompile(`(?is)<html5-block\b[^>]*>(.*?)</html5-block>`)
 	html5BlockSafeNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	whiteboardElementPattern  = regexp.MustCompile(`(?is)<whiteboard\b[^>]*(?:/>|>.*?</whiteboard>)`)
 )
 
 type html5BlockReferenceEntry struct {
@@ -54,6 +59,11 @@ type html5BlockAttr struct {
 }
 
 type html5BlockStartTag struct {
+	Attrs       []html5BlockAttr
+	SelfClosing bool
+}
+
+type whiteboardStartTag struct {
 	Attrs       []html5BlockAttr
 	SelfClosing bool
 }
@@ -115,7 +125,11 @@ func prepareDocsV2WriteInput(runtime *common.RuntimeContext, input docsV2WriteIn
 		return docsV2WriteInput{}, err
 	}
 
-	content, html5RefMap, err := prepareHTML5BlockWriteContent(runtime, runtime.Str("doc-format"), input.Content, html5RefMap)
+	content, err := prepareWhiteboardWriteContent(runtime, runtime.Str("doc-format"), input.Content)
+	if err != nil {
+		return docsV2WriteInput{}, err
+	}
+	content, html5RefMap, err = prepareHTML5BlockWriteContent(runtime, runtime.Str("doc-format"), content, html5RefMap)
 	if err != nil {
 		return docsV2WriteInput{}, err
 	}
@@ -230,6 +244,213 @@ func prepareHTML5BlockWriteContent(runtime *common.RuntimeContext, format string
 		return "", nil, err
 	}
 	return out, compactReferenceMap(refMap), nil
+}
+
+func prepareWhiteboardWriteContent(runtime *common.RuntimeContext, format string, content string) (string, error) {
+	if !strings.Contains(content, "<whiteboard") {
+		return content, nil
+	}
+
+	rewrite := func(segment string) (string, error) {
+		return rewriteWhiteboardFileRefs(runtime, segment)
+	}
+
+	if strings.TrimSpace(format) != "markdown" {
+		return rewrite(content)
+	}
+
+	var (
+		out strings.Builder
+		err error
+	)
+	out.WriteString(applyOutsideCodeFences(content, func(segment string) string {
+		if err != nil {
+			return segment
+		}
+		outSegment, rewriteErr := rewrite(segment)
+		if rewriteErr != nil {
+			err = rewriteErr
+			return segment
+		}
+		return outSegment
+	}))
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+func rewriteWhiteboardFileRefs(runtime *common.RuntimeContext, content string) (string, error) {
+	var rewriteErrs []error
+	out := whiteboardElementPattern.ReplaceAllStringFunc(content, func(raw string) string {
+		rewritten, err := rewriteWhiteboardFileRef(runtime, raw)
+		if err != nil {
+			rewriteErrs = append(rewriteErrs, err)
+			return raw
+		}
+		return rewritten
+	})
+	if len(rewriteErrs) > 0 {
+		return "", aggregateWhiteboardRewriteErrors(rewriteErrs)
+	}
+	return out, nil
+}
+
+func rewriteWhiteboardFileRef(runtime *common.RuntimeContext, raw string) (string, error) {
+	startRaw, body, _, ok := splitWhiteboardElement(raw)
+	if !ok {
+		return raw, nil
+	}
+	tag, err := parseWhiteboardStartTag(startRaw)
+	if err != nil {
+		return "", common.ValidationErrorf("invalid whiteboard tag: %v", err).WithParam("whiteboard")
+	}
+
+	pathValue, hasPath := tag.attr(whiteboardPathAttr)
+	bodyPath, hasBodyPath := whiteboardBodyPathRef(body)
+	if !hasPath && !hasBodyPath {
+		return raw, nil
+	}
+	if hasPath && strings.TrimSpace(body) != "" {
+		return "", common.ValidationErrorf("whiteboard cannot contain both path and inline content").WithParam("whiteboard")
+	}
+	if hasPath && hasBodyPath {
+		return "", common.ValidationErrorf("whiteboard cannot contain both path and @file body").WithParam("whiteboard")
+	}
+
+	typRaw, ok := tag.attr(whiteboardTypeAttr)
+	if !ok || strings.TrimSpace(typRaw) == "" {
+		return "", common.ValidationErrorf("whiteboard file input requires type=\"svg\", type=\"mermaid\", or type=\"plantuml\"").WithParam("type")
+	}
+	typ, ok := canonicalWhiteboardFileType(typRaw)
+	if !ok {
+		return "", common.ValidationErrorf("whiteboard file input only supports type=\"svg\", type=\"mermaid\", or type=\"plantuml\", got %q", typRaw).WithParam("type")
+	}
+
+	if hasBodyPath {
+		pathValue = bodyPath
+	}
+	data, err := readWhiteboardPath(runtime, pathValue, typ)
+	if err != nil {
+		return "", err
+	}
+
+	tag.setAttr(whiteboardTypeAttr, typ)
+	tag.removeAttrs(whiteboardPathAttr)
+	return tag.render(false) + whiteboardContentForType(typ, data) + "</" + whiteboardTag + ">", nil
+}
+
+func splitWhiteboardElement(raw string) (startTag string, body string, selfClosing bool, ok bool) {
+	trimmed := strings.TrimSpace(raw)
+	selfClosing = strings.HasSuffix(trimmed, "/>")
+	if selfClosing {
+		return raw, "", true, true
+	}
+	startEnd := strings.Index(raw, ">")
+	if startEnd < 0 {
+		return "", "", false, false
+	}
+	endStart := strings.LastIndex(strings.ToLower(raw), "</whiteboard>")
+	if endStart < 0 || endStart < startEnd {
+		return "", "", false, false
+	}
+	return raw[:startEnd+1], raw[startEnd+1 : endStart], false, true
+}
+
+func whiteboardBodyPathRef(body string) (string, bool) {
+	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "@") || strings.HasPrefix(trimmed, "@@") {
+		return "", false
+	}
+	if strings.ContainsAny(trimmed, "\r\n") {
+		return "", false
+	}
+	return trimmed, true
+}
+
+func canonicalWhiteboardFileType(raw string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "svg":
+		return "svg", true
+	case "mermaid":
+		return "mermaid", true
+	case "plantuml":
+		return "plantuml", true
+	default:
+		return "", false
+	}
+}
+
+func readWhiteboardPath(runtime *common.RuntimeContext, pathValue string, typ string) (string, error) {
+	pathRaw := strings.TrimSpace(pathValue)
+	if !strings.HasPrefix(pathRaw, "@") {
+		return "", common.ValidationErrorf("whiteboard %s path %q must start with @, for example @diagram.%s", typ, pathValue, exampleWhiteboardExt(typ)).WithParam("path")
+	}
+	relPath := strings.TrimSpace(strings.TrimPrefix(pathRaw, "@"))
+	if relPath == "" {
+		return "", common.ValidationErrorf("whiteboard %s path cannot be empty after @", typ).WithParam("path")
+	}
+	clean := filepath.Clean(relPath)
+	if filepath.IsAbs(clean) || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", common.ValidationErrorf("whiteboard %s path %q must be a relative path within the current working directory", typ, pathValue).WithParam("path")
+	}
+	if !whiteboardExtAllowed(typ, strings.ToLower(filepath.Ext(clean))) {
+		return "", common.ValidationErrorf("whiteboard %s path %q must point to a %s file", typ, pathValue, whiteboardExtList(typ)).WithParam("path")
+	}
+	data, err := cmdutil.ReadInputFile(runtime.FileIO(), clean)
+	if err != nil {
+		return "", common.ValidationErrorf("whiteboard %s path %q cannot be read from the current working directory; check that the file exists relative to where lark-cli is running: %v", typ, clean, err).WithParam("path").WithCause(err)
+	}
+	return string(data), nil
+}
+
+func whiteboardExtAllowed(typ string, ext string) bool {
+	for _, allowed := range whiteboardAllowedExts(typ) {
+		if ext == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func whiteboardAllowedExts(typ string) []string {
+	switch typ {
+	case "svg":
+		return []string{".svg"}
+	case "mermaid":
+		return []string{".mermaid", ".mmd"}
+	case "plantuml":
+		return []string{".plantuml", ".puml", ".pu", ".uml"}
+	default:
+		return nil
+	}
+}
+
+func whiteboardExtList(typ string) string {
+	return strings.Join(whiteboardAllowedExts(typ), ", ")
+}
+
+func exampleWhiteboardExt(typ string) string {
+	exts := whiteboardAllowedExts(typ)
+	if len(exts) == 0 {
+		return "txt"
+	}
+	return strings.TrimPrefix(exts[0], ".")
+}
+
+func whiteboardContentForType(typ string, data string) string {
+	if typ == "svg" {
+		return data
+	}
+	return escapeXMLText(data)
+}
+
+func aggregateWhiteboardRewriteErrors(rewriteErrs []error) error {
+	messages := make([]string, 0, len(rewriteErrs))
+	for _, err := range rewriteErrs {
+		messages = append(messages, err.Error())
+	}
+	return common.ValidationErrorf("whiteboard file input failed: %s", strings.Join(messages, "; ")).WithParam("whiteboard").WithCause(errors.Join(rewriteErrs...))
 }
 
 func validateHTML5BlockWriteElementBodies(format string, content string) error {
@@ -621,7 +842,44 @@ func parseHTML5BlockStartTag(raw string) (html5BlockStartTag, error) {
 	return html5BlockStartTag{}, fmt.Errorf("missing start element") //nolint:forbidigo // intermediate parse helper; callers wrap with typed validation errors.
 }
 
+func parseWhiteboardStartTag(raw string) (whiteboardStartTag, error) {
+	trimmed := strings.TrimSpace(raw)
+	selfClosing := strings.HasSuffix(trimmed, "/>")
+	decoder := xml.NewDecoder(strings.NewReader(raw))
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return whiteboardStartTag{}, err
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if start.Name.Local != whiteboardTag {
+			return whiteboardStartTag{}, fmt.Errorf("expected <%s>, got <%s>", whiteboardTag, start.Name.Local) //nolint:forbidigo // intermediate parse helper; callers wrap with typed validation errors.
+		}
+		attrs := make([]html5BlockAttr, 0, len(start.Attr))
+		for _, attr := range start.Attr {
+			attrs = append(attrs, html5BlockAttr{Name: attr.Name.Local, Value: attr.Value})
+		}
+		return whiteboardStartTag{Attrs: attrs, SelfClosing: selfClosing}, nil
+	}
+	return whiteboardStartTag{}, fmt.Errorf("missing start element") //nolint:forbidigo // intermediate parse helper; callers wrap with typed validation errors.
+}
+
 func (t html5BlockStartTag) attr(name string) (string, bool) {
+	for _, attr := range t.Attrs {
+		if attr.Name == name {
+			return attr.Value, true
+		}
+	}
+	return "", false
+}
+
+func (t whiteboardStartTag) attr(name string) (string, bool) {
 	for _, attr := range t.Attrs {
 		if attr.Name == name {
 			return attr.Value, true
@@ -650,6 +908,31 @@ func (t *html5BlockStartTag) removeAttrs(names ...string) {
 	t.Attrs = attrs
 }
 
+func (t *whiteboardStartTag) removeAttrs(names ...string) {
+	remove := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		remove[name] = struct{}{}
+	}
+	attrs := t.Attrs[:0]
+	for _, attr := range t.Attrs {
+		if _, ok := remove[attr.Name]; ok {
+			continue
+		}
+		attrs = append(attrs, attr)
+	}
+	t.Attrs = attrs
+}
+
+func (t *whiteboardStartTag) setAttr(name string, value string) {
+	for i, attr := range t.Attrs {
+		if attr.Name == name {
+			t.Attrs[i].Value = value
+			return
+		}
+	}
+	t.Attrs = append(t.Attrs, html5BlockAttr{Name: name, Value: value})
+}
+
 func (t html5BlockStartTag) render(selfClosing bool) string {
 	var b strings.Builder
 	b.WriteByte('<')
@@ -674,6 +957,25 @@ func (t html5BlockStartTag) render(selfClosing bool) string {
 	return b.String()
 }
 
+func (t whiteboardStartTag) render(selfClosing bool) string {
+	var b strings.Builder
+	b.WriteByte('<')
+	b.WriteString(whiteboardTag)
+	for _, attr := range t.Attrs {
+		b.WriteByte(' ')
+		b.WriteString(attr.Name)
+		b.WriteString(`="`)
+		b.WriteString(escapeXMLAttr(attr.Value))
+		b.WriteByte('"')
+	}
+	if selfClosing {
+		b.WriteString("/>")
+	} else {
+		b.WriteByte('>')
+	}
+	return b.String()
+}
+
 func escapeXMLAttr(value string) string {
 	var b strings.Builder
 	for _, r := range value {
@@ -688,6 +990,21 @@ func escapeXMLAttr(value string) string {
 			b.WriteString("&quot;")
 		case '\'':
 			b.WriteString("&apos;")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func escapeXMLText(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		switch r {
+		case '&':
+			b.WriteString("&amp;")
+		case '<':
+			b.WriteString("&lt;")
 		default:
 			b.WriteRune(r)
 		}

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -116,6 +116,61 @@ func TestDocsCreateV2HTML5BlockReferenceMapFromPath(t *testing.T) {
 	}
 }
 
+func TestDocsCreateV2WhiteboardFileInputs(t *testing.T) {
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+	files := map[string]string{
+		"diagram.svg":   `<svg viewBox="0 0 10 10"><text>A</text></svg>`,
+		"flow.mmd":      "flowchart TD\nA --> B",
+		"sequence.puml": "@startuml\nAlice -> Bob: hi\n@enduml",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(name, []byte(content), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s) error: %v", name, err)
+		}
+	}
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
+	stub := registerDocsAIStub(reg, "POST", "/open-apis/docs_ai/v1/documents", map[string]interface{}{
+		"document": map[string]interface{}{
+			"document_id": "doxcn_new_doc",
+			"revision_id": float64(1),
+		},
+	})
+
+	err := runDocsCreateShortcut(t, f, stdout, []string{
+		"+create",
+		"--api-version", "v2",
+		"--content", strings.Join([]string{
+			`<whiteboard type="svg" path="@diagram.svg"></whiteboard>`,
+			`<whiteboard type="mermaid">@flow.mmd</whiteboard>`,
+			`<whiteboard type="plantUML" path="@sequence.puml"/>`,
+		}, "\n"),
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := decodeRequestBody(t, stub.CapturedBody)
+	got := body["content"].(string)
+	for _, want := range []string{
+		`<whiteboard type="svg"><svg viewBox="0 0 10 10"><text>A</text></svg></whiteboard>`,
+		"<whiteboard type=\"mermaid\">flowchart TD\nA --> B</whiteboard>",
+		"<whiteboard type=\"plantuml\">@startuml\nAlice -> Bob: hi\n@enduml</whiteboard>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("content missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `path="@`) {
+		t.Fatalf("content still contains whiteboard path attr: %s", got)
+	}
+	if _, ok := body["reference_map"]; ok {
+		t.Fatalf("whiteboard file input must not create reference_map: %#v", body)
+	}
+}
+
 func findDocsTestFlag(flags []common.Flag, name string) common.Flag {
 	for _, flag := range flags {
 		if flag.Name == name {
@@ -404,6 +459,35 @@ func TestDocsCreateV2HTML5BlockPathReadFailure(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), `html5-block path "missing.html" cannot be read from the current working directory`) {
 		t.Fatalf("expected path read error, got: %v", err)
+	}
+}
+
+func TestDocsCreateV2WhiteboardFileInputReportsAllMissingPaths(t *testing.T) {
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+	f, stdout, _, _ := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
+
+	err := runDocsCreateShortcut(t, f, stdout, []string{
+		"+create",
+		"--api-version", "v2",
+		"--content", strings.Join([]string{
+			`<whiteboard type="svg" path="@missing.svg"></whiteboard>`,
+			`<whiteboard type="mermaid">@missing.mmd</whiteboard>`,
+			`<whiteboard type="plantuml" path="@missing.puml"></whiteboard>`,
+		}, "\n"),
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected aggregated whiteboard path error")
+	}
+	for _, want := range []string{
+		`whiteboard svg path "missing.svg" cannot be read`,
+		`whiteboard mermaid path "missing.mmd" cannot be read`,
+		`whiteboard plantuml path "missing.puml" cannot be read`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q:\n%v", want, err)
+		}
 	}
 }
 

--- a/shortcuts/doc/html5_block_resources_test.go
+++ b/shortcuts/doc/html5_block_resources_test.go
@@ -6,11 +6,13 @@ package doc
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -480,13 +482,97 @@ func TestDocsCreateV2WhiteboardFileInputReportsAllMissingPaths(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected aggregated whiteboard path error")
 	}
-	for _, want := range []string{
+	assertWhiteboardFileInputValidation(t, err, []string{
+		"missing.svg",
+		"missing.mmd",
+		"missing.puml",
+	}, []string{
 		`whiteboard svg path "missing.svg" cannot be read`,
 		`whiteboard mermaid path "missing.mmd" cannot be read`,
 		`whiteboard plantuml path "missing.puml" cannot be read`,
-	} {
+	})
+}
+
+func TestDocsCreateV2WhiteboardFileInputMarkdownReportsMissingPathsAcrossFences(t *testing.T) {
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+	f, stdout, _, _ := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
+
+	err := runDocsCreateShortcut(t, f, stdout, []string{
+		"+create",
+		"--api-version", "v2",
+		"--doc-format", "markdown",
+		"--content", strings.Join([]string{
+			`<whiteboard type="svg" path="@before.svg"></whiteboard>`,
+			"```",
+			`<whiteboard type="svg" path="@inside.svg"></whiteboard>`,
+			"```",
+			`<whiteboard type="plantuml" path="@after.puml"></whiteboard>`,
+		}, "\n"),
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected aggregated whiteboard path error")
+	}
+	assertWhiteboardFileInputValidation(t, err, []string{
+		"before.svg",
+		"after.puml",
+	}, []string{
+		`whiteboard svg path "before.svg" cannot be read`,
+		`whiteboard plantuml path "after.puml" cannot be read`,
+	})
+	if strings.Contains(err.Error(), "inside.svg") {
+		t.Fatalf("error should ignore fenced whiteboard path, got: %v", err)
+	}
+}
+
+func assertWhiteboardFileInputValidation(t *testing.T, err error, wantParams []string, wantMessages []string) {
+	t.Helper()
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T %v", err, err)
+	}
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("category/subtype = %s/%s, want %s/%s", problem.Category, problem.Subtype, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+	}
+
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T %v", err, err)
+	}
+	if validationErr.Param != "whiteboard" {
+		t.Fatalf("param = %q, want whiteboard", validationErr.Param)
+	}
+	if validationErr.Cause == nil {
+		t.Fatal("expected aggregated error to preserve cause")
+	}
+	var childValidationErr *errs.ValidationError
+	if !errors.As(validationErr.Cause, &childValidationErr) || childValidationErr.Cause == nil {
+		t.Fatalf("expected child validation cause to preserve file read cause, got %#v", validationErr.Cause)
+	}
+
+	gotParams := make(map[string]string, len(validationErr.Params))
+	for _, param := range validationErr.Params {
+		gotParams[param.Name] = param.Reason
+	}
+	if len(gotParams) != len(wantParams) {
+		t.Fatalf("params = %#v, want names %v", validationErr.Params, wantParams)
+	}
+	for _, param := range wantParams {
+		reason, ok := gotParams[param]
+		if !ok {
+			t.Fatalf("params = %#v, want name %q", validationErr.Params, param)
+		}
+		if reason == "" {
+			t.Fatalf("param %q missing reason: %#v", param, validationErr.Params)
+		}
+	}
+	for _, want := range wantMessages {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error missing %q:\n%v", want, err)
+		}
+		if !strings.Contains(validationErr.Cause.Error(), want) {
+			t.Fatalf("cause missing %q:\n%v", want, validationErr.Cause)
 		}
 	}
 }

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: lark-doc
+version: 2.0.0
 description: "飞书云文档（Docx / Wiki 文档）：读取和编辑飞书文档内容。当用户给出文档 URL 或 token，或需要查看、创建、编辑文档、插入或下载文档图片附件时使用。文档中嵌入的电子表格、多维表格、画板，先用本 skill 提取 token 再切到对应 skill。当用户给出 doubao.com 的 /docx/ 或 /wiki/ URL/token 时，也应直接使用本 skill；路由依据是 URL 路径模式和 token，而不是域名。不负责文档评论管理，也不负责表格或 Base 的数据操作。当用户明确要操作飞书思维笔记时，也使用本 skill。"
 metadata:
   requires:

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: lark-doc
-version: 2.0.0
 description: "飞书云文档（Docx / Wiki 文档）：读取和编辑飞书文档内容。当用户给出文档 URL 或 token，或需要查看、创建、编辑文档、插入或下载文档图片附件时使用。文档中嵌入的电子表格、多维表格、画板，先用本 skill 提取 token 再切到对应 skill。当用户给出 doubao.com 的 /docx/ 或 /wiki/ URL/token 时，也应直接使用本 skill；路由依据是 URL 路径模式和 token，而不是域名。不负责文档评论管理，也不负责表格或 Base 的数据操作。当用户明确要操作飞书思维笔记时，也使用本 skill。"
 metadata:
   requires:

--- a/skills/lark-doc/references/lark-doc-whiteboard.md
+++ b/skills/lark-doc/references/lark-doc-whiteboard.md
@@ -44,6 +44,8 @@ SubAgent 插入 SVG。
 </whiteboard>
 ```
 
+如果 Mermaid 已在本地文件中，可写成 `<whiteboard type="mermaid">@diagram.mmd</whiteboard>` 或 `<whiteboard type="mermaid" path="@diagram.mermaid"></whiteboard>`；CLI 会在写入前读取文件并展开为内联内容。
+
 ### 步骤 2B: SubAgent 使用 SVG 插入图表
 
 主 Agent 启动 SubAgent，让它用 `docs +create` / `docs +update` 插入：
@@ -55,6 +57,8 @@ SubAgent 插入 SVG。
     </svg>
 </whiteboard>
 ```
+
+如果 SVG 已在本地文件中，可写成 `<whiteboard type="svg" path="@diagram.svg"></whiteboard>`；PlantUML 文件同理使用 `<whiteboard type="plantuml" path="@sequence.puml"></whiteboard>` 或 `<whiteboard type="plantuml">@sequence.plantuml</whiteboard>`。
 
 Sub Agent 需要携带以下的最小上下文，以及后续的 [SVG 设计 Workflow] 章节指南：
 

--- a/skills/lark-doc/references/lark-doc-whiteboard.md
+++ b/skills/lark-doc/references/lark-doc-whiteboard.md
@@ -44,7 +44,7 @@ SubAgent 插入 SVG。
 </whiteboard>
 ```
 
-如果 Mermaid 已在本地文件中，可写成 `<whiteboard type="mermaid">@diagram.mmd</whiteboard>` 或 `<whiteboard type="mermaid" path="@diagram.mermaid"></whiteboard>`；CLI 会在写入前读取文件并展开为内联内容。
+如果 Mermaid 已在本地文件中，可写成 `<whiteboard type="mermaid" path="@diagram.mmd"></whiteboard>`；CLI 会在写入前读取文件并展开为内联内容。
 
 ### 步骤 2B: SubAgent 使用 SVG 插入图表
 
@@ -58,7 +58,7 @@ SubAgent 插入 SVG。
 </whiteboard>
 ```
 
-如果 SVG 已在本地文件中，可写成 `<whiteboard type="svg" path="@diagram.svg"></whiteboard>`；PlantUML 文件同理使用 `<whiteboard type="plantuml" path="@sequence.puml"></whiteboard>` 或 `<whiteboard type="plantuml">@sequence.plantuml</whiteboard>`。
+如果 SVG 已在本地文件中，可写成 `<whiteboard type="svg" path="@diagram.svg"></whiteboard>`；PlantUML 文件同理使用 `<whiteboard type="plantuml" path="@sequence.puml"></whiteboard>`。
 
 Sub Agent 需要携带以下的最小上下文，以及后续的 [SVG 设计 Workflow] 章节指南：
 

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -41,7 +41,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 文档中可嵌入外部资源块（属于容器标签的特殊形式），需要额外语法创建：
 
 - `<img>` — `<img href="https://..."/>` 上传网络图片
-- `<whiteboard>` — 简单图由 SubAgent 直接插入 `<whiteboard type="svg">完整自包含 SVG</whiteboard>`；也可用本地文件简写 `<whiteboard type="svg" path="@diagram.svg"></whiteboard>`、`<whiteboard type="mermaid">@flow.mmd</whiteboard>`、`<whiteboard type="plantuml" path="@sequence.puml"></whiteboard>`，CLI 会写入前展开为内联内容；复杂图使用 `<whiteboard type="blank"></whiteboard>` 先创建空白画板，再按 [`lark-doc-whiteboard.md`](lark-doc-whiteboard.md) 启动 SubAgent 调用 `lark-whiteboard` 写入；
+- `<whiteboard>` — 简单图由 SubAgent 直接插入 `<whiteboard type="svg">完整自包含 SVG</whiteboard>`；也可用本地文件简写 `<whiteboard type="svg" path="@diagram.svg"></whiteboard>`、`<whiteboard type="mermaid" path="@flow.mmd"></whiteboard>`、`<whiteboard type="plantuml" path="@sequence.puml"></whiteboard>`，CLI 会写入前展开为内联内容；复杂图使用 `<whiteboard type="blank"></whiteboard>` 先创建空白画板，再按 [`lark-doc-whiteboard.md`](lark-doc-whiteboard.md) 启动 SubAgent 调用 `lark-whiteboard` 写入；
 - `<sheet>` — `<sheet type="blank"></sheet>` 空白；`<sheet sheet-id="SID" token="TOKEN"></sheet>` 复制已有
 - `<task>` — `<task task-id="GUID"></task>`，必传 task-id（任务 guid）
 - `<chat_card>` — `<chat_card chat-id="CHAT_ID"></chat_card>`，必传 chat-id

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -41,7 +41,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 文档中可嵌入外部资源块（属于容器标签的特殊形式），需要额外语法创建：
 
 - `<img>` — `<img href="https://..."/>` 上传网络图片
-- `<whiteboard>` — 简单图由 SubAgent 直接插入 `<whiteboard type="svg">完整自包含 SVG</whiteboard>`；复杂图使用 `<whiteboard type="blank"></whiteboard>` 先创建空白画板，再按 [`lark-doc-whiteboard.md`](lark-doc-whiteboard.md) 启动 SubAgent 调用 `lark-whiteboard` 写入；
+- `<whiteboard>` — 简单图由 SubAgent 直接插入 `<whiteboard type="svg">完整自包含 SVG</whiteboard>`；也可用本地文件简写 `<whiteboard type="svg" path="@diagram.svg"></whiteboard>`、`<whiteboard type="mermaid">@flow.mmd</whiteboard>`、`<whiteboard type="plantuml" path="@sequence.puml"></whiteboard>`，CLI 会写入前展开为内联内容；复杂图使用 `<whiteboard type="blank"></whiteboard>` 先创建空白画板，再按 [`lark-doc-whiteboard.md`](lark-doc-whiteboard.md) 启动 SubAgent 调用 `lark-whiteboard` 写入；
 - `<sheet>` — `<sheet type="blank"></sheet>` 空白；`<sheet sheet-id="SID" token="TOKEN"></sheet>` 复制已有
 - `<task>` — `<task task-id="GUID"></task>`，必传 task-id（任务 guid）
 - `<chat_card>` — `<chat_card chat-id="CHAT_ID"></chat_card>`，必传 chat-id


### PR DESCRIPTION
## Summary
Adds local file expansion for docs XML whiteboard blocks so agents can reference SVG, Mermaid, and PlantUML files with @ paths before sending content to Docs AI.

## Changes
- Expand <whiteboard type="svg|mermaid|plantuml"> file references from path="@..." or body @file into inline whiteboard content.
- Aggregate missing whiteboard file errors after scanning all blocks.
- Document the new file-input shortcuts in lark-doc XML and whiteboard guidance.

## Test Plan
- [x] gofmt -l shortcuts/doc/html5_block_resources.go shortcuts/doc/html5_block_resources_test.go
- [x] go test ./shortcuts/doc -run "TestDocsCreateV2(WhiteboardFileInputs|WhiteboardFileInputReportsAllMissingPaths|HTML5BlockReferenceMapFromPath|HTML5BlockPathReadFailure)"
- [x] go test ./shortcuts/doc
- [x] lark-cli E2E via ccm-e2e-check exec-cli (bot/user 7/7 Pass; report gate passed)
- [ ] skill-creator quick_validate.py skills/lark-doc (blocked by existing `skills/lark-doc/SKILL.md` frontmatter `version`; PR intentionally leaves `SKILL.md` unchanged)

## E2E Result
- Bot identity E2E: 4/4 Pass on BOE via isolated ccm dev env.
- User identity E2E: 3/3 Pass on BOE via isolated ccm dev env.
- Missing-file aggregation validation: Pass.
- Report gate: passed.
- Workflow status: `REQ_ID=lark-cli-whiteboard-at-files-pr1784` recorded as `passed`.
- Local Markdown report: `/Users/bytedance/.ccm-harness/worktrees/lark-cli-whiteboard-at-files/larksuite_cli/.lark-cli-e2e-test/reports/pr-1784-whiteboard-at-files/report.md`
- Local HTML report: `/Users/bytedance/.ccm-harness/worktrees/lark-cli-whiteboard-at-files/larksuite_cli/.lark-cli-e2e-test/reports/pr-1784-whiteboard-at-files/report.html`
- Structured result: `/Users/bytedance/.ccm-harness/worktrees/lark-cli-whiteboard-at-files/larksuite_cli/.lark-cli-e2e-test/reports/pr-1784-whiteboard-at-files/result.json`

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading whiteboard content from local files and inlining it into document writes.
  * Expanded whiteboard handling for SVG, Mermaid, and PlantUML content, including inline file references.

* **Bug Fixes**
  * Improved validation for whiteboard inputs and path formats.
  * Better error reporting when multiple file-backed whiteboards are missing or invalid, including across markdown code fences.

* **Documentation**
  * Updated whiteboard usage examples to show local file-based input options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



