### PR TITLE
Document mail attachment URL lifetime

### DIFF
--- a/skills/lark-mail/references/lark-mail-message.md
+++ b/skills/lark-mail/references/lark-mail-message.md
@@ -194,7 +194,7 @@ lark-cli mail user_mailbox.message.attachments download_url \
 ```
 
 普通附件和内嵌图片使用同一个 `user_mailbox.message.attachments download_url` 原生 API（无 shortcut 封装），传入 `attachments[].id` 即可。
-该 API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并优先读取服务端返回的 `data.download_url_usage_hint`。
+该 API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
 
 ## 日程邀请邮件
 

--- a/skills/lark-mail/references/lark-mail-message.md
+++ b/skills/lark-mail/references/lark-mail-message.md
@@ -194,7 +194,7 @@ lark-cli mail user_mailbox.message.attachments download_url \
 ```
 
 普通附件和内嵌图片使用同一个 `user_mailbox.message.attachments download_url` 原生 API（无 shortcut 封装），传入 `attachments[].id` 即可。
-该 API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
+该 API 返回的 `download_url` 是短时效临时预签名下载链接，通常约 2 小时或更短时间内有效且可能更早失效，并且最多只能下载 2 次。不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
 
 ## 日程邀请邮件
 

--- a/skills/lark-mail/references/lark-mail-message.md
+++ b/skills/lark-mail/references/lark-mail-message.md
@@ -194,6 +194,7 @@ lark-cli mail user_mailbox.message.attachments download_url \
 ```
 
 普通附件和内嵌图片使用同一个 `user_mailbox.message.attachments download_url` 原生 API（无 shortcut 封装），传入 `attachments[].id` 即可。
+该 API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并优先读取服务端返回的 `data.download_url_usage_hint`。
 
 ## 日程邀请邮件
 

--- a/skills/lark-mail/references/lark-mail-messages.md
+++ b/skills/lark-mail/references/lark-mail-messages.md
@@ -77,7 +77,7 @@ lark-cli mail +messages --message-ids <id1>,<id2> --dry-run
 - CLI 每 20 个 ID 拆成一次调用并合并输出，不需要为大列表手动拆请求。
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +messages` 仅返回附件元数据。如后续步骤需要下载 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
-- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
+- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，通常约 2 小时或更短时间内有效且可能更早失效，并且最多只能下载 2 次。不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 
 ## 典型场景

--- a/skills/lark-mail/references/lark-mail-messages.md
+++ b/skills/lark-mail/references/lark-mail-messages.md
@@ -77,7 +77,7 @@ lark-cli mail +messages --message-ids <id1>,<id2> --dry-run
 - CLI 每 20 个 ID 拆成一次调用并合并输出，不需要为大列表手动拆请求。
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +messages` 仅返回附件元数据。如后续步骤需要下载 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
-- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并优先读取服务端返回的 `data.download_url_usage_hint`。
+- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 
 ## 典型场景

--- a/skills/lark-mail/references/lark-mail-messages.md
+++ b/skills/lark-mail/references/lark-mail-messages.md
@@ -77,6 +77,7 @@ lark-cli mail +messages --message-ids <id1>,<id2> --dry-run
 - CLI 每 20 个 ID 拆成一次调用并合并输出，不需要为大列表手动拆请求。
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +messages` 仅返回附件元数据。如后续步骤需要下载 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
+- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并优先读取服务端返回的 `data.download_url_usage_hint`。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 
 ## 典型场景

--- a/skills/lark-mail/references/lark-mail-thread.md
+++ b/skills/lark-mail/references/lark-mail-thread.md
@@ -70,7 +70,7 @@ lark-cli mail +thread --thread-id <thread-id> --dry-run
 - **JSON 输出可直接使用**，可直接读取，无需额外编码转换。
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +thread` 不再在读取会话时获取附件/图片下载 URL。如后续步骤需要 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
-- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并优先读取服务端返回的 `data.download_url_usage_hint`。
+- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 - 查看某条邮件的原始 HTML：
 

--- a/skills/lark-mail/references/lark-mail-thread.md
+++ b/skills/lark-mail/references/lark-mail-thread.md
@@ -70,6 +70,7 @@ lark-cli mail +thread --thread-id <thread-id> --dry-run
 - **JSON 输出可直接使用**，可直接读取，无需额外编码转换。
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +thread` 不再在读取会话时获取附件/图片下载 URL。如后续步骤需要 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
+- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并优先读取服务端返回的 `data.download_url_usage_hint`。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 - 查看某条邮件的原始 HTML：
 

--- a/skills/lark-mail/references/lark-mail-thread.md
+++ b/skills/lark-mail/references/lark-mail-thread.md
@@ -70,7 +70,7 @@ lark-cli mail +thread --thread-id <thread-id> --dry-run
 - **JSON 输出可直接使用**，可直接读取，无需额外编码转换。
 - JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +thread` 不再在读取会话时获取附件/图片下载 URL。如后续步骤需要 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
-- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
+- 原生附件 URL API 返回的 `download_url` 是短时效临时预签名下载链接，通常约 2 小时或更短时间内有效且可能更早失效，并且最多只能下载 2 次。不能当作长期可点击链接发送给用户或持久化；仅在用户准备下载时现取，并读取 OAPI response `data` 顶层字段 `download_url_usage_hint` 的服务端说明。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 - 查看某条邮件的原始 HTML：
 


### PR DESCRIPTION
Clarifies that attachment download URLs returned by mail message APIs are short-lived and should be used promptly.

- Adds the note to message, message list, and thread reference docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that attachment and inline-image `download_url` values are short-lived, temporary pre-signed links.
  * Updated guidance to fetch `download_url` only when the user is ready to download, not for long-term use.
  * Recommended relying on the server-provided `download_url_usage_hint` for the correct download flow, including in `mail + thread` scenarios.
  * Emphasized these links should not be sent as permanent clickable links or persisted for later use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->