### PR TITLE
docs: guide agents to reuse installed CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,21 @@ lark-cli calendar +agenda
 
 > The following steps are for AI Agents. Some steps require the user to complete actions in a browser.
 
-**Step 1 — Install**
+**Step 1 — Detect or install**
+
+First check whether `lark-cli` is already available in the current shell. AI Agents should reuse an existing installation instead of asking the user to reinstall every session:
+
+```bash
+command -v lark-cli && lark-cli --version
+```
+
+If the command is missing or cannot run, install it:
 
 ```bash
 npx @larksuite/cli@latest install
 ```
+
+An MCP server is not required for normal `lark-cli` usage. The CLI is a regular terminal command; the bundled Skills teach the Agent when and how to call it.
 
 **Step 2 — Configure app credentials**
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -96,11 +96,21 @@ lark-cli calendar +agenda
 
 > 以下步骤面向 AI Agent，部分步骤需要用户在浏览器中配合完成。
 
-**第 1 步 — 安装**
+**第 1 步 — 检测或安装**
+
+先检查当前 shell 是否已经能直接使用 `lark-cli`。AI Agent 应优先复用已有安装，不要每个会话都要求用户重新安装：
+
+```bash
+command -v lark-cli && lark-cli --version
+```
+
+如果命令不存在或无法运行，再执行安装：
 
 ```bash
 npx @larksuite/cli@latest install
 ```
+
+正常使用 `lark-cli` 不需要额外配置 MCP。CLI 是普通终端命令；随包安装的 Skills 会告诉 Agent 何时以及如何调用它。
 
 **第 2 步 — 配置应用凭证**
 


### PR DESCRIPTION
## 背景

Fixes #1543.

AI agents can repeatedly ask users to install `lark-cli` because the quick-start flow starts with installation and does not tell agents to detect an existing CLI first.

## 核心改动

- Update the English AI Agent quick start to check `command -v lark-cli && lark-cli --version` before installing.
- Add the same guidance to the Chinese README.
- Clarify that normal `lark-cli` usage does not require an MCP server; the CLI is a regular terminal command and Skills provide usage routing.

## 验证

- `git diff --check`: passed
- conflict marker scan: passed, no matches
- `go test ./internal/qualitygate/rules -count=1`: passed

## 风险与回滚

Docs-only change. Revert this commit to restore the previous quick-start wording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI Agent quick start steps to check whether `lark-cli` is already available before installing it.
  * Clarified that normal CLI use does not require additional MCP setup.
  * Added guidance on when and how bundled Skills can be used during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->