### PR TITLE
test(suggest): add edge-case tests for Levenshtein and Closest

### DIFF
--- a/internal/suggest/suggest_test.go
+++ b/internal/suggest/suggest_test.go
@@ -54,13 +54,21 @@ func TestLevenshtein(t *testing.T) {
 		{"kitten", "sitting", 3},
 		{"cell-get", "cells-get", 1},
 		{"--query", "--find", 5},
-		{"飞书", "飞书", 0}, // rune-aware: multi-byte equal
-		{"飞书", "飞s", 1}, // one rune substitution, not byte count
+		{"飞书", "飞书", 0},   // rune-aware: multi-byte equal
+		{"飞书", "飞s", 1},   // one rune substitution, not byte count
+		{"abc", "ABC", 3}, // case-sensitive: ASCII bytes differ
+		{"abc", "acb", 2}, // classic Levenshtein, no transposition
 	}
 	for _, c := range cases {
 		if d := Levenshtein(c.a, c.b); d != c.want {
 			t.Errorf("Levenshtein(%q,%q) = %d, want %d", c.a, c.b, d, c.want)
 		}
+	}
+}
+
+func TestClosest_EmptyCandidates(t *testing.T) {
+	if got := Closest("+cells-get", nil, 3); len(got) != 0 {
+		t.Errorf("expected no suggestions for empty candidate list, got %v", got)
 	}
 }
 


### PR DESCRIPTION
Adds focused regression tests for `internal/suggest`, the shared "did you mean" primitives used by `cmd/event` and `internal/cmdpolicy`.

**Problem**
The `Levenshtein` distance has two contract properties that the existing tests do not pin, even though callers depend on them:
- It is **case-sensitive** (`Levenshtein("abc", "ABC") == 3`).
- It is the **classic (non-Damerau) distance** with no transposition (`Levenshtein("abc", "acb") == 2`, not `1`).

An accidental case-insensitive or Damerau refactor would silently change suggestion output and not be caught by the current suite.

**Change**
- Two table cases on `TestLevenshtein` documenting the two contracts above.
- `TestClosest_EmptyCandidates` covering the empty candidate-list path (returns no suggestions).

No production code changes.

**Validation**
- `gofmt -d` clean, `go vet ./internal/suggest/` clean.
- `go test ./internal/suggest/` passes (all existing + new cases).