### PR TITLE
docs(calendar): document setting meeting owner via full API

### DIFF
--- a/skills/lark-calendar/references/lark-calendar-create.md
+++ b/skills/lark-calendar/references/lark-calendar-create.md
@@ -63,6 +63,7 @@ lark-cli calendar event.attendees create \
 - 时间参数是 **Unix 秒字符串**（非 ISO 8601）。
 - 全天日程的开始日期和结束日期必须分别是日程开始的第一天和结束的最后一天；单日全天日程两者相同。
 - 手动拆成“创建日程 + 添加参会人”两步时，若第二步失败，建议删除刚创建的空日程，避免遗留无参会人的日程。
+- 设置会议 owner：`+create` 不支持，需用完整 API 命令在 `vchat.meeting_settings.owner_id` 中设置，且必须同时设置 `vchat.vc_type` 为 `vc`（代表该日程为 VC 视频会议）。仅当以应用（bot）身份在应用日历上操作时生效；owner 必须为用户身份（`ou_` open_id），不能为非用户或外部租户用户。
 
 ## 参会人类型
 


### PR DESCRIPTION
## Summary
When creating a calendar event, if the caller wants to set the meeting owner, the `+create` shortcut does not expose this field. This documents how to set it via the full API command so AI agents route to the correct path.

## Changes
- Add a note under the "key differences of the full API command" list in `lark-calendar-create.md`: set the meeting owner via `vchat.meeting_settings.owner_id`, which requires `vchat.vc_type=vc`, is effective only for app (bot) identity operating on an app calendar, and the owner must be a user (`ou_` open_id), not a non-user or external-tenant user.

## Test Plan
- [x] Docs-only change; no code paths affected
- [ ] Unit tests pass (N/A — documentation only)

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that approved meeting rooms cannot have an owner set through the `+create` API.
  * Added guidance for configuring a meeting owner through the full API, including required meeting type, application calendar context, and eligible user identity requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->