### PR TITLE
fix(sheets): pass spreadsheet token to changeset tool

### DIFF
--- a/shortcuts/sheets/lark_sheet_changeset.go
+++ b/shortcuts/sheets/lark_sheet_changeset.go
@@ -43,15 +43,15 @@ var ChangesetGet = common.Shortcut{
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
-		input, _ := changesetInput(runtime)
+		input, _ := changesetInput(runtime, token)
 		return invokeToolDryRun(token, ToolKindRead, "get_changeset", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
-		input, err := changesetInput(runtime)
+		input, err := changesetInput(runtime, token)
 		if err != nil {
 			return err
 		}
@@ -90,12 +90,13 @@ func changesetRevisions(runtime flagView) (start int, end int, err error) {
 
 // changesetInput builds the get_changeset tool input. end_revision is only
 // sent when explicitly provided; otherwise the server defaults to latest.
-func changesetInput(runtime flagView) (map[string]interface{}, error) {
+func changesetInput(runtime flagView, token string) (map[string]interface{}, error) {
 	start, end, err := changesetRevisions(runtime)
 	if err != nil {
 		return nil, err
 	}
 	input := map[string]interface{}{
+		"excel_id":       token,
 		"start_revision": start,
 	}
 	if end > 0 {

--- a/shortcuts/sheets/lark_sheet_changeset_test.go
+++ b/shortcuts/sheets/lark_sheet_changeset_test.go
@@ -23,6 +23,7 @@ func TestChangesetGet_DryRun(t *testing.T) {
 			name: "start + end bounded range",
 			args: []string{"--url", testURL, "--start-revision", "120", "--end-revision", "135"},
 			wantInput: map[string]interface{}{
+				"excel_id":       testToken,
 				"start_revision": float64(120),
 				"end_revision":   float64(135),
 			},
@@ -31,6 +32,7 @@ func TestChangesetGet_DryRun(t *testing.T) {
 			name: "start only → end omitted (server defaults to latest)",
 			args: []string{"--url", testURL, "--start-revision", "120"},
 			wantInput: map[string]interface{}{
+				"excel_id":       testToken,
 				"start_revision": float64(120),
 			},
 		},


### PR DESCRIPTION
## Summary

Fix `+changeset-get` so the `get_changeset` tool input includes `excel_id`, and use Execute-time spreadsheet token resolution so wiki URLs resolve to the backing spreadsheet token before invocation.

## Validation

- `go test ./shortcuts/sheets -run 'TestChangesetGet|TestFlagsFor_EveryRegisteredCommandHasDefs|TestBatchOp_(SchemaValidatesSubOps|RejectsWrongScalarType|DispatchCoversReportedBugs)'`
- `go test ./shortcuts/sheets`
