### PR TITLE
ci: deduplicate PR runs and serialize live E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
     types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
+# PR metadata edits can retrigger full CI for the same head. Keep only the
+# newest run for a pull request; push and manual runs use a unique run ID.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   actions: read
@@ -344,6 +350,11 @@ jobs:
     needs: [unit-test, lint, script-test, deterministic-gate]
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
+    # All live runs share one bot credential and remote resource pool.
+    concurrency:
+      group: lark-cli-e2e-live-shared-bot
+      cancel-in-progress: false
+      queue: max
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,9 +410,10 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             workflow_id="$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID" --jq '.workflow_id')"
             newer_runs="$(
-              gh api --paginate "repos/$REPOSITORY/actions/workflows/$workflow_id/runs?event=pull_request&per_page=100" |
-                jq -r --arg generation "$RUN_GENERATION" --argjson run_number "$RUN_NUMBER" \
-                  '.workflow_runs[] | select(.display_title == $generation and .run_number > $run_number) | .id'
+              gh api --paginate -X GET "repos/$REPOSITORY/actions/workflows/$workflow_id/runs" \
+                -f event=pull_request -f branch="$GITHUB_HEAD_REF" -f per_page=100 |
+                jq -r --arg repository "$REPOSITORY" --arg generation "$RUN_GENERATION" --argjson run_number "$RUN_NUMBER" \
+                  '.workflow_runs[] | select(.head_repository.full_name == $repository and .display_title == $generation and .run_number > $run_number) | .id'
             )"
             if [ -n "$newer_runs" ]; then
               echo "::error::Superseded before live E2E started by newer workflow run(s): $newer_runs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+run-name: ${{ format('CI / {0}', github.event.pull_request.number || github.run_id) }}
 
 on:
   push:
@@ -348,14 +349,16 @@ jobs:
 
   e2e-live:
     needs: [unit-test, lint, script-test, deterministic-gate]
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.unit-test.result == 'success' && needs.lint.result == 'success' && needs.script-test.result == 'success' && needs.deterministic-gate.result == 'success' }}
     runs-on: ubuntu-latest
-    # All live runs share one bot credential and remote resource pool.
+    timeout-minutes: 30
+    # Live E2E uses one repository-wide execution slot.
     concurrency:
-      group: lark-cli-e2e-live-shared-bot
+      group: lark-cli-e2e-live
       cancel-in-progress: false
       queue: max
     permissions:
+      actions: read
       contents: read
       checks: write
     env:
@@ -375,6 +378,7 @@ jobs:
         id: e2e_domains
         run: node scripts/e2e_domains.js
       - name: Build lark-cli
+        id: build_cli
         if: ${{ steps.e2e_domains.outputs.mode != 'skip' }}
         run: make build
       - name: Prepare shared live E2E tenant token
@@ -385,7 +389,17 @@ jobs:
           TEST_BOT1_APP_SECRET: ${{ secrets.TEST_BOT1_APP_SECRET }}
         run: node scripts/fetch_e2e_tat.js
       - name: Run CLI E2E tests
+        # Keep an active Go test alive so t.Cleanup can finish. A queued stale
+        # run is rejected below before it can start live E2E.
+        if: ${{ always() && steps.e2e_domains.outputs.mode != 'skip' && steps.build_cli.outcome == 'success' && steps.live_e2e_tat.outcome == 'success' }}
+        shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_GENERATION: ${{ format('CI / {0}', github.event.pull_request.number || github.run_id) }}
           LARK_CLI_BIN: ${{ github.workspace }}/lark-cli
           E2E_MODE: ${{ steps.e2e_domains.outputs.mode }}
           E2E_REASON: ${{ steps.e2e_domains.outputs.reason }}
@@ -393,6 +407,18 @@ jobs:
           E2E_TENANT_AUTH_FILE: ${{ steps.live_e2e_tat.outputs.path }}
           TEST_USER_ACCESS_TOKEN: ${{ secrets.TEST_USER_ACCESS_TOKEN }}
         run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            workflow_id="$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID" --jq '.workflow_id')"
+            newer_runs="$(
+              gh api --paginate "repos/$REPOSITORY/actions/workflows/$workflow_id/runs?event=pull_request&per_page=100" |
+                jq -r --arg generation "$RUN_GENERATION" --argjson run_number "$RUN_NUMBER" \
+                  '.workflow_runs[] | select(.display_title == $generation and .run_number > $run_number) | .id'
+            )"
+            if [ -n "$newer_runs" ]; then
+              echo "::error::Superseded before live E2E started by newer workflow run(s): $newer_runs"
+              exit 1
+            fi
+          fi
           if [ "$E2E_MODE" = "skip" ]; then
             echo "No live CLI E2E needed: $E2E_REASON"
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-run-name: ${{ format('CI / {0}', github.event.pull_request.number || github.run_id) }}
+run-name: ${{ github.event_name == 'pull_request' && format('CI / {0}', github.event.pull_request.number) || '' }}
 
 on:
   push:
@@ -302,6 +302,10 @@ jobs:
   e2e-dry-run:
     needs: [unit-test, lint, script-test, deterministic-gate]
     runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.e2e_domains.outputs.mode }}
+      reason: ${{ steps.e2e_domains.outputs.reason }}
+      live_packages: ${{ steps.e2e_domains.outputs.live_packages }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -315,6 +319,23 @@ jobs:
       - name: Resolve CLI E2E domains
         id: e2e_domains
         run: node scripts/e2e_domains.js
+      - name: Validate CLI E2E domain outputs
+        env:
+          E2E_MODE: ${{ steps.e2e_domains.outputs.mode }}
+          E2E_LIVE_PACKAGES: ${{ steps.e2e_domains.outputs.live_packages }}
+        run: |
+          case "$E2E_MODE" in
+            skip)
+              [ -z "$E2E_LIVE_PACKAGES" ] || { echo "::error::Skip mode must not resolve live packages"; exit 1; }
+              ;;
+            full|subset)
+              [ -n "$E2E_LIVE_PACKAGES" ] || { echo "::error::No live packages resolved for mode $E2E_MODE"; exit 1; }
+              ;;
+            *)
+              echo "::error::Invalid CLI E2E mode: $E2E_MODE"
+              exit 1
+              ;;
+          esac
       - name: Build lark-cli
         if: ${{ steps.e2e_domains.outputs.mode != 'skip' }}
         run: make build
@@ -348,8 +369,8 @@ jobs:
           fi
 
   e2e-live:
-    needs: [unit-test, lint, script-test, deterministic-gate]
-    if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.unit-test.result == 'success' && needs.lint.result == 'success' && needs.script-test.result == 'success' && needs.deterministic-gate.result == 'success' }}
+    needs: [unit-test, lint, script-test, deterministic-gate, e2e-dry-run]
+    if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.unit-test.result == 'success' && needs.lint.result == 'success' && needs.script-test.result == 'success' && needs.deterministic-gate.result == 'success' && needs.e2e-dry-run.result == 'success' && (needs.e2e-dry-run.outputs.mode == 'full' || needs.e2e-dry-run.outputs.mode == 'subset') && needs.e2e-dry-run.outputs.live_packages != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Live E2E uses one repository-wide execution slot.
@@ -374,16 +395,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
-      - name: Resolve CLI E2E domains
-        id: e2e_domains
-        run: node scripts/e2e_domains.js
       - name: Build lark-cli
         id: build_cli
-        if: ${{ steps.e2e_domains.outputs.mode != 'skip' }}
         run: make build
       - name: Prepare shared live E2E tenant token
         id: live_e2e_tat
-        if: ${{ steps.e2e_domains.outputs.mode != 'skip' }}
         env:
           LARKSUITE_CLI_APP_ID: ${{ secrets.TEST_BOT1_APP_ID }}
           TEST_BOT1_APP_SECRET: ${{ secrets.TEST_BOT1_APP_SECRET }}
@@ -391,7 +407,7 @@ jobs:
       - name: Run CLI E2E tests
         # Keep an active Go test alive so t.Cleanup can finish. A queued stale
         # run is rejected below before it can start live E2E.
-        if: ${{ always() && steps.e2e_domains.outputs.mode != 'skip' && steps.build_cli.outcome == 'success' && steps.live_e2e_tat.outcome == 'success' }}
+        if: ${{ always() && steps.build_cli.outcome == 'success' && steps.live_e2e_tat.outcome == 'success' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -399,11 +415,11 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RUN_ID: ${{ github.run_id }}
           RUN_NUMBER: ${{ github.run_number }}
-          RUN_GENERATION: ${{ format('CI / {0}', github.event.pull_request.number || github.run_id) }}
+          RUN_GENERATION: ${{ github.event_name == 'pull_request' && format('CI / {0}', github.event.pull_request.number) || '' }}
           LARK_CLI_BIN: ${{ github.workspace }}/lark-cli
-          E2E_MODE: ${{ steps.e2e_domains.outputs.mode }}
-          E2E_REASON: ${{ steps.e2e_domains.outputs.reason }}
-          E2E_LIVE_PACKAGES: ${{ steps.e2e_domains.outputs.live_packages }}
+          E2E_MODE: ${{ needs.e2e-dry-run.outputs.mode }}
+          E2E_REASON: ${{ needs.e2e-dry-run.outputs.reason }}
+          E2E_LIVE_PACKAGES: ${{ needs.e2e-dry-run.outputs.live_packages }}
           E2E_TENANT_AUTH_FILE: ${{ steps.live_e2e_tat.outputs.path }}
           TEST_USER_ACCESS_TOKEN: ${{ secrets.TEST_USER_ACCESS_TOKEN }}
         run: |
@@ -419,10 +435,6 @@ jobs:
               echo "::error::Superseded before live E2E started by newer workflow run(s): $newer_runs"
               exit 1
             fi
-          fi
-          if [ "$E2E_MODE" = "skip" ]; then
-            echo "No live CLI E2E needed: $E2E_REASON"
-            exit 0
           fi
           if [ -z "${E2E_TENANT_AUTH_FILE:-}" ] || [ ! -f "$E2E_TENANT_AUTH_FILE" ]; then
             echo "::error::Missing shared live E2E tenant token file"
@@ -454,7 +466,7 @@ jobs:
           echo "Live CLI E2E packages: $packages"
           go run gotest.tools/gotestsum@v1.12.3 --rerun-fails=2 --rerun-fails-max-failures=20 --packages="$packages" --format testname --junitfile cli-e2e-report.xml -- -count=1 -v
       - name: Publish CLI E2E test report
-        if: ${{ !cancelled() && steps.e2e_domains.outputs.mode != 'skip' }}
+        if: ${{ !cancelled() }}
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: CLI E2E Tests
@@ -531,8 +543,8 @@ jobs:
           echo "| L4 | sidecar-integration (observe-only) | ${{ needs.sidecar-integration.result }} |" >> $GITHUB_STEP_SUMMARY
 
           # Any failure or cancellation in any job blocks the merge.
-          # Legitimately skipped jobs (deadcode on push, e2e-live on fork,
-          # license-header on push) are OK.
+          # Legitimately skipped jobs (deadcode on push, e2e-live when not
+          # needed or on a fork, license-header on push) are OK.
           #
           # plugin-integration and sidecar-integration are intentionally NOT
           # in this loop yet: they run on every PR and their status is shown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
   e2e-dry-run:
     needs: [unit-test, lint, script-test, deterministic-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       mode: ${{ steps.e2e_domains.outputs.mode }}
       reason: ${{ steps.e2e_domains.outputs.reason }}

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -51,6 +51,12 @@ results_section="$(awk '
   in_job { print }
 ' "$workflow")"
 fork_safe_guard="github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork"
+live_job_condition="always() && ($fork_safe_guard) && needs.unit-test.result == 'success' && needs.lint.result == 'success' && needs.script-test.result == 'success' && needs.deterministic-gate.result == 'success'"
+
+if ! grep -Fq "run-name: \${{ format('CI / {0}', github.event.pull_request.number || github.run_id) }}" "$workflow"; then
+  echo "CI should expose a stable per-PR run generation for supersession checks" >&2
+  exit 1
+fi
 
 if ! grep -Fq 'group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}' <<<"$workflow_concurrency"; then
   echo "CI should deduplicate runs for the same pull request without grouping push or manual runs" >&2
@@ -225,23 +231,66 @@ if ! grep -Fq "deterministic-gate" <<<"$results_section"; then
   exit 1
 fi
 
-if ! grep -Fq "if: \${{ $fork_safe_guard }}" <<<"$section"; then
-  echo "e2e-live should run on push and same-repository pull_request, but skip fork pull_request"
+if ! grep -Fq "if: \${{ $live_job_condition }}" <<<"$section"; then
+  echo "e2e-live should preserve active cleanup while requiring successful upstream gates and excluding fork pull requests"
   exit 1
 fi
 
-if ! grep -Fq "group: lark-cli-e2e-live-shared-bot" <<<"$section"; then
-  echo "e2e-live should serialize access to the shared bot credential and resource pool" >&2
+if ! grep -Fq "timeout-minutes: 30" <<<"$section"; then
+  echo "e2e-live should release the repository-wide slot after 30 minutes" >&2
+  exit 1
+fi
+
+if ! grep -Fq "group: lark-cli-e2e-live" <<<"$section"; then
+  echo "e2e-live should use one repository-wide execution slot" >&2
   exit 1
 fi
 
 if ! grep -Fq "cancel-in-progress: false" <<<"$section"; then
-  echo "e2e-live should queue shared-resource runs instead of cancelling an active live test" >&2
+  echo "e2e-live should queue waiting runs instead of cancelling an active live test" >&2
   exit 1
 fi
 
 if ! grep -Fq "queue: max" <<<"$section"; then
   echo "e2e-live should preserve queued runs instead of replacing an existing pending run" >&2
+  exit 1
+fi
+
+if ! grep -Fq "actions: read" <<<"$section"; then
+  echo "e2e-live should use read-only Actions access for the supersession check" >&2
+  exit 1
+fi
+
+live_test_step="$(awk '
+  /^      - name: Run CLI E2E tests/ { in_step = 1 }
+  in_step { print }
+  in_step && /^      - name: Publish CLI E2E test report/ { exit }
+' <<<"$section")"
+
+if ! grep -Fq "if: \${{ always() && steps.e2e_domains.outputs.mode != 'skip' && steps.build_cli.outcome == 'success' && steps.live_e2e_tat.outcome == 'success' }}" <<<"$live_test_step"; then
+  echo "the active live test step should survive ordinary workflow supersession only after setup succeeds" >&2
+  exit 1
+fi
+
+for required in \
+  'gh api "repos/$REPOSITORY/actions/runs/$RUN_ID"' \
+  'gh api --paginate "repos/$REPOSITORY/actions/workflows/$workflow_id/runs?event=pull_request&per_page=100"' \
+  '.display_title == $generation and .run_number > $run_number' \
+  '::error::Superseded before live E2E started' \
+  'exit 1'; do
+  if ! grep -Fq "$required" <<<"$live_test_step"; then
+    echo "the live startup check should fail closed before a superseded run starts live E2E: missing $required" >&2
+    exit 1
+  fi
+done
+
+if ! awk '
+  /::error::Superseded before live E2E started/ { superseded = 1; next }
+  superseded && /exit 1/ { rejected = 1 }
+  /go run gotest.tools\/gotestsum@/ { test_started = 1; if (!rejected) exit 2 }
+  END { exit rejected && test_started ? 0 : 1 }
+' <<<"$live_test_step"; then
+  echo "a superseded live run must stop before gotestsum starts" >&2
   exit 1
 fi
 
@@ -437,7 +486,7 @@ if grep -Fq '${{ secrets.CODECOV_TOKEN }}' <<<"$coverage_step" &&
 fi
 
 if grep -Fq '${{ secrets.' <<<"$section" &&
-   ! grep -Fq "if: \${{ $fork_safe_guard }}" <<<"$section"; then
+   ! grep -Fq "$fork_safe_guard" <<<"$section"; then
   echo "live E2E secrets should be available on push and same-repository pull_request, but not fork pull_request" >&2
   exit 1
 fi

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -51,10 +51,15 @@ results_section="$(awk '
   in_job { print }
 ' "$workflow")"
 fork_safe_guard="github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork"
-live_job_condition="always() && ($fork_safe_guard) && needs.unit-test.result == 'success' && needs.lint.result == 'success' && needs.script-test.result == 'success' && needs.deterministic-gate.result == 'success'"
+live_job_condition="always() && ($fork_safe_guard) && needs.unit-test.result == 'success' && needs.lint.result == 'success' && needs.script-test.result == 'success' && needs.deterministic-gate.result == 'success' && needs.e2e-dry-run.result == 'success' && (needs.e2e-dry-run.outputs.mode == 'full' || needs.e2e-dry-run.outputs.mode == 'subset') && needs.e2e-dry-run.outputs.live_packages != ''"
 
-if ! grep -Fq "run-name: \${{ format('CI / {0}', github.event.pull_request.number || github.run_id) }}" "$workflow"; then
-  echo "CI should expose a stable per-PR run generation for supersession checks" >&2
+if ! grep -Fq "run-name: \${{ github.event_name == 'pull_request' && format('CI / {0}', github.event.pull_request.number) || '' }}" "$workflow"; then
+  echo "CI should expose a stable PR generation while preserving default push and manual run titles" >&2
+  exit 1
+fi
+
+if ! grep -Fq "RUN_GENERATION: \${{ github.event_name == 'pull_request' && format('CI / {0}', github.event.pull_request.number) || '' }}" <<<"$section"; then
+  echo "the supersession generation should match the PR-only run name" >&2
   exit 1
 fi
 
@@ -232,7 +237,12 @@ if ! grep -Fq "deterministic-gate" <<<"$results_section"; then
 fi
 
 if ! grep -Fq "if: \${{ $live_job_condition }}" <<<"$section"; then
-  echo "e2e-live should preserve active cleanup while requiring successful upstream gates and excluding fork pull requests"
+  echo "e2e-live should preserve active cleanup while requiring a successful non-skip dry run and excluding fork pull requests"
+  exit 1
+fi
+
+if ! grep -Fq "needs: [unit-test, lint, script-test, deterministic-gate, e2e-dry-run]" <<<"$section"; then
+  echo "e2e-live should wait outside the exclusive queue until e2e-dry-run finishes"
   exit 1
 fi
 
@@ -267,7 +277,7 @@ live_test_step="$(awk '
   in_step && /^      - name: Publish CLI E2E test report/ { exit }
 ' <<<"$section")"
 
-if ! grep -Fq "if: \${{ always() && steps.e2e_domains.outputs.mode != 'skip' && steps.build_cli.outcome == 'success' && steps.live_e2e_tat.outcome == 'success' }}" <<<"$live_test_step"; then
+if ! grep -Fq "if: \${{ always() && steps.build_cli.outcome == 'success' && steps.live_e2e_tat.outcome == 'success' }}" <<<"$live_test_step"; then
   echo "the active live test step should survive ordinary workflow supersession only after setup succeeds" >&2
   exit 1
 fi
@@ -302,6 +312,39 @@ if ! grep -Fq "name: Resolve CLI E2E domains" <<<"$dry_run_section" ||
   exit 1
 fi
 
+for output in \
+  'mode: ${{ steps.e2e_domains.outputs.mode }}' \
+  'reason: ${{ steps.e2e_domains.outputs.reason }}' \
+  'live_packages: ${{ steps.e2e_domains.outputs.live_packages }}'; do
+  if ! grep -Fq "$output" <<<"$dry_run_section"; then
+    echo "e2e-dry-run should publish $output for the live job" >&2
+    exit 1
+  fi
+done
+
+for validation_contract in \
+  'case "$E2E_MODE" in' \
+  'skip)' \
+  '[ -z "$E2E_LIVE_PACKAGES" ]' \
+  'full|subset)' \
+  '[ -n "$E2E_LIVE_PACKAGES" ]' \
+  'Invalid CLI E2E mode' \
+  'exit 1'; do
+  if ! grep -Fq "$validation_contract" <<<"$dry_run_section"; then
+    echo "e2e-dry-run should fail invalid domain output before live can be skipped: missing $validation_contract" >&2
+    exit 1
+  fi
+done
+
+if ! awk '
+  /- name: Validate CLI E2E domain outputs/ { validated = 1 }
+  /- name: Build lark-cli/ { exit validated ? 0 : 1 }
+  END { if (!validated) exit 1 }
+' <<<"$dry_run_section"; then
+  echo "e2e-dry-run should validate domain outputs before building" >&2
+  exit 1
+fi
+
 if ! grep -Fq "steps.e2e_domains.outputs.dry_packages" <<<"$dry_run_section"; then
   echo "e2e-dry-run should use resolved dry_packages instead of always running the full suite"
   exit 1
@@ -324,21 +367,21 @@ if ! grep -Fq "No dry-run CLI E2E needed" <<<"$dry_run_section"; then
   exit 1
 fi
 
-if ! grep -Fq "name: Resolve CLI E2E domains" <<<"$section" ||
-   ! grep -Fq "id: e2e_domains" <<<"$section" ||
-   ! grep -Fq "run: node scripts/e2e_domains.js" <<<"$section"; then
-  echo "e2e-live should resolve changed-file CLI E2E domains before credentials and tests"
+if grep -Fq "name: Resolve CLI E2E domains" <<<"$section" ||
+   grep -Fq "run: node scripts/e2e_domains.js" <<<"$section"; then
+  echo "e2e-live should reuse e2e-dry-run outputs instead of resolving domains again"
   exit 1
 fi
 
-if ! grep -Fq "steps.e2e_domains.outputs.live_packages" <<<"$section"; then
-  echo "e2e-live should use resolved live_packages instead of always running the full suite"
+if ! grep -Fq "E2E_LIVE_PACKAGES: \${{ needs.e2e-dry-run.outputs.live_packages }}" <<<"$section"; then
+  echo "e2e-live should reuse live_packages resolved by e2e-dry-run"
   exit 1
 fi
 
-if ! grep -Fq "E2E_REASON: \${{ steps.e2e_domains.outputs.reason }}" <<<"$section" ||
+if ! grep -Fq "E2E_MODE: \${{ needs.e2e-dry-run.outputs.mode }}" <<<"$section" ||
+   ! grep -Fq "E2E_REASON: \${{ needs.e2e-dry-run.outputs.reason }}" <<<"$section" ||
    ! grep -Fq 'echo "Live CLI E2E domains: $E2E_MODE ($E2E_REASON)"' <<<"$section"; then
-  echo "e2e-live should pass dynamic domain output through env before shell use"
+  echo "e2e-live should consume the exact mode and reason produced by e2e-dry-run"
   exit 1
 fi
 
@@ -352,15 +395,22 @@ if ! awk '
   exit 1
 fi
 
-if ! awk '
-  /^      - name: Build lark-cli/ { in_step = 1 }
-  in_step && /if: \$\{\{ steps\.e2e_domains\.outputs\.mode != '\''skip'\'' \}\}/ { found = 1 }
-  in_step && /^      - name:/ && !/Build lark-cli/ { in_step = 0 }
-  END { exit found ? 0 : 1 }
-' <<<"$section"; then
-  echo "e2e-live should skip building lark-cli when domain mode is skip"
+if grep -Fq "steps.e2e_domains.outputs" <<<"$section"; then
+  echo "e2e-live should not retain step-local domain outputs after adopting the dry-run job gate"
   exit 1
 fi
+
+for step_name in "Build lark-cli" "Prepare shared live E2E tenant token"; do
+  live_setup_step="$(awk -v name="$step_name" '
+    $0 == "      - name: " name { in_step = 1 }
+    in_step { print }
+    in_step && /^      - name:/ && $0 != "      - name: " name { exit }
+  ' <<<"$section")"
+  if grep -Eq '^        if:' <<<"$live_setup_step"; then
+    echo "e2e-live $step_name should run unconditionally after the non-skip job gate" >&2
+    exit 1
+  fi
+done
 
 if ! grep -Fq "permissions:" <<<"$section" ||
    ! grep -Fq "contents: read" <<<"$section" ||
@@ -426,13 +476,13 @@ fi
 if ! awk '
   /^      - name: Prepare shared live E2E tenant token/ { in_step = 1 }
   in_step && /id: live_e2e_tat/ { has_id = 1 }
-  in_step && /if: \$\{\{ steps\.e2e_domains\.outputs\.mode != '\''skip'\'' \}\}/ { has_if = 1 }
+  in_step && /^        if:/ { has_if = 1 }
   in_step && /LARKSUITE_CLI_APP_ID: \$\{\{ secrets\.TEST_BOT1_APP_ID \}\}/ { has_app_id = 1 }
   in_step && /secrets\.TEST_BOT1_APP_SECRET/ { has_bot_credential = 1 }
   in_step && /node scripts\/fetch_e2e_tat\.js/ { has_script = 1 }
   in_step && /GITHUB_ENV/ { uses_github_env = 1 }
   in_step && /^      - name:/ && !/Prepare shared live E2E tenant token/ { in_step = 0 }
-  END { exit has_id && has_if && has_app_id && has_bot_credential && has_script && !uses_github_env ? 0 : 1 }
+  END { exit has_id && !has_if && has_app_id && has_bot_credential && has_script && !uses_github_env ? 0 : 1 }
 ' <<<"$section"; then
   echo "e2e-live should pass only a private tenant token file path through step output"
   exit 1
@@ -459,13 +509,18 @@ if ! awk '
   exit 1
 fi
 
+if grep -Fq 'if [ "$E2E_MODE" = "skip" ]' <<<"$section"; then
+  echo "e2e-live should not retain an unreachable step-level skip branch"
+  exit 1
+fi
+
 if grep -Fq "steps.live_e2e_credentials.outputs.configured" <<<"$section"; then
   echo "e2e-live build, configure, test, and report steps should not be gated by a skip-state output"
   exit 1
 fi
 
-if ! grep -Fq "if: \${{ !cancelled() && steps.e2e_domains.outputs.mode != 'skip' }}" <<<"$section"; then
-  echo "e2e-live report step should run after attempted live tests unless the workflow is cancelled or domain mode is skip"
+if ! grep -Fq "if: \${{ !cancelled() }}" <<<"$section"; then
+  echo "e2e-live report step should run after attempted live tests unless the workflow is cancelled"
   exit 1
 fi
 

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -301,10 +301,17 @@ for required in \
 done
 
 if ! awk '
-  /::error::Superseded before live E2E started/ { superseded = 1; next }
-  superseded && /exit 1/ { rejected = 1 }
-  /go run gotest.tools\/gotestsum@/ { test_started = 1; if (!rejected) exit 2 }
-  END { exit rejected && test_started ? 0 : 1 }
+  /if \[ -n "\$newer_runs" \]; then/ { superseded_state = 1; next }
+  superseded_state == 1 && /::error::Superseded before live E2E started/ { superseded_state = 2; next }
+  superseded_state == 2 && /^[[:space:]]+exit 1[[:space:]]*$/ { superseded_state = 3; next }
+  superseded_state > 0 && /^[[:space:]]+fi[[:space:]]*$/ {
+    if (superseded_state != 3) exit 2
+    superseded_closed = 1
+    superseded_state = 0
+    next
+  }
+  /go run gotest.tools\/gotestsum@/ { test_started = 1; if (!superseded_closed) exit 3 }
+  END { exit superseded_closed && test_started ? 0 : 1 }
 ' <<<"$live_test_step"; then
   echo "a superseded live run must stop before gotestsum starts" >&2
   exit 1

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -274,11 +274,12 @@ fi
 
 for required in \
   'gh api "repos/$REPOSITORY/actions/runs/$RUN_ID"' \
-  'gh api --paginate "repos/$REPOSITORY/actions/workflows/$workflow_id/runs?event=pull_request&per_page=100"' \
-  '.display_title == $generation and .run_number > $run_number' \
+  'gh api --paginate -X GET "repos/$REPOSITORY/actions/workflows/$workflow_id/runs"' \
+  '-f event=pull_request -f branch="$GITHUB_HEAD_REF" -f per_page=100' \
+  '.head_repository.full_name == $repository and .display_title == $generation and .run_number > $run_number' \
   '::error::Superseded before live E2E started' \
   'exit 1'; do
-  if ! grep -Fq "$required" <<<"$live_test_step"; then
+  if ! grep -Fq -- "$required" <<<"$live_test_step"; then
     echo "the live startup check should fail closed before a superseded run starts live E2E: missing $required" >&2
     exit 1
   fi

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -246,6 +246,11 @@ if ! grep -Fq "needs: [unit-test, lint, script-test, deterministic-gate, e2e-dry
   exit 1
 fi
 
+if ! grep -Fq "timeout-minutes: 20" <<<"$dry_run_section"; then
+  echo "e2e-dry-run should bound the planning gate before live E2E" >&2
+  exit 1
+fi
+
 if ! grep -Fq "timeout-minutes: 30" <<<"$section"; then
   echo "e2e-live should release the repository-wide slot after 30 minutes" >&2
   exit 1

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -18,6 +18,11 @@ workflow_permissions="$(awk '
   in_permissions && /^[^[:space:]]/ { exit }
   in_permissions { print }
 ' "$workflow")"
+workflow_concurrency="$(awk '
+  /^concurrency:/ { in_concurrency = 1; print; next }
+  in_concurrency && /^[^[:space:]]/ { exit }
+  in_concurrency { print }
+' "$workflow")"
 fast_gate_section="$(job_section fast-gate)"
 unit_test_section="$(job_section unit-test)"
 lint_section="$(awk '
@@ -46,6 +51,16 @@ results_section="$(awk '
   in_job { print }
 ' "$workflow")"
 fork_safe_guard="github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork"
+
+if ! grep -Fq 'group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}' <<<"$workflow_concurrency"; then
+  echo "CI should deduplicate runs for the same pull request without grouping push or manual runs" >&2
+  exit 1
+fi
+
+if ! grep -Fq "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" <<<"$workflow_concurrency"; then
+  echo "CI should cancel superseded pull request runs but preserve push and manual runs" >&2
+  exit 1
+fi
 
 for denied_permission in "checks: write" "pull-requests: write" "issues: write"; do
   if grep -Eq "^[[:space:]]*${denied_permission}$" <<<"$workflow_permissions"; then
@@ -212,6 +227,21 @@ fi
 
 if ! grep -Fq "if: \${{ $fork_safe_guard }}" <<<"$section"; then
   echo "e2e-live should run on push and same-repository pull_request, but skip fork pull_request"
+  exit 1
+fi
+
+if ! grep -Fq "group: lark-cli-e2e-live-shared-bot" <<<"$section"; then
+  echo "e2e-live should serialize access to the shared bot credential and resource pool" >&2
+  exit 1
+fi
+
+if ! grep -Fq "cancel-in-progress: false" <<<"$section"; then
+  echo "e2e-live should queue shared-resource runs instead of cancelling an active live test" >&2
+  exit 1
+fi
+
+if ! grep -Fq "queue: max" <<<"$section"; then
+  echo "e2e-live should preserve queued runs instead of replacing an existing pending run" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Pull request updates can overlap CI runs, while live E2E uses repository-wide shared resources that require exclusive execution. This PR cancels superseded PR work, keeps no-op live jobs out of the exclusive queue, and lets an already-started live test continue toward normal cleanup before the next live job starts, subject to its timeout and runner availability.

## Changes

- Add PR-scoped workflow concurrency in `.github/workflows/ci.yml`; push and manual runs remain independent, and non-PR runs retain GitHub's default title.
- Make `e2e-dry-run` the live planning gate. It validates and publishes mode/package outputs with a 20-minute timeout; failed or skip-mode plans do not enter the live queue, while the required `results` job still reports dry-run failure.
- Make dry and live consume outputs from the same domain-resolution step. Live therefore waits for the complete dry job outside the exclusive queue: typically about 1.5 minutes in current runs, while full-fallback changes may take longer.
- Serialize `e2e-live` with `queue: max`, no in-progress cancellation, and a 30-minute timeout. Under ordinary PR supersession, an active Go test can continue so `t.Cleanup` has an opportunity to finish. The timeout bounds how long a started live job can hold the exclusive slot; pending queue time is not covered.
- Reject a queued superseded run before `gotestsum` starts. The fail-closed lookup is scoped to the current head branch and GitHub-reported head repository, preventing cross-PR spoofing and avoiding repository-wide workflow-history scans. An Actions API failure may reject a valid live start rather than risk running an unverified stale job.
- Preserve explicit safety limits: force-cancel remains the immediate operator escape hatch; timeout or runner loss can still interrupt cleanup; and a newer run appearing just after the lookup may waste time, but the repository-wide queue still prevents concurrent live tests.
- Extend `scripts/ci-workflow.test.sh` to lock the scheduling, output-validation, permissions, cleanup, timeout, and supersession contracts.

## Test Plan

- [x] `make script-test` passed (103 tests)
- [x] `bash -n scripts/ci-workflow.test.sh`, workflow YAML parsing, and `git diff --check` passed
- [x] `go mod tidy -diff` produced no module changes
- [x] Full CI, including dry-run, live E2E, `results`, and golangci-lint, passed on the dry/live gating commit ([run 29432206219](https://github.com/larksuite/cli/actions/runs/29432206219))

## Related Issues

N/A
