### PR TITLE
docs: clarify OpenAPI quota usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,16 @@ To check whether a command succeeded, test `ok == true` (or the exit code) — *
 --page-delay 500            # 500ms between page requests
 ```
 
+### OpenAPI Quota
+
+Commands that execute real Lark/Feishu Open Platform requests consume the same tenant/app OpenAPI quota as SDK or direct HTTP calls. This includes shortcut commands, generated API commands, and raw `lark-cli api` calls.
+
+Local-only inspection commands do not consume business OpenAPI quota because they do not send platform requests. Examples include `--help`, `schema`, `config`, `profile`, and shortcut `--dry-run` previews. A dry run validates and prints the planned request shape; the real command may still fail on server-side checks such as membership, scope, rate limit, or resource permission.
+
+Pagination consumes quota per actual request. For example, `--page-all` walks multiple pages, so quota usage is proportional to the number of pages fetched; use `--page-limit` and `--page-delay` to bound agent-driven workflows.
+
+Quota visibility is tenant/admin oriented. Enterprise admins can usually inspect usage in Feishu/Lark Admin Console billing or entitlement pages; ordinary personal users may not have access. When quota or rate-limit errors occur, inspect the JSON error envelope (`error.code`, `error.subtype`, `error.hint`, and `error.log_id` when present) before retrying.
+
 ### Dry Run
 
 For commands that may have side effects, preview the request with --dry-run first:

--- a/README.zh.md
+++ b/README.zh.md
@@ -260,6 +260,16 @@ lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_i
 --page-delay 500            # 每页请求间隔 500ms
 ```
 
+### OpenAPI 配额
+
+会实际请求飞书/Lark 开放平台的命令，会和 SDK 或直接 HTTP 调用一样消耗对应租户/应用的 OpenAPI 配额。这包括快捷命令、自动生成的 API 命令，以及 `lark-cli api` 原始调用。
+
+只做本地检查或自省的命令不消耗业务 OpenAPI 配额，因为它们不会发送平台请求。例如 `--help`、`schema`、`config`、`profile` 和快捷命令的 `--dry-run` 预览。dry run 只校验并打印计划请求结构；真正执行时仍可能因为成员关系、scope、限流或资源权限等服务端检查失败。
+
+分页会按实际请求次数消耗配额。例如 `--page-all` 会连续拉取多页，因此配额消耗与实际获取的页数成正比；在 Agent 自动化流程里建议用 `--page-limit` 和 `--page-delay` 控制上限和节奏。
+
+配额可见性通常面向租户/管理员。企业管理员一般可在飞书/Lark 管理后台的费用中心或权益数据页面查看用量；普通个人用户可能没有查看权限。遇到配额或限流错误时，请先查看 JSON 错误信封里的 `error.code`、`error.subtype`、`error.hint`，以及存在时的 `error.log_id`，再决定是否重试。
+
 ### Dry Run
 
 对可能产生副作用的命令，建议先用 --dry-run 预览请求：


### PR DESCRIPTION
## 背景

Fixes #1167.

Users and AI-agent workflows need a clear explanation of when `lark-cli` consumes Lark/Feishu OpenAPI quota, especially for dry-run previews and paginated commands.

## 核心改动

- Add an OpenAPI quota section to `README.md`.
- Add the same guidance to `README.zh.md`.
- Clarify that real shortcut/API/raw requests consume quota, local inspection and `--dry-run` do not, and `--page-all` consumes quota per fetched page.
- Point users to the JSON error envelope fields for quota/rate-limit diagnosis.

## 验证

- `git diff --check`: passed
- conflict marker scan: passed, no matches
- `go test ./internal/qualitygate/rules -count=1`: passed

## 风险与回滚

Docs-only change. Revert this commit to roll back the README guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “OpenAPI Quota” section to the English and Chinese README files.
  * Clarified which CLI commands consume platform quota and which local-only or preview commands do not.
  * Explained that pagination uses quota based on the number of actual requests.
  * Added guidance for checking quota and rate-limit error details when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->