### PR TITLE
fix(skills): preserve update tracking metadata

### DIFF
--- a/internal/selfupdate/updater.go
+++ b/internal/selfupdate/updater.go
@@ -313,17 +313,17 @@ func (u *Updater) ListGlobalSkillsJSON() *NpmResult {
 }
 
 func (u *Updater) InstallSkill(nameList []string) *NpmResult {
-	r := u.runSkillsInstall("https://open.feishu.cn", nameList)
+	r := u.runSkillsInstall("larksuite/cli", nameList)
 	if r.Err != nil {
-		r = u.runSkillsInstall("larksuite/cli", nameList)
+		r = u.runSkillsInstall("https://open.feishu.cn", nameList)
 	}
 	return r
 }
 
 func (u *Updater) InstallAllSkills() *NpmResult {
-	r := u.runSkillsAdd("https://open.feishu.cn")
+	r := u.runSkillsAdd("larksuite/cli")
 	if r.Err != nil {
-		r = u.runSkillsAdd("larksuite/cli")
+		r = u.runSkillsAdd("https://open.feishu.cn")
 	}
 	return r
 }

--- a/internal/selfupdate/updater_test.go
+++ b/internal/selfupdate/updater_test.go
@@ -238,6 +238,59 @@ func TestSkillsCommandsUseExpectedArgs(t *testing.T) {
 	}
 }
 
+func TestInstallSkillsPreferRepoSourceForUpdateTracking(t *testing.T) {
+	calls := []string{}
+	u := &Updater{SkillsCommandOverride: func(args ...string) *NpmResult {
+		calls = append(calls, strings.Join(args, " "))
+		return &NpmResult{}
+	}}
+
+	if result := u.InstallSkill([]string{"lark-mail"}); result.Err != nil {
+		t.Fatalf("InstallSkill() err = %v, want nil", result.Err)
+	}
+	if result := u.InstallAllSkills(); result.Err != nil {
+		t.Fatalf("InstallAllSkills() err = %v, want nil", result.Err)
+	}
+
+	want := []string{
+		"-y skills add larksuite/cli -s lark-mail -g -y",
+		"-y skills add larksuite/cli -g -y",
+	}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("skills install calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestInstallSkillsFallBackToWellKnownSource(t *testing.T) {
+	calls := []string{}
+	u := &Updater{SkillsCommandOverride: func(args ...string) *NpmResult {
+		call := strings.Join(args, " ")
+		calls = append(calls, call)
+		r := &NpmResult{}
+		if strings.Contains(call, "larksuite/cli") {
+			r.Err = errors.New("repo source unavailable")
+		}
+		return r
+	}}
+
+	if result := u.InstallSkill([]string{"lark-mail"}); result.Err != nil {
+		t.Fatalf("InstallSkill() err = %v, want nil after fallback", result.Err)
+	}
+	if result := u.InstallAllSkills(); result.Err != nil {
+		t.Fatalf("InstallAllSkills() err = %v, want nil after fallback", result.Err)
+	}
+
+	want := []string{
+		"-y skills add larksuite/cli -s lark-mail -g -y",
+		"-y skills add https://open.feishu.cn -s lark-mail -g -y",
+		"-y skills add larksuite/cli -g -y",
+		"-y skills add https://open.feishu.cn -g -y",
+	}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("skills install calls = %#v, want %#v", calls, want)
+	}
+}
+
 func TestListOfficialSkillsIndexSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"skills":[{"name":"lark-calendar"}]}`)


### PR DESCRIPTION
## 背景

`lark-cli update` 同步官方 skills 时优先通过 `https://open.feishu.cn` well-known 源安装。该路径会让 `skills` 的 lock metadata 记录为 well-known，导致后续 `npx skills update -g -y` 将 Lark skills 标记为 `Well-known skill` 并跳过自动检查。

Fixes #1125

## 核心改动

- 将 skills 安装同步的主源改为 `larksuite/cli`，让通用 `skills update` 能保留 repo tracking metadata。
- 保留 `https://open.feishu.cn` 作为安装失败时的 fallback，不影响原有可用性。
- 增加回归测试覆盖主源选择和 fallback 顺序。

## 验证

- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./internal/selfupdate -run 'TestInstallSkillsPreferRepoSourceForUpdateTracking|TestInstallSkillsFallBackToWellKnownSource|TestSkillsCommandsUseExpectedArgs' -count=1`：通过
- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./internal/selfupdate ./internal/skillscheck -count=1`：通过
- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./cmd/update -run '^(TestUpdatePnpm_JSON|TestUpdatePnpm_Human|TestUpdatePnpm_InstallError_JSON)$' -count=1 -timeout=30s`：通过
- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go build -o ./lark-cli .`：通过
- `git diff --check`：通过
- `gofmt -l internal/selfupdate/updater.go internal/selfupdate/updater_test.go`：通过，无输出
- `rg -n '^(<<<<<<< .+|=======$|>>>>>>> .+)$' --glob '!vendor/**' --glob '!node_modules/**' .`：通过，无冲突标记

未运行：
- `go test ./cmd/update -count=1`：本地会命中需要真实 `npx skills add ...` 的长路径；已改跑本次 update skills sync 相关的 mock 单测。

## 风险与回滚

风险较低，改动只调整 skills 安装源优先级。若 `larksuite/cli` 源不可用，仍会 fallback 到 `https://open.feishu.cn`。回滚此提交即可恢复原顺序。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skills installation reliability by trying the preferred source first and automatically falling back to an alternate source if needed.
  * This applies to both installing a specific skill and installing all skills, helping reduce setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->