### PR TITLE
docs: refine doubao whiteboard workflow routing

### DIFF
--- a/skills/lark-whiteboard/references/lark-whiteboard-workflow.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-workflow.md
@@ -47,11 +47,14 @@
 
 **然后按图表类型 × 身份选路径**，读对应文件按其完整 workflow 执行（含读 scene 指南、生成内容、渲染审查、交付）：
 
+按上到下匹配, 命中即停:
+
 | 图表类型               | 身份                                  | 路径                                             |
 |--------------------|-------------------------------------|------------------------------------------------|
 | 思维导图、时序图、类图、饼图、甘特图 | 任何身份                                | [`../routes/mermaid.md`](../routes/mermaid.md) |
-| 其他图表               | `Claude` / `Gemini` / `GPT` / `GLM` | [`../routes/svg.md`](../routes/svg.md)         |
-| 其他图表               | `Doubao` / `Seed` / `Other`         | [`../routes/dsl.md`](../routes/dsl.md)         |
+| 鱼骨图、金字塔图、流程图    | `Doubao` / `Seed`                   | [`../routes/dsl.md`](../routes/dsl.md)         |
+| 其他图表               | `Claude` / `Gemini` / `GPT` / `GLM` / `Doubao` / `Seed`  | [`../routes/svg.md`](../routes/svg.md)         |
+| 其他图表               | `Other`                             | [`../routes/dsl.md`](../routes/dsl.md)         |
 
 > **⚠️ SVG 路径失败回退**：走 `routes/svg.md` 时，碰到以下情况之一 → **丢弃当前 SVG，改读 `routes/dsl.md` 从零重画，不要逐行修补**：
 > - 渲染命令直接报错（语法级崩溃，不是 `--check` 的 warn/error）


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->
This PR refine doubao whiteboard workflow, use svg first

## Changes
<!-- List the main changes in this PR. -->
- refine doubao whiteboard workflow, svg first

## Test Plan
<!-- Describe how this change was verified. -->
- [x] Unit tests pass

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that rendering routes are evaluated from top to bottom and stop at the first match.
  * Updated routing guidance for other chart types: Doubao and Seed identities now use SVG routes, while only Other uses DSL routes.
  * Preserved existing routing behavior for Mermaid class diagrams and specified chart types under Doubao and Seed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->