### PR TITLE
docs(task): clarify inline image limitation

### DIFF
--- a/shortcuts/task/task_skill_docs_test.go
+++ b/shortcuts/task/task_skill_docs_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTaskSkillDocumentsInlineImageLimit(t *testing.T) {
+	root := taskSkillRepoRoot(t)
+	files := []string{
+		"skills/lark-task/SKILL.md",
+		"skills/lark-task/references/lark-task-upload-attachment.md",
+		"skills/lark-task/references/lark-task-comment.md",
+	}
+
+	for _, rel := range files {
+		body, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		text := string(body)
+		for _, want := range []string{
+			"inline images",
+			"[Image]",
+			"not downloadable",
+			"task_delivery",
+		} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("%s missing %q", rel, want)
+			}
+		}
+	}
+}
+
+func taskSkillRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found")
+		}
+		dir = parent
+	}
+}

--- a/skills/lark-task/SKILL.md
+++ b/skills/lark-task/SKILL.md
@@ -32,6 +32,7 @@ metadata:
 > 1. 在输出任务详情时，如果需要渲染负责人、创建人等人员字段，除了展示 `id` (例如 open_id) 外，还必须通过其他方式（例如调用通讯录技能）尝试获取并展示这个人的真实名字，以便用户更容易识别。
 > 2. 在输出清单详情时，如果需要渲染 owner、member、角色成员等人员字段，也必须像任务成员展示一样，除了展示 `id` 外，尽量解析并展示对应人员的真实名字。
 > 3. 在输出任务或清单详情时，如果需要渲染创建时间、截止时间等字段，需要使用本地时区来渲染（格式为2006-01-02 15:04:05）。
+> 4. Task description/comment inline images are not downloadable through current Task OpenAPI responses: they are returned only as the literal `[Image]` placeholder and no media/file token is exposed. Do not invent `task +media-download` or use `+upload-attachment` as a download workaround. `+upload-attachment` only uploads normal attachments for `task` or `task_delivery`; it cannot retrieve inline images from descriptions or comments. Ask the user to attach the screenshot as a normal task attachment or download it manually from the Lark UI.
 
 > **Task GUID 定义**：
 > Task OpenAPI 中用于更新/操作任务的 `guid` 是任务的全局唯一标识（GUID），不是客户端展示的任务编号（例如 `t104121` / `suite_entity_num`）。

--- a/skills/lark-task/references/lark-task-comment.md
+++ b/skills/lark-task/references/lark-task-comment.md
@@ -4,6 +4,9 @@
 
 Add a comment to an existing task.
 
+> [!IMPORTANT]
+> Task comment inline images are not downloadable through current Task OpenAPI responses. Existing image-only comments may be returned as the literal `[Image]` placeholder without any media/file token. The Task attachment endpoint only works for normal `task` / `task_delivery` attachments, so it cannot retrieve inline images from comments. Ask the user to upload the screenshot as a normal task attachment or download it manually from the Lark UI.
+
 ## Recommended Commands
 
 ```bash

--- a/skills/lark-task/references/lark-task-upload-attachment.md
+++ b/skills/lark-task/references/lark-task-upload-attachment.md
@@ -4,6 +4,9 @@
 
 Upload a single local file as an attachment to a task (or any resource type accepted by the Task attachment endpoint). Max file size per upload is **50 MB**. For task agents, use `--resource-type=task_delivery`.
 
+> [!IMPORTANT]
+> Task description/comment inline images are not downloadable through this command. Current Task OpenAPI responses expose those images only as the literal `[Image]` placeholder and do not return a media/file token. The attachment endpoint only accepts normal attachments for `task` and `task_delivery`; it does not list or download inline images embedded in descriptions or comments.
+
 ## Recommended Commands
 
 ```bash
@@ -57,3 +60,4 @@ The command returns the single created attachment record as a flat JSON object â
 
 > [!NOTE]
 > The Task attachment upload endpoint accepts exactly one file per call. To upload multiple files, invoke the shortcut once per file.
+> If a screenshot is needed by an agent, ask the user to upload it as a normal task attachment or download it manually from the Lark UI; do not retry `+upload-attachment` as a download path for `[Image]` inline images.


### PR DESCRIPTION
## 背景

Task description/comment 中的内联图片目前通过 Task OpenAPI 只能看到字面量 `[Image]`，没有 media/file token；attachments endpoint 也只覆盖普通 `task` / `task_delivery` 附件，不能列出或下载 comment/description 内联图片。

Fixes #1746

## 核心改动

- 在 `lark-task` 主 skill 中明确 Task inline images 的 OpenAPI 边界。
- 在 `+upload-attachment` 引用页说明它不是 `[Image]` 下载路径，只用于上传普通附件。
- 在 `+comment` 引用页说明 image-only comments 可能只返回 `[Image]`，需要用户上传普通附件或从 UI 手动下载。
- 增加文档回归测试，防止这条关键限制被后续文档改动移除。

## 验证

- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go test ./shortcuts/task -count=1`：通过
- `GOCACHE=$PWD/.cache/go-build GOPROXY=https://goproxy.cn,direct go build -o ./lark-cli .`：通过
- `git diff --check`：通过
- `gofmt -l shortcuts/task/task_skill_docs_test.go`：通过，无输出
- `rg -n '^(<<<<<<< .+|=======$|>>>>>>> .+)$' --glob '!vendor/**' --glob '!node_modules/**' .`：通过，无冲突标记

## 风险与回滚

风险低。该 PR 只更新 task skill 文档并添加文档测试，不改变 CLI 请求、响应或认证行为。回滚提交即可恢复原文档。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that inline images in task descriptions and comments can’t be downloaded and may appear as `[Image]` placeholders.
  * Added guidance on how to handle screenshots by using normal task attachments or downloading them from the Lark UI.

* **Tests**
  * Added coverage to verify task skill documentation includes the expected inline-image restrictions and related guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->