### PR TITLE
feat: document IM message read status APIs

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-im
 version: 1.0.0
-description: "飞书即时通讯：收发消息和管理群聊。发送和回复消息、搜索聊天记录、管理群聊成员、上传下载图片和文件（支持大文件分片下载）、管理表情回复、发送应用内/短信/电话加急、发送和处理交互卡片（Interactive Card）、监听卡片按钮回调（card.action.trigger）。当用户需要发消息、查看或搜索聊天记录、下载聊天中的文件、查看群成员、搜索群、创建群聊或话题群、管理标记数据、管理 Feed 置顶（添加/移除/查询置顶会话）、管理标签数据、处理卡片回调时使用。"
+description: "飞书即时通讯：收发消息和管理群聊。发送和回复消息、搜索聊天记录、批量查询当前用户对消息是否已读、管理群聊成员、上传下载图片和文件（支持大文件分片下载）、管理表情回复、发送应用内/短信/电话加急、发送和处理交互卡片（Interactive Card）、监听卡片按钮回调（card.action.trigger）。当用户需要发消息、查看或搜索聊天记录、查询自己的消息已读状态、下载聊天中的文件、查看群成员、搜索群、创建群聊或话题群、管理标记数据、管理 Feed 置顶（添加/移除/查询置顶会话）、管理标签数据、处理卡片回调时使用。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -169,10 +169,11 @@ lark-cli im <resource> <method> [flags] # 调用 API
 
 ### messages
 
+  - `batch_get_read_status` — 批量查询当前用户对消息的阅读状态。Identity: `user` only (`user_access_token`); accepts up to 50 visible message IDs. `unexpected` is indeterminate and must not be treated as unread.[Must-read](references/lark-im-message-read-status.md)
   - `delete` — 撤回消息。Identity: supports `user` and `bot`; for `bot` calls, the bot must be in the chat to revoke group messages; to revoke another user's group message, the bot must be the owner, an admin, or the creator; for user P2P recalls, the target user must be within the bot's availability.
   - `forward` — 转发消息。Identity: supports `user` and `bot`.
   - `merge_forward` — 合并转发消息。Identity: `bot` only (`tenant_access_token`).
-  - `read_users` — 查询消息已读信息。Identity: `bot` only (`tenant_access_token`); the bot must be in the chat, and can only query read status for messages it sent within the last 7 days.
+  - `read_users` — 查询消息已读用户列表。Identity: supports `user` and `bot`. With `user_access_token`, the caller can query only messages they sent within the last 7 days. With `tenant_access_token`, the bot must be in the chat and can query only its own messages within the last 7 days.[Must-read](references/lark-im-message-read-status.md)
   - `urgent_app` — 发送应用内加急。Identity: `bot` only (`tenant_access_token`); the bot must be the message sender and must be in the conversation that contains the message.
   - `urgent_phone` — 发送电话加急。Identity: `bot` only (`tenant_access_token`); the bot must be the message sender and must be in the conversation that contains the message.
   - `urgent_sms` — 发送短信加急。Identity: `bot` only (`tenant_access_token`); the bot must be the message sender and must be in the conversation that contains the message.
@@ -225,10 +226,11 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `chat.managers.delete_managers` | `im:chat.managers:write_only` |
 | `chat.moderation.get` | `im:chat.moderation:read` |
 | `chat.moderation.update` | `im:chat:moderation:write_only` |
+| `messages.batch_get_read_status` | `im:message.read_status:readonly` |
 | `messages.delete` | `im:message:recall` |
 | `messages.forward` | `im:message` |
 | `messages.merge_forward` | `im:message` |
-| `messages.read_users` | `im:message:readonly` |
+| `messages.read_users` | user: `im:message:get_as_user`; bot: `im:message:readonly` |
 | `messages.urgent_app` | `im:message.urgent` |
 | `messages.urgent_phone` | `im:message.urgent:phone` |
 | `messages.urgent_sms` | `im:message.urgent:sms` |

--- a/skills/lark-im/references/lark-im-message-read-status.md
+++ b/skills/lark-im/references/lark-im-message-read-status.md
@@ -1,0 +1,99 @@
+# im message read status
+
+> **Prerequisite:** Read [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) first to understand authentication and global parameters.
+
+Use these commands for message read-status queries:
+
+- `im messages batch_get_read_status` queries whether the current user has read up to 50 messages.
+- `im messages read_users` lists users who have read one message and supports both user and bot identities.
+
+This is a raw Meta API command backed by `POST /open-apis/im/v1/messages/batch_query_read_status`.
+
+## Identity and scope
+
+- User identity only: always pass `--as user` or use a profile whose default identity is user.
+- Required scope: `im:message.read_status:readonly`.
+- Bot or tenant access tokens are not supported.
+- The request accepts at most 50 message IDs, and results are limited to messages visible to the current user.
+
+For `read_users`:
+
+- User identity requires `im:message:get_as_user`; the user can query only messages they sent within the last 7 days.
+- Bot identity uses an existing bot message scope such as `im:message:readonly`; the bot must be in the chat and can query only messages it sent within the last 7 days.
+
+## Commands
+
+```bash
+# Inspect the exact local schema first
+lark-cli schema im.messages.batch_get_read_status --format json
+
+# Preview without calling the API
+lark-cli im messages batch_get_read_status \
+  --data '{"message_ids":["om_xxx","om_yyy"]}' \
+  --as user \
+  --dry-run \
+  --json
+
+# Execute the query
+lark-cli im messages batch_get_read_status \
+  --data '{"message_ids":["om_xxx","om_yyy"]}' \
+  --as user \
+  --json
+```
+
+For a long list, put the request body in a relative file and pass `--data @request.json`.
+
+To list the users who have read one message as the current user:
+
+```bash
+lark-cli im messages read_users \
+  --params '{"message_id":"om_xxx","user_id_type":"open_id"}' \
+  --as user \
+  --json
+```
+
+Use `--as bot` for the existing bot flow. The command is paginated with optional `page_size` and `page_token` parameters.
+
+## Request
+
+| Field | Required | Limit | Description |
+|------|------|------|------|
+| `message_ids` | Yes | 1–50 | OpenAPI message IDs in `om_xxx` format |
+
+## Response
+
+The response contains `read_statuses`:
+
+```json
+{
+  "read_statuses": [
+    {
+      "message_id": "om_xxx",
+      "read_status": "read"
+    },
+    {
+      "message_id": "om_yyy",
+      "read_status": "unexpected",
+      "unexpected_reason": "no_permission"
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|------|------|
+| `message_id` | Input OpenAPI message ID |
+| `read_status` | `read`, `unread`, or `unexpected` |
+| `unexpected_reason` | Reason when status is `unexpected`, such as `invalid`, `no_permission`, or `not_support` |
+
+## AI usage guidance
+
+1. Never treat `unexpected` as `unread`; it means the service could not determine a read state.
+2. Do not retry the same inaccessible message repeatedly when `unexpected_reason` is `no_permission`.
+3. Preserve the returned `message_id` when correlating results with the input batch.
+4. Use `--dry-run` first when constructing the JSON body programmatically.
+
+## References
+
+- [lark-im](../SKILL.md) — all IM commands
+- [lark-shared](../../lark-shared/SKILL.md) — authentication and global parameters


### PR DESCRIPTION
## Summary
Document the new IM batch read-status command and the existing read-users command user-token support. This PR is draft until the corresponding larksuite-cli-registry change is merged and published.

## Changes
- Add lark-im discovery entries for messages.batch_get_read_status and user-mode messages.read_users
- Add identity, scope, request, response, and unexpected-status guidance

## Test Plan
- [x] make build
- [x] make unit-test
- [x] go test ./internal/registry ./cmd/service
- [x] go vet ./...
- [x] Manual dry-run confirms im messages read_users builds the expected user GET request
- [x] Manual validation confirms batch_get_read_status rejects bot identity

## Related Issues

## Merge Order
1. Merge and publish the registry MR.
2. Mark this PR ready and merge the CLI documentation update.