### PR TITLE
chore: release v1.0.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.70] - 2026-07-15
+
+### Features
+
+- add minutes permission application shortcut (#1876)
+- **drive**: support apps in list comments (#1877)
+- slide style
+- edit ppt template
+- **slides**: add sxsd validation to slides lint
+- **slides**: validate iconpark icon types in slides lint
+- **slides**: lint before create
+- **apps**: add automation trigger commands for Miaoda (#1886)
+
+### Bug Fixes
+
+- unify dry-run output contract (#1870)
+- **skills**: align skill guidance with the typed error contract (#1786)
+- **slides**: limit slides screenshot page requests
+- **slides**: detect lark slides text overflow overlap
+- **vc**: align meeting query scopes by identity (#1850)
+
+### Documentation
+
+- clarify task search relevance filters (#1884)
+- surface minutes permission application in skill description (#1890)
+- clarify okr progress children (#1861)
+- **slides**: prefer slides xml-get shortcut
+- **calendar**: document setting meeting owner via full API (#1903)
+
+### Refactoring
+
+- **slides**: streamline create workflow and validate SML namespaces
+
+### Misc
+
+- **slides**: address PR review feedback
+
 ## [v1.0.69] - 2026-07-13
 
 ### Features
@@ -1469,6 +1506,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.70]: https://github.com/larksuite/cli/releases/tag/v1.0.70
 [v1.0.69]: https://github.com/larksuite/cli/releases/tag/v1.0.69
 [v1.0.68]: https://github.com/larksuite/cli/releases/tag/v1.0.68
 [v1.0.67]: https://github.com/larksuite/cli/releases/tag/v1.0.67

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.69` |
| Release version | `1.0.70` |
| Tag | `v1.0.70` |
| Branch | `release/v1.0.70` |
| Date | `2026-07-15` |

## Changes

- fix: unify dry-run output contract (#1870)
- docs: clarify task search relevance filters (#1884)
- feat: add minutes permission application shortcut (#1876)
- fix(skills): align skill guidance with the typed error contract (#1786)
- docs: surface minutes permission application in skill description (#1890)
- docs: clarify okr progress children (#1861)
- feat(drive): support apps in list comments (#1877)
- feat:slide style
- feat:edit ppt template
- docs(slides): prefer slides xml-get shortcut
- fix(slides): limit slides screenshot page requests
- fix(slides): detect lark slides text overflow overlap
- feat(slides): add sxsd validation to slides lint
- feat(slides): validate iconpark icon types in slides lint
- feat(slides):lint before create
- refactor(slides): streamline create workflow and validate SML namespaces
- chore(slides): address PR review feedback
- feat(apps): add automation trigger commands for Miaoda (#1886)
- docs(calendar): document setting meeting owner via full API (#1903)
- fix(vc): align meeting query scopes by identity (#1850)

## Files Changed

- `package.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Version 1.0.70 includes newly documented feature updates.

- **Bug Fixes**
  - Bug fixes included in the v1.0.70 release.

- **Documentation**
  - Documentation updates have been added to the changelog.

- **Refactor**
  - Refactoring improvements are documented for this release.

- **Chores**
  - Updated the package version to 1.0.70.
  - Added the v1.0.70 changelog entry, dated July 15, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->