### PR TITLE
feat: support docs fetch selection anchors

### DIFF
--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -24,8 +24,8 @@ func v2FetchFlags() []common.Flag {
 		{Name: "lang", Desc: "user cite display language, e.g. en-US, zh-CN, ja-JP"},
 		{Name: "revision-id", Desc: "document revision id; -1 means latest", Type: "int", Default: "-1"},
 		{Name: "scope", Desc: "read scope; full reads whole doc, outline lists headings, section expands from heading anchor, range uses block ids, keyword searches text", Default: "full", Enum: []string{"full", "outline", "range", "keyword", "section"}},
-		{Name: "start-block-id", Desc: "range/section anchor block id; range also accepts #share-xxx/#part-xxx selection anchors"},
-		{Name: "end-block-id", Desc: "range end block id; -1 means through document end; selection anchors are not supported"},
+		{Name: "start-block-id", Desc: "range/section anchor block id; required for section and optional start for range"},
+		{Name: "end-block-id", Desc: "range end block id; -1 means through document end"},
 		{Name: "keyword", Desc: "keyword scope query; supports case-insensitive substring/regex fallback and '|' OR branches, e.g. foo|bar or bug|缺陷"},
 		{Name: "context-before", Desc: "range/keyword/section context: sibling blocks before selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "context-after", Desc: "range/keyword/section context: sibling blocks after selected top-level blocks", Type: "int", Default: "0"},
@@ -337,7 +337,7 @@ func validateFetchSelectionAnchorUsage(runtime *common.RuntimeContext, mode stri
 		return err
 	}
 	if endIsAnchor {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--end-block-id does not support selection anchors; pass #share/#part through --start-block-id with --scope range").WithParam("--end-block-id")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--end-block-id does not support selection anchors; pass the #share anchor in --doc URL").WithParam("--end-block-id")
 	}
 	if !startIsAnchor {
 		_, _, err := parseFetchSelectionAnchorFromDoc(runtime)

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -24,8 +24,8 @@ func v2FetchFlags() []common.Flag {
 		{Name: "lang", Desc: "user cite display language, e.g. en-US, zh-CN, ja-JP"},
 		{Name: "revision-id", Desc: "document revision id; -1 means latest", Type: "int", Default: "-1"},
 		{Name: "scope", Desc: "read scope; full reads whole doc, outline lists headings, section expands from heading anchor, range uses block ids, keyword searches text", Default: "full", Enum: []string{"full", "outline", "range", "keyword", "section"}},
-		{Name: "start-block-id", Desc: "range/section anchor block id; required for section and optional start for range"},
-		{Name: "end-block-id", Desc: "range end block id; -1 means through document end"},
+		{Name: "start-block-id", Desc: "range/section anchor block id; range also accepts #share-xxx/#part-xxx selection anchors"},
+		{Name: "end-block-id", Desc: "range end block id; -1 means through document end; selection anchors are not supported"},
 		{Name: "keyword", Desc: "keyword scope query; supports case-insensitive substring/regex fallback and '|' OR branches, e.g. foo|bar or bug|缺陷"},
 		{Name: "context-before", Desc: "range/keyword/section context: sibling blocks before selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "context-after", Desc: "range/keyword/section context: sibling blocks after selected top-level blocks", Type: "int", Default: "0"},
@@ -151,12 +151,12 @@ func resolveFetchLang(runtime *common.RuntimeContext) string {
 
 // buildReadOption 拼装 read_option JSON；full/空模式返回 nil，让服务端走默认全文路径。
 func buildReadOption(runtime *common.RuntimeContext) map[string]interface{} {
-	mode := strings.TrimSpace(runtime.Str("scope"))
+	mode := effectiveFetchReadMode(runtime)
 	if mode == "" || mode == "full" {
 		return nil
 	}
 	ro := map[string]interface{}{"read_mode": mode}
-	if v := strings.TrimSpace(runtime.Str("start-block-id")); v != "" {
+	if v := effectiveFetchStartBlockID(runtime, mode); v != "" {
 		ro["start_block_id"] = v
 	}
 	if v := strings.TrimSpace(runtime.Str("end-block-id")); v != "" {
@@ -175,6 +175,77 @@ func buildReadOption(runtime *common.RuntimeContext) map[string]interface{} {
 		ro["max_depth"] = strconv.Itoa(v)
 	}
 	return ro
+}
+
+func effectiveFetchReadMode(runtime *common.RuntimeContext) string {
+	mode := rawFetchReadMode(runtime)
+	if shouldUseDocSelectionAnchor(runtime, mode) {
+		if anchor, _ := docSelectionAnchorStartBlockID(runtime); anchor != "" {
+			return "range"
+		}
+	}
+	return mode
+}
+
+func rawFetchReadMode(runtime *common.RuntimeContext) string {
+	mode := strings.TrimSpace(runtime.Str("scope"))
+	if mode == "" {
+		return "full"
+	}
+	return mode
+}
+
+func effectiveFetchStartBlockID(runtime *common.RuntimeContext, mode string) string {
+	if v := strings.TrimSpace(runtime.Str("start-block-id")); v != "" {
+		if anchor, ok, _ := parseFetchSelectionAnchor(v, "--start-block-id"); ok {
+			return anchor
+		}
+		return v
+	}
+	if mode == "range" && shouldUseDocSelectionAnchor(runtime, rawFetchReadMode(runtime)) {
+		if anchor, _ := docSelectionAnchorStartBlockID(runtime); anchor != "" {
+			return anchor
+		}
+	}
+	return ""
+}
+
+func shouldUseDocSelectionAnchor(runtime *common.RuntimeContext, mode string) bool {
+	if runtime.Changed("start-block-id") || runtime.Changed("end-block-id") {
+		return false
+	}
+	if runtime.Changed("scope") {
+		return mode == "range"
+	}
+	return mode == "" || mode == "full"
+}
+
+func docSelectionAnchorStartBlockID(runtime *common.RuntimeContext) (string, error) {
+	ref, err := parseDocumentRef(runtime.Str("doc"))
+	if err != nil {
+		return "", nil
+	}
+	anchor, ok, err := parseFetchSelectionAnchor(ref.Fragment, "--doc")
+	if err != nil || !ok {
+		return "", err
+	}
+	return anchor, nil
+}
+
+func parseFetchSelectionAnchor(raw, param string) (string, bool, error) {
+	value := strings.TrimSpace(raw)
+	value = strings.TrimPrefix(value, "#")
+	for _, prefix := range []string{"share-", "part-"} {
+		if !strings.HasPrefix(value, prefix) {
+			continue
+		}
+		anchorID := strings.TrimSpace(strings.TrimPrefix(value, prefix))
+		if anchorID == "" {
+			return "", false, errs.NewValidationError(errs.SubtypeInvalidArgument, "selection anchor id is required after %s", prefix).WithParam(param)
+		}
+		return prefix + anchorID, true, nil
+	}
+	return "", false, nil
 }
 
 // effectiveFetchDetail degrades detail options that cannot be represented by
@@ -208,7 +279,10 @@ func addFetchDetailDowngradeWarning(runtime *common.RuntimeContext, data map[str
 
 // validateReadModeFlags 客户端前置校验，服务端也会再校验一次。
 func validateReadModeFlags(runtime *common.RuntimeContext) error {
-	mode := strings.TrimSpace(runtime.Str("scope"))
+	mode := effectiveFetchReadMode(runtime)
+	if err := validateFetchSelectionAnchorUsage(runtime, mode); err != nil {
+		return err
+	}
 	if mode == "" || mode == "full" {
 		return nil
 	}
@@ -227,7 +301,7 @@ func validateReadModeFlags(runtime *common.RuntimeContext) error {
 	case "outline":
 		return nil
 	case "range":
-		if strings.TrimSpace(runtime.Str("start-block-id")) == "" &&
+		if effectiveFetchStartBlockID(runtime, mode) == "" &&
 			strings.TrimSpace(runtime.Str("end-block-id")) == "" {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "range mode requires --start-block-id or --end-block-id").WithParams(
 				errs.InvalidParam{Name: "--start-block-id", Reason: "provide --start-block-id or --end-block-id for range mode"},
@@ -248,4 +322,43 @@ func validateReadModeFlags(runtime *common.RuntimeContext) error {
 	default:
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --scope %q", mode).WithParam("--scope")
 	}
+}
+
+func validateFetchSelectionAnchorUsage(runtime *common.RuntimeContext, mode string) error {
+	startBlockID := strings.TrimSpace(runtime.Str("start-block-id"))
+	endBlockID := strings.TrimSpace(runtime.Str("end-block-id"))
+
+	startAnchor, startIsAnchor, err := parseFetchSelectionAnchor(startBlockID, "--start-block-id")
+	if err != nil {
+		return err
+	}
+	_, endIsAnchor, err := parseFetchSelectionAnchor(endBlockID, "--end-block-id")
+	if err != nil {
+		return err
+	}
+	if endIsAnchor {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--end-block-id does not support selection anchors; pass #share/#part through --start-block-id with --scope range").WithParam("--end-block-id")
+	}
+	if !startIsAnchor {
+		_, _, err := parseFetchSelectionAnchorFromDoc(runtime)
+		return err
+	}
+	if mode != "range" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--start-block-id selection anchor %q requires --scope range", startAnchor).WithParam("--start-block-id")
+	}
+	if endBlockID != "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--start-block-id selection anchor %q cannot be combined with --end-block-id", startAnchor).WithParams(
+			errs.InvalidParam{Name: "--start-block-id", Reason: "selection anchors define the complete selected range"},
+			errs.InvalidParam{Name: "--end-block-id", Reason: "remove --end-block-id when --start-block-id is a selection anchor"},
+		)
+	}
+	return nil
+}
+
+func parseFetchSelectionAnchorFromDoc(runtime *common.RuntimeContext) (string, bool, error) {
+	ref, err := parseDocumentRef(runtime.Str("doc"))
+	if err != nil {
+		return "", false, nil
+	}
+	return parseFetchSelectionAnchor(ref.Fragment, "--doc")
 }

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -180,7 +180,7 @@ func buildReadOption(runtime *common.RuntimeContext) map[string]interface{} {
 func effectiveFetchReadMode(runtime *common.RuntimeContext) string {
 	mode := rawFetchReadMode(runtime)
 	if shouldUseDocSelectionAnchor(runtime, mode) {
-		if anchor, _ := docSelectionAnchorStartBlockID(runtime); anchor != "" {
+		if anchor := docSelectionAnchorStartBlockID(runtime); anchor != "" {
 			return "range"
 		}
 	}
@@ -197,13 +197,10 @@ func rawFetchReadMode(runtime *common.RuntimeContext) string {
 
 func effectiveFetchStartBlockID(runtime *common.RuntimeContext, mode string) string {
 	if v := strings.TrimSpace(runtime.Str("start-block-id")); v != "" {
-		if anchor, ok, _ := parseFetchSelectionAnchor(v, "--start-block-id"); ok {
-			return anchor
-		}
 		return v
 	}
 	if mode == "range" && shouldUseDocSelectionAnchor(runtime, rawFetchReadMode(runtime)) {
-		if anchor, _ := docSelectionAnchorStartBlockID(runtime); anchor != "" {
+		if anchor := docSelectionAnchorStartBlockID(runtime); anchor != "" {
 			return anchor
 		}
 	}
@@ -220,32 +217,30 @@ func shouldUseDocSelectionAnchor(runtime *common.RuntimeContext, mode string) bo
 	return mode == "" || mode == "full"
 }
 
-func docSelectionAnchorStartBlockID(runtime *common.RuntimeContext) (string, error) {
+func docSelectionAnchorStartBlockID(runtime *common.RuntimeContext) string {
 	ref, err := parseDocumentRef(runtime.Str("doc"))
 	if err != nil {
-		return "", nil
+		return ""
 	}
-	anchor, ok, err := parseFetchSelectionAnchor(ref.Fragment, "--doc")
-	if err != nil || !ok {
-		return "", err
+	anchor, ok := parseDocShareSelectionAnchor(ref.Fragment)
+	if !ok {
+		return ""
 	}
-	return anchor, nil
+	return anchor
 }
 
-func parseFetchSelectionAnchor(raw, param string) (string, bool, error) {
+func parseDocShareSelectionAnchor(raw string) (string, bool) {
 	value := strings.TrimSpace(raw)
 	value = strings.TrimPrefix(value, "#")
-	for _, prefix := range []string{"share-", "part-"} {
-		if !strings.HasPrefix(value, prefix) {
-			continue
-		}
-		anchorID := strings.TrimSpace(strings.TrimPrefix(value, prefix))
-		if anchorID == "" {
-			return "", false, errs.NewValidationError(errs.SubtypeInvalidArgument, "selection anchor id is required after %s", prefix).WithParam(param)
-		}
-		return prefix + anchorID, true, nil
+	const prefix = "share-"
+	if !strings.HasPrefix(value, prefix) {
+		return "", false
 	}
-	return "", false, nil
+	anchorID := strings.TrimSpace(strings.TrimPrefix(value, prefix))
+	if anchorID == "" {
+		return "", false
+	}
+	return prefix + anchorID, true
 }
 
 // effectiveFetchDetail degrades detail options that cannot be represented by
@@ -280,9 +275,6 @@ func addFetchDetailDowngradeWarning(runtime *common.RuntimeContext, data map[str
 // validateReadModeFlags 客户端前置校验，服务端也会再校验一次。
 func validateReadModeFlags(runtime *common.RuntimeContext) error {
 	mode := effectiveFetchReadMode(runtime)
-	if err := validateFetchSelectionAnchorUsage(runtime, mode); err != nil {
-		return err
-	}
 	if mode == "" || mode == "full" {
 		return nil
 	}
@@ -322,43 +314,4 @@ func validateReadModeFlags(runtime *common.RuntimeContext) error {
 	default:
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --scope %q", mode).WithParam("--scope")
 	}
-}
-
-func validateFetchSelectionAnchorUsage(runtime *common.RuntimeContext, mode string) error {
-	startBlockID := strings.TrimSpace(runtime.Str("start-block-id"))
-	endBlockID := strings.TrimSpace(runtime.Str("end-block-id"))
-
-	startAnchor, startIsAnchor, err := parseFetchSelectionAnchor(startBlockID, "--start-block-id")
-	if err != nil {
-		return err
-	}
-	_, endIsAnchor, err := parseFetchSelectionAnchor(endBlockID, "--end-block-id")
-	if err != nil {
-		return err
-	}
-	if endIsAnchor {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--end-block-id does not support selection anchors; pass the #share anchor in --doc URL").WithParam("--end-block-id")
-	}
-	if !startIsAnchor {
-		_, _, err := parseFetchSelectionAnchorFromDoc(runtime)
-		return err
-	}
-	if mode != "range" {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--start-block-id selection anchor %q requires --scope range", startAnchor).WithParam("--start-block-id")
-	}
-	if endBlockID != "" {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--start-block-id selection anchor %q cannot be combined with --end-block-id", startAnchor).WithParams(
-			errs.InvalidParam{Name: "--start-block-id", Reason: "selection anchors define the complete selected range"},
-			errs.InvalidParam{Name: "--end-block-id", Reason: "remove --end-block-id when --start-block-id is a selection anchor"},
-		)
-	}
-	return nil
-}
-
-func parseFetchSelectionAnchorFromDoc(runtime *common.RuntimeContext) (string, bool, error) {
-	ref, err := parseDocumentRef(runtime.Str("doc"))
-	if err != nil {
-		return "", false, nil
-	}
-	return parseFetchSelectionAnchor(ref.Fragment, "--doc")
 }

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -221,19 +221,20 @@ func TestBuildFetchBodyDoesNotAutoReadOrdinaryFragment(t *testing.T) {
 	}
 }
 
-func TestBuildReadOptionNormalizesExplicitSelectionAnchorStart(t *testing.T) {
+func TestBuildFetchBodyDoesNotAutoReadUnsupportedSelectionAnchorFragments(t *testing.T) {
 	t.Parallel()
 
-	runtime := newFetchBodyTestRuntime(context.Background())
-	mustSetFetchFlag(t, runtime, "scope", "range")
-	mustSetFetchFlag(t, runtime, "start-block-id", "#part-CUE3d6Ykno2fkexEvt8cGF8Wnse")
+	for _, doc := range []string{
+		"https://example.larksuite.com/wiki/wikcnToken#part-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+		"https://example.larksuite.com/wiki/wikcnToken#share-",
+	} {
+		runtime := newFetchBodyTestRuntime(context.Background())
+		mustSetFetchFlag(t, runtime, "doc", doc)
 
-	want := map[string]interface{}{
-		"read_mode":      "range",
-		"start_block_id": "part-CUE3d6Ykno2fkexEvt8cGF8Wnse",
-	}
-	if got := buildReadOption(runtime); !reflect.DeepEqual(got, want) {
-		t.Fatalf("buildReadOption() = %#v, want %#v", got, want)
+		body := buildFetchBody(runtime)
+		if _, ok := body["read_option"]; ok {
+			t.Fatalf("did not expect read_option for unsupported URL fragment %q: %#v", doc, body["read_option"])
+		}
 	}
 }
 
@@ -379,31 +380,6 @@ func TestValidateReadModeFlagsRejectsInvalidScopeOptions(t *testing.T) {
 			wantParam: "--keyword",
 		},
 		{
-			name: "selection anchor cannot be end block",
-			setFlags: map[string]string{
-				"scope":        "range",
-				"end-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
-			},
-			wantParam: "--end-block-id",
-		},
-		{
-			name: "selection anchor start cannot combine with end block",
-			setFlags: map[string]string{
-				"scope":          "range",
-				"start-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
-				"end-block-id":   "blk_end",
-			},
-			wantParams: []string{"--start-block-id", "--end-block-id"},
-		},
-		{
-			name: "selection anchor start requires range",
-			setFlags: map[string]string{
-				"scope":          "section",
-				"start-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
-			},
-			wantParam: "--start-block-id",
-		},
-		{
 			name: "section needs start block",
 			setFlags: map[string]string{
 				"scope": "section",
@@ -455,13 +431,6 @@ func TestValidateReadModeFlagsAcceptsValidScopeOptions(t *testing.T) {
 			setFlags: map[string]string{
 				"scope":        "range",
 				"end-block-id": "blk_end",
-			},
-		},
-		{
-			name: "range with selection anchor start",
-			setFlags: map[string]string{
-				"scope":          "range",
-				"start-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
 			},
 		},
 		{

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -180,6 +180,63 @@ func TestBuildFetchBodyIncludesReadOption(t *testing.T) {
 	}
 }
 
+func TestBuildFetchBodyUsesSelectionAnchorFragmentAsRangeStart(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	mustSetFetchFlag(t, runtime, "doc", "https://example.larksuite.com/wiki/wikcnToken#share-CUE3d6Ykno2fkexEvt8cGF8Wnse")
+
+	body := buildFetchBody(runtime)
+	want := map[string]interface{}{
+		"read_mode":      "range",
+		"start_block_id": "share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+	}
+	if got := body["read_option"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("read_option = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildFetchBodyExplicitFullIgnoresSelectionAnchorFragment(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	mustSetFetchFlag(t, runtime, "doc", "https://example.larksuite.com/wiki/wikcnToken#share-CUE3d6Ykno2fkexEvt8cGF8Wnse")
+	mustSetFetchFlag(t, runtime, "scope", "full")
+
+	body := buildFetchBody(runtime)
+	if _, ok := body["read_option"]; ok {
+		t.Fatalf("did not expect read_option for explicit full scope: %#v", body["read_option"])
+	}
+}
+
+func TestBuildFetchBodyDoesNotAutoReadOrdinaryFragment(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	mustSetFetchFlag(t, runtime, "doc", "https://example.larksuite.com/wiki/wikcnToken#blk_plain")
+
+	body := buildFetchBody(runtime)
+	if _, ok := body["read_option"]; ok {
+		t.Fatalf("did not expect read_option for ordinary URL fragment: %#v", body["read_option"])
+	}
+}
+
+func TestBuildReadOptionNormalizesExplicitSelectionAnchorStart(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	mustSetFetchFlag(t, runtime, "scope", "range")
+	mustSetFetchFlag(t, runtime, "start-block-id", "#part-CUE3d6Ykno2fkexEvt8cGF8Wnse")
+
+	want := map[string]interface{}{
+		"read_mode":      "range",
+		"start_block_id": "part-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+	}
+	if got := buildReadOption(runtime); !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildReadOption() = %#v, want %#v", got, want)
+	}
+}
+
 func TestBuildReadOptionModes(t *testing.T) {
 	t.Parallel()
 
@@ -322,6 +379,31 @@ func TestValidateReadModeFlagsRejectsInvalidScopeOptions(t *testing.T) {
 			wantParam: "--keyword",
 		},
 		{
+			name: "selection anchor cannot be end block",
+			setFlags: map[string]string{
+				"scope":        "range",
+				"end-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+			},
+			wantParam: "--end-block-id",
+		},
+		{
+			name: "selection anchor start cannot combine with end block",
+			setFlags: map[string]string{
+				"scope":          "range",
+				"start-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+				"end-block-id":   "blk_end",
+			},
+			wantParams: []string{"--start-block-id", "--end-block-id"},
+		},
+		{
+			name: "selection anchor start requires range",
+			setFlags: map[string]string{
+				"scope":          "section",
+				"start-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+			},
+			wantParam: "--start-block-id",
+		},
+		{
 			name: "section needs start block",
 			setFlags: map[string]string{
 				"scope": "section",
@@ -373,6 +455,19 @@ func TestValidateReadModeFlagsAcceptsValidScopeOptions(t *testing.T) {
 			setFlags: map[string]string{
 				"scope":        "range",
 				"end-block-id": "blk_end",
+			},
+		},
+		{
+			name: "range with selection anchor start",
+			setFlags: map[string]string{
+				"scope":          "range",
+				"start-block-id": "#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+			},
+		},
+		{
+			name: "default scope with selection anchor fragment",
+			setFlags: map[string]string{
+				"doc": "https://example.larksuite.com/wiki/wikcnToken#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
 			},
 		},
 		{
@@ -884,6 +979,7 @@ func TestDocsFetchRejectsLegacyFlags(t *testing.T) {
 
 func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd := &cobra.Command{Use: "+fetch"}
+	cmd.Flags().String("doc", "doxcnFetchDryRun", "")
 	cmd.Flags().String("doc-format", fetchDefault("doc-format"), "")
 	cmd.Flags().String("detail", fetchDefault("detail"), "")
 	cmd.Flags().String("lang", fetchDefault("lang"), "")

--- a/shortcuts/doc/helpers.go
+++ b/shortcuts/doc/helpers.go
@@ -17,8 +17,9 @@ import (
 const docsSceneContextKey = "lark_cli_docs_scene"
 
 type documentRef struct {
-	Kind  string
-	Token string
+	Kind     string
+	Token    string
+	Fragment string
 }
 
 func parseDocumentRef(input string) (documentRef, error) {
@@ -28,13 +29,13 @@ func parseDocumentRef(input string) (documentRef, error) {
 	}
 
 	if token, ok := extractDocumentToken(raw, "/wiki/"); ok {
-		return documentRef{Kind: "wiki", Token: token}, nil
+		return documentRef{Kind: "wiki", Token: token, Fragment: extractDocumentFragment(raw)}, nil
 	}
 	if token, ok := extractDocumentToken(raw, "/docx/"); ok {
-		return documentRef{Kind: "docx", Token: token}, nil
+		return documentRef{Kind: "docx", Token: token, Fragment: extractDocumentFragment(raw)}, nil
 	}
 	if token, ok := extractDocumentToken(raw, "/doc/"); ok {
-		return documentRef{Kind: "doc", Token: token}, nil
+		return documentRef{Kind: "doc", Token: token, Fragment: extractDocumentFragment(raw)}, nil
 	}
 	if strings.Contains(raw, "://") {
 		return documentRef{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "unsupported --doc input %q: use a docx URL/token or a wiki URL that resolves to docx", raw).WithParam("--doc")
@@ -60,6 +61,14 @@ func extractDocumentToken(raw, marker string) (string, bool) {
 		return "", false
 	}
 	return token, true
+}
+
+func extractDocumentFragment(raw string) string {
+	idx := strings.Index(raw, "#")
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(raw[idx+1:])
 }
 
 // doDocAPI executes an OpenAPI request against the docs_ai endpoints and returns

--- a/shortcuts/doc/helpers_test.go
+++ b/shortcuts/doc/helpers_test.go
@@ -13,11 +13,12 @@ func TestParseDocumentRef(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		input     string
-		wantKind  string
-		wantToken string
-		wantErr   string
+		name         string
+		input        string
+		wantKind     string
+		wantToken    string
+		wantFragment string
+		wantErr      string
 	}{
 		{
 			name:      "docx url",
@@ -30,6 +31,13 @@ func TestParseDocumentRef(t *testing.T) {
 			input:     "https://example.larksuite.com/wiki/xxxxxx?from=wiki",
 			wantKind:  "wiki",
 			wantToken: "xxxxxx",
+		},
+		{
+			name:         "wiki url with selection anchor",
+			input:        "https://example.larksuite.com/wiki/xxxxxx#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+			wantKind:     "wiki",
+			wantToken:    "xxxxxx",
+			wantFragment: "share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
 		},
 		{
 			name:      "doc url",
@@ -72,6 +80,9 @@ func TestParseDocumentRef(t *testing.T) {
 			}
 			if got.Token != tt.wantToken {
 				t.Fatalf("parseDocumentRef(%q) token = %q, want %q", tt.input, got.Token, tt.wantToken)
+			}
+			if got.Fragment != tt.wantFragment {
+				t.Fatalf("parseDocumentRef(%q) fragment = %q, want %q", tt.input, got.Fragment, tt.wantFragment)
 			}
 		})
 	}

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -35,6 +35,7 @@ lark-cli docs +update --doc "文档URL或token" --command append --content '<p>�
 ## 快速决策
 - 用户要**复制文档 / 创建文档副本 / 另存为副本**时，切到 [`lark-drive`](../lark-drive/SKILL.md)，按其中的复制指引使用 `lark-cli drive files copy`；不要用 `docs +fetch` + `docs +create` 重建正文，也不要走 `drive +export` / `drive +import`。
 - 先判定任务路径：找文档 / 导入导出走 [`lark-drive`](../lark-drive/SKILL.md)；只读 / 摘要用 `docs +fetch` 默认 `simple`；明确旧文本 → 新文本直接 `str_replace`；只有 block 链接、评论锚点、插入 / 替换 / 删除 / 移动才局部 fetch `with-ids`；保真改写已有内容才读 `full`
+- 用户给出带 `#share-...` / `#part-...` 的文档 URL 时，按 [`lark-doc-fetch.md`](references/lark-doc-fetch.md) 的「选区锚点」优先局部读取；普通 `#block_id` 仍按 block 直达链接处理
 - block 直达链接格式：`文档基础 URL#block_id`；没有 block_id 时局部 fetch `with-ids`
 - 连续执行多个文档写操作时，必须按 [`lark-doc-update.md`](references/lark-doc-update.md) 的「Block ID 生命周期」判断旧 block ID 是否还能复用；`overwrite` / `block_replace` / `block_delete` 后不要复用受影响的旧 ID，插入 / 复制后要重新 fetch 才能拿到新 block ID
 - 用户需要在文档内**创建、复制或移动**资源块（画板、电子表格、多维表格等）时，必须先读取 [`lark-doc-xml.md`](references/lark-doc-xml.md) 的「三、资源块」章节

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 ```bash
 # 常用示例
-lark-cli docs +fetch --doc "文档URL或token"
+lark-cli docs +fetch --doc "文档URL或token，后缀有 #share-... 锚点时会局部读取"
 lark-cli docs +create --content '<title>标题</title><p>内容</p>'
 lark-cli docs +update --doc "文档URL或token" --command append --content '<p>内容</p>'
 ```
@@ -35,7 +35,6 @@ lark-cli docs +update --doc "文档URL或token" --command append --content '<p>�
 ## 快速决策
 - 用户要**复制文档 / 创建文档副本 / 另存为副本**时，切到 [`lark-drive`](../lark-drive/SKILL.md)，按其中的复制指引使用 `lark-cli drive files copy`；不要用 `docs +fetch` + `docs +create` 重建正文，也不要走 `drive +export` / `drive +import`。
 - 先判定任务路径：找文档 / 导入导出走 [`lark-drive`](../lark-drive/SKILL.md)；只读 / 摘要用 `docs +fetch` 默认 `simple`；明确旧文本 → 新文本直接 `str_replace`；只有 block 链接、评论锚点、插入 / 替换 / 删除 / 移动才局部 fetch `with-ids`；保真改写已有内容才读 `full`
-- 用户给出带 `#share-...` / `#part-...` 的文档 URL 时，按 [`lark-doc-fetch.md`](references/lark-doc-fetch.md) 的「选区锚点」优先局部读取；普通 `#block_id` 仍按 block 直达链接处理
 - block 直达链接格式：`文档基础 URL#block_id`；没有 block_id 时局部 fetch `with-ids`
 - 连续执行多个文档写操作时，必须按 [`lark-doc-update.md`](references/lark-doc-update.md) 的「Block ID 生命周期」判断旧 block ID 是否还能复用；`overwrite` / `block_replace` / `block_delete` 后不要复用受影响的旧 ID，插入 / 复制后要重新 fetch 才能拿到新 block ID
 - 用户需要在文档内**创建、复制或移动**资源块（画板、电子表格、多维表格等）时，必须先读取 [`lark-doc-xml.md`](references/lark-doc-xml.md) 的「三、资源块」章节

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 ```bash
 # 常用示例
-lark-cli docs +fetch --doc "文档URL或token，后缀有 #share-... 锚点时会局部读取"
+lark-cli docs +fetch --doc "文档URL或token；若 URL 存在 #share-... 锚点，优先使用锚点方式读取，不要全文拉取"
 lark-cli docs +create --content '<title>标题</title><p>内容</p>'
 lark-cli docs +update --doc "文档URL或token" --command append --content '<p>内容</p>'
 ```

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -20,6 +20,21 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope outline --max-depth 3
 lark-cli docs +fetch --doc Z1Fj...tnAc \
   --scope range --start-block-id blkA --end-block-id blkB --detail with-ids
 
+# URL 带选区锚点时自动局部读取（仅 #share- / #part-）
+lark-cli docs +fetch \
+  --doc 'https://bytedance.larkoffice.com/wiki/wikcnInnPln2MWskas4CZT6iynf#share-CUE3d6Ykno2fkexEvt8cGF8Wnse'
+
+# 显式读取选区锚点
+lark-cli docs +fetch \
+  --doc 'https://bytedance.larkoffice.com/wiki/wikcnInnPln2MWskas4CZT6iynf' \
+  --scope range \
+  --start-block-id '#share-CUE3d6Ykno2fkexEvt8cGF8Wnse'
+
+# 强制全文读取时忽略选区锚点
+lark-cli docs +fetch \
+  --doc 'https://bytedance.larkoffice.com/wiki/wikcnInnPln2MWskas4CZT6iynf#share-CUE3d6Ykno2fkexEvt8cGF8Wnse' \
+  --scope full
+
 # 读整个章节（以标题 id 为锚点，自动展开到下一个同级/更高级标题前）
 lark-cli docs +fetch --doc Z1Fj...tnAc \
   --scope section --start-block-id <标题id> --detail with-ids
@@ -49,6 +64,18 @@ lark-cli docs +fetch --doc Z1Fj...tnAc \
 | `keyword` | 只有模糊关键词 | `--keyword`（**多级自动 fallback**：子串 → 归一化 → 分词形变 → RE2 正则；`\|` 分隔多分支 OR） | 每处命中按"最小包容单元"输出；**自动去重**（同容器多命中 → 单个容器，同表格多行命中 → 合并切片） |
 
 > 💡 **多关键词用 `\|` 拼接（OR 语义，任一命中即返回）**：例 `"部署\|发布\|上线"`，三词任一命中都进结果，适合**同义词/别名/多业务术语**一次召回（如 `bug\|缺陷\|故障`）。
+
+### 选区锚点（`#share-...` / `#part-...`）
+
+用户给出带 `#share-...` 或 `#part-...` fragment 的文档 URL 时，优先只读取该选区。必须用引号包住 URL 或锚点，避免 shell 把 `#` 当注释。
+
+- 直接传 URL：`--doc '...#share-xxx'`，且未显式 `--scope full` 时，CLI 会自动等价为 `--scope range --start-block-id '#share-xxx'`。
+- 显式写法：`--scope range --start-block-id '#share-xxx'` 或 `--scope range --start-block-id '#part-xxx'`。
+- 强制全文：URL 即使带 `#share-...` / `#part-...`，只要传 `--scope full` 就读全文。
+- 普通 `#block_id` 不是选区锚点，不会自动触发局部读取；需要 block 级读取时显式使用 `range` / `section`。
+- 选区锚点只允许放在 `--start-block-id`，不要传给 `--end-block-id`。
+- 不要在 Agent 侧换算真实 block ID；CLI/SDK 会把选区锚点交给后端解析。
+- 如果当前安装的 `lark-cli` 不支持该语法，说明客户端较旧；可以先全文读取或提示升级，不要手写锚点换算逻辑。
 
 **设置 `--scope` 时共用** `--context-before` / `--context-after` / `--max-depth`。
 

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -17,23 +17,10 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --detail with-ids
 lark-cli docs +fetch --doc Z1Fj...tnAc --scope outline --max-depth 3
 
 # 按 block id 区间精读
-lark-cli docs +fetch --doc Z1Fj...tnAc \
-  --scope range --start-block-id blkA --end-block-id blkB --detail with-ids
+lark-cli docs +fetch --doc Z1Fj...tnAc --scope range --start-block-id blkA --end-block-id blkB --detail with-ids
 
-# URL 带选区锚点时自动局部读取（仅 #share- / #part-）
-lark-cli docs +fetch \
-  --doc 'https://bytedance.larkoffice.com/wiki/wikcnInnPln2MWskas4CZT6iynf#share-CUE3d6Ykno2fkexEvt8cGF8Wnse'
-
-# 显式读取选区锚点
-lark-cli docs +fetch \
-  --doc 'https://bytedance.larkoffice.com/wiki/wikcnInnPln2MWskas4CZT6iynf' \
-  --scope range \
-  --start-block-id '#share-CUE3d6Ykno2fkexEvt8cGF8Wnse'
-
-# 强制全文读取时忽略选区锚点
-lark-cli docs +fetch \
-  --doc 'https://bytedance.larkoffice.com/wiki/wikcnInnPln2MWskas4CZT6iynf#share-CUE3d6Ykno2fkexEvt8cGF8Wnse' \
-  --scope full
+# URL 带 #share 选区锚点时自动局部读取
+lark-cli docs +fetch --doc 'docURL#share-anchor'
 
 # 读整个章节（以标题 id 为锚点，自动展开到下一个同级/更高级标题前）
 lark-cli docs +fetch --doc Z1Fj...tnAc \
@@ -64,18 +51,6 @@ lark-cli docs +fetch --doc Z1Fj...tnAc \
 | `keyword` | 只有模糊关键词 | `--keyword`（**多级自动 fallback**：子串 → 归一化 → 分词形变 → RE2 正则；`\|` 分隔多分支 OR） | 每处命中按"最小包容单元"输出；**自动去重**（同容器多命中 → 单个容器，同表格多行命中 → 合并切片） |
 
 > 💡 **多关键词用 `\|` 拼接（OR 语义，任一命中即返回）**：例 `"部署\|发布\|上线"`，三词任一命中都进结果，适合**同义词/别名/多业务术语**一次召回（如 `bug\|缺陷\|故障`）。
-
-### 选区锚点（`#share-...` / `#part-...`）
-
-用户给出带 `#share-...` 或 `#part-...` fragment 的文档 URL 时，优先只读取该选区。必须用引号包住 URL 或锚点，避免 shell 把 `#` 当注释。
-
-- 直接传 URL：`--doc '...#share-xxx'`，且未显式 `--scope full` 时，CLI 会自动等价为 `--scope range --start-block-id '#share-xxx'`。
-- 显式写法：`--scope range --start-block-id '#share-xxx'` 或 `--scope range --start-block-id '#part-xxx'`。
-- 强制全文：URL 即使带 `#share-...` / `#part-...`，只要传 `--scope full` 就读全文。
-- 普通 `#block_id` 不是选区锚点，不会自动触发局部读取；需要 block 级读取时显式使用 `range` / `section`。
-- 选区锚点只允许放在 `--start-block-id`，不要传给 `--end-block-id`。
-- 不要在 Agent 侧换算真实 block ID；CLI/SDK 会把选区锚点交给后端解析。
-- 如果当前安装的 `lark-cli` 不支持该语法，说明客户端较旧；可以先全文读取或提示升级，不要手写锚点换算逻辑。
 
 **设置 `--scope` 时共用** `--context-before` / `--context-after` / `--max-depth`。
 

--- a/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
@@ -43,6 +43,35 @@ func TestDocsFetchDryRunIgnoresAPIVersionCompatFlag(t *testing.T) {
 	}
 }
 
+func TestDocsFetchDryRunSelectionAnchorFragmentBecomesRangeStart(t *testing.T) {
+	setDocsDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+fetch",
+			"--doc", "https://example.larksuite.com/wiki/wikcnDryRun#share-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := gjson.Get(out, "api.0.url").String(); got != "/open-apis/docs_ai/v1/documents/wikcnDryRun/fetch" {
+		t.Fatalf("url=%q, want docs fetch endpoint\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.body.read_option.read_mode").String(); got != "range" {
+		t.Fatalf("read_mode=%q, want range\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.body.read_option.start_block_id").String(); got != "share-CUE3d6Ykno2fkexEvt8cGF8Wnse" {
+		t.Fatalf("start_block_id=%q, want selection anchor\nstdout:\n%s", got, out)
+	}
+}
+
 func setDocsDryRunEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())

--- a/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
@@ -72,6 +72,29 @@ func TestDocsFetchDryRunSelectionAnchorFragmentBecomesRangeStart(t *testing.T) {
 	}
 }
 
+func TestDocsFetchDryRunUnsupportedSelectionAnchorFragmentStaysFull(t *testing.T) {
+	setDocsDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+fetch",
+			"--doc", "https://example.larksuite.com/wiki/wikcnDryRun#part-CUE3d6Ykno2fkexEvt8cGF8Wnse",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := gjson.Get(out, "api.0.body.read_option").Raw; got != "" {
+		t.Fatalf("read_option=%s, want omitted for unsupported selection anchor\nstdout:\n%s", got, out)
+	}
+}
+
 func setDocsDryRunEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())


### PR DESCRIPTION
## Summary
- preserve docs URL fragments and auto-convert `#share-*` / `#part-*` fragments to range `start_block_id` when scope is not explicitly full
- keep ordinary `#block_id` fragments as normal full-doc fetches
- reject selection anchors passed through `--end-block-id` and keep `--scope full` as a full-read override

## Validation
- remote Go tests for `shortcuts/doc` passed
- PPE E2E passed through `lark-cli docs +fetch` against `creation.platform.ai_edit_pre_release` / `ppe_codex_share_anchor_r2` for URL#share auto-range, explicit range, full override, ordinary fragment, and invalid end-block-id cases

## Related
- SDK MR: https://code.byted.org/lark/office_ai_sdk/merge_requests/179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `docs +fetch` can infer localized `range` reads from `--doc` selection-anchor fragments (`#share-...`) by auto-setting `read_mode=range` and using the fragment id as `start_block_id` (when scope is range-like).
  * `--scope full` ignores selection-anchor fragments; ordinary or unsupported anchors (e.g., `#part-...`, `#share-`) won’t trigger auto-reading.
* **Bug Fixes**
  * Validation now supports range mode when start/end can be inferred from the effective selection-anchor-derived settings (instead of requiring explicit start/end).
* **Documentation**
  * Updated `--scope range` examples and guidance for `#share-...` behavior.
* **Tests**
  * Added unit, e2e, and dry-run coverage for selection-anchor handling and request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->