### PR TITLE
fix(im): make flag list page-all exhaustive

### DIFF
--- a/shortcuts/im/im_flag_list.go
+++ b/shortcuts/im/im_flag_list.go
@@ -224,9 +224,6 @@ func asString(v any) string {
 // contains the newest items.
 func executeListAllPages(rt *common.RuntimeContext) error {
 	maxPages := rt.Int("page-limit")
-	if maxPages > 1000 {
-		maxPages = 1000
-	}
 
 	// Use make([]any, 0) to ensure empty arrays serialize as [] not null
 	allFlagItems := make([]any, 0)

--- a/shortcuts/im/im_flag_list.go
+++ b/shortcuts/im/im_flag_list.go
@@ -28,7 +28,7 @@ var ImFlagList = common.Shortcut{
 		{Name: "page-size", Type: "int", Default: "50", Desc: "page size (1-50)"},
 		{Name: "page-token", Desc: "pagination token for next page"},
 		{Name: "page-all", Type: "bool", Desc: "automatically paginate through all pages"},
-		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages when auto-pagination is enabled (default 20, max 1000)"},
+		{Name: "page-limit", Type: "int", Default: "0", Desc: "max pages when auto-pagination is enabled (0 = unlimited, max 1000)"},
 		{Name: "enrich-feed-thread", Type: "bool", Default: "true", Desc: "fetch message content for feed-type thread entries (default true; may call messages/mget and require im:message.group_msg:get_as_user/im:message.p2p_msg:get_as_user; use --enrich-feed-thread=false to avoid extra scopes)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
@@ -74,8 +74,8 @@ func validateListOptions(rt *common.RuntimeContext) error {
 	if n := rt.Int("page-size"); n < 1 || n > 50 {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-size must be an integer between 1 and 50").WithParam("--page-size")
 	}
-	if n := rt.Int("page-limit"); n < 1 || n > 1000 {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-limit must be an integer between 1 and 1000").WithParam("--page-limit")
+	if n := rt.Int("page-limit"); n < 0 || n > 1000 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-limit must be an integer between 0 and 1000 (0 = unlimited)").WithParam("--page-limit")
 	}
 	return nil
 }
@@ -224,9 +224,6 @@ func asString(v any) string {
 // contains the newest items.
 func executeListAllPages(rt *common.RuntimeContext) error {
 	maxPages := rt.Int("page-limit")
-	if maxPages < 1 {
-		maxPages = 20
-	}
 	if maxPages > 1000 {
 		maxPages = 1000
 	}
@@ -239,7 +236,7 @@ func executeListAllPages(rt *common.RuntimeContext) error {
 	var lastPageToken string
 	prevPageToken := "__START__" // Sentinel to detect unchanged token
 
-	for page := 0; page < maxPages; page++ {
+	for page := 0; maxPages == 0 || page < maxPages; page++ {
 		token := ""
 		if page > 0 {
 			token = lastPageToken
@@ -287,6 +284,12 @@ func executeListAllPages(rt *common.RuntimeContext) error {
 		"messages":          allMessages,
 		"has_more":          lastHasMore,
 		"page_token":        lastPageToken,
+	}
+	if lastHasMore {
+		merged["truncated"] = true
+		if maxPages > 0 {
+			fmt.Fprintf(rt.IO().ErrOut, "warning: page limit (%d) reached before all flags were fetched; result has truncated=true, resume with --page-token or use --page-limit 0\n", maxPages)
+		}
 	}
 
 	if rt.Bool("enrich-feed-thread") {

--- a/shortcuts/im/im_flag_test.go
+++ b/shortcuts/im/im_flag_test.go
@@ -949,7 +949,7 @@ func TestFlagListRejectsInvalidPageLimit(t *testing.T) {
 	if err := cmd.ParseFlags(nil); err != nil {
 		t.Fatalf("ParseFlags() error = %v", err)
 	}
-	if err := cmd.Flags().Set("page-limit", "0"); err != nil {
+	if err := cmd.Flags().Set("page-limit", "-1"); err != nil {
 		t.Fatalf("Set page-limit error = %v", err)
 	}
 	runtime := &common.RuntimeContext{Cmd: cmd}
@@ -964,6 +964,22 @@ func TestFlagListRejectsInvalidPageLimit(t *testing.T) {
 	}
 	if strings.Contains(got, "/open-apis/im/v1/flags") {
 		t.Fatalf("DryRun output = %q, should not include request for invalid input", got)
+	}
+}
+
+func TestFlagListAcceptsUnlimitedPageLimit(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Int("page-size", 50, "")
+	cmd.Flags().String("page-token", "", "")
+	cmd.Flags().Bool("page-all", false, "")
+	cmd.Flags().Int("page-limit", 0, "")
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	runtime := &common.RuntimeContext{Cmd: cmd}
+
+	if err := ImFlagList.Validate(context.Background(), runtime); err != nil {
+		t.Fatalf("Validate() rejected unlimited --page-limit 0: %v", err)
 	}
 }
 
@@ -1538,6 +1554,43 @@ func TestExecuteListAllPages(t *testing.T) {
 	}
 }
 
+func TestExecuteListAllPages_Unlimited(t *testing.T) {
+	callCount := 0
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.Contains(req.URL.Path, "/open-apis/im/v1/flags") {
+			callCount++
+			hasMore := callCount < 21
+			return shortcutJSONResponse(200, map[string]any{
+				"code": 0,
+				"data": map[string]any{
+					"flag_items":        []any{},
+					"delete_flag_items": []any{},
+					"messages":          []any{},
+					"has_more":          hasMore,
+					"page_token":        fmt.Sprintf("token_%d", callCount),
+				},
+			}), nil
+		}
+		return nil, fmt.Errorf("unexpected request: %s", req.URL.Path)
+	}))
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Int("page-size", 50, "")
+	cmd.Flags().Int("page-limit", 0, "")
+	cmd.Flags().Bool("enrich-feed-thread", false, "")
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	setRuntimeField(t, rt, "Cmd", cmd)
+
+	if err := executeListAllPages(rt); err != nil {
+		t.Fatalf("executeListAllPages() error = %v", err)
+	}
+	if callCount != 21 {
+		t.Fatalf("unlimited pagination stopped after %d calls, want 21", callCount)
+	}
+}
+
 func TestExecuteListAllPages_EnrichFeedThread(t *testing.T) {
 	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if strings.Contains(req.URL.Path, "/open-apis/im/v1/flags") {
@@ -1624,6 +1677,18 @@ func TestExecuteListAllPages_PageLimit(t *testing.T) {
 	// Should stop at page-limit
 	if callCount != 3 {
 		t.Fatalf("expected 3 API calls (page limit), got %d", callCount)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(rt.IO().Out.(*bytes.Buffer).Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	data, _ := envelope["data"].(map[string]any)
+	if truncated, _ := data["truncated"].(bool); !truncated {
+		t.Fatalf("limited result must report truncated=true, got %#v", data)
+	}
+	if stderr := rt.IO().ErrOut.(*bytes.Buffer).String(); !strings.Contains(stderr, "page limit") {
+		t.Fatalf("limited result must warn about the page limit, got %q", stderr)
 	}
 }
 

--- a/skills/lark-im/references/lark-im-flag-list.md
+++ b/skills/lark-im/references/lark-im-flag-list.md
@@ -31,7 +31,7 @@ lark-cli im +flag-list --as user --page-all -q '.data.flag_items[].item_id'
 # Disable auto-enrichment of message content (enabled by default)
 lark-cli im +flag-list --as user --page-all --enrich-feed-thread=false
 
-# Limit max pages (default 20, max 1000)
+# Limit max pages (0 is the default and means unlimited; max 1000)
 lark-cli im +flag-list --as user --page-all --page-limit 10
 ```
 
@@ -42,7 +42,7 @@ lark-cli im +flag-list --as user --page-all --page-limit 10
 | `--page-size <n>` | 50 | Range 1-50 (server max is 50) |
 | `--page-token <token>` | empty | Pagination token from previous page; empty string must still be provided |
 | `--page-all` | false | Auto-paginate to fetch all pages and merge results |
-| `--page-limit <n>` | 20 | Max pages in `--page-all` mode (max 1000) |
+| `--page-limit <n>` | 0 | Max pages in `--page-all` mode (`0` = unlimited, max 1000). If a positive limit stops pagination early, the result includes `truncated: true` |
 | `--enrich-feed-thread` | true | Auto-enrich feed-layer thread entries with message content (calls `im.messages.mget`) |
 | `--as user` | Required | Currently only supports user identity |
 
@@ -57,6 +57,7 @@ The response has `data` as the main body, with fields described below:
 | `messages` | array | Message content inlined by the server for `(default, message)` type flags |
 | `has_more` | boolean | Whether there's a next page |
 | `page_token` | string | Pagination token for the next page |
+| `truncated` | boolean | Present and `true` only when pagination stopped before all pages were fetched |
 
 Note: `(thread, feed)` / `(msg_thread, feed)` entries are automatically enriched via `mget` by the shortcut, and written to the corresponding entry's `message` field.
 

--- a/tests/cli_e2e/im/flag_workflow_test.go
+++ b/tests/cli_e2e/im/flag_workflow_test.go
@@ -302,4 +302,20 @@ func TestIM_FlagDryRun(t *testing.T) {
 		require.Contains(t, result.Stdout, "/open-apis/im/v1/flags")
 		require.Contains(t, result.Stdout, "page_size")
 	})
+
+	t.Run("list flag dry-run accepts unlimited pagination", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-list",
+				"--page-all",
+				"--page-limit", "0",
+				"--dry-run",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+		require.Contains(t, result.Stdout, "/open-apis/im/v1/flags")
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #1859. `im +flag-list --page-all` now exhausts all pages by default instead of silently stopping after 20, so agents do not treat a partial count of zero as the real flagged count.

## Changes

- Make `--page-limit 0` the default and define it as unlimited pagination.
- Keep explicit positive page limits, but mark early results with `truncated: true` and emit a stderr warning.
- Add a 21-page regression test that fails under the old hidden 20-page cap.
- Cover validation, limited-result signaling, CLI dry-run, and user-facing documentation.

## Test Plan

- [x] `GOTOOLCHAIN=go1.23.0 go test ./shortcuts/im -count=1`
- [x] `LARK_CLI_BIN=<absolute-built-binary> GOTOOLCHAIN=go1.23.0 go test ./tests/cli_e2e/im -run TestIM_FlagDryRun -count=1`
- [x] `GOTOOLCHAIN=go1.23.0 go vet ./...`
- [x] `GOTOOLCHAIN=go1.23.0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main` (0 issues)
- [x] `gofmt -l .` (no output)
- [x] `GOTOOLCHAIN=go1.23.0 go mod tidy` (no diff)

`GOTOOLCHAIN=go1.23.0 make unit-test` passed all changed and related packages, including `shortcuts/im`. On this machine, the unrelated `shortcuts/minutes` download tests fail because the environment resolves/blocks `example.com` as a local/internal host; no minutes code is changed by this PR.

## Related Issues

- Fixes #1859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `im +flag-list --page-all --page-limit 0` now enables unlimited pagination, and `--page-limit` now defaults to `0` (max `1000`).
  - When pagination ends early, results include `truncated: true`.
  - Pagination warnings are shown only when `--page-limit` is set to a value greater than `0`.
- **Documentation**
  - Updated command reference to reflect the new unlimited default and the `truncated` response field behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->