### PR TITLE
fix: recognize URL schemes case-insensitively

### DIFF
--- a/internal/validate/path_test.go
+++ b/internal/validate/path_test.go
@@ -189,6 +189,8 @@ func TestSafeLocalFlagPath(t *testing.T) {
 		{"empty value passes through", "--image", "", "", ""},
 		{"http URL passes through", "--image", "http://example.com/a.jpg", "http://example.com/a.jpg", ""},
 		{"https URL passes through", "--image", "https://example.com/a.jpg", "https://example.com/a.jpg", ""},
+		{"uppercase HTTP URL passes through", "--image", "HTTP://example.com/a.jpg", "HTTP://example.com/a.jpg", ""},
+		{"mixed-case HTTPS URL passes through", "--image", "HtTpS://example.com/a.jpg", "HtTpS://example.com/a.jpg", ""},
 		{"relative path accepted, returned unchanged", "--file", "photo.jpg", "photo.jpg", ""},
 		{"path traversal rejected", "--file", "../escape.txt", "", "--file"},
 		{"absolute path rejected", "--image", "/etc/passwd", "", "--image"},

--- a/internal/vfs/localfileio/path.go
+++ b/internal/vfs/localfileio/path.go
@@ -25,7 +25,8 @@ func SafeInputPath(path string) (string, error) {
 // SafeLocalFlagPath validates a flag value as a local file path.
 // Empty values and http/https URLs are returned unchanged without validation.
 func SafeLocalFlagPath(flagName, value string) (string, error) {
-	if value == "" || strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+	lowerValue := strings.ToLower(value)
+	if value == "" || strings.HasPrefix(lowerValue, "http://") || strings.HasPrefix(lowerValue, "https://") {
 		return value, nil
 	}
 	if _, err := SafeInputPath(value); err != nil {


### PR DESCRIPTION
## Summary

`SafeLocalFlagPath` only recognized lowercase HTTP/HTTPS prefixes even though URL schemes are case-insensitive. Valid inputs such as `HTTPS://example.com/image.png` therefore fell through to local path validation and could be treated as filesystem paths.

## Changes

- Recognize HTTP and HTTPS prefixes case-insensitively while returning the original URL unchanged.
- Add regression cases for uppercase and mixed-case schemes.

## Test Plan

- [x] `go test -race -count=1 ./internal/validate ./internal/vfs/localfileio`
- [x] `go vet ./...`
- [x] `gofmt -l .` produced no output
- [x] `go mod tidy` produced no dependency changes
- [x] `golangci-lint v2.1.6 run --new-from-rev=upstream/main` reported 0 issues
- [ ] `make unit-test` could not pass its pre-test metadata fetch because the local Python trust store rejected a self-signed certificate in the chain. Running the equivalent full package set with the installed Go 1.26.1 toolchain also exposed unrelated environment failures (missing fetched metadata, sandboxed local listeners, and `-race -gcflags="all=-N -l"` runtime crashes); the affected target packages pass with `-race`.

## Related Issues

- None
