### PR TITLE
fix(doc): warn on markdown heading numbering loss

### DIFF
--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -74,8 +74,10 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if err := processHTML5BlockReferenceMapForFetch(runtime, effectiveFetchFormat(runtime), ref.Token, data); err != nil {
 		return err
 	}
-	if warning := addFetchDetailDowngradeWarning(runtime, data); warning != "" && runtime.Format == "pretty" {
-		fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", warning)
+	for _, warning := range addFetchWarnings(runtime, data) {
+		if runtime.Format == "pretty" {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", warning)
+		}
 	}
 	if isIMMarkdownFetch(runtime) {
 		applyFetchIMMarkdown(data, runtime.Str("doc"))
@@ -192,6 +194,17 @@ func effectiveFetchDetail(runtime *common.RuntimeContext) string {
 	return detail
 }
 
+func addFetchWarnings(runtime *common.RuntimeContext, data map[string]interface{}) []string {
+	var warnings []string
+	if warning := addFetchDetailDowngradeWarning(runtime, data); warning != "" {
+		warnings = append(warnings, warning)
+	}
+	if warning := addFetchMarkdownHeadingSeqWarning(runtime, data); warning != "" {
+		warnings = append(warnings, warning)
+	}
+	return warnings
+}
+
 func addFetchDetailDowngradeWarning(runtime *common.RuntimeContext, data map[string]interface{}) string {
 	format := strings.TrimSpace(runtime.Str("doc-format"))
 	detail := strings.TrimSpace(runtime.Str("detail"))
@@ -202,6 +215,16 @@ func addFetchDetailDowngradeWarning(runtime *common.RuntimeContext, data map[str
 		return ""
 	}
 	warning := fmt.Sprintf("--detail %s is only supported with --doc-format xml; returning %s output and ignoring the unsupported detail option", detail, format)
+	appendDocWarning(data, warning)
+	return warning
+}
+
+func addFetchMarkdownHeadingSeqWarning(runtime *common.RuntimeContext, data map[string]interface{}) string {
+	format := strings.TrimSpace(runtime.Str("doc-format"))
+	if format != "markdown" && format != "im-markdown" {
+		return ""
+	}
+	warning := "markdown output cannot preserve heading auto-numbering metadata (seq/seq-level); refetch with --doc-format xml when heading numbering matters"
 	appendDocWarning(data, warning)
 	return warning
 }

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -691,11 +691,65 @@ func TestDocsFetchMarkdownDetailDowngradeWarnsInOutput(t *testing.T) {
 	}
 	data, _ := envelope["data"].(map[string]interface{})
 	warnings, _ := data["warnings"].([]interface{})
-	if len(warnings) != 1 {
-		t.Fatalf("warnings = %#v, want one downgrade warning", data["warnings"])
+	if len(warnings) != 2 {
+		t.Fatalf("warnings = %#v, want downgrade and heading seq warnings", data["warnings"])
 	}
-	if got, _ := warnings[0].(string); !strings.Contains(got, "returning markdown output") || !strings.Contains(got, "ignoring the unsupported detail option") {
-		t.Fatalf("unexpected warning: %q", got)
+	gotWarnings := fmt.Sprint(warnings)
+	for _, want := range []string{
+		"returning markdown output",
+		"ignoring the unsupported detail option",
+		"seq/seq-level",
+	} {
+		if !strings.Contains(gotWarnings, want) {
+			t.Fatalf("warnings missing %q: %#v", want, data["warnings"])
+		}
+	}
+}
+
+func TestDocsFetchMarkdownWarnsAboutHeadingSeqLoss(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-heading-seq-warning"))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/docs_ai/v1/documents/doxcnFetchSeqWarning/fetch",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"document": map[string]interface{}{
+					"document_id": "doxcnFetchSeqWarning",
+					"revision_id": float64(1),
+					"content":     "# Section A\n\n## Section A.1",
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", "doxcnFetchSeqWarning",
+		"--doc-format", "markdown",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v\nraw=%s", err, stdout.String())
+	}
+	data, _ := envelope["data"].(map[string]interface{})
+	warnings, _ := data["warnings"].([]interface{})
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %#v, want one heading seq warning", data["warnings"])
+	}
+	got, _ := warnings[0].(string)
+	for _, want := range []string{"heading", "seq", "seq-level", "--doc-format xml"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warning missing %q: %q", want, got)
+		}
 	}
 }
 

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -91,7 +91,7 @@ lark-cli docs +fetch --doc Z1Fj...tnAc \
 }
 ```
 
-`content` 的格式由 `--doc-format` 决定；`im-markdown` 仅用于获取内容后在 `lark-im` 场景下使用。设置 `--scope` 时会被 `<fragment>` 包裹，详见上文"局部读取的输出结构"。
+`content` 的格式由 `--doc-format` 决定；`im-markdown` 仅用于获取内容后在 `lark-im` 场景下使用。设置 `--scope` 时会被 `<fragment>` 包裹，详见上文"局部读取的输出结构"。Markdown / im-markdown 输出无法保留标题自动编号元数据（`seq` / `seq-level`）；如果需要判断标题是否启用了自动编号，必须改用 `--doc-format xml`。
 
 ## 参数
 


### PR DESCRIPTION
## Summary
Warn callers when `docs +fetch --doc-format markdown` or `im-markdown` cannot preserve heading `seq` / `seq-level` metadata, so agents know to fetch XML when numbering fidelity matters.

## Changes
- Add fetch response warnings for Markdown formats that drop heading numbering metadata.
- Cover the warning path in docs fetch tests.
- Update the lark-doc fetch reference with XML guidance for heading numbering metadata.

## Test Plan
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./shortcuts/doc -count=1`
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go build -o ./lark-cli .`
- [x] `LARK_CLI_BIN=$PWD/lark-cli GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./tests/cli_e2e/docs -run 'TestDocs_DryRunDefaultsToV2OpenAPI' -count=1`
- [x] `git diff --check`
- [x] conflict marker scan

## Related Issues
- Fixes #1781


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for showing multiple warnings during document fetches.
  * Markdown fetches now warn when heading auto-numbering metadata may be lost, with guidance to use XML when needed.
* **Bug Fixes**
  * Improved warning output so users can see all relevant notices instead of only one.
* **Documentation**
  * Updated fetch guidance to clarify Markdown and im-markdown format limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->