### PR TITLE
fix: honor requiredScopes conjunction in CollectScopesForProjects

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -536,6 +536,43 @@ func TestCollectScopesForProjects_NonexistentProject(t *testing.T) {
 	}
 }
 
+// TestCollectScopesForProjects_HonorsRequiredScopes verifies that a method's
+// full requiredScopes conjunction is collected, not just the umbrella scope.
+// The mail message get/batch_get APIs declare requiredScopes =
+// [readonly, subject:read, address:read, body:read]; the conjunction must be
+// collected together — the umbrella readonly scope alone does not cover
+// subject/address/body.
+func TestCollectScopesForProjects_HonorsRequiredScopes(t *testing.T) {
+	hasMail := false
+	for _, p := range ListFromMetaProjects() {
+		if p == "mail" {
+			hasMail = true
+			break
+		}
+	}
+	if !hasMail {
+		t.Skip("mail domain not present in meta catalog")
+	}
+
+	scopes := CollectScopesForProjects([]string{"mail"}, "user")
+	for _, want := range []string{
+		"mail:user_mailbox.message.subject:read",
+		"mail:user_mailbox.message.address:read",
+		"mail:user_mailbox.message.body:read",
+	} {
+		found := false
+		for _, s := range scopes {
+			if s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected requiredScope %q in collected scopes, got %v", want, scopes)
+		}
+	}
+}
+
 // --- auth_domain functions ---
 
 func TestGetAuthDomain_Configured(t *testing.T) {

--- a/internal/registry/scopes.go
+++ b/internal/registry/scopes.go
@@ -153,15 +153,17 @@ func CollectAllScopesFromMeta(identity string) []string {
 	return result
 }
 
-// CollectScopesForProjects collects the recommended scope for each API method
-// in the specified from_meta projects. For each method, only the scope with
-// the highest priority score is selected.
+// CollectScopesForProjects collects the effective scopes for each API method in
+// the specified from_meta projects. It uses DeclaredScopesForMethod so a
+// method's full requiredScopes conjunction is honored (e.g. reading a mail
+// message needs the subject/address/body scopes together, not just the umbrella
+// readonly scope), falling back to the single recommended scope when a method
+// declares no requiredScopes.
 func CollectScopesForProjects(projects []string, identity string) []string {
-	priorities := LoadScopePriorities()
 	scopeSet := make(map[string]bool)
 	for _, ref := range methodsForProjects(projects, identity) {
-		if best := bestScope(ref.Method.Scopes, priorities); best != "" {
-			scopeSet[best] = true
+		for _, s := range DeclaredScopesForMethod(ref.Method, identity) {
+			scopeSet[s] = true
 		}
 	}
 


### PR DESCRIPTION
## Summary
`CollectScopesForProjects` collected only the single highest-priority scope (`bestScope`) per API method, dropping the rest of a method's `requiredScopes` conjunction, and diverging from `CollectCommandScopes`, which already resolves scopes via `DeclaredScopesForMethod`.

This is a **latent** defect, not an active user-visible failure. In the current runtime catalog only the mail message `get` / `batch_get` methods declare `requiredScopes` (`readonly` + `subject:read` + `address:read` + `body:read`). On the single production path that calls `CollectScopesForProjects` — `auth login`'s domain→scope resolution — the result is unioned with the mail read shortcuts' scopes (`mail +message`, `+messages`, `+thread`, …), which declare the same `subject/address/body:read` set, so today the requested scope set is identical with or without this fix. But `requiredScopes` is server-side meta that takes effect without a CLI release: the moment a method with no shortcut coverage gains `requiredScopes`, the under-collection becomes user-visible. This change makes the correct behavior a property of the code rather than a coincidence of the current shortcut declarations.

## Changes
- `CollectScopesForProjects` now resolves scopes via `DeclaredScopesForMethod` (the single policy source): it returns a method's full `requiredScopes` set when declared, and otherwise falls back to the recommended single scope. For methods that declare no `requiredScopes` the fallback is the same `bestScope` / `LoadScopePriorities` path as before, so the output is byte-identical — the behavior change is strictly limited to methods that declare `requiredScopes`.
- Impact is bounded: only two methods in the current production meta declare `requiredScopes`, so a collected set grows by at most three scopes. `LoadScopePriorities` is package-cached, so resolving per method inside the loop adds no performance regression.

## Test Plan
- [x] `go test ./internal/registry/...` passes
- [x] Added `TestCollectScopesForProjects_HonorsRequiredScopes`, which asserts the mail message required scopes are collected (runs in CI, not skipped) and pins the `requiredScopes`-conjunction contract

## Related Issues
- None
