### PR TITLE
docs(wiki): clarify personal space discovery limits

### DIFF
--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 
 `wiki spaces list` 目前可能只返回 `space_type: team`，即使使用 `--as user` 也可能不列出 `person`（个人知识库）和 `my_library`（我的文档库）。这不是调用方没有权限的充分证据，也不要因为列表为空就重复翻页或改用 bot 身份。
 
-当用户需要查找个人空间中的内容时，先用 `lark-cli drive +search --query "<关键词>" --as user --format json` 定位内容；从结果读取 `origin_space_id`，再用 `lark-cli wiki +node-list --space-id "<origin_space_id>" --as user --format json` 查询节点。只有用户已经给出 Wiki URL/token 时，才优先用 `wiki spaces get_node` 解析 space_id。
+当用户已经给出 `my_library` 时，优先用 `lark-cli wiki spaces get --params '{"space_id":"my_library"}' --as user` 直接获取个人文档库。只有用户已经给出 Wiki URL/token 时，才优先用 `wiki spaces get_node` 解析 space_id。目标个人空间未知时，再用 `lark-cli drive +search --query "<关键词>" --as user --format json` 定位内容；从结果读取 `origin_space_id`，再用 `lark-cli wiki +node-list --space-id "<origin_space_id>" --as user --format json` 查询节点。
 
 ## 快速决策
 

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -22,6 +22,12 @@ metadata:
 
 知识空间和节点都是用户的个人资源，**策略上应优先显式使用 `--as user`**（CLI 的 `--as` 默认值为 `auto`，不带 `--as` 时常被解析成 `bot`，列出的是应用所属空间而非用户的）。仅当用户明确要求“应用 / bot 视角”时才用 `--as bot`（仍受上面的成员管理硬限制约束）。
 
+### 个人空间与“我的文档库”发现限制
+
+`wiki spaces list` 目前可能只返回 `space_type: team`，即使使用 `--as user` 也可能不列出 `person`（个人知识库）和 `my_library`（我的文档库）。这不是调用方没有权限的充分证据，也不要因为列表为空就重复翻页或改用 bot 身份。
+
+当用户需要查找个人空间中的内容时，先用 `lark-cli drive +search --query "<关键词>" --as user --format json` 定位内容；从结果读取 `origin_space_id`，再用 `lark-cli wiki +node-list --space-id "<origin_space_id>" --as user --format json` 查询节点。只有用户已经给出 Wiki URL/token 时，才优先用 `wiki spaces get_node` 解析 space_id。
+
 ## 快速决策
 
 - 用户要**整理 / 盘点 / 归类 / 重构知识库、个人文档库、文档库目录或 Wiki 节点结构**，或要生成整理方案、目标目录树、移动计划时，不要只使用 Wiki 节点 API。必须先阅读 [`../lark-drive/references/lark-drive-workflow.md`](../lark-drive/references/lark-drive-workflow.md)，再按其中 `Workflow Registry` 进入 [`knowledge_organize`](../lark-drive/references/lark-drive-workflow-knowledge-organize.md) workflow；该 workflow 负责 Drive / Wiki / 个人文档库的统一入口解析、资源盘点、分类计划、写前确认和结果验证。

--- a/skills/lark-wiki/references/lark-wiki-space-list.md
+++ b/skills/lark-wiki/references/lark-wiki-space-list.md
@@ -61,7 +61,7 @@ When the default single-page fetch (or `--page-all` capped by `--page-limit`) do
 ## Notes
 
 - `spaces list` cannot reliably enumerate `person` spaces or the `my_library` personal library, even with `--as user`. Do not retry pagination or switch to bot identity solely because they are absent.
-- For the known personal-library ID, resolve it directly with `lark-cli wiki spaces get --params '{"space_id":"my_library"}'`.
+- For the known personal-library ID, resolve it directly with `lark-cli wiki spaces get --params '{"space_id":"my_library"}' --as user`.
 - When the target space is unknown, search the user's Drive first: `lark-cli drive +search --query "<keyword>" --as user --format json`. Then use the matching document's `origin_space_id` with `lark-cli wiki +node-list --space-id "<origin_space_id>" --as user --format json`.
 - Use `space_id` from the output as `--space-id` for `+node-list` or `+node-copy`.
 

--- a/skills/lark-wiki/references/lark-wiki-space-list.md
+++ b/skills/lark-wiki/references/lark-wiki-space-list.md
@@ -60,7 +60,9 @@ When the default single-page fetch (or `--page-all` capped by `--page-limit`) do
 
 ## Notes
 
-- **The underlying API never returns the my_library personal library**; resolve it via `lark-cli wiki spaces get --params '{"space_id":"my_library"}'`.
+- `spaces list` cannot reliably enumerate `person` spaces or the `my_library` personal library, even with `--as user`. Do not retry pagination or switch to bot identity solely because they are absent.
+- For the known personal-library ID, resolve it directly with `lark-cli wiki spaces get --params '{"space_id":"my_library"}'`.
+- When the target space is unknown, search the user's Drive first: `lark-cli drive +search --query "<keyword>" --as user --format json`. Then use the matching document's `origin_space_id` with `lark-cli wiki +node-list --space-id "<origin_space_id>" --as user --format json`.
 - Use `space_id` from the output as `--space-id` for `+node-list` or `+node-copy`.
 
 ## Required Scope


### PR DESCRIPTION
Fixes #1773

## 背景
`wiki spaces list` 可能不返回个人知识库或“我的文档库”。将空列表当作权限缺失会导致无效翻页或错误地切换为 bot 身份。

## 核心改动
- 说明 `person` 与 `my_library` 不能可靠地通过 spaces list 枚举。
- 保留已知 `my_library` ID 的直接获取路径。
- 为未知目标补充 Drive 搜索到 `origin_space_id` 再列节点的发现流程。

## 验证
- `go test ./internal/qualitygate/rules -count=1`
- `git diff --check`

## 风险与回滚
仅补充 Skill/reference 的发现策略，不改变 CLI 命令或 API 行为。回滚本提交即可恢复原文档。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that personal spaces and the “My Document Library” may not be reliably enumerated in `space-list` results (including when using user-mode listing).
  * Updated discovery workflow for unknown personal spaces: search in Drive to find the matching document and use its `origin_space_id`, then list nodes from that space.
  * Specified that if a Wiki URL/token is provided, users should resolve the `space_id` directly first to avoid unreliable listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->