### PR TITLE
ci: schedule live skills integration tests

### DIFF
--- a/.github/workflows/live-skills.yml
+++ b/.github/workflows/live-skills.yml
@@ -43,6 +43,12 @@ jobs:
         run: |
           title="Live skills integration schedule is failing"
           run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          body=$(cat <<EOF
+          The scheduled live skills integration run failed: $run_url
+
+          The job runs \`make live-skills-test\` against the real \`npx skills\` CLI; a failure here usually means upstream drift in the skills CLI rather than a regression in this repo. Reproduce locally with \`make live-skills-test\`.
+          EOF
+          )
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
             --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
@@ -50,7 +56,5 @@ jobs:
               --body "Still failing: $run_url"
           else
             gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
-              --body "The scheduled live skills integration run failed: $run_url
-
-The job runs \`make live-skills-test\` against the real \`npx skills\` CLI; a failure here usually means upstream drift in the skills CLI rather than a regression in this repo. Reproduce locally with \`make live-skills-test\`."
+              --body "$body"
           fi

--- a/.github/workflows/live-skills.yml
+++ b/.github/workflows/live-skills.yml
@@ -1,0 +1,56 @@
+name: Live skills integration
+
+# The live skills tests exercise the real `npx skills` CLI against the live
+# registry. Their dominant failure mode is upstream drift — a new skills CLI
+# release changing output or flags — which breaks without any commit in this
+# repo, so this runs on a daily schedule rather than per PR (where live
+# network flakiness would block unrelated changes).
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  live-skills:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.x'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+      - name: Run live skills integration tests
+        run: make live-skills-test
+      # A scheduled job nobody is notified about rots as silently as no job
+      # at all: keep one open issue as the failure signal, commenting on
+      # repeats instead of piling up duplicates.
+      - name: Report failure as a tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Live skills integration schedule is failing"
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Still failing: $run_url"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
+              --body "The scheduled live skills integration run failed: $run_url
+
+The job runs \`make live-skills-test\` against the real \`npx skills\` CLI; a failure here usually means upstream drift in the skills CLI rather than a regression in this repo. Reproduce locally with \`make live-skills-test\`."
+          fi

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ fmt-check:
 script-test:
 	bash scripts/resolve-changed-from.test.sh
 	bash scripts/ci-workflow.test.sh
+	bash scripts/live-skills-workflow.test.sh
 	bash scripts/semantic-review-workflow.test.sh
 	$(NODE) --test scripts/e2e_domains.test.js scripts/semantic-review-verify-artifact.test.js scripts/pr-quality-summary.test.js scripts/semantic-review-publish.test.js scripts/ci-quality-summary-publish.test.js
 

--- a/scripts/live-skills-workflow.test.sh
+++ b/scripts/live-skills-workflow.test.sh
@@ -11,6 +11,13 @@ if [[ ! -f "$workflow" ]]; then
   exit 1
 fi
 
+# Parse the workflow as real YAML so a structurally invalid file (for example a
+# run: block scalar broken by an un-indented continuation line) fails here
+# instead of silently failing to load at GitHub Actions runtime. The grep
+# assertions below check content but cannot catch YAML structural errors. Ruby
+# ships a YAML parser on both ubuntu-latest CI and dev machines.
+ruby -ryaml -e "YAML.load_file(ARGV[0])" "$workflow" >/dev/null
+
 grep -Eq '^[[:space:]]+workflow_dispatch:[[:space:]]*$' "$workflow"
 grep -Eq '^[[:space:]]+schedule:[[:space:]]*$' "$workflow"
 if grep -Eq '^[[:space:]]*(push|pull_request|pull_request_target|merge_group):|^[[:space:]]*on:[[:space:]]*\[[^]]*(push|pull_request|pull_request_target|merge_group)' "$workflow"; then

--- a/scripts/live-skills-workflow.test.sh
+++ b/scripts/live-skills-workflow.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+workflow=.github/workflows/live-skills.yml
+
+if [[ ! -f "$workflow" ]]; then
+  echo "live skills workflow is missing" >&2
+  exit 1
+fi
+
+grep -Eq '^[[:space:]]+workflow_dispatch:[[:space:]]*$' "$workflow"
+grep -Eq '^[[:space:]]+schedule:[[:space:]]*$' "$workflow"
+if grep -Eq '^[[:space:]]*(push|pull_request|pull_request_target|merge_group):|^[[:space:]]*on:[[:space:]]*\[[^]]*(push|pull_request|pull_request_target|merge_group)' "$workflow"; then
+  echo "live skills workflow must only run on schedule or workflow_dispatch" >&2
+  exit 1
+fi
+
+grep -Fq "permissions:" "$workflow"
+grep -Fq "contents: read" "$workflow"
+grep -Fq "persist-credentials: false" "$workflow"
+grep -Fq "timeout-minutes: 15" "$workflow"
+grep -Fq "runs-on: ubuntu-latest" "$workflow"
+grep -Fq "node-version: '22'" "$workflow"
+grep -Fq "make live-skills-test" "$workflow"
+
+if grep -Fq '${{ secrets.' "$workflow"; then
+  echo "live skills workflow must not reference secrets" >&2
+  exit 1
+fi
+uses_lines=$(grep -E '^[[:space:]]*-[[:space:]]+uses:' "$workflow" || true)
+if [[ -z "$uses_lines" ]]; then
+  echo "live skills workflow must use pinned setup actions" >&2
+  exit 1
+fi
+if grep -Ev 'uses:[[:space:]]+[^@[:space:]]+@[0-9a-f]{40}([[:space:]]+#.*)?$' <<<"$uses_lines" >/dev/null; then
+  echo "workflow actions must be pinned to commit SHAs" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

PR #1883 made the two live skills integration tests strictly opt-in (`make live-skills-test`), which removed their accidental execution on developer machines — but also left them with no automated runs at all. Their dominant failure mode is upstream drift: `npx -y skills` always resolves the latest skills CLI release, so the integration can break without any commit in this repo. This PR restores the scheduled workflow (daily instead of weekly) and adds a failure-notification step, so breakage surfaces as an open issue instead of rotting silently.

## Changes

- Restore `.github/workflows/live-skills.yml`: daily cron (`0 3 * * *`) plus `workflow_dispatch`, running `make live-skills-test`
- Add a failure step that keeps one open tracking issue current (creates it on first failure, comments on repeats) via `gh` with the workflow `github.token` (`issues: write`)
- Restore `scripts/live-skills-workflow.test.sh` (workflow contract: schedule/dispatch-only triggers, SHA-pinned actions, no secrets) and wire it into `make script-test`

## Test Plan

- [x] `bash scripts/live-skills-workflow.test.sh` passed on this branch
- [x] `make live-skills-test` itself verified by real opt-in runs on #1883 (2/2 tests passed against the live skills CLI, isolated home, no leakage)
- [ ] skipped: unit-test / local-eval / acceptance-reviewer — CI-workflow-only change, no CLI behavior touched
- [x] manual verification: workflow triggers reviewed against the contract script; failure path exercised by dry-reading `gh issue` commands (will validate end-to-end via `workflow_dispatch` after merge)

## Related Issues

N/A (follow-up to #1883 review feedback; depends on #1883 — merge after it so `make live-skills-test` exists on main)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a scheduled “Live skills integration” workflow (daily) with manual run support.
  - On failure, the workflow reports status by creating or updating a tracking issue with the run link.

- **Tests**
  - Extended the `script-test` target to run a new workflow validation script.
  - Added checks to ensure correct triggers, tightened permissions/security settings, required limits/steps, and fully pinned action references (and no `secrets.*` usage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->