### PR TITLE
fix: route brand-sensitive endpoints through the resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,10 @@ jobs:
         run: echo "QUALITY_GATE_CHANGED_FROM=$(bash scripts/resolve-changed-from.sh)" >> "$GITHUB_ENV"
       - name: Run golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev="$QUALITY_GATE_CHANGED_FROM"
-      - name: Run errs/ lint guards (lintcheck)
+      - name: Run source-contract lint guards (lintcheck)
         run: go run -C lint . --changed-from "$QUALITY_GATE_CHANGED_FROM" ..
+      - name: Run lint module tests
+        run: go test -C lint ./... -count=1
 
   script-test:
     needs: fast-gate

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,8 +25,10 @@ import (
 	"github.com/larksuite/cli/internal/build"
 	"github.com/larksuite/cli/internal/cmdpolicy"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/hook"
 	"github.com/larksuite/cli/internal/keychain"
+	"github.com/larksuite/cli/internal/registry"
 	"github.com/larksuite/cli/shortcuts"
 	"github.com/spf13/cobra"
 )
@@ -42,6 +44,18 @@ type buildConfig struct {
 	skipStrictMode bool
 	skipService    bool
 	serviceCatalog *apicatalog.Catalog
+	startupBrand   core.LarkBrand
+}
+
+// WithStartupBrand initializes the API registry with the given brand before
+// any command registration touches the runtime catalog. Without it the
+// registry's sync.Once locks onto the Feishu default at first catalog access,
+// long before the lazily-resolved config brand is known — see
+// ResolveStartupBrand for the caller-side resolution.
+func WithStartupBrand(brand core.LarkBrand) BuildOption {
+	return func(c *buildConfig) {
+		c.startupBrand = brand
+	}
 }
 
 // WithIO sets the IO streams for the CLI by wrapping raw reader/writers.
@@ -152,6 +166,12 @@ func buildInternal(ctx context.Context, inv cmdutil.InvocationContext, opts ...B
 	// the same values the Factory ends up using.
 	if cfg.streams == nil {
 		cfg.streams = cmdutil.SystemIO()
+	}
+
+	// Initialize the registry brand before anything touches the runtime
+	// catalog (its sync.Once would otherwise lock onto the Feishu default).
+	if cfg.startupBrand != "" {
+		registry.InitWithBrand(cfg.startupBrand)
 	}
 
 	f := cmdutil.NewDefault(cfg.streams, inv)

--- a/cmd/config/bind_test.go
+++ b/cmd/config/bind_test.go
@@ -916,25 +916,6 @@ func TestReadDotenv_ValueWithEquals(t *testing.T) {
 	}
 }
 
-func TestNormalizeBrand(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"", "feishu"},
-		{"feishu", "feishu"},
-		{"lark", "lark"},
-		{"LARK", "lark"},
-		{" lark ", "lark"},
-		{"Lark", "lark"},
-	}
-	for _, tt := range tests {
-		if got := normalizeBrand(tt.input); got != tt.want {
-			t.Errorf("normalizeBrand(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 func TestResolveOpenClawConfigPath_Overrides(t *testing.T) {
 	t.Run("OPENCLAW_CONFIG_PATH wins", func(t *testing.T) {
 		custom := filepath.Join(t.TempDir(), "custom.json")

--- a/cmd/config/binder.go
+++ b/cmd/config/binder.go
@@ -205,7 +205,7 @@ func (b *openclawBinder) Build(appID string) (*core.AppConfig, error) {
 	return &core.AppConfig{
 		AppId:     selected.AppID,
 		AppSecret: stored,
-		Brand:     core.LarkBrand(normalizeBrand(selected.Brand)),
+		Brand:     core.ParseBrand(selected.Brand),
 	}, nil
 }
 
@@ -261,7 +261,7 @@ func (b *hermesBinder) Build(appID string) (*core.AppConfig, error) {
 	return &core.AppConfig{
 		AppId:     appID,
 		AppSecret: stored,
-		Brand:     core.LarkBrand(normalizeBrand(b.envMap["FEISHU_DOMAIN"])),
+		Brand:     core.ParseBrand(b.envMap["FEISHU_DOMAIN"]),
 	}, nil
 }
 
@@ -326,7 +326,7 @@ func (b *larkChannelBinder) Build(appID string) (*core.AppConfig, error) {
 	return &core.AppConfig{
 		AppId:     appID,
 		AppSecret: stored,
-		Brand:     core.LarkBrand(normalizeBrand(b.cfg.Accounts.App.Tenant)),
+		Brand:     core.ParseBrand(b.cfg.Accounts.App.Tenant),
 	}, nil
 }
 
@@ -348,16 +348,6 @@ func sourceDisplayName(source string) string {
 	default:
 		return source
 	}
-}
-
-// normalizeBrand applies .strip().lower() and defaults to "feishu".
-// Aligns with Hermes gateway/platforms/feishu.py:1119 behavior.
-func normalizeBrand(raw string) string {
-	s := strings.TrimSpace(strings.ToLower(raw))
-	if s == "" {
-		return "feishu"
-	}
-	return s
 }
 
 // resolveHermesEnvPath returns the path to Hermes's .env file.

--- a/cmd/config/init_interactive.go
+++ b/cmd/config/init_interactive.go
@@ -5,7 +5,9 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 
 	"github.com/charmbracelet/huh"
 	"github.com/larksuite/cli/internal/build"
@@ -180,9 +182,9 @@ func runCreateAppFlow(ctx context.Context, f *cmdutil.Factory, brandOverride cor
 	// Use the shared proxy-plugin-aware transport so registration traffic is not
 	// a bypass of proxy plugin mode.
 	httpClient := transport.NewHTTPClient(0)
-	authResp, err := larkauth.RequestAppRegistration(httpClient, larkBrand, f.IOStreams.ErrOut)
+	authResp, err := larkauth.RequestAppRegistration(ctx, httpClient, larkBrand, f.IOStreams.ErrOut)
 	if err != nil {
-		return nil, errs.NewConfigError(errs.SubtypeInvalidClient, "app registration failed: %v", err).WithCause(err)
+		return nil, classifyRegistrationBeginError(err)
 	}
 
 	// Step 2: Build and display verification URL + QR code
@@ -208,31 +210,15 @@ func runCreateAppFlow(ctx context.Context, f *cmdutil.Factory, brandOverride cor
 		fmt.Fprintf(f.IOStreams.ErrOut, "  %s\n\n", verificationURL)
 		fmt.Fprintf(f.IOStreams.ErrOut, "%s\n", msg.WaitingForScanNonTTY)
 	}
-	result, err := larkauth.PollAppRegistration(ctx, httpClient, core.BrandFeishu, authResp.DeviceCode, authResp.Interval, authResp.ExpiresIn, f.IOStreams.ErrOut)
+	// Step 4: Poll for credentials (brand discovery lives in internal/auth);
+	// this layer only classifies the terminal error and saves the result.
+	result, finalBrand, err := larkauth.RegisterAppWithDiscovery(ctx, httpClient, authResp, f.IOStreams.ErrOut)
 	if err != nil {
-		return nil, errs.NewAuthenticationError(errs.SubtypeUnknown, "%v", err).WithCause(err)
-	}
-
-	// Step 4: Handle Lark brand special case
-	// If tenant_brand=lark and no client_secret, retry with lark brand endpoint
-	if result.ClientSecret == "" && result.UserInfo != nil && result.UserInfo.TenantBrand == "lark" {
-		// fmt.Fprintf(f.IOStreams.ErrOut, "%s\n", msg.DetectedLarkTenant)
-		result, err = larkauth.PollAppRegistration(ctx, httpClient, core.BrandLark, authResp.DeviceCode, authResp.Interval, authResp.ExpiresIn, f.IOStreams.ErrOut)
-		if err != nil {
-			return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "lark endpoint retry failed: %v", err).WithCause(err)
-		}
+		return nil, classifyRegistrationError(err)
 	}
 
 	if result.ClientID == "" || result.ClientSecret == "" {
 		return nil, errs.NewConfigError(errs.SubtypeInvalidClient, "app registration succeeded but missing client_id or client_secret")
-	}
-
-	// Determine final brand from response
-	finalBrand := larkBrand
-	if result.UserInfo != nil && result.UserInfo.TenantBrand == "lark" {
-		finalBrand = core.BrandLark
-	} else if result.UserInfo != nil && result.UserInfo.TenantBrand == "feishu" {
-		finalBrand = core.BrandFeishu
 	}
 
 	fmt.Fprintln(f.IOStreams.ErrOut)
@@ -244,4 +230,41 @@ func runCreateAppFlow(ctx context.Context, f *cmdutil.Factory, brandOverride cor
 		AppID:     result.ClientID,
 		AppSecret: result.ClientSecret,
 	}, nil
+}
+
+// classifyRegistrationBeginError keeps transport/cancellation failures out of
+// the invalid-client category: the begin request sends no app credentials.
+func classifyRegistrationBeginError(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return errs.NewAuthenticationError(errs.SubtypeUnknown, "app registration cancelled").WithCause(err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return errs.NewNetworkError(errs.SubtypeNetworkTimeout, "app registration begin timed out: %v", err).WithCause(err)
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		subtype := errs.SubtypeNetworkTransport
+		if netErr.Timeout() {
+			subtype = errs.SubtypeNetworkTimeout
+		}
+		return errs.NewNetworkError(subtype, "app registration begin failed: %v", err).WithCause(err)
+	}
+	return errs.NewAPIError(errs.SubtypeUnknown, "app registration begin failed: %v", err).WithCause(err)
+}
+
+// classifyRegistrationError maps registration terminal outcomes to typed
+// errors, preserving causes.
+func classifyRegistrationError(err error) error {
+	switch {
+	case errors.Is(err, larkauth.ErrRegistrationDenied):
+		return errs.NewAuthenticationError(errs.SubtypeUnknown, "%v", err).
+			WithHint("re-run `lark-cli config init --new` and approve the authorization request").
+			WithCause(err)
+	case errors.Is(err, larkauth.ErrRegistrationExpired), errors.Is(err, larkauth.ErrRegistrationTimedOut):
+		return errs.NewAuthenticationError(errs.SubtypeTokenExpired, "%v", err).
+			WithHint("re-run `lark-cli config init --new` and complete the scan before the code expires").
+			WithCause(err)
+	default:
+		return errs.NewAuthenticationError(errs.SubtypeUnknown, "app registration failed: %v", err).WithCause(err)
+	}
 }

--- a/cmd/config/init_interactive_test.go
+++ b/cmd/config/init_interactive_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	larkauth "github.com/larksuite/cli/internal/auth"
+)
+
+func assertRegistrationProblem(t *testing.T, got, cause error, category errs.Category, subtype errs.Subtype) *errs.Problem {
+	t.Helper()
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("error %T is not typed: %v", got, got)
+	}
+	if p.Category != category || p.Subtype != subtype {
+		t.Errorf("problem = (%q, %q), want (%q, %q)", p.Category, p.Subtype, category, subtype)
+	}
+	if !errors.Is(got, cause) {
+		t.Errorf("error %v does not preserve cause %v", got, cause)
+	}
+	return p
+}
+
+func TestClassifyRegistrationBeginError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		category errs.Category
+		subtype  errs.Subtype
+	}{
+		{"cancelled", context.Canceled, errs.CategoryAuthentication, errs.SubtypeUnknown},
+		{"deadline", context.DeadlineExceeded, errs.CategoryNetwork, errs.SubtypeNetworkTimeout},
+		{"transport", &net.DNSError{Err: "lookup failed", Name: "accounts.example"}, errs.CategoryNetwork, errs.SubtypeNetworkTransport},
+		{"response", errors.New("response not JSON"), errs.CategoryAPI, errs.SubtypeUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertRegistrationProblem(t, classifyRegistrationBeginError(tt.err), tt.err, tt.category, tt.subtype)
+		})
+	}
+}
+
+func TestClassifyRegistrationError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		subtype errs.Subtype
+		hint    bool
+	}{
+		{"denied", larkauth.ErrRegistrationDenied, errs.SubtypeUnknown, true},
+		{"expired", larkauth.ErrRegistrationExpired, errs.SubtypeTokenExpired, true},
+		{"timed-out", larkauth.ErrRegistrationTimedOut, errs.SubtypeTokenExpired, true},
+		{"cancelled", context.Canceled, errs.SubtypeUnknown, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := assertRegistrationProblem(t, classifyRegistrationError(tt.err), tt.err, errs.CategoryAuthentication, tt.subtype)
+			if (p.Hint != "") != tt.hint {
+				t.Errorf("hint = %q, want non-empty=%v", p.Hint, tt.hint)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,6 +107,7 @@ func Execute() int {
 		ctx, inv,
 		WithIO(os.Stdin, os.Stdout, os.Stderr),
 		HideProfile(isSingleAppMode()),
+		WithStartupBrand(ResolveStartupBrand(inv.Profile)),
 	)
 
 	// --- Notices (non-blocking) ---

--- a/cmd/startup_brand.go
+++ b/cmd/startup_brand.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+// ResolveStartupBrand resolves the brand before the command tree is built, so
+// the registry's remote metadata overlay uses the configured brand from the
+// first catalog access. It mirrors the credential chain's brand precedence —
+// environment, then the active profile's raw config entry — without touching
+// the keychain (no secrets are needed to know the brand).
+func ResolveStartupBrand(profile string) core.LarkBrand {
+	if raw := os.Getenv(envvars.CliBrand); raw != "" {
+		return core.ParseBrand(raw)
+	}
+	if cfg, err := core.LoadMultiAppConfig(); err == nil {
+		if app := cfg.CurrentAppConfig(profile); app != nil {
+			return core.ParseBrand(string(app.Brand))
+		}
+	}
+	return core.BrandFeishu
+}

--- a/cmd/startup_brand_test.go
+++ b/cmd/startup_brand_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/registry"
+)
+
+func TestResolveStartupBrand_Precedence(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmp)
+	t.Setenv("LARKSUITE_CLI_BRAND", "")
+	os.Unsetenv("LARKSUITE_CLI_BRAND")
+
+	// No config at all → default brand.
+	if got := ResolveStartupBrand(""); got != core.BrandFeishu {
+		t.Errorf("empty state brand = %q, want feishu", got)
+	}
+
+	// Raw config supplies the active profile's brand — no keychain involved.
+	raw := `{"currentApp":"feishu-app","apps":[` +
+		`{"name":"feishu-app","appId":"cli_f","appSecret":"test-secret","brand":"feishu","users":[]},` +
+		`{"name":"lark-prof","appId":"cli_l","appSecret":"test-secret","brand":"LARK","users":[]}]}`
+	if err := os.WriteFile(filepath.Join(tmp, "config.json"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveStartupBrand(""); got != core.BrandFeishu {
+		t.Errorf("default profile brand = %q, want feishu", got)
+	}
+	if got := ResolveStartupBrand("lark-prof"); got != core.BrandLark {
+		t.Errorf("lark profile brand = %q, want lark (normalized)", got)
+	}
+
+	// Environment wins over the config file.
+	t.Setenv("LARKSUITE_CLI_BRAND", "lark")
+	if got := ResolveStartupBrand(""); got != core.BrandLark {
+		t.Errorf("env brand = %q, want lark", got)
+	}
+}
+
+// TestStartupBrandReachesRegistry_RealStartupOrder proves the fix for the
+// production startup sequence: building the command tree locks the registry's
+// sync.Once, so the brand must be injected before the first catalog access.
+// It runs in a subprocess because the registry is process-global.
+func TestStartupBrandReachesRegistry_RealStartupOrder(t *testing.T) {
+	if os.Getenv("GO_TEST_STARTUP_BRAND_HELPER") == "1" {
+		// Helper: replicate Execute()'s build wiring with a lark config.
+		buildInternal(
+			context.Background(), cmdutil.InvocationContext{},
+			WithIO(strings.NewReader(""), os.Stdout, os.Stderr),
+			WithStartupBrand(ResolveStartupBrand("")),
+		)
+		fmt.Printf("CONFIGURED_BRAND=%s\n", registry.ConfiguredBrand())
+		os.Exit(0)
+	}
+
+	tmp := t.TempDir()
+	raw := `{"apps":[{"appId":"cli_l","appSecret":"test-secret","brand":"lark","users":[]}]}`
+	if err := os.WriteFile(filepath.Join(tmp, "config.json"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run", "TestStartupBrandReachesRegistry_RealStartupOrder")
+	cmd.Env = append(os.Environ(),
+		"GO_TEST_STARTUP_BRAND_HELPER=1",
+		"LARKSUITE_CLI_CONFIG_DIR="+tmp,
+		"LARKSUITE_CLI_REMOTE_META=off", // no network during the subprocess build
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "CONFIGURED_BRAND=lark") {
+		t.Errorf("registry brand after real startup order = %s, want lark", out)
+	}
+}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -5,6 +5,7 @@ package cmdupdate
 
 import (
 	"fmt"
+	stdio "io"
 	"runtime"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/build"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/selfupdate"
 	"github.com/larksuite/cli/internal/skillscheck"
@@ -125,13 +127,15 @@ func updateRun(opts *UpdateOptions) error {
 	io := opts.Factory.IOStreams
 	cur := currentVersion()
 	updater := newUpdater()
-
+	// Brand only steers skills sync. updateRun skips that resolution in --check,
+	// where the Updater's zero-value brand retains the Feishu default.
 	if !opts.Check {
+		updater.Brand = resolveSkillsBrand(opts.Factory, io.ErrOut)
 		updater.CleanupStaleFiles()
 	}
 	output.PendingNotice = nil
 
-	// 1. Fetch latest version
+	// 1. Fetch latest version.
 	latest, err := fetchLatest()
 	if err != nil {
 		return reportError(opts, io, "network",
@@ -153,7 +157,7 @@ func updateRun(opts *UpdateOptions) error {
 		return reportAlreadyUpToDate(opts, io, cur, latest, skillsResult, opts.Check)
 	}
 
-	// 4. Detect installation method
+	// 4. Detect installation method.
 	detect := updater.DetectInstallMethod()
 
 	// 5. --check
@@ -166,6 +170,22 @@ func updateRun(opts *UpdateOptions) error {
 		return doManualUpdate(opts, io, cur, latest, detect, updater)
 	}
 	return doAutoUpdate(opts, io, cur, latest, detect, updater)
+}
+
+// resolveSkillsBrand returns the skills-source brand: resolved config first,
+// then the active profile's raw config entry (the brand is not a secret; a
+// locked keychain must not flip the source), then the default with a notice.
+func resolveSkillsBrand(f *cmdutil.Factory, errOut stdio.Writer) core.LarkBrand {
+	if cfg, err := f.Config(); err == nil && cfg != nil {
+		return core.ParseBrand(string(cfg.Brand))
+	}
+	if raw, err := core.LoadMultiAppConfig(); err == nil {
+		if app := raw.CurrentAppConfig(f.Invocation.Profile); app != nil {
+			return core.ParseBrand(string(app.Brand))
+		}
+	}
+	fmt.Fprintf(errOut, "note: could not resolve the configured brand; syncing skills from the default source\n")
+	return core.BrandFeishu
 }
 
 // --- Output helpers ---

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1730,4 +1732,65 @@ func containsString(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func TestResolveSkillsBrand_LayeredFallback(t *testing.T) {
+	// Layer 1: resolved config wins.
+	var errBuf bytes.Buffer
+	f := &cmdutil.Factory{Config: func() (*core.CliConfig, error) {
+		return &core.CliConfig{Brand: core.LarkBrand(" LARK ")}, nil
+	}}
+	if got := resolveSkillsBrand(f, &errBuf); got != core.BrandLark {
+		t.Errorf("resolved-config brand = %q, want lark", got)
+	}
+
+	// Layer 2: credential resolution fails, raw config file still supplies the
+	// brand (a locked keychain must not flip a Lark profile to Feishu).
+	tmp := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmp)
+	raw := `{"apps":[{"appId":"cli_x","appSecret":"test-secret","brand":"lark","users":[]}]}`
+	if err := os.WriteFile(filepath.Join(tmp, "config.json"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+	f = &cmdutil.Factory{Config: func() (*core.CliConfig, error) { return nil, errors.New("keychain locked") }}
+	errBuf.Reset()
+	if got := resolveSkillsBrand(f, &errBuf); got != core.BrandLark {
+		t.Errorf("raw-config brand = %q, want lark", got)
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("unexpected notice when raw config supplied the brand: %q", errBuf.String())
+	}
+
+	// Layer 3: nothing readable → default brand with a notice.
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	errBuf.Reset()
+	if got := resolveSkillsBrand(f, &errBuf); got != core.BrandFeishu {
+		t.Errorf("fallback brand = %q, want feishu", got)
+	}
+	if !strings.Contains(errBuf.String(), "could not resolve the configured brand") {
+		t.Errorf("expected fallback notice, got %q", errBuf.String())
+	}
+}
+
+// The raw-config fallback must read the active profile, not the default one.
+func TestResolveSkillsBrand_RespectsActiveProfile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmp)
+	raw := `{"currentApp":"feishu-app","apps":[` +
+		`{"name":"feishu-app","appId":"cli_f","appSecret":"test-secret","brand":"feishu","users":[]},` +
+		`{"name":"lark-prof","appId":"cli_l","appSecret":"test-secret","brand":"lark","users":[]}]}`
+	if err := os.WriteFile(filepath.Join(tmp, "config.json"), []byte(raw), 0600); err != nil {
+		t.Fatal(err)
+	}
+	f := &cmdutil.Factory{
+		Invocation: cmdutil.InvocationContext{Profile: "lark-prof"},
+		Config:     func() (*core.CliConfig, error) { return nil, errors.New("keychain locked") },
+	}
+	var errBuf bytes.Buffer
+	if got := resolveSkillsBrand(f, &errBuf); got != core.BrandLark {
+		t.Errorf("brand = %q, want lark (the active profile's brand)", got)
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("unexpected notice: %q", errBuf.String())
+	}
 }

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
 )
 
@@ -41,10 +42,7 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 			Reason:   envvars.CliAppID + " is set but no app secret or access token is available",
 		}
 	}
-	brand := credential.Brand(os.Getenv(envvars.CliBrand))
-	if brand == "" {
-		brand = credential.BrandFeishu
-	}
+	brand := credential.Brand(core.ParseBrand(os.Getenv(envvars.CliBrand)))
 	acct := &credential.Account{AppID: appID, AppSecret: appSecret, Brand: brand}
 
 	switch id := credential.Identity(os.Getenv(envvars.CliDefaultAs)); id {

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -22,13 +22,13 @@ func TestProvider_Name(t *testing.T) {
 func TestResolveAccount_BothSet(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "cli_test")
 	t.Setenv(envvars.CliAppSecret, "secret_test")
-	t.Setenv(envvars.CliBrand, "feishu")
+	t.Setenv(envvars.CliBrand, " LARK ")
 
 	acct, err := (&Provider{}).ResolveAccount(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if acct.AppID != "cli_test" || acct.AppSecret != "secret_test" || acct.Brand != "feishu" {
+	if acct.AppID != "cli_test" || acct.AppSecret != "secret_test" || acct.Brand != "lark" {
 		t.Errorf("unexpected: %+v", acct)
 	}
 }

--- a/extension/credential/sidecar/provider.go
+++ b/extension/credential/sidecar/provider.go
@@ -16,6 +16,7 @@ import (
 	"os"
 
 	"github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/sidecar"
 )
@@ -58,10 +59,7 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 		}
 	}
 
-	brand := credential.Brand(os.Getenv(envvars.CliBrand))
-	if brand == "" {
-		brand = credential.BrandFeishu
-	}
+	brand := credential.Brand(core.ParseBrand(os.Getenv(envvars.CliBrand)))
 
 	acct := &credential.Account{
 		AppID:     appID,

--- a/extension/credential/sidecar/provider_test.go
+++ b/extension/credential/sidecar/provider_test.go
@@ -56,7 +56,7 @@ func TestResolveAccount_Active(t *testing.T) {
 	setEnv(t, envvars.CliAuthProxy, "http://127.0.0.1:16384")
 	setEnv(t, envvars.CliProxyKey, "test-key")
 	setEnv(t, envvars.CliAppID, "cli_test123")
-	setEnv(t, envvars.CliBrand, "lark")
+	setEnv(t, envvars.CliBrand, " LARK ")
 	unsetEnv(t, envvars.CliDefaultAs)
 	unsetEnv(t, envvars.CliStrictMode)
 

--- a/internal/auth/app_registration.go
+++ b/internal/auth/app_registration.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,46 @@ import (
 
 	"github.com/larksuite/cli/internal/core"
 )
+
+// Terminal registration outcomes, exposed for typed classification by callers.
+var (
+	ErrRegistrationDenied   = errors.New("app registration denied by user")
+	ErrRegistrationExpired  = errors.New("device code expired, please try again")
+	ErrRegistrationTimedOut = errors.New("app registration timed out, please try again")
+)
+
+// Protocol defaults, mirroring the official SDK registration flow.
+const (
+	registrationBootstrapBrand = core.BrandFeishu
+	defaultPollIntervalSeconds = 5
+	defaultExpireInSeconds     = 600
+	beginRequestTimeout        = 30 * time.Second
+	maxPollIntervalSeconds     = 60
+)
+
+// normalizedInterval clamps a non-positive poll interval to the protocol default.
+func normalizedInterval(v int) int {
+	if v <= 0 {
+		return defaultPollIntervalSeconds
+	}
+	return v
+}
+
+// normalizedExpireIn clamps a non-positive expiry budget to the protocol default.
+func normalizedExpireIn(v int) int {
+	if v <= 0 {
+		return defaultExpireInSeconds
+	}
+	return v
+}
+
+// registrationContextError maps a done context to its terminal reason, keeping the cause.
+func registrationContextError(ctx context.Context) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", ErrRegistrationTimedOut, ctx.Err())
+	}
+	return fmt.Errorf("app registration cancelled: %w", ctx.Err())
+}
 
 // AppRegistrationResponse is the response from the app registration begin endpoint.
 type AppRegistrationResponse struct {
@@ -39,15 +80,24 @@ type AppRegUserInfo struct {
 	TenantBrand string // "feishu" or "lark"
 }
 
-// RequestAppRegistration initiates the app registration device flow.
-func RequestAppRegistration(httpClient *http.Client, brand core.LarkBrand, errOut io.Writer) (*AppRegistrationResponse, error) {
+// appRegistrationEndpoint returns the brand's accounts registration endpoint.
+func appRegistrationEndpoint(brand core.LarkBrand) string {
+	return core.ResolveEndpoints(brand).Accounts + PathAppRegistration
+}
+
+// RequestAppRegistration initiates the device flow. The registration protocol
+// always bootstraps on Feishu; brand selects the user-facing verification host.
+// The request is bounded by ctx and a begin timeout.
+func RequestAppRegistration(ctx context.Context, httpClient *http.Client, brand core.LarkBrand, errOut io.Writer) (*AppRegistrationResponse, error) {
 	if errOut == nil {
 		errOut = io.Discard
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, beginRequestTimeout)
+	defer cancel()
+
 	ep := core.ResolveEndpoints(brand)
-	regEp := core.ResolveEndpoints(core.BrandFeishu) // registration begin always uses feishu
-	endpoint := regEp.Accounts + PathAppRegistration
+	endpoint := appRegistrationEndpoint(registrationBootstrapBrand)
 
 	form := url.Values{}
 	form.Set("action", "begin")
@@ -55,7 +105,7 @@ func RequestAppRegistration(httpClient *http.Client, brand core.LarkBrand, errOu
 	form.Set("auth_method", "client_secret")
 	form.Set("request_user_info", "open_id tenant_brand")
 
-	req, err := http.NewRequest("POST", endpoint, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +120,7 @@ func RequestAppRegistration(httpClient *http.Client, brand core.LarkBrand, errOu
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("app registration failed: read body: %v", err)
+		return nil, fmt.Errorf("app registration failed: read body: %w", err)
 	}
 
 	var data map[string]interface{}
@@ -90,15 +140,26 @@ func RequestAppRegistration(httpClient *http.Client, brand core.LarkBrand, errOu
 		return nil, fmt.Errorf("app registration failed: %s", msg)
 	}
 
-	expiresIn := getInt(data, "expires_in", 300)
-	interval := getInt(data, "interval", 5)
+	// The protocol field is expire_in; accept the legacy expires_in spelling,
+	// then normalize to protocol defaults.
+	expiresIn := getInt(data, "expire_in", 0)
+	if expiresIn <= 0 {
+		expiresIn = getInt(data, "expires_in", 0)
+	}
+	expiresIn = normalizedExpireIn(expiresIn)
+	interval := normalizedInterval(getInt(data, "interval", 0))
+
+	deviceCode := getStr(data, "device_code")
+	if deviceCode == "" {
+		return nil, fmt.Errorf("app registration failed: response missing device_code")
+	}
 
 	userCode := getStr(data, "user_code")
 	verificationUri := getStr(data, "verification_uri")
 	verificationUriComplete := fmt.Sprintf("%s/page/cli?user_code=%s", ep.Open, userCode)
 
 	return &AppRegistrationResponse{
-		DeviceCode:              getStr(data, "device_code"),
+		DeviceCode:              deviceCode,
 		UserCode:                getStr(data, "user_code"),
 		VerificationUri:         verificationUri,
 		VerificationUriComplete: verificationUriComplete,
@@ -118,72 +179,97 @@ func BuildVerificationURL(baseURL, cliVersion string) string {
 		"&from=cli"
 }
 
-// PollAppRegistration polls the app registration endpoint until the app is created or the flow times out.
-// If the result has ClientSecret == "" and UserInfo.TenantBrand == "lark", the caller should
-// retry with BrandLark to get the secret from accounts.larksuite.com.
-func PollAppRegistration(ctx context.Context, httpClient *http.Client, brand core.LarkBrand, deviceCode string, interval, expiresIn int, errOut io.Writer) (*AppRegistrationResult, error) {
+// pollOnce performs one ctx-bound poll request and decodes the payload.
+func pollOnce(ctx context.Context, httpClient *http.Client, brand core.LarkBrand, deviceCode string) (map[string]interface{}, error) {
+	form := url.Values{}
+	form.Set("action", "poll")
+	form.Set("device_code", deviceCode)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", appRegistrationEndpoint(brand), strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("poll request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("poll network error: %w", err)
+	}
+	defer resp.Body.Close()
+	logHTTPResponse(resp)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("poll read error: %w", err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("poll parse error: %w", err)
+	}
+	return data, nil
+}
+
+// RegisterAppWithDiscovery polls for credentials, mirroring the official SDK
+// flow: the first poll and the (at most one) cross-brand switch are immediate,
+// non-error responses without complete credentials keep polling, and one
+// deadline from the begin expiry bounds all waits and in-flight requests.
+// The returned brand is the one the credentials were issued on.
+func RegisterAppWithDiscovery(ctx context.Context, httpClient *http.Client, resp *AppRegistrationResponse, errOut io.Writer) (*AppRegistrationResult, core.LarkBrand, error) {
 	if errOut == nil {
 		errOut = io.Discard
 	}
 
-	const maxPollInterval = 60
-	const maxPollAttempts = 200
+	// Interval and expiry arrive normalized from begin-response parsing
+	// (normalizedInterval floors them there); the loop trusts them as-is.
+	interval := resp.Interval
+	ctx, cancel := context.WithDeadline(ctx,
+		time.Now().Add(time.Duration(resp.ExpiresIn)*time.Second))
+	defer cancel()
 
-	ep := core.ResolveEndpoints(brand)
-	endpoint := ep.Accounts + PathAppRegistration
-	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
-	currentInterval := interval
-	attempts := 0
+	currentBrand := registrationBootstrapBrand
+	effectiveBrand := currentBrand
+	switched := false
+	waitBeforePoll := false
 
-	for time.Now().Before(deadline) && attempts < maxPollAttempts {
-		attempts++
+	for {
+		if waitBeforePoll {
+			select {
+			case <-time.After(time.Duration(interval) * time.Second):
+			case <-ctx.Done():
+				return nil, effectiveBrand, registrationContextError(ctx)
+			}
+		}
+		waitBeforePoll = true
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("polling was cancelled")
+			return nil, effectiveBrand, registrationContextError(ctx)
 		}
 
-		select {
-		case <-time.After(time.Duration(currentInterval) * time.Second):
-		case <-ctx.Done():
-			return nil, fmt.Errorf("polling was cancelled")
-		}
-
-		form := url.Values{}
-		form.Set("action", "poll")
-		form.Set("device_code", deviceCode)
-
-		req, err := http.NewRequest("POST", endpoint, strings.NewReader(form.Encode()))
+		data, err := pollOnce(ctx, httpClient, currentBrand, resp.DeviceCode)
 		if err != nil {
-			continue
-		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			fmt.Fprintf(errOut, "[lark-cli] [WARN] app-registration: poll network error: %v\n", err)
-			currentInterval = minInt(currentInterval+1, maxPollInterval)
-			continue
-		}
-		logHTTPResponse(resp)
-
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			fmt.Fprintf(errOut, "[lark-cli] [WARN] app-registration: poll read error: %v\n", err)
-			currentInterval = minInt(currentInterval+1, maxPollInterval)
+			fmt.Fprintf(errOut, "[lark-cli] [WARN] app-registration: %v\n", err)
+			interval = minInt(interval+1, maxPollIntervalSeconds)
 			continue
 		}
 
-		var data map[string]interface{}
-		if err := json.Unmarshal(body, &data); err != nil {
-			fmt.Fprintf(errOut, "[lark-cli] [WARN] app-registration: poll parse error: %v\n", err)
-			currentInterval = minInt(currentInterval+1, maxPollInterval)
-			continue
+		// A cross-brand tenant report switches the polled domain (once,
+		// immediately) regardless of the accompanying status — the signal can
+		// arrive alongside authorization_pending, mirroring the official SDK.
+		if !switched {
+			if userInfoRaw, ok := data["user_info"].(map[string]interface{}); ok {
+				if tb := getStr(userInfoRaw, "tenant_brand"); tb != "" {
+					if actual := core.ParseBrand(tb); actual != currentBrand {
+						currentBrand = actual
+						effectiveBrand = actual
+						switched = true
+						waitBeforePoll = false
+						continue
+					}
+				}
+			}
 		}
 
 		errStr := getStr(data, "error")
-
-		// Success: client_id present
-		if errStr == "" && getStr(data, "client_id") != "" {
+		if errStr == "" {
 			result := &AppRegistrationResult{
 				ClientID:     getStr(data, "client_id"),
 				ClientSecret: getStr(data, "client_secret"),
@@ -194,34 +280,37 @@ func PollAppRegistration(ctx context.Context, httpClient *http.Client, brand cor
 					TenantBrand: getStr(userInfoRaw, "tenant_brand"),
 				}
 			}
-			return result, nil
+
+			if result.ClientID != "" && result.ClientSecret != "" {
+				// The issuing domain is authoritative; a contradictory final
+				// tenant report is a protocol violation, not a brand override.
+				if result.UserInfo != nil && result.UserInfo.TenantBrand != "" &&
+					core.ParseBrand(result.UserInfo.TenantBrand) != effectiveBrand {
+					return nil, effectiveBrand, fmt.Errorf("app registration returned credentials with a contradictory tenant brand %q", result.UserInfo.TenantBrand)
+				}
+				return result, effectiveBrand, nil
+			}
+			// Incomplete credentials without an error: keep polling.
+			continue
 		}
 
 		switch errStr {
 		case "authorization_pending":
 			continue
 		case "slow_down":
-			currentInterval = minInt(currentInterval+5, maxPollInterval)
-			fmt.Fprintf(errOut, "[lark-cli] app-registration: slow_down, interval increased to %ds\n", currentInterval)
+			interval = minInt(interval+5, maxPollIntervalSeconds)
+			fmt.Fprintf(errOut, "[lark-cli] app-registration: slow_down, interval increased to %ds\n", interval)
 			continue
 		case "access_denied":
-			return nil, fmt.Errorf("app registration denied by user")
+			return nil, effectiveBrand, ErrRegistrationDenied
 		case "expired_token", "invalid_grant":
-			return nil, fmt.Errorf("device code expired, please try again")
+			return nil, effectiveBrand, ErrRegistrationExpired
 		}
 
 		desc := getStr(data, "error_description")
 		if desc == "" {
 			desc = errStr
 		}
-		if desc == "" {
-			desc = "Unknown error"
-		}
-		return nil, fmt.Errorf("app registration failed: %s", desc)
+		return nil, effectiveBrand, fmt.Errorf("app registration failed: %s", desc)
 	}
-
-	if attempts >= maxPollAttempts {
-		fmt.Fprintf(errOut, "[lark-cli] [WARN] app-registration: max poll attempts (%d) reached\n", maxPollAttempts)
-	}
-	return nil, fmt.Errorf("app registration timed out, please try again")
 }

--- a/internal/auth/app_registration_test.go
+++ b/internal/auth/app_registration_test.go
@@ -4,10 +4,27 @@
 package auth
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/larksuite/cli/internal/core"
 	"github.com/smartystreets/goconvey/convey"
 )
+
+// jsonResponse builds a canned registration response (transport fakes reuse
+// roundTripFunc from device_flow_test.go).
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
 
 // Test_BuildVerificationURL verifies that tracking parameters are correctly appended.
 func Test_BuildVerificationURL(t *testing.T) {
@@ -31,3 +48,358 @@ func Test_BuildVerificationURL(t *testing.T) {
 		})
 	})
 }
+
+func TestAppRegistrationEndpoint(t *testing.T) {
+	cases := []struct {
+		brand core.LarkBrand
+		want  string
+	}{
+		{core.BrandFeishu, "https://accounts.feishu.cn" + PathAppRegistration},
+		{core.BrandLark, "https://accounts.larksuite.com" + PathAppRegistration},
+	}
+	for _, c := range cases {
+		if got := appRegistrationEndpoint(c.brand); got != c.want {
+			t.Errorf("brand %q: endpoint = %q, want %q", c.brand, got, c.want)
+		}
+	}
+}
+
+func TestRequestAppRegistration_UsesFeishuBootstrapAndConfiguredVerificationBrand(t *testing.T) {
+	cases := []struct {
+		brand            core.LarkBrand
+		verificationHost string
+	}{
+		{core.BrandFeishu, "open.feishu.cn"},
+		{core.BrandLark, "open.larksuite.com"},
+	}
+	for _, c := range cases {
+		t.Run(string(c.brand), func(t *testing.T) {
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if got, want := r.URL.Host, "accounts.feishu.cn"; got != want {
+					t.Errorf("begin host = %q, want bootstrap host %q", got, want)
+				}
+				return jsonResponse(`{"device_code":"d","user_code":"TEST-CODE","expire_in":60,"interval":5}`), nil
+			})}
+			resp, err := RequestAppRegistration(context.Background(), client, c.brand, io.Discard)
+			if err != nil {
+				t.Fatalf("RequestAppRegistration(%q) error = %v", c.brand, err)
+			}
+			if !strings.HasPrefix(resp.VerificationUriComplete, "https://"+c.verificationHost+"/page/cli?") {
+				t.Errorf("verification URL = %q, want host %q", resp.VerificationUriComplete, c.verificationHost)
+			}
+		})
+	}
+}
+
+// Full Lark routing contract: Lark selects the Lark verification page, while
+// registration bootstraps on Feishu and switches only after the tenant signal.
+// The Lark credential response omits user_info, so the effective domain must
+// still determine the saved brand.
+func TestRegisterAppWithDiscovery_LarkFlowUsesProtocolBootstrap(t *testing.T) {
+	var calls []string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		action := r.Form.Get("action")
+		calls = append(calls, action+"@"+r.URL.Host)
+		if action == "begin" {
+			return jsonResponse(`{"device_code":"device","user_code":"TEST-CODE","expire_in":60,"interval":0}`), nil
+		}
+		switch r.URL.Host {
+		case "accounts.feishu.cn":
+			return jsonResponse(`{"user_info":{"open_id":"ou_x","tenant_brand":"lark"}}`), nil
+		case "accounts.larksuite.com":
+			return jsonResponse(`{"client_id":"cli_x","client_secret":"test-secret"}`), nil
+		}
+		t.Errorf("unexpected host polled: %s", r.URL.Host)
+		return jsonResponse(`{}`), nil
+	})}
+	resp, err := RequestAppRegistration(context.Background(), client, core.BrandLark, io.Discard)
+	if err != nil {
+		t.Fatalf("RequestAppRegistration error = %v", err)
+	}
+	if got, want := resp.VerificationUriComplete, "https://open.larksuite.com/page/cli?user_code=TEST-CODE"; got != want {
+		t.Errorf("verification URL = %q, want %q", got, want)
+	}
+
+	result, finalBrand, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err != nil {
+		t.Fatalf("RegisterAppWithDiscovery error = %v, want nil", err)
+	}
+	if finalBrand != core.BrandLark {
+		t.Errorf("finalBrand = %q, want %q (credentials were issued on the lark domain)", finalBrand, core.BrandLark)
+	}
+	if result.ClientID != "cli_x" || result.ClientSecret != "test-secret" {
+		t.Errorf("credentials = (%q, %q), want (cli_x, test-secret)", result.ClientID, result.ClientSecret)
+	}
+	want := []string{"begin@accounts.feishu.cn", "poll@accounts.feishu.cn", "poll@accounts.larksuite.com"}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Errorf("calls = %v, want %v", calls, want)
+			break
+		}
+	}
+}
+
+// Plain path: the bootstrap domain can return complete Feishu credentials in
+// one poll, even when user_info is absent.
+func TestRegisterAppWithDiscovery_BootstrapBrandSinglePoll(t *testing.T) {
+	polls := 0
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		polls++
+		if got, want := r.URL.Host, "accounts.feishu.cn"; got != want {
+			t.Errorf("poll host = %q, want %q", got, want)
+		}
+		return jsonResponse(`{"client_id":"cli_x","client_secret":"test-secret"}`), nil
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 0, ExpiresIn: 5}
+
+	_, finalBrand, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err != nil {
+		t.Fatalf("RegisterAppWithDiscovery error = %v, want nil", err)
+	}
+	if finalBrand != core.BrandFeishu {
+		t.Errorf("finalBrand = %q, want %q", finalBrand, core.BrandFeishu)
+	}
+	if polls != 1 {
+		t.Errorf("polls = %d, want 1", polls)
+	}
+}
+
+// The discovery deadline must cancel in-flight requests: the fake transport
+// hangs until the request context is done.
+func TestRegisterAppWithDiscovery_DeadlineBoundsInFlightRequests(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 0, ExpiresIn: 1}
+
+	start := time.Now()
+	_, _, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %v, want a timed-out terminal reason", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("discovery not bounded by its deadline: took %v", elapsed)
+	}
+}
+
+// Empty payloads and incomplete same-brand responses are not terminal.
+func TestRegisterAppWithDiscovery_PollsUntilCredentials(t *testing.T) {
+	responses := []string{
+		`{}`,
+		`{"client_id":"cli_x","user_info":{"open_id":"ou_x","tenant_brand":"feishu"}}`,
+		`{"client_id":"cli_x","client_secret":"test-secret","user_info":{"open_id":"ou_x","tenant_brand":"feishu"}}`,
+	}
+	polls := 0
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		body := responses[polls]
+		polls++
+		return jsonResponse(body), nil
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 0, ExpiresIn: 5}
+
+	result, finalBrand, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err != nil {
+		t.Fatalf("RegisterAppWithDiscovery error = %v, want nil", err)
+	}
+	if polls != 3 {
+		t.Errorf("polls = %d, want 3", polls)
+	}
+	if result.ClientSecret != "test-secret" || finalBrand != core.BrandFeishu {
+		t.Errorf("result = (%q, %q), want (test-secret, feishu)", result.ClientSecret, finalBrand)
+	}
+}
+
+// Neither the first poll nor the cross-brand switch waits out the interval
+// (a 5s interval would blow the elapsed bound).
+func TestRegisterAppWithDiscovery_ImmediateFirstPollAndSwitch(t *testing.T) {
+	var polledHosts []string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		polledHosts = append(polledHosts, r.URL.Host)
+		if r.URL.Host == "accounts.feishu.cn" {
+			return jsonResponse(`{"user_info":{"open_id":"ou_x","tenant_brand":"lark"}}`), nil
+		}
+		return jsonResponse(`{"client_id":"cli_x","client_secret":"test-secret"}`), nil
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 5, ExpiresIn: 60}
+
+	start := time.Now()
+	result, finalBrand, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err != nil {
+		t.Fatalf("RegisterAppWithDiscovery error = %v, want nil", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("discovery waited an interval somewhere: took %v", elapsed)
+	}
+	if finalBrand != core.BrandLark || result.ClientSecret != "test-secret" {
+		t.Errorf("result = (%q, %q), want (test-secret, lark)", result.ClientSecret, finalBrand)
+	}
+	want := []string{"accounts.feishu.cn", "accounts.larksuite.com"}
+	if len(polledHosts) != 2 || polledHosts[0] != want[0] || polledHosts[1] != want[1] {
+		t.Errorf("polled hosts = %v, want %v", polledHosts, want)
+	}
+}
+
+// Denial and expiry map to sentinels; cancellation preserves its cause.
+func TestRegisterAppWithDiscovery_TerminalSentinels(t *testing.T) {
+	deny := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"error":"access_denied"}`), nil
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 0, ExpiresIn: 5}
+	_, _, err := RegisterAppWithDiscovery(context.Background(), deny, resp, io.Discard)
+	if !errors.Is(err, ErrRegistrationDenied) {
+		t.Errorf("denied err = %v, want ErrRegistrationDenied", err)
+	}
+
+	expired := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(`{"error":"expired_token"}`), nil
+	})}
+	_, _, err = RegisterAppWithDiscovery(context.Background(), expired, resp, io.Discard)
+	if !errors.Is(err, ErrRegistrationExpired) {
+		t.Errorf("expired err = %v, want ErrRegistrationExpired", err)
+	}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err = RegisterAppWithDiscovery(cancelledCtx, deny, resp, io.Discard)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cancelled err = %v, want a context.Canceled cause", err)
+	}
+}
+
+// Begin parsing: expire_in (legacy expires_in fallback), normalization, and
+// required device_code.
+func TestRequestAppRegistration_ProtocolFields(t *testing.T) {
+	serve := func(body string) *http.Client {
+		return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(body), nil
+		})}
+	}
+
+	resp, err := RequestAppRegistration(context.Background(),
+		serve(`{"device_code":"d","expire_in":60,"interval":3}`), core.BrandFeishu, io.Discard)
+	if err != nil {
+		t.Fatalf("begin error = %v", err)
+	}
+	if resp.ExpiresIn != 60 || resp.Interval != 3 {
+		t.Errorf("parsed (expire=%d, interval=%d), want (60, 3)", resp.ExpiresIn, resp.Interval)
+	}
+
+	resp, err = RequestAppRegistration(context.Background(),
+		serve(`{"device_code":"d","expires_in":45}`), core.BrandFeishu, io.Discard)
+	if err != nil {
+		t.Fatalf("legacy begin error = %v", err)
+	}
+	if resp.ExpiresIn != 45 || resp.Interval != 5 {
+		t.Errorf("legacy parsed (expire=%d, interval=%d), want (45, 5 — normalized default)", resp.ExpiresIn, resp.Interval)
+	}
+
+	resp, err = RequestAppRegistration(context.Background(),
+		serve(`{"device_code":"d","interval":0}`), core.BrandFeishu, io.Discard)
+	if err != nil {
+		t.Fatalf("defaults begin error = %v", err)
+	}
+	if resp.ExpiresIn != 600 || resp.Interval != 5 {
+		t.Errorf("defaults parsed (expire=%d, interval=%d), want (600, 5)", resp.ExpiresIn, resp.Interval)
+	}
+
+	if _, err := RequestAppRegistration(context.Background(),
+		serve(`{"interval":5}`), core.BrandFeishu, io.Discard); err == nil {
+		t.Error("missing device_code: expected error, got nil")
+	}
+}
+
+// A tenant signal arriving alongside authorization_pending must still switch
+// the polled domain (the official SDK checks the signal before the error).
+func TestRegisterAppWithDiscovery_PendingWithTenantSignalSwitches(t *testing.T) {
+	var polledHosts []string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		polledHosts = append(polledHosts, r.URL.Host)
+		if r.URL.Host == "accounts.feishu.cn" {
+			return jsonResponse(`{"error":"authorization_pending","user_info":{"tenant_brand":"lark"}}`), nil
+		}
+		return jsonResponse(`{"client_id":"cli_x","client_secret":"test-secret"}`), nil
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 0, ExpiresIn: 5}
+
+	result, finalBrand, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err != nil {
+		t.Fatalf("RegisterAppWithDiscovery error = %v, want nil", err)
+	}
+	if finalBrand != core.BrandLark || result.ClientSecret != "test-secret" {
+		t.Errorf("result = (%q, %q), want (test-secret, lark)", result.ClientSecret, finalBrand)
+	}
+	want := []string{"accounts.feishu.cn", "accounts.larksuite.com"}
+	if len(polledHosts) != 2 || polledHosts[0] != want[0] || polledHosts[1] != want[1] {
+		t.Errorf("polled hosts = %v, want %v", polledHosts, want)
+	}
+}
+
+// Polling has no attempt cap: only the expiry budget terminates the loop.
+func TestRegisterAppWithDiscovery_NoAttemptCap(t *testing.T) {
+	polls := 0
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		polls++
+		if polls <= 250 {
+			return jsonResponse(`{"error":"authorization_pending"}`), nil
+		}
+		return jsonResponse(`{"client_id":"cli_x","client_secret":"test-secret"}`), nil
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 0, ExpiresIn: 30}
+
+	result, _, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err != nil {
+		t.Fatalf("RegisterAppWithDiscovery error = %v, want nil (no attempts cap)", err)
+	}
+	if polls != 251 || result.ClientSecret != "test-secret" {
+		t.Errorf("polls = %d (want 251), secret = %q", polls, result.ClientSecret)
+	}
+}
+
+// A final tenant report contradicting the issuing domain is a protocol
+// violation, not a brand override: the saved brand must never diverge from
+// the domain that issued the credentials.
+func TestRegisterAppWithDiscovery_ContradictoryFinalBrandFails(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host == "accounts.feishu.cn" {
+			return jsonResponse(`{"error":"authorization_pending","user_info":{"tenant_brand":"lark"}}`), nil
+		}
+		// The lark domain issues credentials but reports a feishu tenant.
+		return jsonResponse(`{"client_id":"cli_x","client_secret":"test-secret","user_info":{"tenant_brand":"feishu"}}`), nil
+	})}
+	resp := &AppRegistrationResponse{DeviceCode: "device", Interval: 0, ExpiresIn: 5}
+
+	_, _, err := RegisterAppWithDiscovery(context.Background(), client, resp, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "contradictory tenant brand") {
+		t.Errorf("err = %v, want contradictory-tenant-brand protocol error", err)
+	}
+}
+
+// A cancelled body read during begin must keep its context cause so the
+// command layer classifies it as a cancellation, not an API failure.
+func TestRequestAppRegistration_BodyReadCancelKeepsCause(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(&errReader{err: context.Canceled}),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	_, err := RequestAppRegistration(context.Background(), client, core.BrandFeishu, io.Discard)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want a context.Canceled cause", err)
+	}
+}
+
+type errReader struct{ err error }
+
+func (r *errReader) Read([]byte) (int, error) { return 0, r.err }

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -268,7 +268,7 @@ func ResolveConfigFromMulti(raw *MultiAppConfig, kc keychain.KeychainAccess, pro
 		ProfileName: app.ProfileName(),
 		AppID:       app.AppId,
 		AppSecret:   secret,
-		Brand:       app.Brand,
+		Brand:       ParseBrand(string(app.Brand)),
 		Lang:        app.Lang,
 		DefaultAs:   app.DefaultAs,
 	}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -230,3 +230,20 @@ func TestCliConfig_CanBot(t *testing.T) {
 		})
 	}
 }
+
+// Runtime configs must never carry raw brand casing: the config ingress
+// normalizes it, so downstream equality checks see canonical values.
+func TestResolveConfigFromMulti_NormalizesBrand(t *testing.T) {
+	multi := &MultiAppConfig{Apps: []AppConfig{{
+		AppId:     "cli_x",
+		AppSecret: PlainSecret("test-secret"),
+		Brand:     LarkBrand(" LARK "),
+	}}}
+	cfg, err := ResolveConfigFromMulti(multi, nil, "")
+	if err != nil {
+		t.Fatalf("ResolveConfigFromMulti error = %v", err)
+	}
+	if cfg.Brand != BrandLark {
+		t.Errorf("Brand = %q, want %q (normalized at ingress)", cfg.Brand, BrandLark)
+	}
+}

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -3,9 +3,11 @@
 
 package core
 
+import "strings"
+
 // LarkBrand represents the Lark platform brand.
 // "feishu" targets China-mainland, "lark" targets international.
-// Any other string is treated as a custom base URL.
+// ParseBrand and ResolveEndpoints map unrecognized values to BrandFeishu.
 type LarkBrand string
 
 const (
@@ -13,10 +15,10 @@ const (
 	BrandLark   LarkBrand = "lark"
 )
 
-// ParseBrand normalizes a brand string to a LarkBrand constant.
-// Unrecognized values default to BrandFeishu.
+// ParseBrand normalizes a brand string (case-insensitive, whitespace-tolerant);
+// anything other than "lark" normalizes to BrandFeishu.
 func ParseBrand(value string) LarkBrand {
-	if value == "lark" {
+	if strings.ToLower(strings.TrimSpace(value)) == "lark" {
 		return BrandLark
 	}
 	return BrandFeishu
@@ -36,9 +38,10 @@ type Endpoints struct {
 	AppLink  string // e.g. "https://applink.feishu.cn"
 }
 
-// ResolveEndpoints resolves endpoint URLs based on brand.
+// ResolveEndpoints resolves endpoint URLs for the brand, normalizing its
+// input so stored values with unusual casing still resolve correctly.
 func ResolveEndpoints(brand LarkBrand) Endpoints {
-	switch brand {
+	switch ParseBrand(string(brand)) {
 	case BrandLark:
 		return Endpoints{
 			Open:     "https://open.larksuite.com",

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -57,3 +57,37 @@ func TestResolveOpenBaseURL(t *testing.T) {
 		t.Errorf("ResolveOpenBaseURL(lark) = %q", got)
 	}
 }
+
+func TestParseBrand(t *testing.T) {
+	cases := []struct {
+		in   string
+		want LarkBrand
+	}{
+		{"", BrandFeishu},
+		{"feishu", BrandFeishu},
+		{"lark", BrandLark},
+		{"LARK", BrandLark},
+		{" lark ", BrandLark},
+		{"Lark", BrandLark},
+		{"xyz", BrandFeishu},
+	}
+	for _, c := range cases {
+		if got := ParseBrand(c.in); got != c.want {
+			t.Errorf("ParseBrand(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestResolveEndpoints_NormalizesBrand locks the boundary invariant: the
+// resolver normalizes its brand input, so historical config values with
+// unusual casing or whitespace still resolve to their intended endpoints.
+func TestResolveEndpoints_NormalizesBrand(t *testing.T) {
+	for _, raw := range []string{"LARK", " lark ", "Lark"} {
+		if got := ResolveEndpoints(LarkBrand(raw)).Open; got != "https://open.larksuite.com" {
+			t.Errorf("ResolveEndpoints(%q).Open = %q, want the lark endpoint", raw, got)
+		}
+	}
+	if got := ResolveEndpoints(LarkBrand("unexpected")).Open; got != "https://open.feishu.cn" {
+		t.Errorf("ResolveEndpoints(unexpected).Open = %q, want the feishu default", got)
+	}
+}

--- a/internal/credential/types.go
+++ b/internal/credential/types.go
@@ -72,7 +72,8 @@ func AccountFromCliConfig(cfg *core.CliConfig) *Account {
 	}
 }
 
-// ToCliConfig copies the credential-layer account into the downstream config shape.
+// ToCliConfig copies the credential-layer account into the downstream config
+// shape, normalizing the brand so runtime consumers never see raw casing.
 func (a *Account) ToCliConfig() *core.CliConfig {
 	if a == nil {
 		return nil
@@ -81,7 +82,7 @@ func (a *Account) ToCliConfig() *core.CliConfig {
 		ProfileName:         a.ProfileName,
 		AppID:               a.AppID,
 		AppSecret:           normalizeAccountAppSecret(a.AppSecret),
-		Brand:               a.Brand,
+		Brand:               core.ParseBrand(string(a.Brand)),
 		DefaultAs:           a.DefaultAs,
 		UserOpenId:          a.UserOpenId,
 		UserName:            a.UserName,

--- a/internal/credential/types_test.go
+++ b/internal/credential/types_test.go
@@ -130,3 +130,11 @@ func TestRuntimeAppSecret_TokenOnlyUsesPlaceholder(t *testing.T) {
 		t.Fatalf("RuntimeAppSecret(real) = %q, want %q", got, "secret-1")
 	}
 }
+
+// The credential-layer ingress normalizes brand casing for all runtime consumers.
+func TestToCliConfig_NormalizesBrand(t *testing.T) {
+	acct := &Account{AppID: "cli_x", Brand: " LARK "}
+	if got := acct.ToCliConfig().Brand; got != core.BrandLark {
+		t.Errorf("Brand = %q, want %q", got, core.BrandLark)
+	}
+}

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -69,6 +69,12 @@ func Init() {
 	InitWithBrand(core.BrandFeishu)
 }
 
+// ConfiguredBrand reports the brand the registry was initialized with
+// (empty before initialization). Diagnostics and startup-order tests use it.
+func ConfiguredBrand() core.LarkBrand {
+	return configuredBrand
+}
+
 // InitWithBrand initializes the registry by loading embedded data and optionally
 // overlaying cached remote data. The brand determines which remote API host to use.
 // It is safe to call multiple times (sync.Once).

--- a/internal/registry/remote.go
+++ b/internal/registry/remote.go
@@ -75,13 +75,7 @@ func remoteMetaURL(version string) string {
 	if testMetaURL != "" {
 		return testMetaURL
 	}
-	var base string
-	switch configuredBrand {
-	case core.BrandLark:
-		base = "https://open.larksuite.com/api/tools/open/api_definition"
-	default:
-		base = "https://open.feishu.cn/api/tools/open/api_definition"
-	}
+	base := core.ResolveEndpoints(configuredBrand).Open + "/api/tools/open/api_definition"
 	q := "protocol=meta&client_version=" + url.QueryEscape(build.Version)
 	if version != "" {
 		q += "&data_version=" + url.QueryEscape(version)

--- a/internal/selfupdate/updater.go
+++ b/internal/selfupdate/updater.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/transport"
 	"github.com/larksuite/cli/internal/vfs"
 )
@@ -49,7 +50,9 @@ const (
 
 var (
 	skillsIndexFetchTimeout = 10 * time.Second
-	officialSkillsIndexURL  = "https://open.feishu.cn/.well-known/skills/index.json"
+	// officialSkillsIndexURL overrides the brand-derived skills index URL in
+	// tests; empty in production.
+	officialSkillsIndexURL = ""
 )
 
 // DetectResult holds installation detection results.
@@ -101,6 +104,9 @@ func (r *NpmResult) CombinedOutput() string {
 // Override DetectOverride / NpmInstallOverride / SkillsCommandOverride / VerifyOverride
 // / RestoreAvailableOverride for testing.
 type Updater struct {
+	// Brand selects the skills index/source endpoints (zero value = feishu).
+	Brand core.LarkBrand
+
 	DetectOverride           func() DetectResult
 	NpmInstallOverride       func(version string) *NpmResult
 	PnpmInstallOverride      func(version string) *NpmResult
@@ -128,6 +134,19 @@ type Updater struct {
 
 // New creates an Updater with default (real) behavior.
 func New() *Updater { return &Updater{} }
+
+// skillsIndexURL returns the brand's well-known skills index URL.
+func (u *Updater) skillsIndexURL() string {
+	if officialSkillsIndexURL != "" {
+		return officialSkillsIndexURL
+	}
+	return core.ResolveEndpoints(u.Brand).Open + "/.well-known/skills/index.json"
+}
+
+// skillsSource returns the brand's skills source host for `npx skills add`.
+func (u *Updater) skillsSource() string {
+	return core.ResolveEndpoints(u.Brand).Open
+}
 
 // DetectInstallMethod determines how the CLI was installed and whether the
 // owning package manager is available for auto-update.
@@ -258,7 +277,7 @@ func (u *Updater) ListOfficialSkillsIndex() *NpmResult {
 	ctx, cancel := context.WithTimeout(context.Background(), skillsIndexFetchTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, officialSkillsIndexURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.skillsIndexURL(), nil)
 	if err != nil {
 		r.Err = err
 		return r
@@ -297,7 +316,7 @@ func (u *Updater) ListOfficialSkillsIndex() *NpmResult {
 }
 
 func (u *Updater) ListOfficialSkills() *NpmResult {
-	r := u.runSkillsListOfficial("https://open.feishu.cn")
+	r := u.runSkillsListOfficial(u.skillsSource())
 	if r.Err != nil {
 		r = u.runSkillsListOfficial("larksuite/cli")
 	}
@@ -313,7 +332,7 @@ func (u *Updater) ListGlobalSkillsJSON() *NpmResult {
 }
 
 func (u *Updater) InstallSkill(nameList []string) *NpmResult {
-	r := u.runSkillsInstall("https://open.feishu.cn", nameList)
+	r := u.runSkillsInstall(u.skillsSource(), nameList)
 	if r.Err != nil {
 		r = u.runSkillsInstall("larksuite/cli", nameList)
 	}
@@ -321,7 +340,7 @@ func (u *Updater) InstallSkill(nameList []string) *NpmResult {
 }
 
 func (u *Updater) InstallAllSkills() *NpmResult {
-	r := u.runSkillsAdd("https://open.feishu.cn")
+	r := u.runSkillsAdd(u.skillsSource())
 	if r.Err != nil {
 		r = u.runSkillsAdd("larksuite/cli")
 	}

--- a/internal/selfupdate/updater_test.go
+++ b/internal/selfupdate/updater_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/vfs"
 )
 
@@ -513,5 +514,25 @@ func TestDetectInstallMethod_Caches(t *testing.T) {
 	got := u.DetectInstallMethod()
 	if got.Method != InstallPnpm || !got.PnpmAvailable {
 		t.Errorf("expected cached pnpm result to be returned, got %+v", got)
+	}
+}
+
+func TestSkillsBrandHosts(t *testing.T) {
+	cases := []struct {
+		brand      core.LarkBrand
+		wantIndex  string
+		wantSource string
+	}{
+		{core.BrandFeishu, "https://open.feishu.cn/.well-known/skills/index.json", "https://open.feishu.cn"},
+		{core.BrandLark, "https://open.larksuite.com/.well-known/skills/index.json", "https://open.larksuite.com"},
+	}
+	for _, c := range cases {
+		u := &Updater{Brand: c.brand}
+		if got := u.skillsIndexURL(); got != c.wantIndex {
+			t.Errorf("brand %q: skillsIndexURL = %q, want %q", c.brand, got, c.wantIndex)
+		}
+		if got := u.skillsSource(); got != c.wantSource {
+			t.Errorf("brand %q: skillsSource = %q, want %q", c.brand, got, c.wantSource)
+		}
 	}
 }

--- a/lint/README.md
+++ b/lint/README.md
@@ -30,7 +30,41 @@ lint/
     ├── rule_subtype_classifier.go
     ├── rule_typed_error_completeness.go
     └── *_test.go
+└── domaincontract/     # endpoint domain contract: no hardcoded resolver hosts
+    ├── scan.go         # ScanRepo(root) ([]lintapi.Violation, error)  ← public entry
+    └── scan_test.go
 ```
+
+## Endpoint domain contract (`domaincontract`)
+
+`domaincontract` is a syntax-level regression guard for the resolver-owned
+Open, Accounts, MCP, and AppLink hosts used by the Go CLI. In production `.go`
+files it rejects:
+
+- string literals containing a resolver-owned host FQDN
+  (`{open,accounts,mcp,applink}.{feishu.cn,larksuite.com}`), and
+- direct references to the SDK base-URL globals (`FeishuBaseUrl` / `LarkBaseUrl`)
+  selected off an import of the SDK root package, which pick a host without
+  going through the resolver. Unrelated identifiers sharing the name are not
+  flagged.
+
+Host literals are permitted only inside the resolver's `ResolveEndpoints`
+function body (`internal/core/types.go`) and in this rule's own host list
+(`lint/domaincontract/scan.go`); a helper elsewhere in the resolver file
+returning a hardcoded host is still rejected. Comments and `_test.go` files
+are not scanned. Literals are unquoted before matching (escape sequences
+cannot hide a host) and match case-insensitively, and dot-imports of the SDK
+root package are rejected outright (they would hide the globals from this
+parse-level guard). The forbidden-host list is bound to the resolver source by
+`TestForbiddenHostsMatchResolver`, so adding a resolver domain without updating
+the guard fails the lint module's tests.
+
+This is not a general outbound-URL or data-flow analyzer. It does not inspect
+non-Go assets, hosts assembled from string fragments, SDK constructor option
+flow, or previously unknown Feishu/Lark hosts. The literal rule and code review
+remain the backstop for those cases.
+
+To add or change an outbound endpoint, edit the resolver — never hardcode a host.
 
 ## Running
 
@@ -42,7 +76,7 @@ go run -C lint . ..
 `-C lint` switches Go's working directory to `lint/`; the `..` argument
 is the repo root to scan (relative to `lint/`).
 
-CI: `.github/workflows/ci.yml` step `Run errs/ lint guards (lintcheck)`.
+CI: `.github/workflows/ci.yml` step `Run source-contract lint guards (lintcheck)`.
 
 Exit codes follow `lint/main.go`:
 

--- a/lint/domaincontract/enforce_test.go
+++ b/lint/domaincontract/enforce_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package domaincontract
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestLintcheckExitCode proves the guard gates CI end to end: a violating
+// fixture must make the lintcheck binary exit 1, and a clean tree exit 0.
+func TestLintcheckExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("compiles the lintcheck binary")
+	}
+	dirty := t.TempDir()
+	writeFile(t, dirty, "internal/x/x.go", "package x\n\nvar h = \"https://open.feishu.cn\"\n")
+
+	run := func(dir string) (string, error) {
+		cmd := exec.Command("go", "run", "..", dir)
+		cmd.Dir = "." // lint/domaincontract — `..` is the lintcheck main package
+		cmd.Env = os.Environ()
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	out, err := run(dirty)
+	if err == nil || !strings.Contains(out, "no-hardcoded-endpoint") {
+		t.Fatalf("violating fixture: err=%v out=%s (want exit 1 with a no-hardcoded-endpoint REJECT)", err, out)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("violating fixture exit = %v, want 1", err)
+	}
+
+	clean := t.TempDir()
+	writeFile(t, clean, "internal/x/x.go", "package x\n\nvar ok = 1\n")
+	if out, err := run(clean); err != nil {
+		t.Fatalf("clean fixture: err=%v out=%s (want exit 0)", err, out)
+	}
+}

--- a/lint/domaincontract/scan.go
+++ b/lint/domaincontract/scan.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package domaincontract guards the Go CLI against direct reuse of the current
+// resolver-owned host FQDNs outside core.ResolveEndpoints.
+package domaincontract
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/larksuite/cli/lint/lintapi"
+)
+
+// forbiddenHosts are the resolver-owned FQDNs. They may only appear as string
+// literals in the allowlisted resolver source.
+var forbiddenHosts = []string{
+	"open.feishu.cn", "accounts.feishu.cn", "mcp.feishu.cn", "applink.feishu.cn",
+	"open.larksuite.com", "accounts.larksuite.com", "mcp.larksuite.com", "applink.larksuite.com",
+}
+
+// forbiddenIdents are the SDK root package's base-URL globals; referencing
+// them picks a host without the resolver. Matched as selectors on an SDK root
+// import, so unrelated same-name identifiers are not flagged.
+var forbiddenIdents = map[string]bool{
+	"FeishuBaseUrl": true,
+	"LarkBaseUrl":   true,
+}
+
+// sdkModulePrefix identifies imports of the Lark OAPI SDK.
+const sdkModulePrefix = "github.com/larksuite/oapi-sdk-go/"
+
+// sdkImportAliases returns the file's local names for the SDK root package
+// (subpackages do not export the base-URL globals).
+func sdkImportAliases(file *ast.File) map[string]bool {
+	aliases := map[string]bool{}
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || !strings.HasPrefix(path, sdkModulePrefix) {
+			continue
+		}
+		if strings.Contains(strings.TrimPrefix(path, sdkModulePrefix), "/") {
+			continue // subpackage, not the root
+		}
+		name := "lark" // the SDK root package's package name
+		if imp.Name != nil {
+			name = imp.Name.Name
+		}
+		aliases[name] = true
+	}
+	return aliases
+}
+
+// allowlist holds the only file allowed to carry the literals wholesale:
+// this rule's own host list. The resolver file is scoped per-function instead
+// (see resolverPath).
+var allowlist = map[string]bool{
+	filepath.FromSlash("lint/domaincontract/scan.go"): true,
+}
+
+// resolverPath is the resolver source; host literals are permitted only
+// inside its ResolveEndpoints function body.
+var resolverPath = filepath.FromSlash("internal/core/types.go")
+
+func skipDir(name string) bool {
+	switch name {
+	case "vendor", "testdata", "node_modules", ".git", ".claude":
+		return true
+	}
+	return false
+}
+
+// ScanRepo walks production .go files under root and flags string literals
+// containing a forbidden resolver host outside the allowlist. Comments and
+// _test.go files are not scanned.
+func ScanRepo(root string) ([]lintapi.Violation, error) {
+	var out []lintapi.Violation
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr == nil && allowlist[rel] {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil // unparseable file: not our concern
+		}
+		display := path
+		if relErr == nil {
+			display = rel
+		}
+		var allowedFrom, allowedTo token.Pos
+		if relErr == nil && rel == resolverPath {
+			for _, d := range file.Decls {
+				if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv == nil && fd.Name.Name == "ResolveEndpoints" && fd.Body != nil {
+					allowedFrom, allowedTo = fd.Body.Pos(), fd.Body.End()
+					break
+				}
+			}
+		}
+		inResolverBody := func(p token.Pos) bool {
+			return allowedFrom != token.NoPos && p >= allowedFrom && p <= allowedTo
+		}
+		// Dot-imports of the SDK root would hide its globals from this
+		// parse-level guard, so the import form itself is rejected.
+		for _, imp := range file.Imports {
+			path, uerr := strconv.Unquote(imp.Path.Value)
+			if uerr != nil || imp.Name == nil || imp.Name.Name != "." {
+				continue
+			}
+			if strings.HasPrefix(path, sdkModulePrefix) &&
+				!strings.Contains(strings.TrimPrefix(path, sdkModulePrefix), "/") {
+				pos := fset.Position(imp.Pos())
+				out = append(out, lintapi.Violation{
+					Rule:       "no-hardcoded-endpoint",
+					Action:     lintapi.ActionReject,
+					File:       display,
+					Line:       pos.Line,
+					Message:    "dot-import of the SDK root package defeats the endpoint guard",
+					Suggestion: "import the SDK with a package name",
+				})
+			}
+		}
+		sdkAliases := sdkImportAliases(file)
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.SelectorExpr:
+				pkg, ok := node.X.(*ast.Ident)
+				if ok && pkg.Obj == nil && forbiddenIdents[node.Sel.Name] && sdkAliases[pkg.Name] {
+					pos := fset.Position(node.Pos())
+					out = append(out, lintapi.Violation{
+						Rule:       "no-hardcoded-endpoint",
+						Action:     lintapi.ActionReject,
+						File:       display,
+						Line:       pos.Line,
+						Message:    "SDK base-URL global " + pkg.Name + "." + node.Sel.Name + " bypasses the resolver — use core.ResolveEndpoints",
+						Suggestion: "derive the host from core.ResolveEndpoints(brand) instead of the SDK global",
+					})
+				}
+			case *ast.BasicLit:
+				if node.Kind != token.STRING {
+					return true
+				}
+				if inResolverBody(node.Pos()) {
+					return true
+				}
+				// Unquote and lowercase so escapes or casing cannot hide a host.
+				value := node.Value
+				if v, err := strconv.Unquote(value); err == nil {
+					value = v
+				}
+				lower := strings.ToLower(value)
+				for _, host := range forbiddenHosts {
+					if strings.Contains(lower, host) {
+						pos := fset.Position(node.Pos())
+						out = append(out, lintapi.Violation{
+							Rule:       "no-hardcoded-endpoint",
+							Action:     lintapi.ActionReject,
+							File:       display,
+							Line:       pos.Line,
+							Message:    "hardcoded resolver host " + host + " — outbound domains must come from core.ResolveEndpoints",
+							Suggestion: "use core.ResolveEndpoints(brand) instead of a literal host",
+						})
+						return true
+					}
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	return out, err
+}

--- a/lint/domaincontract/scan_test.go
+++ b/lint/domaincontract/scan_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package domaincontract
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/lint/lintapi"
+)
+
+// requireEnforced pins every violation to the rejecting rule: a regression
+// that downgrades the guard to an advisory action must fail here.
+func requireEnforced(t *testing.T, vs []lintapi.Violation) {
+	t.Helper()
+	for _, v := range vs {
+		if v.Rule != "no-hardcoded-endpoint" || v.Action != lintapi.ActionReject {
+			t.Fatalf("violation not CI-enforced: rule=%q action=%q (%s:%d)", v.Rule, v.Action, v.File, v.Line)
+		}
+	}
+}
+
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanRepo(t *testing.T) {
+	root := t.TempDir()
+	// Negative: the resolver may hold the literals inside ResolveEndpoints.
+	writeFile(t, root, "internal/core/types.go", "package core\n\nfunc ResolveEndpoints(b string) string {\n\treturn \"https://open.feishu.cn\"\n}\n")
+	// Negative: non-resolver hosts + a comment reference must not trip the guard.
+	writeFile(t, root, "shortcuts/x/display.go", "package x\n\n// see https://open.feishu.cn/document/foo\nvar h = \"https://www.feishu.cn\"\nvar e = \"https://example.feishu.cn\"\nvar r = \"https://registry.npmjs.org/pkg\"\n")
+	// Negative: _test.go files may assert literals.
+	writeFile(t, root, "internal/y/y_test.go", "package y\n\nvar w = \"https://open.larksuite.com\"\n")
+	// Positive: production literal outside the allowlist.
+	writeFile(t, root, "internal/z/z.go", "package z\n\nvar bad = \"https://accounts.larksuite.com/oauth\"\n")
+
+	vs, err := ScanRepo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireEnforced(t, vs)
+	if len(vs) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(vs), vs)
+	}
+	if filepath.Base(vs[0].File) != "z.go" {
+		t.Errorf("violation in %q, want z.go", vs[0].File)
+	}
+}
+
+// SDK base-URL globals are rejected only when selected off an SDK root
+// import; same-name identifiers elsewhere pass.
+func TestScanRepoSDKConstants(t *testing.T) {
+	root := t.TempDir()
+	// Positive: default and renamed imports of the SDK root package.
+	writeFile(t, root, "shortcuts/x/ws.go",
+		"package x\n\nimport \"github.com/larksuite/oapi-sdk-go/v3\"\n\nvar d = lark.FeishuBaseUrl\n")
+	writeFile(t, root, "shortcuts/x/ws2.go",
+		"package x\n\nimport sdk \"github.com/larksuite/oapi-sdk-go/v3\"\n\nvar e = sdk.LarkBaseUrl\n")
+	// Negative: test file may reference the globals.
+	writeFile(t, root, "shortcuts/x/ws_test.go",
+		"package x\n\nimport lark \"github.com/larksuite/oapi-sdk-go/v3\"\n\nvar p = lark.LarkBaseUrl\n")
+	// Negative: same-name local identifier without the SDK import.
+	writeFile(t, root, "shortcuts/y/local.go",
+		"package y\n\nvar FeishuBaseUrl = \"local\"\nvar q = FeishuBaseUrl\n")
+	// Negative: same-name symbol from an unrelated package.
+	writeFile(t, root, "shortcuts/z/other.go",
+		"package z\n\nimport other \"example.com/other\"\n\nvar r = other.FeishuBaseUrl\n")
+	// Negative: SDK subpackage import does not export the globals.
+	writeFile(t, root, "shortcuts/w/sub.go",
+		"package w\n\nimport larkws \"github.com/larksuite/oapi-sdk-go/v3/ws\"\n\nvar s = larkws.FeishuBaseUrl\n")
+	// Negative: a local value shadowing the SDK import alias is not the package.
+	writeFile(t, root, "shortcuts/v/shadow.go",
+		"package v\n\nimport lark \"github.com/larksuite/oapi-sdk-go/v3\"\n\ntype endpoint struct { FeishuBaseUrl string }\nvar _ *lark.Client\nfunc local() string { lark := endpoint{}; return lark.FeishuBaseUrl }\n")
+
+	vs, err := ScanRepo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireEnforced(t, vs)
+	if len(vs) != 2 {
+		t.Fatalf("got %d violations, want 2: %+v", len(vs), vs)
+	}
+	files := map[string]bool{}
+	for _, v := range vs {
+		files[filepath.Base(v.File)] = true
+	}
+	if !files["ws.go"] || !files["ws2.go"] {
+		t.Errorf("violations in %v, want ws.go and ws2.go", files)
+	}
+}
+
+// forbiddenHosts must equal the https hosts in the resolver source, both ways;
+// a resolver domain change without a guard update fails here.
+func TestForbiddenHostsMatchResolver(t *testing.T) {
+	src := filepath.Join("..", "..", "internal", "core", "types.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		t.Fatalf("parse resolver source: %v", err)
+	}
+	// Walk only the receiverless ResolveEndpoints body — the same scope the
+	// production scanner exempts — so unrelated URLs in the file cannot skew
+	// the parity check.
+	var resolverBody ast.Node
+	for _, d := range file.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv == nil && fd.Name.Name == "ResolveEndpoints" && fd.Body != nil {
+			resolverBody = fd.Body
+			break
+		}
+	}
+	if resolverBody == nil {
+		t.Fatal("ResolveEndpoints function not found in resolver source")
+	}
+	resolverHosts := map[string]bool{}
+	ast.Inspect(resolverBody, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		v, err := strconv.Unquote(lit.Value)
+		if err != nil || !strings.HasPrefix(v, "https://") {
+			return true
+		}
+		// Parse instead of prefix-stripping so a resolver URL that ever gains a
+		// path component still compares by bare host against forbiddenHosts.
+		u, err := url.Parse(v)
+		if err != nil || u.Host == "" {
+			return true
+		}
+		resolverHosts[u.Host] = true
+		return true
+	})
+
+	guardHosts := map[string]bool{}
+	for _, h := range forbiddenHosts {
+		guardHosts[h] = true
+	}
+	for h := range resolverHosts {
+		if !guardHosts[h] {
+			t.Errorf("resolver host %q is not in the guard's forbidden list", h)
+		}
+	}
+	for h := range guardHosts {
+		if !resolverHosts[h] {
+			t.Errorf("guard forbids %q which the resolver does not define", h)
+		}
+	}
+}
+
+// Dot-import rejection and case-insensitive literal matching.
+func TestScanRepoDotImportAndCase(t *testing.T) {
+	root := t.TempDir()
+	// Positive: dot-import of the SDK root package.
+	writeFile(t, root, "shortcuts/a/dot.go",
+		"package a\n\nimport . \"github.com/larksuite/oapi-sdk-go/v3\"\n\nvar d = FeishuBaseUrl\n")
+	// Positive: uppercase host literal.
+	writeFile(t, root, "shortcuts/b/upper.go",
+		"package b\n\nvar u = \"https://OPEN.FEISHU.CN/api\"\n")
+	// Negative: dot-import of an SDK subpackage is out of the globals' scope.
+	writeFile(t, root, "shortcuts/c/sub.go",
+		"package c\n\nimport . \"github.com/larksuite/oapi-sdk-go/v3/ws\"\n\nvar s = 1\n")
+
+	vs, err := ScanRepo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireEnforced(t, vs)
+	if len(vs) != 2 {
+		t.Fatalf("got %d violations, want 2: %+v", len(vs), vs)
+	}
+	files := map[string]bool{}
+	for _, v := range vs {
+		files[filepath.Base(v.File)] = true
+	}
+	if !files["dot.go"] || !files["upper.go"] {
+		t.Errorf("violations in %v, want dot.go and upper.go", files)
+	}
+}
+
+// The resolver file is scoped per-function: a hardcoded host outside the
+// ResolveEndpoints body is rejected.
+func TestScanRepoResolverFunctionScope(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "internal/core/types.go",
+		"package core\n\nfunc ResolveEndpoints(b string) string {\n\treturn \"https://open.feishu.cn\"\n}\n\nfunc bypass() string { return \"https://open.feishu.cn\" }\n\ntype localResolver struct{}\nfunc (localResolver) ResolveEndpoints() string { return \"https://open.feishu.cn\" }\n")
+
+	vs, err := ScanRepo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 2 {
+		t.Fatalf("got %d violations, want 2 (helper and receiver method): %+v", len(vs), vs)
+	}
+	for _, v := range vs {
+		if filepath.Base(v.File) != "types.go" {
+			t.Errorf("violation in %q, want types.go", v.File)
+		}
+	}
+}
+
+// Escape sequences cannot hide a host: literals are unquoted before matching.
+func TestScanRepoEscapedLiteral(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "internal/e/e.go",
+		"package e\n\nvar h = \"https://open.feishu\\u002ecn\"\n")
+
+	vs, err := ScanRepo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireEnforced(t, vs)
+	if len(vs) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(vs), vs)
+	}
+}

--- a/lint/main.go
+++ b/lint/main.go
@@ -1,10 +1,9 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
-// Command lintcheck runs the source-level errs/ contract guards (all four checks).
-// The fifth contract rule (business path must use typed errors) lives in
-// .golangci.yml as a forbidigo entry; the four checks here are AST-level
-// guards that golangci-lint cannot express.
+// Command lintcheck runs repository source-contract guards that golangci-lint
+// cannot express directly. It currently covers typed-error contracts and the
+// resolver-owned endpoint contract.
 //
 // lintcheck lives in its own Go module under lint/ so its build-time
 // dependency on golang.org/x/tools/go/packages does not leak into the
@@ -30,6 +29,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/larksuite/cli/lint/domaincontract"
 	"github.com/larksuite/cli/lint/errscontract"
 	"github.com/larksuite/cli/lint/lintapi"
 )
@@ -43,6 +43,9 @@ type scanner struct {
 
 var scanners = []scanner{
 	{name: "errscontract", fn: errscontract.ScanRepoWithOptions},
+	{name: "domaincontract", fn: func(root string, _ errscontract.ScanOptions) ([]lintapi.Violation, error) {
+		return domaincontract.ScanRepo(root)
+	}},
 }
 
 func main() {

--- a/shortcuts/event/subscribe.go
+++ b/shortcuts/event/subscribe.go
@@ -21,7 +21,6 @@ import (
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 
-	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
@@ -247,10 +246,7 @@ var EventSubscribe = common.Shortcut{
 		}
 
 		// --- WebSocket ---
-		domain := lark.FeishuBaseUrl
-		if runtime.Config.Brand == core.BrandLark {
-			domain = lark.LarkBaseUrl
-		}
+		domain := core.ResolveEndpoints(runtime.Config.Brand).Open
 
 		info(fmt.Sprintf("%sConnecting to Lark event WebSocket...%s", output.Cyan, output.Reset))
 		if eventTypeFilter != nil {

--- a/shortcuts/event/subscribe_test.go
+++ b/shortcuts/event/subscribe_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/core"
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+)
+
+// The resolver's Open host must equal the SDK's per-brand WS base URL;
+// fails if the SDK constants ever drift from the resolver.
+func TestWSDomainMatchesResolver(t *testing.T) {
+	if got, want := core.ResolveEndpoints(core.BrandFeishu).Open, lark.FeishuBaseUrl; got != want {
+		t.Errorf("feishu WS domain = %q, want SDK %q", got, want)
+	}
+	if got, want := core.ResolveEndpoints(core.BrandLark).Open, lark.LarkBaseUrl; got != want {
+		t.Errorf("lark WS domain = %q, want SDK %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Route the brand-sensitive, resolver-owned Go CLI endpoints touched here through the single `core.ResolveEndpoints` source of truth. Feishu remains the default; Lark uses the corresponding resolver endpoints while app registration preserves its protocol-defined Feishu bootstrap and switches to Lark only after tenant discovery.

This PR intentionally leaves package-manager version lookup, npm registry behavior, update caching, and general URL data-flow analysis unchanged.

## Changes

- Normalize brand values through `core.ParseBrand` at every runtime ingress (config resolution, credential accounts) and defensively at the `ResolveEndpoints` boundary
- Route API metadata, skills index/source, event WebSocket, and app-registration hosts through the resolver, and resolve the brand before the command tree builds so the registry's metadata overlay uses it from the first catalog access
- Keep app-registration discovery in one `internal/auth` state machine with Feishu begin and first poll, immediate tenant-signaled Lark switching (even when the signal accompanies authorization_pending), one expiry budget with no attempt cap, context-bound requests, and the issuing brand as the only saved brand (a contradictory final tenant report is a protocol error)
- Preserve the existing brand-specific verification-page UX; endpoint consolidation does not change the registration protocol or product entry path
- Resolve the skills source from the active profile, including a raw-config brand fallback when credential-backed config resolution is unavailable
- Add a syntax-level Go guard for the current resolver-owned host literals, direct SDK base-URL globals, and SDK root dot-imports; this guard is deliberately not a general URL or data-flow analyzer
- Run lint module tests in CI so resolver/guard host parity and guard behavior cannot silently drift

## Test Plan

- Resolver tables cover Feishu/Lark, casing, whitespace, invalid values, and normalization at the endpoint boundary and both config ingresses; a subprocess regression test locks the real startup order (registry brand = configured brand before the first catalog access)
- App-registration tests lock the full Lark sequence: Lark verification UI, Feishu begin, Feishu first poll, tenant signal (including alongside authorization_pending), immediate Lark poll, final Lark brand even when the credential response omits `user_info`, no attempt cap, and rejection of contradictory final tenant reports
- Registration tests also cover incomplete responses, protocol defaults, one expiry budget, in-flight cancellation, terminal sentinels, and command-facing typed errors
- Skills tests cover Feishu/Lark index/source selection plus resolved-config, active-profile raw fallback, and default behavior
- Event WebSocket and API metadata tests assert the effective host per brand
- Lint tests cover host literals, SDK globals, dot imports, local-shadow/subpackage negatives, case/escape handling, exact resolver-function scoping (parity included), and pin enforcement itself: every violation is asserted as a rejecting action and an end-to-end fixture proves lintcheck exits 1
- Manual Lark acceptance completed against real services: scan and app creation succeeded, the saved brand was `lark`, bot credentials verified, and the Lark Open and MCP endpoints were reachable; temporary local config and Keychain data were removed afterward
- Local gates: build, race unit tests, focused timeout reruns, vet, gofmt, go mod tidy, golangci-lint, lint module/full-repo scans, and quality gate

## Related Issues

N/A

