### PR TITLE
docs(lark-doc): document poll blocks

### DIFF
--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: lark-doc
-version: 2.0.0
 description: "飞书云文档（Docx / Wiki 文档）：读取和编辑飞书文档内容。当用户给出文档 URL 或 token，或需要查看、创建、编辑文档、插入或下载文档图片附件时使用。文档中嵌入的电子表格、多维表格、画板，先用本 skill 提取 token 再切到对应 skill。当用户给出 doubao.com 的 /docx/ 或 /wiki/ URL/token 时，也应直接使用本 skill；路由依据是 URL 路径模式和 token，而不是域名。不负责文档评论管理，也不负责表格或 Base 的数据操作。当用户明确要操作飞书思维笔记时，也使用本 skill。"
 metadata:
   requires:

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -122,6 +122,8 @@ lark-cli docs +update --doc "<doc_id>" --command block_replace \
   --content '<p>替换后的段落内容</p>'
 ```
 
+投票 block 也使用 `block_replace` 做整块替换：replacement 中的新 `<poll>` 会创建新的投票 block，不继承旧投票的 block id、option id、票数、投票人、发布时间或当前用户选择；如需把投票改成普通内容，直接把 `--content` 写成目标 XML。
+
 ### block_delete — 删除指定 block
 
 ```bash

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -75,6 +75,7 @@ lark-cli docs +update --doc "xx" --command block_delete --start-block-id blkFirs
 
 ## 通用安全规则
 
+- 投票也使用 `block_replace` 整块替换；新 `<poll>` 不继承旧 block id、票数、投票人或发布状态。替换成普通内容时直接提供目标 XML。
 - 每次写操作后都按 block ID 已变化处理。新插入或复制的内容一定使用新 ID；替换、删除和覆盖会使旧 ID 失效；移动会改变章节与 range 语义。
 - 同一 block 有多处修改时，应合并为一次 `block_replace`，避免连续使用旧 ID。
 

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -9,6 +9,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 |-|-|-|
 | `<title>` | 文档标题（每篇唯一）| `align` |
 | `<checkbox>` | 待办项| `done="true"\|"false"` |
+| `<poll>` | 投票块，支持创建草稿、可选创建后发布 | `poll-type`, `is-anonymous`, `enable-due-time`, `due-time`, `publish-on-create` |
 
 ## 容器标签
 |标签|说明|关键属性|
@@ -48,6 +49,44 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 - `<sub-page-list>` — `<sub-page-list></sub-page-list>` 子页面列表块；仅 wiki 文档可插入
 - bitable、base_ref、synced_reference、synced_source — 不可创建，仅支持移动
 - `<okr>` — 创建时仅支持 root-only `<okr cycle-id="..."/>` 挂载已有 OKR；完整结构与字段规则见 [`lark-doc-xml-extended-blocks.md`](lark-doc-xml-extended-blocks.md#okr-block)
+
+## 投票 block
+
+投票使用结构化 XML 表达。默认创建未发布草稿：空标题、两个空选项、单选、实名、无截止时间、结果策略固定为投票后可见。
+
+```xml
+<poll></poll>
+```
+
+带内容创建：
+
+```xml
+<poll poll-type="single" is-anonymous="false">
+  <poll-title>午饭吃什么？</poll-title>
+  <poll-option>米饭</poll-option>
+  <poll-option>面条</poll-option>
+</poll>
+```
+
+创建后尝试发布：
+
+```xml
+<poll publish-on-create="true">
+  <poll-title>午饭吃什么？</poll-title>
+  <poll-option>米饭</poll-option>
+  <poll-option>面条</poll-option>
+</poll>
+```
+
+`publish-on-create` 会先创建草稿，再尝试发布。发布失败不会回滚正文：新投票会保留为草稿，命令结果会返回 warning。调用方应检查 warning；需要确认最终状态时，重新读取并检查 `is-published`。
+
+公开可写属性只有：`poll-type="single|multiple"`、`is-anonymous="true|false"`、`enable-due-time="true|false"`、`due-time="毫秒时间戳"`、`publish-on-create="true|false"`。不要写入 `when-result-visible`、`option-id`、票数、投票人或当前用户投票状态。
+
+读取已发布投票时，XML 可能带只读结果字段，例如 `is-published`、`result-visible`、`user-count`、`poll-option count/percent/selected/voters-ref`。这些字段只用于展示，重新导入或 `block_replace` 时会被忽略；匿名投票不会通过 `reference_map` 暴露真实投票人。`voters-ref` 是读取详情的 opaque handle，不是投票操作入口。
+
+若读取结果的 `tips` 包含 `poll_detail_unavailable`，表示正文中的静态投票结构可用，但动态发布状态、进展或 voters 获取失败，本次结果不应被当作完整投票详情。
+
+修改投票配置、替换已发布投票、把投票替换成普通内容，都使用 `block_replace`，语义是删除旧 block 并插入 replacement。新 `<poll>` 会创建新的投票 block，不继承旧 block id、option id、票数、投票人、发布时间或当前用户选择。
 
 # 四、块级复制与移动
 

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -27,6 +27,44 @@
 - `<colgroup><col /></colgroup>` 紧跟 `<table>` 定义列宽；`width` 表示列宽，可选 `span` 表示连续作用的列数。
 - `<th>` / `<td>` 支持 `background-color`、`vertical-align`、`colspan`、`rowspan`；`vertical-align`：`top | middle | bottom`；`background-color` 支持基础色相、`light-{色相}`、`medium-gray`，表头优先使用 `light-gray` 或 `medium-gray`，彩色单元格仅用于表达状态或分类。被合并的单元格不再写入。
 
+## 投票 block
+
+投票使用结构化 XML 表达。默认创建未发布草稿：空标题、两个空选项、单选、实名、无截止时间、结果策略固定为投票后可见。
+
+```xml
+<poll></poll>
+```
+
+带内容创建：
+
+```xml
+<poll poll-type="single" is-anonymous="false">
+  <poll-title>午饭吃什么？</poll-title>
+  <poll-option>米饭</poll-option>
+  <poll-option>面条</poll-option>
+</poll>
+```
+
+创建后尝试发布：
+
+```xml
+<poll publish-on-create="true">
+  <poll-title>午饭吃什么？</poll-title>
+  <poll-option>米饭</poll-option>
+  <poll-option>面条</poll-option>
+</poll>
+```
+
+`publish-on-create` 会先创建草稿，再尝试发布。发布失败不会回滚正文：新投票会保留为草稿，命令结果会返回 warning。调用方应检查 warning；需要确认最终状态时，重新读取并检查 `is-published`。
+
+公开可写属性只有：`poll-type="single|multiple"`、`is-anonymous="true|false"`、`enable-due-time="true|false"`、`due-time="毫秒时间戳"`、`publish-on-create="true|false"`。不要写入 `when-result-visible`、`option-id`、票数、投票人或当前用户投票状态。
+
+读取已发布投票时，XML 可能带只读结果字段，例如 `is-published`、`result-visible`、`user-count`、`poll-option count/percent/selected/voters-ref`。这些字段只用于展示，重新导入或 `block_replace` 时会被忽略；匿名投票不会通过 `reference_map` 暴露真实投票人。`voters-ref` 是读取详情的 opaque handle，不是投票操作入口。
+
+若读取结果的 `tips` 包含 `poll_detail_unavailable`，表示正文中的静态投票结构可用，但动态发布状态、进展或 voters 获取失败，本次结果不应被当作完整投票详情。
+
+修改投票配置、替换已发布投票、把投票替换成普通内容，都使用 `block_replace`，语义是删除旧 block 并插入 replacement。新 `<poll>` 会创建新的投票 block，不继承旧 block id、option id、票数、投票人、发布时间或当前用户选择。
+
 ## 扩展标签
 
 - `<cite type="user" user-id="ou_xxx"/>`：@人，会渲染为用户头像；必须显式传入用户 `open_id`，不得用纯文本名字冒充 @人。


### PR DESCRIPTION
## Summary

- document structured poll creation and whole-block replacement for `lark docs v2`
- document writable versus read-only poll fields and `poll-voters` references
- clarify that `publish-on-create` keeps a draft and returns a warning when publishing fails
- explain the `poll_detail_unavailable` export tip
- remove the legacy top-level `version` key, which is rejected by the current skill frontmatter schema

## Validation

```text
quick_validate.py skills/lark-doc
Skill is valid!
```

This is documentation-only; CLI Go code is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for creating, publishing, reading, and updating poll blocks.
  * Clarified poll configuration options, publication behavior, result visibility, anonymous voting, and unavailable-detail warnings.
  * Documented that replacing a poll creates a new poll without preserving prior identifiers, votes, participants, timestamps, or selections.
  * Explained how to convert a poll block into regular content using block replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->