### PR TITLE
feat(base): add resource-level permission error handling for error code 91403

### DIFF
--- a/shortcuts/base/base_errors.go
+++ b/shortcuts/base/base_errors.go
@@ -160,12 +160,42 @@ func baseAPIErrorFromResult(resultMap map[string]interface{}, cc errclass.Classi
 	if logID := extractBaseErrorLogID(resultMap); logID != "" {
 		resultMap["log_id"] = logID
 	}
+	if err := baseResourcePermissionError(resultMap, cc, hint); err != nil {
+		return err
+	}
 	err := errclass.BuildAPIError(resultMap, cc)
 	if err == nil {
 		return nil
 	}
 	if p, ok := errs.ProblemOf(err); ok && hint != "" {
 		p.Hint = hint
+	}
+	return err
+}
+
+func baseResourcePermissionError(resultMap map[string]interface{}, cc errclass.ClassifyContext, upstreamHint string) error {
+	code, ok := util.ToFloat64(resultMap["code"])
+	if !ok || int(code) != 91403 {
+		return nil
+	}
+	msg, _ := resultMap["msg"].(string)
+	if strings.TrimSpace(msg) == "" {
+		msg = "you don't have permission"
+	}
+	identity := strings.TrimSpace(cc.Identity)
+	if identity == "" {
+		identity = "current identity"
+	}
+	hint := fmt.Sprintf("resource access denied for %s; ask the Base owner to grant access, or retry once with --as user only if a user identity is already logged in. Do not run auth login or switch identities repeatedly for this resource-level permission error", identity)
+	if upstreamHint != "" {
+		hint = upstreamHint + "; " + hint
+	}
+	err := errs.NewPermissionError(errs.SubtypePermissionDenied, "%s", msg).
+		WithCode(91403).
+		WithHint("%s", hint)
+	err.Identity = identity
+	if logID, _ := resultMap["log_id"].(string); strings.TrimSpace(logID) != "" {
+		err.WithLogID(strings.TrimSpace(logID))
 	}
 	return err
 }

--- a/shortcuts/base/base_errors_test.go
+++ b/shortcuts/base/base_errors_test.go
@@ -118,6 +118,38 @@ func TestHandleBaseAPIResultClassifiesKnownPermissionCode(t *testing.T) {
 	}
 }
 
+func TestHandleBaseAPIResultClassifiesBaseResourcePermission(t *testing.T) {
+	result := map[string]interface{}{
+		"code": 91403,
+		"msg":  "you don't have permission",
+		"data": map[string]interface{}{},
+	}
+
+	_, err := handleBaseAPIResultAny(result, nil, "list dashboards")
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T %v", err, err)
+	}
+	if p.Code != 91403 {
+		t.Fatalf("code=%d", p.Code)
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied {
+		t.Fatalf("category/subtype=%s/%s", p.Category, p.Subtype)
+	}
+	perm, ok := err.(*errs.PermissionError)
+	if !ok {
+		t.Fatalf("err=%T, want *errs.PermissionError", err)
+	}
+	if perm.Identity != "current identity" {
+		t.Fatalf("identity=%q", perm.Identity)
+	}
+	for _, want := range []string{"resource access denied", "Base owner", "Do not run auth login"} {
+		if !strings.Contains(p.Hint, want) {
+			t.Fatalf("hint=%q missing %q", p.Hint, want)
+		}
+	}
+}
+
 func TestAttachBaseResponseLogIDFromHeader(t *testing.T) {
 	result := map[string]interface{}{
 		"code": 91402,


### PR DESCRIPTION
## Summary

Add dedicated handling for Base API error code 91403 (resource access denied). Previously this code fell through to generic error building; it now surfaces as a typed `PermissionError` with an actionable hint that tells the user to ask the Base owner for access or retry with `--as user`, and explicitly warns against running `auth login` repeatedly for resource-level permission errors.

## Changes

- `shortcuts/base/base_errors.go`: introduce `baseResourcePermissionError` helper called early in `baseAPIErrorFromResult`; intercepts code 91403, constructs a `PermissionError` with `SubtypePermissionDenied`, populates `Identity` from `ClassifyContext`, appends upstream hint if present, and attaches `log_id` when available.
- `shortcuts/base/base_errors_test.go`: add `TestHandleBaseAPIResultClassifiesBaseResourcePermission` covering the new path — validates error code, category/subtype, identity fallback to `"current identity"`, and required hint keywords (`resource access denied`, `Base owner`, `Do not run auth login`).

## Test Plan

- `TestHandleBaseAPIResultClassifiesBaseResourcePermission` exercises the full 91403 path end-to-end via `handleBaseAPIResultAny`.
- Existing permission-code tests (`TestHandleBaseAPIResultClassifiesKnownPermissionCode`) continue to pass, confirming no regression on other error codes.
- Run: `go test ./shortcuts/base/...`

## Related Issues

Auto research task: 01KWYNV56GBPYYSFEHMHM8ZWMP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Base v3 resource-permission failures so they surface as a clear permission denied response (instead of a generic error).
  * Added more actionable guidance, including ownership context and a suggested retry using an alternative identity when appropriate.
  * Preserved and incorporated upstream hint text and key error details (such as request log id) when present.
  * Added a test covering the specific permission-denied classification and hint content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->