### PR TITLE
Document mail sender allow/block commands

### DIFF
--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -5,6 +5,7 @@ package schema
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -44,6 +45,36 @@ func TestSchemaCmd_NoArgs(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Available services") {
 		t.Error("expected service list output")
+	}
+}
+
+func TestSchemaCmd_MailSenderAllowBlockList(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+
+	cmd := NewCmdSchema(f, nil)
+	cmd.SetArgs([]string{"mail.user_mailbox.allow_senders.list"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var env map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if env["id"] != "user_mailbox.allow_sender.list" {
+		t.Fatalf("id = %v, want user_mailbox.allow_sender.list", env["id"])
+	}
+	if env["path"] != "user_mailboxes/{user_mailbox_id}/allow_senders" {
+		t.Fatalf("path = %v, want user_mailboxes/{user_mailbox_id}/allow_senders", env["path"])
+	}
+	params, _ := env["parameters"].(map[string]interface{})
+	for _, key := range []string{"user_mailbox_id", "keyword", "page_size", "page_token"} {
+		if _, ok := params[key]; !ok {
+			t.Fatalf("parameters.%s missing in %s", key, stdout.String())
+		}
+	}
+	requiredScopes, _ := env["requiredScopes"].([]interface{})
+	if len(requiredScopes) != 1 || requiredScopes[0] != "mail:user_mailbox.message:readonly" {
+		t.Fatalf("requiredScopes = %v, want [mail:user_mailbox.message:readonly]", env["requiredScopes"])
 	}
 }
 

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -6,12 +6,79 @@ package schema
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 )
+
+var schemaTestConfigDir string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "larksuite-cli-schema-test-*")
+	if err != nil {
+		panic(err)
+	}
+	schemaTestConfigDir = dir
+	cacheDir := filepath.Join(dir, "cache")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		panic(err)
+	}
+	remoteMeta := map[string]interface{}{
+		"version": "schema-test",
+		"services": []map[string]interface{}{
+			{
+				"name":        "mail",
+				"version":     "v1",
+				"servicePath": "/open-apis/mail/v1",
+				"resources": map[string]interface{}{
+					"user_mailbox.allow_senders": map[string]interface{}{
+						"methods": map[string]interface{}{
+							"list": map[string]interface{}{
+								"id":         "user_mailbox.allow_senders.list",
+								"path":       "user_mailboxes/{user_mailbox_id}/allow_senders",
+								"httpMethod": "GET",
+								"parameters": map[string]interface{}{
+									"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+									"keyword":         map[string]interface{}{"type": "string", "location": "query"},
+									"page_size":       map[string]interface{}{"type": "integer", "location": "query"},
+									"page_token":      map[string]interface{}{"type": "string", "location": "query"},
+								},
+								"requiredScopes": []interface{}{"mail:user_mailbox.message:readonly"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	meta := map[string]interface{}{
+		"last_check_at": time.Now().Unix(),
+		"version":       "schema-test",
+		"brand":         "feishu",
+	}
+	writeJSON := func(path string, value interface{}) {
+		data, err := json.Marshal(value)
+		if err != nil {
+			panic(err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			panic(err)
+		}
+	}
+	writeJSON(filepath.Join(cacheDir, "remote_meta.json"), remoteMeta)
+	writeJSON(filepath.Join(cacheDir, "remote_meta.meta.json"), meta)
+	os.Setenv("LARKSUITE_CLI_CONFIG_DIR", dir)
+	os.Setenv("LARKSUITE_CLI_REMOTE_META", "on")
+	os.Setenv("LARKSUITE_CLI_META_TTL", "3600")
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 func TestSchemaCmd_FlagParsing(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, nil)
@@ -49,6 +116,7 @@ func TestSchemaCmd_NoArgs(t *testing.T) {
 }
 
 func TestSchemaCmd_MailSenderAllowBlockList(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", schemaTestConfigDir)
 	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
 
 	cmd := NewCmdSchema(f, nil)
@@ -60,8 +128,8 @@ func TestSchemaCmd_MailSenderAllowBlockList(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
 		t.Fatalf("not valid JSON: %v\n%s", err, stdout.String())
 	}
-	if env["id"] != "user_mailbox.allow_sender.list" {
-		t.Fatalf("id = %v, want user_mailbox.allow_sender.list", env["id"])
+	if env["id"] != "user_mailbox.allow_senders.list" {
+		t.Fatalf("id = %v, want user_mailbox.allow_senders.list", env["id"])
 	}
 	if env["path"] != "user_mailboxes/{user_mailbox_id}/allow_senders" {
 		t.Fatalf("path = %v, want user_mailboxes/{user_mailbox_id}/allow_senders", env["path"])

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -4,7 +4,9 @@
 package service
 
 import (
+	"encoding/json"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -118,6 +120,202 @@ func TestRegisterService_MergesExistingCommand(t *testing.T) {
 	_, _, err := parent.Find([]string{"base", "tables", "list"})
 	if err != nil {
 		t.Fatalf("expected 'list' under existing 'base' command, got err=%v", err)
+	}
+}
+
+func TestMailSenderAllowBlockCommandsDryRun(t *testing.T) {
+	spec := map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	}
+	resources := map[string]interface{}{
+		"user_mailbox.allow_senders": map[string]interface{}{
+			"methods": map[string]interface{}{
+				"list": map[string]interface{}{
+					"path":       "user_mailboxes/{user_mailbox_id}/allow_senders",
+					"httpMethod": "GET",
+					"parameters": map[string]interface{}{
+						"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+						"keyword":         map[string]interface{}{"type": "string", "location": "query"},
+						"page_size":       map[string]interface{}{"type": "integer", "location": "query"},
+						"page_token":      map[string]interface{}{"type": "string", "location": "query"},
+					},
+				},
+				"batch_create": map[string]interface{}{
+					"path":       "user_mailboxes/{user_mailbox_id}/allow_senders/batch_create",
+					"httpMethod": "POST",
+					"parameters": map[string]interface{}{
+						"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+					},
+					"requestBody": map[string]interface{}{
+						"items": map[string]interface{}{"type": "array", "required": true},
+					},
+				},
+				"batch_remove": map[string]interface{}{
+					"path":       "user_mailboxes/{user_mailbox_id}/allow_senders/batch_remove",
+					"httpMethod": "POST",
+					"parameters": map[string]interface{}{
+						"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+					},
+					"requestBody": map[string]interface{}{
+						"senders": map[string]interface{}{"type": "array", "required": true},
+					},
+				},
+			},
+		},
+		"user_mailbox.blocked_senders": map[string]interface{}{
+			"methods": map[string]interface{}{
+				"list": map[string]interface{}{
+					"path":       "user_mailboxes/{user_mailbox_id}/blocked_senders",
+					"httpMethod": "GET",
+					"parameters": map[string]interface{}{
+						"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+						"keyword":         map[string]interface{}{"type": "string", "location": "query"},
+						"page_size":       map[string]interface{}{"type": "integer", "location": "query"},
+						"page_token":      map[string]interface{}{"type": "string", "location": "query"},
+					},
+				},
+				"batch_create": map[string]interface{}{
+					"path":       "user_mailboxes/{user_mailbox_id}/blocked_senders/batch_create",
+					"httpMethod": "POST",
+					"parameters": map[string]interface{}{
+						"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+					},
+					"requestBody": map[string]interface{}{
+						"items": map[string]interface{}{"type": "array", "required": true},
+					},
+				},
+				"batch_remove": map[string]interface{}{
+					"path":       "user_mailboxes/{user_mailbox_id}/blocked_senders/batch_remove",
+					"httpMethod": "POST",
+					"parameters": map[string]interface{}{
+						"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+					},
+					"requestBody": map[string]interface{}{
+						"senders": map[string]interface{}{"type": "array", "required": true},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		args       []string
+		wantURL    string
+		wantMethod string
+		wantParams map[string]interface{}
+		wantBody   map[string]interface{}
+	}{
+		{
+			args: []string{
+				"mail", "user_mailbox.allow_senders", "list",
+				"--params", `{"user_mailbox_id":"me","keyword":"example.com","page_size":20}`,
+				"--dry-run",
+			},
+			wantMethod: "GET",
+			wantURL:    "/open-apis/mail/v1/user_mailboxes/me/allow_senders",
+			wantParams: map[string]interface{}{"keyword": "example.com", "page_size": float64(20)},
+		},
+		{
+			args: []string{
+				"mail", "user_mailbox.allow_senders", "batch_create",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"items":[{"sender":"ok@example.com"}]}`,
+				"--dry-run",
+			},
+			wantMethod: "POST",
+			wantURL:    "/open-apis/mail/v1/user_mailboxes/me/allow_senders/batch_create",
+			wantBody: map[string]interface{}{
+				"items": []interface{}{map[string]interface{}{"sender": "ok@example.com"}},
+			},
+		},
+		{
+			args: []string{
+				"mail", "user_mailbox.allow_senders", "batch_remove",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"senders":["ok@example.com"]}`,
+				"--dry-run",
+			},
+			wantMethod: "POST",
+			wantURL:    "/open-apis/mail/v1/user_mailboxes/me/allow_senders/batch_remove",
+			wantBody: map[string]interface{}{
+				"senders": []interface{}{"ok@example.com"},
+			},
+		},
+		{
+			args: []string{
+				"mail", "user_mailbox.blocked_senders", "list",
+				"--params", `{"user_mailbox_id":"me","keyword":"bad.example","page_size":20}`,
+				"--dry-run",
+			},
+			wantMethod: "GET",
+			wantURL:    "/open-apis/mail/v1/user_mailboxes/me/blocked_senders",
+			wantParams: map[string]interface{}{"keyword": "bad.example", "page_size": float64(20)},
+		},
+		{
+			args: []string{
+				"mail", "user_mailbox.blocked_senders", "batch_create",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"items":[{"sender":"bad@example.com"}]}`,
+				"--dry-run",
+			},
+			wantMethod: "POST",
+			wantURL:    "/open-apis/mail/v1/user_mailboxes/me/blocked_senders/batch_create",
+			wantBody: map[string]interface{}{
+				"items": []interface{}{map[string]interface{}{"sender": "bad@example.com"}},
+			},
+		},
+		{
+			args: []string{
+				"mail", "user_mailbox.blocked_senders", "batch_remove",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"senders":["bad@example.com"]}`,
+				"--dry-run",
+			},
+			wantMethod: "POST",
+			wantURL:    "/open-apis/mail/v1/user_mailboxes/me/blocked_senders/batch_remove",
+			wantBody: map[string]interface{}{
+				"senders": []interface{}{"bad@example.com"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args[:3], " "), func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+			root := &cobra.Command{Use: "lark-cli"}
+			registerService(root, spec, resources, f)
+			root.SetArgs(tt.args)
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var got map[string]interface{}
+			out := stdout.String()
+			jsonStart := strings.Index(out, "{")
+			if jsonStart < 0 {
+				t.Fatalf("dry-run stdout does not contain JSON: %s", out)
+			}
+			if err := json.Unmarshal([]byte(out[jsonStart:]), &got); err != nil {
+				t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			api := got["api"].([]interface{})
+			call := api[0].(map[string]interface{})
+			if call["method"] != tt.wantMethod {
+				t.Errorf("method = %q, want %q", call["method"], tt.wantMethod)
+			}
+			if call["url"] != tt.wantURL {
+				t.Errorf("url = %q, want %q\nstdout:\n%s", call["url"], tt.wantURL, stdout.String())
+			}
+			if tt.wantParams != nil && !reflect.DeepEqual(call["params"], tt.wantParams) {
+				t.Errorf("params = %#v, want %#v", call["params"], tt.wantParams)
+			}
+			if tt.wantBody != nil {
+				if !reflect.DeepEqual(call["body"], tt.wantBody) {
+					t.Errorf("body = %#v, want %#v", call["body"], tt.wantBody)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -124,6 +124,7 @@ func TestRegisterService_MergesExistingCommand(t *testing.T) {
 }
 
 func TestMailSenderAllowBlockCommandsDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	spec := map[string]interface{}{
 		"name":        "mail",
 		"servicePath": "/open-apis/mail/v1",

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -115,6 +115,8 @@ metadata:
 
 无论是 Shortcut（`+triage`、`+send` 等）还是原生 API，**首次调用前必须先运行 `-h` 查看可用参数**，不要猜测参数名称：
 
+用户级发件人白/黑名单使用原生 API `user_mailbox.allow_senders` / `user_mailbox.blocked_senders`。`list` 支持 `keyword` 搜索；批量添加用 `batch_create` + `--data '{"items":[{"sender":"a@example.com"}]}'`；批量删除用 `batch_remove` + `--data '{"senders":["a@example.com"]}'`。
+
 ```bash
 # Shortcut
 lark-cli mail +triage -h
@@ -444,6 +446,24 @@ lark-cli mail user_mailbox.folders create \
   --data '{"name":"newsletter","parent_folder_id":"0"}'
 ```
 
+**用户级发件人白/黑名单**：
+
+```bash
+# 列出白名单；加入 keyword 即搜索
+lark-cli mail user_mailbox.allow_senders list \
+  --params '{"user_mailbox_id":"me","keyword":"example.com"}'
+
+# 批量加入黑名单
+lark-cli mail user_mailbox.blocked_senders batch_create \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"items":[{"sender":"bad@example.com"}]}'
+
+# 批量移除黑名单
+lark-cli mail user_mailbox.blocked_senders batch_remove \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"senders":["bad@example.com"]}'
+```
+
 ### 常用约定
 
 - `user_mailbox_id` 几乎所有邮箱 API 都需要，一般传 `"me"` 代表当前用户
@@ -645,4 +665,3 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 | `user_mailbox.threads.list` | `mail:user_mailbox.message:readonly` |
 | `user_mailbox.threads.modify` | `mail:user_mailbox.message:modify` |
 | `user_mailbox.threads.trash` | `mail:user_mailbox.message:modify` |
-


### PR DESCRIPTION
Adds documentation and tests for the mail sender allow/block command surface in the generated CLI metadata. The change updates the mail skill reference and covers schema and help visibility so users can discover the list, search, batch_set, and batch_delete commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added native API usage guidance for user-level email sender allowlists and blocklists, including `list` (keyword search), `batch_create`, and `batch_remove` with request examples.
* **Tests**
  * Expanded schema command tests to validate allowlist/blocklist JSON output, including required fields and scopes.
  * Added dry-run integration-style checks to confirm generated API request method, URL, and expected parameters/body for allow/blocked sender scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->