### PR TITLE
fix(auth): clarify app scope checks for missing scopes

### DIFF
--- a/internal/errclass/classify.go
+++ b/internal/errclass/classify.go
@@ -371,7 +371,10 @@ func PermissionHint(missing []string, identity string, subtype errs.Subtype, con
 		return "the app developer must apply for the required scope(s) at the developer console"
 	case errs.SubtypeMissingScope:
 		if len(missing) > 0 {
-			return fmt.Sprintf("run `lark-cli auth login --scope \"%s\"` to re-authorize the user with the updated scope set", strings.Join(missing, " "))
+			return appendAppScopeCheckHint(
+				fmt.Sprintf("run `lark-cli auth login --scope \"%s\"` to re-authorize the user with the updated scope set", strings.Join(missing, " ")),
+				missing,
+			)
 		}
 		return "run `lark-cli auth login` to re-authorize the user with the updated scope set"
 	case errs.SubtypeTokenScopeInsufficient:
@@ -390,6 +393,36 @@ func PermissionHint(missing []string, identity string, subtype errs.Subtype, con
 		return fmt.Sprintf("check the resource owner has granted access to %s", who)
 	}
 	return "check the calling identity has the required scope"
+}
+
+func appendAppScopeCheckHint(hint string, missing []string) string {
+	if domain, ok := singleScopeDomain(missing); ok {
+		return fmt.Sprintf("%s. If re-authorization still reports missing scope, run `lark-cli auth scopes --format json` and verify the current app has %s:* scopes enabled in the Open Platform permission management page before retrying", hint, domain)
+	}
+	return hint
+}
+
+func singleScopeDomain(scopes []string) (string, bool) {
+	if len(scopes) == 0 {
+		return "", false
+	}
+	domain := scopeDomain(scopes[0])
+	if domain == "" {
+		return "", false
+	}
+	for _, scope := range scopes[1:] {
+		if scopeDomain(scope) != domain {
+			return "", false
+		}
+	}
+	return domain, true
+}
+
+func scopeDomain(scope string) string {
+	if before, _, ok := strings.Cut(scope, ":"); ok && before != "" {
+		return before
+	}
+	return ""
 }
 
 // liftErrorDetailValues collects the non-empty resp.error.details[].value reason

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -741,6 +741,23 @@ func TestBuildPermissionHint_MissingScopeRoutesToAuthLogin(t *testing.T) {
 	}
 }
 
+func TestBuildPermissionHint_SingleDomainMissingScopeMentionsAppScopeCheck(t *testing.T) {
+	got := errclass.PermissionHint([]string{
+		"slides:presentation:create",
+		"slides:presentation:write_only",
+	}, "user", errs.SubtypeMissingScope, "")
+	for _, want := range []string{
+		"lark-cli auth login",
+		"lark-cli auth scopes --format json",
+		"Open Platform",
+		"slides:*",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("PermissionHint() = %q, want it to mention %q", got, want)
+		}
+	}
+}
+
 func TestBuildPermissionHint_NoScopes(t *testing.T) {
 	// missing_scope with empty list — still suggests auth login even
 	// without the explicit --scope argument.

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -1009,7 +1009,39 @@ func checkShortcutScopes(f *cmdutil.Factory, ctx context.Context, as core.Identi
 		"missing required scope(s): %s", strings.Join(missing, ", ")).
 		WithIdentity(string(as)).
 		WithMissingScopes(missing...).
-		WithHint("run `lark-cli auth login --scope \"%s\"` in the background. It blocks and outputs a verification URL — retrieve the URL and open it in a browser to complete login.", strings.Join(missing, " "))
+		WithHint("%s", missingScopeHint(missing))
+}
+
+func missingScopeHint(missing []string) string {
+	scopeArg := strings.Join(missing, " ")
+	hint := fmt.Sprintf("run `lark-cli auth login --scope \"%s\"` in the background. It blocks and outputs a verification URL — retrieve the URL and open it in a browser to complete login.", scopeArg)
+	if domain, ok := singleScopeDomain(missing); ok {
+		hint += fmt.Sprintf(" If re-authorization still reports missing scope, run `lark-cli auth scopes --format json` and verify the current app has %s:* scopes enabled in the Open Platform permission management page before retrying.", domain)
+	}
+	return hint
+}
+
+func singleScopeDomain(scopes []string) (string, bool) {
+	if len(scopes) == 0 {
+		return "", false
+	}
+	domain := scopeDomain(scopes[0])
+	if domain == "" {
+		return "", false
+	}
+	for _, scope := range scopes[1:] {
+		if scopeDomain(scope) != domain {
+			return "", false
+		}
+	}
+	return domain, true
+}
+
+func scopeDomain(scope string) string {
+	if before, _, ok := strings.Cut(scope, ":"); ok && before != "" {
+		return before
+	}
+	return ""
 }
 
 func newRuntimeContext(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, config *core.CliConfig, as core.Identity, botOnly bool) (*RuntimeContext, error) {

--- a/shortcuts/common/runner_scope_test.go
+++ b/shortcuts/common/runner_scope_test.go
@@ -166,6 +166,38 @@ func TestCheckShortcutScopes_ReturnsTypedPermissionError(t *testing.T) {
 	}
 }
 
+func TestCheckShortcutScopes_SlidesHintMentionsAppScopeCheck(t *testing.T) {
+	f := &cmdutil.Factory{
+		Credential: credential.NewCredentialProvider(nil, nil, &scopeCheckTokenResolver{
+			result: &credential.TokenResult{Token: "t", Scopes: "docs:document.media:upload"},
+		}, nil),
+	}
+
+	required := []string{"slides:presentation:create", "slides:presentation:write_only"}
+	err := checkShortcutScopes(f, context.Background(), core.AsUser, &core.CliConfig{
+		AppID: "cli_slides",
+		Brand: core.BrandFeishu,
+	}, required)
+	if err == nil {
+		t.Fatal("expected missing slides scope error, got nil")
+	}
+
+	var permErr *errs.PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *errs.PermissionError, got %T: %v", err, err)
+	}
+	for _, want := range []string{
+		"auth login --scope",
+		"auth scopes --format json",
+		"Open Platform",
+		"slides:*",
+	} {
+		if !strings.Contains(permErr.Hint, want) {
+			t.Fatalf("Hint = %q, want it to mention %q", permErr.Hint, want)
+		}
+	}
+}
+
 func TestCheckShortcutScopes_IgnoresNonContextTokenErrors(t *testing.T) {
 	f := &cmdutil.Factory{
 		Credential: credential.NewCredentialProvider(nil, nil, &scopeCheckTokenResolver{err: errors.New("token cache unavailable")}, nil),


### PR DESCRIPTION
## 背景

当 Slides 命令缺少 `slides:*` scope 时，CLI 只提示重新执行 `auth login --scope ...`。如果当前开放平台 app 根本没有开通对应 Slides scope，重复授权无法解决问题，AI/自动化会陷入 re-auth 循环。

## 核心改动

- 增强 shortcut 本地 scope precheck 的 `missing_scope` hint：当缺失 scope 都属于同一 domain 时，除 `auth login --scope` 外，提示先用 `lark-cli auth scopes --format json` 检查当前 app scope。
- 同步增强 `errclass.PermissionHint`，覆盖 API 返回的 `missing_scope` 分类路径。
- 明确需要到 Open Platform permission management 确认当前 app 已启用对应 `<domain>:*` scopes。
- 增加 Slides 缺 scope 的回归测试，覆盖 shortcut precheck 和 API classification hint 两条路径。

## 验证

- `go test ./shortcuts/common -run 'TestCheckShortcutScopes_SlidesHintMentionsAppScopeCheck|TestCheckShortcutScopes_ReturnsTypedPermissionError|TestEnhancePermissionError' -count=1`: passed
- `go test ./shortcuts/common -count=1`: passed
- `go test ./internal/errclass -run 'TestBuildPermissionHint_MissingScopeRoutesToAuthLogin|TestBuildPermissionHint_SingleDomainMissingScopeMentionsAppScopeCheck|TestBuildAPIError_AppMissingScope_UserIdentityHintRoutesToConsole|TestPermissionError_HintPopulated' -count=1`: passed
- `go test ./internal/errclass -count=1`: passed
- `go test ./cmd/service ./cmd/auth ./internal/errclass ./shortcuts/common ./shortcuts/slides -count=1`: passed
- `go build -o ./lark-cli .`: passed
- `git diff --check`: passed
- conflict marker scan: passed (no matches)

## 风险与回滚

低风险。只增强 authorization/missing_scope 的 hint 文案，不改变 scope 判断、exit code、typed metadata 或 API 调用行为。若有问题，revert 本 PR 即可。

Fixes #1081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission error guidance when multiple missing scopes belong to the same area.
  * Added clearer next steps for re-authentication and checking enabled app scopes in the permission management page.
  * Expanded scope-related error hints to include both login and scope-verification instructions when applicable.

* **Tests**
  * Added coverage for single-domain missing-scope hints to ensure the updated guidance appears as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->