### PR TITLE
fix(doc): reject unsafe str_replace code spans

### DIFF
--- a/shortcuts/doc/docs_update_test.go
+++ b/shortcuts/doc/docs_update_test.go
@@ -207,6 +207,42 @@ func TestValidateUpdateV2RejectsInvalidReferenceMap(t *testing.T) {
 	}
 }
 
+func TestValidateUpdateV2RejectsStrReplacePunctuationOnlyInlineCode(t *testing.T) {
+	t.Parallel()
+
+	runtime := newUpdateShortcutTestRuntime(t, "", map[string]string{
+		"command": "str_replace",
+		"pattern": "TEST :: and .",
+		"content": `<p>TEST <code>::</code> and <code>.</code> and <code>ok</code></p>`,
+	})
+
+	err := validateUpdateV2(context.Background(), runtime)
+	assertValidationContract(t, err, errs.SubtypeInvalidArgument, "--content")
+	for _, want := range []string{
+		"punctuation-only <code>",
+		"docs_ai str_replace",
+		"block_replace",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validateUpdateV2() error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestValidateUpdateV2AllowsStrReplaceAlphanumericInlineCode(t *testing.T) {
+	t.Parallel()
+
+	runtime := newUpdateShortcutTestRuntime(t, "", map[string]string{
+		"command": "str_replace",
+		"pattern": "TEST fmt.Println",
+		"content": `<p>TEST <code>fmt.Println</code></p>`,
+	})
+
+	if err := validateUpdateV2(context.Background(), runtime); err != nil {
+		t.Fatalf("validateUpdateV2() error = %v", err)
+	}
+}
+
 func TestDocsUpdateRejectsLegacyFlags(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -6,8 +6,11 @@ package doc
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"strings"
+	"unicode"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -73,6 +76,9 @@ func validateUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 		if pattern == "" {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--command str_replace requires --pattern").WithParam("--pattern")
 		}
+		if err := validateStrReplaceInlineCodeContent(runtime.Str("doc-format"), content); err != nil {
+			return err
+		}
 	case "block_delete":
 		if blockID == "" {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--command block_delete requires --block-id").WithParam("--block-id")
@@ -122,6 +128,81 @@ func validateUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 		return err
 	}
 	return nil
+}
+
+func validateStrReplaceInlineCodeContent(format, content string) error {
+	if strings.TrimSpace(format) != "xml" || content == "" {
+		return nil
+	}
+	code, ok := firstPunctuationOnlyInlineCode(content)
+	if !ok {
+		return nil
+	}
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, "docs_ai str_replace can strip punctuation-only <code> content %q; fetch block ids and use --command block_replace for this rich-text edit", code).WithParam("--content")
+}
+
+func firstPunctuationOnlyInlineCode(raw string) (string, bool) {
+	decoder := xml.NewDecoder(strings.NewReader("<root>" + raw + "</root>"))
+	var inCode bool
+	var depth int
+	var text strings.Builder
+
+	for {
+		tok, err := decoder.Token()
+		if err == io.EOF {
+			return "", false
+		}
+		if err != nil {
+			return "", false
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if inCode {
+				depth++
+				continue
+			}
+			if t.Name.Local == "code" {
+				inCode = true
+				depth = 1
+				text.Reset()
+			}
+		case xml.EndElement:
+			if !inCode {
+				continue
+			}
+			depth--
+			if depth == 0 {
+				code := strings.TrimSpace(text.String())
+				if isPunctuationOnlyCodeText(code) {
+					return code, true
+				}
+				inCode = false
+			}
+		case xml.CharData:
+			if inCode {
+				text.Write([]byte(t))
+			}
+		}
+	}
+}
+
+func isPunctuationOnlyCodeText(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return false
+		}
+		if unicode.IsPunct(r) || unicode.IsSymbol(r) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func dryRunUpdateV2(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -241,7 +241,7 @@ lark-cli docs +update --doc "<doc_id>" --command str_replace \
   - **XML 模式（默认）**：`--pattern` 只支持**行内**匹配，不支持跨行 / 跨 block。段落、整块或容器级（列表、表格、分栏、引用块等）改动请改用 `block_replace` 指定 block_id 重建。
   - **Markdown 模式**（`--doc-format markdown`）：`--pattern` 同时支持**行内和跨行**匹配，还支持 `前缀...后缀` 省略号语法（用 `...` 串联首尾片段匹配一大段内容），可以一次替换多行文本；但仍建议优先按最小片段匹配，跨 block 容器级重写仍优先用 `block_replace`，避免副作用。
 - **保护不可重建的内容**：图片、画板、电子表格等以 token 形式存储，替换时避开这些 block
-- **str_replace 的 replacement 支持富文本**：可以用行内标签 `<b>`、`<a>`、`<cite>`、`<latex>` 等替换普通文本为富文本
+- **str_replace 的 replacement 支持富文本**：可以用行内标签 `<b>`、`<a>`、`<cite>`、`<latex>` 等替换普通文本为富文本；如果 replacement 含纯标点行内代码（例如 `<code>::</code>`、`<code>.</code>`、`<code>-></code>`），`docs_ai str_replace` 可能把 `<code>` 静默降级为普通文本，CLI 会拒绝该输入。先 `docs +fetch --detail with-ids` 获取 block_id，再用 `block_replace` 重建目标 block。
 - **同一 block 只能被 replace 一次**：多次修改同一 block 请合并为一次 block_replace
 - **block_delete 支持批量**：用逗号分隔多个 block_id 一次删除
 - **复杂结构重组**：将多个段落转换为 grid / table 等复杂布局时，分步操作比 overwrite 更安全：

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -226,3 +226,36 @@ func TestDocs_CreateTitleDryRunPrependsContent(t *testing.T) {
 	require.Equal(t, "markdown", gjson.Get(out, "api.0.body.format").String(), "stdout:\n%s", out)
 	require.Equal(t, "<title>Dry Run &amp; Title</title>\n## Body", gjson.Get(out, "api.0.body.content").String(), "stdout:\n%s", out)
 }
+
+func TestDocs_UpdateRejectsStrReplacePunctuationOnlyInlineCode(t *testing.T) {
+	// Fake creds are enough — validation fails before any real API call.
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+update",
+			"--doc", "doxcnDryRunE2E",
+			"--command", "str_replace",
+			"--pattern", "TEST :: and .",
+			"--content", `<p>TEST <code>::</code> and <code>.</code></p>`,
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+
+	combined := result.Stdout + "\n" + result.Stderr
+	for _, want := range []string{
+		"--content",
+		"punctuation-only <code>",
+		"block_replace",
+	} {
+		require.Contains(t, combined, want, "stdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
+	}
+}


### PR DESCRIPTION
## Summary
Reject unsafe `docs +update --command str_replace` content that contains punctuation-only inline `<code>` spans, because the upstream str_replace path strips those tags while `block_replace` preserves them.

## Changes
- Detect punctuation-only XML `<code>` inline spans for `str_replace` replacement content.
- Return a typed validation error bound to `--content` with guidance to use `block_replace`.
- Add shortcut and CLI dry-run regression coverage.
- Document the `str_replace` edge case in the lark-doc update reference.

## Test Plan
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./shortcuts/doc -count=1`
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go build -o ./lark-cli .`
- [x] `LARK_CLI_BIN=$PWD/lark-cli GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./tests/cli_e2e/docs -run 'TestDocs_DryRunDefaultsToV2OpenAPI|TestDocs_UpdateRejectsStrReplacePunctuationOnlyInlineCode' -count=1`
- [x] `git diff --check`
- [x] conflict marker scan

## Related Issues
- Fixes #1680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for document updates so punctuation-only inline code is rejected in cases where it could produce unreliable replacements.
  * Clarified error feedback to guide users toward a safer block-based replacement workflow.
* **Documentation**
  * Expanded best-practice guidance for rich-text replacements, including when to use block replacements instead of inline code updates.
* **Tests**
  * Added coverage for both rejected and accepted inline-code replacement scenarios, plus an end-to-end CLI check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->