### PR TITLE
fix(auth): preserve user token state on refresh failure

### DIFF
--- a/internal/auth/uat_client.go
+++ b/internal/auth/uat_client.go
@@ -122,7 +122,14 @@ func refreshWithLock(httpClient *http.Client, opts UATCallOptions, stored *Store
 			// fallback in case of unexpected type
 			refreshLocks.Delete(key)
 		}
-		return getStoredUAToken(opts.AppId, opts.UserOpenId), nil
+		refreshed := getStoredUAToken(opts.AppId, opts.UserOpenId)
+		if refreshed == nil {
+			return nil, nil
+		}
+		if TokenStatus(refreshed) == "valid" {
+			return refreshed, nil
+		}
+		return nil, preservedRefreshStateError(opts)
 	}
 
 	// We own the process lock; done is the channel stored in the map
@@ -138,7 +145,8 @@ func refreshWithLock(httpClient *http.Client, opts UATCallOptions, stored *Store
 
 	lockDir := filepath.Join(configDir, "locks")
 	if err := vfs.MkdirAll(lockDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create lock directory: %w", err)
+		return nil, errs.NewInternalError(errs.SubtypeFileIO, "failed to create token refresh lock directory").
+			WithCause(err)
 	}
 
 	safeAppId := sanitizeID(opts.AppId)
@@ -152,10 +160,11 @@ func refreshWithLock(httpClient *http.Client, opts UATCallOptions, stored *Store
 
 	locked, err := fileLock.TryLockContext(ctx, 500*time.Millisecond)
 	if err != nil {
-		return nil, fmt.Errorf("failed to acquire cross-process lock: %w", err)
+		return nil, errs.NewInternalError(errs.SubtypeFileIO, "failed to acquire token refresh lock").
+			WithCause(err)
 	}
 	if !locked {
-		return nil, fmt.Errorf("timeout waiting for cross-process lock")
+		return nil, errs.NewInternalError(errs.SubtypeStorage, "timeout waiting for token refresh lock")
 	}
 	defer fileLock.Unlock()
 
@@ -227,7 +236,7 @@ func doRefreshToken(httpClient *http.Client, opts UATCallOptions, stored *Stored
 
 	data, err := callEndpoint()
 	if err != nil {
-		return nil, err
+		return nil, wrapRefreshTransportError(err)
 	}
 
 	code := getInt(data, "code", -1)
@@ -258,7 +267,7 @@ func doRefreshToken(httpClient *http.Client, opts UATCallOptions, stored *Stored
 			data, err = callEndpoint()
 			if err != nil {
 				fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh retry network error for %s; preserving token state for retry\n", opts.UserOpenId)
-				return nil, err
+				return nil, wrapRefreshTransportError(err)
 			}
 			code = getInt(data, "code", -1)
 			errStr = getStr(data, "error")
@@ -275,7 +284,7 @@ func doRefreshToken(httpClient *http.Client, opts UATCallOptions, stored *Stored
 
 	accessToken := getStr(data, "access_token")
 	if accessToken == "" {
-		return nil, fmt.Errorf("Token refresh returned no access_token")
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "token refresh returned no access_token")
 	}
 
 	refreshToken := getStr(data, "refresh_token")
@@ -307,9 +316,24 @@ func doRefreshToken(httpClient *http.Client, opts UATCallOptions, stored *Stored
 	}
 
 	if err := setStoredUAToken(updated); err != nil {
-		return nil, err
+		return nil, errs.NewInternalError(errs.SubtypeStorage, "failed to store refreshed user access token").
+			WithCause(err)
 	}
 	return updated, nil
+}
+
+func preservedRefreshStateError(opts UATCallOptions) error {
+	return errs.NewAuthenticationError(errs.SubtypeRefreshServerError, "token refresh did not produce a valid access token").
+		WithUserOpenID(opts.UserOpenId).
+		WithHint("refresh failed but local auth state was preserved; retry after any concurrent lark-cli command finishes, or run `lark-cli auth login` if the refresh token was revoked")
+}
+
+func wrapRefreshTransportError(err error) error {
+	if _, ok := errs.ProblemOf(err); ok {
+		return err
+	}
+	return errs.NewNetworkError(errs.SubtypeNetworkTransport, "token refresh retry failed: %v", err).
+		WithCause(err)
 }
 
 func buildRefreshFailureError(data map[string]interface{}, opts UATCallOptions) error {
@@ -324,23 +348,21 @@ func buildRefreshFailureError(data map[string]interface{}, opts UATCallOptions) 
 	if msg == "" {
 		msg = fmt.Sprintf("token refresh failed with code %d", code)
 	}
-	if err := errclass.BuildAPIError(map[string]interface{}{
-		"code": code,
-		"msg":  msg,
-	}, errclass.ClassifyContext{
-		Brand: string(opts.Domain),
-		AppID: opts.AppId,
-	}); err != nil {
-		if authErr, ok := err.(*errs.AuthenticationError); ok {
-			authErr.UserOpenID = opts.UserOpenId
-			if authErr.Hint == "" {
-				authErr.Hint = "refresh failed but local auth state was preserved; retry after any concurrent lark-cli command finishes, or run `lark-cli auth login` if the refresh token was revoked"
+	if code != -1 {
+		if err := errclass.BuildAPIError(data, errclass.ClassifyContext{
+			Brand: string(opts.Domain),
+			AppID: opts.AppId,
+		}); err != nil {
+			if authErr, ok := err.(*errs.AuthenticationError); ok {
+				authErr.UserOpenID = opts.UserOpenId
+				if authErr.Hint == "" {
+					authErr.Hint = "refresh failed but local auth state was preserved; retry after any concurrent lark-cli command finishes, or run `lark-cli auth login` if the refresh token was revoked"
+				}
 			}
+			return err
 		}
-		return err
 	}
 	return errs.NewAuthenticationError(errs.SubtypeRefreshServerError, "%s", msg).
-		WithCode(code).
 		WithUserOpenID(opts.UserOpenId).
 		WithHint("refresh failed but local auth state was preserved; retry after any concurrent lark-cli command finishes, or run `lark-cli auth login` if the refresh token was revoked")
 }

--- a/internal/auth/uat_client.go
+++ b/internal/auth/uat_client.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -353,7 +354,8 @@ func buildRefreshFailureError(data map[string]interface{}, opts UATCallOptions) 
 			Brand: string(opts.Domain),
 			AppID: opts.AppId,
 		}); err != nil {
-			if authErr, ok := err.(*errs.AuthenticationError); ok {
+			var authErr *errs.AuthenticationError
+			if errors.As(err, &authErr) {
 				authErr.UserOpenID = opts.UserOpenId
 				if authErr.Hint == "" {
 					authErr.Hint = "refresh failed but local auth state was preserved; retry after any concurrent lark-cli command finishes, or run `lark-cli auth login` if the refresh token was revoked"

--- a/internal/auth/uat_client.go
+++ b/internal/auth/uat_client.go
@@ -67,9 +67,15 @@ func NewUATCallOptions(cfg *core.CliConfig, errOut io.Writer) UATCallOptions {
 
 var refreshLocks sync.Map
 
+var (
+	getStoredUAToken    = GetStoredToken
+	setStoredUAToken    = SetStoredToken
+	removeStoredUAToken = RemoveStoredToken
+)
+
 // GetValidAccessToken obtains a valid access token for the given user.
 func GetValidAccessToken(httpClient *http.Client, opts UATCallOptions) (string, error) {
-	stored := GetStoredToken(opts.AppId, opts.UserOpenId)
+	stored := getStoredUAToken(opts.AppId, opts.UserOpenId)
 	if stored == nil {
 		return "", NewNeedUserAuthorizationError(opts.UserOpenId)
 	}
@@ -92,7 +98,7 @@ func GetValidAccessToken(httpClient *http.Client, opts UATCallOptions) (string, 
 	}
 
 	// expired
-	if err := RemoveStoredToken(opts.AppId, opts.UserOpenId); err != nil {
+	if err := removeStoredUAToken(opts.AppId, opts.UserOpenId); err != nil {
 		if opts.ErrOut != nil {
 			fmt.Fprintf(opts.ErrOut, "[lark-cli] [WARN] uat-client: failed to remove token: %v\n", err)
 		} else {
@@ -116,7 +122,7 @@ func refreshWithLock(httpClient *http.Client, opts UATCallOptions, stored *Store
 			// fallback in case of unexpected type
 			refreshLocks.Delete(key)
 		}
-		return GetStoredToken(opts.AppId, opts.UserOpenId), nil
+		return getStoredUAToken(opts.AppId, opts.UserOpenId), nil
 	}
 
 	// We own the process lock; done is the channel stored in the map
@@ -154,7 +160,7 @@ func refreshWithLock(httpClient *http.Client, opts UATCallOptions, stored *Store
 	defer fileLock.Unlock()
 
 	// 3. Double-checked locking: Check if another process has already refreshed the token
-	freshStored := GetStoredToken(opts.AppId, opts.UserOpenId)
+	freshStored := getStoredUAToken(opts.AppId, opts.UserOpenId)
 	if freshStored != nil {
 		status := TokenStatus(freshStored)
 		if status == "valid" {
@@ -180,7 +186,7 @@ func doRefreshToken(httpClient *http.Client, opts UATCallOptions, stored *Stored
 	now := time.Now().UnixMilli()
 	if now >= stored.RefreshExpiresAt {
 		fmt.Fprintf(errOut, "[lark-cli] uat-client: refresh_token expired for %s, clearing\n", opts.UserOpenId)
-		if err := RemoveStoredToken(opts.AppId, opts.UserOpenId); err != nil {
+		if err := removeStoredUAToken(opts.AppId, opts.UserOpenId); err != nil {
 			fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: failed to remove expired token: %v\n", err)
 		}
 		return nil, nil
@@ -251,29 +257,19 @@ func doRefreshToken(httpClient *http.Client, opts UATCallOptions, stored *Stored
 			fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh transient error (code=%d) for %s, retrying once\n", code, opts.UserOpenId)
 			data, err = callEndpoint()
 			if err != nil {
-				fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh retry network error for %s, clearing token\n", opts.UserOpenId)
-				if err := RemoveStoredToken(opts.AppId, opts.UserOpenId); err != nil {
-					fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: failed to remove token: %v\n", err)
-				}
-				return nil, nil
+				fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh retry network error for %s; preserving token state for retry\n", opts.UserOpenId)
+				return nil, err
 			}
 			code = getInt(data, "code", -1)
 			errStr = getStr(data, "error")
 			if (code != -1 && code != 0) || errStr != "" {
-				fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh failed after retry (code=%d) for %s, clearing token\n", code, opts.UserOpenId)
-				if err := RemoveStoredToken(opts.AppId, opts.UserOpenId); err != nil {
-					fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: failed to remove token: %v\n", err)
-				}
-				return nil, nil
+				fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh failed after retry (code=%d) for %s; preserving token state for retry/diagnosis\n", code, opts.UserOpenId)
+				return nil, buildRefreshFailureError(data, opts)
 			}
 			// Retry succeeded, fall through to parse token below.
 		} else {
-			// All other errors: clear token, require re-authorization.
-			fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh failed (code=%d), clearing token for %s\n", code, opts.UserOpenId)
-			if err := RemoveStoredToken(opts.AppId, opts.UserOpenId); err != nil {
-				fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: failed to remove token: %v\n", err)
-			}
-			return nil, nil
+			fmt.Fprintf(errOut, "[lark-cli] [WARN] uat-client: refresh failed (code=%d) for %s; preserving token state for retry/diagnosis\n", code, opts.UserOpenId)
+			return nil, buildRefreshFailureError(data, opts)
 		}
 	}
 
@@ -310,8 +306,41 @@ func doRefreshToken(httpClient *http.Client, opts UATCallOptions, stored *Stored
 		GrantedAt:        stored.GrantedAt,
 	}
 
-	if err := SetStoredToken(updated); err != nil {
+	if err := setStoredUAToken(updated); err != nil {
 		return nil, err
 	}
 	return updated, nil
+}
+
+func buildRefreshFailureError(data map[string]interface{}, opts UATCallOptions) error {
+	code := getInt(data, "code", -1)
+	msg := getStr(data, "msg")
+	if msg == "" {
+		msg = getStr(data, "error_description")
+	}
+	if msg == "" {
+		msg = getStr(data, "error")
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("token refresh failed with code %d", code)
+	}
+	if err := errclass.BuildAPIError(map[string]interface{}{
+		"code": code,
+		"msg":  msg,
+	}, errclass.ClassifyContext{
+		Brand: string(opts.Domain),
+		AppID: opts.AppId,
+	}); err != nil {
+		if authErr, ok := err.(*errs.AuthenticationError); ok {
+			authErr.UserOpenID = opts.UserOpenId
+			if authErr.Hint == "" {
+				authErr.Hint = "refresh failed but local auth state was preserved; retry after any concurrent lark-cli command finishes, or run `lark-cli auth login` if the refresh token was revoked"
+			}
+		}
+		return err
+	}
+	return errs.NewAuthenticationError(errs.SubtypeRefreshServerError, "%s", msg).
+		WithCode(code).
+		WithUserOpenID(opts.UserOpenId).
+		WithHint("refresh failed but local auth state was preserved; retry after any concurrent lark-cli command finishes, or run `lark-cli auth login` if the refresh token was revoked")
 }

--- a/internal/auth/uat_client_test.go
+++ b/internal/auth/uat_client_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 
 func withStubbedUATStore(t *testing.T, initial *StoredUAToken) (*StoredUAToken, *int) {
 	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	origGet := getStoredUAToken
 	origSet := setStoredUAToken
 	origRemove := removeStoredUAToken
@@ -138,7 +140,203 @@ func TestGetValidAccessToken_ClearsLocallyExpiredRefreshToken(t *testing.T) {
 	if !errors.As(err, &needAuth) {
 		t.Fatalf("expected need authorization cause, got %T: %v", err, err)
 	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthentication || p.Subtype != errs.SubtypeTokenMissing {
+		t.Fatalf("problem = %#v, want authentication/token_missing", p)
+	}
 	if *removeCalls != 1 {
 		t.Fatalf("RemoveStoredToken calls = %d, want 1", *removeCalls)
+	}
+}
+
+func TestGetValidAccessToken_WaitingRefreshDoesNotReturnExpiredStoredToken(t *testing.T) {
+	now := time.Now()
+	initial := &StoredUAToken{
+		UserOpenId:       "ou_user",
+		AppId:            "cli_test",
+		AccessToken:      "expired-access-token",
+		RefreshToken:     "refresh-token",
+		ExpiresAt:        now.Add(-time.Minute).UnixMilli(),
+		RefreshExpiresAt: now.Add(time.Hour).UnixMilli(),
+	}
+	_, removeCalls := withStubbedUATStore(t, initial)
+
+	key := "cli_test:ou_user"
+	ch := make(chan struct{})
+	refreshLocks.Store(key, ch)
+	t.Cleanup(func() {
+		refreshLocks.Delete(key)
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var got string
+	var err error
+	go func() {
+		defer wg.Done()
+		got, err = GetValidAccessToken(&http.Client{}, UATCallOptions{
+			UserOpenId: "ou_user",
+			AppId:      "cli_test",
+			AppSecret:  "secret",
+			Domain:     core.BrandFeishu,
+			ErrOut:     &bytes.Buffer{},
+		})
+	}()
+	close(ch)
+	wg.Wait()
+
+	if err == nil {
+		t.Fatalf("expected refresh failure, got token %q", got)
+	}
+	if got != "" {
+		t.Fatalf("access token = %q, want empty", got)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthentication || p.Subtype != errs.SubtypeRefreshServerError {
+		t.Fatalf("problem = %#v, want authentication/refresh_server_error", p)
+	}
+	if *removeCalls != 0 {
+		t.Fatalf("RemoveStoredToken calls = %d, want 0", *removeCalls)
+	}
+}
+
+func TestGetValidAccessToken_WrapsRetryTransportFailure(t *testing.T) {
+	now := time.Now()
+	initial := &StoredUAToken{
+		UserOpenId:       "ou_user",
+		AppId:            "cli_test",
+		AccessToken:      "expired-access-token",
+		RefreshToken:     "refresh-token",
+		ExpiresAt:        now.Add(-time.Minute).UnixMilli(),
+		RefreshExpiresAt: now.Add(time.Hour).UnixMilli(),
+	}
+	_, removeCalls := withStubbedUATStore(t, initial)
+
+	reg := &httpmock.Registry{}
+	t.Cleanup(func() { reg.Verify(t) })
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/authen/v2/oauth/token",
+		Body: map[string]interface{}{
+			"code": 20050,
+			"msg":  "refresh endpoint transient error",
+		},
+	})
+
+	_, err := GetValidAccessToken(httpmock.NewClient(reg), UATCallOptions{
+		UserOpenId: "ou_user",
+		AppId:      "cli_test",
+		AppSecret:  "secret",
+		Domain:     core.BrandFeishu,
+		ErrOut:     &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected retry transport error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryNetwork || p.Subtype != errs.SubtypeNetworkTransport {
+		t.Fatalf("problem = %#v, want network/transport", p)
+	}
+	if *removeCalls != 0 {
+		t.Fatalf("RemoveStoredToken calls = %d, want 0", *removeCalls)
+	}
+}
+
+func TestGetValidAccessToken_WrapsInitialTransportFailure(t *testing.T) {
+	now := time.Now()
+	initial := &StoredUAToken{
+		UserOpenId:       "ou_user",
+		AppId:            "cli_test",
+		AccessToken:      "expired-access-token",
+		RefreshToken:     "refresh-token",
+		ExpiresAt:        now.Add(-time.Minute).UnixMilli(),
+		RefreshExpiresAt: now.Add(time.Hour).UnixMilli(),
+	}
+	_, removeCalls := withStubbedUATStore(t, initial)
+
+	_, err := GetValidAccessToken(httpmock.NewClient(&httpmock.Registry{}), UATCallOptions{
+		UserOpenId: "ou_user",
+		AppId:      "cli_test",
+		AppSecret:  "secret",
+		Domain:     core.BrandFeishu,
+		ErrOut:     &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected initial transport error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryNetwork || p.Subtype != errs.SubtypeNetworkTransport {
+		t.Fatalf("problem = %#v, want network/transport", p)
+	}
+	if *removeCalls != 0 {
+		t.Fatalf("RemoveStoredToken calls = %d, want 0", *removeCalls)
+	}
+}
+
+func TestBuildRefreshFailureError_OAuthStyleNoCodeIsAuthenticationError(t *testing.T) {
+	err := buildRefreshFailureError(map[string]interface{}{
+		"error":             "invalid_grant",
+		"error_description": "refresh token revoked",
+	}, UATCallOptions{
+		UserOpenId: "ou_user",
+		AppId:      "cli_test",
+		Domain:     core.BrandFeishu,
+	})
+	if err == nil {
+		t.Fatal("expected refresh error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthentication || p.Subtype != errs.SubtypeRefreshServerError {
+		t.Fatalf("problem = %#v, want authentication/refresh_server_error", p)
+	}
+	if p.Code != 0 {
+		t.Fatalf("problem code = %d, want 0 for no-code OAuth error", p.Code)
+	}
+	var authErr *errs.AuthenticationError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthenticationError, got %T", err)
+	}
+	if authErr.UserOpenID != "ou_user" {
+		t.Fatalf("user_open_id = %q, want ou_user", authErr.UserOpenID)
+	}
+}
+
+func TestBuildRefreshFailureError_PreservesAPIResponseMetadata(t *testing.T) {
+	err := buildRefreshFailureError(map[string]interface{}{
+		"code":   99991400,
+		"msg":    "too many requests",
+		"log_id": "log-123",
+	}, UATCallOptions{
+		UserOpenId: "ou_user",
+		AppId:      "cli_test",
+		Domain:     core.BrandFeishu,
+	})
+	if err == nil {
+		t.Fatal("expected refresh error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeRateLimit {
+		t.Fatalf("problem = %#v, want api/rate_limit", p)
+	}
+	if p.LogID != "log-123" {
+		t.Fatalf("log_id = %q, want log-123", p.LogID)
 	}
 }

--- a/internal/auth/uat_client_test.go
+++ b/internal/auth/uat_client_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func withStubbedUATStore(t *testing.T, initial *StoredUAToken) (*StoredUAToken, *int) {
+	t.Helper()
+	origGet := getStoredUAToken
+	origSet := setStoredUAToken
+	origRemove := removeStoredUAToken
+
+	stored := initial
+	removeCalls := 0
+	getStoredUAToken = func(appID, userOpenID string) *StoredUAToken {
+		if stored == nil || stored.AppId != appID || stored.UserOpenId != userOpenID {
+			return nil
+		}
+		copy := *stored
+		return &copy
+	}
+	setStoredUAToken = func(token *StoredUAToken) error {
+		copy := *token
+		stored = &copy
+		return nil
+	}
+	removeStoredUAToken = func(appID, userOpenID string) error {
+		removeCalls++
+		if stored != nil && stored.AppId == appID && stored.UserOpenId == userOpenID {
+			stored = nil
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		getStoredUAToken = origGet
+		setStoredUAToken = origSet
+		removeStoredUAToken = origRemove
+	})
+
+	return stored, &removeCalls
+}
+
+func TestGetValidAccessToken_PreservesUnexpiredRefreshTokenOnRefreshReused(t *testing.T) {
+	now := time.Now()
+	initial := &StoredUAToken{
+		UserOpenId:       "ou_user",
+		AppId:            "cli_test",
+		AccessToken:      "expired-access-token",
+		RefreshToken:     "refresh-token",
+		ExpiresAt:        now.Add(-time.Minute).UnixMilli(),
+		RefreshExpiresAt: now.Add(72 * time.Hour).UnixMilli(),
+		Scope:            "offline_access",
+		GrantedAt:        now.Add(-24 * time.Hour).UnixMilli(),
+	}
+	_, removeCalls := withStubbedUATStore(t, initial)
+
+	reg := &httpmock.Registry{}
+	t.Cleanup(func() { reg.Verify(t) })
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/authen/v2/oauth/token",
+		Body: map[string]interface{}{
+			"code": 20073,
+			"msg":  "refresh token has already been used",
+		},
+	})
+
+	_, err := GetValidAccessToken(httpmock.NewClient(reg), UATCallOptions{
+		UserOpenId: "ou_user",
+		AppId:      "cli_test",
+		AppSecret:  "secret",
+		Domain:     core.BrandFeishu,
+		ErrOut:     &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected refresh error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthentication || p.Subtype != errs.SubtypeRefreshTokenReused {
+		t.Fatalf("problem = %#v, want authentication/refresh_token_reused", p)
+	}
+	if p.Code != 20073 {
+		t.Fatalf("problem code = %d, want 20073", p.Code)
+	}
+	if p.Hint == "" {
+		t.Fatal("expected non-empty hint for preserved refresh state")
+	}
+	if *removeCalls != 0 {
+		t.Fatalf("RemoveStoredToken calls = %d, want 0", *removeCalls)
+	}
+	got := getStoredUAToken("cli_test", "ou_user")
+	if got == nil {
+		t.Fatal("stored token was removed; want preserved for retry/diagnosis")
+	}
+	if got.RefreshToken != initial.RefreshToken || got.RefreshExpiresAt != initial.RefreshExpiresAt {
+		t.Fatalf("stored refresh state changed: got token=%q expires=%d, want token=%q expires=%d",
+			got.RefreshToken, got.RefreshExpiresAt, initial.RefreshToken, initial.RefreshExpiresAt)
+	}
+}
+
+func TestGetValidAccessToken_ClearsLocallyExpiredRefreshToken(t *testing.T) {
+	now := time.Now()
+	initial := &StoredUAToken{
+		UserOpenId:       "ou_user",
+		AppId:            "cli_test",
+		AccessToken:      "expired-access-token",
+		RefreshToken:     "refresh-token",
+		ExpiresAt:        now.Add(-2 * time.Hour).UnixMilli(),
+		RefreshExpiresAt: now.Add(-time.Minute).UnixMilli(),
+	}
+	_, removeCalls := withStubbedUATStore(t, initial)
+
+	_, err := GetValidAccessToken(&http.Client{}, UATCallOptions{
+		UserOpenId: "ou_user",
+		AppId:      "cli_test",
+		AppSecret:  "secret",
+		Domain:     core.BrandFeishu,
+		ErrOut:     &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected missing authorization error")
+	}
+	var needAuth *NeedAuthorizationError
+	if !errors.As(err, &needAuth) {
+		t.Fatalf("expected need authorization cause, got %T: %v", err, err)
+	}
+	if *removeCalls != 1 {
+		t.Fatalf("RemoveStoredToken calls = %d, want 1", *removeCalls)
+	}
+}


### PR DESCRIPTION
## Summary
Preserve local user auth state when a refresh endpoint failure happens before the locally recorded `refreshExpiresAt`, so a failed refresh no longer collapses immediately to `token_missing`.

## Changes
- Return typed refresh errors for failed refresh responses instead of deleting the stored user token.
- Keep local refresh state available for retry and diagnosis when the refresh token is not locally expired.
- Continue clearing the stored token when local metadata says `refreshExpiresAt` is already expired.
- Add focused UAT refresh regression tests using a stubbed token store and token endpoint.

## Test Plan
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./internal/auth -run 'TestGetValidAccessToken_PreservesUnexpiredRefreshTokenOnRefreshReused|TestGetValidAccessToken_ClearsLocallyExpiredRefreshToken' -count=1`
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./internal/auth -count=1`
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./cmd/auth ./internal/credential -count=1`
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./internal/errclass -count=1`
- [x] `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go build -o ./lark-cli .`
- [x] `git diff --check`
- [x] conflict marker scan

## Related Issues
- Fixes #1404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in token refresh behavior to preserve existing local authentication state during retryable failures (avoids unnecessary token clearing).
  * Added clearer, structured refresh errors for cases like “refresh token already used,” authorization required, and “refresh in progress.”
  * Automatically clears locally expired refresh tokens so users can re-authenticate cleanly when needed.
* **Tests**
  * Expanded automated coverage for refresh-state preservation and refresh failure/error shaping, including transport-level failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->