### PR TITLE
chore: release v1.0.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.68] - 2026-07-08
+
+### Features
+
+- **mail**: add message modify and trash shortcuts (#1567)
+- support whiteboard file inputs in docs XML (#1784)
+- **vc**: refine meeting-events output and reaction forwarding (#1674)
+- **affordance**: usage guidance for shortcuts and per-command skills (#1793)
+
+### Bug Fixes
+
+- accept opaque wiki node tokens (#1789)
+- **apps**: make db --environment optional, auto-select branch server-side (#1735)
+- preserve original filename in multipart file upload (#1767)
+
+### Documentation
+
+- restore one-time authorization guidance in lark-apps skill (#1794)
+
+### Misc
+
+- e2e: harden CLI E2E retry, cleanup, and domain selection (#1709)
+
 ## [v1.0.67] - 2026-07-08
 
 ### Features
@@ -1421,6 +1444,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.68]: https://github.com/larksuite/cli/releases/tag/v1.0.68
 [v1.0.67]: https://github.com/larksuite/cli/releases/tag/v1.0.67
 [v1.0.66]: https://github.com/larksuite/cli/releases/tag/v1.0.66
 [v1.0.65]: https://github.com/larksuite/cli/releases/tag/v1.0.65

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.67",
+  "version": "1.0.68",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.67` |
| Release version | `1.0.68` |
| Tag | `v1.0.68` |
| Branch | `release/v1.0.68` |
| Date | `2026-07-08` |

## Changes

- e2e: harden CLI E2E retry, cleanup, and domain selection (#1709)
- feat(mail): add message modify and trash shortcuts (#1567)
- feat: support whiteboard file inputs in docs XML (#1784)
- fix: accept opaque wiki node tokens (#1789)
- fix(apps): make db --environment optional, auto-select branch server-side (#1735)
- docs: restore one-time authorization guidance in lark-apps skill (#1794)
- feat(vc): refine meeting-events output and reaction forwarding (#1674)
- fix: preserve original filename in multipart file upload (#1767)
- feat(affordance): usage guidance for shortcuts and per-command skills (#1793)

## Files Changed

- `package.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release note entry for v1.0.68 with categorized highlights.
  * Updated the release reference list to include the new version.

* **Chores**
  * Bumped the package version to 1.0.68.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->