### PR TITLE
feat: support env credential files

### DIFF
--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -50,7 +50,7 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 		}
 	}
 	if appID == "" {
-		return nil, &credential.BlockError{Provider: "env", Reason: envvars.CliAppSecret + " is set but " + envvars.CliAppID + " is missing"}
+		return nil, &credential.BlockError{Provider: "env", Reason: envvars.CliAppSecret + " is set but " + tokenName(envvars.CliAppID, envvars.CliAppIDFile) + " is missing"}
 	}
 	if appSecret == "" && !hasUAT && !hasTAT {
 		return nil, &credential.BlockError{
@@ -151,12 +151,16 @@ func readCredentialValue(envKey, fileEnvKey string) (string, string, error) {
 	if err != nil {
 		return "", "", &credential.BlockError{Provider: "env", Reason: err.Error()}
 	}
+	info, err := vfs.Stat(safePath)
+	if err != nil {
+		return "", "", &credential.BlockError{Provider: "env", Reason: "cannot stat " + fileEnvKey + ": " + err.Error()}
+	}
+	if info.Size() > maxCredentialFileBytes {
+		return "", "", &credential.BlockError{Provider: "env", Reason: fileEnvKey + " file is too large"}
+	}
 	data, err := vfs.ReadFile(safePath)
 	if err != nil {
 		return "", "", &credential.BlockError{Provider: "env", Reason: "cannot read " + fileEnvKey + ": " + err.Error()}
-	}
-	if len(data) > maxCredentialFileBytes {
-		return "", "", &credential.BlockError{Provider: "env", Reason: fileEnvKey + " file is too large"}
 	}
 	value := strings.TrimSpace(string(data))
 	if value == "" {

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -7,11 +7,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/internal/vfs"
 )
+
+const maxCredentialFileBytes = 64 * 1024
 
 // Provider resolves credentials from environment variables.
 type Provider struct{}
@@ -19,16 +24,27 @@ type Provider struct{}
 func (p *Provider) Name() string { return "env" }
 
 func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, error) {
-	appID := os.Getenv(envvars.CliAppID)
+	appID, _, err := readCredentialValue(envvars.CliAppID, envvars.CliAppIDFile)
+	if err != nil {
+		return nil, err
+	}
 	appSecret := os.Getenv(envvars.CliAppSecret)
-	hasUAT := os.Getenv(envvars.CliUserAccessToken) != ""
-	hasTAT := os.Getenv(envvars.CliTenantAccessToken) != ""
+	uat, _, err := readCredentialValue(envvars.CliUserAccessToken, envvars.CliUserAccessTokenFile)
+	if err != nil {
+		return nil, err
+	}
+	tat, _, err := readCredentialValue(envvars.CliTenantAccessToken, envvars.CliTenantAccessTokenFile)
+	if err != nil {
+		return nil, err
+	}
+	hasUAT := uat != ""
+	hasTAT := tat != ""
 	if appID == "" && appSecret == "" {
 		switch {
 		case hasUAT:
-			return nil, &credential.BlockError{Provider: "env", Reason: envvars.CliUserAccessToken + " is set but " + envvars.CliAppID + " is missing"}
+			return nil, &credential.BlockError{Provider: "env", Reason: tokenName(envvars.CliUserAccessToken, envvars.CliUserAccessTokenFile) + " is set but " + tokenName(envvars.CliAppID, envvars.CliAppIDFile) + " is missing"}
 		case hasTAT:
-			return nil, &credential.BlockError{Provider: "env", Reason: envvars.CliTenantAccessToken + " is set but " + envvars.CliAppID + " is missing"}
+			return nil, &credential.BlockError{Provider: "env", Reason: tokenName(envvars.CliTenantAccessToken, envvars.CliTenantAccessTokenFile) + " is set but " + tokenName(envvars.CliAppID, envvars.CliAppIDFile) + " is missing"}
 		default:
 			return nil, nil
 		}
@@ -93,22 +109,65 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 }
 
 func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (*credential.Token, error) {
-	var envKey string
+	var envKey, fileEnvKey string
 	switch req.Type {
 	case credential.TokenTypeUAT:
 		envKey = envvars.CliUserAccessToken
+		fileEnvKey = envvars.CliUserAccessTokenFile
 	case credential.TokenTypeTAT:
 		envKey = envvars.CliTenantAccessToken
+		fileEnvKey = envvars.CliTenantAccessTokenFile
 	default:
 		return nil, nil
 	}
-	token := os.Getenv(envKey)
+	token, source, err := readCredentialValue(envKey, fileEnvKey)
+	if err != nil {
+		return nil, err
+	}
 	if token == "" {
 		return nil, nil
 	}
-	return &credential.Token{Value: token, Source: "env:" + envKey}, nil
+	return &credential.Token{Value: token, Source: source}, nil
 }
 
 func init() {
 	credential.Register(&Provider{})
+}
+
+func readCredentialValue(envKey, fileEnvKey string) (string, string, error) {
+	envValue := os.Getenv(envKey)
+	filePath := os.Getenv(fileEnvKey)
+	if envValue != "" && filePath != "" {
+		return "", "", &credential.BlockError{Provider: "env", Reason: "set only one of " + envKey + " or " + fileEnvKey}
+	}
+	if envValue != "" {
+		return envValue, "env:" + envKey, nil
+	}
+	if filePath == "" {
+		return "", "", nil
+	}
+
+	safePath, err := validate.SafeEnvFilePath(filePath, fileEnvKey)
+	if err != nil {
+		return "", "", &credential.BlockError{Provider: "env", Reason: err.Error()}
+	}
+	data, err := vfs.ReadFile(safePath)
+	if err != nil {
+		return "", "", &credential.BlockError{Provider: "env", Reason: "cannot read " + fileEnvKey + ": " + err.Error()}
+	}
+	if len(data) > maxCredentialFileBytes {
+		return "", "", &credential.BlockError{Provider: "env", Reason: fileEnvKey + " file is too large"}
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		return "", "", &credential.BlockError{Provider: "env", Reason: fileEnvKey + " file is empty"}
+	}
+	if strings.ContainsAny(value, "\r\n") {
+		return "", "", &credential.BlockError{Provider: "env", Reason: fileEnvKey + " file must contain exactly one credential value"}
+	}
+	return value, "file:" + fileEnvKey, nil
+}
+
+func tokenName(envKey, fileEnvKey string) string {
+	return envKey + " or " + fileEnvKey
 }

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -6,11 +6,13 @@ package env
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/envvars"
+	"github.com/larksuite/cli/internal/vfs"
 )
 
 func TestProvider_Name(t *testing.T) {
@@ -68,6 +70,31 @@ func TestResolveAccount_AppIDAndUserTokenWithoutSecret(t *testing.T) {
 	}
 }
 
+func TestResolveAccount_AppIDFileAndUserTokenFileWithoutSecret(t *testing.T) {
+	t.Setenv(envvars.CliAppIDFile, writeEnvFile(t, "app_id", "cli_file\n"))
+	t.Setenv(envvars.CliUserAccessTokenFile, writeEnvFile(t, "uat", "uat_file\n"))
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct == nil {
+		t.Fatal("expected account, got nil")
+	}
+	if acct.AppID != "cli_file" {
+		t.Fatalf("AppID = %q, want cli_file", acct.AppID)
+	}
+	if acct.AppSecret != credential.NoAppSecret {
+		t.Fatalf("AppSecret = %q, want credential.NoAppSecret", acct.AppSecret)
+	}
+	if !acct.SupportedIdentities.UserOnly() {
+		t.Fatalf("expected user-only identity support, got %d", acct.SupportedIdentities)
+	}
+	if acct.DefaultAs != "user" {
+		t.Fatalf("DefaultAs = %q, want user", acct.DefaultAs)
+	}
+}
+
 func TestResolveAccount_OnlySecretSet(t *testing.T) {
 	t.Setenv(envvars.CliAppSecret, "secret_test")
 	_, err := (&Provider{}).ResolveAccount(context.Background())
@@ -87,6 +114,33 @@ func TestResolveAccount_OnlyTokenSetWithoutAppID(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), envvars.CliAppID) {
 		t.Fatalf("error = %v, want mention of %s", err, envvars.CliAppID)
+	}
+}
+
+func TestResolveAccount_OnlyTokenFileSetWithoutAppID(t *testing.T) {
+	t.Setenv(envvars.CliUserAccessTokenFile, writeEnvFile(t, "uat", "uat_test"))
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if !strings.Contains(err.Error(), envvars.CliAppIDFile) {
+		t.Fatalf("error = %v, want mention of %s", err, envvars.CliAppIDFile)
+	}
+}
+
+func TestResolveAccount_EnvAndFileConflictRejected(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_env")
+	t.Setenv(envvars.CliAppIDFile, writeEnvFile(t, "app_id", "cli_file"))
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "set only one of "+envvars.CliAppID+" or "+envvars.CliAppIDFile) {
+		t.Fatalf("error = %v, want conflict message", err)
 	}
 }
 
@@ -124,6 +178,17 @@ func TestResolveToken_UATSet(t *testing.T) {
 	}
 }
 
+func TestResolveToken_UATFileSet(t *testing.T) {
+	t.Setenv(envvars.CliUserAccessTokenFile, writeEnvFile(t, "uat", "u-file\n"))
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "u-file" || tok.Source != "file:"+envvars.CliUserAccessTokenFile {
+		t.Errorf("unexpected: %+v", tok)
+	}
+}
+
 func TestResolveToken_TATSet(t *testing.T) {
 	t.Setenv(envvars.CliTenantAccessToken, "t-env")
 	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT})
@@ -135,10 +200,57 @@ func TestResolveToken_TATSet(t *testing.T) {
 	}
 }
 
+func TestResolveToken_TATFileSet(t *testing.T) {
+	t.Setenv(envvars.CliTenantAccessTokenFile, writeEnvFile(t, "tat", "t-file\n"))
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "t-file" || tok.Source != "file:"+envvars.CliTenantAccessTokenFile {
+		t.Errorf("unexpected: %+v", tok)
+	}
+}
+
 func TestResolveToken_NotSet(t *testing.T) {
 	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
 	if err != nil || tok != nil {
 		t.Errorf("expected nil, nil; got %+v, %v", tok, err)
+	}
+}
+
+func TestResolveToken_EmptyFileRejected(t *testing.T) {
+	t.Setenv(envvars.CliUserAccessTokenFile, writeEnvFile(t, "uat", "\n"))
+	_, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "file is empty") {
+		t.Fatalf("error = %v, want empty file message", err)
+	}
+}
+
+func TestResolveToken_MultilineFileRejected(t *testing.T) {
+	t.Setenv(envvars.CliUserAccessTokenFile, writeEnvFile(t, "uat", "one\ntwo"))
+	_, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "exactly one credential value") {
+		t.Fatalf("error = %v, want multiline file message", err)
+	}
+}
+
+func TestResolveToken_RelativeFileRejected(t *testing.T) {
+	t.Setenv(envvars.CliUserAccessTokenFile, "relative-token")
+	_, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("error = %v, want absolute path message", err)
 	}
 }
 
@@ -279,4 +391,13 @@ func TestResolveAccount_InvalidDefaultAsRejected(t *testing.T) {
 	if !strings.Contains(err.Error(), envvars.CliDefaultAs) {
 		t.Fatalf("error = %v, want mention of %s", err, envvars.CliDefaultAs)
 	}
+}
+
+func writeEnvFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := vfs.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -6,13 +6,13 @@ package env
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/envvars"
-	"github.com/larksuite/cli/internal/vfs"
 )
 
 func TestProvider_Name(t *testing.T) {
@@ -396,7 +396,7 @@ func TestResolveAccount_InvalidDefaultAsRejected(t *testing.T) {
 func writeEnvFile(t *testing.T, name, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)
-	if err := vfs.WriteFile(path, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 	return path

--- a/internal/envvars/envvars.go
+++ b/internal/envvars/envvars.go
@@ -4,13 +4,16 @@
 package envvars
 
 const (
-	CliAppID             = "LARKSUITE_CLI_APP_ID"
-	CliAppSecret         = "LARKSUITE_CLI_APP_SECRET"
-	CliBrand             = "LARKSUITE_CLI_BRAND"
-	CliUserAccessToken   = "LARKSUITE_CLI_USER_ACCESS_TOKEN"
-	CliTenantAccessToken = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN"
-	CliDefaultAs         = "LARKSUITE_CLI_DEFAULT_AS"
-	CliStrictMode        = "LARKSUITE_CLI_STRICT_MODE"
+	CliAppID                 = "LARKSUITE_CLI_APP_ID"
+	CliAppIDFile             = "LARKSUITE_CLI_APP_ID_FILE"
+	CliAppSecret             = "LARKSUITE_CLI_APP_SECRET"
+	CliBrand                 = "LARKSUITE_CLI_BRAND"
+	CliUserAccessToken       = "LARKSUITE_CLI_USER_ACCESS_TOKEN"
+	CliUserAccessTokenFile   = "LARKSUITE_CLI_USER_ACCESS_TOKEN_FILE"
+	CliTenantAccessToken     = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN"
+	CliTenantAccessTokenFile = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN_FILE"
+	CliDefaultAs             = "LARKSUITE_CLI_DEFAULT_AS"
+	CliStrictMode            = "LARKSUITE_CLI_STRICT_MODE"
 
 	// Sidecar proxy (auth proxy mode)
 	CliAuthProxy = "LARKSUITE_CLI_AUTH_PROXY" // sidecar HTTP address, e.g. "http://127.0.0.1:16384"

--- a/internal/validate/path.go
+++ b/internal/validate/path.go
@@ -23,6 +23,12 @@ func SafeEnvDirPath(path, envName string) (string, error) {
 	return localfileio.SafeEnvDirPath(path, envName)
 }
 
+// SafeEnvFilePath validates an environment-provided application file path.
+// Delegates to localfileio.SafeEnvFilePath.
+func SafeEnvFilePath(path, envName string) (string, error) {
+	return localfileio.SafeEnvFilePath(path, envName)
+}
+
 // SafeLocalFlagPath validates a flag value as a local file path.
 // Delegates to localfileio.SafeLocalFlagPath.
 func SafeLocalFlagPath(flagName, value string) (string, error) {

--- a/internal/vfs/localfileio/path.go
+++ b/internal/vfs/localfileio/path.go
@@ -54,6 +54,33 @@ func SafeEnvDirPath(path, envName string) (string, error) {
 	return resolved, nil
 }
 
+// SafeEnvFilePath validates an environment-provided file path.
+// It requires an absolute path, rejects control characters, resolves symlinks,
+// and requires the final target to be a regular file.
+func SafeEnvFilePath(path, envName string) (string, error) {
+	if err := charcheck.RejectControlChars(path, envName); err != nil {
+		return "", err
+	}
+
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("%s must be an absolute path, got %q", envName, path)
+	}
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve symlinks: %w", err)
+	}
+	info, err := vfs.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("cannot stat %q: %w", envName, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s must point to a file, got directory", envName)
+	}
+	return resolved, nil
+}
+
 // safePath is the shared implementation for SafeOutputPath and SafeInputPath.
 func safePath(raw, flagName string) (string, error) {
 	if err := charcheck.RejectControlChars(raw, flagName); err != nil {

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -175,6 +175,37 @@ func TestSafeOutputPath_DeepNonExistentPathStaysInCWD(t *testing.T) {
 	}
 }
 
+func TestSafeEnvFilePath_AllowsAbsoluteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credential")
+	if err := os.WriteFile(path, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := SafeEnvFilePath(path, "TEST_CREDENTIAL_FILE")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want, _ := filepath.EvalSymlinks(path)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSafeEnvFilePath_RejectsRelativePath(t *testing.T) {
+	_, err := SafeEnvFilePath("credential", "TEST_CREDENTIAL_FILE")
+	if err == nil {
+		t.Fatal("expected error for relative path, got nil")
+	}
+}
+
+func TestSafeEnvFilePath_RejectsDirectory(t *testing.T) {
+	_, err := SafeEnvFilePath(t.TempDir(), "TEST_CREDENTIAL_FILE")
+	if err == nil {
+		t.Fatal("expected error for directory, got nil")
+	}
+}
+
 func TestSafeUploadPath_AllowsTempFileAbsolutePath(t *testing.T) {
 	// GIVEN: a real temp file (absolute path under os.TempDir())
 	f, err := os.CreateTemp("", "upload-test-*.bin")


### PR DESCRIPTION
## Summary
Add file-backed credential inputs for the env credential provider so sandboxed agents can pass app IDs and short-lived access tokens via protected files instead of expanding token values into command-line arguments or shell environment setup scripts.

## Changes
- Add `LARKSUITE_CLI_APP_ID_FILE`, `LARKSUITE_CLI_USER_ACCESS_TOKEN_FILE`, and `LARKSUITE_CLI_TENANT_ACCESS_TOKEN_FILE`.
- Teach the env credential provider to read exactly one credential value from an absolute file path, fail closed on env/file conflicts, empty files, multiline files, or oversized files, and report token sources without exposing raw values.
- Add `SafeEnvFilePath` validation for environment-provided credential files.
- Cover file-backed app ID, UAT, TAT, conflict, empty/multiline, relative-path, and path-validation cases with focused tests.

## Test Plan
- [x] `go test ./internal/vfs/localfileio ./internal/validate ./internal/envvars ./extension/credential/env`
- [x] `git diff --check`
- [x] `gofmt` on changed Go files
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected with real file-backed credentials

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credentials can now be supplied through secure `*_FILE` environment variables, including application IDs and access tokens.
  * File-based credentials support absolute paths and canonical file resolution.
* **Bug Fixes**
  * Clear errors are provided when both direct and file-based variables are set.
  * Invalid credential files are rejected when empty, multiline, oversized, inaccessible, relative, or pointing to directories.
* **Tests**
  * Added coverage for file-based account and token resolution and path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->