### PR TITLE
test: isolate semantic waiver fixtures from wall clock

### DIFF
--- a/internal/qualitygate/cmd/semantic-review/main_test.go
+++ b/internal/qualitygate/cmd/semantic-review/main_test.go
@@ -9,12 +9,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/larksuite/cli/internal/qualitygate/facts"
 	"github.com/larksuite/cli/internal/qualitygate/semantic"
 )
 
 func TestRunLoadsPolicyAndWaivers(t *testing.T) {
+	freezeNow(t, time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC))
+
 	repo := t.TempDir()
 	writeSemanticConfig(t, repo, `{
 	  "schema_version": 1,
@@ -65,6 +68,8 @@ func TestRunLoadsPolicyAndWaivers(t *testing.T) {
 }
 
 func TestRunLoadsWaiversFromOverrideFile(t *testing.T) {
+	freezeNow(t, time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC))
+
 	repo := t.TempDir()
 	writeSemanticConfig(t, repo, `{
 	  "schema_version": 1,
@@ -368,6 +373,13 @@ func writeSemanticConfig(t *testing.T, repo, policy, models, waivers string) {
 			t.Fatalf("write waivers: %v", err)
 		}
 	}
+}
+
+func freezeNow(t *testing.T, fixed time.Time) {
+	t.Helper()
+	original := now
+	now = func() time.Time { return fixed }
+	t.Cleanup(func() { now = original })
 }
 
 func readDecision(t *testing.T, path string) semantic.Decision {


### PR DESCRIPTION
## Summary

Remove wall-clock dependence from semantic-review waiver fixture tests. This prevents fixed waiver expiration dates from breaking repository-wide CI while preserving production expiration behavior.

## Changes

- Freeze the clock in both command-level tests that require active semantic-review waivers.
- Restore the original clock after each test with `t.Cleanup`.
- Keep production waiver parsing and expiration semantics unchanged.

## Test Plan

- [x] `go test ./internal/qualitygate/... -count=1`
- [x] `go test -race ./internal/qualitygate/semantic ./internal/qualitygate/cmd/semantic-review -count=1`
- [x] Full CI unit-test package set passes with `-race`.
- [x] Full CI coverage package set passes with `-race`.
- [x] Manual CLI flow verification is not applicable because this is a test-only change.

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using a fixed timestamp during policy and waiver validation tests.
  * Ensured test clock settings are automatically restored after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->