### PR TITLE
docs(auth): explain pending scope request carryover

### DIFF
--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -86,6 +86,12 @@ lark-cli auth login --scope "<missing_scope>"   # 按具体 scope 授权（推�
 
 **规则**：auth login 必须指定范围（`--domain` 或 `--scope`）。多次 login 的 scope 会累积（增量授权）。
 
+### 指定最小 scope 后页面仍出现历史权限
+
+当用户已经执行最小化的 `auth login --scope "<scope>"`，但开发者后台授权页面仍显示此前申请过的全部常用权限时，不要反复更换 `--scope` 或重复发起登录。先让应用管理员在开发者后台的权限申请/授权管理页面检查并取消、驳回或处理遗留的待审批申请；历史申请没有清理时，后台可能继续合并展示旧请求。
+
+CLI 无法代替管理员取消开发者后台的待审批 scope 申请。清理后重新执行最小 scope 登录，并用 `lark-cli auth status --verify --format json` 核对实际已授予的 scope。
+
 #### Agent 代理发起认证（推荐）
 
 当你作为 AI agent 需要帮用户完成认证时，优先使用 split-flow，避免在同一轮对话中阻塞等待用户授权：

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -90,7 +90,7 @@ lark-cli auth login --scope "<missing_scope>"   # 按具体 scope 授权（推�
 
 当用户已经执行最小化的 `auth login --scope "<scope>"`，但开发者后台授权页面仍显示此前申请过的全部常用权限时，不要反复更换 `--scope` 或重复发起登录。先让应用管理员在开发者后台的权限申请/授权管理页面检查并取消、驳回或处理遗留的待审批申请；历史申请没有清理时，后台可能继续合并展示旧请求。
 
-CLI 无法代替管理员取消开发者后台的待审批 scope 申请。清理后重新执行最小 scope 登录，并用 `lark-cli auth status --verify --format json` 核对实际已授予的 scope。
+CLI 无法代替管理员取消开发者后台的待审批 scope 申请。清理后重新执行最小 scope 登录，并用 `lark-cli auth status --verify --json` 核对实际已授予的 scope。
 
 #### Agent 代理发起认证（推荐）
 


### PR DESCRIPTION
Fixes #1493

## 背景
用户已按最小 scope 发起授权，但开发者后台仍显示历史常用权限时，重复登录不会清理后台遗留的待审批申请。

## 核心改动
- 说明后台遗留申请可能被合并展示的原因。
- 引导管理员在后台取消、驳回或处理旧申请。
- 明确 CLI 无法替代管理员清理后台申请，并要求用 auth status 验证最终 scope。

## 验证
- `go test ./internal/qualitygate/rules -count=1`
- `git diff --check`

## 风险与回滚
仅补充 Skill 运行指引，不改变 CLI 命令或 API 行为。回滚本提交即可恢复原文档。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling previously requested permissions after minimal-scope authorization.
  * Clarified not to repeatedly re-run authorization with different scopes.
  * Included steps to clear/handle pending or historical requests and verify actually granted permissions via CLI status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->