### PR TITLE
docs: clarify Mindnote token handling

### DIFF
--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -46,7 +46,7 @@ lark-cli docs +update --doc "文档URL或token" --command append --content '<p>�
 - 用户明确说"下载/更新/删除文档封面图" → 用 `lark-cli docs +resource-download/+resource-update/+resource-delete --type cover`
 - `resource-*` 目前仅支持 Docx 封面资源；其他图片、附件或素材请走 `+media-*`
 - 如果目标是画板/whiteboard/画板缩略图 → 只能用 `lark-cli docs +media-download --type whiteboard`（不要用 `+media-preview`）
-- 用户明确要操作思维笔记时；已有**思维笔记**，走 [思维笔记链路](references/lark-doc-mindnote.md)；新建**思维笔记**，走 [lark-doc-whiteboard](references/lark-doc-whiteboard.md)
+- 用户明确要操作思维笔记时；已有**思维笔记**，走 [思维笔记链路](references/lark-doc-mindnote.md)，未给 URL/token 时先用 `lark-cli drive +search --doc-types mindnote` 定位 Mindnote 文档 token；新建**思维笔记**，走 [lark-doc-whiteboard](references/lark-doc-whiteboard.md)
 - 拿到 spreadsheet URL/token 后 → 切到 `lark-sheets` 做对象内部操作
 - 用户需要统计文档的**总字数 / 总字符数**（word count / character count）时，先读取 [`lark-doc-word-stat.md`](references/lark-doc-word-stat.md)，并按其中流程调用 [`scripts/doc_word_stat.py`](scripts/doc_word_stat.py)；统计口径以该脚本为准，不要改用其他方式自行计算。
 - 用户说"给文档加评论""查看评论""回复评论""给评论加/删除表情 reaction" → 切到 `lark-drive` 处理

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -46,7 +46,7 @@ lark-cli docs +update --doc "文档URL或token" --command append --content '<p>�
 - 用户明确说"下载/更新/删除文档封面图" → 用 `lark-cli docs +resource-download/+resource-update/+resource-delete --type cover`
 - `resource-*` 目前仅支持 Docx 封面资源；其他图片、附件或素材请走 `+media-*`
 - 如果目标是画板/whiteboard/画板缩略图 → 只能用 `lark-cli docs +media-download --type whiteboard`（不要用 `+media-preview`）
-- 用户明确要操作思维笔记时；已有**思维笔记**，走 [思维笔记链路](references/lark-doc-mindnote.md)，未给 URL/token 时先用 `lark-cli drive +search --doc-types mindnote` 定位 Mindnote 文档 token；新建**思维笔记**，走 [lark-doc-whiteboard](references/lark-doc-whiteboard.md)
+- 用户明确要操作思维笔记时；已有**思维笔记**，走 [思维笔记链路](references/lark-doc-mindnote.md)；新建**思维笔记**，走 [lark-doc-whiteboard](references/lark-doc-whiteboard.md)
 - 拿到 spreadsheet URL/token 后 → 切到 `lark-sheets` 做对象内部操作
 - 用户需要统计文档的**总字数 / 总字符数**（word count / character count）时，先读取 [`lark-doc-word-stat.md`](references/lark-doc-word-stat.md)，并按其中流程调用 [`scripts/doc_word_stat.py`](scripts/doc_word_stat.py)；统计口径以该脚本为准，不要改用其他方式自行计算。
 - 用户说"给文档加评论""查看评论""回复评论""给评论加/删除表情 reaction" → 切到 `lark-drive` 处理

--- a/skills/lark-doc/references/lark-doc-mindnote.md
+++ b/skills/lark-doc/references/lark-doc-mindnote.md
@@ -9,6 +9,32 @@
 > `mindnotes nodes create` 是新增/更新节点命令，**不是**新建一个新的思维笔记。
 > 如果用户要**新建思维笔记**，不要走本链路，改走 [lark-doc-whiteboard](lark-doc-whiteboard.md)。
 
+## 获取 `mindnote_id`
+
+`--mindnote-id` 传 **Mindnote 文档 token**，不是节点 ID。`lark-cli mindnotes` 只负责读取和写入思维笔记内部节点，不提供按标题列出 Mindnote 文档的入口；找文档要先走 Drive。
+
+```bash
+# 用户给了 Mindnote URL，或给了可能包着 Mindnote 的 Wiki URL
+lark-cli drive +inspect --url "<mindnote_or_wiki_url>"
+
+# 用户只给了标题、关键词，或需要在云空间里找思维笔记
+lark-cli drive +search --query "<关键词>" --doc-types mindnote --format table
+
+# 用户想浏览自己负责的思维笔记
+lark-cli drive +search --doc-types mindnote --mine --sort edit_time --format table
+```
+
+处理规则：
+
+- 普通 Mindnote URL：`drive +inspect` 返回的 Mindnote token 可作为 `--mindnote-id`。
+- Wiki URL：不要把 `/wiki/` 路径里的 wiki token 当作 `--mindnote-id`；必须先 `drive +inspect` 解包，确认底层类型是 `mindnote` 后再使用返回的真实 token。直接把 wiki token 传给 `mindnotes nodes list` 通常会返回 `3410003 resource not found`。
+- 标题 / 关键词：用 `drive +search --doc-types mindnote` 定位；多候选时先让用户确认目标，不要猜。
+
+## 所需权限
+
+- 读取节点：需要用户授权包含 `mindnote:node:read`。
+- 创建 / 更新节点：需要用户授权包含对应写入 scope；如果命令返回 `missing_scope`，按 [`lark-shared`](../../lark-shared/SKILL.md) 的授权恢复流程，用错误里的 `hint` 或 `missing_scopes` 重新执行 `lark-cli auth login --scope ...`。
+
 ## 命令
 
 ```bash
@@ -96,8 +122,8 @@ lark-cli mindnotes nodes create \
 
 1. 先判断用户目标是不是“新建一个思维笔记”。
 2. 如果是新建思维笔记，切到 [lark-doc-whiteboard](lark-doc-whiteboard.md)。
-3. 如果是操作已有思维笔记，先通过 token 类别判断。
-4. 确认是 **Mindnote** 后再拿到 `mindnote_id`。
+3. 如果是操作已有思维笔记，先按上方「获取 `mindnote_id`」定位 Mindnote 文档 token。
+4. 确认目标类型是 **Mindnote** 后，把真实 Mindnote token 作为 `--mindnote-id`。
 5. 先执行 `mindnotes nodes list`，确认目标 `parent_id`。
 6. 新增子节点时，在 `nodes[]` 里传 `parent_id`；更新已有节点时，在 `nodes[]` 里传已有 `node_id`。
 7. 再执行 `mindnotes nodes create`。
@@ -110,4 +136,5 @@ lark-cli mindnotes nodes create \
 
 - [lark-doc-fetch](lark-doc-fetch.md) — 获取文档内容
 - [lark-doc-whiteboard](lark-doc-whiteboard.md) — 新建思维笔记走画板链路
+- [lark-drive](../../lark-drive/SKILL.md) — 搜索和解析 Mindnote / Wiki 等云空间资源
 - [lark-shared](../../lark-shared/SKILL.md) — 认证和全局参数

--- a/skills/lark-doc/references/lark-doc-mindnote.md
+++ b/skills/lark-doc/references/lark-doc-mindnote.md
@@ -11,24 +11,17 @@
 
 ## 获取 `mindnote_id`
 
-`--mindnote-id` 传 **Mindnote 文档 token**，不是节点 ID。`lark-cli mindnotes` 只负责读取和写入思维笔记内部节点，不提供按标题列出 Mindnote 文档的入口；找文档要先走 Drive。
+`--mindnote-id` 传 **Mindnote 文档 token**，不是节点 ID。`lark-cli mindnotes` 只负责读取和写入思维笔记内部节点。
 
 ```bash
 # 用户给了 Mindnote URL，或给了可能包着 Mindnote 的 Wiki URL
 lark-cli drive +inspect --url "<mindnote_or_wiki_url>"
-
-# 用户只给了标题、关键词，或需要在云空间里找思维笔记
-lark-cli drive +search --query "<关键词>" --doc-types mindnote --format table
-
-# 用户想浏览自己负责的思维笔记
-lark-cli drive +search --doc-types mindnote --mine --sort edit_time --format table
 ```
 
 处理规则：
 
 - 普通 Mindnote URL：`drive +inspect` 返回的 Mindnote token 可作为 `--mindnote-id`。
 - Wiki URL：不要把 `/wiki/` 路径里的 wiki token 当作 `--mindnote-id`；必须先 `drive +inspect` 解包，确认底层类型是 `mindnote` 后再使用返回的真实 token。直接把 wiki token 传给 `mindnotes nodes list` 通常会返回 `3410003 resource not found`。
-- 标题 / 关键词：用 `drive +search --doc-types mindnote` 定位；多候选时先让用户确认目标，不要猜。
 
 ## 所需权限
 
@@ -122,7 +115,7 @@ lark-cli mindnotes nodes create \
 
 1. 先判断用户目标是不是“新建一个思维笔记”。
 2. 如果是新建思维笔记，切到 [lark-doc-whiteboard](lark-doc-whiteboard.md)。
-3. 如果是操作已有思维笔记，先按上方「获取 `mindnote_id`」定位 Mindnote 文档 token。
+3. 如果是操作已有思维笔记，先按上方「获取 `mindnote_id`」确认已拿到 Mindnote 文档 token。
 4. 确认目标类型是 **Mindnote** 后，把真实 Mindnote token 作为 `--mindnote-id`。
 5. 先执行 `mindnotes nodes list`，确认目标 `parent_id`。
 6. 新增子节点时，在 `nodes[]` 里传 `parent_id`；更新已有节点时，在 `nodes[]` 里传已有 `node_id`。
@@ -136,5 +129,5 @@ lark-cli mindnotes nodes create \
 
 - [lark-doc-fetch](lark-doc-fetch.md) — 获取文档内容
 - [lark-doc-whiteboard](lark-doc-whiteboard.md) — 新建思维笔记走画板链路
-- [lark-drive](../../lark-drive/SKILL.md) — 搜索和解析 Mindnote / Wiki 等云空间资源
+- [lark-drive](../../lark-drive/SKILL.md) — 解析 Mindnote / Wiki 等云空间资源
 - [lark-shared](../../lark-shared/SKILL.md) — 认证和全局参数

--- a/skills/lark-doc/references/lark-doc-mindnote.md
+++ b/skills/lark-doc/references/lark-doc-mindnote.md
@@ -23,11 +23,6 @@ lark-cli drive +inspect --url "<mindnote_or_wiki_url>"
 - 普通 Mindnote URL：`drive +inspect` 返回的 Mindnote token 可作为 `--mindnote-id`。
 - Wiki URL：不要把 `/wiki/` 路径里的 wiki token 当作 `--mindnote-id`；必须先 `drive +inspect` 解包，确认底层类型是 `mindnote` 后再使用返回的真实 token。直接把 wiki token 传给 `mindnotes nodes list` 通常会返回 `3410003 resource not found`。
 
-## 所需权限
-
-- 读取节点：需要用户授权包含 `mindnote:node:read`。
-- 创建 / 更新节点：需要用户授权包含对应写入 scope；如果命令返回 `missing_scope`，按 [`lark-shared`](../../lark-shared/SKILL.md) 的授权恢复流程，用错误里的 `hint` 或 `missing_scopes` 重新执行 `lark-cli auth login --scope ...`。
-
 ## 命令
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that `mindnote_id` is the Mindnote document token, not a node ID
- document using `drive +inspect` to resolve Mindnote and Wiki URLs before calling `mindnotes`
- update the recommended workflow to confirm a real Mindnote token before node operations

## Tests
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--mindnote-id` requires the Mindnote document token, not a node ID.
  * Added instructions for retrieving the correct token from Mindnote and Wiki URLs.
  * Updated the recommended workflow to verify the document type before use.
  * Added a reference link for drive inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->