### PR TITLE
feat(sheets): eval round 2 — cut agent error rate and --help lookups

### DIFF
--- a/internal/cmdutil/confirm.go
+++ b/internal/cmdutil/confirm.go
@@ -4,6 +4,10 @@
 package cmdutil
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/larksuite/cli/errs"
 )
 
@@ -14,12 +18,58 @@ import (
 // with --yes.
 //
 // action identifies the operation for the agent (e.g. "mail +send",
-// "drive.files.delete"). The envelope does not carry a pre-built retry
-// command: agents already know their original invocation and only need to
-// append --yes per the hint, which keeps the protocol free of shell-quoting
-// pitfalls.
+// "drive.files.delete"). When the original invocation can be re-run safely,
+// the hint carries the complete retry command with --yes appended — eval
+// traces show agents always self-heal by appending --yes, so handing them
+// the exact line saves the reconstruction step. The retry line is omitted
+// (falling back to the plain hint) when any argument reads stdin ("-",
+// whose piped data a bare re-run would not reproduce) or when the rendered
+// command would be unreasonably long to echo back.
 func RequireConfirmation(action string) error {
-	return errs.NewConfirmationRequiredError(errs.RiskHighRiskWrite, action,
-		"%s requires confirmation", action).
-		WithHint("add --yes to confirm")
+	err := errs.NewConfirmationRequiredError(errs.RiskHighRiskWrite, action,
+		"%s requires confirmation", action)
+	if retry := retryCommandWithYes(os.Args); retry != "" {
+		return err.WithHint("add --yes to confirm; re-run: %s", retry)
+	}
+	return err.WithHint("add --yes to confirm")
+}
+
+// retryCommandMaxLen caps the rendered retry command: past this, echoing the
+// full invocation back (e.g. a +batch-update with a large inline JSON)
+// costs more context than it saves.
+const retryCommandMaxLen = 300
+
+// retryCommandWithYes renders args as a shell-safe command line with --yes
+// appended, or "" when a safe rendering isn't possible (see
+// RequireConfirmation).
+func retryCommandWithYes(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, filepath.Base(args[0]))
+	for _, a := range args[1:] {
+		if a == "-" {
+			return ""
+		}
+		parts = append(parts, shellQuoteArg(a))
+	}
+	parts = append(parts, "--yes")
+	line := strings.Join(parts, " ")
+	if len(line) > retryCommandMaxLen {
+		return ""
+	}
+	return line
+}
+
+// shellQuoteArg single-quotes an argument when it contains any character a
+// POSIX shell could interpret, so the retry line is copy-paste safe.
+func shellQuoteArg(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(s, " \t\n\"'\\$`!*?[](){}<>|&;#~") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/cmdutil/confirm.go
+++ b/internal/cmdutil/confirm.go
@@ -22,9 +22,10 @@ import (
 // the hint carries the complete retry command with --yes appended — eval
 // traces show agents always self-heal by appending --yes, so handing them
 // the exact line saves the reconstruction step. The retry line is omitted
-// (falling back to the plain hint) when any argument reads stdin ("-",
-// whose piped data a bare re-run would not reproduce) or when the rendered
-// command would be unreasonably long to echo back.
+// (falling back to the plain hint) when any argument reads stdin (a bare "-",
+// as its own token or bundled onto a flag as --flag=-, whose piped data a
+// bare re-run would not reproduce) or when the rendered command would be
+// unreasonably long to echo back.
 func RequireConfirmation(action string) error {
 	err := errs.NewConfirmationRequiredError(errs.RiskHighRiskWrite, action,
 		"%s requires confirmation", action)
@@ -49,7 +50,7 @@ func retryCommandWithYes(args []string) string {
 	parts := make([]string, 0, len(args)+1)
 	parts = append(parts, filepath.Base(args[0]))
 	for _, a := range args[1:] {
-		if a == "-" {
+		if argReadsStdin(a) {
 			return ""
 		}
 		parts = append(parts, shellQuoteArg(a))
@@ -60,6 +61,22 @@ func retryCommandWithYes(args []string) string {
 		return ""
 	}
 	return line
+}
+
+// argReadsStdin reports whether an argument makes a flag read from stdin — the
+// portable bare "-" value, whether passed as its own token (--flag -) or
+// bundled onto the flag (--flag=- / -f=-). Piped stdin is one-shot data a bare
+// re-run cannot reproduce, so any such argument suppresses the retry line.
+func argReadsStdin(a string) bool {
+	if a == "-" {
+		return true
+	}
+	if strings.HasPrefix(a, "-") {
+		if i := strings.IndexByte(a, '='); i >= 0 && a[i+1:] == "-" {
+			return true
+		}
+	}
+	return false
 }
 
 // shellQuoteArg single-quotes an argument when it contains any character a

--- a/internal/cmdutil/confirm_test.go
+++ b/internal/cmdutil/confirm_test.go
@@ -35,8 +35,11 @@ func TestRequireConfirmation_TypedShape(t *testing.T) {
 	if !strings.Contains(cre.Message, "drive +delete") || !strings.Contains(cre.Message, "requires confirmation") {
 		t.Errorf("Message = %q, want it to mention action and 'requires confirmation'", cre.Message)
 	}
-	if cre.Hint != "add --yes to confirm" {
-		t.Errorf("Hint = %q, want 'add --yes to confirm'", cre.Hint)
+	// The hint may additionally carry a re-run line composed from the live
+	// os.Args (environment-dependent under `go test`), but the add-yes
+	// contract always leads.
+	if !strings.HasPrefix(cre.Hint, "add --yes to confirm") {
+		t.Errorf("Hint = %q, want prefix 'add --yes to confirm'", cre.Hint)
 	}
 	if cre.Risk != errs.RiskHighRiskWrite {
 		t.Errorf("Risk = %q, want %q", cre.Risk, errs.RiskHighRiskWrite)
@@ -61,8 +64,8 @@ func TestRequireConfirmation_JSONShape(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	// No fix_command field leaks into the envelope: the protocol avoids
-	// shell-quoting hazards by delegating retry to agent-side logic.
+	// No fix_command field leaks into the envelope: the retry line lives in
+	// the free-text hint only; the typed protocol stays action-only.
 	if _, has := back["fix_command"]; has {
 		t.Errorf("unexpected fix_command present in JSON: %s", raw)
 	}
@@ -77,4 +80,40 @@ func TestRequireConfirmation_JSONShape(t *testing.T) {
 	if _, has := back["upgraded_by"]; has {
 		t.Errorf("unexpected upgraded_by present in JSON: %s", raw)
 	}
+}
+
+// TestRetryCommandWithYes pins the retry-line contract: shell-safe quoting,
+// basename argv[0], and the two omission guards (stdin args, oversized
+// commands).
+func TestRetryCommandWithYes(t *testing.T) {
+	t.Run("quotes what needs quoting and appends --yes", func(t *testing.T) {
+		got := retryCommandWithYes([]string{
+			"/usr/local/bin/lark-cli", "sheets", "+cells-clear",
+			"--url", "https://x.feishu.cn/sheets/tok",
+			"--range", "A1:B2", "--sheet-name", "第 1 班",
+		})
+		want := `lark-cli sheets +cells-clear --url https://x.feishu.cn/sheets/tok --range A1:B2 --sheet-name '第 1 班' --yes`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("single quotes inside args survive", func(t *testing.T) {
+		got := retryCommandWithYes([]string{"lark-cli", "x", "--title", "it's"})
+		if !strings.Contains(got, `'it'\''s'`) {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("stdin arg omits the retry line", func(t *testing.T) {
+		if got := retryCommandWithYes([]string{"lark-cli", "sheets", "+batch-update", "--operations", "-"}); got != "" {
+			t.Errorf("stdin invocation must not render a retry line, got %q", got)
+		}
+	})
+
+	t.Run("oversized command omits the retry line", func(t *testing.T) {
+		if got := retryCommandWithYes([]string{"lark-cli", "x", "--operations", strings.Repeat("a", 400)}); got != "" {
+			t.Errorf("oversized invocation must not render a retry line, got %q", got)
+		}
+	})
 }

--- a/internal/cmdutil/confirm_test.go
+++ b/internal/cmdutil/confirm_test.go
@@ -111,6 +111,13 @@ func TestRetryCommandWithYes(t *testing.T) {
 		}
 	})
 
+	t.Run("bundled stdin flag omits the retry line", func(t *testing.T) {
+		// --flag=- reads stdin the same as --flag -; both must suppress the line.
+		if got := retryCommandWithYes([]string{"lark-cli", "sheets", "+cells-set", "--cells=-"}); got != "" {
+			t.Errorf("--flag=- stdin invocation must not render a retry line, got %q", got)
+		}
+	})
+
 	t.Run("oversized command omits the retry line", func(t *testing.T) {
 		if got := retryCommandWithYes([]string{"lark-cli", "x", "--operations", strings.Repeat("a", 400)}); got != "" {
 			t.Errorf("oversized invocation must not render a retry line, got %q", got)

--- a/shortcuts/sheets/chart_examples.go
+++ b/shortcuts/sheets/chart_examples.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+// ─── +chart-create --print-example ─────────────────────────────────────
+//
+// chart-create's --properties schema is ~1,750 pretty-printed lines; eval
+// traces show agents paging through the full --print-schema dump for every
+// chart (25 round trips in one 35-task batch) and still missing deep
+// required fields. A ready-to-edit minimal template per chart type answers
+// the actual question ("what does a valid payload look like") in one local
+// call. Wired through PostMount, same pattern as +csv-put's flag-group
+// tweaks — no framework change.
+//
+// Templates mirror the canonical examples in the lark-sheets-chart
+// reference (sheet-skill-spec canonical-spec/references/lark_sheet_chart):
+// inline headerMode with refs covering the header row, 1-based indices,
+// quoted sheet prefix in refs.
+
+var chartExampleTemplates = map[string]string{
+	"column": chartSimpleExample("column"),
+	"bar":    chartSimpleExample("bar"),
+	"line":   chartSimpleExample("line"),
+	"area":   chartSimpleExample("area"),
+	"radar":  chartSimpleExample("radar"),
+	"scatter": `{
+  "position": {"row": 1, "col": "F"},
+  "size": {"width": 600, "height": 400},
+  "snapshot": {
+    "title": {"text": "图表标题"},
+    "plotArea": {"plot": {"type": "scatter"}},
+    "data": {
+      "refs": [{"value": "'Sheet1'!A1:B20"}],
+      "dim1": {"serie": {"index": 1}},
+      "dim2": {"series": [{"index": 2}]}
+    }
+  }
+}`,
+	"pie": `{
+  "position": {"row": 1, "col": "F"},
+  "size": {"width": 600, "height": 450},
+  "snapshot": {
+    "title": {"text": "占比标题"},
+    "plotArea": {"plot": {
+      "type": "pie",
+      "series": [{
+        "index": 1,
+        "sectors": {"sector": [{"index": 1, "offsetRadius": 0.05}]}
+      }]
+    }},
+    "data": {
+      "refs": [{"value": "'Sheet1'!A1:B11"}],
+      "dim1": {"serie": {"index": 1, "aggregate": true}},
+      "dim2": {"series": [{"index": 2, "aggregateType": "sum"}]}
+    }
+  }
+}`,
+	"combo": `{
+  "position": {"row": 1, "col": "F"},
+  "size": {"width": 700, "height": 400},
+  "snapshot": {
+    "title": {"text": "柱线组合"},
+    "plotArea": {"plot": {
+      "type": "combo",
+      "series": [
+        {"index": 2, "comboType": "column"},
+        {"index": 3, "comboType": "line"}
+      ]
+    }},
+    "data": {
+      "refs": [{"value": "'Sheet1'!A1:C13"}],
+      "dim1": {"serie": {"index": 1}},
+      "dim2": {"series": [{"index": 2}, {"index": 3}]}
+    }
+  }
+}`,
+}
+
+// chartSimpleExample renders the shared minimal shape for plot types that
+// need nothing beyond plot.type (column / bar / line / area / radar).
+func chartSimpleExample(typ string) string {
+	return fmt.Sprintf(`{
+  "position": {"row": 1, "col": "F"},
+  "size": {"width": 600, "height": 400},
+  "snapshot": {
+    "title": {"text": "图表标题"},
+    "plotArea": {"plot": {"type": %q}},
+    "data": {
+      "refs": [{"value": "'Sheet1'!A1:C10"}],
+      "dim1": {"serie": {"index": 1}},
+      "dim2": {"series": [{"index": 2}, {"index": 3}]}
+    }
+  }
+}`, typ)
+}
+
+func chartExampleTypes() []string {
+	types := make([]string, 0, len(chartExampleTemplates))
+	for t := range chartExampleTemplates {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
+}
+
+// withChartPrintExample wraps +chart-create's PostMount so the command grows
+// a --print-example flag that short-circuits execution and prints a minimal
+// ready-to-edit --properties template — purely local, no identity or
+// network. --properties' cobra-level required annotation is relaxed (the
+// input builder still enforces it on the real path, same trick as
+// +csv-put's --csv).
+func withChartPrintExample(prev func(cmd *cobra.Command)) func(cmd *cobra.Command) {
+	return func(cmd *cobra.Command) {
+		if prev != nil {
+			prev(cmd)
+		}
+		cmd.Flags().String("print-example", "",
+			"Print a minimal ready-to-edit --properties template for a chart type ("+strings.Join(chartExampleTypes(), "|")+") and exit")
+		// Only --properties carries a cobra-level required annotation (the
+		// locator flags are xor pairs, enforced later); the input builder
+		// still errors "--properties is required" on the real path.
+		if fl := cmd.Flags().Lookup("properties"); fl != nil {
+			delete(fl.Annotations, cobra.BashCompOneRequiredFlag)
+		}
+		prevRunE := cmd.RunE
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			typ, _ := c.Flags().GetString("print-example")
+			if typ == "" {
+				return prevRunE(c, args)
+			}
+			tmpl, ok := chartExampleTemplates[typ]
+			if !ok {
+				return common.ValidationErrorf("no example for chart type %q; available: %s",
+					typ, strings.Join(chartExampleTypes(), ", ")).WithParam("--print-example")
+			}
+			fmt.Fprintln(c.OutOrStdout(), tmpl)
+			return nil
+		}
+	}
+}

--- a/shortcuts/sheets/chart_examples_test.go
+++ b/shortcuts/sheets/chart_examples_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestChartPrintExample pins the --print-example contract: a known type
+// prints its template and skips execution entirely; an unknown type lists
+// the available ones.
+func TestChartPrintExample(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prints template without locator flags", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+chart-create")
+		parent, _, _, _ := newTestRig(t, sc)
+		var buf bytes.Buffer
+		parent.SetOut(&buf) // --print-example writes via cobra's OutOrStdout
+		parent.SetArgs([]string{sc.Command, "--print-example", "pie"})
+		if err := parent.Execute(); err != nil {
+			t.Fatalf("print-example should run standalone, got: %v", err)
+		}
+		if !strings.Contains(buf.String(), `"sectors"`) {
+			t.Errorf("pie template should carry sectors, got %q", buf.String())
+		}
+	})
+
+	t.Run("unknown type lists available", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+chart-create")
+		_, _, err := runShortcutCapturingErr(t, sc, []string{"--print-example", "donut"})
+		ve := requireValidation(t, err, `no example for chart type "donut"`)
+		if !strings.Contains(ve.Message, "pie") {
+			t.Errorf("message should list available types, got %q", ve.Message)
+		}
+	})
+}
+
+// TestChartExampleTemplates_ValidateAgainstSchema drift-guards every
+// template against the embedded chart-create properties schema — a template
+// the CLI itself would reject is worse than none.
+func TestChartExampleTemplates_ValidateAgainstSchema(t *testing.T) {
+	t.Parallel()
+	for typ, tmpl := range chartExampleTemplates {
+		t.Run(typ, func(t *testing.T) {
+			t.Parallel()
+			var v interface{}
+			if err := json.Unmarshal([]byte(tmpl), &v); err != nil {
+				t.Fatalf("template is not valid JSON: %v", err)
+			}
+			fv := newMapFlagViewForCommand("+chart-create", map[string]interface{}{"properties": v})
+			if err := validateValueAgainstSchema(fv, "properties", v); err != nil {
+				t.Errorf("template rejected by embedded schema: %v", err)
+			}
+		})
+	}
+}

--- a/shortcuts/sheets/flag_ergonomics.go
+++ b/shortcuts/sheets/flag_ergonomics.go
@@ -38,7 +38,93 @@ func withFlagErgonomics(prev func(cmd *cobra.Command)) func(cmd *cobra.Command) 
 		}
 		cmd.SetFlagErrorFunc(sheetsFlagErrorFunc)
 		chainEnumNormalization(cmd)
+		chainFlagAliases(cmd)
 	}
+}
+
+// ─── intuitive flag names: silent aliases & prescriptions ───────────────
+//
+// Eval traces show unknown-flag failures cluster on a handful of habitual
+// names (--file, --cols, --dimension, --start-cell, --bold, --source…) that
+// agents import from generic CLI / Excel vocabulary. Two tiers, mirroring
+// the enum-normalization contract above: a name whose value semantics are
+// identical to the real flag is rewritten silently (zero round-trips); a
+// name whose fix changes the value or moves it into a JSON field gets a
+// curated prescription on the unknown-flag error instead — never a silent
+// rewrite.
+
+// commandFlagAliases maps, per command, habitual flag names onto the flag
+// actually registered. Only pairs with identical value semantics belong
+// here: the rewrite is invisible, so it must be safe to apply unread
+// (+csv-put --file with a path value still trips the file-path guard, which
+// prescribes @file / stdin).
+var commandFlagAliases = map[string]map[string]string{
+	"+csv-put":      {"file": "csv"},
+	"+sheet-create": {"name": "title"},
+	"+cols-resize":  {"cols": "range"},
+	"+rows-resize":  {"rows": "range"},
+	"+range-fill":   {"source": "source-range", "target": "target-range"},
+	"+range-copy":   {"source": "source-range", "target": "target-range"},
+	"+range-move":   {"source": "source-range", "target": "target-range"},
+}
+
+// intuitiveFlagHints carries the prescription for habitual names whose fix
+// is not a 1:1 rename — the value belongs to a different flag or to a field
+// inside a JSON payload. The hint spells the exact correct form so the
+// retry needs no --help round trip.
+var intuitiveFlagHints = map[string]map[string]string{
+	"+sheet-copy": {
+		"new-sheet-name":    "the copy's name goes in --title; --sheet-name / --sheet-id selects the source sheet",
+		"target-sheet-name": "the copy's name goes in --title; --sheet-name / --sheet-id selects the source sheet",
+		"new-name":          "the copy's name goes in --title; --sheet-name / --sheet-id selects the source sheet",
+	},
+	"+dim-insert": {
+		"dimension": "+dim-insert infers rows vs columns from --position: a row number like 3 inserts rows, a column letter like C inserts columns; pair with --count N",
+	},
+	"+dim-freeze": {
+		"frozen-rows":    "freeze the first N rows with --dimension row --count N",
+		"frozen-cols":    "freeze the first N columns with --dimension column --count N",
+		"frozen-columns": "freeze the first N columns with --dimension column --count N",
+	},
+	"+cells-set-style": {
+		"bold":      "use --font-weight bold",
+		"italic":    "use --font-style italic",
+		"underline": "use --font-line underline",
+	},
+	"+table-put": {
+		"start-cell": `anchor each sub-sheet via the "start_cell" field inside --sheets (e.g. {"sheets":[{"name":"Sheet1","start_cell":"B2",…}]}); to paste CSV at a cell use +csv-put --start-cell`,
+		"sheet-name": `+table-put has no sheet selector — each --sheets item carries its own "name" field ({"sheets":[{"name":"Sheet1",…}]})`,
+		"sheet-id":   `+table-put has no sheet selector — each --sheets item carries its own "name" field ({"sheets":[{"name":"Sheet1",…}]})`,
+	},
+}
+
+// chainFlagAliases composes two rewrites onto the flag-name normalize hook
+// (on top of any hook a prior PostMount installed, e.g. --token →
+// --spreadsheet-token): the wire-vocabulary underscore form of any flag
+// (--sheet_name, --border_styles — no sheets flag has an underscore in its
+// canonical name), and the command's intuitive-alias table. Either way a
+// habitual name parses as the real flag with zero round trips. Aliases
+// never shadow a registered flag and never appear in --help; an alias whose
+// target vanished (spec-side rename) is dropped, degrading to the
+// unknown-flag prescription.
+func chainFlagAliases(cmd *cobra.Command) {
+	aliases := commandFlagAliases[cmd.Name()]
+	usable := make(map[string]string, len(aliases))
+	for alias, target := range aliases {
+		if cmd.Flags().Lookup(alias) == nil && cmd.Flags().Lookup(target) != nil {
+			usable[alias] = target
+		}
+	}
+	prev := cmd.Flags().GetNormalizeFunc()
+	cmd.Flags().SetNormalizeFunc(func(fs *pflag.FlagSet, name string) pflag.NormalizedName {
+		if strings.Contains(name, "_") {
+			name = strings.ReplaceAll(name, "_", "-")
+		}
+		if target, ok := usable[name]; ok {
+			name = target
+		}
+		return prev(fs, name)
+	})
 }
 
 // sheetsFlagErrorFunc overrides the root FlagErrorFunc for sheets commands.
@@ -65,6 +151,14 @@ func sheetsFlagErrorFunc(c *cobra.Command, ferr error) error {
 		if len(suggestions) > 0 {
 			hint = fmt.Sprintf("did you mean %s? valid flags: %s",
 				strings.Join(suggestions, ", "), list)
+		}
+	}
+	// A curated prescription beats both: it spells the exact correct form
+	// for a habitual name whose fix is not a rename (see intuitiveFlagHints).
+	if rx, ok := intuitiveFlagHints[c.Name()][name]; ok {
+		hint = rx
+		if list := inlineFlagList(valid); list != "" {
+			hint = rx + "; valid flags: " + list
 		}
 	}
 	return errs.NewValidationError(errs.SubtypeInvalidArgument,
@@ -139,6 +233,16 @@ var enumAliases = map[string]string{
 	"center": "middle", // CSS vertical-align: center → Lark "middle"
 	"centre": "center",
 	"middle": "center", // CSS-style middle → Lark horizontal "center"
+	// Raw Lark OpenAPI merge vocabulary (MERGE_ALL/…) — agents reproduce it
+	// from the API docs; lowercased by canonicalEnumValue before lookup.
+	"merge_all":     "all",
+	"merge_rows":    "rows",
+	"merge_columns": "columns",
+	// Boolean-style word-wrap habits: true unambiguously means wrap on;
+	// false means "don't wrap", whose Lark default is overflow (word-clip is
+	// a distinct truncation mode nobody spells "false").
+	"true":  "auto-wrap",
+	"false": "overflow",
 }
 
 // canonicalEnumValue returns the enum entry an off-vocabulary value

--- a/shortcuts/sheets/flag_ergonomics_test.go
+++ b/shortcuts/sheets/flag_ergonomics_test.go
@@ -284,13 +284,168 @@ func TestShortcuts_FlagErgonomicsMounted(t *testing.T) {
 		_, _, err := runShortcutCapturingErr(t, sc, []string{
 			"--url", testURL,
 			"--sheet-name", "s",
-			"--cols", "A:D",
+			"--col-size", "A:D",
 		})
-		ve := requireValidation(t, err, `unknown flag "--cols"`)
+		ve := requireValidation(t, err, `unknown flag "--col-size"`)
 		for _, want := range []string{"valid flags:", "--range", "--width", "--widths"} {
 			if !strings.Contains(ve.Hint, want) {
 				t.Errorf("hint should contain %q, got %q", want, ve.Hint)
 			}
 		}
 	})
+}
+
+// TestShortcuts_IntuitiveFlagAliases verifies the silent-alias tier: a
+// habitual name with identical value semantics parses as the real flag on a
+// mounted command, costing zero round trips (eval: --cols, --file, --name,
+// --source/--target each burned an unknown-flag failure plus a --help call).
+func TestShortcuts_IntuitiveFlagAliases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cols-resize --cols parses as --range", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+cols-resize")
+		stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--sheet-name", "s",
+			"--cols", "A:D",
+			"--width", "100",
+			"--dry-run",
+		})
+		if err != nil {
+			t.Fatalf("--cols should alias to --range and pass, got: %v", err)
+		}
+		if !strings.Contains(stdout, "A:D") {
+			t.Errorf("dry-run body should carry the aliased range, got %q", stdout)
+		}
+	})
+
+	t.Run("sheet-create --name parses as --title", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+sheet-create")
+		stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--name", "汇总",
+			"--dry-run",
+		})
+		if err != nil {
+			t.Fatalf("--name should alias to --title and pass, got: %v", err)
+		}
+		if !strings.Contains(stdout, "汇总") {
+			t.Errorf("dry-run body should carry the aliased title, got %q", stdout)
+		}
+	})
+
+	t.Run("range-fill --source/--target parse as ranges", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+range-fill")
+		stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--sheet-name", "s",
+			"--source", "B2",
+			"--target", "B3:B10",
+			"--dry-run",
+		})
+		if err != nil {
+			t.Fatalf("--source/--target should alias to the -range flags, got: %v", err)
+		}
+		for _, want := range []string{"B2", "B3:B10"} {
+			if !strings.Contains(stdout, want) {
+				t.Errorf("dry-run body should carry %q, got %q", want, stdout)
+			}
+		}
+	})
+
+	t.Run("csv-put --file parses as --csv", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+csv-put")
+		stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--sheet-name", "s",
+			"--start-cell", "A1",
+			"--file", "a,b\n1,2",
+			"--dry-run",
+		})
+		if err != nil {
+			t.Fatalf("--file with CSV text should alias to --csv and pass, got: %v", err)
+		}
+		if !strings.Contains(stdout, "a,b") {
+			t.Errorf("dry-run body should carry the CSV text, got %q", stdout)
+		}
+	})
+
+	t.Run("alias never shadows a registered flag", func(t *testing.T) {
+		t.Parallel()
+		c := &cobra.Command{Use: "+csv-put"}
+		c.Flags().String("csv", "", "")
+		c.Flags().String("file", "", "") // hypothetical real flag wins
+		chainFlagAliases(c)
+		if err := c.ParseFlags([]string{"--file", "x"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if got, _ := c.Flags().GetString("file"); got != "x" {
+			t.Errorf("registered --file should keep its own value, got %q", got)
+		}
+		if got, _ := c.Flags().GetString("csv"); got != "" {
+			t.Errorf("--csv must stay empty when --file is a real flag, got %q", got)
+		}
+	})
+}
+
+// TestShortcuts_IntuitiveFlagHints verifies the prescription tier: habitual
+// names whose fix is not a rename answer with the exact correct form, so the
+// retry needs no --help round trip (eval: +sheet-copy burned 3/3 post-error
+// --help calls, +dim-insert kept failing even after reading help).
+func TestShortcuts_IntuitiveFlagHints(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		command  string
+		args     []string
+		wrong    string
+		wantHint []string
+	}{
+		{
+			command:  "+dim-insert",
+			args:     []string{"--url", testURL, "--sheet-name", "s", "--dimension", "row"},
+			wrong:    "--dimension",
+			wantHint: []string{"--position", "--count"},
+		},
+		{
+			command:  "+dim-freeze",
+			args:     []string{"--url", testURL, "--sheet-name", "s", "--frozen-rows", "2"},
+			wrong:    "--frozen-rows",
+			wantHint: []string{"--dimension row --count N"},
+		},
+		{
+			command:  "+cells-set-style",
+			args:     []string{"--url", testURL, "--sheet-name", "s", "--range", "A1", "--bold", "true"},
+			wrong:    "--bold",
+			wantHint: []string{"--font-weight bold"},
+		},
+		{
+			command:  "+sheet-copy",
+			args:     []string{"--url", testURL, "--sheet-name", "s", "--new-sheet-name", "副本"},
+			wrong:    "--new-sheet-name",
+			wantHint: []string{"--title", "source sheet"},
+		},
+		{
+			command:  "+table-put",
+			args:     []string{"--url", testURL, "--sheets", "{}", "--start-cell", "B2"},
+			wrong:    "--start-cell",
+			wantHint: []string{`"start_cell"`, "+csv-put"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.command+" "+tc.wrong, func(t *testing.T) {
+			t.Parallel()
+			sc := shortcutFromRegistry(t, tc.command)
+			_, _, err := runShortcutCapturingErr(t, sc, tc.args)
+			ve := requireValidation(t, err, "unknown flag \""+tc.wrong+"\"")
+			for _, want := range tc.wantHint {
+				if !strings.Contains(ve.Hint, want) {
+					t.Errorf("hint should contain %q, got %q", want, ve.Hint)
+				}
+			}
+		})
+	}
 }

--- a/shortcuts/sheets/flag_schema.go
+++ b/shortcuts/sheets/flag_schema.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/larksuite/cli/errs"
@@ -84,6 +85,13 @@ func commandsWithFlagSchema() map[string]struct{} {
 // listing of introspectable flags; otherwise it returns the schema
 // subtree JSON for the named flag, or an error if the flag is not
 // registered.
+//
+// flagName also accepts a dotted path (properties.plotArea.axes): the
+// first segment names the flag, the rest walk the schema's properties
+// (descending through array items implicitly), returning just that
+// subtree. Large schemas — chart-create's properties is ~1,750 pretty
+// lines — otherwise force agents to page through the full dump for one
+// nested field; eval traces show 25 such round trips in one batch.
 func printFlagSchemaFor(command string) func(flagName string) ([]byte, error) {
 	return func(flagName string) ([]byte, error) {
 		idx, err := loadFlagSchemas()
@@ -103,10 +111,19 @@ func printFlagSchemaFor(command string) func(flagName string) ([]byte, error) {
 			return json.MarshalIndent(map[string]interface{}{
 				"shortcut":             command,
 				"introspectable_flags": flags,
-				"hint":                 "run again with --flag-name <name> to dump the JSON Schema for that flag",
+				"hint":                 "run again with --flag-name <name> to dump that flag's JSON Schema, or a dotted path like <name>.plotArea.axes to dump just one subtree",
 			}, "", "  ")
 		}
-		schema, ok := entry[flagName]
+		name, path := splitSchemaPath(flagName)
+		schema, ok := entry[name]
+		if !ok {
+			// Tolerate the wire-vocabulary underscore form (--flag-name
+			// border_styles for border-styles) — agents copy field names out
+			// of JSON payloads where underscores are canonical.
+			if alt := strings.ReplaceAll(name, "_", "-"); alt != name {
+				schema, ok = entry[alt]
+			}
+		}
 		if !ok {
 			flags := make([]string, 0, len(entry))
 			for f := range entry {
@@ -114,14 +131,121 @@ func printFlagSchemaFor(command string) func(flagName string) ([]byte, error) {
 			}
 			sort.Strings(flags)
 			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
-				"no JSON Schema registered for %s --%s; available: %v", command, flagName, flags).
+				"no JSON Schema registered for %s --%s; available: %v", command, name, flags).
 				WithParam("--flag-name")
 		}
-		// Reformat for readability — schema files store compact JSON.
 		var pretty interface{}
 		if err := json.Unmarshal(schema, &pretty); err != nil {
 			return nil, err
 		}
+		if len(path) > 0 {
+			pretty, err = sliceSchemaByPath(pretty, name, path)
+			if err != nil {
+				return nil, err
+			}
+		}
+		// Reformat for readability — schema files store compact JSON.
 		return json.MarshalIndent(pretty, "", "  ")
 	}
+}
+
+// splitSchemaPath splits a --flag-name value into the flag name and the
+// optional dotted schema path after it.
+func splitSchemaPath(flagName string) (string, []string) {
+	parts := strings.Split(flagName, ".")
+	return parts[0], parts[1:]
+}
+
+// sliceSchemaByPath walks a decoded JSON Schema along dotted path segments.
+// Each segment matches a key under "properties"; array levels are descended
+// implicitly through "items" (an explicit "items" segment also works), and
+// oneOf branches are searched for the first one carrying the key. A miss
+// errors with the keys actually available at that level so the caller can
+// re-issue the path without a full dump.
+func sliceSchemaByPath(schema interface{}, flagName string, path []string) (interface{}, error) {
+	node := schema
+	walked := flagName
+	for _, seg := range path {
+		next, ok := schemaChild(node, seg)
+		if !ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"no %q under %s; available keys: %v", seg, walked, schemaChildKeys(node)).
+				WithParam("--flag-name")
+		}
+		node = next
+		walked += "." + seg
+	}
+	return node, nil
+}
+
+// schemaChild resolves one path segment against a schema node, descending
+// through items / oneOf wrappers as needed.
+func schemaChild(node interface{}, seg string) (interface{}, bool) {
+	for depth := 0; depth < 8; depth++ {
+		m, ok := node.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		if seg == "items" {
+			if items, ok := m["items"]; ok {
+				return items, true
+			}
+		}
+		if props, ok := m["properties"].(map[string]interface{}); ok {
+			if child, ok := props[seg]; ok {
+				return child, true
+			}
+		}
+		if items, ok := m["items"]; ok {
+			node = items
+			continue
+		}
+		if branches, ok := m["oneOf"].([]interface{}); ok {
+			for _, b := range branches {
+				if child, ok := schemaChild(b, seg); ok {
+					return child, true
+				}
+			}
+		}
+		return nil, false
+	}
+	return nil, false
+}
+
+// schemaChildKeys lists the property keys reachable at a schema node (through
+// items / oneOf wrappers), for the path-miss error.
+func schemaChildKeys(node interface{}) []string {
+	seen := map[string]struct{}{}
+	var collect func(n interface{}, depth int)
+	collect = func(n interface{}, depth int) {
+		if depth > 8 {
+			return
+		}
+		m, ok := n.(map[string]interface{})
+		if !ok {
+			return
+		}
+		if props, ok := m["properties"].(map[string]interface{}); ok {
+			for k := range props {
+				seen[k] = struct{}{}
+			}
+			return
+		}
+		if items, ok := m["items"]; ok {
+			collect(items, depth+1)
+			return
+		}
+		if branches, ok := m["oneOf"].([]interface{}); ok {
+			for _, b := range branches {
+				collect(b, depth+1)
+			}
+		}
+	}
+	collect(node, 0)
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -681,7 +681,10 @@ func expandBorderAllShorthand(border map[string]interface{}) {
 }
 
 // borderStylesFromFlag parses --border-styles as a JSON object (top/bottom/
-// left/right with style sub-objects). Returns nil when the flag is empty.
+// left/right with style sub-objects), expanding the "all" side shorthand the
+// same as the typed --cells and --styles paths so +cells-set-style /
+// +cells-batch-set-style don't ship {"all":…} for the backend to reject.
+// Returns nil when the flag is empty.
 func borderStylesFromFlag(runtime flagView) (map[string]interface{}, error) {
 	if runtime.Str("border-styles") == "" {
 		return nil, nil
@@ -694,6 +697,7 @@ func borderStylesFromFlag(runtime flagView) (map[string]interface{}, error) {
 	if !ok {
 		return nil, sheetsValidationForFlag("border-styles", "--border-styles must be a JSON object")
 	}
+	expandBorderAllShorthand(m)
 	return m, nil
 }
 

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -407,6 +407,13 @@ func parseJSONFlag(runtime flagView, name string) (interface{}, error) {
 		}
 		return nil, sheetsValidationForFlag(name, "--%s: invalid JSON: %v", name, err).WithCause(err)
 	}
+	// Unambiguous habitual shapes are rewritten onto the wire contract
+	// before validation (see jsonFlagNormalizers). Runs on the parsed value,
+	// so both the standalone cobra path and +batch-update sub-ops (whose
+	// mapFlagView.Str re-encodes composites through here) get the rewrite.
+	if norm := jsonFlagNormalizers[runtime.Command()][name]; norm != nil {
+		out = norm(out)
+	}
 	// Schema-driven flag validation at the user-input boundary. Skips
 	// --properties (validated at the input-builder tail after enhance
 	// hooks fill in flat-flag-derived fields) and any flag without an
@@ -415,6 +422,92 @@ func parseJSONFlag(runtime flagView, name string) (interface{}, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// jsonFlagNormalizers rewrites, per (command, flag), unambiguous habitual
+// input shapes onto the wire contract before schema validation — same
+// contract as enum normalization: only a shape whose meaning is beyond
+// doubt may be rewritten; anything ambiguous must fail with a prescription
+// instead. Applied to the parsed JSON value inside parseJSONFlag.
+var jsonFlagNormalizers = map[string]map[string]func(interface{}) interface{}{
+	"+cells-set":    {"cells": wrapLoneCellObject},
+	"+chart-create": {"properties": normalizeChartHexColors},
+	"+chart-update": {"properties": normalizeChartHexColors},
+}
+
+// normalizeChartHexColors walks a chart properties payload and prefixes bare
+// 6/8-digit hex values on color keys with '#' (4472C4 → #4472C4 — the
+// Excel-habit form the chart backend rejects with "expected rgba() or
+// #RRGGBB/#RRGGBBAA"). In-place, recursive; anything not unambiguously a
+// bare hex color is untouched.
+func normalizeChartHexColors(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		for k, val := range t {
+			if s, ok := val.(string); ok && isColorKey(k) && isBareHexColor(s) {
+				t[k] = "#" + s
+				continue
+			}
+			normalizeChartHexColors(val)
+		}
+	case []interface{}:
+		for _, e := range t {
+			normalizeChartHexColors(e)
+		}
+	}
+	return v
+}
+
+func isColorKey(k string) bool {
+	return k == "color" || strings.HasSuffix(k, "_color") || strings.HasSuffix(k, "Color")
+}
+
+func isBareHexColor(s string) bool {
+	if len(s) != 6 && len(s) != 8 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// cellObjectKeys pins the property vocabulary of a single cell in the
+// +cells-set --cells schema ([[{…}]]). Drift against the embedded schema is
+// guarded by TestCellObjectKeys_MatchEmbeddedSchema.
+var cellObjectKeys = map[string]struct{}{
+	"border_styles":   {},
+	"cell_styles":     {},
+	"data_validation": {},
+	"formula":         {},
+	"multiple_values": {},
+	"note":            {},
+	"rich_text":       {},
+	"value":           {},
+}
+
+// wrapLoneCellObject rewrites a bare cell object into the [[cell]] the
+// --cells contract expects. Eval traces show agents writing a single cell
+// routinely pass {"value":…} without the two array layers; when every key
+// belongs to the cell vocabulary the meaning is a 1×1 write and the wrap is
+// safe. Anything else (unknown keys, arrays — one bracket layer could be a
+// row or a column) is returned untouched for the schema validator to
+// prescribe.
+func wrapLoneCellObject(v interface{}) interface{} {
+	obj, ok := v.(map[string]interface{})
+	if !ok || len(obj) == 0 {
+		return v
+	}
+	for k := range obj {
+		if _, known := cellObjectKeys[k]; !known {
+			return v
+		}
+	}
+	return []interface{}{[]interface{}{obj}}
 }
 
 // requireJSONObject is parseJSONFlag + a type assertion to map[string]interface{}.
@@ -533,8 +626,11 @@ func normalizeCellStyleAliases(style map[string]interface{}, path string) error 
 // normalizeTypedCellsStyleAliases walks a typed --cells 2D array and applies
 // normalizeCellStyleAliases to every cell's inline cell_styles object, so the
 // alignment shorthands are accepted on +cells-set the same as on --styles.
-// Structure is checked leniently to match the pass-through contract: any
-// element that isn't the expected shape is skipped, not rejected.
+// It also expands the border "all" shorthand and intercepts border_styles
+// mis-nested inside cell_styles — both server-rejected shapes that eval
+// traces show surviving CLI validation and costing a full network round
+// trip. Structure is checked leniently to match the pass-through contract:
+// any element that isn't the expected shape is skipped, not rejected.
 func normalizeTypedCellsStyleAliases(cells []interface{}, path string) error {
 	for r, rowRaw := range cells {
 		row, ok := rowRaw.([]interface{})
@@ -546,9 +642,17 @@ func normalizeTypedCellsStyleAliases(cells []interface{}, path string) error {
 			if !ok {
 				continue
 			}
+			if bs, ok := cell["border_styles"].(map[string]interface{}); ok {
+				expandBorderAllShorthand(bs)
+			}
 			st, ok := cell["cell_styles"].(map[string]interface{})
 			if !ok {
 				continue
+			}
+			if _, misNested := st["border_styles"]; misNested {
+				return common.ValidationErrorf(
+					"%s[%d][%d].cell_styles.border_styles is not valid — border_styles is a top-level cell field, a sibling of cell_styles; move it up one level",
+					path, r, c)
 			}
 			if err := normalizeCellStyleAliases(st, fmt.Sprintf("%s[%d][%d].cell_styles", path, r, c)); err != nil {
 				return err
@@ -556,6 +660,24 @@ func normalizeTypedCellsStyleAliases(cells []interface{}, path string) error {
 		}
 	}
 	return nil
+}
+
+// expandBorderAllShorthand rewrites the "all" side shorthand — habitual from
+// Excel / openpyxl vocabulary, rejected by the backend — into the four
+// explicit sides, in place. An explicitly set side wins over the shorthand.
+// Applied on both the typed --cells path and the --styles path, so batch
+// sub-ops get the same rewrite as standalone calls.
+func expandBorderAllShorthand(border map[string]interface{}) {
+	all, ok := border["all"]
+	if !ok {
+		return
+	}
+	for _, side := range []string{"top", "bottom", "left", "right"} {
+		if _, exists := border[side]; !exists {
+			border[side] = all
+		}
+	}
+	delete(border, "all")
 }
 
 // borderStylesFromFlag parses --border-styles as a JSON object (top/bottom/

--- a/shortcuts/sheets/json_flag_normalize_test.go
+++ b/shortcuts/sheets/json_flag_normalize_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestWrapLoneCellObject pins the auto-wrap contract: a bare cell object —
+// the classic missing-[[…]] shape agents produce for a 1×1 write — is
+// rewritten to [[cell]]; anything whose meaning is not beyond doubt stays
+// untouched for the schema validator to prescribe.
+func TestWrapLoneCellObject(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      string
+		wrapped bool
+	}{
+		{"lone value cell", `{"value":"hi"}`, true},
+		{"lone formula cell with styles", `{"formula":"=SUM(A1:A3)","cell_styles":{"font_weight":"bold"}}`, true},
+		{"unknown key stays", `{"value":"hi","range":"A1"}`, false},
+		{"array of cells stays (row vs column ambiguous)", `[{"value":"a"},{"value":"b"}]`, false},
+		{"proper 2D array stays", `[[{"value":"a"}]]`, false},
+		{"empty object stays", `{}`, false},
+		{"scalar stays", `"hi"`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var v interface{}
+			if err := json.Unmarshal([]byte(tc.in), &v); err != nil {
+				t.Fatalf("bad fixture: %v", err)
+			}
+			out := wrapLoneCellObject(v)
+			_, isWrapped := out.([]interface{})
+			_, wasArray := v.([]interface{})
+			if tc.wrapped && (!isWrapped || wasArray) {
+				t.Errorf("expected wrap to [[cell]], got %#v", out)
+			}
+			if !tc.wrapped && !wasArray && isWrapped {
+				t.Errorf("expected no wrap, got %#v", out)
+			}
+			if tc.wrapped {
+				rows, _ := out.([]interface{})
+				if len(rows) != 1 {
+					t.Fatalf("want 1 row, got %d", len(rows))
+				}
+				cells, _ := rows[0].([]interface{})
+				if len(cells) != 1 {
+					t.Fatalf("want 1 cell, got %d", len(cells))
+				}
+			}
+		})
+	}
+}
+
+// TestCellObjectKeys_MatchEmbeddedSchema drift-guards the hardcoded cell
+// vocabulary against the embedded +cells-set --cells schema: if the spec
+// repo adds or removes a cell property, this fails and cellObjectKeys must
+// be updated (an outdated set only narrows the auto-wrap, but silently
+// narrowing is still drift).
+func TestCellObjectKeys_MatchEmbeddedSchema(t *testing.T) {
+	t.Parallel()
+	idx, err := loadFlagSchemas()
+	if err != nil {
+		t.Fatalf("loadFlagSchemas: %v", err)
+	}
+	raw, ok := idx.Flags["+cells-set"]["cells"]
+	if !ok {
+		t.Fatal("embedded schema for +cells-set --cells missing")
+	}
+	var schema schemaProperty
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	cell := schema.Items
+	if cell != nil && cell.Items != nil {
+		cell = cell.Items
+	}
+	if cell == nil || len(cell.Properties) == 0 {
+		t.Fatal("schema shape changed: expected array→array→object with properties")
+	}
+	for k := range cell.Properties {
+		if _, ok := cellObjectKeys[k]; !ok {
+			t.Errorf("schema property %q missing from cellObjectKeys", k)
+		}
+	}
+	for k := range cellObjectKeys {
+		if _, ok := cell.Properties[k]; !ok {
+			t.Errorf("cellObjectKeys has %q which the schema no longer declares", k)
+		}
+	}
+}
+
+// TestCellsSet_LoneCellObjectAutoWraps runs the mounted path end-to-end: the
+// eval-trace failure shape (--cells with a bare object) now dry-runs clean
+// instead of failing "expected type array, got object".
+func TestCellsSet_LoneCellObjectAutoWraps(t *testing.T) {
+	t.Parallel()
+	sc := shortcutFromRegistry(t, "+cells-set")
+	stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+		"--url", testURL,
+		"--sheet-name", "s",
+		"--range", "A1",
+		"--cells", `{"value":"hello"}`,
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("lone cell object should auto-wrap to [[cell]], got: %v", err)
+	}
+	if !strings.Contains(stdout, "hello") {
+		t.Errorf("dry-run body should carry the cell value, got %q", stdout)
+	}
+}
+
+// TestTablePut_SheetsDecodeHints pins the two decode-failure prescriptions:
+// wrong JSON kind inlines the expected shape; mangled JSON steers to
+// stdin/@file.
+func TestTablePut_SheetsDecodeHints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("type mismatch inlines skeleton", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+table-put")
+		_, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--sheets", `{"sheets":[{"name":"s","columns":[{"name":"a"}],"data":[]}]}`,
+			"--dry-run",
+		})
+		ve := requireValidation(t, err, "--sheets: invalid JSON")
+		for _, want := range []string{"expected shape:", `"columns":["City","Revenue"]`, `"dtypes":{"Revenue":"float64"}`} {
+			if !strings.Contains(ve.Hint, want) {
+				t.Errorf("hint should contain %q, got %q", want, ve.Hint)
+			}
+		}
+	})
+
+	t.Run("syntax error steers to stdin or @file", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+table-put")
+		_, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--sheets", `{"sheets":[)`,
+			"--dry-run",
+		})
+		ve := requireValidation(t, err, "--sheets: invalid JSON")
+		for _, want := range []string{"stdin", "@./payload.json"} {
+			if !strings.Contains(ve.Hint, want) {
+				t.Errorf("hint should contain %q, got %q", want, ve.Hint)
+			}
+		}
+	})
+}
+
+// TestNormalizeChartHexColors pins the '#' prefixing on bare hex color
+// values (eval V2U024: bars.color "4472C4" rejected server-side) and the
+// pass-through of everything else, including the parseJSONFlag wiring for
+// the batch sub-op path.
+func TestNormalizeChartHexColors(t *testing.T) {
+	t.Parallel()
+	props := map[string]interface{}{
+		"plotArea": map[string]interface{}{
+			"plot": map[string]interface{}{
+				"series": []interface{}{
+					map[string]interface{}{"bars": map[string]interface{}{"color": "4472C4"}},
+					map[string]interface{}{"line": map[string]interface{}{"color": "#ED7D31"}},
+					map[string]interface{}{"area": map[string]interface{}{"color": "rgba(1,2,3,0.5)"}},
+					map[string]interface{}{"font_color": "ED7D31AA", "label": "not a color 4472C4"},
+				},
+			},
+		},
+	}
+	normalizeChartHexColors(props)
+	series := props["plotArea"].(map[string]interface{})["plot"].(map[string]interface{})["series"].([]interface{})
+	if got := series[0].(map[string]interface{})["bars"].(map[string]interface{})["color"]; got != "#4472C4" {
+		t.Errorf("bare hex should gain #, got %v", got)
+	}
+	if got := series[1].(map[string]interface{})["line"].(map[string]interface{})["color"]; got != "#ED7D31" {
+		t.Errorf("already-prefixed color must not change, got %v", got)
+	}
+	if got := series[2].(map[string]interface{})["area"].(map[string]interface{})["color"]; got != "rgba(1,2,3,0.5)" {
+		t.Errorf("rgba color must not change, got %v", got)
+	}
+	last := series[3].(map[string]interface{})
+	if got := last["font_color"]; got != "#ED7D31AA" {
+		t.Errorf("8-digit hex on a *_color key should gain #, got %v", got)
+	}
+	if got := last["label"]; got != "not a color 4472C4" {
+		t.Errorf("non-color key must not change, got %v", got)
+	}
+
+	// Wiring: a +chart-create sub-op style view routes through parseJSONFlag
+	// and picks up the normalizer.
+	fv := newMapFlagViewForCommand("+chart-create", map[string]interface{}{
+		"properties": map[string]interface{}{"title": map[string]interface{}{"font_color": "112233"}},
+	})
+	out, err := parseJSONFlag(fv, "properties")
+	if err != nil {
+		t.Fatalf("parseJSONFlag: %v", err)
+	}
+	title := out.(map[string]interface{})["title"].(map[string]interface{})
+	if title["font_color"] != "#112233" {
+		t.Errorf("parseJSONFlag should apply the chart color normalizer, got %v", title["font_color"])
+	}
+}

--- a/shortcuts/sheets/lark_sheet_batch_update.go
+++ b/shortcuts/sheets/lark_sheet_batch_update.go
@@ -83,6 +83,7 @@ var BatchUpdate = common.Shortcut{
 		return nil
 	},
 	Tips: []string{
+		"high-risk-write: always pass --yes (or --dry-run to preview) — without it the call exits 10 asking for confirmation.",
 		"Default is strict transaction — any sub-tool failure rolls the whole batch back. Pass --continue-on-error to keep partial successes.",
 		"Each sub-op is {shortcut, input}. Do NOT pass input.operation (implied by shortcut name) or input.excel_id / input.url (set at the +batch-update top level).",
 	},
@@ -160,6 +161,10 @@ var CellsBatchSetStyle = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-batch-set-style"),
+	Tips: []string{
+		`Example: lark-cli sheets +cells-batch-set-style --url <URL> --ranges '["Sheet1!A1:B2","汇总!C1:C9"]' --font-weight bold`,
+		"Every range carries its sheet-NAME prefix (Sheet1!A1:B2, not a sheet_id) — there is no --sheet-id / --sheet-name flag here.",
+	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if _, err := resolveSpreadsheetToken(runtime); err != nil {
 			return err

--- a/shortcuts/sheets/lark_sheet_range_operations.go
+++ b/shortcuts/sheets/lark_sheet_range_operations.go
@@ -67,7 +67,7 @@ var CellsClear = common.Shortcut{
 		return nil
 	},
 	Tips: []string{
-		"high-risk-write — always preview with --dry-run; clear is not undoable.",
+		"high-risk-write — pass --yes to confirm (exit 10 without it), or preview with --dry-run first; clear is not undoable.",
 		"Can't delete an embedded pivot/chart by clearing cells — remove the object itself with +pivot-delete / +chart-delete.",
 	},
 }
@@ -266,9 +266,13 @@ var ColsResize = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cols-resize"),
-	Validate:    validateViaResize("column"),
-	DryRun:      resizeDryRun("column"),
-	Execute:     resizeExecute("column"),
+	Tips: []string{
+		"Example: lark-cli sheets +cols-resize --url <URL> --sheet-name Sheet1 --range A:C --width 120",
+		`Different widths per column in one atomic call: --widths '{"A":80,"C:E":120}'. Widths are pixels (px ≈ chars × 8 + 16), not Excel character units.`,
+	},
+	Validate: validateViaResize("column"),
+	DryRun:   resizeDryRun("column"),
+	Execute:  resizeExecute("column"),
 }
 
 // resizeDryRun / resizeExecute route a resize shortcut through resizeToolCall

--- a/shortcuts/sheets/lark_sheet_sheet_structure.go
+++ b/shortcuts/sheets/lark_sheet_sheet_structure.go
@@ -128,7 +128,11 @@ var DimInsert = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+dim-insert"),
-	Validate:    validateViaInput(dimInsertInput),
+	Tips: []string{
+		"Example: lark-cli sheets +dim-insert --url <URL> --sheet-name Sheet1 --position 3 --count 2 --inherit-style before",
+		"Rows vs columns comes from --position alone: a row number (3) inserts rows, a column letter (C) inserts columns — there is no --dimension flag.",
+	},
+	Validate: validateViaInput(dimInsertInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -292,7 +296,10 @@ var DimFreeze = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+dim-freeze"),
-	Validate:    validateViaInput(dimFreezeInput),
+	Tips: []string{
+		"Example: lark-cli sheets +dim-freeze --url <URL> --sheet-name Sheet1 --dimension row --count 2 (freezes the first 2 rows; --count 0 unfreezes)",
+	},
+	Validate: validateViaInput(dimFreezeInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)

--- a/shortcuts/sheets/lark_sheet_table_io.go
+++ b/shortcuts/sheets/lark_sheet_table_io.go
@@ -88,6 +88,7 @@ var TablePut = common.Shortcut{
 		return tablePutWrite(ctx, runtime, token, payload, styles)
 	},
 	Tips: []string{
+		`Example: lark-cli sheets +table-put --url <URL> --sheets '{"sheets":[{"name":"S1","columns":["City","Rev"],"dtypes":{"Rev":"float64"},"data":[["SH",1234.5]]}]}'`,
 		"Writes into an existing spreadsheet — pass --url or --spreadsheet-token. To create a new workbook first, use +workbook-create, then point --spreadsheet-token here.",
 		"Payload sheets are matched to existing sub-sheets by name (created when absent). Date columns take ISO yyyy-mm-dd strings — converted to real dates (serial + date format).",
 		"--styles applies number formats, colors, merges, and row/col sizes in the same call (same shape as +workbook-create's --styles): one styles item per written sheet, name-matched. Skips the separate +cells-set-style round-trip.",
@@ -241,6 +242,11 @@ func decoderExpectEOF(dec *json.Decoder) error {
 	return nil
 }
 
+// tablePutSheetsSkeleton is the one-line --sheets shape inlined on a decode
+// error, so the retry needs no --print-schema round trip. Field vocabulary
+// mirrors tableSheetIn.
+const tablePutSheetsSkeleton = `{"sheets":[{"name":"Sheet1","columns":["City","Revenue"],"dtypes":{"Revenue":"float64"},"data":[["SH",123.4],["BJ",56.7]],"start_cell":"A1"}]}`
+
 // parseTablePutPayload reads --sheets (JSON, supports @file / stdin) into a
 // validated payload. UseNumber keeps numeric cells as json.Number so large
 // integers (order IDs, etc.) survive without precision loss or scientific
@@ -259,7 +265,19 @@ func parseTablePutPayload(runtime flagView) (*tablePayload, error) {
 		Sheets []tableSheetIn `json:"sheets"`
 	}
 	if err := dec.Decode(&wire); err != nil {
-		return nil, common.ValidationErrorf("--sheets: invalid JSON: %v", err).WithCause(err)
+		// Eval traces show two distinct decode failures that each burned
+		// retries: a field with the wrong JSON kind (columns as objects,
+		// dtypes as an array) — fixed by seeing the expected shape once —
+		// and shell-mangled JSON, fixed by moving the payload to stdin/@file.
+		verr := common.ValidationErrorf("--sheets: invalid JSON: %v", err).WithCause(err)
+		var ute *json.UnmarshalTypeError
+		if errors.As(err, &ute) {
+			return nil, verr.WithHint(
+				"expected shape: %s (columns is a flat string array; dtypes/formats are column-name-keyed maps; data is row-major)",
+				tablePutSheetsSkeleton)
+		}
+		return nil, verr.WithHint(
+			"if the payload contains formulas / quotes / commas, pass it via stdin (`--sheets - < file`) or a relative @file (`--sheets @./payload.json`)")
 	}
 	// Reject trailing non-whitespace after the first JSON value: json.Decoder
 	// accepts it silently (unlike json.Unmarshal), so e.g. `--sheets '{...} oops'`

--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -405,7 +405,11 @@ var SheetCopy = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+sheet-copy"),
-	Validate:    validateViaInput(sheetCopyInput),
+	Tips: []string{
+		"Example: lark-cli sheets +sheet-copy --url <URL> --sheet-name 数据源 --title 数据源-副本",
+		"--sheet-name / --sheet-id selects the SOURCE sheet; the copy's new name goes in --title.",
+	},
+	Validate: validateViaInput(sheetCopyInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -965,7 +969,11 @@ func parseWorkbookCreateStyles(runtime flagView) (*workbookCreateStylePayload, e
 	if len(items) != 1 {
 		return nil, common.ValidationErrorf("--styles.styles must contain exactly one item when using --values")
 	}
-	return parseWorkbookCreateStyleItem(items[0], "--styles.styles[0]")
+	payload, probs := parseWorkbookCreateStyleItem(items[0], "--styles.styles[0]")
+	if err := joinStyleValidationErrors(probs); err != nil {
+		return nil, err
+	}
+	return payload, nil
 }
 
 // parseWorkbookCreateSheetStyles parses --styles for the typed --sheets path.
@@ -988,20 +996,27 @@ func parseWorkbookCreateSheetStyles(runtime flagView, payload *tablePayload) (*w
 	}
 	out := &workbookCreateSheetStyles{ByName: map[string]*workbookCreateStylePayload{}}
 	out.ByIndex = make([]*workbookCreateStylePayload, len(payload.Sheets))
+	var probs []error
 	for i, item := range items {
 		name, _ := item["name"].(string)
 		if strings.TrimSpace(name) == "" {
-			return nil, common.ValidationErrorf("--styles.styles[%d].name is required", i)
+			probs = append(probs, common.ValidationErrorf("--styles.styles[%d].name is required", i))
+			continue
 		}
 		if name != payload.Sheets[i].Name {
-			return nil, common.ValidationErrorf("--styles.styles[%d].name %q must match --sheets.sheets[%d].name %q", i, name, i, payload.Sheets[i].Name)
+			probs = append(probs, common.ValidationErrorf("--styles.styles[%d].name %q must match --sheets.sheets[%d].name %q", i, name, i, payload.Sheets[i].Name))
+			continue
 		}
-		style, err := parseWorkbookCreateStyleItem(item, fmt.Sprintf("--styles.styles[%d]", i))
-		if err != nil {
-			return nil, err
+		style, itemProbs := parseWorkbookCreateStyleItem(item, fmt.Sprintf("--styles.styles[%d]", i))
+		if len(itemProbs) > 0 {
+			probs = append(probs, itemProbs...)
+			continue
 		}
 		out.ByIndex[i] = style
 		out.ByName[name] = style
+	}
+	if err := joinStyleValidationErrors(probs); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -1030,182 +1045,268 @@ func parseWorkbookCreateStylesItems(v interface{}) ([]map[string]interface{}, er
 	return items, nil
 }
 
-func parseWorkbookCreateStyleItem(item map[string]interface{}, path string) (*workbookCreateStylePayload, error) {
+// parseWorkbookCreateStyleItem parses one --styles item. All four sections
+// are validated even after one fails, and every issue is returned in the
+// slice: eval traces show agents fixing --styles errors one round trip per
+// error (border side, then row_sizes.type, then size…) because only the
+// first was ever reported.
+func parseWorkbookCreateStyleItem(item map[string]interface{}, path string) (*workbookCreateStylePayload, []error) {
 	payload := &workbookCreateStylePayload{}
-	var err error
+	var probs []error
 	if raw, ok := item["cell_styles"]; ok {
-		payload.CellStyles, err = parseWorkbookCreateCellStyleOps(raw, path+".cell_styles")
-		if err != nil {
-			return nil, err
-		}
+		var errsHere []error
+		payload.CellStyles, errsHere = parseWorkbookCreateCellStyleOps(raw, path+".cell_styles")
+		probs = append(probs, errsHere...)
 	}
 	if raw, ok := item["row_sizes"]; ok {
-		payload.RowSizes, err = parseWorkbookCreateResizeOps(raw, path+".row_sizes", "row")
-		if err != nil {
-			return nil, err
-		}
+		var errsHere []error
+		payload.RowSizes, errsHere = parseWorkbookCreateResizeOps(raw, path+".row_sizes", "row")
+		probs = append(probs, errsHere...)
 	}
 	if raw, ok := item["col_sizes"]; ok {
-		payload.ColSizes, err = parseWorkbookCreateResizeOps(raw, path+".col_sizes", "column")
-		if err != nil {
-			return nil, err
-		}
+		var errsHere []error
+		payload.ColSizes, errsHere = parseWorkbookCreateResizeOps(raw, path+".col_sizes", "column")
+		probs = append(probs, errsHere...)
 	}
 	if raw, ok := item["cell_merges"]; ok {
-		payload.CellMerges, err = parseWorkbookCreateMergeOps(raw, path+".cell_merges")
-		if err != nil {
-			return nil, err
-		}
+		var errsHere []error
+		payload.CellMerges, errsHere = parseWorkbookCreateMergeOps(raw, path+".cell_merges")
+		probs = append(probs, errsHere...)
+	}
+	if len(probs) > 0 {
+		return nil, probs
 	}
 	if len(payload.CellStyles) == 0 && len(payload.RowSizes) == 0 && len(payload.ColSizes) == 0 && len(payload.CellMerges) == 0 {
-		return nil, common.ValidationErrorf("%s must include at least one of cell_styles/row_sizes/col_sizes/cell_merges", path)
+		return nil, []error{common.ValidationErrorf("%s must include at least one of cell_styles/row_sizes/col_sizes/cell_merges", path)}
 	}
 	return payload, nil
 }
 
-func parseWorkbookCreateCellStyleOps(v interface{}, path string) ([]workbookCreateCellStyleOp, error) {
+// joinStyleValidationErrors folds the issues collected across one --styles
+// parse into a single typed error that lists them all, so the caller can fix
+// the whole payload in one retry instead of one error per round trip.
+func joinStyleValidationErrors(probs []error) error {
+	switch len(probs) {
+	case 0:
+		return nil
+	case 1:
+		return probs[0]
+	}
+	const maxShown = 8
+	msgs := make([]string, 0, len(probs))
+	for _, e := range probs {
+		if p, ok := errs.ProblemOf(e); ok {
+			msgs = append(msgs, p.Message)
+			continue
+		}
+		msgs = append(msgs, e.Error())
+	}
+	suffix := ""
+	if len(msgs) > maxShown {
+		suffix = fmt.Sprintf(" (+%d more)", len(msgs)-maxShown)
+		msgs = msgs[:maxShown]
+	}
+	return common.ValidationErrorf("--styles has %d issues: %s%s", len(probs), strings.Join(msgs, " | "), suffix)
+}
+
+func parseWorkbookCreateCellStyleOps(v interface{}, path string) ([]workbookCreateCellStyleOp, []error) {
 	arr, ok := v.([]interface{})
 	if !ok {
-		return nil, common.ValidationErrorf("%s must be an array", path)
+		return nil, []error{common.ValidationErrorf("%s must be an array", path)}
 	}
 	ops := make([]workbookCreateCellStyleOp, 0, len(arr))
+	var probs []error
 	for i, raw := range arr {
-		op, ok := raw.(map[string]interface{})
-		if !ok {
-			return nil, common.ValidationErrorf("%s[%d] must be an object", path, i)
-		}
-		rangeStr, err := requireWorkbookCreateRange(op, fmt.Sprintf("%s[%d]", path, i))
+		op, err := parseWorkbookCreateCellStyleOp(raw, fmt.Sprintf("%s[%d]", path, i))
 		if err != nil {
-			return nil, err
+			probs = append(probs, err)
+			continue
 		}
-		if _, _, _, _, err := workbookCreateStyleRangeBounds(rangeStr); err != nil {
-			return nil, common.ValidationErrorf("%s[%d].range %q: %v", path, i, rangeStr, err)
-		}
-		styleObj := make(map[string]interface{}, len(op)-1)
-		for k, v := range op {
-			if k == "range" {
-				continue
-			}
-			styleObj[k] = v
-		}
-		style, err := normalizeWorkbookCreateStyleObject(styleObj, fmt.Sprintf("%s[%d]", path, i))
-		if err != nil {
-			return nil, err
-		}
-		if len(style) == 0 {
-			return nil, common.ValidationErrorf("%s[%d] must include at least one style field", path, i)
-		}
-		ops = append(ops, workbookCreateCellStyleOp{Range: rangeStr, Style: style})
+		ops = append(ops, op)
 	}
-	return ops, nil
+	return ops, probs
 }
 
-func parseWorkbookCreateMergeOps(v interface{}, path string) ([]workbookCreateMergeOp, error) {
+func parseWorkbookCreateCellStyleOp(raw interface{}, path string) (workbookCreateCellStyleOp, error) {
+	op, ok := raw.(map[string]interface{})
+	if !ok {
+		return workbookCreateCellStyleOp{}, common.ValidationErrorf("%s must be an object", path)
+	}
+	rangeStr, err := requireWorkbookCreateRange(op, path)
+	if err != nil {
+		return workbookCreateCellStyleOp{}, err
+	}
+	if _, _, _, _, err := workbookCreateStyleRangeBounds(rangeStr); err != nil {
+		return workbookCreateCellStyleOp{}, common.ValidationErrorf("%s.range %q: %v", path, rangeStr, err)
+	}
+	styleObj := make(map[string]interface{}, len(op)-1)
+	for k, v := range op {
+		if k == "range" {
+			continue
+		}
+		styleObj[k] = v
+	}
+	style, err := normalizeWorkbookCreateStyleObject(styleObj, path)
+	if err != nil {
+		return workbookCreateCellStyleOp{}, err
+	}
+	if len(style) == 0 {
+		return workbookCreateCellStyleOp{}, common.ValidationErrorf("%s must include at least one style field", path)
+	}
+	return workbookCreateCellStyleOp{Range: rangeStr, Style: style}, nil
+}
+
+func parseWorkbookCreateMergeOps(v interface{}, path string) ([]workbookCreateMergeOp, []error) {
 	arr, ok := v.([]interface{})
 	if !ok {
-		return nil, common.ValidationErrorf("%s must be an array", path)
+		return nil, []error{common.ValidationErrorf("%s must be an array", path)}
 	}
 	ops := make([]workbookCreateMergeOp, 0, len(arr))
+	var probs []error
 	for i, raw := range arr {
-		op, ok := raw.(map[string]interface{})
-		if !ok {
-			return nil, common.ValidationErrorf("%s[%d] must be an object", path, i)
-		}
-		rangeStr, err := requireWorkbookCreateRange(op, fmt.Sprintf("%s[%d]", path, i))
+		op, err := parseWorkbookCreateMergeOp(raw, fmt.Sprintf("%s[%d]", path, i))
 		if err != nil {
-			return nil, err
+			probs = append(probs, err)
+			continue
 		}
-		if _, _, _, _, err := workbookCreateStyleRangeBounds(rangeStr); err != nil {
-			return nil, common.ValidationErrorf("%s[%d].range %q: %v", path, i, rangeStr, err)
-		}
-		mergeType := "all"
-		if raw, ok := op["merge_type"]; ok {
-			v, ok := raw.(string)
-			if !ok || strings.TrimSpace(v) == "" {
-				return nil, common.ValidationErrorf("%s[%d].merge_type must be a non-empty string", path, i)
-			}
-			mergeType = strings.TrimSpace(v)
-		}
-		switch mergeType {
-		case "all", "rows", "columns":
-		default:
-			return nil, common.ValidationErrorf("%s[%d].merge_type %q is invalid (want all/rows/columns)", path, i, mergeType)
-		}
-		if err := rejectUnexpectedWorkbookStyleFields(op, fmt.Sprintf("%s[%d]", path, i), "range", "merge_type"); err != nil {
-			return nil, err
-		}
-		ops = append(ops, workbookCreateMergeOp{Range: rangeStr, MergeType: mergeType})
+		ops = append(ops, op)
 	}
-	return ops, nil
+	return ops, probs
 }
 
-func parseWorkbookCreateResizeOps(v interface{}, path, dimension string) ([]workbookCreateResizeOp, error) {
+func parseWorkbookCreateMergeOp(raw interface{}, path string) (workbookCreateMergeOp, error) {
+	op, ok := raw.(map[string]interface{})
+	if !ok {
+		return workbookCreateMergeOp{}, common.ValidationErrorf("%s must be an object", path)
+	}
+	rangeStr, err := requireWorkbookCreateRange(op, path)
+	if err != nil {
+		return workbookCreateMergeOp{}, err
+	}
+	if _, _, _, _, err := workbookCreateStyleRangeBounds(rangeStr); err != nil {
+		return workbookCreateMergeOp{}, common.ValidationErrorf("%s.range %q: %v", path, rangeStr, err)
+	}
+	mergeType := "all"
+	if raw, ok := op["merge_type"]; ok {
+		v, ok := raw.(string)
+		if !ok || strings.TrimSpace(v) == "" {
+			return workbookCreateMergeOp{}, common.ValidationErrorf("%s.merge_type must be a non-empty string", path)
+		}
+		mergeType = normalizeMergeType(strings.TrimSpace(v))
+	}
+	switch mergeType {
+	case "all", "rows", "columns":
+	default:
+		return workbookCreateMergeOp{}, common.ValidationErrorf("%s.merge_type %q is invalid (want all/rows/columns)", path, mergeType)
+	}
+	if err := rejectUnexpectedWorkbookStyleFields(op, path, "range", "merge_type"); err != nil {
+		return workbookCreateMergeOp{}, err
+	}
+	return workbookCreateMergeOp{Range: rangeStr, MergeType: mergeType}, nil
+}
+
+// normalizeMergeType maps the raw OpenAPI merge vocabulary (MERGE_ALL /
+// MERGE_ROWS / MERGE_COLUMNS — which agents reproduce from the Lark API
+// docs) onto the CLI's all/rows/columns. Unknown values pass through for
+// the caller's enum check to reject.
+func normalizeMergeType(v string) string {
+	lower := strings.ToLower(v)
+	lower = strings.TrimPrefix(lower, "merge_")
+	switch lower {
+	case "all", "rows", "columns":
+		return lower
+	}
+	return v
+}
+
+func parseWorkbookCreateResizeOps(v interface{}, path, dimension string) ([]workbookCreateResizeOp, []error) {
 	arr, ok := v.([]interface{})
 	if !ok {
-		return nil, common.ValidationErrorf("%s must be an array", path)
+		return nil, []error{common.ValidationErrorf("%s must be an array", path)}
 	}
 	ops := make([]workbookCreateResizeOp, 0, len(arr))
+	var probs []error
 	for i, raw := range arr {
-		op, ok := raw.(map[string]interface{})
-		if !ok {
-			return nil, common.ValidationErrorf("%s[%d] must be an object", path, i)
-		}
-		rangeStr, err := requireWorkbookCreateRange(op, fmt.Sprintf("%s[%d]", path, i))
+		op, err := parseWorkbookCreateResizeOp(raw, fmt.Sprintf("%s[%d]", path, i), dimension)
 		if err != nil {
-			return nil, err
+			probs = append(probs, err)
+			continue
 		}
-		parsedDim, _, _, err := parseA1Range(rangeStr)
-		if err != nil {
-			want := "row numbers like 2:10"
-			if dimension == "column" {
-				want = "column letters like A:E"
-			}
-			return nil, common.ValidationErrorf("%s[%d].range %q must use %s: %v", path, i, rangeStr, want, err)
-		}
-		if parsedDim != dimension {
-			want := "row numbers like 2:10"
-			if dimension == "column" {
-				want = "column letters like A:E"
-			}
-			return nil, common.ValidationErrorf("%s[%d].range %q must use %s", path, i, rangeStr, want)
-		}
-		typeHint := "pixel/standard"
-		if dimension == "row" {
-			typeHint = "pixel/standard/auto"
-		}
-		resizeType, _ := op["type"].(string)
-		resizeType = strings.TrimSpace(resizeType)
-		if resizeType == "" {
-			return nil, common.ValidationErrorf("%s[%d].type is required (%s)", path, i, typeHint)
-		}
-		if dimension == "column" && resizeType == "auto" {
-			return nil, common.ValidationErrorf("%s[%d].type auto is rows-only", path, i)
-		}
-		switch resizeType {
-		case "pixel", "standard", "auto":
-		default:
-			return nil, common.ValidationErrorf("%s[%d].type %q is invalid (want %s)", path, i, resizeType, typeHint)
-		}
-		size := 0
-		if raw, ok := op["size"]; ok {
-			n, ok := util.ToFloat64(raw)
-			if !ok || n <= 0 {
-				return nil, common.ValidationErrorf("%s[%d].size must be a positive number", path, i)
-			}
-			size = int(n)
-		}
-		if resizeType == "pixel" && size <= 0 {
-			return nil, common.ValidationErrorf("%s[%d].type pixel requires size", path, i)
-		}
-		if resizeType != "pixel" && size > 0 {
-			return nil, common.ValidationErrorf("%s[%d].size is only valid with type pixel", path, i)
-		}
-		if err := rejectUnexpectedWorkbookStyleFields(op, fmt.Sprintf("%s[%d]", path, i), "range", "type", "size"); err != nil {
-			return nil, err
-		}
-		ops = append(ops, workbookCreateResizeOp{Range: normalizeWorkbookResizeRange(rangeStr), ResizeType: resizeType, Size: size})
+		ops = append(ops, op)
 	}
-	return ops, nil
+	return ops, probs
+}
+
+// resizeOpExample renders a complete valid op for the dimension, inlined on
+// every type/size error: eval traces show the field errors chaining (type
+// "custom" → fixed to pixel → "pixel requires size"), each costing a round
+// trip, because no error ever showed a whole valid op at once.
+func resizeOpExample(dimension string) string {
+	if dimension == "column" {
+		return `{"range":"A:C","type":"pixel","size":120} (or {"range":"A:C","type":"standard"} to reset)`
+	}
+	return `{"range":"2:10","type":"pixel","size":32} (or "type":"auto" to fit content)`
+}
+
+func parseWorkbookCreateResizeOp(raw interface{}, path, dimension string) (workbookCreateResizeOp, error) {
+	op, ok := raw.(map[string]interface{})
+	if !ok {
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s must be an object", path)
+	}
+	rangeStr, err := requireWorkbookCreateRange(op, path)
+	if err != nil {
+		return workbookCreateResizeOp{}, err
+	}
+	parsedDim, _, _, err := parseA1Range(rangeStr)
+	if err != nil {
+		want := "row numbers like 2:10"
+		if dimension == "column" {
+			want = "column letters like A:E"
+		}
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s.range %q must use %s: %v", path, rangeStr, want, err)
+	}
+	if parsedDim != dimension {
+		want := "row numbers like 2:10"
+		if dimension == "column" {
+			want = "column letters like A:E"
+		}
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s.range %q must use %s", path, rangeStr, want)
+	}
+	typeHint := "pixel/standard"
+	if dimension == "row" {
+		typeHint = "pixel/standard/auto"
+	}
+	resizeType, _ := op["type"].(string)
+	resizeType = strings.TrimSpace(resizeType)
+	if resizeType == "" {
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s.type is required (%s), e.g. %s", path, typeHint, resizeOpExample(dimension))
+	}
+	if dimension == "column" && resizeType == "auto" {
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s.type auto is rows-only", path)
+	}
+	switch resizeType {
+	case "pixel", "standard", "auto":
+	default:
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s.type %q is invalid (want %s), e.g. %s", path, resizeType, typeHint, resizeOpExample(dimension))
+	}
+	size := 0
+	if raw, ok := op["size"]; ok {
+		n, ok := util.ToFloat64(raw)
+		if !ok || n <= 0 {
+			return workbookCreateResizeOp{}, common.ValidationErrorf("%s.size must be a positive number", path)
+		}
+		size = int(n)
+	}
+	if resizeType == "pixel" && size <= 0 {
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s.type pixel requires size, e.g. %s", path, resizeOpExample(dimension))
+	}
+	if resizeType != "pixel" && size > 0 {
+		return workbookCreateResizeOp{}, common.ValidationErrorf("%s.size is only valid with type pixel", path)
+	}
+	if err := rejectUnexpectedWorkbookStyleFields(op, path, "range", "type", "size"); err != nil {
+		return workbookCreateResizeOp{}, err
+	}
+	return workbookCreateResizeOp{Range: normalizeWorkbookResizeRange(rangeStr), ResizeType: resizeType, Size: size}, nil
 }
 
 func requireWorkbookCreateRange(op map[string]interface{}, path string) (string, error) {
@@ -1259,6 +1360,7 @@ func normalizeWorkbookCreateStyleObject(in map[string]interface{}, path string) 
 			if !ok {
 				return nil, common.ValidationErrorf("%s.border_styles must be a JSON object", path)
 			}
+			expandBorderAllShorthand(m)
 			if err := validateWorkbookBorderStyles(m, path); err != nil {
 				return nil, err
 			}
@@ -1299,7 +1401,7 @@ func validateWorkbookBorderStyles(m map[string]interface{}, path string) error {
 		switch side {
 		case "top", "bottom", "left", "right":
 		default:
-			return common.ValidationErrorf("%s.border_styles.%s is not a valid side (want top/bottom/left/right)", path, side)
+			return common.ValidationErrorf("%s.border_styles.%s is not a valid side (want top/bottom/left/right; a horizontal line is the top/bottom side of its range, a vertical line is left/right)", path, side)
 		}
 		spec, ok := raw.(map[string]interface{})
 		if !ok {

--- a/shortcuts/sheets/lark_sheet_write_cells.go
+++ b/shortcuts/sheets/lark_sheet_write_cells.go
@@ -48,7 +48,11 @@ var CellsSet = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-set"),
-	Validate:    validateViaInput(cellsSetInput),
+	Tips: []string{
+		`Example: lark-cli sheets +cells-set --url <URL> --sheet-name Sheet1 --range A1:B1 --cells '[[{"value":"名称"},{"formula":"=SUM(B2:B9)"}]]'`,
+		`--cells is always a 2D array (rows × cells), even for one cell: [[{"value":…}]].`,
+	},
+	Validate: validateViaInput(cellsSetInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -124,7 +128,11 @@ var CellsSetStyle = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-set-style"),
-	Validate:    validateViaInput(cellsSetStyleInput),
+	Tips: []string{
+		`Example: lark-cli sheets +cells-set-style --url <URL> --sheet-name Sheet1 --range A1:D1 --font-weight bold --background-color "#F0F0F0" --horizontal-alignment center`,
+		`Borders take JSON: --border-styles '{"top":{"style":"solid","weight":"thin","color":"#000000"}}' (sides: top/bottom/left/right).`,
+	},
+	Validate: validateViaInput(cellsSetStyleInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)

--- a/shortcuts/sheets/sheet_ai_api.go
+++ b/shortcuts/sheets/sheet_ai_api.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/util"
@@ -83,7 +84,7 @@ func callTool(
 	code, _ := util.ToFloat64(envelope["code"])
 	if code != 0 {
 		msg, _ := envelope["msg"].(string)
-		return nil, errs.NewAPIError(errs.SubtypeServerError, "tool %q failed: [%d] %s", toolName, int(code), msg).
+		return nil, errs.NewAPIError(errs.SubtypeServerError, "tool %q failed: [%d] %s", toolName, int(code), flattenToolErrorMsg(msg)).
 			WithCode(int(code))
 	}
 	data, _ := envelope["data"].(map[string]interface{})
@@ -98,6 +99,47 @@ func callTool(
 			"tool %q returned invalid JSON output: %v", toolName, err).WithCause(err)
 	}
 	return out, nil
+}
+
+// flattenToolErrorMsg unwraps the nested-escaped-JSON error payload some
+// sheet-ai tools put in msg — batch_update in particular wraps its result as
+// {"error":"{\"message\":\"batch_update: N succeeded, M failed\",
+// \"failures\":[…]}","errorType":…,"data":{…}} — into one readable line
+// naming each failed operation. Eval traces show agents (and even the eval
+// aggregator) failing to extract the real cause from the double-escaped
+// form. Anything that doesn't match the nested shape passes through
+// untouched.
+func flattenToolErrorMsg(msg string) string {
+	trimmed := strings.TrimSpace(msg)
+	if !strings.HasPrefix(trimmed, "{") {
+		return msg
+	}
+	var outer struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(trimmed), &outer) != nil || strings.TrimSpace(outer.Error) == "" {
+		return msg
+	}
+	inner := strings.TrimSpace(outer.Error)
+	var detail struct {
+		Message  string `json:"message"`
+		Failures []struct {
+			Index    int    `json:"index"`
+			ToolName string `json:"tool_name"`
+			Error    string `json:"error"`
+		} `json:"failures"`
+	}
+	if strings.HasPrefix(inner, "{") && json.Unmarshal([]byte(inner), &detail) == nil && detail.Message != "" {
+		if len(detail.Failures) == 0 {
+			return detail.Message
+		}
+		parts := make([]string, 0, len(detail.Failures))
+		for _, f := range detail.Failures {
+			parts = append(parts, fmt.Sprintf("operations[%d] (%s): %s", f.Index, f.ToolName, f.Error))
+		}
+		return detail.Message + " — " + strings.Join(parts, "; ")
+	}
+	return inner
 }
 
 // invokeToolDryRun renders the One-OpenAPI request the shortcut would send.

--- a/shortcuts/sheets/sheet_ai_api_flatten_test.go
+++ b/shortcuts/sheets/sheet_ai_api_flatten_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFlattenToolErrorMsg pins the unwrap of batch_update's double-escaped
+// error payload (the exact shape from eval V2U038/V2U013 traces) and the
+// pass-through of everything else.
+func TestFlattenToolErrorMsg(t *testing.T) {
+	t.Parallel()
+
+	t.Run("batch failures flatten to one line", func(t *testing.T) {
+		t.Parallel()
+		msg := `{"error":"{\"message\":\"batch_update: 0 succeeded, 1 failed\",\"succeeded\":0,\"failed\":1,\"failures\":[{\"index\":0,\"tool_name\":\"manage_chart_object\",\"error\":\"invalid snapshot.data.dim1.serie.index: 0, must be >= 1 (index is 1-based)\",\"errorType\":\"param_error\"}]}","errorType":"param_error","data":{"total":2,"succeeded":0,"failed":1}}`
+		got := flattenToolErrorMsg(msg)
+		for _, want := range []string{
+			"batch_update: 0 succeeded, 1 failed",
+			"operations[0] (manage_chart_object): invalid snapshot.data.dim1.serie.index",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("flattened msg should contain %q, got %q", want, got)
+			}
+		}
+		if strings.Contains(got, `\"`) {
+			t.Errorf("flattened msg must not carry escaped JSON, got %q", got)
+		}
+	})
+
+	t.Run("plain-string inner error unwraps", func(t *testing.T) {
+		t.Parallel()
+		got := flattenToolErrorMsg(`{"error":"sheet \"s\" not found","errorType":"param_error"}`)
+		if got != `sheet "s" not found` {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("non-JSON msg passes through", func(t *testing.T) {
+		t.Parallel()
+		msg := `cell at row 0, col 1 is inside a merged region (top-left: A1)`
+		if got := flattenToolErrorMsg(msg); got != msg {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("JSON without error field passes through", func(t *testing.T) {
+		t.Parallel()
+		msg := `{"detail":"x"}`
+		if got := flattenToolErrorMsg(msg); got != msg {
+			t.Errorf("got %q", got)
+		}
+	})
+}

--- a/shortcuts/sheets/shortcuts.go
+++ b/shortcuts/sheets/shortcuts.go
@@ -35,6 +35,11 @@ func Shortcuts() []common.Shortcut {
 		if hasFlag(all[i].Flags, "spreadsheet-token") {
 			all[i].PostMount = withTokenAlias(all[i].PostMount)
 		}
+		// +chart-create grows --print-example (minimal per-type --properties
+		// templates) — the biggest --print-schema consumer in eval traces.
+		if all[i].Command == "+chart-create" {
+			all[i].PostMount = withChartPrintExample(all[i].PostMount)
+		}
 		// Sheets-scoped flag ergonomics (unknown-flag hints with the valid
 		// flags inlined, enum vocabulary normalization) ride the same
 		// PostMount composition, so no other domain's behavior shifts.

--- a/shortcuts/sheets/styles_prescription_test.go
+++ b/shortcuts/sheets/styles_prescription_test.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTablePut_StylesErrorsAggregate pins the one-retry contract for
+// --styles: every issue across sections and ops is reported in a single
+// error (eval V2U032 burned three round trips fixing a border side, then
+// row_sizes.type, then size — each surfaced only after the previous fix).
+func TestTablePut_StylesErrorsAggregate(t *testing.T) {
+	t.Parallel()
+	sc := shortcutFromRegistry(t, "+table-put")
+	_, _, err := runShortcutCapturingErr(t, sc, []string{
+		"--url", testURL,
+		"--sheets", `{"sheets":[{"name":"s","columns":["a"],"data":[["x"]]}]}`,
+		"--styles", `{"styles":[{"name":"s",
+			"cell_styles":[{"range":"A1:A1","border_styles":{"horizontal":{"style":"solid"}}}],
+			"row_sizes":[{"range":"1:1","type":"custom"}],
+			"col_sizes":[{"range":"A:A","type":"pixel"}]}]}`,
+		"--dry-run",
+	})
+	ve := requireValidation(t, err, "--styles has 3 issues")
+	for _, want := range []string{
+		"border_styles.horizontal is not a valid side",
+		`row_sizes[0].type "custom" is invalid`,
+		"col_sizes[0].type pixel requires size",
+	} {
+		if !strings.Contains(ve.Message, want) {
+			t.Errorf("aggregated message should contain %q, got %q", want, ve.Message)
+		}
+	}
+	// D2: each type/size error inlines a complete valid op.
+	if !strings.Contains(ve.Message, `{"range":"2:10","type":"pixel","size":32}`) {
+		t.Errorf("row_sizes error should inline a full valid example, got %q", ve.Message)
+	}
+	if !strings.Contains(ve.Message, `{"range":"A:C","type":"pixel","size":120}`) {
+		t.Errorf("col_sizes error should inline a full valid example, got %q", ve.Message)
+	}
+}
+
+// TestTablePut_StylesBorderAllExpands verifies the "all" shorthand is
+// rewritten to four explicit sides instead of being rejected (or worse,
+// passed through for the server to reject, as happened on the typed-cells
+// path in eval V2U013/V2U021).
+func TestTablePut_StylesBorderAllExpands(t *testing.T) {
+	t.Parallel()
+	sc := shortcutFromRegistry(t, "+table-put")
+	stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+		"--url", testURL,
+		"--sheets", `{"sheets":[{"name":"s","columns":["a"],"data":[["x"]]}]}`,
+		"--styles", `{"styles":[{"name":"s","cell_styles":[{"range":"A1:A1","border_styles":{"all":{"style":"solid","weight":"thin"}}}]}]}`,
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("border all should expand to four sides and pass, got: %v", err)
+	}
+	// table-put's dry-run body carries the tool input as an escaped JSON
+	// string, so match the escaped key form.
+	for _, side := range []string{`\"top\"`, `\"bottom\"`, `\"left\"`, `\"right\"`} {
+		if !strings.Contains(stdout, side) {
+			t.Errorf("dry-run body should carry expanded side %s, got %q", side, stdout)
+		}
+	}
+	if strings.Contains(stdout, `\"all\"`) {
+		t.Errorf("dry-run body must not carry the raw all shorthand, got %q", stdout)
+	}
+}
+
+// TestCellsSet_BorderAllAndMisNestedBorder covers the typed --cells path:
+// the "all" shorthand expands CLI-side, and border_styles mis-nested inside
+// cell_styles is intercepted with a move-it prescription instead of a
+// server-side 900015206.
+func TestCellsSet_BorderAllAndMisNestedBorder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("border all expands", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+cells-set")
+		stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--sheet-name", "s",
+			"--range", "A1",
+			"--cells", `[[{"value":"x","border_styles":{"all":{"style":"solid"}}}]]`,
+			"--dry-run",
+		})
+		if err != nil {
+			t.Fatalf("border all should expand and pass, got: %v", err)
+		}
+		if strings.Contains(stdout, `"all"`) || !strings.Contains(stdout, `"top"`) {
+			t.Errorf("dry-run body should carry expanded sides, got %q", stdout)
+		}
+	})
+
+	t.Run("mis-nested border_styles intercepted", func(t *testing.T) {
+		t.Parallel()
+		sc := shortcutFromRegistry(t, "+cells-set")
+		_, _, err := runShortcutCapturingErr(t, sc, []string{
+			"--url", testURL,
+			"--sheet-name", "s",
+			"--range", "A1",
+			"--cells", `[[{"value":"x","cell_styles":{"font_weight":"bold","border_styles":{"top":{"style":"solid"}}}}]]`,
+			"--dry-run",
+		})
+		ve := requireValidation(t, err, "cell_styles.border_styles is not valid")
+		if !strings.Contains(ve.Message, "sibling of cell_styles") {
+			t.Errorf("message should prescribe moving it up one level, got %q", ve.Message)
+		}
+	})
+}
+
+// TestCellsMerge_RawAPIVocabularyNormalizes pins MERGE_ALL → all (the raw
+// OpenAPI enum agents copy from Lark API docs) via the enum alias table.
+func TestCellsMerge_RawAPIVocabularyNormalizes(t *testing.T) {
+	t.Parallel()
+	sc := shortcutFromRegistry(t, "+cells-merge")
+	stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+		"--url", testURL,
+		"--sheet-name", "s",
+		"--range", "A1:B2",
+		"--merge-type", "MERGE_ALL",
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("MERGE_ALL should normalize to all and pass, got: %v", err)
+	}
+	if !strings.Contains(stdout, `"all"`) {
+		t.Errorf("dry-run body should carry the normalized merge type, got %q", stdout)
+	}
+}
+
+// TestCellsSetStyle_WordWrapBooleanNormalizes pins --word-wrap true →
+// auto-wrap (eval V2U029).
+func TestCellsSetStyle_WordWrapBooleanNormalizes(t *testing.T) {
+	t.Parallel()
+	sc := shortcutFromRegistry(t, "+cells-set-style")
+	stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+		"--url", testURL,
+		"--sheet-name", "s",
+		"--range", "A1:A1",
+		"--word-wrap", "true",
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("--word-wrap true should normalize to auto-wrap, got: %v", err)
+	}
+	if !strings.Contains(stdout, "auto-wrap") {
+		t.Errorf("dry-run body should carry auto-wrap, got %q", stdout)
+	}
+}
+
+// TestUnderscoreFlagFormsParse pins the wire-vocabulary underscore rewrite:
+// --sheet_name / --border_styles parse as their hyphen forms (agents copy
+// field names out of JSON payloads where underscores are canonical).
+func TestUnderscoreFlagFormsParse(t *testing.T) {
+	t.Parallel()
+	sc := shortcutFromRegistry(t, "+cells-set-style")
+	stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+		"--url", testURL,
+		"--sheet_name", "s",
+		"--range", "A1:A1",
+		"--font_weight", "bold",
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("underscore flag forms should parse as hyphen forms, got: %v", err)
+	}
+	if !strings.Contains(stdout, "bold") {
+		t.Errorf("dry-run body should carry the style, got %q", stdout)
+	}
+}
+
+// TestPrintFlagSchema_UnderscoreFlagName pins --flag-name border_styles
+// resolving the border-styles schema (eval V2U013 burned a retry on this).
+func TestPrintFlagSchema_UnderscoreFlagName(t *testing.T) {
+	t.Parallel()
+	print := printFlagSchemaFor("+cells-set-style")
+	out, err := print("border_styles")
+	if err != nil {
+		t.Fatalf("underscore flag-name should resolve the hyphen schema, got: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected schema output")
+	}
+}
+
+// TestPrintFlagSchema_DottedPathSlices pins the schema sub-path slicing
+// contract on the real embedded chart schema: a dotted --flag-name returns
+// just that subtree, and a path miss lists the keys actually available.
+func TestPrintFlagSchema_DottedPathSlices(t *testing.T) {
+	t.Parallel()
+	print := printFlagSchemaFor("+chart-create")
+
+	t.Run("slices a nested subtree", func(t *testing.T) {
+		t.Parallel()
+		out, err := print("properties.snapshot.plotArea.axes")
+		if err != nil {
+			t.Fatalf("dotted path should slice, got: %v", err)
+		}
+		full, err2 := print("properties")
+		if err2 != nil {
+			t.Fatalf("full dump: %v", err2)
+		}
+		if len(out) == 0 || len(out) >= len(full) {
+			t.Errorf("slice should be non-empty and smaller than the full schema (%d vs %d bytes)", len(out), len(full))
+		}
+	})
+
+	t.Run("path miss lists available keys", func(t *testing.T) {
+		t.Parallel()
+		_, err := print("properties.snapshot.nosuchkey")
+		if err == nil {
+			t.Fatal("expected error for unknown path segment")
+		}
+		if !strings.Contains(err.Error(), "available keys:") {
+			t.Errorf("error should list available keys, got %v", err)
+		}
+	})
+}

--- a/shortcuts/sheets/styles_prescription_test.go
+++ b/shortcuts/sheets/styles_prescription_test.go
@@ -113,6 +113,33 @@ func TestCellsSet_BorderAllAndMisNestedBorder(t *testing.T) {
 	})
 }
 
+// TestCellsSetStyle_BorderAllExpands covers the --border-styles flag path
+// (+cells-set-style / +cells-batch-set-style go through borderStylesFromFlag,
+// not the typed --cells or --styles walkers): the "all" shorthand must expand
+// CLI-side here too, or the backend rejects {"all":…}.
+func TestCellsSetStyle_BorderAllExpands(t *testing.T) {
+	t.Parallel()
+	sc := shortcutFromRegistry(t, "+cells-set-style")
+	stdout, _, err := runShortcutCapturingErr(t, sc, []string{
+		"--url", testURL,
+		"--sheet-name", "s",
+		"--range", "A1:A1",
+		"--border-styles", `{"all":{"style":"solid","weight":"thin"}}`,
+		"--dry-run",
+	})
+	if err != nil {
+		t.Fatalf("border all should expand to four sides and pass, got: %v", err)
+	}
+	for _, side := range []string{`"top"`, `"bottom"`, `"left"`, `"right"`} {
+		if !strings.Contains(stdout, side) {
+			t.Errorf("dry-run body should carry expanded side %s, got %q", side, stdout)
+		}
+	}
+	if strings.Contains(stdout, `"all"`) {
+		t.Errorf("dry-run body must not carry the raw all shorthand, got %q", stdout)
+	}
+}
+
 // TestCellsMerge_RawAPIVocabularyNormalizes pins MERGE_ALL → all (the raw
 // OpenAPI enum agents copy from Lark API docs) via the enum alias table.
 func TestCellsMerge_RawAPIVocabularyNormalizes(t *testing.T) {

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -15,13 +15,7 @@ metadata:
 
 ## 术语约定
 
-下列词在本 skill 各文档中可能交替出现，但**指同一对象**；解析用户口语时按此映射，不要当成不同概念：
-
-| 标准用语 | 同义 / 口语（均指同一对象） | 说明 |
-| --- | --- | --- |
-| 工作表（sheet） | 子表、tab、标签页 | spreadsheet 内的单张表；`sheet_id` 是其稳定标识 |
-| 电子表格（spreadsheet） | 工作簿、表格 | 顶层容器；由 `--url` 或 `--spreadsheet-token` 定位 |
-| reference_id | id | **表内对象**的稳定标识，即各对象主键 flag 接受的值（见下表）。⚠️ 与 `lark-sheets-float-image` 的 `--image-uri`（图片上传句柄）不是一回事，后者不属于 reference_id |
+同一对象的交替说法，按此映射解析用户口语：**工作表（sheet）**= 子表 / tab / 标签页（`sheet_id` 是稳定标识）；**电子表格（spreadsheet）**= 工作簿 / 表格（顶层容器，由 `--url` 或 `--spreadsheet-token` 定位）；**reference_id** = 表内对象的稳定标识，即各对象主键 flag 接受的值（与 `--image-uri` 图片上传句柄不是一回事）。
 
 每类对象用各自的主键 flag 定位（命名不统一，按此表对照，不要凭直觉拼）：
 
@@ -34,30 +28,30 @@ metadata:
 
 ## 飞书表格编辑准则（动手前必守，所有编辑类任务一律生效）
 
-下列准则横切所有飞书表格任务，**动手前先过一遍**——即使你是被索引直接路由进某个工具参考也一律生效。每条只给一句话纲要，展开与边界见括注的 reference。
+下列准则横切所有任务，**动手前先过一遍**——被索引直接路由进某个工具参考也一律生效；展开与边界见括注的 reference。
 
 1. **最小改动**：除任务要改的单元格 / 列外，原表其它单元格、行列结构、Sheet 名、合并区、格式 1:1 保持；中间结果放原数据右侧或新建空白 Sheet，**禁止删 / 改名 / 隐藏 / 移动已存在 Sheet**；改写类任务精确圈定行列，不该转的原值 1:1 保留。
 2. **真实写回 + 回读校验**：交付必须是对在线表格的真实写入，写完用 `+csv-get` / `+cells-get` / `+<对象>-list` 回读确认实际生效——**写操作返回 `ok` 只代表请求被接受、不代表结果符合预期**；写公式后查错误码、筛选 / 排序后核对前几行、删除 / 清空后确认已空。禁止只在文本里声称"已完成"。
 3. **读全再写**：批量填充 / 补齐 / 修正类任务先确认真实数据末行再写，只探前 N 行会漏写表尾（确定末行流程见 `lark-sheets-read-data`）。
-4. **公式优先于硬编码**：能用公式表达的计算（总计 / 占比 / 增长率 / 提取 / 查找）一律写公式而非静态值；**凡可由表内其它单元格推导的派生值默认就用公式，即使用户没说"联动 / 自动更新"**；写任何飞书公式前先读 `lark-sheets-formula-translation`，而且**只要公式真实写入表格，收尾默认就要继续跑 `lark-sheets-formula-verify` 的 `+formula-verify`，直到 `status='success'`**。
+4. **公式优先于硬编码**：能用公式表达的计算（总计 / 占比 / 提取 / 查找）一律写公式而非静态值——**凡可由表内其它单元格推导的派生值默认用公式，即使用户没说"联动"**；写公式前先读 `lark-sheets-formula-translation`，**公式落表后收尾必跑 `+formula-verify` 直到 `status='success'`**。
 5. **续写 / 扩展继承样式**：续写、补齐、复制区块、新增行列时禁止只读值只写值，必须连带 `cell_styles` + `border_styles` + 合并 + 行高一起继承（清单见 `lark-sheets-write-cells`，四边框最易漏）。
-6. **多步写入合并 `+batch-update`**：多个连续写入、或同一工具对多区域重复调用，合并为单次原子 `+batch-update`（语义见 `lark-sheets-batch-update`）。
+6. **多步写入合并 `+batch-update`**：多个连续写入、或同一工具对多区域重复调用，合并为单次原子 `+batch-update`（high-risk-write，**调用必带 `--yes`**；语义见 `lark-sheets-batch-update`）。
 7. **分组汇总用透视表**："按 X 统计 Y / 分组汇总 / 各类数量金额"用 `+pivot-{create|update|delete}`，禁止用 SUMIF / 本地脚本拼一张假透视表。
 8. **拆成可验证 checklist**：落地前把指令拆成所有"独立可验证子要点"，逐点 `assert` 全过才交付（多维排序每维一点、多目标每目标一点、范围类核起 / 末 / 边界）；只做第一个要点属违规。
 9. **全量处理前置断言条数**：翻译 / 打标 / 批量公式落地等逐条任务，先把预期条数硬编码再 `assert actual == expected`，禁止输出"已完成前 N 条，剩余继续"的半成品。
 
-> 上述准则的实操展开——读取路径、原生工具优先级、脚本配合、易漏陷阱——见下方「执行要点」节；端到端工作流为：了解结构（`+workbook-info`）→ 读数据 → 理解语义 → 原生工具优先 → 写入 → 回读验证。
+> 端到端工作流：了解结构（`+workbook-info`）→ 读数据 → 理解语义 → 原生工具优先 → 写入 → 回读验证；实操展开见下方「执行要点」。
 
 ## 场景 → 命令速查（拿不准命令名先查这里，别按直觉拼）
 
-把高频意图映射到**真实存在**的 shortcut / flag。agent 常从 Excel / Google Sheets / 飞书 OpenAPI 误迁移命令名或 flag，先对照本表，避免一次必然失败的试错。完整 shortcut 见各工具参考。**选定命令后别急着写——先读「动手前读」列指向的 reference 再动手**：命令名对得上不代表用法对，写入 / 清除 / 透视类尤其容易漏掉 reference 里的防错、类型与样式继承规则。
+把高频意图映射到**真实存在**的 shortcut / flag（agent 常从 Excel / Google Sheets / OpenAPI 误迁移命令名）。**选定命令后先读「动手前读」列指向的 reference 再动手**——命令名对得上不代表用法对。
 
 | 你要做的事 | ✅ 正确写法 | 动手前读 | ❌ 不存在（会被 cobra 拒） |
 | --- | --- | --- | --- |
 | 读数据（纯值 / CSV） | `+csv-get`（范围用 `--range`） | `lark-sheets-read-data` | `+get-range`、`+range-get`、`+cells-read` |
 | 读值 + 公式 / 样式 / 批注 | `+cells-get --include value,formula,style,comment,data_validation` | `lark-sheets-read-data` | `+get-cell`、`+cell-get`、`--with-styles`、`--with-merges`、`--include-merged-cells` |
-| 写纯文本值（整块 CSV 平铺；列里**没有**需字面保真的数值 / 日期标签 / 编号——点分日期 `12.10`、编号 `001` 会被 csv-put 数值化，不算纯文本） | `+csv-put`（定位用 `--start-cell`，单个左上角锚点格；也接受 `--range` 别名，区间自动取左上角） | `lark-sheets-write-cells` | 把含点分日期(`12.10`)/编号(`001`)的列裸灌 `+csv-put`——会被数值化（`12.10`→`12.1`、`001`→`1`，尾零/前导零丢失），改用 `+table-put` 声明 `dtypes:object` |
-| 写带类型的数据到**已有**表（列里有数字 / 金额 / 百分比 / 日期 / 计数等**本质是量值**的数据——不看当下要不要排序 / 求和，量值一律走这里） | `+table-put --sheets` 完整 payload `{"sheets":[{...}]}`（列名走 `columns`、二维数据走 `data`、列 pandas dtype 走 `dtypes`、列展示格式走 `formats`；来源不限 DataFrame——Counter / dict / list 同理；要同时美化加 `--styles` 一步带样式（区域底色 / 边框 / 列宽 / 行高 / 合并），不必事后再刷；payload 里不存在的 sheet 名会自动建子表，详见 write-cells） | `lark-sheets-write-cells` | 在本地把数字拼成 `"$1,234"` / `"30.5%"` 字符串再 `+csv-put`（会落成文本、丢失计算能力；常见借口见下方 ⚠️） |
+| 写纯文本值（整块 CSV 平铺；列里没有需字面保真的编号 / 点分日期） | `+csv-put`（定位用 `--start-cell` 左上角锚点格，也接受 `--range` 别名） | `lark-sheets-write-cells` | 把含点分日期(`12.10`)/编号(`001`)的列裸灌 `+csv-put`——会被数值化（`12.10`→`12.1`、`001`→`1`），改用 `+table-put` 声明 `dtypes:object` |
+| 写带类型的数据到**已有**表（列里有数字 / 金额 / 百分比 / 日期等**量值**——不看当下要不要排序求和，量值一律走这里） | `+table-put --sheets '{"sheets":[{"name":…,"columns":[…],"dtypes":{…},"formats":{…},"data":[[…]]}]}'`（不存在的 sheet 名自动建子表；同时美化加 `--styles` 一步带样式，详见 write-cells） | `lark-sheets-write-cells` | 在本地把数字拼成 `"$1,234"` / `"30.5%"` 字符串再 `+csv-put`（落成文本、丢计算能力，见下方 ⚠️） |
 | **新建**电子表格并写带类型的数据（类型保真需求同上，但目标表还不存在） | `+workbook-create --sheets`（协议与 `+table-put` 同构、一步建表 + typed 写入，无需先建空表再 `+table-put`；date / number 不丢；`--styles` 同样可在建表同一步带全套样式，详见 workbook） | `lark-sheets-workbook` | 用 `--values` 灌日期 / 数字（会落成文本、丢类型） |
 | 写公式 / 富写入（样式 · 批注 · 图片 · 富文本），或需精确矩形定位的值 | `+cells-set`（定位用 `--range`；批注 / 图片 / 富文本只能用它，公式也可；**公式落表后继续 `+formula-verify` 收尾**） | `lark-sheets-write-cells` | — |
 | 插图：图片**绑定到某条记录**、随行走（凭证 / 证件照 / 商品图 / 头像 / 二维码 / 每行配图） | `+cells-set-image`（单格 `--range`，嵌入单元格内） | `lark-sheets-write-cells` | — |
@@ -68,37 +62,50 @@ metadata:
 | 复核某次（AI）编辑改了什么 / 取两个版本间的变更 | `+changeset-get --start-revision <编辑前版本>`（省略 `--end-revision` 取到最新；版本差 ≤ 20） | `lark-sheets-changeset` | — |
 | 取当前文档 revision（版本号） | `+revision-get` | `lark-sheets-workbook` | — |
 | 导出 xlsx / 单表 csv | `+workbook-export` | `lark-sheets-workbook` | — |
-| 导入本地 xlsx/xls/csv 文件为飞书电子表格 | `+workbook-import --file ./x.xlsx`（本地表格文件 → 飞书电子表格的正解；仅要导成多维表格 bitable 时才用 `drive +import --type bitable`） | `lark-sheets-workbook` | `drive +import`（导电子表格时绕了 drive 通道、还要多给 `--type`，应直接用 `+workbook-import`）、把 .xlsx 在本地读成数据再 `+workbook-create` 重灌（多此一举，应直接 `+workbook-import`）、要把文件并入某个**已有在线工作簿**（给它加子表）却用它——import 只会新建独立表，加子表应走 `+sheet-copy` / `+sheet-create` |
-| 参考某个**已有在线表**、把多个本地文件 / 数据各作为一张子表**追加**进去（不另起独立表） | 先 `+workbook-info` 拿模板子表 `sheet_id` → `+sheet-copy` 逐张复制模板子表（公式 / 合并 / 分组底色 / 列宽 / 条件格式全继承）再用 `+cells-*` 只改数据；无模板可继承时 `+sheet-create` 建空子表 + `+table-put --sheets/--styles` 写入 | `lark-sheets-workbook` | 把文件 `+workbook-import` / `+workbook-create` 另起一张**独立新表**（目标是并入已有工作簿时就跑偏了；这两条只产新表、不接受已有表定位） |
-| 清除内容 / 格式 | `+cells-clear`（范围维度用 `--scope`，取值 content / formats / all） | `lark-sheets-range-operations` | `--type` |
-| 批量清除多区域 | `+cells-batch-clear`（`--scope`） | `lark-sheets-batch-update` | `--target` |
+| 导入本地 xlsx/xls/csv 文件为飞书电子表格 | `+workbook-import --file ./x.xlsx`（仅要导成多维表格 bitable 时才用 `drive +import --type bitable`） | `lark-sheets-workbook` | `drive +import`（绕路）、本地读 .xlsx 再 `+workbook-create` 重灌（多此一举）、想并入**已有工作簿**却用它（import 只会另起新表，加子表走 `+sheet-copy` / `+sheet-create`） |
+| 参考某个**已有在线表**、把多份数据各作为一张子表**追加**进去 | 先 `+workbook-info` → `+sheet-copy` 复制模板子表（公式 / 合并 / 底色 / 列宽全继承）再 `+cells-*` 只改数据；无模板可继承时 `+sheet-create` + `+table-put --sheets/--styles` | `lark-sheets-workbook` | `+workbook-import` / `+workbook-create` 另起独立新表（这两条只产新表、不接受已有表定位） |
+| 清除内容 / 格式 | `+cells-clear --yes`（需确认；范围维度用 `--scope`，取值 content / formats / all） | `lark-sheets-range-operations` | `--type` |
+| 批量清除多区域 | `+cells-batch-clear --yes`（需确认；`--scope`） | `lark-sheets-batch-update` | `--target` |
 | 调整列宽 / 行高 | `+cols-resize` / `+rows-resize`（行、列是两个独立命令） | `lark-sheets-range-operations` | `--dimension`（无此 flag） |
 | 分组汇总 / 透视 | `+pivot-create`（默认不传落点 flag → 自动新建子表，零覆盖） | `lark-sheets-pivot-table` | 用 SUMIF / 本地脚本拼一张假透视表 |
-| 画图表 / 可视化（柱 / 折线 / 饼 / 条 / 散点 / 组合…） | `+chart-create` | `lark-sheets-chart` | matplotlib / 本地画图再贴图（原生图表可交互、随数据更新） |
+| 画图表 / 可视化（柱 / 折线 / 饼 / 条 / 散点 / 组合…） | `+chart-create`（先 `+chart-create --print-example <column\|bar\|line\|pie\|combo…>` 本地拿最小可用 `--properties` 模板，改 refs / index 即可用） | `lark-sheets-chart` | matplotlib / 本地画图再贴图（原生图表可交互、随数据更新） |
 | 条件高亮 / 数据条 / 色阶 / 重复值标记 | `+cond-format-create` | `lark-sheets-conditional-format` | `+highlight`、`+conditional-format`、逐格 `+cells-set-style` 硬凑 |
 | 筛选 / 只看符合条件的行 | `+filter-create` | `lark-sheets-filter` | pandas filter 后覆盖写回（会毁原数据；要保存多份筛选状态用 `+filter-view-create`） |
 
-> ⚠️ **动手前的触发式必读（按动作判定，不看主场景）**：本次操作只要**涉及样式 / 美化**（底色 / 边框 / 字号 / 对齐 / 数字格式 / 汇总行 / 配色 / 列宽行高），动手前先读 `lark-sheets-visual-standards`；只要**要写飞书公式**，动手前先读 `lark-sheets-formula-translation`（飞书函数与 Excel 有差异，凭直觉迁移易错），**写完后再读 `lark-sheets-formula-verify` 并执行 `+formula-verify` 收尾**。哪怕主任务是"建表 / 展开数据 / 录入"，只要动作里含美化或写公式就适用——别因"这不算专门的美化 / 公式任务"而跳过。
-> ⚠️ **两种图片别选错**：图若**绑定某条记录、要随行排序 / 筛选 / 增删**（凭证 / 证件照 / 每行配图，话里带「对应 / 每行 / 这列」等绑定词）→ 单元格图片 `+cells-set-image`；只是自由摆放的装饰（logo / 水印 / 封面）→ 浮动图片 `+float-image-create`。别因「浮动图更好控制 / 更熟」默认选浮动图。
-> ⚠️ **纯文本还是数值语义（看数据本质，不看当下用途）**：金额 / 百分比 / 比率 / 计数 / 日期等**本质是量值**的数据 → 一律数值写入，常规二维表用 `+table-put`（`dtypes` 声明类型 + `formats` 设展示格式），版式装不下（多级 / 合并表头的宽表 leaderboard 等）改用 `+cells-set` 传数字（百分比传小数 `0.4`）+ `number_format`，照样显示 `40%` 且数值无损。只有编号 / 身份证 / 单据号这类**本质是标识符**、要字面保真的才用 `+csv-put` 平铺。**几个常见借口都不成立**——"只是 leaderboard / 报表展示不用算""版式复杂""样式以后再刷、先铺文本"都不是把百分比写成 `"40%"` 字符串灌 `+csv-put` 的理由（展示不改变它是数值；类型不能后补，落成文本就回不来）。判据与操作展开见 `lark-sheets-write-cells`「数字还是文本」。
-> ⚠️ **要新建子表 / 整表美化 → 别默认「`+csv-put` 写值再事后刷样式」**：`+table-put` / `+workbook-create` 的 `--styles` 能在写数据的**同一步**带全套样式（区域底色 / 边框 / 列宽 / 行高 / 合并），且 `+table-put` 的 payload 里若 sheet 名不在工作簿中会自动新建子表——**纯文本表要新建子表 + 美化时同样走这里**（`--styles` 与列是否 typed 无关），比「`+csv-put` 写值 + 多次 `+cells-batch-set-style` / `+*-resize` 刷样式」少好几次调用（冻结行列等 sheet 级属性仍需 `+dim-freeze` 单独一步）。
-> ⚠️ **定位 flag**：`+cells-get` / `+cells-set` / `+csv-get` 用 `--range`；`+csv-put` 规范用 `--start-cell`（单个左上角锚点格），也接受 `--range` 别名（区间自动取左上角），二者择一即可。
-> ⚠️ **读取附加信息**一律走 `+cells-get --include …`，**没有** `--with-styles` 这类 flag；**看合并单元格**用 `+sheet-info` 的 `merged_cells`，不要在 `+cells-get` 里找 merge flag。
+> ⚠️ **动手前的触发式必读（按动作判定，不看主场景）**：动作里**含样式 / 美化**（底色 / 边框 / 字号 / 对齐 / 数字格式 / 配色 / 列宽行高）→ 先读 `lark-sheets-visual-standards`；**要写飞书公式** → 先读 `lark-sheets-formula-translation`，写完跑 `+formula-verify` 收尾（见 `lark-sheets-formula-verify`）。主任务是建表 / 录入也一样适用。
+> ⚠️ **两种图片别选错**：图**绑定某条记录、随行走**（凭证 / 证件照 / 每行配图）→ `+cells-set-image`；自由摆放的装饰（logo / 水印 / 封面）→ `+float-image-create`。别因「浮动图更熟」默认选浮动图。
+> ⚠️ **纯文本还是数值语义（看数据本质，不看当下用途）**：金额 / 百分比 / 日期 / 计数等**量值**一律数值写入——常规二维表用 `+table-put`（`dtypes` + `formats`），宽表 / 合并表头版式用 `+cells-set` 传数字（百分比传小数 `0.4`）+ `number_format`。只有编号 / 身份证等**标识符**才 `+csv-put` 平铺。"只是展示不用算 / 样式以后再刷"不构成把量值写成字符串的理由——类型不能后补。判据见 `lark-sheets-write-cells`「数字还是文本」。
+> ⚠️ **要新建子表 / 整表美化 → 别「`+csv-put` 写值再事后刷样式」**：`+table-put` / `+workbook-create` 的 `--styles` 在写数据**同一步**带全套样式（底色 / 边框 / 列宽行高 / 合并），payload 里不存在的 sheet 名自动建子表，纯文本表同样适用；比事后多次刷样式少好几次调用（冻结行列仍需 `+dim-freeze` 单独一步）。
+> ⚠️ **定位 flag**：`+cells-get` / `+cells-set` / `+csv-get` 用 `--range`；`+csv-put` 用 `--start-cell`（也接受 `--range` 别名，区间取左上角）。
+> ⚠️ **读取附加信息**一律走 `+cells-get --include …`（无 `--with-styles` 这类 flag）；**看合并单元格**用 `+sheet-info` 的 `merged_cells`。
+
+💡 **高频写命令签名（照抄改参即可；各命令 `--help` 的 Tips 段有同款示例）**：
+
+```bash
+lark-cli sheets +cells-set --url <U> --sheet-name S1 --range A1:B1 --cells '[[{"value":"名称"},{"formula":"=SUM(B2:B9)"}]]'  # --cells 恒为二维数组 [[…]]，单格也是 [[{…}]]
+lark-cli sheets +cells-set-style --url <U> --sheet-name S1 --range A1:D1 --font-weight bold --background-color "#F0F0F0" --horizontal-alignment center
+lark-cli sheets +cells-batch-set-style --url <U> --ranges '["S1!A1:B2","汇总!C1:C9"]' --font-weight bold  # range 带表名前缀，无 sheet 定位 flag
+lark-cli sheets +batch-update --url <U> --yes --operations - <<'JSON'
+[{"shortcut":"+cells-set","input":{"sheet_name":"S1","range":"A1","cells":[[{"value":"x"}]]}}]
+JSON
+lark-cli sheets +dim-freeze --url <U> --sheet-name S1 --dimension row --count 2
+lark-cli sheets +dim-insert --url <U> --sheet-name S1 --position 3 --count 2 --inherit-style before  # 行/列由 --position 决定：数字=行、字母=列，无 --dimension
+lark-cli sheets +cols-resize --url <U> --sheet-name S1 --range A:C --width 120  # 像素；分列不同宽用 --widths '{"A":80,"C:E":120}'
+lark-cli sheets +sheet-copy --url <U> --sheet-name 源表名 --title 副本名  # --sheet-name=源表、--title=新表名
+```
 
 ## 执行要点（读取 / 原生工具 / 陷阱）
-
-准则的实操展开。端到端工作流：了解结构 → 读数据 → 理解语义 → 原生工具优先 → 写入 → 回读验证。
 
 ### 读取：按需求选路径（细则见 `lark-sheets-read-data`）
 
 | 用户需求 | 读取路径 |
 |---|---|
-| "完善 / 补齐 / 填空 / 修正所有 XX"、分析 / 清洗 / 大数据 | 原生优先（公式 / `+pivot` / `+filter`）；表达不了再分批 `+csv-get` 导出 + 脚本处理 + 分批回写（默认覆盖所有对应数据行，不以用户选区为准） |
-| "查一下 / 看看 / 统计 / 汇总"等只读 | `+csv-get` 读到上下文 |
+| "完善 / 补齐 / 修正所有 XX"、分析 / 清洗 / 大数据 | 原生优先（公式 / `+pivot` / `+filter`）；表达不了再分批 `+csv-get` 导出 + 脚本处理 + 分批回写（默认覆盖所有对应数据行） |
+| "查一下 / 统计 / 汇总"等只读 | `+csv-get` 读到上下文 |
 | 需要公式 / 样式 / 批注 | `+cells-get` |
 | 续写 / 扩展已有内容 | `+csv-get` 看结构 + `+cells-get` 读源区样式 + `+sheet-info --include row_heights,merges`（见准则 5） |
 
-> "补齐 / 填空"类用只读路径探 10 行就写会漏写表尾——写入前先按 `lark-sheets-read-data` 确认真实数据末行（准则 3）。
+> "补齐 / 填空"类只探前 10 行就写会漏写表尾——先按 `lark-sheets-read-data` 确认真实数据末行（准则 3）。
 
 ### 计算：原生工具优先，代码兜底（强化准则 7）
 
@@ -122,16 +129,16 @@ metadata:
 
 ### 易漏陷阱
 
-- **`+dim-insert` 不继承行高**：只继承值 / 公式 / 边框，新行回落默认高度截断长文本；插行填长文本前读相邻行 `row_height`，用 `+batch-update` 合 `+rows-resize` 补齐。
-- **公式容错**：日期 / 查找 / 数值转换公式用 `IFERROR` 包裹；写完读结果列首末各 5 行查 `#VALUE!` / `#REF!` / `#DIV/0!`，然后继续跑 `+formula-verify` 直到 `status='success'`；同一方案试错上限 3 次。
+- **`+dim-insert` 不继承行高**：只继承值 / 公式 / 边框；插行填长文本前读相邻行 `row_height`，用 `+batch-update` 合 `+rows-resize` 补齐。
+- **公式容错**：日期 / 查找 / 转换公式用 `IFERROR` 包裹；写完查首末各 5 行错误码，再跑 `+formula-verify` 到 `status='success'`；同一方案试错上限 3 次。
 - **循环引用**：聚合公式引用范围不能含目标 cell 自身或其传递依赖。
-- **隐藏行列**：`+csv-get` 默认含隐藏行列；设 `--skip-hidden=true` 只看可见，但返回行序号与实际行号不再对应。
-- **跨 sheet 对象**：图表 / 条件格式 / 透视表 / 浮动图片可能分布在多个子表，操作前先 `+workbook-info` 掌握全局。
-- **NLP 任务分批**：语义理解 / 翻译 / 改写 / 分类等用 NLP 处理（代码只做分批 / 行号映射 / 写回）；数据量大必须分批（通常 30 行 / 批），每批处理完即时写回，单批生成通常 ≤ 300 行，多批用 `+batch-update`。
+- **隐藏行列**：`+csv-get` 默认含隐藏行列；`--skip-hidden=true` 只看可见，但返回行序号与实际行号不再对应。
+- **跨 sheet 对象**：图表 / 条件格式 / 透视表 / 浮动图片可能分布在多个子表，先 `+workbook-info` 掌握全局。
+- **NLP 任务分批**：语义理解 / 翻译 / 打标用 NLP 处理（代码只做分批 / 行号映射 / 写回）；大数据量分批（约 30 行 / 批）即时写回，多批用 `+batch-update`。
 
 ## References
 
-本 skill 的 reference 分两组：先读**通用方法与规范**（横切所有任务的样式、公式规则，不含具体 shortcut），它们规定了"怎么做对"；再按操作对象进入**工具参考**查具体 shortcut 与调用细节。编辑类任务务必先过一遍通用方法与规范，连同上方「飞书表格编辑准则」对所有工具参考一律生效。
+reference 分两组：先读**通用方法与规范**（横切所有任务的样式 / 公式规则），再按操作对象进入**工具参考**查具体 shortcut。编辑类任务务必先过通用方法与规范，连同上方「飞书表格编辑准则」对所有工具参考一律生效。
 
 ### 通用方法与规范（先读，横切所有任务，不含具体 shortcut）
 
@@ -164,42 +171,22 @@ metadata:
 
 ## 公共 flag 速查
 
-各 reference 的每个 shortcut 标题下用一行徽章标注该 shortcut 支持的公共 / 系统 flag，例如：
-
-- `_公共四件套 · 系统：--dry-run_` — URL/token + sheet 定位（两组各**必给一个**，详见下方「公共 flag」），加 `--dry-run`
-- `_公共：URL/token（无 sheet 定位） · 系统：--yes、--dry-run_` — 只接 URL/token，常见于 `+batch-update` 等不强制 sheet 定位的 shortcut
-
-徽章里只列名字。type / 必填 / 描述都在本段统一声明：
+各 reference 的 shortcut 标题下用一行徽章标注支持的公共 / 系统 flag（如 `_公共四件套 · 系统：--dry-run_`；`_公共：URL/token（无 sheet 定位）…_` 表示只接 URL/token）。type / 必填 / 描述在本段统一声明：
 
 ### 公共 flag（定位资源）
 
 **公共四件套** = `--url` / `--spreadsheet-token` / `--sheet-id` / `--sheet-name`，分成两组 XOR，**每组都必须给且只能给一个**（XOR = 二选一必填，不是"可选"）：
 
-1. **spreadsheet 定位（必填）**：`--url` 与 `--spreadsheet-token` 二选一，**必须给其中之一**。两个都不给 → 校验报错 `specify at least one of --url or --spreadsheet-token`；两个都给 → 互斥冲突。
-   - **`--url` 解析 `/sheets/`、`/spreadsheets/` 与 `/wiki/` 三种链接**（从路径里抽出 token；也可以直接把裸 token 传给 `--spreadsheet-token`）。其它形态的链接不会被解析成表格 token。
-   - **`/wiki/` 知识库链接可直接传 `--url`**：会自动定位到链接背后的电子表格；若该链接背后不是电子表格（而是文档 / 多维表格等），则报错。
-   - **例外**：`+workbook-create`（新建表 + 可选写入数据）与 `+workbook-import`（把本地文件导入为新表）都产出一张**还不存在**的表格，**不接受任何 spreadsheet / sheet 定位 flag**——`+workbook-create` 只有 `--title` / `--folder-token` / `--values` / `--styles` / `--sheets`，`+workbook-import` 只有 `--file`（必填）/ `--folder-token` / `--name`。
-2. **sheet 定位（公共四件套 shortcut 必填）**：`--sheet-id` 与 `--sheet-name` 二选一，**必须给其中之一**。两个都不给 → 校验报错 `specify at least one of --sheet-id or --sheet-name`。
-   - ⚠️ **不确定 sheet 名时禁止直接猜 `Sheet1`**：除非用户对话明确说出 sheet 名 / id，或上下文（之前的工具调用 / URL 锚点 `?sheet=xxx`）已经出现过具体值，否则**第一步先调 `+workbook-info --url "..."`**（或 `--spreadsheet-token`）拿 `sheets[].sheet_id` / `sheets[].title` 列表再选。中文环境下子表常叫"数据" / "Sheet"（无数字）/ "工作表 1" / 业务名，猜 `Sheet1` 大概率撞 `sheet not found`，比先查多耗一次失败调用 + 重试。
-   - ⚠️ **`--range` 里的 `Sheet1!` 前缀不能替代 sheet 定位**：即使写了 `--range 'Sheet1!A1:B2'`，仍**必须**额外传 `--sheet-id` 或 `--sheet-name`，否则照样报上面的错。
-   - ⚠️ **A1 reference 含 `!`**（`--source` / `--range` / `--ranges`）**：整段用单引号包裹**，如 `--range 'Sheet1!A1:B2'`——单引号能挡住 bash 的 history expansion（`!` 被拦成 `event not found`；双引号挡不住；别改用 `set +H`，原因见下方「复合 JSON / 大入参」）。sheet 名含特殊字符（`-` / 空格 / 非 ASCII）需在内部按 A1 标准再包一层单引号时，用 `'\''` 转义保持外层单引号，如 `--source ''\''Sales-2025'\''!A1:D100'`。
-   - **例外**：徽章标为 `_公共：URL/token（无 sheet 定位）…_` 的 shortcut（如 `+workbook-info` / `+workbook-export` / `+batch-update` / `+dropdown-update|delete` / `+cells-batch-set-style` / `+cells-batch-clear` / `+sheet-create`）**不接受也不需要** sheet 定位，只给一组 spreadsheet 定位即可。`+pivot-create` 用 `--target-sheet-id` / `--target-sheet-name`（XOR，可都不传，落点细节见 `lark-sheets-pivot-table`）。
-
-| Flag | Type | 必填 | 说明 |
-| --- | --- | --- | --- |
-| `--url` | string | 二选一必填（与 `--spreadsheet-token`） | spreadsheet 或 wiki URL |
-| `--spreadsheet-token` | string | 二选一必填（与 `--url`） | spreadsheet token |
-| `--sheet-id` | string | 二选一必填（与 `--sheet-name`；仅公共四件套 shortcut） | 工作表 reference_id |
-| `--sheet-name` | string | 二选一必填（与 `--sheet-id`；仅公共四件套 shortcut） | 工作表名称 |
-
-**统一调用范式**（公共四件套 shortcut 的所有示例都遵循此形状，两组定位缺一不可）：
+1. **spreadsheet 定位（必填）**：`--url`（解析 `/sheets/`、`/spreadsheets/`、`/wiki/` 三种链接；wiki 链接自动定位背后的电子表格）与 `--spreadsheet-token`（裸 token）二选一。**例外**：`+workbook-create` / `+workbook-import` 产出**还不存在**的表，不接受任何定位 flag。
+2. **sheet 定位（公共四件套 shortcut 必填）**：`--sheet-id` 与 `--sheet-name` 二选一。
+   - ⚠️ **不确定 sheet 名时禁止猜 `Sheet1`**：除非对话或上下文已出现具体值，第一步先 `+workbook-info` 拿 `sheets[].sheet_id/title` 再选——中文表的子表常叫"数据"/"工作表 1"/业务名，猜名大概率撞 `sheet not found`。
+   - ⚠️ **`--range` 里的 `Sheet1!` 前缀不能替代 sheet 定位**：仍必须传 `--sheet-id` / `--sheet-name`。
+   - ⚠️ **A1 引用含 `!` 时整段用单引号包裹**（`--range 'Sheet1!A1:B2'`，挡 bash history expansion；别用 `set +H`，sh/dash 下非法）。sheet 名含 `-`/空格需内层再包单引号时用 `'\''` 转义：`--source ''\''Sales-2025'\''!A1:D100'`。
+   - **例外**：徽章标 `_公共：URL/token（无 sheet 定位）…_` 的 shortcut（`+workbook-info` / `+workbook-export` / `+batch-update` / `+dropdown-update|delete` / `+cells-batch-set-style` / `+cells-batch-clear` / `+sheet-create`）不接受 sheet 定位。`+pivot-create` 用 `--target-sheet-id/name`（XOR，可都不传）。
 
 ```bash
-lark-cli sheets <shortcut> <workbook 定位> <sheet 定位> <其它 flag>
-#   workbook 定位：--url "..."        或 --spreadsheet-token "..."           （二选一，必给）
-#   sheet 定位：    --sheet-id "$SID"  或 --sheet-name "<真实表名>"            （二选一，必给；占位符不要原样填）
-# 例：lark-cli sheets +csv-get --url "https://.../sheets/shtXXX" --sheet-name "<真实表名>" --range "A1:F30"
-# 注意：真实表名不要直接填 "Sheet1"——大多数表的子表不叫这个；先 +workbook-info 拿 sheets[].title 再代入。
+# 统一调用范式：两组定位缺一不可（占位符别原样填；表名先 +workbook-info 查）
+lark-cli sheets +csv-get --url "https://.../sheets/shtXXX" --sheet-name "<真实表名>" --range "A1:F30"
 ```
 
 ### 系统 flag
@@ -208,27 +195,27 @@ lark-cli sheets <shortcut> <workbook 定位> <sheet 定位> <其它 flag>
 | --- | --- | --- | --- |
 | `--dry-run` | bool | 否 | 零副作用：仅打印请求路径与参数模板，不发起调用；多步操作会输出每个子操作的请求模板 |
 | `--yes` | bool | 是（仅 `high-risk-write`） | 二次确认；不带时退出码 10。详见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) 高风险审批协议 |
-| `--print-schema` | bool | 否 | 本地打印复合 JSON flag 的 JSON Schema 并退出，不发起任何调用、不需要其它 required flag。与 `--flag-name <name>` 搭配指定要查哪个 flag；省略 `--flag-name` 时列出该 shortcut 所有可查询的 flag。**仅在 shortcut 含复合 JSON flag 时有效**——判断方法：该 shortcut 的 Flags 表里出现类型标注为「复合 JSON」的 flag（如 `--cells` / `--properties` / `--operations` / `--border-styles` / `--sort-keys` / `--options`）即支持；纯标量 flag 的 shortcut 不支持。 |
-| `--flag-name` | string | 否 | 配合 `--print-schema` 使用，指定要打印 JSON Schema 的 flag 名（不带 `--` 前缀，如 `cells` / `properties` / `operations`）。 |
+| `--print-schema` | bool | 否 | 本地打印复合 JSON flag 的 JSON Schema 并退出，不发起调用、不需要其它 required flag。搭配 `--flag-name` 指定查哪个 flag；省略时列出该 shortcut 可查询的 flag。仅对含复合 JSON flag 的 shortcut 有效。 |
+| `--flag-name` | string | 否 | 配合 `--print-schema`：flag 名不带 `--` 前缀（`cells` / `properties`）。**支持点分路径切片**：`--flag-name properties.snapshot.plotArea.axes` 只打印该子树，大 schema（chart 的 properties 约 1700 行）按需取，别整篇翻页。 |
 
-**Agent 使用提示**：写复合 JSON flag（`--cells` / `--properties` / `--operations` / `--border-styles` / `--sort-keys` / `--options` 等）时，如果对结构不确定，先跑 `lark-cli sheets <shortcut> --print-schema --flag-name <name>` 把完整 JSON Schema 读出来再构造 payload，比靠 reference 的速查表更精确，也避免因为字段拼写或缺失被服务端拒绝。reference 的 `## Schemas` 段只给一层结构，深层只能靠 `--print-schema` 或 `## Examples` 的真实示例。
+> ⚠️ **high-risk-write 命令清单（首次调用就带 `--yes`，别等 exit 10 再补；或先 `--dry-run` 预览）**：`+batch-update`、`+cells-clear`、`+cells-batch-clear`、`+sheet-delete`、`+dim-delete`、`+dropdown-delete`，以及各对象删除 `+chart-delete` / `+pivot-delete` / `+cond-format-delete` / `+filter-delete` / `+filter-view-delete` / `+sparkline-delete` / `+float-image-delete`。
+
+**Agent 使用提示**：写复合 JSON flag 前对结构不确定时，先 `--print-schema --flag-name <name>`（深层字段用点分路径切片）再构造 payload；图表直接 `+chart-create --print-example <type>` 拿最小可用模板改参。reference 的 `## Schemas` 段只给一层结构。
 
 ### flag 内容类型与输出约定（术语速记）
 
-- flag 表里 JSON 类入参标三类：**复合 JSON** = 深层嵌套对象（用 `--print-schema` 取完整结构）；**简单 JSON** = 一维 / 二维标量数组（如 `["sheet1!A1:B2",...]` / `[["alice",95]]`，结构简单无需 print-schema）；**非 JSON 文本** = 原样文本（如 CSV）。`--print-schema` 只对**复合 JSON** flag 有效（同一 shortcut 的简单 JSON flag 如 `--colors` 不在此列）。
-- **envelope**：所有 shortcut 返回统一外层结构 `{ok, identity, data, ...}`。正文里 `envelope.data` 指业务数据层（如 `+csv-get` 的 `annotated_csv`）；写操作不会自动回读，如需校验请自行调用对应的 `+*-list` / `+*-get` / `+cells-get`。
+- JSON 类入参分三类：**复合 JSON** = 深层嵌套对象（`--print-schema` 可查）；**简单 JSON** = 一二维标量数组；**非 JSON 文本** = 原样文本（如 CSV）。`--print-schema` 只对复合 JSON flag 有效。
+- **envelope**：所有 shortcut 返回统一外层 `{ok, identity, data, ...}`；写操作不会自动回读，校验自行调用 `+*-list` / `+*-get` / `+cells-get`。
 
 ## 复合 JSON / 大入参：优先 stdin
 
-flag 帮助里标注支持 **Stdin** 的入参，当 payload 较大、含换行 / 引号等特殊字符，或已经落在某个文件里时，优先用 stdin（`-`）传入，避免命令行超长与 shell 转义问题。
-
-推荐写法：payload 写到用户项目目录之外的临时文件（放系统临时目录，避免污染项目），再用 stdin 喂进去：
+大 payload（`--operations` / `--cells` / `--sheets` / `--styles` / `--properties`…）、或含换行 / 引号 / `!` 等特殊字符时，优先 heredoc stdin（`-`）传入，避免命令行超长与 shell 转义问题：
 
 ```bash
-# TMPFILE 指向系统临时目录下的 payload 文件（脚本里用 tempfile.gettempdir() / os.tmpdir() 等取临时目录）
-lark-cli sheets +cells-set --url "..." --sheet-name "Sheet1" --range "A1:B2" --cells - < "$TMPFILE"
+lark-cli sheets +batch-update --url "..." --yes --operations - <<'JSON'
+[{"shortcut":"+cells-set","input":{...}}]
+JSON
 ```
 
-**参数含特殊字符（`!` / 引号 / 空格 / 非 ASCII）时，用单引号包裹该参数即可，不要起手 `set +H` 之类的 shell 开关来防转义。** `set +H`（关 bash history expansion）在 `sh` / `dash` 下是非法选项（`set: Illegal option -H`）、会让整条命令直接失败；而单引号挡得住 `!` 的 history expansion（否则报 `event not found`），对 bash 与 `sh` / `dash` 一致安全。参数本身含单引号、或 payload 较大时，按上文走 stdin。
-
-**`@file` 接绝对路径会被拒，且被拒后不要照报错提示做。** `@file` 出于安全只接受 cwd 下的相对路径，传 cwd 之外的绝对路径会被拒。此时报错会建议"先 cd 到目标目录，或改用相对路径"——**两条都不要照做**：cd 过去、或把临时文件写进用户项目目录，都会污染工作目录。正解是改用 stdin（`--<flag> - < 文件`）。
+- **stdin 每次调用只能给一个 flag**：`+table-put` 同时传 `--sheets` 与 `--styles` 两个大 JSON 时，一个走 `-`、另一个走 `@./styles.json`（`@file` 只接受 cwd 下相对路径，**绝对路径会被拒**；正解是 stdin，别 cd、别把临时文件写进用户项目目录）。
+- **参数含特殊字符时用单引号包裹即可，不要 `set +H`**（sh/dash 下非法直接报错）；参数本身含单引号或 payload 大时走 stdin。

--- a/skills/lark-sheets/references/lark-sheets-chart.md
+++ b/skills/lark-sheets/references/lark-sheets-chart.md
@@ -27,7 +27,7 @@
 
 **多图表需求**：当用户同时提到多种分析（如"统计占比 + 对比数量"），必须创建多个图表，每个对应一种类型，不要只做一个。
 
-**`--properties` 结构锚点（构造前必读）**：`--properties` 顶层只有 `position` / `offset` / `size` / `snapshot` 四个字段，**没有**顶层 `data`，也没有再嵌一层 `properties`。图表数据配置全部挂在 `snapshot.data` 下——下文及示例里出现的 `refs` / `headerMode` / `dim1` / `dim2` / `nameRef` 一律指 `snapshot.data.refs` / `snapshot.data.headerMode` / `snapshot.data.dim1` / `snapshot.data.dim2`（及其下的 `serie.nameRef` / `series[].nameRef`）；样式 / 堆叠 / 数据标签等在 `snapshot.plotArea` 下。完整结构以 `lark-cli sheets +chart-create --print-schema --flag-name properties` 为准。
+**`--properties` 结构锚点（构造前必读）**：`--properties` 顶层只有 `position` / `offset` / `size` / `snapshot` 四个字段，**没有**顶层 `data`，也没有再嵌一层 `properties`。图表数据配置全部挂在 `snapshot.data` 下——下文及示例里出现的 `refs` / `headerMode` / `dim1` / `dim2` / `nameRef` 一律指 `snapshot.data.refs` / `snapshot.data.headerMode` / `snapshot.data.dim1` / `snapshot.data.dim2`（及其下的 `serie.nameRef` / `series[].nameRef`）；样式 / 堆叠 / 数据标签等在 `snapshot.plotArea` 下。**构造起点优先用 `lark-cli sheets +chart-create --print-example <column|bar|line|area|pie|scatter|radar|combo>` 拿最小可用模板改参**（本地即时返回）；查深层字段用点分路径切片 `--print-schema --flag-name properties.snapshot.plotArea.axes`，别整篇 dump 翻页。完整结构以 `--print-schema --flag-name properties` 为准。
 
 **常见配置错误（必须注意）**：
 - **图表类型选择错误**：用户说"堆积柱形图/百分比堆积"时，应在 `properties.snapshot.plotArea.plot.extra.stack` 中配置堆叠；百分比堆叠需在该 stack 下设置 `percentage: true`。用户说"占比/比例"时，优先考虑饼图或百分比堆积图。注意区分 `column`（柱形图，纵向）与 `bar`（条形图，横向）是两个不同的 type 取值，"对比/各 XX" 类纵向柱默认用 `column`

--- a/skills/lark-sheets/references/lark-sheets-write-cells.md
+++ b/skills/lark-sheets/references/lark-sheets-write-cells.md
@@ -73,7 +73,7 @@
 
 > 以下是用 `+cells-set`（及 `+cells-set-style`）做富写入时的常用模式与准则；选哪个 shortcut 见上方「使用场景」。
 
-`+cells-set` 为一块区域设置值 / 公式 / 批注 / 样式，也支持 `rich_text` 的 `type: "embed-image"` 嵌入单元格图片。**关键：`cells` 二维数组的行列维度必须与 `range`（闭区间）严格一致，否则触发 `InvalidCellRangeError`**——维度计算示例见文末 `## Schemas` 的 `--cells`。
+`+cells-set` 为一块区域设置值 / 公式 / 批注 / 样式，也支持 `rich_text` 的 `type: "embed-image"` 嵌入单元格图片。**关键：`--cells` 恒为二维数组（行 × 格），单格也是 `[[{"value":…}]]`；且行列维度必须与 `range`（闭区间）严格一致，否则触发 `InvalidCellRangeError`**——维度计算示例见文末 `## Schemas` 的 `--cells`。
 
 > **单元格图片 vs 浮动图片（最易选错）**：图若**属于某条记录、要随那行排序 / 筛选 / 增删**（凭证 / 证件照 / 每行配图，话里带「对应 / 每行 / 这列」等绑定词）→ **单元格图片**（本工具）：用 `+cells-set-image`（最短）或 `+cells-set` 的 `rich_text` + `type: "embed-image"`。只是自由摆放的装饰（logo / 水印 / 封面）→ 浮动图片，见 lark-sheets-float-image。别因「浮动图更好控制 / 更熟」默认选浮动图——它承载"对应某记录"的图会随增删行 / 排序错位。
 
@@ -511,6 +511,8 @@ lark-cli sheets +csv-put --spreadsheet-token shtXXX --sheet-id "$SID" \
 python export.py | lark-cli sheets +table-put --url "<表URL>" --sheets -
 # 某 sheet 带 "mode":"append" 追加到已有数据末尾、默认不重复表头
 lark-cli sheets +table-put --spreadsheet-token "<token>" --sheets @payload.json
+# --sheets 与 --styles 都是大 JSON 时：stdin 每次调用只能给一个 flag，一个走 -、另一个走 @cwd 相对路径
+lark-cli sheets +table-put --url "<表URL>" --sheets - --styles @styles.json < sheets.json
 ```
 
 每个 sheet 还可带 `"allow_overwrite": false`（遇非空拒写、保护原数据）、`"header": false`（只写数据不写表头）。完整字段跑 `+table-put --print-schema --flag-name sheets`。


### PR DESCRIPTION
## Background

Round 2 of eval-driven sheets optimization, rebased onto the latest `feat/lark-sheets-develop` (`8897196d`).

## Changes

- **feat(sheets): cut agent error rate and --help lookups (eval round 2)** — targets the top failure modes from round 2 evals, reducing agent error rate and the number of `--help` lookups.
- **chore(sheets): sync skill docs and flag data from sheet-skill-spec** — syncs skill docs and flag data from sheet-skill-spec.

## Notes

- During rebase, the "import mislabeled .xls workbooks by sniffing content" fix already existed on the target branch (identical patch-id), so it was auto-skipped — no duplicate.
- The target branch was force-rewritten and advanced in the meantime; the two new commits were cleanly replayed onto the new tip via `--onto` with no conflicts. One hunk touching the `--type` description in `lark-sheets-workbook.md` was auto-dropped because upstream already has the same end state — no content lost.
