### PR TITLE
fix(auth): diagnose non-JSON device authorization failures

### DIFF
--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -104,7 +105,7 @@ func RequestDeviceAuthorization(httpClient *http.Client, appId, appSecret string
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(body, &data); err != nil {
-		return nil, fmt.Errorf("Device authorization failed: HTTP %d – response not JSON", resp.StatusCode)
+		return nil, deviceAuthorizationNonJSONError(resp, scope)
 	}
 
 	_, hasError := data["error"]
@@ -136,6 +137,21 @@ func RequestDeviceAuthorization(httpClient *http.Client, appId, appSecret string
 		ExpiresIn:               expiresIn,
 		Interval:                interval,
 	}, nil
+}
+
+func deviceAuthorizationNonJSONError(resp *http.Response, scope string) error {
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	message := fmt.Sprintf("Device authorization failed: HTTP %d returned a non-JSON response", resp.StatusCode)
+	if contentType != "" {
+		message += fmt.Sprintf(" (content-type %q)", contentType)
+	}
+	if logID := strings.TrimSpace(resp.Header.Get("X-Tt-Logid")); logID != "" {
+		message += fmt.Sprintf("; request log id: %s", logID)
+	}
+	if resp.StatusCode == http.StatusForbidden && strings.TrimSpace(scope) != "" {
+		message += "; an upstream gateway may have rejected the requested scope combination; retry with a smaller --scope set and add scopes incrementally"
+	}
+	return errors.New(message)
 }
 
 // PollDeviceToken polls the token endpoint until authorization completes or times out.

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/core"
 )
 
@@ -105,7 +105,7 @@ func RequestDeviceAuthorization(httpClient *http.Client, appId, appSecret string
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(body, &data); err != nil {
-		return nil, deviceAuthorizationNonJSONError(resp, scope)
+		return nil, deviceAuthorizationNonJSONError(resp, scope, err)
 	}
 
 	_, hasError := data["error"]
@@ -139,7 +139,7 @@ func RequestDeviceAuthorization(httpClient *http.Client, appId, appSecret string
 	}, nil
 }
 
-func deviceAuthorizationNonJSONError(resp *http.Response, scope string) error {
+func deviceAuthorizationNonJSONError(resp *http.Response, scope string, cause error) error {
 	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
 	message := fmt.Sprintf("Device authorization failed: HTTP %d returned a non-JSON response", resp.StatusCode)
 	if contentType != "" {
@@ -151,7 +151,7 @@ func deviceAuthorizationNonJSONError(resp *http.Response, scope string) error {
 	if resp.StatusCode == http.StatusForbidden && strings.TrimSpace(scope) != "" {
 		message += "; an upstream gateway may have rejected the requested scope combination; retry with a smaller --scope set and add scopes incrementally"
 	}
-	return errors.New(message)
+	return errs.NewNetworkError(errs.SubtypeNetworkTransport, "%s", message).WithCause(cause)
 }
 
 // PollDeviceToken polls the token endpoint until authorization completes or times out.

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -106,6 +106,45 @@ func TestRequestDeviceAuthorization_LogsResponse(t *testing.T) {
 	}
 }
 
+func TestRequestDeviceAuthorization_NonJSONForbiddenIncludesGatewayDiagnostics(t *testing.T) {
+	reg := &httpmock.Registry{}
+	t.Cleanup(func() { reg.Verify(t) })
+
+	reg.Register(&httpmock.Stub{
+		Method:      "POST",
+		URL:         PathDeviceAuthorization,
+		Status:      http.StatusForbidden,
+		RawBody:     []byte("<html>blocked</html>"),
+		ContentType: "text/html; charset=utf-8",
+		Headers: http.Header{
+			"Content-Type": []string{"text/html; charset=utf-8"},
+			"X-Tt-Logid":   []string{"gateway-log-id"},
+		},
+	})
+
+	_, err := RequestDeviceAuthorization(
+		httpmock.NewClient(reg),
+		"cli_a",
+		"secret_b",
+		core.BrandLark,
+		"minutes:minutes.transcript:export task:task:read",
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected non-JSON authorization failure")
+	}
+	for _, want := range []string{
+		"HTTP 403",
+		"text/html; charset=utf-8",
+		"gateway-log-id",
+		"smaller --scope set",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want %q", err, want)
+		}
+	}
+}
+
 // TestFormatAuthCmdline_TruncatesExtraArgs verifies that long command lines are truncated.
 func TestFormatAuthCmdline_TruncatesExtraArgs(t *testing.T) {
 	got := keychain.FormatAuthCmdline([]string{

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -6,6 +6,8 @@ package auth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -14,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/keychain"
@@ -133,14 +136,31 @@ func TestRequestDeviceAuthorization_NonJSONForbiddenIncludesGatewayDiagnostics(t
 	if err == nil {
 		t.Fatal("expected non-JSON authorization failure")
 	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if p.Category != errs.CategoryNetwork {
+		t.Errorf("Category = %q, want %q", p.Category, errs.CategoryNetwork)
+	}
+	if p.Subtype != errs.SubtypeNetworkTransport {
+		t.Errorf("Subtype = %q, want %q", p.Subtype, errs.SubtypeNetworkTransport)
+	}
+	if errors.Unwrap(err) == nil {
+		t.Error("expected JSON parse cause to be preserved")
+	}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Errorf("expected JSON syntax cause, got %T", errors.Unwrap(err))
+	}
 	for _, want := range []string{
 		"HTTP 403",
 		"text/html; charset=utf-8",
 		"gateway-log-id",
 		"smaller --scope set",
 	} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error = %q, want %q", err, want)
+		if !strings.Contains(p.Message, want) {
+			t.Errorf("Message = %q, want %q", p.Message, want)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1846

## 背景
设备授权端点返回非 JSON 的 403 时，现有错误只显示状态码，无法定位网关拒绝或向维护方提供请求标识。

## 核心改动
- 在非 JSON 设备授权失败中加入 Content-Type 和 `X-Tt-Logid`。
- 对带 scope 的 HTTP 403 提示从更小 scope 集合逐项排查。
- 不记录响应体或凭据，避免泄漏敏感信息。
- 增加 HTTP 403 HTML 网关响应的回归测试。

## 验证
- `go test ./internal/auth -count=1`
- `go build -o ./lark-cli .`

## 风险与回滚
只增强非 JSON 失败信息，不改变设备授权请求、成功响应或重试逻辑。回滚本提交即可恢复原行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device authorization error handling when the server returns a non-JSON response.
  * Error details now include HTTP status, response content type, and gateway log identifier when available.
  * For `403 Forbidden` with a requested scope, added guidance to retry with a simpler/smaller scope.
* **Tests**
  * Added coverage to verify the new non-JSON/`403` error message contents and error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->