### PR TITLE
docs: optimize base workflow guidance

### DIFF
--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -607,7 +607,7 @@ func TestBaseWorkflowHelpGuidesAgents(t *testing.T) {
 				"workflow-id must start with wkf",
 				"steps may be an empty array",
 				"Use +workflow-get before +workflow-update",
-				"lark-base-workflow-schema.md",
+				"lark-base-workflow-quick.md",
 			},
 		},
 		{
@@ -621,7 +621,7 @@ func TestBaseWorkflowHelpGuidesAgents(t *testing.T) {
 				"Step ids must be unique",
 				"lark-base-workflow-guide.md as the entry guide",
 				"lark-base-workflow-schema.md as the steps JSON SSOT",
-				"do not invent steps[].type/data/next/children from natural language",
+				"Do not invent steps[].type/data/next/children from natural language",
 			},
 		},
 		{
@@ -634,7 +634,8 @@ func TestBaseWorkflowHelpGuidesAgents(t *testing.T) {
 				"keep title/status/steps fields",
 				"workflow-id must start with wkf",
 				"Updating does not enable or disable",
-				"do not invent steps[].type/data/next/children from natural language",
+				"lark-base-workflow-quick.md first",
+				"Do not invent steps[].type/data/next/children from natural language",
 			},
 		},
 		{

--- a/shortcuts/base/workflow_create.go
+++ b/shortcuts/base/workflow_create.go
@@ -27,7 +27,8 @@ var BaseWorkflowCreate = common.Shortcut{
 		"New workflows are created disabled; call +workflow-enable after creation when the user wants it active.",
 		"Before constructing steps, use +table-list and +field-list to confirm real table and field names.",
 		"Step ids must be unique, and every next/children link must reference an existing step id.",
-		"Use lark-base-workflow-guide.md as the entry guide and lark-base-workflow-schema.md as the steps JSON SSOT; do not invent steps[].type/data/next/children from natural language.",
+		"Use lark-base-workflow-guide.md as the entry guide and lark-base-workflow-schema.md as the steps JSON SSOT.",
+		"Do not invent steps[].type/data/next/children from natural language.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if strings.TrimSpace(runtime.Str("base-token")) == "" {

--- a/shortcuts/base/workflow_get.go
+++ b/shortcuts/base/workflow_get.go
@@ -26,7 +26,7 @@ var BaseWorkflowGet = common.Shortcut{
 		"workflow-id must start with wkf; use +workflow-list if the ID is unknown.",
 		"steps may be an empty array; that is valid for an unconfigured workflow.",
 		"Use +workflow-get before +workflow-update, then edit the returned definition and keep fields you do not intend to change.",
-		"Read lark-base-workflow-schema.md when interpreting or reusing returned steps.",
+		"Use lark-base-workflow-quick.md to decide whether the full workflow schema is needed.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if strings.TrimSpace(runtime.Str("base-token")) == "" {

--- a/shortcuts/base/workflow_update.go
+++ b/shortcuts/base/workflow_update.go
@@ -20,7 +20,7 @@ var BaseWorkflowUpdate = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "base-token", Desc: "base token", Required: true},
 		{Name: "workflow-id", Desc: "workflow ID (wkf... prefix)", Required: true},
-		{Name: "json", Desc: "workflow body JSON; read lark-base-workflow-guide.md and lark-base-workflow-schema.md before replacing steps", Required: true},
+		{Name: "json", Desc: "workflow body JSON; read lark-base-workflow-quick.md first, then guide/schema only for needed step details", Required: true},
 	},
 	Tips: []string{
 		"lark-cli base +workflow-update --base-token <base_token> --workflow-id <workflow_id> --json @workflow.json",
@@ -29,7 +29,8 @@ var BaseWorkflowUpdate = common.Shortcut{
 		"workflow-id must start with wkf; do not pass a tbl table ID.",
 		"Step ids must be unique, and every next/children link must reference an existing step id.",
 		"Updating does not enable or disable a workflow; call +workflow-enable or +workflow-disable separately.",
-		"Use lark-base-workflow-guide.md as the entry guide and lark-base-workflow-schema.md as the steps JSON SSOT; do not invent steps[].type/data/next/children from natural language.",
+		"Use lark-base-workflow-quick.md first; read lark-base-workflow-guide.md or lark-base-workflow-schema.md only for needed step details.",
+		"Do not invent steps[].type/data/next/children from natural language.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if strings.TrimSpace(runtime.Str("base-token")) == "" {

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -65,7 +65,7 @@ metadata:
 | 表单题目创建/更新 | `+form-questions-create` / `+form-questions-update` | 读 [lark-base-form-questions-create.md](references/lark-base-form-questions-create.md) / [lark-base-form-questions-update.md](references/lark-base-form-questions-update.md) |
 | 其他表单管理 | `+form-list/get/detail/create/update/delete` / `+form-questions-list/delete` | `+form-detail` 读 [lark-base-form-detail.md](references/lark-base-form-detail.md)；删除前确认目标表单 |
 | 仪表盘与组件 | `+dashboard-*` / `+dashboard-block-*` | 提到图表/看板/block 时先读 [lark-base-dashboard.md](references/lark-base-dashboard.md)；组件 `data_config` 读 [dashboard-block-data-config.md](references/dashboard-block-data-config.md)；读取图表计算结果用 `+dashboard-block-get-data` |
-| Workflow | `+workflow-*` | 更新/查看先读 [lark-base-workflow-quick.md](references/lark-base-workflow-quick.md) 判断是否需要完整 schema；只 list/get 标题、ID、状态、空 steps、启停，或改标题并原样保留返回的 status/steps 时不要读完整 schema；启停只用 `+workflow-enable/disable`；创建 workflow、理解/解释完整 steps、构造新 step、修改 step data/next/children、分支、循环、引用或恢复平台 schema 错误时，读 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) / [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md) |
+| Workflow | `+workflow-*` | 更新或理解 steps 时先读 [lark-base-workflow-quick.md](references/lark-base-workflow-quick.md) 判断是否需要完整 schema；创建 workflow、构造新 step、修改 step 结构或恢复平台 schema 错误时，读 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) / [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)；list/get/enable/disable 只处理 workflow ID 与启停状态 |
 | 高级权限与角色 | `+advperm-*` / `+role-*` | 角色操作先读入口 [lark-base-role-guide.md](references/lark-base-role-guide.md)；角色 create/update 或解读完整配置再读权限 JSON SSOT [role-config.md](references/role-config.md)；系统角色不可删除；关闭高级权限会影响自定义角色 |
 
 ## Base 心智模型
@@ -123,7 +123,7 @@ metadata:
 ## Dashboard / Workflow / Role
 
 - Dashboard 的复杂点是 block 的 `data_config`，不是 list/get/create/delete 命令参数。创建或更新 block 前先读 [dashboard-block-data-config.md](references/dashboard-block-data-config.md)，组件必须串行创建；`+dashboard-arrange` 是服务端智能布局，只在用户明确要求重排/美化时执行。`+dashboard-block-get-data` 读取图表最终计算结果，不返回 block 名称、类型、布局或 `data_config`；需要元数据先用 `+dashboard-block-get`。
-- Workflow 的复杂点是 `steps` 结构。查看、更新或解释 workflow 时先读 [lark-base-workflow-quick.md](references/lark-base-workflow-quick.md)：quick 能判断是否只需 ID/状态、是否可复用 `+workflow-get` 返回结构，以及何时才需要打开完整 guide/schema 的相关小节；enable/disable/list 不读 steps schema；创建 workflow、解释完整 steps 或修改 step 结构时仍以 guide/schema 为准。
+- Workflow 的复杂点是 `steps` 结构。更新或理解 steps 时先读 [lark-base-workflow-quick.md](references/lark-base-workflow-quick.md)，只有 quick 不够时再读 guide/schema；创建 workflow 或修改 step 结构时直接读 guide/schema；list/get/enable/disable 只处理 workflow ID 与启停状态。
 - Role 的复杂点是权限 JSON。角色操作先读入口 [lark-base-role-guide.md](references/lark-base-role-guide.md)；`+role-create` 只支持自定义角色；`+role-update` 是 delta merge；角色 create/update 或解读完整配置时读权限 JSON SSOT [role-config.md](references/role-config.md)。`+role-delete` 只适用于自定义角色，系统角色不可删除；删除角色和关闭高级权限前必须确认目标和影响。
 
 ## 常见恢复

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -65,7 +65,7 @@ metadata:
 | 表单题目创建/更新 | `+form-questions-create` / `+form-questions-update` | 读 [lark-base-form-questions-create.md](references/lark-base-form-questions-create.md) / [lark-base-form-questions-update.md](references/lark-base-form-questions-update.md) |
 | 其他表单管理 | `+form-list/get/detail/create/update/delete` / `+form-questions-list/delete` | `+form-detail` 读 [lark-base-form-detail.md](references/lark-base-form-detail.md)；删除前确认目标表单 |
 | 仪表盘与组件 | `+dashboard-*` / `+dashboard-block-*` | 提到图表/看板/block 时先读 [lark-base-dashboard.md](references/lark-base-dashboard.md)；组件 `data_config` 读 [dashboard-block-data-config.md](references/dashboard-block-data-config.md)；读取图表计算结果用 `+dashboard-block-get-data` |
-| Workflow | `+workflow-*` | 创建/更新或理解 steps 时读入口 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) 和 steps JSON SSOT [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)；list/get/enable/disable 只处理 workflow ID 与启停状态 |
+| Workflow | `+workflow-*` | 更新/查看先读 [lark-base-workflow-quick.md](references/lark-base-workflow-quick.md) 判断是否需要完整 schema；只 list/get 标题、ID、状态、空 steps、启停，或改标题并原样保留返回的 status/steps 时不要读完整 schema；启停只用 `+workflow-enable/disable`；创建 workflow、理解/解释完整 steps、构造新 step、修改 step data/next/children、分支、循环、引用或恢复平台 schema 错误时，读 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) / [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md) |
 | 高级权限与角色 | `+advperm-*` / `+role-*` | 角色操作先读入口 [lark-base-role-guide.md](references/lark-base-role-guide.md)；角色 create/update 或解读完整配置再读权限 JSON SSOT [role-config.md](references/role-config.md)；系统角色不可删除；关闭高级权限会影响自定义角色 |
 
 ## Base 心智模型
@@ -123,7 +123,7 @@ metadata:
 ## Dashboard / Workflow / Role
 
 - Dashboard 的复杂点是 block 的 `data_config`，不是 list/get/create/delete 命令参数。创建或更新 block 前先读 [dashboard-block-data-config.md](references/dashboard-block-data-config.md)，组件必须串行创建；`+dashboard-arrange` 是服务端智能布局，只在用户明确要求重排/美化时执行。`+dashboard-block-get-data` 读取图表最终计算结果，不返回 block 名称、类型、布局或 `data_config`；需要元数据先用 `+dashboard-block-get`。
-- Workflow 的复杂点是 `steps` 结构。创建、更新或解释完整 workflow 时读入口 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) 和 steps JSON SSOT [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)；enable/disable/list 只需确认 workflow ID、当前启停状态和用户意图。
+- Workflow 的复杂点是 `steps` 结构。查看、更新或解释 workflow 时先读 [lark-base-workflow-quick.md](references/lark-base-workflow-quick.md)：quick 能判断是否只需 ID/状态、是否可复用 `+workflow-get` 返回结构，以及何时才需要打开完整 guide/schema 的相关小节；enable/disable/list 不读 steps schema；创建 workflow、解释完整 steps 或修改 step 结构时仍以 guide/schema 为准。
 - Role 的复杂点是权限 JSON。角色操作先读入口 [lark-base-role-guide.md](references/lark-base-role-guide.md)；`+role-create` 只支持自定义角色；`+role-update` 是 delta merge；角色 create/update 或解读完整配置时读权限 JSON SSOT [role-config.md](references/role-config.md)。`+role-delete` 只适用于自定义角色，系统角色不可删除；删除角色和关闭高级权限前必须确认目标和影响。
 
 ## 常见恢复
@@ -153,5 +153,5 @@ metadata:
 - [lark-base-view-set-filter.md](references/lark-base-view-set-filter.md)：视图筛选 JSON
 - [lark-base-form-detail.md](references/lark-base-form-detail.md) / [lark-base-form-submit.md](references/lark-base-form-submit.md) / [lark-base-form-questions-create.md](references/lark-base-form-questions-create.md) / [lark-base-form-questions-update.md](references/lark-base-form-questions-update.md)：表单详情、提交和复杂 JSON
 - [lark-base-dashboard.md](references/lark-base-dashboard.md) / [dashboard-block-data-config.md](references/dashboard-block-data-config.md) / [lark-base-dashboard-block-get-data.md](references/lark-base-dashboard-block-get-data.md)：仪表盘、组件配置与图表结果协议
-- [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) / [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)：workflow 入口与 steps JSON SSOT
+- [lark-base-workflow-quick.md](references/lark-base-workflow-quick.md) / [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) / [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)：workflow 高频路径、入口示例与 steps JSON SSOT
 - [lark-base-role-guide.md](references/lark-base-role-guide.md) / [role-config.md](references/role-config.md)：角色入口与权限 JSON SSOT

--- a/skills/lark-base/references/lark-base-workflow-guide.md
+++ b/skills/lark-base/references/lark-base-workflow-guide.md
@@ -785,7 +785,7 @@
 | 3 | `At least one of filter info and ref info is required` | SetRecordAction/FindRecordAction 缺少定位条件 | 必须提供 `filter_info` 或 `ref_info` 之一 |
 | 4 | `client token is empty` | 缺少 `client_token` | 每次请求传入唯一值（时间戳或随机字符串） |
 | 5 | `valueType 'text' not allowed for fieldType '3'` | select 类型字段值格式错误 | 改用 `option` 类型 |
-| 6 | `Undefined Step Type` | 使用了不支持的 StepType | 使用 `AddRecordTrigger` 而非 `CreateRecordTrigger` |
+| 6 | `Undefined Step Type` | 使用了不支持的 StepType | 使用 `AddRecordTrigger` 而非 `CreateRecordTrigger`；没有 `DeleteRecordTrigger`，删除事件要用状态/字段变更建模 |
 | 7 | `prompt references an unknown reference from step` | 引用的 stepId 不存在 | 确保引用的 step 在同一 workflow 的 steps 数组中 |
 | 8 | `[2200] Internal Error` | 1. steps[].id 重复 2. next/children.links 引用了不存在的 step | 确保所有 step id 唯一；检查引用关系 |
 | 9 | 工作流结构不完整 | Branch/Loop 节点缺少 `children` | 仅 Branch（IfElseBranch/SwitchBranch）和 Loop 节点需要 `children`，Trigger/Action 节点无需设置 |

--- a/skills/lark-base/references/lark-base-workflow-quick.md
+++ b/skills/lark-base/references/lark-base-workflow-quick.md
@@ -1,0 +1,94 @@
+# Workflow quick
+
+本文档是 Base Workflow 的高频路径速查。先用它判断是否能走短路径；完整 guide 和 schema 仍是新 step 字段的事实来源，只有 quick 不够时再读相关小节。
+
+## 路由
+
+| 任务 | 优先命令 | 下一步/阅读判断 |
+|---|---|---|
+| 按名称查找 workflow | `+workflow-list --base-token <base> --as user --format json --jq '<filter>'` | 只有唯一匹配且需要查看或更新时，才对该 workflow 用 `+workflow-get`；查 ID 不读 schema。 |
+| 启用或停用 | `+workflow-list` -> `+workflow-disable` / `+workflow-enable` | 不读 steps schema；启停不修改 steps。 |
+| 查看 title/status/steps | `+workflow-get --workflow-id <wkf>` | 只报告 title、status、ID 或 steps 为空时，不读 schema。 |
+| 更新 workflow steps | `+workflow-get` -> 编辑返回的 `title/status/steps` -> `+workflow-update` | 更新是全量替换语义；不想改的字段必须保留。修改 step 结构或字段含义时再读 schema/guide。 |
+
+## 保持短路径
+
+以下任务不要打开完整 guide/schema：
+
+- 列出 workflow、查找唯一 workflow ID、启用、停用、报告当前状态；
+- 只改 `title`，并原样保留返回的 `status` 和 `steps`；状态变更使用 `+workflow-enable` 或 `+workflow-disable`；
+- 基于 `+workflow-get` 返回结果小幅修改现有 workflow，并保持已有 step 的 `type`、`data`、`next`、`children` 结构不变；
+
+创建 workflow、从零构造 steps、新增 step 类型、修改 branch/loop 链接、编写 ref 路径，或恢复平台 schema 错误时，不走 quick 的短路径，直接读完整 guide/schema 的相关小节。本地阅读时先搜索标题，只读必要的小节。
+
+## 不支持的触发边界
+
+- 当前 workflow step schema 没有原生“记录被物理删除”触发器。不要搜索或编造 `DeleteRecordTrigger`、`DeletedRecordTrigger`、`RecordDeletedTrigger`。
+- 如果用户要求“record deleted” / “删除记录”触发 workflow，说明 Base workflow steps 不支持精确的物理删除事件。可建议可建模替代方案：删除前先把状态改为“离职/已删除”、清空标记字段，或更新一个布尔字段，再用 `SetRecordTrigger` / `ChangeRecordTrigger` 监听该字段变化。
+- 如果任务必须在物理行已经删除之后触发，停止并说明能力边界，不要创建误导性的 workflow。
+
+## 常见 Step Data Key
+
+下面这些 key 足够搭出常见 workflow 骨架。只有下表不够、平台错误要求特定字段，或需要 branch/loop/ref 细节时，才读完整 schema。
+
+| Step type | 最小 `data` key |
+|---|---|
+| `AddRecordTrigger` | `table_name`、`watched_field_name`，可选 `trigger_control_list` 和 `condition_list` |
+| `TimerTrigger` | `rule`（常见 `DAILY` / `WORKDAY`）、`start_time`（`YYYY-MM-DD HH:mm`），可选 `is_never_end` |
+| `SetRecordTrigger` | `table_name`、`field_watch_info: [{ "field_name": "<field>" }]`，可选 `trigger_control_list` 和 `condition_list` |
+| `ChangeRecordTrigger` | `table_name`，可选 `trigger_control_list` 和 `condition_list`；需要新增或修改都触发时使用 |
+| `FindRecordAction` | `table_name`、`field_names`、`should_proceed_when_no_results`，并且 `filter_info` / `ref_info` 二选一；构造定位条件时读 schema/guide |
+| `GenerateAiTextAction` | `prompt` 使用 text/ref items；后续 step 引用生成文本时用 `$.<stepId>`，不是嵌套路径 |
+| `LarkMessageAction` | `receiver`、`send_to_everyone`、`content`，可选 `title`，不需要按钮时 `btn_list` 为 `[]` |
+| `Delay` | `duration` 单位为分钟，范围 1-120 |
+
+## 必要检查
+
+- 从 `/base/<token>` URL 中提取 `base_token` 后再运行 Base 命令。
+- 使用命令返回的真实名称和 ID。不要猜 table name、field name、workflow ID、group ID、user ID 或 receiver。
+- 构造 `steps` 前，读取会引用的真实 Base 结构：表用 `+table-list`，字段用 `+field-list`，现有 workflow 用 `+workflow-list/get`。
+- `+workflow-update` 会替换完整 workflow 定义。更新现有 workflow 时先从 `+workflow-get` 开始，并保留不变的 `title`、`status` 和 `steps`。
+- 写操作默认继续使用 `--as user`，除非用户明确要求 bot 身份，或权限恢复需要走 shared auth 流程。
+
+## Step Schema 指针
+
+只有 quick 不包含所需 step 细节时，才读完整 schema 或 guide。
+
+| 需求 | 阅读位置 |
+|---|---|
+| 记录删除触发器 | 不要为了 `DeleteRecordTrigger` 继续读；当前不支持。改用删除前状态/字段变化建模，或在必须精确监听物理删除时说明不支持。 |
+| 常见简单流程：record/timer trigger -> message、add/update/find record、delay、AI text action | 先搜索标题；只读缺失的 guide 示例或 schema step data 小节 |
+| 基础 step 结构、`next`、`children.links` | `lark-base-workflow-schema.md` -> WorkflowStep / StepChildren |
+| 触发器类型选择 | `lark-base-workflow-schema.md` -> Trigger types |
+| 消息接收人与内容 | `lark-base-workflow-schema.md` -> LarkMessageAction |
+| AI 文本生成 | `lark-base-workflow-schema.md` -> GenerateAiTextAction |
+| 查找记录、新增记录、更新记录 | `lark-base-workflow-schema.md` -> Action data |
+| 定时、工作日、提醒时间 | `lark-base-workflow-schema.md` -> TimerTrigger / ReminderTrigger |
+| if/else、switch、loop | `lark-base-workflow-guide.md` 示例，以及 schema 的 branch/system 小节 |
+
+## 最小 Body 形状
+
+```json
+{
+  "title": "workflow title",
+  "status": "disabled",
+  "steps": [
+    {
+      "id": "step_trigger",
+      "type": "AddRecordTrigger",
+      "title": "trigger title",
+      "next": "step_action",
+      "data": {}
+    },
+    {
+      "id": "step_action",
+      "type": "LarkMessageAction",
+      "title": "action title",
+      "next": null,
+      "data": {}
+    }
+  ]
+}
+```
+
+这只是外层结构。每个 `data` 对象必须来自相关 schema 小节或已有 `+workflow-get` 返回；不要根据自然语言编造不支持的字段。

--- a/skills/lark-base/references/lark-base-workflow-quick.md
+++ b/skills/lark-base/references/lark-base-workflow-quick.md
@@ -65,30 +65,3 @@
 | 查找记录、新增记录、更新记录 | `lark-base-workflow-schema.md` -> Action data |
 | 定时、工作日、提醒时间 | `lark-base-workflow-schema.md` -> TimerTrigger / ReminderTrigger |
 | if/else、switch、loop | `lark-base-workflow-guide.md` 示例，以及 schema 的 branch/system 小节 |
-
-## 最小 Body 形状
-
-```json
-{
-  "title": "workflow title",
-  "status": "disabled",
-  "steps": [
-    {
-      "id": "step_trigger",
-      "type": "AddRecordTrigger",
-      "title": "trigger title",
-      "next": "step_action",
-      "data": {}
-    },
-    {
-      "id": "step_action",
-      "type": "LarkMessageAction",
-      "title": "action title",
-      "next": null,
-      "data": {}
-    }
-  ]
-}
-```
-
-这只是外层结构。每个 `data` 对象必须来自相关 schema 小节或已有 `+workflow-get` 返回；不要根据自然语言编造不支持的字段。

--- a/skills/lark-base/references/lark-base-workflow-schema.md
+++ b/skills/lark-base/references/lark-base-workflow-schema.md
@@ -110,9 +110,11 @@
 | 新增记录时 | `AddRecordTrigger` |
 | 字段变为特定值时（**仅修改**） | `SetRecordTrigger` |
 | **新增或修改**都触发 | `ChangeRecordTrigger` |
+| 记录被物理删除时 | 不支持；不要使用 `DeleteRecordTrigger`，改用删除前状态/字段变更建模 |
 | 拿不准用哪个 | `ChangeRecordTrigger` |
 
 > ⚠️ `SetRecordTrigger` 仅监听修改，`ChangeRecordTrigger` 同时监听新增 + 修改。
+> ⚠️ 当前 StepType 不包含记录删除触发器。需要“删除时通知”时，先把记录标记为离职/待删除/已删除，再用 `SetRecordTrigger` 或 `ChangeRecordTrigger` 监听该字段变化；如果必须监听物理删除事件，则 Base workflow 暂不支持。
 
 ### Action 类型
 


### PR DESCRIPTION
## Changes
- Add a concise Base workflow quick guide for common read/update paths.
- Clarify when agents should read the full workflow guide/schema versus staying on the quick path.
- Tighten workflow command tips around full-update semantics and schema usage.

## Related Issues
- None.

## Test Plan
- `git diff --check`
- `go test -p 1 ./shortcuts/base`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a quick-reference guide for common workflow operations and when to consult detailed schema documentation.
  * Updated workflow guidance to prioritize the quick guide for routine tasks and clarify full-schema requirements for step changes.
  * Clarified supported trigger types, including alternatives for deletion-related notifications.
  * Added guidance to avoid inventing unsupported workflow step fields or event types.
* **Usability**
  * Improved workflow create, view, and update instructions for clearer, safer operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->