### PR TITLE
docs(vc): clarify meeting join gray release

### DIFF
--- a/shortcuts/vc/vc_meeting_join.go
+++ b/shortcuts/vc/vc_meeting_join.go
@@ -25,7 +25,7 @@ func validMeetingNumber(s string) bool {
 var VCMeetingJoin = common.Shortcut{
 	Service:     "vc",
 	Command:     "+meeting-join",
-	Description: "Join a meeting by meeting number (bot join)",
+	Description: "Join a meeting by meeting number (bot join; code 10012/gray release means the VC Agent join capability is not enabled)",
 	Risk:        "write",
 	Scopes:      []string{"vc:meeting.bot.join:write"},
 	AuthTypes:   []string{"user", "bot"},

--- a/shortcuts/vc/vc_meeting_test.go
+++ b/shortcuts/vc/vc_meeting_test.go
@@ -155,6 +155,15 @@ func TestBuildMeetingJoinBody_TrimsCallIDWhitespace(t *testing.T) {
 	}
 }
 
+func TestMeetingJoinDescriptionMentionsGrayRelease(t *testing.T) {
+	desc := VCMeetingJoin.Description
+	for _, want := range []string{"gray release", "10012"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("Description = %q, want it to mention %q", desc, want)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Validate tests: VCMeetingJoin
 // ---------------------------------------------------------------------------

--- a/skills/lark-vc-agent/SKILL.md
+++ b/skills/lark-vc-agent/SKILL.md
@@ -20,6 +20,7 @@ metadata:
 - 当前功能正在内测中，仅少数用户可用。忽略 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) 中的权限申请流程，以下方的指引为准。
 - 如果 `lark-cli` 提示 `missing required scope(s)` / `permission_violations`，不要走普通权限申请流程；先提示用户加入早鸟群确认内测权限已开通，再按“应用身份权限配置检查”处理应用权限、安装和数据范围。
 - 如果 `lark-cli` 返回 `error.code=20017` / `ErrNotInGray`，提示用户加入早鸟群：`https://go.larkoffice.com/join-chat/2f4nb0e1-fe00-4f67-bed7-25beaf533fbd`。
+- 如果 `+meeting-join` 返回 `error.code=10012` 且消息包含 `gray release scope`，这是“应用机器人入会 / VC Agent join 能力”仍未开通灰度，不是 `auth login`、普通 scope 或应用可用范围能单独解决的问题。不要让用户反复授权；说明需要按内测 / 灰度白名单路径开通，现阶段可用 `--as user` 的 `+meeting-list-active` + `+meeting-events` 旁听式读取当前用户可见的会中事件。
 
 ## 定位
 
@@ -62,6 +63,7 @@ metadata:
 4. 入会对所有参会人可见，执行前核实 9 位会议号来源，避免误入错会。
 5. 使用应用身份 `--as bot` 执行真实入会；不要用当前登录用户身份尝试让应用机器人入会。
 6. 若入会失败，优先查看 `+meeting-join` reference 的错误排查段落，重点确认会议号、密码、会议状态、等候室 / 审批以及会议是否禁止当前身份加入。
+7. 如果错误是 `10012` / `gray release scope`，停止排查普通权限和重复登录，按内测 / 灰度白名单处理；需要旁听当前用户所在会议时，改用用户身份 `+meeting-list-active` 找 `meeting_id` 后再 `+meeting-events`。
 
 ### 2. 感知会中事件（读操作）
 
@@ -177,6 +179,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli vc +<verb> [flags]`）。
 3. 开放平台“权限可访问的数据范围”已开通并保存。
 4. 数据范围选择“按条件筛选”，条件配置为：**会议的归属者 包含 与应用的可用范围一致**。
 5. 如果 scope、安装和数据范围都正确，仍返回 `ErrNotInGray` / `20017`，再按 VC Agent 内测 privilege / 灰度白名单处理，提示加入早鸟群或联系平台同学开通。
+6. 如果返回 `10012` / `gray release scope`，按同一类 VC Agent 入会灰度处理：说明该租户 / 会议归属者尚未进入应用机器人入会灰度范围，普通 scope 已通过也不能直接使用 `+meeting-join`。
 
 ## 用户身份被拒绝时
 

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-join.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-join.md
@@ -37,6 +37,16 @@ lark-cli vc +meeting-join --as bot --meeting-number 123456789 --dry-run
 
 ## 核心约束
 
+### 0. 内测 / 灰度前置
+
+`+meeting-join` 使用的是“应用机器人入会 / VC Agent join”能力。该能力仍处于内测 / 灰度阶段，普通 OpenAPI scope、应用发布安装和可用范围正确，并不等于已经能让应用机器人入会。
+
+如果返回 `code=10012`，消息包含 `gray release scope`（例如 `The meeting owner is not included in the gray release scope...`），把它解释为 **VC Agent 入会能力未对该租户 / 会议归属者开通灰度**，不要引导用户反复执行 `auth login` 或重新申请普通 scope。处理方式：
+
+- 说明这是能力灰度白名单 / 内测开通问题，不是会议号格式或普通权限问题。
+- 需要真实应用机器人入会时，按内测 / 灰度路径开通后再重试（例如加入早鸟群或联系平台同学）。
+- 只是想了解当前用户所在会议发生了什么时，不要调用 `+meeting-join`；改用旁听式读取：`lark-cli vc +meeting-list-active --as user --format json` 找到 `meeting_id`，再 `lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --format pretty`。
+
 ### 1. 使用应用身份
 
 这是应用机器人入会能力，使用 `--as bot`。不要用当前登录用户身份尝试让应用机器人入会。
@@ -119,6 +129,7 @@ lark-cli vc +detail --meeting-ids <meeting.id>
 | 会议密码错误 | `--password` 错误或未提供 | 向主持人确认会议密码 |
 | 会议不存在 / 已结束 | 会议号错误或会议未进行中 | 确认会议正在进行中 |
 | `HTTP 403: no permission` / `121003` | 入会前置条件不满足，通常不是单纯 scope 问题 | 依次确认：1）会议允许智能体加入；2）会议号正确；3）如有密码，已正确传入 `--password`；4）会议已开始；5）等候室 / 入会审批已放行；6）会议未禁止当前身份加入（如限制外部、限制应用机器人、仅特定成员可入会）；确认后重试 |
+| `10012` / `gray release scope` | VC Agent 应用机器人入会能力未对该租户 / 会议归属者开通灰度 | 不要重复 `auth login` 或只调整普通 scope；按内测 / 灰度白名单路径开通。若只是读取当前用户可见会中事件，改用用户身份 `+meeting-list-active` + `+meeting-events` |
 | 应用身份权限不足 | 应用权限、租户安装、权限可访问的数据范围或 VC Agent privilege 未配置完整 | 不要执行 `auth login`。以 CLI 返回的 metadata / error envelope 为准确认缺失权限；检查应用发布/安装，以及开放平台“权限可访问的数据范围”：选择“按条件筛选”，条件为“会议的归属者 包含 与应用的可用范围一致”；仍失败再排查内测 privilege / 灰度 |
 | 入会被拒绝 | 等候室 / 入会审批 / 限制外部入会 | 联系主持人放行或调整会议设置 |
 


### PR DESCRIPTION
## 背景

`vc +meeting-join` 遇到 code 10012 / `gray release scope` 时，用户容易误以为是普通 scope、auth login 或应用可用范围配置问题。Issue #1788 需要明确这是 VC Agent 应用机器人入会能力的灰度/内测前置，并给出可行替代路径。

## 核心改动

- 在 `vc +meeting-join` shortcut description 中标出 code 10012 / gray release 的含义，方便 help/manifest 消费方发现。
- 在 `lark-vc-agent` 主 skill 和 `+meeting-join` reference 中补充灰度前置说明。
- 明确 10012 / gray release scope 不应通过重复 `auth login` 或普通 scope 排查处理。
- 给出旁听式替代路径：用户身份 `+meeting-list-active` 发现当前会议，再 `+meeting-events` 读取当前用户可见事件。
- 增加测试确保 `+meeting-join` description 持续暴露 gray release / 10012 提示。

## 验证

- `go test ./shortcuts/vc -run 'TestMeetingJoinDescriptionMentionsGrayRelease|TestMeetingJoin_Validate|TestMeetingJoin_DryRun|TestMeetingJoin_Execute' -count=1`: passed
- `go test ./shortcuts/vc -count=1`: passed
- `node scripts/skill-format-check/index.js`: passed
- `go build -o ./lark-cli .`: passed
- `git diff --check`: passed
- conflict marker scan: passed (no matches)

## 风险与回滚

低风险。主要是 help/skill 文档补充，唯一代码行为变化是 shortcut description 文案。若需要回滚，revert 本 PR 即可。

Fixes #1788


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified the meeting-join shortcut description so users can better understand when join access may be unavailable in gray-release scenarios.
* **Documentation**
  * Added clearer guidance for handling meeting-join errors related to gray-release restrictions.
  * Included recommended fallback steps for read-only access when join permissions aren’t enabled.
* **Tests**
  * Added coverage to ensure the meeting-join description continues to mention the gray-release status and error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->