### PR TITLE
fix(base): clarify 91403 permission guidance

### DIFF
--- a/internal/errclass/codemeta_base.go
+++ b/internal/errclass/codemeta_base.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package errclass
+
+import "github.com/larksuite/cli/errs"
+
+// baseCodeMeta holds Base/Bitable Lark code -> CodeMeta mappings.
+// Only codes whose meaning is verified from Base responses are registered here.
+var baseCodeMeta = map[int]CodeMeta{
+	91403: {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied}, // Base Forbidden/resource permission denied
+}
+
+func init() { mergeCodeMeta(baseCodeMeta, "base") }

--- a/internal/errclass/codemeta_test.go
+++ b/internal/errclass/codemeta_test.go
@@ -70,6 +70,22 @@ func TestLookupCodeMeta_TaskPermissionDenied_MergedViaInit(t *testing.T) {
 	}
 }
 
+func TestLookupCodeMeta_BasePermissionDenied_MergedViaInit(t *testing.T) {
+	got, ok := LookupCodeMeta(91403)
+	if !ok {
+		t.Fatalf("LookupCodeMeta(91403) ok=false, want true (base sub-table init merge)")
+	}
+	if got.Category != errs.CategoryAuthorization {
+		t.Errorf("Category = %q, want %q", got.Category, errs.CategoryAuthorization)
+	}
+	if got.Subtype != errs.SubtypePermissionDenied {
+		t.Errorf("Subtype = %q, want %q", got.Subtype, errs.SubtypePermissionDenied)
+	}
+	if got.Retryable {
+		t.Errorf("Retryable = true, want false")
+	}
+}
+
 func TestLookupCodeMeta_MinutesEndpointSpecificCode_NotGlobal(t *testing.T) {
 	if got, ok := LookupCodeMeta(2091001); ok {
 		t.Fatalf("LookupCodeMeta(2091001) = %+v, want unregistered; minutes endpoints use this code for different failures", got)

--- a/shortcuts/base/base_errors.go
+++ b/shortcuts/base/base_errors.go
@@ -164,10 +164,18 @@ func baseAPIErrorFromResult(resultMap map[string]interface{}, cc errclass.Classi
 	if err == nil {
 		return nil
 	}
-	if p, ok := errs.ProblemOf(err); ok && hint != "" {
-		p.Hint = hint
+	if p, ok := errs.ProblemOf(err); ok {
+		if hint != "" {
+			p.Hint = hint
+		} else if p.Code == 91403 {
+			p.Hint = basePermissionDeniedHint()
+		}
 	}
 	return err
+}
+
+func basePermissionDeniedHint() string {
+	return "Base permission denied. Verify user auth and identity with `lark-cli auth login --domain all`, `lark-cli config default-as user`, then `lark-cli auth status --json --verify`. If scopes are present, grant the CLI app Base collaborator access to this bitable and ensure the app has the required base:app permissions enabled and published."
 }
 
 func enrichBaseAPIErrorFromBody(err error, body []byte, cc errclass.ClassifyContext) error {

--- a/shortcuts/base/base_errors_test.go
+++ b/shortcuts/base/base_errors_test.go
@@ -118,6 +118,37 @@ func TestHandleBaseAPIResultClassifiesKnownPermissionCode(t *testing.T) {
 	}
 }
 
+func TestHandleBaseAPIResultAddsGuidanceForBasePermissionCode91403(t *testing.T) {
+	result := map[string]interface{}{
+		"code": 91403,
+		"msg":  "Forbidden",
+		"data": map[string]interface{}{},
+	}
+
+	_, err := handleBaseAPIResultAny(result, nil, "list records")
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T %v", err, err)
+	}
+	if p.Code != 91403 {
+		t.Fatalf("code=%d", p.Code)
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied {
+		t.Fatalf("category/subtype=%s/%s", p.Category, p.Subtype)
+	}
+	for _, want := range []string{
+		"lark-cli auth login --domain all",
+		"lark-cli config default-as user",
+		"lark-cli auth status --json --verify",
+		"Base collaborator",
+		"base:app",
+	} {
+		if !strings.Contains(p.Hint, want) {
+			t.Fatalf("hint=%q missing %q", p.Hint, want)
+		}
+	}
+}
+
 func TestAttachBaseResponseLogIDFromHeader(t *testing.T) {
 	result := map[string]interface{}{
 		"code": 91402,


### PR DESCRIPTION
## 背景

Base/Bitable 返回 `91403 Forbidden` 时，CLI 之前会落到 `api/unknown`，缺少可执行恢复步骤。用户遇到扫码登录后仍然 91403 时，很难区分是身份仍在 bot/app 模式、用户授权 scope 不完整，还是 Base 文档协作者 / 应用权限未授予。

Fixes #1778

## 核心改动

- 为 Base code `91403` 增加 `authorization/permission_denied` 分类。
- 在 Base 错误封装中为 `91403` 增加具体 hint：
  - 重新用 `lark-cli auth login --domain all` 授权；
  - 切到 `lark-cli config default-as user`；
  - 用 `lark-cli auth status --json --verify` 核对授权；
  - 若 scopes 已具备，则检查 Base collaborator 访问和 `base:app` 应用权限发布状态。
- 增加单测覆盖 typed metadata 和 hint 内容。

## 验证

- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./shortcuts/base ./internal/errclass -count=1`：通过
- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go build -o ./lark-cli .`：通过
- `git diff --check`：通过
- `gofmt -l shortcuts/base/base_errors.go shortcuts/base/base_errors_test.go internal/errclass/codemeta_base.go internal/errclass/codemeta_test.go`：通过，无输出
- `rg -n '^(<<<<<<< .+|=======$|>>>>>>> .+)$' --glob '!vendor/**' --glob '!node_modules/**' .`：通过，无冲突标记

## 风险与回滚

风险较低。改动只影响 Base `91403` 错误分类和提示，不改变请求参数、认证流程或 API 调用。回滚本提交即可恢复原行为。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance when a Base permission-denied error occurs, helping users understand what went wrong and what to check next.
  * Expanded error metadata so this permission issue is consistently recognized as an authorization problem.

* **Bug Fixes**
  * Improved error handling to show a specific hint for code `91403` when no API hint is provided.

* **Tests**
  * Added coverage for the new permission-denied behavior and metadata lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->