### PR TITLE
fix: accept opaque wiki node tokens

### DIFF
--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -199,6 +199,19 @@ func TestWikiNodeListNormalizesWikiURLParentNodeToken(t *testing.T) {
 	}
 }
 
+func TestWikiNodeListAcceptsOpaqueParentNodeToken(t *testing.T) {
+	t.Parallel()
+
+	const opaqueNodeToken = "Q6ZM_EXAMPLE_TOKEN"
+	token, err := normalizeWikiNodeListParentToken(opaqueNodeToken)
+	if err != nil {
+		t.Fatalf("normalizeWikiNodeListParentToken() error = %v", err)
+	}
+	if token != opaqueNodeToken {
+		t.Fatalf("token = %q, want %q", token, opaqueNodeToken)
+	}
+}
+
 func TestWikiNodeListRejectsAmbiguousSpaceAndParentTokens(t *testing.T) {
 	t.Parallel()
 
@@ -223,11 +236,6 @@ func TestWikiNodeListRejectsAmbiguousSpaceAndParentTokens(t *testing.T) {
 			name:    "partial wiki path",
 			input:   "wik_placeholder/child",
 			wantMsg: "raw wiki node token",
-		},
-		{
-			name:    "document token",
-			input:   "docx_placeholder_parent",
-			wantMsg: "must be a wiki node token",
 		},
 	}
 	for _, tt := range tests {
@@ -351,10 +359,11 @@ func TestWikiNodeListPassesParentNodeToken(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 
 	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+	const parentNodeToken = "Q6ZM_EXAMPLE_TOKEN"
 
 	stub := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/7211568716812369922/nodes?page_size=50&parent_node_token=wik_parent",
+		URL:    "/open-apis/wiki/v2/spaces/7211568716812369922/nodes?page_size=50&parent_node_token=" + parentNodeToken,
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -365,7 +374,7 @@ func TestWikiNodeListPassesParentNodeToken(t *testing.T) {
 						"node_token":        "wik_child",
 						"obj_token":         "docx_child",
 						"obj_type":          "docx",
-						"parent_node_token": "wik_parent",
+						"parent_node_token": parentNodeToken,
 						"node_type":         "origin",
 						"title":             "Child Doc",
 						"has_child":         false,
@@ -378,7 +387,7 @@ func TestWikiNodeListPassesParentNodeToken(t *testing.T) {
 	reg.Register(stub)
 
 	err := mountAndRunWiki(t, WikiNodeList, []string{
-		"+node-list", "--space-id", "7211568716812369922", "--parent-node-token", "wik_parent", "--as", "bot",
+		"+node-list", "--space-id", "7211568716812369922", "--parent-node-token", parentNodeToken, "--as", "bot",
 	}, factory, stdout)
 	if err != nil {
 		t.Fatalf("mountAndRunWiki() error = %v", err)
@@ -400,8 +409,8 @@ func TestWikiNodeListPassesParentNodeToken(t *testing.T) {
 	if len(envelope.Data.Nodes) != 1 {
 		t.Fatalf("len(nodes) = %d, want 1", len(envelope.Data.Nodes))
 	}
-	if envelope.Data.Nodes[0]["parent_node_token"] != "wik_parent" {
-		t.Fatalf("nodes[0].parent_node_token = %v, want %q", envelope.Data.Nodes[0]["parent_node_token"], "wik_parent")
+	if envelope.Data.Nodes[0]["parent_node_token"] != parentNodeToken {
+		t.Fatalf("nodes[0].parent_node_token = %v, want %q", envelope.Data.Nodes[0]["parent_node_token"], parentNodeToken)
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -69,8 +69,8 @@ var WikiNodeGet = common.Shortcut{
 		{Name: "space-id", Desc: "optional: assert the resolved node lives in this space"},
 	},
 	Tips: []string{
-		"--node-token accepts a raw token (wikcnXXX, docxXXX, ...) or a Lark URL like https://feishu.cn/wiki/<token> or https://feishu.cn/docx/<token>.",
-		"For raw obj_tokens (not starting with wik), pass --obj-type so the API knows how to resolve them; URL inputs infer it from the path.",
+		"--node-token accepts a raw wiki node_token, obj_token, or a Lark URL like https://feishu.cn/wiki/<token> or https://feishu.cn/docx/<token>.",
+		"For raw obj_tokens, pass --obj-type so the API knows how to resolve them; URL inputs infer it from the path.",
 		"Pair with +move / +node-copy / +delete-space to confirm space_id, obj_type, and parent before mutating.",
 		"--token is the deprecated original name and still works for backward compatibility; new scripts should use --node-token.",
 	},
@@ -235,29 +235,10 @@ func parseWikiNodeGetSpec(rawToken, rawObjType, rawSpaceID string) (wikiNodeGetS
 		).WithParam("--node-token")
 	} else {
 		spec.Token = tokenInput
-		if looksLikeWikiNodeToken(spec.Token) {
+		if spec.ObjType == "" {
 			spec.SourceKind = "raw-node"
-			// node_tokens take no obj_type; reject a conflicting flag rather
-			// than silently passing it (the API would just ignore it, but the
-			// mismatch signals caller confusion).
-			if spec.ObjType != "" {
-				return wikiNodeGetSpec{}, errs.NewValidationError(errs.SubtypeInvalidArgument,
-					"--obj-type is only valid for obj_tokens; %q looks like a node_token",
-					spec.Token,
-				).WithParam("--obj-type")
-			}
 		} else {
 			spec.SourceKind = "raw-obj"
-			// A raw obj_token needs an explicit obj_type: get_node would
-			// otherwise default to "doc" and fail confusingly for docx /
-			// sheet / bitable / ... Fail fast with the same upfront contract
-			// as +node-delete instead of deferring to an opaque API error.
-			if spec.ObjType == "" {
-				return wikiNodeGetSpec{}, errs.NewValidationError(errs.SubtypeInvalidArgument,
-					"--obj-type is required for a raw obj_token %q (one of: %s); or pass a typed Lark URL (e.g. /docx/<token>) so it can be inferred",
-					spec.Token, strings.Join(wikiNodeGetObjTypeEnum, ", "),
-				).WithParam("--obj-type")
-			}
 		}
 	}
 
@@ -268,18 +249,6 @@ func parseWikiNodeGetSpec(rawToken, rawObjType, rawSpaceID string) (wikiNodeGetS
 		return wikiNodeGetSpec{}, err
 	}
 	return spec, nil
-}
-
-// looksLikeWikiNodeToken returns true when the token has the `wik` prefix used
-// for node_tokens. Lark wiki tokens are case-insensitive in practice; callers
-// pass `wikcn`/`wikus`/`Wik...` interchangeably, so normalize for the check.
-//
-// This is a heuristic based on the current Lark token-naming convention, not a
-// guaranteed invariant: if Lark ever introduces a non-node token type that
-// also starts with `wik`, it would be misclassified. Worst case is a
-// confusing API error (no data risk); revisit if the token scheme changes.
-func looksLikeWikiNodeToken(token string) bool {
-	return strings.HasPrefix(strings.ToLower(token), "wik")
 }
 
 // tokenAndObjTypeFromWikiURL extracts the token and inferred obj_type from a

--- a/shortcuts/wiki/wiki_node_get_test.go
+++ b/shortcuts/wiki/wiki_node_get_test.go
@@ -31,6 +31,22 @@ func TestParseWikiNodeGetSpecRawNodeToken(t *testing.T) {
 	}
 }
 
+func TestParseWikiNodeGetSpecOpaqueRawNodeToken(t *testing.T) {
+	t.Parallel()
+
+	const opaqueNodeToken = "Sm78_EXAMPLE_TOKEN"
+	spec, err := parseWikiNodeGetSpec(opaqueNodeToken, "", "")
+	if err != nil {
+		t.Fatalf("parseWikiNodeGetSpec() error = %v", err)
+	}
+	if spec.Token != opaqueNodeToken || spec.ObjType != "" || spec.SourceKind != "raw-node" {
+		t.Fatalf("spec = %+v, want raw-node %s with no obj_type", spec, opaqueNodeToken)
+	}
+	if got := spec.RequestParams(); !reflect.DeepEqual(got, map[string]interface{}{"token": opaqueNodeToken}) {
+		t.Fatalf("RequestParams() = %v, want {token: %s}", got, opaqueNodeToken)
+	}
+}
+
 func TestParseWikiNodeGetSpecRawObjTokenWithExplicitObjType(t *testing.T) {
 	t.Parallel()
 
@@ -43,23 +59,30 @@ func TestParseWikiNodeGetSpecRawObjTokenWithExplicitObjType(t *testing.T) {
 	}
 }
 
-func TestParseWikiNodeGetSpecRejectsRawObjTokenWithoutObjType(t *testing.T) {
+func TestParseWikiNodeGetSpecRawTokenWithoutObjTypeDefaultsToNodeToken(t *testing.T) {
 	t.Parallel()
 
-	// Mirrors +node-delete: a raw obj_token with no --obj-type must fail
-	// upfront instead of defaulting to "doc" and hitting an opaque API error.
-	_, err := parseWikiNodeGetSpec("bascnXYZ", "", "")
-	if err == nil || !strings.Contains(err.Error(), "--obj-type is required for a raw obj_token") {
-		t.Fatalf("expected raw obj_token obj-type-required error, got %v", err)
+	spec, err := parseWikiNodeGetSpec("bascnXYZ", "", "")
+	if err != nil {
+		t.Fatalf("parseWikiNodeGetSpec() error = %v", err)
+	}
+	if spec.Token != "bascnXYZ" || spec.ObjType != "" || spec.SourceKind != "raw-node" {
+		t.Fatalf("spec = %+v, want raw-node bascnXYZ with no obj_type", spec)
 	}
 }
 
-func TestParseWikiNodeGetSpecRejectsObjTypeOnNodeToken(t *testing.T) {
+func TestParseWikiNodeGetSpecRawTokenWithObjTypeUsesObjTokenLookup(t *testing.T) {
 	t.Parallel()
 
-	_, err := parseWikiNodeGetSpec("wikcnABC", "docx", "")
-	if err == nil || !strings.Contains(err.Error(), "only valid for obj_tokens") {
-		t.Fatalf("expected node_token + obj_type rejection, got %v", err)
+	spec, err := parseWikiNodeGetSpec("wikcnABC", "docx", "")
+	if err != nil {
+		t.Fatalf("parseWikiNodeGetSpec() error = %v", err)
+	}
+	if spec.Token != "wikcnABC" || spec.ObjType != "docx" || spec.SourceKind != "raw-obj" {
+		t.Fatalf("spec = %+v, want raw-obj wikcnABC with obj_type docx", spec)
+	}
+	if got := spec.RequestParams(); !reflect.DeepEqual(got, map[string]interface{}{"token": "wikcnABC", "obj_type": "docx"}) {
+		t.Fatalf("RequestParams() = %v, want {token: wikcnABC, obj_type: docx}", got)
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_list.go
+++ b/shortcuts/wiki/wiki_node_list.go
@@ -207,11 +207,6 @@ func normalizeWikiNodeListParentToken(parentNodeToken string) (string, error) {
 			"--parent-node-token must be a raw wiki node token, not a partial URL or path",
 		).WithParam("--parent-node-token")
 	}
-	if !looksLikeWikiNodeToken(parentNodeToken) {
-		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
-			"--parent-node-token must be a wiki node token; do not pass a docx/sheet/base/file token",
-		).WithParam("--parent-node-token").WithHint("Run `lark-cli wiki +node-get --node-token <url-or-token>` to resolve a document URL or obj_token to the wiki `node_token` first.")
-	}
 	if err := validateOptionalResourceName(parentNodeToken, "--parent-node-token"); err != nil {
 		return "", err
 	}

--- a/skills/lark-wiki/references/lark-wiki-node-get.md
+++ b/skills/lark-wiki/references/lark-wiki-node-get.md
@@ -19,7 +19,7 @@ lark-cli wiki +node-get \
 |------|------|----------|---------|-------------|
 | `--node-token` | string | **Yes** | — | `node_token`, cloud-doc `obj_token`, or a Lark URL embedding one (e.g. `https://feishu.cn/wiki/<token>` or `https://feishu.cn/docx/<token>`). Matches the `--node-token` naming used by sibling `+node-delete` / `+node-copy` / `+move`. |
 | `--token` | string | — (deprecated) | — | Deprecated original name; still accepted for backward compatibility but emits a `Flag --token has been deprecated, use --node-token instead` warning on stderr. New scripts should use `--node-token`. |
-| `--obj-type` | enum | No | — | Needed when `--node-token` is a raw `obj_token`; auto-inferred from the URL path. Not allowed when the token looks like a `node_token` (`wik...`) |
+| `--obj-type` | enum | No | — | Needed when `--node-token` is a raw `obj_token`; auto-inferred from typed Lark URLs. If omitted for a raw token, the shortcut treats it as a wiki `node_token`. |
 | `--space-id` | string | No | — | Optional cross-check: fail if the resolved node does not live in this space |
 | `--format` | enum | No | `json` | `json` / `pretty` / `table` / `csv` / `ndjson` |
 | `--as` | enum | No | `auto` | Identity `user`/`bot`; wiki is user-centric → pass `--as user` |


### PR DESCRIPTION
## Summary
Fix wiki shortcuts that treated the historical `wik` prefix as a hard requirement for wiki node tokens. Newer or opaque wiki node tokens can now be passed through without being blocked by client-side validation.

## Changes
- Update `wiki +node-get` so raw tokens without `--obj-type` are treated as node tokens and `--obj-type` is ignored for obvious wiki node tokens.
- Update `wiki +node-list --parent-node-token` to validate raw token syntax only, while preserving URL type checks for non-wiki URLs.
- Add regression coverage for opaque wiki node tokens in `+node-get` and `+node-list`.

## Test Plan
- [x] Unit tests pass: `go test ./shortcuts/wiki`
- [x] Manual local verification confirms the `lark-cli wiki +node-list` and `lark-cli wiki +node-get` dry-run flows work as expected

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki token handling across node lookup and list flows, consistently accepting opaque raw node tokens.
  * Updated `--parent-node-token` normalization to avoid incorrectly rejecting valid opaque values.
  * Relaxed `--obj-type` parsing: raw node token mode now defaults when omitted, and `--obj-type` cleanly switches lookup behavior.
* **Documentation**
  * Refreshed `WikiNodeGet` `--node-token` and `--obj-type` help/usage wording for clearer URL inference and raw token behavior.
* **Tests**
  * Updated and added coverage for opaque parent/node tokens and the revised `obj_type` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->