### PR TITLE
fix(im): +flag-list --page-all no longer silently truncates at default page-limit

### DIFF
--- a/shortcuts/im/im_flag_list.go
+++ b/shortcuts/im/im_flag_list.go
@@ -28,7 +28,7 @@ var ImFlagList = common.Shortcut{
 		{Name: "page-size", Type: "int", Default: "50", Desc: "page size (1-50)"},
 		{Name: "page-token", Desc: "pagination token for next page"},
 		{Name: "page-all", Type: "bool", Desc: "automatically paginate through all pages"},
-		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages when auto-pagination is enabled (default 20, max 1000)"},
+		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages when auto-pagination is enabled (default 20, max 1000; 0 = unlimited)"},
 		{Name: "enrich-feed-thread", Type: "bool", Default: "true", Desc: "fetch message content for feed-type thread entries (default true; may call messages/mget and require im:message.group_msg:get_as_user/im:message.p2p_msg:get_as_user; use --enrich-feed-thread=false to avoid extra scopes)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
@@ -74,8 +74,8 @@ func validateListOptions(rt *common.RuntimeContext) error {
 	if n := rt.Int("page-size"); n < 1 || n > 50 {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-size must be an integer between 1 and 50").WithParam("--page-size")
 	}
-	if n := rt.Int("page-limit"); n < 1 || n > 1000 {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-limit must be an integer between 1 and 1000").WithParam("--page-limit")
+	if n := rt.Int("page-limit"); n < 0 || n > 1000 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-limit must be an integer between 0 and 1000 (0 = unlimited)").WithParam("--page-limit")
 	}
 	return nil
 }
@@ -223,10 +223,9 @@ func asString(v any) string {
 // The flag list API returns items sorted by update_time ascending, so the last page
 // contains the newest items.
 func executeListAllPages(rt *common.RuntimeContext) error {
+	// page-limit 0 means unlimited (aligns with im +chat-members-list / +messages-search).
+	// Validation already guarantees 0 <= page-limit <= 1000, so we only clamp the upper bound.
 	maxPages := rt.Int("page-limit")
-	if maxPages < 1 {
-		maxPages = 20
-	}
 	if maxPages > 1000 {
 		maxPages = 1000
 	}
@@ -239,7 +238,7 @@ func executeListAllPages(rt *common.RuntimeContext) error {
 	var lastPageToken string
 	prevPageToken := "__START__" // Sentinel to detect unchanged token
 
-	for page := 0; page < maxPages; page++ {
+	for page := 0; ; page++ {
 		token := ""
 		if page > 0 {
 			token = lastPageToken
@@ -276,6 +275,14 @@ func executeListAllPages(rt *common.RuntimeContext) error {
 		// Detect server anomaly: same token returned twice means infinite loop
 		if lastPageToken == prevPageToken {
 			fmt.Fprintf(rt.IO().ErrOut, "warning: page_token did not change, stopping pagination to avoid infinite loop\n")
+			break
+		}
+		// Stop when the page limit is reached while the server still has more.
+		// Surface it so callers don't read a truncated flag_items as "no flags".
+		// maxPages == 0 means unlimited. (aligns with im +chat-members-list)
+		if maxPages > 0 && page+1 >= maxPages {
+			fmt.Fprintf(rt.IO().ErrOut,
+				"[pagination] reached page limit (%d), stopping. Use --page-all --page-limit 0 to fetch all pages.\n", maxPages)
 			break
 		}
 		prevPageToken = lastPageToken

--- a/shortcuts/im/im_flag_test.go
+++ b/shortcuts/im/im_flag_test.go
@@ -941,29 +941,49 @@ func TestListQuery(t *testing.T) {
 }
 
 func TestFlagListRejectsInvalidPageLimit(t *testing.T) {
-	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().Int("page-size", 50, "")
-	cmd.Flags().String("page-token", "", "")
-	cmd.Flags().Bool("page-all", false, "")
-	cmd.Flags().Int("page-limit", 20, "")
-	if err := cmd.ParseFlags(nil); err != nil {
-		t.Fatalf("ParseFlags() error = %v", err)
+	// page-limit 0 means "unlimited" and must pass validation; negatives and
+	// values above 1000 must still be rejected.
+	newRuntime := func(t *testing.T, pageLimit string) *common.RuntimeContext {
+		t.Helper()
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().Int("page-size", 50, "")
+		cmd.Flags().String("page-token", "", "")
+		cmd.Flags().Bool("page-all", false, "")
+		cmd.Flags().Int("page-limit", 20, "")
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatalf("ParseFlags() error = %v", err)
+		}
+		if err := cmd.Flags().Set("page-limit", pageLimit); err != nil {
+			t.Fatalf("Set page-limit error = %v", err)
+		}
+		return &common.RuntimeContext{Cmd: cmd}
 	}
-	if err := cmd.Flags().Set("page-limit", "0"); err != nil {
-		t.Fatalf("Set page-limit error = %v", err)
-	}
-	runtime := &common.RuntimeContext{Cmd: cmd}
 
-	if err := ImFlagList.Validate(context.Background(), runtime); err == nil {
-		t.Fatalf("Validate() expected page-limit error, got nil")
-	}
+	t.Run("zero is accepted (unlimited)", func(t *testing.T) {
+		runtime := newRuntime(t, "0")
+		if err := ImFlagList.Validate(context.Background(), runtime); err != nil {
+			t.Fatalf("Validate() page-limit=0 error = %v, want nil", err)
+		}
+		got := ImFlagList.DryRun(context.Background(), runtime).Format()
+		if !strings.Contains(got, "/open-apis/im/v1/flags") {
+			t.Fatalf("DryRun output = %q, want request for valid input", got)
+		}
+	})
 
-	got := ImFlagList.DryRun(context.Background(), runtime).Format()
-	if !strings.Contains(got, "--page-limit") {
-		t.Fatalf("DryRun output = %q, want page-limit validation error", got)
-	}
-	if strings.Contains(got, "/open-apis/im/v1/flags") {
-		t.Fatalf("DryRun output = %q, should not include request for invalid input", got)
+	for _, bad := range []string{"-1", "1001"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			runtime := newRuntime(t, bad)
+			if err := ImFlagList.Validate(context.Background(), runtime); err == nil {
+				t.Fatalf("Validate() page-limit=%s expected error, got nil", bad)
+			}
+			got := ImFlagList.DryRun(context.Background(), runtime).Format()
+			if !strings.Contains(got, "--page-limit") {
+				t.Fatalf("DryRun output = %q, want page-limit validation error", got)
+			}
+			if strings.Contains(got, "/open-apis/im/v1/flags") {
+				t.Fatalf("DryRun output = %q, should not include request for invalid input", got)
+			}
+		})
 	}
 }
 
@@ -1624,6 +1644,66 @@ func TestExecuteListAllPages_PageLimit(t *testing.T) {
 	// Should stop at page-limit
 	if callCount != 3 {
 		t.Fatalf("expected 3 API calls (page limit), got %d", callCount)
+	}
+	// Stopping because of the page limit (while has_more is still true) must be
+	// surfaced on stderr, otherwise a truncated flag_items reads as "no flags".
+	errOut := rt.Factory.IOStreams.ErrOut.(*bytes.Buffer).String()
+	if !strings.Contains(errOut, "reached page limit (3)") {
+		t.Fatalf("stderr = %q, want truncation warning mentioning the page limit", errOut)
+	}
+}
+
+func TestExecuteListAllPages_Unlimited(t *testing.T) {
+	// page-limit 0 means unlimited: pagination must continue until the server
+	// reports has_more=false, even past the old default cap of 20 pages.
+	const totalPages = 25
+	callCount := 0
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.Contains(req.URL.Path, "/open-apis/im/v1/flags") {
+			callCount++
+			last := callCount >= totalPages
+			flagItems := []any{}
+			if last {
+				// The single active flag lives on the final page, mirroring the
+				// real-world ordering where active flags trail canceled ones.
+				flagItems = []any{map[string]any{"item_id": "flag_last"}}
+			}
+			return shortcutJSONResponse(200, map[string]any{
+				"code": 0,
+				"data": map[string]any{
+					"flag_items":        flagItems,
+					"delete_flag_items": []any{},
+					"messages":          []any{},
+					"has_more":          !last,
+					"page_token":        fmt.Sprintf("token_%d", callCount),
+				},
+			}), nil
+		}
+		return nil, fmt.Errorf("unexpected request: %s", req.URL.Path)
+	}))
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Int("page-size", 50, "")
+	cmd.Flags().Int("page-limit", 0, "") // 0 = unlimited
+	cmd.Flags().Bool("enrich-feed-thread", false, "")
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	setRuntimeField(t, rt, "Cmd", cmd)
+
+	err := executeListAllPages(rt)
+	if err != nil {
+		t.Fatalf("executeListAllPages() error = %v", err)
+	}
+	// Must scan every page, not stop at the old default of 20.
+	if callCount != totalPages {
+		t.Fatalf("expected %d API calls (unlimited), got %d", totalPages, callCount)
+	}
+	// Naturally exhausting the server (has_more=false) must NOT print the
+	// page-limit truncation warning.
+	errOut := rt.Factory.IOStreams.ErrOut.(*bytes.Buffer).String()
+	if strings.Contains(errOut, "reached page limit") {
+		t.Fatalf("stderr = %q, unexpected truncation warning for unlimited scan", errOut)
 	}
 }
 


### PR DESCRIPTION
## Summary

`im +flag-list --page-all` was still capped by the default `--page-limit` of 20 and stopped there without any signal, even when `has_more` was true. Because the server returns canceled flags before active ones, active flags often live past page 20, so callers saw `flag_items: []` and read it as "no flags" — misleading for both humans and AI agents. This aligns `+flag-list` with the pagination contract already used by `im +chat-members-list` and `im +messages-search`.

## Changes

- Allow `--page-limit 0` to mean **unlimited** (validation now accepts `0`–`1000`; `0` was previously rejected).
- When the page limit is reached while more pages remain, emit a stderr warning pointing to `--page-all --page-limit 0`, instead of stopping silently.
- Update the flag description to document `0 = unlimited`.
- Default behavior is unchanged (still 20 pages) — this only makes truncation visible and adds an unlimited escape hatch.

## Test Plan

- [x] Unit tests pass (`go test -race ./shortcuts/im/...`)
- [x] Manual local verification confirms the `lark-cli im +flag-list` flow works as expected
  - `--page-limit -1` / `1001` → typed validation error
  - `--page-limit 0` → passes validation, dry-run shows the request
- [x] `go vet`, `gofmt -l`, and `golangci-lint run --new-from-rev=origin/main` (0 issues) all pass

New/updated tests pin the reversed validation contract (`0` accepted, `-1`/`1001` rejected), assert the truncation warning is emitted, and verify an unlimited scan reaches every page without falsely warning.

## Related Issues

- Closes #1859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unlimited pagination support for the `+flag-list` shortcut by setting `--page-limit=0`.
  * Updated the flag description and validation guidance to clarify unlimited mode.

* **Bug Fixes**
  * Flag listing now clearly reports when the configured page limit is reached while more results are available.
  * Invalid page-limit values continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->