### PR TITLE
fix(sheets): hide bitable sheet creation

### DIFF
--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -159,11 +159,10 @@
         "kind": "own",
         "type": "string",
         "required": "optional",
-        "desc": "New sub-sheet type: sheet (spreadsheet) | bitable; default sheet. bitable creates an empty table only — edit its content via lark-base commands",
+        "desc": "New sub-sheet type: sheet (spreadsheet); default sheet.",
         "default": "sheet",
         "enum": [
-          "sheet",
-          "bitable"
+          "sheet"
         ]
       },
       {

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -828,7 +828,7 @@ var flagDefs = map[string]commandDef{
 			{Name: "index", Kind: "own", Type: "int", Required: "optional", Desc: "Insert position (0-based); appended to the end when omitted", Default: "-1"},
 			{Name: "row-count", Kind: "own", Type: "int", Required: "optional", Desc: "Initial row count (default 200, max 50000)", Default: "200"},
 			{Name: "col-count", Kind: "own", Type: "int", Required: "optional", Desc: "Initial column count (default 20, max 200)", Default: "20"},
-			{Name: "type", Kind: "own", Type: "string", Required: "optional", Desc: "New sub-sheet type: sheet (spreadsheet) | bitable; default sheet. bitable creates an empty table only — edit its content via lark-base commands", Default: "sheet", Enum: []string{"sheet", "bitable"}},
+			{Name: "type", Kind: "own", Type: "string", Required: "optional", Desc: "New sub-sheet type: sheet (spreadsheet); default sheet.", Default: "sheet", Enum: []string{"sheet"}},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},

--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -123,25 +123,12 @@ func sheetCreateInput(runtime flagView, token string) (map[string]interface{}, e
 	if strings.TrimSpace(runtime.Str("title")) == "" {
 		return nil, common.ValidationErrorf("--title is required")
 	}
-	// --type bitable 建一张空白多维表格子表（operation=create_bitable）；默认 sheet 为普通
-	// 电子表格子表。bitable 子表内容编辑走 lark-base 命令，row-count/col-count 不适用。
 	sheetType := strings.TrimSpace(runtime.Str("type"))
 	if sheetType == "" {
 		sheetType = "sheet"
 	}
-	if sheetType != "sheet" && sheetType != "bitable" {
-		return nil, common.ValidationErrorf("--type must be 'sheet' or 'bitable'")
-	}
-	if sheetType == "bitable" {
-		input := map[string]interface{}{
-			"excel_id":   token,
-			"operation":  "create_bitable",
-			"sheet_name": strings.TrimSpace(runtime.Str("title")),
-		}
-		if runtime.Changed("index") {
-			input["target_index"] = runtime.Int("index")
-		}
-		return input, nil
+	if sheetType != "sheet" {
+		return nil, common.ValidationErrorf("--type must be 'sheet'")
 	}
 	if n := runtime.Int("row-count"); n < 0 || n > 50000 {
 		return nil, common.ValidationErrorf("--row-count must be between 0 and 50000")

--- a/shortcuts/sheets/lark_sheet_workbook_test.go
+++ b/shortcuts/sheets/lark_sheet_workbook_test.go
@@ -281,6 +281,12 @@ func TestWorkbook_Validation(t *testing.T) {
 			args:    []string{"--url", testURL, "--title", "X", "--row-count", "999999"},
 			wantMsg: "--row-count must be between",
 		},
+		{
+			name:    "+sheet-create rejects hidden bitable type",
+			sc:      SheetCreate,
+			args:    []string{"--url", testURL, "--title", "Tasks", "--type", "bitable"},
+			wantMsg: `invalid value "bitable" for --type`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/skills/lark-sheets/references/lark-sheets-workbook.md
+++ b/skills/lark-sheets/references/lark-sheets-workbook.md
@@ -77,7 +77,7 @@ _公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
 | `--index` | int | optional | 插入位置（0-based）；省略时附加到末尾 |
 | `--row-count` | int | optional | 初始行数（默认 200，上限 50000） |
 | `--col-count` | int | optional | 初始列数（默认 20，上限 200） |
-| `--type` | string | optional | 新子表类型：sheet（电子表格）\| bitable（多维表格）；默认 sheet。bitable 只建空表，内容编辑改用 lark-base 命令（可选值：`sheet` / `bitable`） |
+| `--type` | string | optional | 新子表类型：sheet（电子表格）；默认 sheet。（可选值：`sheet`） |
 
 ### `+sheet-delete`
 
@@ -364,16 +364,7 @@ lark-cli sheets +sheet-create --url "https://example.feishu.cn/sheets/shtXXX" \
   --title "汇总" --index 0
 ```
 
-新建一张**多维表格（bitable）子表**：加 `--type bitable`（默认 `sheet`，即普通电子表格子表）。
-
-```bash
-lark-cli sheets +sheet-create --url "https://example.feishu.cn/sheets/shtXXX" \
-  --title "任务表" --type bitable
-```
-
 > 💡 `+sheet-create` 只建一张**空子表**。要在已有工作簿里建子表并一步写入 typed 数据和/或样式，用 `+table-put`（payload 里命名的子表缺则自动新建）配合它的 `--sheets` / `--styles`，省掉先建表再 `+cells-set` / `+cells-set-style` 的二次往返。
-
-> 💡 `--type bitable` 只建一张**空的多维表格子表**（默认表 + 网格视图 + 默认字段）。它的内容编辑（字段、记录、视图）走 `lark-cli base`：先用 `+workbook-info` 拿到该子表的 `bitable_app_token` + `bitable_table_id`，再用 `lark-cli base +record-list` / `+record-create` 等操作；sheets 侧的网格类命令（`+cells-get` / `+cells-set` 等）对 bitable 子表会被拒。
 
 ### `+sheet-delete`
 


### PR DESCRIPTION
## Summary

Hide the `+sheet-create --type bitable` CLI entry point while keeping the underlying tool-layer operation untouched for a later rollout.

Changes:
- limit `+sheet-create --type` metadata to `sheet`
- reject `--type bitable` in the CLI input builder
- remove the `--type bitable` example and flag description from the lark-sheets workbook reference

## Related

- Spec MR: https://code.byted.org/ee/sheet-skill-spec/merge_requests/50
- Re-enable PR: https://github.com/larksuite/cli/pull/1844

## Validation

- `go test ./shortcuts/sheets -run 'TestWorkbookShortcuts_DryRun|TestWorkbook_Validation|TestShortcuts_FlagErgonomicsMounted|TestFlagsFor_EveryRegisteredCommandHasDefs'`
- `go test ./shortcuts/sheets`
