### PR TITLE
feat(im): show bot sender display names when reading messages

### DIFF
--- a/shortcuts/im/builders_test.go
+++ b/shortcuts/im/builders_test.go
@@ -879,7 +879,7 @@ func TestShortcutDryRunShapes(t *testing.T) {
 			"message-ids": "om_1,om_2",
 		}, nil)
 		got := mustMarshalDryRun(t, ImMessagesMGet.DryRun(context.Background(), runtime))
-		if !strings.Contains(got, `"/open-apis/im/v1/messages/mget?card_msg_content_type=raw_card_content\u0026message_ids=om_1\u0026message_ids=om_2"`) {
+		if !strings.Contains(got, `"/open-apis/im/v1/messages/mget?card_msg_content_type=raw_card_content\u0026with_sender_name=true\u0026message_ids=om_1\u0026message_ids=om_2"`) {
 			t.Fatalf("ImMessagesMGet.DryRun() = %s", got)
 		}
 	})

--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -6,14 +6,11 @@ package convertlib
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // ParseJSONObject parses a raw JSON string into a map.
@@ -72,161 +69,66 @@ func formatTimestamp(ts string) string {
 	return time.Unix(n, 0).Local().Format("2006-01-02 15:04:05")
 }
 
-// ResolveSenderNames batch-resolves sender open_ids to display names.
-// The cache map is used to share already-resolved IDs across calls; newly resolved
-// names are written back into it. Pass an empty map if no prior cache exists.
-//
-// Step 1: extract names from message mentions (free, no API call).
-// Step 2: for remaining unresolved IDs, call contact batch API (requires contact:user.base:readonly).
-// Silently returns partial results on API error.
-//
-// [#22] Changed from variadic `cache ...map[string]string` to a required parameter.
-// The variadic form was misleading: every caller passed exactly one map, and the function
-// body both modified it and returned it, making the dual semantics confusing.
-func ResolveSenderNames(runtime *common.RuntimeContext, messages []map[string]interface{}, cache map[string]string) map[string]string {
+// pickSenderName returns the server-provided display name from a message sender:
+// the plain `sender_name` (the server's default-locale name). Callers wanting a
+// specific locale should read the full `sender_i18n_names` map, which is preserved
+// on the sender. Returns "" when the server supplied no name, so the caller can
+// fall back to the raw id.
+func pickSenderName(sender map[string]interface{}) string {
+	name, _ := sender["sender_name"].(string)
+	return name
+}
+
+// ResolveSenderNames harvests the server-provided sender_name for each message
+// sender into the shared cache (keyed by sender id), so a sender appearing across
+// the render tree (e.g. merge_forward sub-items, thread replies) resolves once.
+// The message read API is the single source of truth for names (opt in via
+// with_sender_name=true); there is NO contact/mention fallback — a sender the
+// server did not name resolves to its id downstream. Pass an empty map if none exists.
+func ResolveSenderNames(_ *common.RuntimeContext, messages []map[string]interface{}, cache map[string]string) map[string]string {
 	nameMap := cache
 	if nameMap == nil {
 		nameMap = make(map[string]string)
 	}
-
-	// Step 1: extract names from mentions (free)
-	for _, msg := range messages {
-		switch mentions := msg["mentions"].(type) {
-		case []interface{}:
-			for _, raw := range mentions {
-				m, _ := raw.(map[string]interface{})
-				id, _ := m["id"].(string)
-				name, _ := m["name"].(string)
-				if id != "" && name != "" && strings.HasPrefix(id, "ou_") {
-					nameMap[id] = name
-				}
-			}
-		case []map[string]interface{}:
-			// Backward-compatible path for tests/callers that construct typed slices.
-			for _, m := range mentions {
-				id, _ := m["id"].(string)
-				name, _ := m["name"].(string)
-				if id != "" && name != "" && strings.HasPrefix(id, "ou_") {
-					nameMap[id] = name
-				}
-			}
-		}
-	}
-
-	// Collect sender IDs still missing a name
-	seen := make(map[string]bool)
-	var missingIDs []string
 	for _, msg := range messages {
 		sender, ok := msg["sender"].(map[string]interface{})
 		if !ok {
 			continue
 		}
-		senderType, _ := sender["sender_type"].(string)
-		if senderType != "user" {
-			continue
-		}
 		id, _ := sender["id"].(string)
-		if id == "" || !strings.HasPrefix(id, "ou_") || seen[id] || nameMap[id] != "" {
+		if id == "" {
 			continue
 		}
-		seen[id] = true
-		missingIDs = append(missingIDs, id)
+		if name := pickSenderName(sender); name != "" {
+			nameMap[id] = name
+		}
 	}
-	if len(missingIDs) == 0 {
-		return nameMap
-	}
-
-	// Step 2: batch resolve remaining via contact API.
-	// Use basic_batch for user identity (lighter permission requirement),
-	// full batch for bot identity.
-	if runtime.As().IsBot() {
-		batchResolveUsers(runtime, missingIDs, nameMap)
-	} else {
-		batchResolveByBasicContact(runtime, missingIDs, nameMap)
-	}
-
 	return nameMap
 }
 
-// batchResolveByBasicContact resolves user names via POST /contact/v3/users/basic_batch.
-// This API has lighter permission requirements and works with user identity
-// even when the target user is not in the app's visible range.
-// Response uses "users" (not "items") and "user_id" (not "open_id").
-// The basic_batch endpoint caps user_ids at 10 per request.
-func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []string, nameMap map[string]string) {
-	const batchSize = 10
-	for i := 0; i < len(missingIDs); i += batchSize {
-		end := i + batchSize
-		if end > len(missingIDs) {
-			end = len(missingIDs)
-		}
-		batch := missingIDs[i:end]
-
-		data, err := runtime.DoAPIJSONTyped(http.MethodPost,
-			"/open-apis/contact/v3/users/basic_batch",
-			larkcore.QueryParams{"user_id_type": []string{"open_id"}},
-			map[string]interface{}{"user_ids": batch},
-		)
-		if err != nil {
-			break
-		}
-
-		users, _ := data["users"].([]interface{})
-		for _, item := range users {
-			user, _ := item.(map[string]interface{})
-			userID, _ := user["user_id"].(string)
-			name, _ := user["name"].(string)
-			if userID != "" && name != "" {
-				nameMap[userID] = name
-			}
-		}
-	}
-}
-
-func batchResolveUsers(runtime *common.RuntimeContext, missingIDs []string, nameMap map[string]string) {
-	const batchSize = 50
-	for i := 0; i < len(missingIDs); i += batchSize {
-		end := i + batchSize
-		if end > len(missingIDs) {
-			end = len(missingIDs)
-		}
-		batch := missingIDs[i:end]
-
-		parts := []string{"user_id_type=open_id"}
-		for _, uid := range batch {
-			parts = append(parts, "user_ids="+url.QueryEscape(uid))
-		}
-		apiURL := "/open-apis/contact/v3/users/batch?" + strings.Join(parts, "&")
-
-		data, err := runtime.DoAPIJSONTyped(http.MethodGet, apiURL, nil, nil)
-		if err != nil {
-			break
-		}
-
-		items, _ := data["items"].([]interface{})
-		for _, item := range items {
-			user, _ := item.(map[string]interface{})
-			openID, _ := user["open_id"].(string)
-			name, _ := user["name"].(string)
-			if openID != "" && name != "" {
-				nameMap[openID] = name
-			}
-		}
-	}
-}
-
-// AttachSenderNames enriches message sender objects with resolved display names.
-// Senders whose name could not be resolved are left unchanged (id is preserved).
+// AttachSenderNames enriches message sender objects with a single resolved display
+// name in `name`, taken from the server-provided sender_name (via the sender itself
+// or the shared cache). Senders the server did not name keep no `name` (id is
+// preserved for downstream id fallback) — there is no contact/mention lookup.
+//
+// The raw `sender_name` is stripped from the output because it exactly duplicates
+// `name`; `sender_i18n_names` (the full i18n set, all locales) and `open_bot_id`
+// are preserved for consumers that need a specific locale or the id alignment.
 func AttachSenderNames(messages []map[string]interface{}, nameMap map[string]string) {
 	for _, msg := range messages {
 		sender, ok := msg["sender"].(map[string]interface{})
 		if !ok {
 			continue
 		}
-		id, _ := sender["id"].(string)
-		if name, ok := nameMap[id]; ok {
+		if name := pickSenderName(sender); name != "" {
 			sender["name"] = name
+		} else if id, _ := sender["id"].(string); id != "" {
+			if name, ok := nameMap[id]; ok {
+				sender["name"] = name
+			}
 		}
+		// sender_name exactly duplicates `name`; drop it. Keep sender_i18n_names + open_bot_id.
+		delete(sender, "sender_name")
 	}
 }
 

--- a/shortcuts/im/convert_lib/helpers_test.go
+++ b/shortcuts/im/convert_lib/helpers_test.go
@@ -4,12 +4,9 @@
 package convertlib
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 )
@@ -129,114 +126,172 @@ func TestExtractPostBlocksText(t *testing.T) {
 }
 
 func TestResolveSenderNames(t *testing.T) {
-	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/batch"):
-			if got := req.URL.Query()["user_ids"]; !reflect.DeepEqual(got, []string{"ou_api", "ou_missing"}) {
-				t.Fatalf("contact batch user_ids = %#v, want %#v", got, []string{"ou_api", "ou_missing"})
-			}
-			return convertlibJSONResponse(200, map[string]interface{}{
-				"code": 0,
-				"data": map[string]interface{}{
-					"items": []interface{}{
-						map[string]interface{}{"open_id": "ou_api", "name": "API User"},
-					},
-				},
-			}), nil
-		default:
-			return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
-		}
+	// Server-provided sender_name is harvested into the cache for both user and bot;
+	// senders the server did not name are absent (id fallback downstream). There is no
+	// contact/mention lookup, so no API call is ever made.
+	rt := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("no API call expected: %s", req.URL.String())
 	}))
 
 	messages := []map[string]interface{}{
+		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_named", "sender_name": "Named User"}},
+		{"sender": map[string]interface{}{"sender_type": "app", "id": "cli_bot", "sender_name": "Bot Alpha"}},
+		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_unnamed"}},
+	}
+
+	got := ResolveSenderNames(rt, messages, nil)
+	if got["ou_named"] != "Named User" {
+		t.Fatalf("named user = %#v, want %#v", got["ou_named"], "Named User")
+	}
+	if got["cli_bot"] != "Bot Alpha" {
+		t.Fatalf("named bot = %#v, want %#v", got["cli_bot"], "Bot Alpha")
+	}
+	if _, has := got["ou_unnamed"]; has {
+		t.Fatalf("unnamed sender must not be resolved (no contact fallback), got %#v", got["ou_unnamed"])
+	}
+}
+
+// TestResolveSenderNamesServerNameBeatsMention locks the priority: when a sender's id
+// also appears as a mention, the server-provided sender_name must win over the mention
+// name (which can be a remark/nickname), and no contact call is made.
+func TestResolveSenderNamesServerNameBeatsMention(t *testing.T) {
+	rt := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("no contact call expected: %s", req.URL.String())
+	}))
+	messages := []map[string]interface{}{
 		{
-			"sender": map[string]interface{}{"sender_type": "user", "id": "ou_mention"},
+			"sender": map[string]interface{}{"sender_type": "user", "id": "ou_dual", "sender_name": "Server Name"},
 			"mentions": []interface{}{
-				map[string]interface{}{"id": "ou_mention", "name": "Mention User"},
+				map[string]interface{}{"id": "ou_dual", "name": "Mention Remark"},
 			},
 		},
-		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_api"}},
-		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_missing"}},
-		{"sender": map[string]interface{}{"sender_type": "bot", "id": "cli_1"}},
 	}
-
-	got := ResolveSenderNames(runtime, messages, nil)
-	if got["ou_mention"] != "Mention User" {
-		t.Fatalf("mention-resolved sender = %#v, want %#v", got["ou_mention"], "Mention User")
-	}
-	if got["ou_api"] != "API User" {
-		t.Fatalf("api-resolved sender = %#v, want %#v", got["ou_api"], "API User")
-	}
-	if got["ou_missing"] != "" {
-		t.Fatalf("missing sender = %#v, want empty", got["ou_missing"])
+	got := ResolveSenderNames(rt, messages, nil)
+	if got["ou_dual"] != "Server Name" {
+		t.Fatalf("server sender_name must beat mention name: got %#v, want %#v", got["ou_dual"], "Server Name")
 	}
 }
 
-func TestBatchResolveByBasicContactRespectsAPILimit(t *testing.T) {
-	// basic_batch allows at most 10 user_ids per request. Given 25 missing IDs,
-	// expect three requests with sizes 10 / 10 / 5.
-	var batchSizes []int
+// TestFormatMessageItemSenderPassthrough covers AC5: the formatted message must
+// carry the sender object through verbatim — retaining open_bot_id and leaving
+// id / id_type unchanged after enrichment.
+func TestFormatMessageItemSenderPassthrough(t *testing.T) {
 	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if !strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/basic_batch") {
-			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
-		}
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
-		}
-		var payload map[string]interface{}
-		if err := json.Unmarshal(body, &payload); err != nil {
-			return nil, err
-		}
-		userIDs, _ := payload["user_ids"].([]interface{})
-		if len(userIDs) > 10 {
-			t.Fatalf("batch exceeded API limit: size = %d", len(userIDs))
-		}
-		batchSizes = append(batchSizes, len(userIDs))
-
-		users := make([]interface{}, 0, len(userIDs))
-		for _, raw := range userIDs {
-			id, _ := raw.(string)
-			users = append(users, map[string]interface{}{
-				"user_id": id,
-				"name":    "name-" + id,
-			})
-		}
-		return convertlibJSONResponse(200, map[string]interface{}{
-			"code": 0,
-			"data": map[string]interface{}{"users": users},
-		}), nil
+		return convertlibJSONResponse(200, map[string]interface{}{"code": 0, "data": map[string]interface{}{}}), nil
 	}))
-
-	missingIDs := make([]string, 25)
-	for i := range missingIDs {
-		missingIDs[i] = fmt.Sprintf("ou_%02d", i)
+	m := map[string]interface{}{
+		"message_id": "om_1",
+		"msg_type":   "text",
+		"body":       map[string]interface{}{"content": `{"text":"hi"}`},
+		"sender": map[string]interface{}{
+			"id":          "cli_bot",
+			"id_type":     "app_id",
+			"sender_type": "app",
+			"sender_name": "Bot Alpha",
+			"open_bot_id": "ou_bot",
+		},
 	}
-	nameMap := map[string]string{}
-	batchResolveByBasicContact(runtime, missingIDs, nameMap)
 
-	if want := []int{10, 10, 5}; !reflect.DeepEqual(batchSizes, want) {
-		t.Fatalf("batch sizes = %v, want %v", batchSizes, want)
+	out := FormatMessageItem(m, runtime)
+	sender, ok := out["sender"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("formatted sender missing/mistyped: %#v", out["sender"])
 	}
-	if len(nameMap) != 25 {
-		t.Fatalf("resolved name count = %d, want 25", len(nameMap))
+	if sender["open_bot_id"] != "ou_bot" {
+		t.Fatalf("open_bot_id passthrough = %#v, want %#v", sender["open_bot_id"], "ou_bot")
+	}
+	if sender["id"] != "cli_bot" || sender["id_type"] != "app_id" {
+		t.Fatalf("id/id_type must be unchanged, got id=%#v id_type=%#v", sender["id"], sender["id_type"])
 	}
 }
 
-func TestResolveSenderNamesAPIFailure(t *testing.T) {
-	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/batch"):
-			return nil, fmt.Errorf("contact api failed")
-		default:
-			return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
-		}
+func TestPickSenderName(t *testing.T) {
+	// Uses the server-provided sender_name.
+	if got := pickSenderName(map[string]interface{}{"sender_name": "Bot Alpha"}); got != "Bot Alpha" {
+		t.Fatalf("pickSenderName(sender_name) = %q, want %q", got, "Bot Alpha")
+	}
+	// sender_i18n_names is NOT consulted for the display name (it stays in output for
+	// consumers that want a specific locale); no sender_name -> empty (caller uses id).
+	i18nOnly := map[string]interface{}{
+		"sender_i18n_names": map[string]interface{}{"en_us": "Bot Beta", "zh_cn": "机器人乙", "ja_jp": "ロボット"},
+	}
+	if got := pickSenderName(i18nOnly); got != "" {
+		t.Fatalf("pickSenderName(i18n only, no sender_name) = %q, want empty", got)
+	}
+	// Empty sender_name -> empty (no i18n fallthrough).
+	if got := pickSenderName(map[string]interface{}{"sender_name": ""}); got != "" {
+		t.Fatalf("pickSenderName(empty sender_name) = %q, want empty", got)
+	}
+	// Nothing available -> empty (caller falls back to id).
+	if got := pickSenderName(map[string]interface{}{"id": "cli_x"}); got != "" {
+		t.Fatalf("pickSenderName(no name) = %q, want empty", got)
+	}
+}
+
+// TestAttachSenderNamesPrefersProducerName covers AC1 (bot display name), AC2
+// (user producer name), AC5 (open_bot_id passthrough) and AC3 (id fallback).
+func TestAttachSenderNamesPrefersProducerName(t *testing.T) {
+	i18n := map[string]interface{}{"en_us": "Bot Alpha", "zh_cn": "机器人甲"}
+	messages := []map[string]interface{}{
+		// bot sender with producer-filled sender_name (AC1) + sender_i18n_names + open_bot_id (AC5)
+		{"sender": map[string]interface{}{"sender_type": "app", "id": "cli_bot", "sender_name": "机器人甲", "sender_i18n_names": i18n, "open_bot_id": "ou_bot"}},
+		// user sender with producer-filled sender_name (AC2, unified read)
+		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_user1", "sender_name": "Producer User"}},
+		// user sender without producer name -> resolved from the shared name cache (nameMap)
+		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_user2"}},
+		// bot sender without any name -> stays id (AC3)
+		{"sender": map[string]interface{}{"sender_type": "app", "id": "cli_unknown"}},
+	}
+	nameMap := map[string]string{"ou_user2": "Contact User"}
+
+	AttachSenderNames(messages, nameMap)
+
+	s0 := messages[0]["sender"].(map[string]interface{})
+	if s0["name"] != "机器人甲" {
+		t.Fatalf("bot sender name = %#v, want %#v", s0["name"], "机器人甲")
+	}
+	if s0["open_bot_id"] != "ou_bot" {
+		t.Fatalf("bot open_bot_id passthrough = %#v, want %#v", s0["open_bot_id"], "ou_bot")
+	}
+	// sender_name is dropped (duplicate of name); sender_i18n_names is kept.
+	if _, has := s0["sender_name"]; has {
+		t.Fatalf("sender_name should be stripped from output, got %#v", s0["sender_name"])
+	}
+	if _, has := s0["sender_i18n_names"]; !has {
+		t.Fatalf("sender_i18n_names should be preserved in output")
+	}
+	if s := messages[1]["sender"].(map[string]interface{}); s["name"] != "Producer User" {
+		t.Fatalf("user producer name = %#v, want %#v", s["name"], "Producer User")
+	}
+	if s := messages[2]["sender"].(map[string]interface{}); s["name"] != "Contact User" {
+		t.Fatalf("user contact-fallback name = %#v, want %#v", s["name"], "Contact User")
+	}
+	if s := messages[3]["sender"].(map[string]interface{}); s["name"] != nil {
+		t.Fatalf("unresolved bot sender should keep no name (id fallback), got %#v", s["name"])
+	}
+}
+
+// TestSystemMessageNeedsNoName documents that system messages — identified by
+// msg_type=="system", not by any sender id — need no display name: the producer
+// fills none and their sender carries no ou_ id, so they never hit the contact API
+// and are left without a name (no error). An empty sender name is normal here.
+func TestSystemMessageNeedsNoName(t *testing.T) {
+	failIfContactCalled := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("system message must not trigger any API call: %s", req.URL.String())
 	}))
 
-	got := ResolveSenderNames(runtime, []map[string]interface{}{
-		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_fail"}},
-	}, map[string]string{})
-	if got["ou_fail"] != "" {
-		t.Fatalf("failed sender resolution = %#v, want empty", got["ou_fail"])
+	messages := []map[string]interface{}{
+		{"msg_type": "system", "sender": map[string]interface{}{"sender_type": "system"}},
+		{"msg_type": "system"}, // system message without a sender object at all
+	}
+
+	got := ResolveSenderNames(failIfContactCalled, messages, nil)
+	if len(got) != 0 {
+		t.Fatalf("system messages resolved names = %#v, want empty", got)
+	}
+
+	AttachSenderNames(messages, got)
+	if s := messages[0]["sender"].(map[string]interface{}); s["name"] != nil {
+		t.Fatalf("system message sender should keep no name, got %#v", s["name"])
 	}
 }

--- a/shortcuts/im/convert_lib/merge.go
+++ b/shortcuts/im/convert_lib/merge.go
@@ -209,6 +209,10 @@ func fetchMergeForwardSubMessages(messageID string, runtime *common.RuntimeConte
 	data, err := runtime.DoAPIJSONTyped(http.MethodGet, mergeForwardMessagesPath(messageID), larkcore.QueryParams{
 		"user_id_type":          []string{"open_id"},
 		"card_msg_content_type": []string{"raw_card_content"},
+		// Opt in to server-side sender names: without it, senders that appear
+		// only inside this merge_forward carry no sender_name and — since there
+		// is no contact/mention fallback — render as their raw id.
+		"with_sender_name": []string{"true"},
 	}, nil)
 	if err != nil {
 		return nil, err

--- a/shortcuts/im/convert_lib/merge_test.go
+++ b/shortcuts/im/convert_lib/merge_test.go
@@ -65,6 +65,12 @@ func TestFetchMergeForwardSubMessages(t *testing.T) {
 		runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			switch {
 			case strings.Contains(req.URL.Path, "/open-apis/im/v1/messages/om_root"):
+				// Sub-item senders that appear only inside the merge_forward
+				// have no name unless we opt into server-side sender names;
+				// there is no contact/mention fallback anymore.
+				if got := req.URL.Query().Get("with_sender_name"); got != "true" {
+					t.Fatalf("with_sender_name = %q, want %q", got, "true")
+				}
 				return convertlibJSONResponse(200, map[string]interface{}{
 					"code": 0,
 					"data": map[string]interface{}{

--- a/shortcuts/im/convert_lib/thread.go
+++ b/shortcuts/im/convert_lib/thread.go
@@ -258,6 +258,10 @@ func fetchThreadReplies(runtime *common.RuntimeContext, threadID string, limit i
 		"sort_type":             []string{"ByCreateTimeAsc"},
 		"page_size":             []string{fmt.Sprint(limit)},
 		"card_msg_content_type": []string{"raw_card_content"},
+		// Opt in to server-side sender names: without it, reply senders that
+		// appear only inside this thread carry no sender_name and — since there
+		// is no contact/mention fallback — render as their raw id.
+		"with_sender_name": []string{"true"},
 	}, nil)
 	if err != nil {
 		return nil, false, fmt.Errorf("fetch thread replies for %s: %w", threadID, err) //nolint:forbidigo // best-effort internal thread fetch; never surfaced as a final shortcut error (ExpandThreadReplies is void)

--- a/shortcuts/im/convert_lib/thread_test.go
+++ b/shortcuts/im/convert_lib/thread_test.go
@@ -18,6 +18,12 @@ func TestExpandThreadReplies(t *testing.T) {
 			if req.URL.Query().Get("container_id") != "omt_1" {
 				return nil, fmt.Errorf("unexpected thread lookup: %s", req.URL.String())
 			}
+			// Reply senders that appear only inside the thread have no name
+			// unless we opt into server-side sender names; there is no
+			// contact/mention fallback anymore.
+			if got := req.URL.Query().Get("with_sender_name"); got != "true" {
+				t.Fatalf("with_sender_name = %q, want %q", got, "true")
+			}
 			return convertlibJSONResponse(200, map[string]interface{}{
 				"code": 0,
 				"data": map[string]interface{}{

--- a/shortcuts/im/coverage_additional_test.go
+++ b/shortcuts/im/coverage_additional_test.go
@@ -213,6 +213,7 @@ func TestBuildChatMessageListRequest(t *testing.T) {
 			"page_size":                 {"50"},
 			"only_thread_root_messages": {"true"},
 			"card_msg_content_type":     {"raw_card_content"},
+			"with_sender_name":          {"true"},
 			"start_time":                {"1772294400"},
 			"end_time":                  {"1772467199"},
 			"page_token":                {"next"},

--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -54,12 +54,31 @@ func normalizeAtMentions(content string) string {
 // Uses repeated params (?message_ids=x&message_ids=y) — RFC 6570 standard array
 // encoding, shorter and more broadly compatible than indexed params ([0]=x).
 func buildMGetURL(ids []string) string {
-	parts := make([]string, 0, len(ids)+1)
+	parts := make([]string, 0, len(ids)+2)
 	parts = append(parts, "card_msg_content_type=raw_card_content")
+	// Opt into server-side sender name filling (user + bot); without it the server
+	// omits sender_name / sender_i18n_names / open_bot_id. Used by messages-mget and
+	// the mget step of messages-search.
+	parts = append(parts, "with_sender_name=true")
 	for _, id := range ids {
 		parts = append(parts, "message_ids="+url.QueryEscape(id))
 	}
 	return "/open-apis/im/v1/messages/mget?" + strings.Join(parts, "&")
+}
+
+// senderDisplay returns the human-readable sender column value: the resolved
+// display name (set by convertlib.AttachSenderNames from the producer-filled
+// sender_name / sender_i18n_names or contact enrichment) when available,
+// otherwise the sender id as a fallback (AC3). System messages carrying neither
+// yield an empty string — an absent sender name is normal, not an error.
+func senderDisplay(sender map[string]interface{}) string {
+	if name, _ := sender["name"].(string); name != "" {
+		return name
+	}
+	if id, _ := sender["id"].(string); id != "" {
+		return id
+	}
+	return ""
 }
 
 func validateMessageID(input string) (string, error) {

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -675,3 +675,27 @@ func TestShortcuts(t *testing.T) {
 		t.Fatalf("Shortcuts() commands = %#v, want %#v", commands, want)
 	}
 }
+
+// TestSenderDisplay covers the human-readable sender column: a resolved name wins,
+// otherwise the sender id is shown (AC3 fallback), and a system/senderless message
+// with neither yields an empty string (no name is normal, not an error).
+func TestSenderDisplay(t *testing.T) {
+	cases := []struct {
+		name   string
+		sender map[string]interface{}
+		want   string
+	}{
+		{"name wins", map[string]interface{}{"name": "Bot Alpha", "id": "cli_bot"}, "Bot Alpha"},
+		{"id fallback when no name (AC3)", map[string]interface{}{"id": "cli_bot", "open_bot_id": "ou_bot"}, "cli_bot"},
+		{"user id fallback", map[string]interface{}{"id": "ou_user"}, "ou_user"},
+		{"empty name falls back to id", map[string]interface{}{"name": "", "id": "cli_x"}, "cli_x"},
+		{"no name no id (system)", map[string]interface{}{"sender_type": "system"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := senderDisplay(c.sender); got != c.want {
+				t.Fatalf("senderDisplay(%#v) = %q, want %q", c.sender, got, c.want)
+			}
+		})
+	}
+}

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -23,7 +23,7 @@ var ImChatMessageList = common.Shortcut{
 	Description: "List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range/sort/pagination",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read", "contact:user.base:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
 	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
@@ -168,8 +168,8 @@ var ImChatMessageList = common.Shortcut{
 					"type": msg["msg_type"],
 				}
 				if sender, ok := msg["sender"].(map[string]interface{}); ok {
-					if name, _ := sender["name"].(string); name != "" {
-						row["sender"] = name
+					if disp := senderDisplay(sender); disp != "" {
+						row["sender"] = disp
 					}
 				}
 				if content, _ := msg["content"].(string); content != "" {
@@ -206,6 +206,9 @@ func buildChatMessageListParams(sortFlag, pageSizeStr, chatId string) larkcore.Q
 		"page_size":                 []string{strconv.Itoa(pageSize)},
 		"card_msg_content_type":     []string{"raw_card_content"},
 		"only_thread_root_messages": []string{"true"},
+		// Opt into server-side sender name filling (sender_name / sender_i18n_names /
+		// open_bot_id) for both user and bot senders; without it the server omits them.
+		"with_sender_name": []string{"true"},
 	}
 }
 

--- a/shortcuts/im/im_messages_mget.go
+++ b/shortcuts/im/im_messages_mget.go
@@ -23,8 +23,8 @@ var ImMessagesMGet = common.Shortcut{
 	Description: "Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read", "contact:user.basic_profile:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read", "contact:user.base:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
@@ -112,8 +112,8 @@ var ImMessagesMGet = common.Shortcut{
 					"type":       msg["msg_type"],
 				}
 				if sender, ok := msg["sender"].(map[string]interface{}); ok {
-					if name, _ := sender["name"].(string); name != "" {
-						row["sender"] = name
+					if disp := senderDisplay(sender); disp != "" {
+						row["sender"] = disp
 					}
 				}
 				if content, _ := msg["content"].(string); content != "" {

--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -30,7 +30,7 @@ var ImMessagesSearch = common.Shortcut{
 	Command:     "+messages-search",
 	Description: "Search messages across chats (supports keyword, sender, time range filters) with user identity; user-only; filters by chat/sender/attachment/time, enriches results via mget and chats batch_query",
 	Risk:        "read",
-	Scopes:      []string{"search:message", "im:message.reactions:read", "contact:user.basic_profile:readonly"},
+	Scopes:      []string{"search:message", "im:message.reactions:read"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
@@ -227,8 +227,8 @@ var ImMessagesSearch = common.Shortcut{
 					"type": msg["msg_type"],
 				}
 				if sender, ok := msg["sender"].(map[string]interface{}); ok {
-					if name, _ := sender["name"].(string); name != "" {
-						row["sender"] = name
+					if disp := senderDisplay(sender); disp != "" {
+						row["sender"] = disp
 					}
 				}
 				if chatName, ok := msg["chat_name"].(string); ok && chatName != "" {

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -25,8 +25,8 @@ var ImThreadsMessagesList = common.Shortcut{
 	Description: "List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports sort/pagination",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read", "contact:user.basic_profile:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read", "contact:user.base:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
@@ -142,8 +142,8 @@ var ImThreadsMessagesList = common.Shortcut{
 					"type": msg["msg_type"],
 				}
 				if sender, ok := msg["sender"].(map[string]interface{}); ok {
-					if name, _ := sender["name"].(string); name != "" {
-						row["sender"] = name
+					if disp := senderDisplay(sender); disp != "" {
+						row["sender"] = disp
 					}
 				}
 				if content, _ := msg["content"].(string); content != "" {
@@ -176,6 +176,8 @@ func buildThreadsMessagesListParams(dir, containerID string, pageSize int, pageT
 		"sort_type":             {sortType},
 		"page_size":             {strconv.Itoa(pageSize)},
 		"card_msg_content_type": {"raw_card_content"},
+		// Opt into server-side sender name filling (user + bot); see buildChatMessageListParams.
+		"with_sender_name": {"true"},
 	}
 	if pageToken != "" {
 		params["page_token"] = []string{pageToken}

--- a/shortcuts/im/with_sender_name_test.go
+++ b/shortcuts/im/with_sender_name_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReadRequestsSendWithSenderName asserts every message-read request opts into
+// server-side sender name filling by sending with_sender_name=true. Without this
+// the producer never fills sender_name/sender_i18n_names/open_bot_id, so bot names
+// never appear (AC1/AC5). Covers chat-messages-list, threads-messages-list, and the
+// shared mget URL used by messages-mget and messages-search.
+func TestReadRequestsSendWithSenderName(t *testing.T) {
+	if got := buildChatMessageListParams("desc", "50", "oc_x")["with_sender_name"]; len(got) != 1 || got[0] != "true" {
+		t.Fatalf("chat-messages-list with_sender_name = %#v, want [true]", got)
+	}
+	if got := buildThreadsMessagesListParams("desc", "t_x", 50, "")["with_sender_name"]; len(got) != 1 || got[0] != "true" {
+		t.Fatalf("threads-messages-list with_sender_name = %#v, want [true]", got)
+	}
+	if u := buildMGetURL([]string{"om_1"}); !strings.Contains(u, "with_sender_name=true") {
+		t.Fatalf("buildMGetURL = %q, want to contain with_sender_name=true", u)
+	}
+}

--- a/skill-template/domains/im.md
+++ b/skill-template/domains/im.md
@@ -27,13 +27,14 @@ Chat (oc_xxx)
 - `--as bot` means **bot identity** and uses `tenant_access_token`. Calls run as the app bot, so behavior depends on the bot's membership, app visibility, availability range, and bot-specific scopes.
 - If an IM API says it supports both `user` and `bot`, the token type changes who the operator is. The same API can succeed with one identity and fail with the other because owner/admin status, chat membership, tenant boundary, or app availability are checked against the current caller.
 
-### Sender Name Resolution with Bot Identity
+### Sender Name Resolution
 
-When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-list`, `+threads-messages-list`, `+messages-mget`), sender names may not be resolved (shown as open_id instead of display name). This happens when the bot cannot access the user's contact info.
+When fetching messages (`+chat-messages-list`, `+threads-messages-list`, `+messages-mget`, `+messages-search`), the CLI shows a display name for both user and bot senders:
 
-**Root cause**: The bot's app visibility settings do not include the message sender, so the contact API returns no name.
+- **Server-provided name**: the read APIs return `sender_name` (plus the full-i18n `sender_i18n_names` map) on each message `sender`; the CLI surfaces it as the sender's `name` for users and bots alike. No name lookup and no extra permission are needed — **no contact scope** and no `application:bot.basic_info:read`.
+- **Fallback to id**: when the server does not provide a name, the sender is shown by its id and the command still exits 0. There is no contact-directory fallback.
 
-**Solution**: Check the app's visibility settings in the Lark Developer Console — ensure the app's visible range covers the users whose names need to be resolved. Alternatively, use `--as user` to fetch messages with user identity, which typically has broader contact access.
+The raw `sender_name` is not duplicated in output (its value is in `name`); the full `sender_i18n_names` map (all locales) is preserved for consumers that need a specific language, alongside an optional `open_bot_id` (`ou_`) for bot senders aligned with the message-receive event channel. System messages (`msg_type: system`) have no sender name — that is normal, not an error.
 
 ### Default message enrichment (reactions / update_time)
 

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -41,13 +41,14 @@ Chat (oc_xxx)
 - `--as bot` means **bot identity** and uses `tenant_access_token`. Calls run as the app bot, so behavior depends on the bot's membership, app visibility, availability range, and bot-specific scopes.
 - If an IM API says it supports both `user` and `bot`, the token type changes who the operator is. The same API can succeed with one identity and fail with the other because owner/admin status, chat membership, tenant boundary, or app availability are checked against the current caller.
 
-### Sender Name Resolution with Bot Identity
+### Sender Name Resolution
 
-When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-list`, `+threads-messages-list`, `+messages-mget`), sender names may not be resolved (shown as open_id instead of display name). This happens when the bot cannot access the user's contact info.
+When fetching messages (`+chat-messages-list`, `+threads-messages-list`, `+messages-mget`, `+messages-search`), the CLI shows a display name for both user and bot senders:
 
-**Root cause**: The bot's app visibility settings do not include the message sender, so the contact API returns no name.
+- **Server-provided name**: the read APIs return `sender_name` (plus the full-i18n `sender_i18n_names` map) on each message `sender`; the CLI surfaces it as the sender's `name` for users and bots alike. No name lookup and no extra permission are needed — **no contact scope** and no `application:bot.basic_info:read`.
+- **Fallback to id**: when the server does not provide a name, the sender is shown by its id and the command still exits 0. There is no contact-directory fallback.
 
-**Solution**: Check the app's visibility settings in the Lark Developer Console — ensure the app's visible range covers the users whose names need to be resolved. Alternatively, use `--as user` to fetch messages with user identity, which typically has broader contact access.
+The raw `sender_name` is not duplicated in output (its value is in `name`); the full `sender_i18n_names` map (all locales) is preserved for consumers that need a specific language, alongside an optional `open_bot_id` (`ou_`) for bot senders aligned with the message-receive event channel. System messages (`msg_type: system`) have no sender name — that is normal, not an error.
 
 ### Default message enrichment (reactions / update_time)
 


### PR DESCRIPTION
## Summary

When reading messages, the CLI now shows a display name for **bot** senders as well as users (previously only users resolved). Names come **solely from the server**: the CLI opts in with `with_sender_name=true` and reads the returned `sender_name` / `sender_i18n_names` for both users and bots, with `open_bot_id` passthrough and a graceful fallback to the sender id. There is **no contact/mention fallback** and **no new permission scope**.

## Changes

- **`convert_lib`**: read the server-provided `sender_name` / `sender_i18n_names` for both user and bot senders (`pickSenderName`, i18n by locale); `open_bot_id` passes through the whole sender object. The previous contact-batch and mention-based resolution is **removed** — a sender the server does not name falls back to its id.
- **`with_sender_name=true` opt-in**: added to `chat-messages-list` / `messages-mget` / `messages-search` / `threads-messages-list`, **and** to the inline fetches that render nested senders — merge_forward sub-messages and auto-expanded thread replies — so senders that appear only inside those nested views also get named.
- **Read commands**: fall back to the sender id when no name is available (shared `senderDisplay` helper). System messages (`msg_type: system`) show no sender name, as expected.
- **Docs**: rewrite the "Sender Name Resolution" section in the `lark-im` skill (template + generated) and add a `CHANGELOG` entry.

## Test Plan

- [x] Unit tests pass: `go test ./shortcuts/im ./shortcuts/im/convert_lib` (user+bot display, id fallback, system messages, i18n selection, `open_bot_id` passthrough, `with_sender_name` on all four commands + merge_forward / thread-reply inline fetches)
- [x] `go build ./...` / `go vet` / `gofmt` clean
- [x] Manual local verification against a real conversation containing bot messages

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message lists, search, and fetch results now show sender display names directly when provided by the server.
  * Bot messages can include an optional bot identifier in JSON output.
* **Bug Fixes**
  * Sender names now fall back to a sender ID when no display name is available.
  * System messages no longer appear as missing-name errors.
* **Documentation**
  * Updated message-handling docs and changelog to reflect the latest sender-name behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
