### PR TITLE
docs(apps): add platform SQL authoring guide to the db-execute skill

### DIFF
--- a/skills/lark-apps/SKILL.md
+++ b/skills/lark-apps/SKILL.md
@@ -38,7 +38,7 @@ lark-cli auth login --domain apps
 | 管理应用环境变量（查看/设置/删除） | `+env-list`, `+env-set`, `+env-delete` | [`lark-apps-env.md`](references/lark-apps-env.md) |
 | 查线上日志、Trace、请求数、错误率、延迟、CPU、memory、PV/UV/访问量 | `+log-list`, `+log-get`, `+trace-list`, `+trace-get`, `+metric-list`, `+analytics-list` | [`lark-apps-observability.md`](references/lark-apps-observability.md) |
 | 看表 / 看结构 / 初始化多环境 / 导入导出数据 / 变更追溯 / 行级审计 / dev→online 发布 / 时间点恢复 / 查 DB 用量 | `+db-table-list`、`+db-table-get`、`+db-env-create`、`+db-data-export`/`+db-data-import`、`+db-changelog-list`、`+db-audit-status`/`+db-audit-enable`/`+db-audit-disable`/`+db-audit-list`、`+db-env-diff`/`+db-env-migrate`、`+db-recovery-diff`/`+db-recovery-apply`、`+db-quota-get` | [`lark-apps-db.md`](references/lark-apps-db.md) |
-| 逐条执行 SQL（SELECT / DML / DDL） | `+db-execute` | [`lark-apps-db-execute.md`](references/lark-apps-db-execute.md) |
+| 逐条执行 SQL（SELECT / DML / DDL）；建表 / 改表 / 写 SQL 的平台规范 | `+db-execute` | [`lark-apps-db-execute.md`](references/lark-apps-db-execute.md)（含「平台 SQL 规范」：审计列 / RLS / `user_profile` / 禁用 SQL / PG 陷阱） |
 | 管理应用文件存储：上传/下载本地文件、列出/查看/删除已存文件、生成临时分享链接、查存储用量 | `+file-upload`/`+file-download`/`+file-list`/`+file-get`/`+file-sign`/`+file-delete`/`+file-quota-get` | [`lark-apps-file.md`](references/lark-apps-file.md) |
 | **部署/上线全栈应用**（"部署""上线""推上去并部署""发布到云端"）；查发布状态/历史 | `+release-create`（部署上线动作）, `+release-get`（轮询发布结果，finished 给 online_url / failed 给 error_logs）, `+release-list` | [`lark-apps-release-create.md`](references/lark-apps-release-create.md), [`lark-apps-release-get.md`](references/lark-apps-release-get.md), [`lark-apps-release-list.md`](references/lark-apps-release-list.md) |
 | 设置或查看运行时可见范围 | `+access-scope-set`, `+access-scope-get` | 对应 access-scope reference |

--- a/skills/lark-apps/references/lark-apps-db-execute.md
+++ b/skills/lark-apps/references/lark-apps-db-execute.md
@@ -145,12 +145,6 @@ CREATE UNIQUE INDEX uk_teacher_user_id ON teacher (((teacher_profile).user_id));
 | 删表 / 删列 | 有业务数据默认禁止；必须用户明确授权后才执行，并说明数据丢失风险 |
 | 强约束 | `UNIQUE` / `FOREIGN KEY` / `NOT NULL` 默认谨慎，不确定不加 |
 
-**`IF NOT EXISTS` 支持矩阵**（用错会直接语法/执行错）：
-
-| 支持 | 不支持 |
-|---|---|
-| `CREATE TABLE` / `CREATE INDEX` / `CREATE EXTENSION` / `ALTER TABLE ADD COLUMN` | `CREATE TYPE` / `CREATE POLICY` / `ALTER TABLE ADD CONSTRAINT` |
-
 **多环境库加约束前先查 online 存量**：`dev` 干净不代表 `online` 干净，约束发布到 online 会撞线上存量数据而失败。发布前一律先用 `--environment online` 查清楚，按约束类型分三种：
 
 - **加唯一约束（`UNIQUE` / 唯一索引）**：线上不能有重复值。先查重复，有则先清理再加：
@@ -212,7 +206,7 @@ WHERE id = (SELECT id FROM task WHERE title = '梳理需求' ORDER BY _created_a
 
 | 陷阱 | 正确做法 |
 |---|---|
-| 表名带 schema 前缀 | 业务表一律裸表名 `FROM user_profile`，别写 `public.t` |
+| 表名带 schema 前缀 | 业务表一律裸表名 `FROM orders`，别写 `public.orders` |
 | 保留字作标识符 | 避免 `user` / `order` / `desc` / `offset` / `references` 等 |
 | 内联 COMMENT | 禁止 `col TEXT COMMENT 'xx'`，用独立 `COMMENT ON COLUMN` |
 | 手写系统表查结构 | 常规结构查询用 `+db-table-list` / `+db-table-get`，别手写 `information_schema` / `pg_indexes` 模拟 |
@@ -226,7 +220,7 @@ WHERE id = (SELECT id FROM task WHERE title = '梳理需求' ORDER BY _created_a
 
 | 项目 | 规则 |
 |---|---|
-| 主键 | 默认 `id uuid PRIMARY KEY DEFAULT gen_random_uuid()`；人员实体表可用 `user_profile PRIMARY KEY` |
+| 主键 | 默认 `id uuid PRIMARY KEY DEFAULT gen_random_uuid()` |
 | 命名 | 表名单数、全小写、snake_case、无冗余后缀 |
 | 枚举 / 状态 | 用 `varchar(255)`，值用小写英文 + 下划线 |
 | JSONB | 必须 `COMMENT ON COLUMN ... IS '@type { ... }'` 声明类型 |

--- a/skills/lark-apps/references/lark-apps-db-execute.md
+++ b/skills/lark-apps/references/lark-apps-db-execute.md
@@ -2,9 +2,11 @@
 
 经妙搭服务端在应用数据库执行 SQL。运行时命令事实以 `lark-cli apps +db-execute --help` 为准。
 
+> **写 SQL 前先看文末「平台 SQL 规范」**：妙搭底层是 PostgreSQL + 一层平台约束，SQL 内容不符合会被服务端直接拒或建出行为不对的表。最容易踩的三条：① 建业务表必须带 4 个审计列（`_created_at`/`_updated_at`/`_created_by`/`_updated_by`）+ 启用 RLS + 4 条 policy，一次调用里写全；② 人员字段用内置复合类型 `user_profile`（写入 `ROW('<user_id>')::user_profile`，查询解引用 `(field).user_id`）；③ `CREATE/DROP DATABASE·SCHEMA·USER·ROLE`、非白名单 `CREATE EXTENSION`、平台保留表 `auth`/`users` 会被硬拒，`online` 环境禁 DDL。
+
 ## 何时用
 
-用于通过妙搭服务端执行应用数据库 SQL。不要从环境变量里取连接串裸连数据库；本地调试也走这个 shortcut。
+用于通过妙搭服务端执行应用数据库 SQL。不要从环境变量里取连接串裸连数据库；本地调试也走这个 shortcut。写什么样的 SQL（平台约束、建表模板、`user_profile`、审计列、禁用 SQL、PG 陷阱）见文末「平台 SQL 规范」。
 
 ## 命令骨架
 
@@ -42,3 +44,191 @@ lark-cli apps +db-execute --app-id app_xxx --environment dev --sql - --yes < /Us
 - 多语句失败时，失败前的语句可能已经 commit 落地。不要整批重跑；按错误 message/hint 修失败语句，并从剩余语句继续。
 - 如果需要原子性，让用户在 SQL 内显式写 `BEGIN` / `COMMIT`，不要假设 CLI 会包事务。
 - 不要把数据库连接串从 env 中取出来裸连。
+
+---
+
+# 平台 SQL 规范
+
+上面讲命令怎么调，这里讲**该写出什么样的 SQL**：妙搭底层是 PostgreSQL + 一层平台约束（RLS、审计列、`user_profile` 复合类型、禁用 SQL 白名单），不符合会被服务端直接拒或建出行为不对的表。看表 / 看结构用 [`+db-table-list`/`+db-table-get`](lark-apps-db.md)，别手写系统表查询模拟。
+
+## 平台禁用 SQL（硬拒绝）
+
+以下命中会被服务端拒，`error`（`type:"api"`）的 message/hint 会说明原因——先按 hint 修再重试，不要反复重试同一句。
+
+| 类别 | 禁止 |
+|---|---|
+| 数据库级 | `CREATE / DROP / ALTER DATABASE` |
+| Schema 级 | `CREATE / DROP SCHEMA` |
+| 用户 / 角色级 | `CREATE / DROP USER`、`CREATE / DROP / ALTER ROLE` |
+| Owner 切换 | `REASSIGN OWNED` / `DROP OWNED` |
+
+## 建表规范（CREATE TABLE）
+
+新建业务表必须：4 个审计列 + 启用 RLS + 4 条默认 policy，**放在同一次 `+db-execute` 调用里**（RLS / policy / COMMENT / INDEX 一起）。裸表名，不写 `public.` 或 schema 前缀。
+
+```sql
+CREATE TABLE IF NOT EXISTS <table> (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- ... 业务列 ...
+  name varchar(100) NOT NULL,
+  _created_at TIMESTAMP(3) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  _created_by user_profile DEFAULT (
+    CASE
+      WHEN current_setting('app.user_id', TRUE) = '' THEN NULL
+      ELSE concat('(', current_setting('app.user_id', TRUE), ')')::user_profile
+    END
+  ),
+  _updated_at TIMESTAMP(3) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  _updated_by user_profile DEFAULT (
+    CASE
+      WHEN current_setting('app.user_id', TRUE) = '' THEN NULL
+      ELSE concat('(', current_setting('app.user_id', TRUE), ')')::user_profile
+    END
+  )
+);
+
+ALTER TABLE <table> ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_bypass_policy ON <table>
+  TO service_role USING (true);
+
+CREATE POLICY "修改全部数据" ON <table>
+  AS PERMISSIVE FOR ALL TO authenticated USING (true);
+
+CREATE POLICY "查看全部数据" ON <table>
+  AS PERMISSIVE FOR SELECT TO authenticated, anon USING (true);
+
+CREATE POLICY "修改本人数据" ON <table>
+  AS PERMISSIVE FOR ALL TO authenticated USING (
+    (current_setting('app.user_id'::text) = ANY (ARRAY[]::text[]))
+    AND (current_setting('app.user_id'::text) = ((_created_by).user_id)::text)
+  );
+```
+
+建表流程：先 `+db-table-list` / `+db-table-get` 确认表不存在或看现有结构 → 生成 DDL → 向用户展示影响并取得授权 → `+db-execute ... --yes` 执行。
+
+## 审计列
+
+- 平台自动维护的四列固定叫 `_created_at` / `_updated_at` / `_created_by` / `_updated_by`（**下划线开头**）。查询 / 排序 / 过滤一律用这些名字，别写 `created_at`。
+- `_created_at` / `_updated_at` 在 INSERT 时可省略（有默认值）；需要业务归属时显式写 `_created_by` / `_updated_by`。
+- UPDATE 业务字段时建议同步 `_updated_at = CURRENT_TIMESTAMP` 和 `_updated_by`。
+
+## `user_profile` 复合类型
+
+平台内置类型 `(user_id varchar, name varchar, email varchar, avatar text, status integer)`，无需创建。**业务 SQL 只允许访问 `(field).user_id`**，不要依赖 `name` / `email` / `avatar` / `status`（可能为空或过期）。
+
+```sql
+-- 写入 / 更新：用 ROW()::user_profile，更新时替换整个字段，不改单个属性
+INSERT INTO teacher (teacher_profile, class_id)
+VALUES (ROW('<user_id>')::user_profile, gen_random_uuid());
+
+UPDATE teacher SET teacher_profile = ROW('<user_id>')::user_profile
+WHERE (teacher_profile).user_id = '<old_user_id>';
+
+-- 查询 / 过滤：解引用取 user_id；raw SQL 返回给前端前必须解引用，别直接返回复合类型
+SELECT (teacher_profile).user_id AS teacher_profile, class_id FROM teacher;
+
+-- 索引 / 唯一性：表达式列用三重括号；表达式唯一性用 CREATE UNIQUE INDEX，
+-- 不能用 ALTER TABLE ADD CONSTRAINT UNIQUE（不支持表达式列）
+CREATE INDEX idx_teacher_user_id ON teacher (((teacher_profile).user_id));
+CREATE UNIQUE INDEX uk_teacher_user_id ON teacher (((teacher_profile).user_id));
+```
+
+## DDL 规则
+
+| 场景 | 做法 |
+|---|---|
+| 加列 | `ALTER TABLE <t> ADD COLUMN IF NOT EXISTS <col> <type>`，相关 `COMMENT ON` 同次执行 |
+| 加索引 | `CREATE INDEX IF NOT EXISTS idx_<t>_<cols> ON <t>(...)` |
+| JSONB 类型声明 | 必须 `COMMENT ON COLUMN <t>.<col> IS '@type { ... }'` 声明 TypeScript 类型，和 CREATE / ALTER 同次调用 |
+| 加 NOT NULL 列 | 必须带 `DEFAULT` 让存量行自动填：`ADD COLUMN <col> <type> NOT NULL DEFAULT <值>` |
+| 删表 / 删列 | 有业务数据默认禁止；必须用户明确授权后才执行，并说明数据丢失风险 |
+| 强约束 | `UNIQUE` / `FOREIGN KEY` / `NOT NULL` 默认谨慎，不确定不加 |
+
+**`IF NOT EXISTS` 支持矩阵**（用错会直接语法/执行错）：
+
+| 支持 | 不支持 |
+|---|---|
+| `CREATE TABLE` / `CREATE INDEX` / `CREATE EXTENSION` / `ALTER TABLE ADD COLUMN` | `CREATE TYPE` / `CREATE POLICY` / `ALTER TABLE ADD CONSTRAINT` |
+
+**多环境库加约束前先查 online 存量**：`dev` 干净不代表 `online` 干净，约束发布到 online 会撞线上存量数据而失败。发布前一律先用 `--environment online` 查清楚，按约束类型分三种：
+
+- **加唯一约束（`UNIQUE` / 唯一索引）**：线上不能有重复值。先查重复，有则先清理再加：
+
+  ```bash
+  lark-cli apps +db-execute --app-id app_xxx --environment online --sql \
+    "SELECT <cols>, count(*) FROM t GROUP BY <cols> HAVING count(*) > 1" --yes
+  ```
+
+- **已有列改 `NOT NULL`（收紧约束）**：线上该列不能有 NULL。先查 NULL 行数，有就先回填（`UPDATE t SET <col> = <默认值> WHERE <col> IS NULL`）再加约束：
+
+  ```bash
+  lark-cli apps +db-execute --app-id app_xxx --environment online --sql \
+    "SELECT count(*) FROM t WHERE <col> IS NULL" --yes
+  ```
+
+- **新加 `NOT NULL` 字段**：必须带 `DEFAULT`，且要求线上该表**无存量数据**，否则发布报错。线上已有数据时别直接加，改走三步安全变更：先 `ADD COLUMN <col> <type>`（可空）→ 回填 `UPDATE t SET <col> = <值>` → 再 `ALTER COLUMN <col> SET NOT NULL`。先查线上行数判断走哪条：
+
+  ```bash
+  lark-cli apps +db-execute --app-id app_xxx --environment online --sql \
+    "SELECT count(*) FROM t" --yes
+  ```
+
+## SELECT 规则
+
+| 规则 | 要求                                                               |
+|---|------------------------------------------------------------------|
+| 行数 | 结果集有硬上限（平台限制 1000 行），超限**报错而非静默截断**；大表必须显式 `LIMIT`、聚合或游标分页       |
+| 分页 | 大表优先游标分页 `WHERE id > <last_id> ORDER BY id LIMIT n`，避免大 `OFFSET` |
+| user_profile | 返回给前端前解引用：`(owner).user_id AS owner`                             |
+| 统计 | 总数用 `count(*)`、分组用 `GROUP BY`，别把全量拉到 agent 侧再统计                  |
+| 慢查询 | 用 `EXPLAIN (ANALYZE, BUFFERS)`；大表 Seq Scan 考虑加索引                 |
+
+## DML 规则
+
+**INSERT**
+- UUID 主键省略，交给 `DEFAULT gen_random_uuid()`；外键 UUID 用子查询取父表 id，不手写。
+- NOT NULL 且无默认值的列必须给值；批量 INSERT 每行列数一致。
+- 需要幂等用 `ON CONFLICT ... DO NOTHING / DO UPDATE`。
+- 标量子查询必须保证单行，非唯一条件加 `ORDER BY ... LIMIT 1`。
+
+**UPDATE**
+- **必须有明确 `WHERE`，禁止无条件 UPDATE**。
+- 用户说「修改 / 更新 / 改一下」数据时用 UPDATE，**禁止 DELETE + INSERT** 模式。
+- 更新 `user_profile` / 复合类型时替换整个字段。
+- 批量更新前影响范围不明确，先 `SELECT count(*)` 给用户确认。
+
+**DELETE / TRUNCATE**（属会丢数据的高影响操作，按上面「Agent 规则」的确认流程走）
+- 已有表 / 已有数据默认禁止；先 `SELECT count(*)` 展示命中行数、取得用户明确授权，再带 `--yes` 执行。
+- `TRUNCATE` 影响整表，视同高风险删除。
+
+```sql
+UPDATE task
+SET status = 'done', _updated_at = CURRENT_TIMESTAMP, _updated_by = ROW('<user_id>')::user_profile
+WHERE id = (SELECT id FROM task WHERE title = '梳理需求' ORDER BY _created_at DESC LIMIT 1);
+```
+
+## 常见 PostgreSQL 陷阱
+
+| 陷阱 | 正确做法 |
+|---|---|
+| 表名带 schema 前缀 | 业务表一律裸表名 `FROM user_profile`，别写 `public.t` |
+| 保留字作标识符 | 避免 `user` / `order` / `desc` / `offset` / `references` 等 |
+| 内联 COMMENT | 禁止 `col TEXT COMMENT 'xx'`，用独立 `COMMENT ON COLUMN` |
+| 手写系统表查结构 | 常规结构查询用 `+db-table-list` / `+db-table-get`，别手写 `information_schema` / `pg_indexes` 模拟 |
+| 空数组类型不明 | 写 `ARRAY[]::text[]` 或 `'{}'::text[]` |
+| `ROUND` 报错 | 用 `ROUND(num::numeric, n)` 或 `ROUND(num::double precision)` |
+| `DISTINCT` + 窗口函数 | 分两层查询，先 DISTINCT 再窗口函数 |
+| MySQL 方言 | 不用 `SHOW TABLES` / `DESCRIBE` / 内联 `COMMENT`；用 `+db-table-*` 和 `COMMENT ON` |
+| 多语句以为自动回滚 | `A; B; C` 不自动包事务，B 失败时 A 已提交；要原子性显式 `BEGIN; ... COMMIT;`（见上「命令骨架」「Agent 规则」） |
+
+## 数据类型与设计
+
+| 项目 | 规则 |
+|---|---|
+| 主键 | 默认 `id uuid PRIMARY KEY DEFAULT gen_random_uuid()`；人员实体表可用 `user_profile PRIMARY KEY` |
+| 命名 | 表名单数、全小写、snake_case、无冗余后缀 |
+| 枚举 / 状态 | 用 `varchar(255)`，值用小写英文 + 下划线 |
+| JSONB | 必须 `COMMENT ON COLUMN ... IS '@type { ... }'` 声明类型 |
+| 附件 / 图片 | URL 用 `TEXT`，命名 `xxx_url` |
+| 约束 | `UNIQUE` / `FOREIGN KEY` / `NOT NULL` 默认谨慎，新增 NOT NULL 列优先带 `DEFAULT` |

--- a/skills/lark-apps/references/lark-apps-db.md
+++ b/skills/lark-apps/references/lark-apps-db.md
@@ -4,7 +4,7 @@
 
 ## 何时用
 
-用户要看应用里有哪些表 / 某张表的结构、把单库应用拆成 dev/online 多环境、把数据导进导出表、查谁在什么时候改了表结构或表数据、开关行级审计、把开发环境的库结构发布到线上、把库恢复到过去某个时间点、或看数据库用量时。逐条执行 SQL 走 [`+db-execute`](lark-apps-db-execute.md)；文件存储（上传/下载文件）走 [`lark-apps-file.md`](lark-apps-file.md)。
+用户要看应用里有哪些表 / 某张表的结构、把单库应用拆成 dev/online 多环境、把数据导进导出表、查谁在什么时候改了表结构或表数据、开关行级审计、把开发环境的库结构发布到线上、把库恢复到过去某个时间点、或看数据库用量时。逐条执行 SQL 走 [`+db-execute`](lark-apps-db-execute.md)；文件存储（上传/下载文件）走 [`lark-apps-file.md`](lark-apps-file.md)。**建表 / 改表 / 写 SQL 的平台内容规范**（审计列、RLS、`user_profile`、禁用 SQL、PG 陷阱）见 [`lark-apps-db-execute.md`](lark-apps-db-execute.md) 的「平台 SQL 规范」。
 
 ## 命令一览
 


### PR DESCRIPTION
## What

Aligns the `lark-cli apps +db-execute` skill with the Miaoda platform's SQL constraints — the same dataloom backend the sandbox `miaoda-sql` skill targets — so agents writing SQL through the CLI don't get server-rejected or build tables that misbehave. Previously the db-execute skill documented only the command contract (flags/output/transactions) with **zero SQL-content guidance**.

Adds a **「平台 SQL 规范」** section to `lark-apps-db-execute.md` (后半部分):

- **平台禁用 SQL**（硬拒绝）：`CREATE/DROP DATABASE·SCHEMA·USER·ROLE`、`REASSIGN/DROP OWNED`。
- **建表规范**：4 个审计列 + 启用 RLS + 4 条默认 policy 模板，一次调用写全。
- **`user_profile` 复合类型**：`ROW('<user_id>')::user_profile` 写入、`(field).user_id` 解引用、三重括号表达式索引。
- **审计列**：`_created_at`/`_updated_at`/`_created_by`/`_updated_by` 命名与语义。
- **DDL 规则**：`IF NOT EXISTS` 支持矩阵；多环境库加约束前查 online 存量，按「唯一约束 / 已有列改 NOT NULL / 新加 NOT NULL 字段」三类分别给检查 SQL + 处理方式。
- **SELECT / DML 安全规则** 与 **常见 PostgreSQL 陷阱**。

## Scope decisions

来源是 `code.byted.org/apaas/miaoda-skills` 的 `miaoda-sql` skill。**迁移**平台后端共享的 SQL 内容正确性规范；**排除**沙箱/agent 环境特定内容：`miaoda db` 命令名、`generate_image`/Picsum 图片规则、测试用户 id 列表、`schema.ts` codegen、miaoda 字符串错误码（我们用 typed error envelope）。

`SKILL.md` 意图路由与 `lark-apps-db.md` 加了指向该规范的指针。

## Testing

- `TestSkillDocsCommandsConsistentWithShortcuts` / `TestAppsShortcuts_*` 通过。
- 文档引用的命令（`+db-execute`/`+db-table-list`/`+db-table-get`/`+db-env-migrate`）均真实存在，交叉链接目标文件都在。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 更新 `+db-execute` 的“意图路由”说明，强调其包含平台 SQL 标准（审计列、RLS、`user_profile` 约束、禁用 SQL 与 PostgreSQL 陷阱等）。
  * 在 `+db-execute` 文档新增“何时用”与完整“平台 SQL 规范”章节，覆盖建表/改表、默认策略、复合类型使用限制、SELECT 行数与分页、DML 风险与安全流程。
  * 更新 `+db` 相关指引，新增引用提醒：涉及建表/改表/SQL 时需先对照平台 SQL 规范。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->