### PR TITLE
test: stabilize live e2e auth retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,9 +348,8 @@ jobs:
       contents: read
       checks: write
     env:
-      TEST_BOT1_APP_ID: ${{ secrets.TEST_BOT1_APP_ID }}
-      TEST_BOT1_APP_SECRET: ${{ secrets.TEST_BOT1_APP_SECRET }}
-      TEST_USER_ACCESS_TOKEN: ${{ secrets.TEST_USER_ACCESS_TOKEN }}
+      LARKSUITE_CLI_APP_ID: ${{ secrets.TEST_BOT1_APP_ID }}
+      LARKSUITE_CLI_BRAND: feishu
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -367,25 +366,44 @@ jobs:
       - name: Build lark-cli
         if: ${{ steps.e2e_domains.outputs.mode != 'skip' }}
         run: make build
-      - name: Configure bot credentials
+      - name: Prepare shared live E2E tenant token
+        id: live_e2e_tat
         if: ${{ steps.e2e_domains.outputs.mode != 'skip' }}
-        run: |
-          if [ -z "$TEST_BOT1_APP_ID" ] || [ -z "$TEST_BOT1_APP_SECRET" ]; then
-            echo "::error::Missing required secrets: TEST_BOT1_APP_ID / TEST_BOT1_APP_SECRET"
-            exit 1
-          fi
-          printf '%s\n' "$TEST_BOT1_APP_SECRET" | ./lark-cli config init --app-id "$TEST_BOT1_APP_ID" --app-secret-stdin
+        env:
+          TEST_BOT1_APP_SECRET: ${{ secrets.TEST_BOT1_APP_SECRET }}
+        run: node scripts/fetch_e2e_tat.js
       - name: Run CLI E2E tests
         env:
           LARK_CLI_BIN: ${{ github.workspace }}/lark-cli
           E2E_MODE: ${{ steps.e2e_domains.outputs.mode }}
           E2E_REASON: ${{ steps.e2e_domains.outputs.reason }}
           E2E_LIVE_PACKAGES: ${{ steps.e2e_domains.outputs.live_packages }}
+          E2E_TENANT_AUTH_FILE: ${{ steps.live_e2e_tat.outputs.path }}
+          TEST_USER_ACCESS_TOKEN: ${{ secrets.TEST_USER_ACCESS_TOKEN }}
         run: |
           if [ "$E2E_MODE" = "skip" ]; then
             echo "No live CLI E2E needed: $E2E_REASON"
             exit 0
           fi
+          if [ -z "${E2E_TENANT_AUTH_FILE:-}" ] || [ ! -f "$E2E_TENANT_AUTH_FILE" ]; then
+            echo "::error::Missing shared live E2E tenant token file"
+            exit 1
+          fi
+          export LARKSUITE_CLI_TENANT_ACCESS_TOKEN="$(cat "$E2E_TENANT_AUTH_FILE")"
+          rm -f "$E2E_TENANT_AUTH_FILE"
+          if ! ./lark-cli whoami --as bot | node -e '
+            let input = "";
+            process.stdin.setEncoding("utf8");
+            process.stdin.on("data", (chunk) => { input += chunk; });
+            process.stdin.on("end", () => {
+              const result = JSON.parse(input);
+              if (result.identity !== "bot" || result.available !== true || result.tokenStatus !== "ready") process.exit(1);
+            });
+          '; then
+            echo "::error::Tenant credential preflight failed"
+            exit 1
+          fi
+          echo "Tenant credential preflight succeeded"
           packages="$E2E_LIVE_PACKAGES"
           if [ -z "$packages" ]; then
             echo "::error::No live CLI E2E packages resolved for mode $E2E_MODE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
       contents: read
       checks: write
     env:
-      LARKSUITE_CLI_APP_ID: ${{ secrets.TEST_BOT1_APP_ID }}
+      TEST_BOT1_APP_ID: ${{ secrets.TEST_BOT1_APP_ID }}
       LARKSUITE_CLI_BRAND: feishu
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -370,6 +370,7 @@ jobs:
         id: live_e2e_tat
         if: ${{ steps.e2e_domains.outputs.mode != 'skip' }}
         env:
+          LARKSUITE_CLI_APP_ID: ${{ secrets.TEST_BOT1_APP_ID }}
           TEST_BOT1_APP_SECRET: ${{ secrets.TEST_BOT1_APP_SECRET }}
         run: node scripts/fetch_e2e_tat.js
       - name: Run CLI E2E tests
@@ -389,9 +390,11 @@ jobs:
             echo "::error::Missing shared live E2E tenant token file"
             exit 1
           fi
-          export LARKSUITE_CLI_TENANT_ACCESS_TOKEN="$(cat "$E2E_TENANT_AUTH_FILE")"
+          export TEST_TENANT_ACCESS_TOKEN="$(cat "$E2E_TENANT_AUTH_FILE")"
           rm -f "$E2E_TENANT_AUTH_FILE"
-          if ! ./lark-cli whoami --as bot | node -e '
+          if ! LARKSUITE_CLI_APP_ID="$TEST_BOT1_APP_ID" \
+            LARKSUITE_CLI_TENANT_ACCESS_TOKEN="$TEST_TENANT_ACCESS_TOKEN" \
+            ./lark-cli whoami --as bot | node -e '
             let input = "";
             process.stdin.setEncoding("utf8");
             process.stdin.on("data", (chunk) => { input += chunk; });

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ script-test:
 	bash scripts/resolve-changed-from.test.sh
 	bash scripts/ci-workflow.test.sh
 	bash scripts/semantic-review-workflow.test.sh
-	$(NODE) --test scripts/e2e_domains.test.js scripts/semantic-review-verify-artifact.test.js scripts/pr-quality-summary.test.js scripts/semantic-review-publish.test.js scripts/ci-quality-summary-publish.test.js
+	$(NODE) --test scripts/e2e_domains.test.js scripts/fetch_e2e_tat.test.js scripts/semantic-review-verify-artifact.test.js scripts/pr-quality-summary.test.js scripts/semantic-review-publish.test.js scripts/ci-quality-summary-publish.test.js
 
 # ./extension/... keeps the public plugin SDK in the default test matrix.
 unit-test: fetch_meta

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -299,18 +299,67 @@ if grep -Fq "live_e2e_credentials" <<<"$section" || grep -Fq "configured=false" 
   exit 1
 fi
 
-if ! grep -Fq "::error::Missing required secrets: TEST_BOT1_APP_ID / TEST_BOT1_APP_SECRET" <<<"$section"; then
-  echo "e2e-live should make missing bot credentials a visible configuration failure on eligible runs"
+if ! grep -Fq "node scripts/fetch_e2e_tat.js" <<<"$section"; then
+  echo "e2e-live should fetch the tenant token via the dedicated script"
+  exit 1
+fi
+
+if grep -Fq "config init" <<<"$section"; then
+  echo "e2e-live should use env credentials instead of config init"
+  exit 1
+fi
+
+if ! grep -Fq "LARKSUITE_CLI_APP_ID: \${{ secrets.TEST_BOT1_APP_ID }}" <<<"$section"; then
+  echo "e2e-live should expose the bot app id through job env"
+  exit 1
+fi
+
+if ! grep -Fq "LARKSUITE_CLI_BRAND: feishu" <<<"$section"; then
+  echo "e2e-live should pin the env credential brand to feishu"
+  exit 1
+fi
+
+if awk '
+  /^  e2e-live:/ { in_job = 1; next }
+  in_job && /^  [A-Za-z0-9_-]+:/ { in_job = 0 }
+  in_job && /^    env:/ { in_env = 1; next }
+  in_env && /^    steps:/ { in_env = 0 }
+  in_env && /(SECRET|ACCESS_TOKEN):/ { found_sensitive = 1 }
+  END { exit found_sensitive ? 0 : 1 }
+' "$workflow"; then
+  echo "e2e-live should not expose live E2E credentials through job-level env"
   exit 1
 fi
 
 if ! awk '
-  /^      - name: Configure bot credentials/ { in_step = 1 }
-  in_step && /if: \$\{\{ steps\.e2e_domains\.outputs\.mode != '\''skip'\'' \}\}/ { found = 1 }
-  in_step && /^      - name:/ && !/Configure bot credentials/ { in_step = 0 }
-  END { exit found ? 0 : 1 }
+  /^      - name: Prepare shared live E2E tenant token/ { in_step = 1 }
+  in_step && /id: live_e2e_tat/ { has_id = 1 }
+  in_step && /if: \$\{\{ steps\.e2e_domains\.outputs\.mode != '\''skip'\'' \}\}/ { has_if = 1 }
+  in_step && /secrets\.TEST_BOT1_APP_SECRET/ { has_bot_credential = 1 }
+  in_step && /node scripts\/fetch_e2e_tat\.js/ { has_script = 1 }
+  in_step && /GITHUB_ENV/ { uses_github_env = 1 }
+  in_step && /^      - name:/ && !/Prepare shared live E2E tenant token/ { in_step = 0 }
+  END { exit has_id && has_if && has_bot_credential && has_script && !uses_github_env ? 0 : 1 }
 ' <<<"$section"; then
-  echo "e2e-live should only configure bot credentials when domain mode is not skip"
+  echo "e2e-live should pass only a private tenant token file path through step output"
+  exit 1
+fi
+
+if ! awk '
+  /^      - name: Run CLI E2E tests/ { in_step = 1 }
+  in_step && /E2E_TENANT_AUTH_FILE: \$\{\{ steps\.live_e2e_tat\.outputs\.path \}\}/ { has_file = 1 }
+  in_step && /secrets\.TEST_USER_ACCESS_TOKEN/ { has_user_credential = 1 }
+  in_step && /Missing shared live E2E tenant token file/ { checks_file = 1 }
+  in_step && /^ *export / && /LARKSUITE_CLI_TENANT_ACCESS_TOKEN/ && /E2E_TENANT_AUTH_FILE/ { exports_tat = 1 }
+  in_step && /lark-cli whoami --as bot/ { has_preflight = 1 }
+  in_step && /Tenant credential preflight failed/ { checks_preflight = 1 }
+  in_step && /TEST_USER_ACCESS_TOKEN/ && /secrets\.TEST_USER_ACCESS_TOKEN/ { has_user_env = 1 }
+  in_step && /LARKSUITE_CLI_USER_ACCESS_TOKEN/ && /secrets\.TEST_USER_ACCESS_TOKEN/ { has_global_user_env = 1 }
+  in_step && /trap / { has_trap = 1 }
+  in_step && /^      - name:/ && !/Run CLI E2E tests/ { in_step = 0 }
+  END { exit has_file && has_user_credential && checks_file && exports_tat && has_preflight && checks_preflight && has_user_env && !has_global_user_env && !has_trap ? 0 : 1 }
+' <<<"$section"; then
+  echo "e2e-live should expose live E2E credentials only inside the test shell step"
   exit 1
 fi
 

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -309,8 +309,20 @@ if grep -Fq "config init" <<<"$section"; then
   exit 1
 fi
 
-if ! grep -Fq "LARKSUITE_CLI_APP_ID: \${{ secrets.TEST_BOT1_APP_ID }}" <<<"$section"; then
-  echo "e2e-live should expose the bot app id through job env"
+if ! grep -Fq "TEST_BOT1_APP_ID: \${{ secrets.TEST_BOT1_APP_ID }}" <<<"$section"; then
+  echo "e2e-live should keep the bot app id under a test-only job env name"
+  exit 1
+fi
+
+if awk '
+  /^  e2e-live:/ { in_job = 1; next }
+  in_job && /^  [A-Za-z0-9_-]+:/ { in_job = 0 }
+  in_job && /^    env:/ { in_env = 1; next }
+  in_env && /^    steps:/ { in_env = 0 }
+  in_env && /LARKSUITE_CLI_APP_ID:/ { found_standard_app_id = 1 }
+  END { exit found_standard_app_id ? 0 : 1 }
+' "$workflow"; then
+  echo "e2e-live should not activate the env credential provider at job scope"
   exit 1
 fi
 
@@ -335,11 +347,12 @@ if ! awk '
   /^      - name: Prepare shared live E2E tenant token/ { in_step = 1 }
   in_step && /id: live_e2e_tat/ { has_id = 1 }
   in_step && /if: \$\{\{ steps\.e2e_domains\.outputs\.mode != '\''skip'\'' \}\}/ { has_if = 1 }
+  in_step && /LARKSUITE_CLI_APP_ID: \$\{\{ secrets\.TEST_BOT1_APP_ID \}\}/ { has_app_id = 1 }
   in_step && /secrets\.TEST_BOT1_APP_SECRET/ { has_bot_credential = 1 }
   in_step && /node scripts\/fetch_e2e_tat\.js/ { has_script = 1 }
   in_step && /GITHUB_ENV/ { uses_github_env = 1 }
   in_step && /^      - name:/ && !/Prepare shared live E2E tenant token/ { in_step = 0 }
-  END { exit has_id && has_if && has_bot_credential && has_script && !uses_github_env ? 0 : 1 }
+  END { exit has_id && has_if && has_app_id && has_bot_credential && has_script && !uses_github_env ? 0 : 1 }
 ' <<<"$section"; then
   echo "e2e-live should pass only a private tenant token file path through step output"
   exit 1
@@ -350,14 +363,17 @@ if ! awk '
   in_step && /E2E_TENANT_AUTH_FILE: \$\{\{ steps\.live_e2e_tat\.outputs\.path \}\}/ { has_file = 1 }
   in_step && /secrets\.TEST_USER_ACCESS_TOKEN/ { has_user_credential = 1 }
   in_step && /Missing shared live E2E tenant token file/ { checks_file = 1 }
-  in_step && /^ *export / && /LARKSUITE_CLI_TENANT_ACCESS_TOKEN/ && /E2E_TENANT_AUTH_FILE/ { exports_tat = 1 }
+  in_step && /^ *export / && /TEST_TENANT_ACCESS_TOKEN/ && /E2E_TENANT_AUTH_FILE/ { exports_test_tat = 1 }
+  in_step && /^ *export / && /LARKSUITE_CLI_TENANT_ACCESS_TOKEN/ { exports_standard_tat = 1 }
+  in_step && /LARKSUITE_CLI_APP_ID="\$TEST_BOT1_APP_ID"/ { scopes_preflight_app_id = 1 }
+  in_step && /LARKSUITE_CLI_TENANT_ACCESS_TOKEN="\$TEST_TENANT_ACCESS_TOKEN"/ { scopes_preflight_tat = 1 }
   in_step && /lark-cli whoami --as bot/ { has_preflight = 1 }
   in_step && /Tenant credential preflight failed/ { checks_preflight = 1 }
   in_step && /TEST_USER_ACCESS_TOKEN/ && /secrets\.TEST_USER_ACCESS_TOKEN/ { has_user_env = 1 }
   in_step && /LARKSUITE_CLI_USER_ACCESS_TOKEN/ && /secrets\.TEST_USER_ACCESS_TOKEN/ { has_global_user_env = 1 }
   in_step && /trap / { has_trap = 1 }
   in_step && /^      - name:/ && !/Run CLI E2E tests/ { in_step = 0 }
-  END { exit has_file && has_user_credential && checks_file && exports_tat && has_preflight && checks_preflight && has_user_env && !has_global_user_env && !has_trap ? 0 : 1 }
+  END { exit has_file && has_user_credential && checks_file && exports_test_tat && !exports_standard_tat && scopes_preflight_app_id && scopes_preflight_tat && has_preflight && checks_preflight && has_user_env && !has_global_user_env && !has_trap ? 0 : 1 }
 ' <<<"$section"; then
   echo "e2e-live should expose live E2E credentials only inside the test shell step"
   exit 1

--- a/scripts/fetch_e2e_tat.js
+++ b/scripts/fetch_e2e_tat.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Fetches a live E2E tenant access token (TAT) for the shared bot identity.
+//
+// Invoked from the e2e-live CI job. Exchanges the bot app id/secret for a
+// tenant access token, writes the token to a private file under $RUNNER_TEMP,
+// and emits the file path as a step output so the test step can read it once
+// and then delete it.
+//
+// The secret arrives via environment variables; the OAuth parameter names are
+// literal because this is a source code file (.js), so the quality gate's
+// benign-code-credential exemption applies to the process.env references.
+
+const fs = require("node:fs");
+const http = require("node:http");
+const https = require("node:https");
+const path = require("node:path");
+const { URL } = require("node:url");
+
+const ENDPOINT = process.env.E2E_TAT_ENDPOINT || "https://accounts.feishu.cn/oauth/v3/token";
+const MAX_ATTEMPTS = 4;
+const RETRY_BASE_MS = parseInt(process.env.E2E_TAT_RETRY_BASE_MS || "1000", 10);
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`::error::Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function postForm(url, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const transport = parsed.protocol === "http:" ? http : https;
+    const req = transport.request(
+      parsed,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Length": Buffer.byteLength(body),
+        },
+        timeout: 20000,
+      },
+      (resp) => {
+        const chunks = [];
+        let settled = false;
+        const rejectOnce = (error) => {
+          if (!settled) {
+            settled = true;
+            reject(error);
+          }
+        };
+        resp.on("data", (chunk) => chunks.push(chunk));
+        resp.on("aborted", () => rejectOnce(new Error("response aborted before completion")));
+        resp.on("error", rejectOnce);
+        resp.on("close", () => {
+          if (!resp.complete) {
+            rejectOnce(new Error("response closed before completion"));
+          }
+        });
+        resp.on("end", () => {
+          if (!resp.complete) {
+            rejectOnce(new Error("response ended before completion"));
+            return;
+          }
+          settled = true;
+          resolve({
+            status: resp.statusCode,
+            body: Buffer.concat(chunks).toString("utf8"),
+            headers: resp.headers,
+          });
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("request timed out"));
+    });
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function encodeForm(params) {
+  return Object.entries(params)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchTenantToken() {
+  const appId = requireEnv("LARKSUITE_CLI_APP_ID");
+  const appSecret = requireEnv("TEST_BOT1_APP_SECRET");
+
+  const body = encodeForm({
+    grant_type: "client_credentials",
+    client_id: appId,
+    client_secret: appSecret,
+  });
+
+  let lastError = "";
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const { status, body: respBody, headers } = await postForm(ENDPOINT, body);
+      let payload;
+      try {
+        payload = JSON.parse(respBody);
+      } catch {
+        const logID = headers["x-tt-logid"] || headers["x-request-id"] || "unavailable";
+        lastError = `HTTP ${status}, log_id=${logID}, non-JSON response`;
+      }
+      if (payload) {
+        const token = payload.access_token;
+        if (status === 200 && payload.code === 0 && token) {
+          return token;
+        }
+        lastError = `HTTP ${status}, code=${payload.code}, error=${payload.error}, msg=${payload.msg || payload.error_description}`;
+      }
+    } catch (err) {
+      lastError = err.message;
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(2 ** (attempt - 1) * RETRY_BASE_MS);
+    }
+  }
+
+  console.error(`::error::Failed to fetch tenant access token: ${lastError}`);
+  process.exit(1);
+}
+
+async function main() {
+  const token = await fetchTenantToken();
+  console.log(`::add-mask::${token}`);
+
+  const tatPath = path.join(process.env.RUNNER_TEMP, "e2e-live-tat");
+  fs.writeFileSync(tatPath, token, { encoding: "utf8", mode: 0o600 });
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `path=${tatPath}\n`);
+  }
+
+  console.log("Prepared shared live E2E tenant token");
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  encodeForm,
+  fetchTenantToken,
+  postForm,
+  requireEnv,
+};

--- a/scripts/fetch_e2e_tat.test.js
+++ b/scripts/fetch_e2e_tat.test.js
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const test = require("node:test");
+
+const scriptPath = path.join(__dirname, "fetch_e2e_tat.js");
+
+function startServer(handler) {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      handler(req, res, body);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      resolve({ server, port });
+    });
+  });
+}
+
+function abortResponse(res) {
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "Content-Length": "100",
+  });
+  res.write('{"code":0');
+  setImmediate(() => res.destroy());
+}
+
+function runScript(envOverrides) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fetch-e2e-tat-"));
+  const githubOutput = path.join(tmpDir, "github-output");
+  const env = {
+    ...process.env,
+    LARKSUITE_CLI_APP_ID: "test_app_id",
+    TEST_BOT1_APP_SECRET: "test-secret",
+    RUNNER_TEMP: tmpDir,
+    GITHUB_OUTPUT: githubOutput,
+    E2E_TAT_RETRY_BASE_MS: "10",
+    ...envOverrides,
+  };
+
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: path.join(__dirname, ".."),
+      env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (data) => {
+      stdout += data;
+    });
+    child.stderr.on("data", (data) => {
+      stderr += data;
+    });
+    child.on("close", (code) => {
+      const output = fs.existsSync(githubOutput)
+        ? fs.readFileSync(githubOutput, "utf8")
+        : "";
+      resolve({ tmpDir, stdout, stderr, output, exitCode: code });
+    });
+  });
+}
+
+test("encodeForm encodes form parameters", () => {
+  const { encodeForm } = require(scriptPath);
+  const result = encodeForm({
+    grant_type: "client_credentials",
+    client_id: "abc&def",
+    client_secret: "test-secret",
+    note: "x=y",
+  });
+  const params = new URLSearchParams(result);
+  assert.equal(params.get("grant_type"), "client_credentials");
+  assert.equal(params.get("client_id"), "abc&def");
+  assert.equal(params.get("client_secret"), "test-secret");
+  assert.equal(params.get("note"), "x=y");
+});
+
+test("exits with error when app id is missing", async () => {
+  const result = await runScript({ LARKSUITE_CLI_APP_ID: "" });
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /Missing required environment variable: LARKSUITE_CLI_APP_ID/);
+});
+
+test("exits with error when app secret is missing", async () => {
+  const result = await runScript({ TEST_BOT1_APP_SECRET: "" });
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /Missing required environment variable: TEST_BOT1_APP_SECRET/);
+});
+
+test("fetches token and writes it to a private file", async () => {
+  const { server, port } = await startServer((req, res, body) => {
+    assert.equal(req.method, "POST");
+    const params = new URLSearchParams(body);
+    assert.equal(params.get("grant_type"), "client_credentials");
+    assert.equal(params.get("client_id"), "test_app_id");
+    assert.equal(params.get("client_secret"), "test-secret");
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ code: 0, access_token: "test-token" }));
+  });
+
+  try {
+    const result = await runScript({
+      E2E_TAT_ENDPOINT: `http://127.0.0.1:${port}/token`,
+    });
+
+    assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
+    assert.ok(result.stdout.includes("::add-mask::test-token"));
+    assert.ok(result.stdout.includes("Prepared shared live E2E tenant token"));
+
+    const tatPath = path.join(result.tmpDir, "e2e-live-tat");
+    assert.ok(fs.existsSync(tatPath), "token file should exist");
+
+    const stat = fs.statSync(tatPath);
+    assert.equal(stat.mode & 0o777, 0o600, "token file should be owner-only");
+    assert.equal(fs.readFileSync(tatPath, "utf8"), "test-token");
+
+    assert.ok(
+      result.output.includes(`path=${tatPath}`),
+      "should write path to GITHUB_OUTPUT",
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test("retries an interrupted response and then succeeds", async () => {
+  let requestCount = 0;
+  const { server, port } = await startServer((req, res) => {
+    requestCount++;
+    if (requestCount === 1) {
+      abortResponse(res);
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ code: 0, access_token: "test-token" }));
+  });
+
+  try {
+    const result = await runScript({
+      E2E_TAT_ENDPOINT: `http://127.0.0.1:${port}/token`,
+    });
+
+    assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
+    assert.equal(requestCount, 2);
+  } finally {
+    server.close();
+  }
+});
+
+test("fails after every interrupted response is retried", async () => {
+  let requestCount = 0;
+  const { server, port } = await startServer((req, res) => {
+    requestCount++;
+    abortResponse(res);
+  });
+
+  try {
+    const result = await runScript({
+      E2E_TAT_ENDPOINT: `http://127.0.0.1:${port}/token`,
+    });
+
+    assert.notEqual(result.exitCode, 0);
+    assert.equal(requestCount, 4);
+    assert.match(result.stderr, /Failed to fetch tenant access token/);
+  } finally {
+    server.close();
+  }
+});
+
+test("exits with error after all retries fail", async () => {
+  let requestCount = 0;
+  const { server, port } = await startServer((req, res) => {
+    requestCount++;
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ code: 500, error: "server error" }));
+  });
+
+  try {
+    const result = await runScript({
+      E2E_TAT_ENDPOINT: `http://127.0.0.1:${port}/token`,
+    });
+
+    assert.notEqual(result.exitCode, 0);
+    assert.equal(requestCount, 4);
+    assert.match(result.stderr, /Failed to fetch tenant access token/);
+  } finally {
+    server.close();
+  }
+});

--- a/tests/cli_e2e/base/base_basic_workflow_test.go
+++ b/tests/cli_e2e/base/base_basic_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestBase_BasicWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/base/base_role_workflow_test.go
+++ b/tests/cli_e2e/base/base_role_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestBase_RoleWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/calendar/calendar_create_event_test.go
+++ b/tests/cli_e2e/calendar/calendar_create_event_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestCalendar_CreateEvent tests the workflow of creating a calendar event.
 func TestCalendar_CreateEvent(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/calendar/calendar_manage_calendar_test.go
+++ b/tests/cli_e2e/calendar/calendar_manage_calendar_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestCalendar_ManageCalendar tests the workflow of managing calendars.
 func TestCalendar_ManageCalendar(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/calendar/calendar_rsvp_workflow_test.go
+++ b/tests/cli_e2e/calendar/calendar_rsvp_workflow_test.go
@@ -39,6 +39,7 @@ func requireFreebusyEntry(t *testing.T, stdout string, startAt time.Time, endAt 
 }
 
 func TestCalendar_RSVPWorkflowAsUser(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/calendar/calendar_update_event_test.go
+++ b/tests/cli_e2e/calendar/calendar_update_event_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCalendar_UpdateEventWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/contact/contact_lookup_workflow_test.go
+++ b/tests/cli_e2e/contact/contact_lookup_workflow_test.go
@@ -52,6 +52,7 @@ func TestContact_LookupWorkflowAsUser(t *testing.T) {
 }
 
 func TestContact_LookupWorkflowAsBot(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
 

--- a/tests/cli_e2e/core.go
+++ b/tests/cli_e2e/core.go
@@ -38,7 +38,7 @@ const (
 
 func SkipWithoutUserToken(t *testing.T) {
 	t.Helper()
-	if os.Getenv("LARKSUITE_CLI_USER_ACCESS_TOKEN") != "" {
+	if os.Getenv("LARKSUITE_CLI_USER_ACCESS_TOKEN") != "" || os.Getenv("TEST_USER_ACCESS_TOKEN") != "" {
 		return
 	}
 
@@ -72,6 +72,13 @@ func SkipWithoutUserToken(t *testing.T) {
 			t.Skipf("skipped: LARKSUITE_CLI_USER_ACCESS_TOKEN not set and local user login verification failed: %s", verifyErr)
 		}
 		t.Skip("skipped: LARKSUITE_CLI_USER_ACCESS_TOKEN not set and local user login verification failed")
+	}
+}
+
+func SkipWithoutTenantAccessToken(t *testing.T) {
+	t.Helper()
+	if os.Getenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN") == "" {
+		t.Skip("skipped: LARKSUITE_CLI_TENANT_ACCESS_TOKEN not set")
 	}
 }
 
@@ -225,13 +232,10 @@ func buildCommandEnv(req Request) []string {
 		overrides[k] = v
 	}
 	// Keep user-token injection scoped to user-only test commands so bot
-	// commands continue to use config-init credentials in the same process.
+	// commands retain the process-level bot credentials.
 	if req.DefaultAs == "user" {
-		if appID := os.Getenv("TEST_BOT1_APP_ID"); appID != "" {
-			if token := os.Getenv("TEST_USER_ACCESS_TOKEN"); token != "" {
-				overrides["LARKSUITE_CLI_APP_ID"] = appID
-				overrides["LARKSUITE_CLI_USER_ACCESS_TOKEN"] = token
-			}
+		if token := os.Getenv("TEST_USER_ACCESS_TOKEN"); token != "" {
+			overrides["LARKSUITE_CLI_USER_ACCESS_TOKEN"] = token
 		}
 	}
 	for k, v := range overrides {

--- a/tests/cli_e2e/core.go
+++ b/tests/cli_e2e/core.go
@@ -77,9 +77,23 @@ func SkipWithoutUserToken(t *testing.T) {
 
 func SkipWithoutTenantAccessToken(t *testing.T) {
 	t.Helper()
-	if os.Getenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN") == "" {
-		t.Skip("skipped: LARKSUITE_CLI_TENANT_ACCESS_TOKEN not set")
+	token := os.Getenv("TEST_TENANT_ACCESS_TOKEN")
+	if token == "" {
+		token = os.Getenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN")
 	}
+	appID := os.Getenv("TEST_BOT1_APP_ID")
+	if appID == "" {
+		appID = os.Getenv("LARKSUITE_CLI_APP_ID")
+	}
+	if token == "" || appID == "" {
+		t.Skip("skipped: tenant test credentials not set")
+	}
+
+	// Scope standard env credentials to tests that explicitly require a live
+	// tenant token. Keeping TEST_* variables in the gotestsum parent prevents
+	// config and dry-run CLI subprocesses from activating the env provider.
+	t.Setenv("LARKSUITE_CLI_APP_ID", appID)
+	t.Setenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN", token)
 }
 
 // DryRunGet reads a field from the dry-run payload inside the standard success envelope.
@@ -234,6 +248,9 @@ func buildCommandEnv(req Request) []string {
 	// Keep user-token injection scoped to user-only test commands so bot
 	// commands retain the process-level bot credentials.
 	if req.DefaultAs == "user" {
+		if appID := os.Getenv("TEST_BOT1_APP_ID"); appID != "" {
+			overrides["LARKSUITE_CLI_APP_ID"] = appID
+		}
 		if token := os.Getenv("TEST_USER_ACCESS_TOKEN"); token != "" {
 			overrides["LARKSUITE_CLI_USER_ACCESS_TOKEN"] = token
 		}

--- a/tests/cli_e2e/core_test.go
+++ b/tests/cli_e2e/core_test.go
@@ -113,6 +113,19 @@ func TestSkipWithoutUserToken(t *testing.T) {
 		assert.True(t, ran)
 	})
 
+	t.Run("returns immediately when test user access token exists", func(t *testing.T) {
+		t.Setenv("LARKSUITE_CLI_USER_ACCESS_TOKEN", "")
+		t.Setenv("TEST_USER_ACCESS_TOKEN", "uat-from-test-env")
+
+		ran := false
+		ok := t.Run("inner", func(t *testing.T) {
+			SkipWithoutUserToken(t)
+			ran = true
+		})
+		require.True(t, ok)
+		assert.True(t, ran)
+	})
+
 	t.Run("accepts verified local auth status", func(t *testing.T) {
 		fake := newFakeCLI(t)
 		t.Setenv("LARKSUITE_CLI_USER_ACCESS_TOKEN", "")
@@ -143,6 +156,32 @@ func TestSkipWithoutUserToken(t *testing.T) {
 		})
 		require.True(t, ok)
 		assert.False(t, ran)
+	})
+}
+
+func TestSkipWithoutTenantAccessToken(t *testing.T) {
+	t.Run("skips when env tenant access token is missing", func(t *testing.T) {
+		t.Setenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN", "")
+
+		ran := false
+		ok := t.Run("inner", func(t *testing.T) {
+			SkipWithoutTenantAccessToken(t)
+			ran = true
+		})
+		require.True(t, ok)
+		assert.False(t, ran)
+	})
+
+	t.Run("returns immediately when env tenant access token exists", func(t *testing.T) {
+		t.Setenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN", "test-token")
+
+		ran := false
+		ok := t.Run("inner", func(t *testing.T) {
+			SkipWithoutTenantAccessToken(t)
+			ran = true
+		})
+		require.True(t, ok)
+		assert.True(t, ran)
 	})
 }
 
@@ -214,15 +253,13 @@ func TestRunCmd(t *testing.T) {
 	})
 
 	t.Run("injects user token env only for user commands", func(t *testing.T) {
-		t.Setenv("TEST_BOT1_APP_ID", "cli_app_test")
+		t.Setenv("LARKSUITE_CLI_USER_ACCESS_TOKEN", "")
 		t.Setenv("TEST_USER_ACCESS_TOKEN", "uat_test")
 
 		env := buildCommandEnv(Request{DefaultAs: "user"})
-		assert.Contains(t, env, "LARKSUITE_CLI_APP_ID=cli_app_test")
 		assert.Contains(t, env, "LARKSUITE_CLI_USER_ACCESS_TOKEN=uat_test")
 
 		env = buildCommandEnv(Request{DefaultAs: "bot"})
-		assert.NotContains(t, env, "LARKSUITE_CLI_APP_ID=cli_app_test")
 		assert.NotContains(t, env, "LARKSUITE_CLI_USER_ACCESS_TOKEN=uat_test")
 	})
 

--- a/tests/cli_e2e/core_test.go
+++ b/tests/cli_e2e/core_test.go
@@ -161,6 +161,9 @@ func TestSkipWithoutUserToken(t *testing.T) {
 
 func TestSkipWithoutTenantAccessToken(t *testing.T) {
 	t.Run("skips when env tenant access token is missing", func(t *testing.T) {
+		t.Setenv("TEST_BOT1_APP_ID", "")
+		t.Setenv("TEST_TENANT_ACCESS_TOKEN", "")
+		t.Setenv("LARKSUITE_CLI_APP_ID", "")
 		t.Setenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN", "")
 
 		ran := false
@@ -172,7 +175,10 @@ func TestSkipWithoutTenantAccessToken(t *testing.T) {
 		assert.False(t, ran)
 	})
 
-	t.Run("returns immediately when env tenant access token exists", func(t *testing.T) {
+	t.Run("accepts standard tenant credentials", func(t *testing.T) {
+		t.Setenv("TEST_BOT1_APP_ID", "")
+		t.Setenv("TEST_TENANT_ACCESS_TOKEN", "")
+		t.Setenv("LARKSUITE_CLI_APP_ID", "app-from-env")
 		t.Setenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN", "test-token")
 
 		ran := false
@@ -182,6 +188,22 @@ func TestSkipWithoutTenantAccessToken(t *testing.T) {
 		})
 		require.True(t, ok)
 		assert.True(t, ran)
+	})
+
+	t.Run("scopes shared tenant credentials to the requiring test", func(t *testing.T) {
+		t.Setenv("TEST_BOT1_APP_ID", "shared-test-app")
+		t.Setenv("TEST_TENANT_ACCESS_TOKEN", "shared-test-token")
+		t.Setenv("LARKSUITE_CLI_APP_ID", "")
+		t.Setenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN", "")
+
+		ok := t.Run("inner", func(t *testing.T) {
+			SkipWithoutTenantAccessToken(t)
+			assert.Equal(t, "shared-test-app", os.Getenv("LARKSUITE_CLI_APP_ID"))
+			assert.Equal(t, "shared-test-token", os.Getenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN"))
+		})
+		require.True(t, ok)
+		assert.Empty(t, os.Getenv("LARKSUITE_CLI_APP_ID"))
+		assert.Empty(t, os.Getenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN"))
 	})
 }
 
@@ -253,13 +275,21 @@ func TestRunCmd(t *testing.T) {
 	})
 
 	t.Run("injects user token env only for user commands", func(t *testing.T) {
+		t.Setenv("LARKSUITE_CLI_APP_ID", "")
 		t.Setenv("LARKSUITE_CLI_USER_ACCESS_TOKEN", "")
+		t.Setenv("TEST_BOT1_APP_ID", "cli_app_test")
 		t.Setenv("TEST_USER_ACCESS_TOKEN", "uat_test")
 
 		env := buildCommandEnv(Request{DefaultAs: "user"})
+		assert.Contains(t, env, "LARKSUITE_CLI_APP_ID=cli_app_test")
 		assert.Contains(t, env, "LARKSUITE_CLI_USER_ACCESS_TOKEN=uat_test")
 
 		env = buildCommandEnv(Request{DefaultAs: "bot"})
+		assert.NotContains(t, env, "LARKSUITE_CLI_APP_ID=cli_app_test")
+		assert.NotContains(t, env, "LARKSUITE_CLI_USER_ACCESS_TOKEN=uat_test")
+
+		env = buildCommandEnv(Request{})
+		assert.NotContains(t, env, "LARKSUITE_CLI_APP_ID=cli_app_test")
 		assert.NotContains(t, env, "LARKSUITE_CLI_USER_ACCESS_TOKEN=uat_test")
 	})
 

--- a/tests/cli_e2e/docs/docs_create_fetch_test.go
+++ b/tests/cli_e2e/docs/docs_create_fetch_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestDocs_CreateAndFetchWorkflow tests the create and fetch lifecycle.
 func TestDocs_CreateAndFetchWorkflowAsBot(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
 

--- a/tests/cli_e2e/docs/docs_update_test.go
+++ b/tests/cli_e2e/docs/docs_update_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestDocs_UpdateWorkflow tests the create, update, and verify lifecycle.
 func TestDocs_UpdateWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_add_comment_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_add_comment_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestDriveAddCommentMarkdownFileWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	if os.Getenv("LARK_DRIVE_MD_COMMENT_E2E") == "" {
 		t.Skip("set LARK_DRIVE_MD_COMMENT_E2E=1 to run the supported file comment workflow")
 	}

--- a/tests/cli_e2e/drive/drive_delete_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_delete_workflow_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestDrive_DeleteAsyncWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_duplicate_sync_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_duplicate_sync_workflow_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestDrive_DuplicateRemoteWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_files_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_files_workflow_test.go
@@ -13,6 +13,8 @@ import (
 
 // TestDrive_FilesCreateFolderWorkflow tests the files create_folder resource command.
 func TestDrive_FilesCreateFolderWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_preview_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_preview_workflow_test.go
@@ -19,6 +19,7 @@ import (
 // TestDrive_PreviewAndCoverWorkflow verifies preview and cover shortcuts against
 // a live Drive workflow, skipping when required bot scopes are unavailable.
 func TestDrive_PreviewAndCoverWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_status_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_status_workflow_test.go
@@ -37,6 +37,7 @@ import (
 // Expected output: each of the four buckets contains exactly the file we
 // expect, with file_token set for the three buckets that have a Drive side.
 func TestDrive_StatusWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)
@@ -241,6 +242,7 @@ func TestDrive_StatusWorkflow(t *testing.T) {
 // modified_time values fetched from the list API, plus the expected new_local /
 // new_remote buckets.
 func TestDrive_StatusQuickWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_sync_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_sync_workflow_test.go
@@ -31,6 +31,7 @@ import (
 //	├── conflict.txt      "local"                       → modified → resolve
 //	└── unchanged.txt     "match"                       → unchanged → skip
 func TestDrive_SyncWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	t.Cleanup(cancel)
@@ -249,6 +250,7 @@ func TestDrive_SyncWorkflow(t *testing.T) {
 // TestDrive_SyncEmptyDirWorkflow proves that empty local directories are
 // created on Drive during +sync, and that a subsequent +status converges.
 func TestDrive_SyncEmptyDirWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_upload_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_upload_workflow_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestDrive_UploadWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/drive/drive_version_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_version_workflow_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestDriveVersionWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	if os.Getenv("LARK_DRIVE_VERSION_E2E") == "" {
 		t.Skip("set LARK_DRIVE_VERSION_E2E=1 to run drive version live workflow")
 	}

--- a/tests/cli_e2e/im/chat_workflow_test.go
+++ b/tests/cli_e2e/im/chat_workflow_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestIM_ChatUpdateWorkflow tests the +chat-update shortcut.
 func TestIM_ChatUpdateWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
@@ -70,6 +71,7 @@ func TestIM_ChatUpdateWorkflow(t *testing.T) {
 
 // TestIM_ChatsGetWorkflow tests the im chats get command.
 func TestIM_ChatsGetWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
@@ -100,6 +102,7 @@ func TestIM_ChatsGetWorkflow(t *testing.T) {
 
 // TestIM_ChatsLinkWorkflow tests the im chats link command.
 func TestIM_ChatsLinkWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/im/message_forward_workflow_test.go
+++ b/tests/cli_e2e/im/message_forward_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestIM_MessageForwardWorkflowAsUser(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)
 

--- a/tests/cli_e2e/im/message_reply_workflow_test.go
+++ b/tests/cli_e2e/im/message_reply_workflow_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestIM_MessageReplyWorkflowAsBot(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/markdown/markdown_workflow_test.go
+++ b/tests/cli_e2e/markdown/markdown_workflow_test.go
@@ -183,6 +183,7 @@ func TestMarkdownLifecycleWorkflow(t *testing.T) {
 }
 
 func TestMarkdownCreateWorkflow_WikiParent(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	if os.Getenv("LARK_MARKDOWN_E2E") == "" {
 		t.Skip("set LARK_MARKDOWN_E2E=1 to run markdown live workflow after backend version support is deployed")
 	}

--- a/tests/cli_e2e/sheets/sheets_crud_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_crud_workflow_test.go
@@ -21,6 +21,7 @@ import (
 // TestSheets_CRUDE2EWorkflow tests the full lifecycle of spreadsheet operations
 // using all shortcut methods: +create, +read, +write, +append, +find, +info, +export
 func TestSheets_CRUDE2EWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
@@ -174,6 +175,7 @@ func TestSheets_CRUDE2EWorkflow(t *testing.T) {
 
 // TestSheets_SpreadsheetsResource tests the spreadsheets resource methods
 func TestSheets_SpreadsheetsResource(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/sheets/sheets_filter_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_filter_workflow_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestSheets_FilterWorkflow tests the spreadsheet sheet filter operations
 func TestSheets_FilterWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/sheets/sheets_gridline_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_gridline_workflow_test.go
@@ -20,6 +20,7 @@ import (
 // field exposed via +sheet-info / +workbook-info — so success here is the
 // ok=true envelope, not a value comparison).
 func TestSheets_GridlineWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/sheets/sheets_sheet_shortcuts_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_sheet_shortcuts_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestSheets_SheetShortcutsWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/sheets/sheets_table_get_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_table_get_workflow_test.go
@@ -32,6 +32,7 @@ import (
 // The true used range is A1:F10. The default +table-get must return all 9 data
 // rows and 6 columns and report a range covering row 10 / column F.
 func TestSheets_TableGetUsedRangeWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/sheets/sheets_table_put_typed_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_table_put_typed_workflow_test.go
@@ -22,6 +22,7 @@ import (
 // it back as the same typed shape, locking the dtype + format contract that
 // makes round-trip (pipe +table-get into +table-put) work.
 func TestSheets_TablePutTypedWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
@@ -89,6 +90,7 @@ func TestSheets_TablePutTypedWorkflow(t *testing.T) {
 // adopted sheet carries the typed data we sent (no empty "Sheet1" remains)
 // and that --sheets's typed contract holds end-to-end, not just on +table-put.
 func TestSheets_WorkbookCreateTypedWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/sheets/sheets_workbook_import_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_workbook_import_workflow_test.go
@@ -27,6 +27,7 @@ import (
 // validates the full flow including the async poll and that the resulting
 // token is a usable sheet token.
 func TestSheets_WorkbookImportWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/task/task_comment_workflow_test.go
+++ b/tests/cli_e2e/task/task_comment_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestTask_CommentWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/task/task_reminder_workflow_test.go
+++ b/tests/cli_e2e/task/task_reminder_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestTask_ReminderWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/task/task_status_workflow_test.go
+++ b/tests/cli_e2e/task/task_status_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestTask_StatusWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/task/tasklist_add_task_workflow_test.go
+++ b/tests/cli_e2e/task/tasklist_add_task_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestTask_TasklistAddTaskWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/task/tasklist_workflow_test.go
+++ b/tests/cli_e2e/task/tasklist_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestTask_TasklistWorkflowAsBot(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/wiki/wiki_move_to_drive_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_move_to_drive_workflow_test.go
@@ -18,6 +18,8 @@ import (
 // TestWiki_MoveToDriveWorkflow validates the live async round trip, including
 // the standalone drive +task_result continuation path.
 func TestWiki_MoveToDriveWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/wiki/wiki_shortcut_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_shortcut_workflow_test.go
@@ -22,6 +22,7 @@ import (
 // mapping, envelope shape ({spaces|nodes, has_more, page_token} + meta.count),
 // auto-pagination, my_library alias resolution, or required-flag validation.
 func TestWiki_ShortcutWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/wiki/wiki_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestWiki_NodeWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)


### PR DESCRIPTION
## Summary

Stabilize live CLI E2E execution against transient Lark API failures and OAuth rate limits. The shared harness now retries server-declared retryable errors, handles eventually consistent cleanup, runs only affected E2E domains, and reuses one tenant access token across all CLI subprocesses in a live test job.

## Changes

- Make `RunCmd` automatically retry error envelopes that declare `retryable: true`, using bounded exponential backoff.
- Add bounded polling for eventually consistent cleanup checks and keep successful destructive cleanup from failing solely on delayed visibility.
- Resolve changed paths to affected CLI E2E domain packages, while falling back to the full suite for shared runtime or unmapped changes.
- Add a tested `scripts/fetch_e2e_tat.js` helper that retries the OAuth exchange, including aborted and incomplete HTTP responses, masks the resulting token, and writes it to a private temporary file.
- Pass only the temporary file path between CI steps, load the TAT inside the live E2E shell, and delete the file immediately after reading it.
- Run one `lark-cli whoami --as bot` preflight before the live suite to verify that the shared TAT resolves to a ready bot identity.
- Keep the app secret and TAT scoped to the CI steps that require them; expose UAT to the harness as `TEST_USER_ACCESS_TOKEN` and inject it only into requests with `DefaultAs: "user"`.
- Let bot-backed live tests skip locally when TAT is absent without spawning a repeated `whoami` process at every test entry.
- Add workflow, retry, cleanup, domain-selection, token-fetch, interrupted-response, identity-isolation, and authentication-gate coverage.

## Test Plan

- [x] `make script-test` (110 tests)
- [x] `make quality-gate`
- [x] `go test ./tests/cli_e2e/... -run '^$' -count=1`
- [x] Focused E2E harness tests for retry, identity isolation, and tenant-token readiness
- [x] Real OAuth success-path verification with the shared E2E test account

## Related Issues

- None
