### PR TITLE
fix(auth): hint when open IDs belong to another app

### DIFF
--- a/internal/errclass/classify.go
+++ b/internal/errclass/classify.go
@@ -144,7 +144,11 @@ func BuildAPIError(resp map[string]any, cc ClassifyContext) error {
 		}
 	case errs.CategoryAPI:
 		// A server-supplied detail (lifted into base.Hint above) wins over the
-		// context-free APIHint default; only fall back to APIHint when absent.
+		// message-specific and context-free recovery hints; only fill a hint when
+		// the upstream response did not provide a more precise detail.
+		if base.Hint == "" {
+			base.Hint = apiMessageHint(base.Message)
+		}
 		if base.Hint == "" {
 			base.Hint = APIHint(base.Subtype) // "" for subtypes without a context-free default
 		}
@@ -268,6 +272,15 @@ func APIHint(subtype errs.Subtype) string {
 		return "operate on source and target within the same brand environment"
 	case errs.SubtypeQuotaExceeded:
 		return "reduce the request volume or free quota, then retry after the relevant quota resets"
+	}
+	return ""
+}
+
+// apiMessageHint supplies recovery guidance for stable, app-context-specific
+// upstream messages that do not have a distinct API code.
+func apiMessageHint(message string) string {
+	if strings.Contains(strings.ToLower(message), "open_id cross app") {
+		return "the open_id may belong to a different app or profile; run `lark-cli config show` and `lark-cli auth status --verify`, then resolve the ID again under the active app"
 	}
 	return ""
 }

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -189,6 +189,9 @@ func TestBuildAPIError_OpenIDCrossAppIncludesProfileRecoveryHint(t *testing.T) {
 	if !strings.Contains(p.Hint, "lark-cli config show") {
 		t.Errorf("Hint = %q, want profile recovery guidance", p.Hint)
 	}
+	if !strings.Contains(p.Hint, "lark-cli auth status --verify") {
+		t.Errorf("Hint = %q, want auth verification guidance", p.Hint)
+	}
 }
 
 // TestBuildAPIError_TroubleshooterLiftedOnAPIArm pins that BuildAPIError lifts

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -174,6 +174,23 @@ func TestBuildAPIError_TaskInvalidParamsRoutesToAPIError(t *testing.T) {
 	}
 }
 
+func TestBuildAPIError_OpenIDCrossAppIncludesProfileRecoveryHint(t *testing.T) {
+	err := errclass.BuildAPIError(map[string]any{
+		"code": 999999,
+		"msg":  "open_id cross app",
+	}, errclass.ClassifyContext{})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if p.Category != errs.CategoryAPI {
+		t.Errorf("Category = %q, want %q", p.Category, errs.CategoryAPI)
+	}
+	if !strings.Contains(p.Hint, "lark-cli config show") {
+		t.Errorf("Hint = %q, want profile recovery guidance", p.Hint)
+	}
+}
+
 // TestBuildAPIError_TroubleshooterLiftedOnAPIArm pins that BuildAPIError lifts
 // resp.error.troubleshooter into Problem.Troubleshooter when the response
 // routes to the catch-all CategoryAPI arm. troubleshooter is the only


### PR DESCRIPTION
Fixes #913

## 背景
当 open_id 属于另一应用或 profile 时，上游可能只返回 `open_id cross app`，CLI 目前将其归为通用 API 错误，缺少恢复路径。

## 核心改动
- 仅为稳定的 `open_id cross app` 消息补充应用/profile 恢复提示。
- 保持服务端 `error.details` 优先级高于本地提示。
- 增加分类与提示的回归测试。

## 验证
- `go test ./internal/errclass -count=1`
- `go build -o ./lark-cli .`

## 风险与回滚
仅改变该错误消息缺少服务端详情时的 Hint 文本，不影响 API 分类、请求或响应处理。回滚本提交即可恢复原行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenID cross-application auth error handling with clearer, actionable recovery guidance.
  * Error hints now better combine profile configuration recovery steps with auth verification instructions when appropriate.
* **Tests**
  * Added coverage to ensure OpenID cross-app errors include the expected combined recovery hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->