### PR TITLE
fix(mail): complete reorder rule ids

### DIFF
--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -537,6 +537,138 @@ func missingParamHint(opts *ServiceMethodOptions, f meta.Field) string {
 	return fmt.Sprintf("set %s; see: lark-cli schema %s", paramsForm, opts.SchemaPath)
 }
 
+func isMailRuleReorder(schemaPath string) bool {
+	return schemaPath == "mail.user_mailbox.rules.reorder"
+}
+
+func completeMailRuleOrder(input []string, all []string) ([]string, error) {
+	if len(input) == 0 {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must contain at least one rule ID").WithParam("rule_ids")
+	}
+	if len(all) == 0 {
+		return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition, "current mailbox has no rules to reorder").WithParam("rule_ids")
+	}
+
+	allSet := make(map[string]struct{}, len(all))
+	for _, id := range all {
+		if id == "" {
+			continue
+		}
+		allSet[id] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(input))
+	ordered := make([]string, 0, len(all))
+	for _, id := range input {
+		if id == "" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must not contain empty rule IDs").WithParam("rule_ids")
+		}
+		if _, ok := seen[id]; ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids contains duplicate rule ID %q", id).WithParam("rule_ids")
+		}
+		if _, ok := allSet[id]; !ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids contains unknown rule ID %q", id).WithParam("rule_ids")
+		}
+		seen[id] = struct{}{}
+		ordered = append(ordered, id)
+	}
+
+	for _, id := range all {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		ordered = append(ordered, id)
+	}
+	return ordered, nil
+}
+
+func extractRuleIDsFromListResponse(result interface{}) ([]string, error) {
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list returned a non-object response")
+	}
+	dataMap, ok := resultMap["data"].(map[string]interface{})
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing data object")
+	}
+	rawItems, ok := dataMap["items"].([]interface{})
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing items array")
+	}
+
+	ids := make([]string, 0, len(rawItems))
+	for _, rawItem := range rawItems {
+		itemMap, ok := rawItem.(map[string]interface{})
+		if !ok {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list returned an invalid item shape")
+		}
+		id, ok := itemMap["id"].(string)
+		if !ok || id == "" {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item missing id")
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func completeMailRuleReorderRequest(ctx context.Context, opts *ServiceMethodOptions, userMailboxID string, requestData interface{}) (interface{}, error) {
+	if !isMailRuleReorder(opts.SchemaPath) {
+		return requestData, nil
+	}
+
+	body, ok := requestData.(map[string]interface{})
+	if !ok {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "mail rule reorder requires --data JSON object with rule_ids").WithParam("--data")
+	}
+	rawRuleIDs, ok := body["rule_ids"].([]interface{})
+	if !ok {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "mail rule reorder requires rule_ids array").WithParam("rule_ids")
+	}
+
+	if userMailboxID == "" {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "missing required path parameter: user_mailbox_id").WithParam("user_mailbox_id")
+	}
+
+	inputRuleIDs := make([]string, 0, len(rawRuleIDs))
+	for _, rawID := range rawRuleIDs {
+		id, ok := rawID.(string)
+		if !ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must be an array of strings").WithParam("rule_ids")
+		}
+		inputRuleIDs = append(inputRuleIDs, id)
+	}
+
+	config, err := opts.Factory.Config()
+	if err != nil {
+		return nil, err
+	}
+	ac, err := opts.Factory.NewAPIClientWithConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	listResult, err := ac.CallAPI(ctx, client.RawApiRequest{
+		Method: "GET",
+		URL:    opts.ServicePath + "/user_mailboxes/" + validate.EncodePathSegment(userMailboxID) + "/rules",
+		As:     opts.As,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	allRuleIDs, err := extractRuleIDsFromListResponse(listResult)
+	if err != nil {
+		return nil, err
+	}
+	completedRuleIDs, err := completeMailRuleOrder(inputRuleIDs, allRuleIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	body["rule_ids"] = completedRuleIDs
+	return body, nil
+}
+
 // buildServiceRequest parses flags, builds the URL with path/query params, and returns a RawApiRequest.
 // When dryRun is true and a file is provided, file reading is skipped and
 // FileUploadMeta is returned instead so the caller can render dry-run output.
@@ -561,6 +693,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		return client.RawApiRequest{}, nil, err
 	}
 	opts.binder.overlay(opts.Cmd, params)
+	pathValues := map[string]string{}
 
 	url := opts.ServicePath + "/" + method.Path
 
@@ -580,6 +713,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		if err := validate.ResourceName(valStr, s.Name); err != nil {
 			return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam(s.Name).WithCause(err)
 		}
+		pathValues[s.Name] = valStr
 		url = strings.Replace(url, "{"+s.Name+"}", validate.EncodePathSegment(valStr), 1)
 		delete(params, s.Name)
 	}
@@ -655,6 +789,10 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileUpload())
 	} else {
 		data, err := cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin, fileIO)
+		if err != nil {
+			return client.RawApiRequest{}, nil, err
+		}
+		data, err = completeMailRuleReorderRequest(opts.Ctx, opts, pathValues["user_mailbox_id"], data)
 		if err != nil {
 			return client.RawApiRequest{}, nil, err
 		}

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -54,6 +54,34 @@ func driveMethod(httpMethod string, params map[string]interface{}) meta.Method {
 	return meta.FromMap(m)
 }
 
+func mailSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRuleReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "string",
+				},
+				"required": true,
+			},
+		},
+	})
+}
+
 // ── registerService ──
 
 func TestRegisterService(t *testing.T) {
@@ -1209,5 +1237,186 @@ func TestServiceMethod_JsonFlag_Accepted(t *testing.T) {
 	}
 	if captured == nil {
 		t.Fatal("expected runF to be called")
+	}
+}
+
+func TestCompleteMailRuleOrder_AppendsMissingRulesInOriginalOrder(t *testing.T) {
+	got, err := completeMailRuleOrder([]string{"rule_3", "rule_1"}, []string{"rule_1", "rule_2", "rule_3", "rule_4"})
+	if err != nil {
+		t.Fatalf("completeMailRuleOrder() error = %v", err)
+	}
+	want := []string{"rule_3", "rule_1", "rule_2", "rule_4"}
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestCompleteMailRuleOrder_RejectsDuplicateAndUnknownIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		all     []string
+		wantErr string
+	}{
+		{
+			name:    "duplicate",
+			input:   []string{"rule_1", "rule_1"},
+			all:     []string{"rule_1", "rule_2"},
+			wantErr: "duplicate rule ID",
+		},
+		{
+			name:    "unknown",
+			input:   []string{"rule_9"},
+			all:     []string{"rule_1", "rule_2"},
+			wantErr: "unknown rule ID",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := completeMailRuleOrder(tt.input, tt.all)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceMethod_MailRuleReorder_DryRunCompletesRuleIDs(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, testConfig)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/mbox_123/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"id": "rule_1"},
+					map[string]interface{}{"id": "rule_2"},
+					map[string]interface{}{"id": "rule_3"},
+				},
+			},
+		},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--params", `{"user_mailbox_id":"mbox_123"}`,
+		"--data", `{"rule_ids":["rule_3"]}`,
+		"--dry-run",
+		"--as", "bot",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"rule_ids": [`) || !strings.Contains(out, `"rule_3"`) || !strings.Contains(out, `"rule_1"`) || !strings.Contains(out, `"rule_2"`) {
+		t.Fatalf("expected completed rule_ids in dry-run output, got:\n%s", out)
+	}
+}
+
+func TestServiceMethod_MailRuleReorder_RejectsUnknownRuleID(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/mbox_123/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"id": "rule_1"},
+				},
+			},
+		},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--params", `{"user_mailbox_id":"mbox_123"}`,
+		"--data", `{"rule_ids":["rule_9"]}`,
+		"--dry-run",
+		"--as", "bot",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "unknown rule ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServiceMethod_MailRuleReorder_ExecutesListThenReorder(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, testConfig)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/mbox_123/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"id": "rule_1"},
+					map[string]interface{}{"id": "rule_2"},
+					map[string]interface{}{"id": "rule_3"},
+				},
+			},
+		},
+	})
+	reorderStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/mbox_123/rules/reorder",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{},
+		},
+	}
+	reg.Register(reorderStub)
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--params", `{"user_mailbox_id":"mbox_123"}`,
+		"--data", `{"rule_ids":["rule_3"]}`,
+		"--as", "bot",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var captured map[string]interface{}
+	if err := json.Unmarshal(reorderStub.CapturedBody, &captured); err != nil {
+		t.Fatalf("unmarshal reorder body: %v", err)
+	}
+	gotRuleIDs, ok := captured["rule_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("captured rule_ids type = %T, want []interface{}", captured["rule_ids"])
+	}
+	want := []string{"rule_3", "rule_1", "rule_2"}
+	if len(gotRuleIDs) != len(want) {
+		t.Fatalf("len(rule_ids) = %d, want %d (%v)", len(gotRuleIDs), len(want), gotRuleIDs)
+	}
+	for i := range want {
+		if gotRuleIDs[i] != want[i] {
+			t.Fatalf("rule_ids[%d] = %v, want %q (full=%v)", i, gotRuleIDs[i], want[i], gotRuleIDs)
+		}
+	}
+	if !strings.Contains(stdout.String(), `"ok": true`) {
+		t.Fatalf("expected success envelope, got:\n%s", stdout.String())
 	}
 }

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -1258,22 +1258,28 @@ func TestCompleteMailRuleOrder_AppendsMissingRulesInOriginalOrder(t *testing.T) 
 
 func TestCompleteMailRuleOrder_RejectsDuplicateAndUnknownIDs(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   []string
-		all     []string
-		wantErr string
+		name       string
+		input      []string
+		all        []string
+		wantErr    string
+		wantParam  string
+		wantSubtype errs.Subtype
 	}{
 		{
-			name:    "duplicate",
-			input:   []string{"rule_1", "rule_1"},
-			all:     []string{"rule_1", "rule_2"},
-			wantErr: "duplicate rule ID",
+			name:        "duplicate",
+			input:       []string{"rule_1", "rule_1"},
+			all:         []string{"rule_1", "rule_2"},
+			wantErr:     "duplicate rule ID",
+			wantParam:   "rule_ids",
+			wantSubtype: errs.SubtypeInvalidArgument,
 		},
 		{
-			name:    "unknown",
-			input:   []string{"rule_9"},
-			all:     []string{"rule_1", "rule_2"},
-			wantErr: "unknown rule ID",
+			name:        "unknown",
+			input:       []string{"rule_9"},
+			all:         []string{"rule_1", "rule_2"},
+			wantErr:     "unknown rule ID",
+			wantParam:   "rule_ids",
+			wantSubtype: errs.SubtypeInvalidArgument,
 		},
 	}
 	for _, tt := range tests {
@@ -1281,6 +1287,14 @@ func TestCompleteMailRuleOrder_RejectsDuplicateAndUnknownIDs(t *testing.T) {
 			_, err := completeMailRuleOrder(tt.input, tt.all)
 			if err == nil {
 				t.Fatal("expected validation error")
+			}
+			requireProblem(t, err, errs.CategoryValidation, tt.wantSubtype, 0)
+			var ve *errs.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("expected ValidationError, got %T: %v", err, err)
+			}
+			if ve.Param != tt.wantParam {
+				t.Fatalf("ValidationError.Param = %q, want %q", ve.Param, tt.wantParam)
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
@@ -1353,6 +1367,14 @@ func TestServiceMethod_MailRuleReorder_RejectsUnknownRuleID(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected validation error")
+	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if ve.Param != "rule_ids" {
+		t.Fatalf("ValidationError.Param = %q, want %q", ve.Param, "rule_ids")
 	}
 	if !strings.Contains(err.Error(), "unknown rule ID") {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- fetch all mailbox rule IDs before calling mail rule reorder
- complete missing rule_ids in CLI while preserving user-specified order first
- validate duplicate and unknown rule IDs before sending the reorder request

## Testing
- go test ./cmd/service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter handling for mail rule reordering by completing and ordering the rule ID list before sending the request.
  * Enhanced request preparation to carry resolved path values into payload rewriting.
* **Bug Fixes**
  * Validates reorder input to reject empty, duplicate, or unknown rule IDs.
  * Preserves the current rule order and appends missing IDs in the original sequence.
* **Tests**
  * Added coverage for validation, dry-run output, and execution flow ensuring the reorder request uses the completed ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->