### PR TITLE
fix: reduce public content credential fixture false positives

### DIFF
--- a/internal/qualitygate/cmd/comment-audit/main.go
+++ b/internal/qualitygate/cmd/comment-audit/main.go
@@ -19,10 +19,16 @@ import (
 type eventPayload struct {
 	Comment *struct {
 		Body string `json:"body"`
+		Path string `json:"path"`
 	} `json:"comment"`
 	Review *struct {
 		Body string `json:"body"`
 	} `json:"review"`
+}
+
+type commentContent struct {
+	Body string
+	Path string
 }
 
 func main() {
@@ -34,12 +40,11 @@ func main() {
 		fmt.Fprintln(os.Stderr, "comment-audit: --event or GITHUB_EVENT_PATH is required")
 		os.Exit(2)
 	}
-	body, err := commentBody(*eventPath)
+	diags, err := auditEvent(*eventPath, *kind)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "comment-audit: %v\n", err)
 		os.Exit(2)
 	}
-	diags := diagnostics(publiccontent.ScanComment(*kind, body))
 	if len(diags) > 0 {
 		fmt.Fprintln(os.Stderr, auditFailureSummary(len(diags)))
 	}
@@ -47,32 +52,44 @@ func main() {
 	os.Exit(report.ExitCode(diags))
 }
 
+func auditEvent(eventPath, kind string) ([]report.Diagnostic, error) {
+	content, err := commentBody(eventPath)
+	if err != nil {
+		return nil, err
+	}
+	return scanCommentContent(kind, content), nil
+}
+
+func scanCommentContent(kind string, content commentContent) []report.Diagnostic {
+	return diagnostics(publiccontent.ScanCommentAtPath(kind, content.Path, content.Body))
+}
+
 func auditFailureSummary(count int) string {
 	return fmt.Sprintf("post-publication audit found public content findings: %d", count)
 }
 
-func commentBody(path string) (string, error) {
+func commentBody(path string) (commentContent, error) {
 	safePath, err := validate.SafeInputPath(path)
 	if err != nil {
-		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --event: %v", err).
+		return commentContent{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --event: %v", err).
 			WithParam("--event").
 			WithCause(err)
 	}
 	data, err := vfs.ReadFile(safePath)
 	if err != nil {
-		return "", err
+		return commentContent{}, err
 	}
 	var payload eventPayload
 	if err := json.Unmarshal(data, &payload); err != nil {
-		return "", err
+		return commentContent{}, err
 	}
 	switch {
 	case payload.Comment != nil:
-		return payload.Comment.Body, nil
+		return commentContent{Body: payload.Comment.Body, Path: payload.Comment.Path}, nil
 	case payload.Review != nil:
-		return payload.Review.Body, nil
+		return commentContent{Body: payload.Review.Body}, nil
 	default:
-		return "", nil
+		return commentContent{}, nil
 	}
 }
 

--- a/internal/qualitygate/cmd/comment-audit/main_test.go
+++ b/internal/qualitygate/cmd/comment-audit/main_test.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/qualitygate/publiccontent"
 )
 
 func TestCommentBodyReadsSafeRelativeEventPath(t *testing.T) {
@@ -32,9 +34,90 @@ func TestCommentBodyReadsSafeRelativeEventPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commentBody() error = %v", err)
 	}
-	if got != "clean comment" {
-		t.Fatalf("comment body = %q", got)
+	if got.Body != "clean comment" || got.Path != "" {
+		t.Fatalf("comment content = %#v", got)
 	}
+}
+
+func TestCommentBodyReadsReviewCommentPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeTestFile(filepath.Join(dir, "event.json"), `{"comment":{"body":"test suggestion","path":"cmd/agent/list_test.go"}}`); err != nil {
+		t.Fatal(err)
+	}
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+	})
+
+	got, err := commentBody("event.json")
+	if err != nil {
+		t.Fatalf("commentBody() error = %v", err)
+	}
+	if got.Body != "test suggestion" || got.Path != "cmd/agent/list_test.go" {
+		t.Fatalf("comment content = %#v", got)
+	}
+}
+
+func TestCommentAuditUsesReviewCommentPathForFixtureClassification(t *testing.T) {
+	dir := t.TempDir()
+	body := `CLIENT_SECRET=$(security find-generic-password -w)`
+	event := `{"comment":{"body":` + strconv.Quote(body) + `,"path":"scripts/config_test.sh"}}`
+	if err := writeTestFile(filepath.Join(dir, "event.json"), event); err != nil {
+		t.Fatal(err)
+	}
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+	})
+
+	diags, err := auditEvent("event.json", "pull_request_review_comment")
+	if err != nil {
+		t.Fatalf("auditEvent() error = %v", err)
+	}
+	for _, diag := range diags {
+		if diag.Rule == "public_content_generic_credential" {
+			t.Fatalf("review comment fixture should not be a credential diagnostic: %#v", diags)
+		}
+	}
+	pathless := publiccontent.ScanComment("pull_request_review_comment", body)
+	for _, finding := range pathless {
+		if finding.Rule == "public_content_generic_credential" {
+			return
+		}
+	}
+	t.Fatalf("test precondition failed: pathless comment should be classified as a credential: %#v", pathless)
+}
+
+func TestScanCommentContentPreservesReviewCommentPath(t *testing.T) {
+	providerValue := "gh" + "p_" + "1234567890abcdef" + "1234567890abcdef" + "1234"
+	content := commentContent{
+		Body: `cfg := &Config{AccessToken: "` + providerValue + `"}`,
+		Path: "cmd/agent/list_test.go",
+	}
+
+	diags := scanCommentContent("pull_request_review_comment", content)
+	for _, diag := range diags {
+		if diag.Rule != "public_content_generic_credential" {
+			continue
+		}
+		if diag.File != content.Path {
+			t.Fatalf("credential diagnostic file = %q, want %q", diag.File, content.Path)
+		}
+		return
+	}
+	t.Fatalf("missing provider credential diagnostic: %#v", diags)
 }
 
 func TestCommentBodyRejectsUnsafeEventPath(t *testing.T) {

--- a/internal/qualitygate/publiccontent/collect_test.go
+++ b/internal/qualitygate/publiccontent/collect_test.go
@@ -23,9 +23,10 @@ func TestCollectScansOnlyCurrentContributionAndMetadata(t *testing.T) {
 	runGit(t, repo, "add", "baseline.md")
 	runGit(t, repo, "commit", "-m", "base")
 
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
 	writeFile(t, filepath.Join(repo, "docs", "public.md"), `# Public change
 
-api_`+`key = "example-public-key"
+api_`+`key = "`+providerValue+`"
 `)
 	runGit(t, repo, "add", "docs/public.md")
 	runGit(t, repo, "commit", "-m", "add public doc", "-m", "Change"+"-Id: I0123456789abcdef0123456789abcdef01234567")
@@ -199,13 +200,14 @@ func TestCollectDetectsQuotedJSONCredentialAssignments(t *testing.T) {
 	runGit(t, repo, "add", "docs/public.json")
 	runGit(t, repo, "commit", "-m", "base")
 
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
 	writeFile(t, filepath.Join(repo, "docs", "public.json"), strings.Join([]string{
-		`{"access_` + `token":"real-json-token"}`,
-		`{"client_` + `secret": "real ` + `secret value"}`,
-		`{"tenantAccess` + `Token":"real-tenant-camel-token"}`,
-		`{"github` + `Token":"real-github-token"}`,
-		`{"vendorApi` + `Key":"real-vendor-key"}`,
-		`{"slackBot` + `Token":"xoxb-real-token"}`,
+		`{"access_` + `token":"` + providerValue + `"}`,
+		`{"client_` + `secret": "` + providerValue + `"}`,
+		`{"tenantAccess` + `Token":"` + providerValue + `"}`,
+		`{"github` + `Token":"` + providerValue + `"}`,
+		`{"vendorApi` + `Key":"` + providerValue + `"}`,
+		`{"slackBot` + `Token":"xoxb_` + `1234567890abcdef"}`,
 	}, "\n")+"\n")
 	runGit(t, repo, "add", "docs/public.json")
 	runGit(t, repo, "commit", "-m", "add json config")
@@ -215,14 +217,7 @@ func TestCollectDetectsQuotedJSONCredentialAssignments(t *testing.T) {
 	for _, item := range got {
 		if item.File == "docs/public.json" && item.Rule == "public_content_generic_credential" {
 			count++
-			for _, forbidden := range []string{
-				"real-json-token",
-				"real secret value",
-				"real-tenant-camel-token",
-				"real-github-token",
-				"real-vendor-key",
-				"xoxb-real-token",
-			} {
+			for _, forbidden := range []string{providerValue, "xoxb_" + "1234567890abcdef"} {
 				if strings.Contains(item.Excerpt, forbidden) {
 					t.Fatalf("JSON credential finding leaked value %q in excerpt %q", forbidden, item.Excerpt)
 				}
@@ -306,8 +301,8 @@ func TestCollectDetectsAngleWrappedRealisticCredentialValues(t *testing.T) {
 			count++
 		}
 	}
-	if count != 3 {
-		t.Fatalf("angle-wrapped realistic credential findings = %d, want 3: %#v", count, got)
+	if count != 2 {
+		t.Fatalf("angle-wrapped provider credential findings = %d, want 2: %#v", count, got)
 	}
 }
 
@@ -338,12 +333,12 @@ func TestCollectDetectsCredentialShapedValuesUnderBenignKeys(t *testing.T) {
 			count++
 		}
 	}
-	if count != 7 {
-		t.Fatalf("credential-shaped benign-key findings = %d, want 7: %#v", count, got)
+	if count != 4 {
+		t.Fatalf("provider-shaped benign-key findings = %d, want 4: %#v", count, got)
 	}
 }
 
-func TestCollectDetectsBareIdentifierCredentialsWithMetadataSuffixes(t *testing.T) {
+func TestCollectAllowsBareIdentifierCredentialsWithMetadataSuffixes(t *testing.T) {
 	repo := newGitRepo(t)
 	writeFile(t, filepath.Join(repo, "docs", "config.yaml"), "base: true\n")
 	runGit(t, repo, "add", "docs/config.yaml")
@@ -358,14 +353,10 @@ func TestCollectDetectsBareIdentifierCredentialsWithMetadataSuffixes(t *testing.
 	runGit(t, repo, "commit", "-m", "add credential config")
 
 	got := collectFromPreviousCommit(t, repo)
-	var count int
 	for _, item := range got {
 		if item.File == "docs/config.yaml" && item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("readable metadata values should not be credential findings: %#v", got)
 		}
-	}
-	if count != 3 {
-		t.Fatalf("metadata-suffixed bare credential findings = %d, want 3: %#v", count, got)
 	}
 }
 
@@ -374,7 +365,7 @@ func TestCollectDetectsAccessKeyCredentials(t *testing.T) {
 	writeFile(t, filepath.Join(repo, "docs", "config.yaml"), "base: true\n")
 	runGit(t, repo, "add", "docs/config.yaml")
 	runGit(t, repo, "commit", "-m", "base")
-	accessKey := "AK" + "IAIOSFODNN7EXAMPX"
+	accessKey := "AK" + "IAIOSFODNN7EXAMPXX"
 
 	writeFile(t, filepath.Join(repo, "docs", "config.yaml"), strings.Join([]string{
 		"AWS_ACCESS_KEY_ID: " + accessKey,
@@ -391,7 +382,7 @@ func TestCollectDetectsAccessKeyCredentials(t *testing.T) {
 			continue
 		}
 		count++
-		if strings.Contains(item.Excerpt, "AKIAIOSFODNN7EXAMPX") {
+		if strings.Contains(item.Excerpt, accessKey) {
 			t.Fatalf("access key finding leaked value in excerpt %q", item.Excerpt)
 		}
 	}
@@ -432,7 +423,7 @@ func TestCollectDetectsPrivateKeyAssignments(t *testing.T) {
 	}
 }
 
-func TestCollectDetectsCredentialValuesThatLookLikeBareIdentifiers(t *testing.T) {
+func TestCollectAllowsCredentialValuesThatLookLikeBareIdentifiers(t *testing.T) {
 	repo := newGitRepo(t)
 	writeFile(t, filepath.Join(repo, "docs", "config.yaml"), "base: true\n")
 	runGit(t, repo, "add", "docs/config.yaml")
@@ -448,14 +439,10 @@ func TestCollectDetectsCredentialValuesThatLookLikeBareIdentifiers(t *testing.T)
 	runGit(t, repo, "commit", "-m", "add credential config")
 
 	got := collectFromPreviousCommit(t, repo)
-	var count int
 	for _, item := range got {
 		if item.File == "docs/config.yaml" && item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("readable identifiers should not be credential findings: %#v", got)
 		}
-	}
-	if count != 4 {
-		t.Fatalf("bare identifier credential findings = %d, want 4: %#v", count, got)
 	}
 }
 
@@ -489,12 +476,13 @@ func TestCollectDetectsCredentialPhraseBeforeEnvironmentSuffix(t *testing.T) {
 	runGit(t, repo, "add", "docs/config.yaml")
 	runGit(t, repo, "commit", "-m", "base")
 
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
 	writeFile(t, filepath.Join(repo, "docs", "config.yaml"), strings.Join([]string{
-		"API_KEY_OPENAI: real-openai-key",
-		"TOKEN_GITHUB: real-github-token",
-		"CLIENT_SECRET_GOOGLE: real-google-secret",
-		"SECRET_KEY_BASE: real-secret-key-base",
-		"APP_PASSWORD_PROD: real-prod-password",
+		"API_KEY_OPENAI: " + providerValue,
+		"TOKEN_GITHUB: " + providerValue,
+		"CLIENT_SECRET_GOOGLE: " + providerValue,
+		"SECRET_KEY_BASE: " + providerValue,
+		"APP_PASSWORD_PROD: " + providerValue,
 	}, "\n")+"\n")
 	runGit(t, repo, "add", "docs/config.yaml")
 	runGit(t, repo, "commit", "-m", "add credential config")
@@ -506,13 +494,7 @@ func TestCollectDetectsCredentialPhraseBeforeEnvironmentSuffix(t *testing.T) {
 			continue
 		}
 		count++
-		for _, forbidden := range []string{
-			"real-openai-key",
-			"real-github-token",
-			"real-google-secret",
-			"real-secret-key-base",
-			"real-prod-password",
-		} {
+		for _, forbidden := range []string{providerValue} {
 			if strings.Contains(item.Excerpt, forbidden) {
 				t.Fatalf("credential finding leaked value %q in excerpt %q", forbidden, item.Excerpt)
 			}
@@ -621,7 +603,8 @@ func TestCollectSkipsOnlyKnownQualityGateFixtureFiles(t *testing.T) {
 	writeFile(t, filepath.Join(repo, "internal", "qualitygate", "publiccontent", "scan_test.go"), "SECRET_TOKEN=fixture\n")
 	writeFile(t, filepath.Join(repo, "internal", "qualitygate", "publiccontent", "scan.go"), "const privateKeyFixture = \""+privateKeyBeginPrefix+privateKeyMarker+"\"\n")
 	writeFile(t, filepath.Join(repo, "internal", "qualitygate", "publiccontent", "rules.go"), "markers := []string{\"generated with automation\"}\n")
-	writeFile(t, filepath.Join(repo, "tests", "e2e", "new-public-workflow.test.sh"), "SECRET_TOKEN=real-leak\n")
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	writeFile(t, filepath.Join(repo, "tests", "e2e", "new-public-workflow.test.sh"), "SECRET_TOKEN="+providerValue+"\n")
 	runGit(t, repo, "add", ".")
 	runGit(t, repo, "commit", "-m", "add scanner fixtures")
 
@@ -685,10 +668,11 @@ func TestCollectScansAddedLinesInSpecialPathNames(t *testing.T) {
 	runGit(t, repo, "add", ".")
 	runGit(t, repo, "commit", "-m", "base")
 
-	writeFile(t, filepath.Join(repo, "docs", "has space.md"), "SECRET_TOKEN=space-value\n")
-	writeFile(t, filepath.Join(repo, `weird"quote.md`), "SECRET_TOKEN=quote-value\n")
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	writeFile(t, filepath.Join(repo, "docs", "has space.md"), "SECRET_TOKEN="+providerValue+"\n")
+	writeFile(t, filepath.Join(repo, `weird"quote.md`), "SECRET_TOKEN="+providerValue+"\n")
 	runGit(t, repo, "mv", "docs/old.md", "docs/new name.md")
-	writeFile(t, filepath.Join(repo, "docs", "new name.md"), "base\nSECRET_TOKEN=rename-value\n")
+	writeFile(t, filepath.Join(repo, "docs", "new name.md"), "base\nSECRET_TOKEN="+providerValue+"\n")
 	runGit(t, repo, "add", ".")
 	runGit(t, repo, "commit", "-m", "add special paths")
 

--- a/internal/qualitygate/publiccontent/comment_audit.go
+++ b/internal/qualitygate/publiccontent/comment_audit.go
@@ -4,8 +4,15 @@
 package publiccontent
 
 func ScanComment(kind, body string) []Finding {
+	return ScanCommentAtPath(kind, "", body)
+}
+
+func ScanCommentAtPath(kind, path, body string) []Finding {
 	if kind == "" {
 		kind = "comment"
 	}
-	return scanText(kind, "comment", body, false)
+	if path == "" {
+		path = kind
+	}
+	return scanText(path, "comment", body, isDetectorRuleFile(path))
 }

--- a/internal/qualitygate/publiccontent/comment_audit_test.go
+++ b/internal/qualitygate/publiccontent/comment_audit_test.go
@@ -3,7 +3,10 @@
 
 package publiccontent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestScanCommentAuditsPublishedCommentBodies(t *testing.T) {
 	got := ScanComment("issue_comment", `The published comment included /tmp/harness`+`-agent/run and CCM`+`-Harness: stage-4`)
@@ -15,5 +18,62 @@ func TestScanCommentAuditsPublishedCommentBodies(t *testing.T) {
 		if item.File != "issue_comment" {
 			t.Fatalf("comment finding file = %q, want issue_comment", item.File)
 		}
+	}
+}
+
+func TestScanCommentAllowsMermaidCredentialTerminology(t *testing.T) {
+	body := strings.Join([]string{
+		"```mermaid",
+		"sequenceDiagram",
+		"  participant Client",
+		"  participant AccessTokenHashTransport",
+		"  participant SecurityPolicyTransport",
+		"  Client->>AccessTokenHashTransport: Send request with bearer token",
+		"  AccessTokenHashTransport->>AccessTokenHashTransport: Clone request and inject token hash",
+		"  Client -> ClientSecret: Resolve configured credential",
+		"  AccessTokenHashTransport->>SecurityPolicyTransport: Forward enriched request",
+		"```",
+	}, "\n")
+
+	got := ScanComment("issue_comment", body)
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			t.Fatalf("mermaid credential terminology should not be a credential finding: %#v", got)
+		}
+	}
+}
+
+func TestScanCommentDetectsCredentialAssignmentInsideMermaidMessage(t *testing.T) {
+	providerValue := strings.Join([]string{"gh", "p_", "1234567890abcdef", "1234567890abcdef", "1234"}, "")
+	credentialAssignment := "password=" + providerValue
+	body := strings.Join([]string{
+		"```mermaid",
+		"sequenceDiagram",
+		"  Client->>Server: Send " + credentialAssignment,
+		"```",
+	}, "\n")
+
+	got := ScanComment("issue_comment", body)
+	if !findingRules(got)["public_content_generic_credential"] {
+		t.Fatalf("credential assignment inside mermaid message should be reported: %#v", got)
+	}
+}
+
+func TestScanCommentAtPathAllowsTestFixtureCredentialPlaceholder(t *testing.T) {
+	body := `cfg := &core.CliConfig{AppID: "cli_x", AppSecret: "fake-secret"}`
+	got := ScanCommentAtPath("pull_request_review_comment", "cmd/agent/list_test.go", body)
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			t.Fatalf("review comment test fixture should not be a credential finding: %#v", got)
+		}
+	}
+}
+
+func TestScanCommentAtPathDetectsProviderCredentialInTestFile(t *testing.T) {
+	providerValue := strings.Join([]string{"gh", "p_", "1234567890abcdef", "1234567890abcdef", "1234"}, "")
+	body := `cfg := &Config{AccessToken: "` + providerValue + `"}`
+	got := ScanCommentAtPath("pull_request_review_comment", "cmd/agent/list_test.go", body)
+	if !findingRules(got)["public_content_generic_credential"] {
+		t.Fatalf("provider credential in review comment should be reported: %#v", got)
 	}
 }

--- a/internal/qualitygate/publiccontent/credential.go
+++ b/internal/qualitygate/publiccontent/credential.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package publiccontent
+
+import (
+	"encoding/base64"
+	"net/url"
+	"strings"
+)
+
+func credentialValueHasStrongEvidence(key, value string) bool {
+	normalized := strings.TrimRight(strings.TrimSpace(value), ",;")
+	normalized = strings.TrimSpace(strings.Trim(normalized, `"'<>`))
+	candidates := credentialEvidenceCandidates(unwrapCredentialValue(normalized))
+	for _, candidate := range candidates {
+		if providerCredentialIdentifier(candidate) {
+			return true
+		}
+	}
+	if isCredentialMetadataField(key) {
+		return false
+	}
+	for _, candidate := range candidates {
+		if highEntropyCredentialValue(strings.ToLower(candidate)) || base64PaddedCredentialValue(candidate) {
+			return true
+		}
+	}
+	return percentEncodedCredentialValue(strings.ToLower(candidates[0])) ||
+		commandSubstitutionLooksCredentialLike(strings.ToLower(normalized))
+}
+
+func credentialEvidenceCandidates(value string) []string {
+	candidates := []string{value}
+	for range 3 {
+		decoded, err := url.PathUnescape(value)
+		if err != nil || decoded == value {
+			break
+		}
+		candidates = append(candidates, decoded)
+		value = decoded
+	}
+	return candidates
+}
+
+func isCredentialMetadataField(key string) bool {
+	if isBenignTokenField(key) {
+		return true
+	}
+	parts := credentialKeyParts(strings.ReplaceAll(strings.ToLower(key), "-", "_"))
+	if len(parts) < 2 {
+		return false
+	}
+	switch parts[len(parts)-1] {
+	case "hash", "id", "kind", "marker", "prefix", "transport":
+		return true
+	default:
+		return false
+	}
+}
+
+func base64PaddedCredentialValue(value string) bool {
+	if len(value) < 16 || !strings.HasSuffix(value, "=") {
+		return false
+	}
+	if _, err := base64.StdEncoding.DecodeString(value); err != nil {
+		return false
+	}
+	return shannonEntropy(strings.TrimRight(value, "=")) >= 3.5
+}
+
+func percentEncodedCredentialValue(value string) bool {
+	if len(value) < 16 {
+		return false
+	}
+	var escapes int
+	for i := 0; i+2 < len(value); i++ {
+		if value[i] == '%' && isHexByte(value[i+1]) && isHexByte(value[i+2]) {
+			escapes++
+			i += 2
+		}
+	}
+	return escapes >= 2
+}
+
+func isHexByte(value byte) bool {
+	return (value >= '0' && value <= '9') || (value >= 'a' && value <= 'f')
+}

--- a/internal/qualitygate/publiccontent/rules.go
+++ b/internal/qualitygate/publiccontent/rules.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	credentialAssignmentRE = regexp.MustCompile(`(?i)["']?\b[A-Za-z0-9_-]*(?:api[_-]?key|access[_-]?key|private[_-]?key|secret|password|passwd|token|webhook|access[_-]?token|client[_-]?secret)[A-Za-z0-9_-]*\b["']?\s*[:=]\s*(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|(\$\([^)]*\))|(\$\{\{[^}]+\}\})|([^"'\s,}\]]+))`)
+	credentialAssignmentRE = regexp.MustCompile(`(?i)["']?\b[A-Za-z0-9_-]*(?:api[_-]?key|access[_-]?key|private[_-]?key|secret|password|passwd|token|webhook|access[_-]?token|client[_-]?secret)[A-Za-z0-9_-]*\b["']?\s*(?::=|[:=])\s*(?:!!str\s+)?(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|(\x60[^\x60]*\x60)|(\$\([^)]*\))|(\$\{\{[^}]+\}\})|([^"'\x60\s,}\]]+))`)
 	jwtLikeRE              = regexp.MustCompile(`\b[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`)
 	credentialURLRE        = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]*://[^/\s:@]*:[^@\s/]+@[^)\s]+`)
 	bearerHeaderRE         = regexp.MustCompile(`(?i)(?:\bAuthorization\s*:\s*Bearer\s+|["']Authorization["']\s*:\s*["']Bearer\s+)[A-Za-z0-9._+/=-]{12,}`)
@@ -383,31 +383,61 @@ func anglePlaceholderIdentifier(value string) bool {
 }
 
 func credentialShapedValue(value string) bool {
-	normalized := strings.ToLower(strings.Trim(value, `"'<>`))
+	normalized := strings.TrimSpace(strings.Trim(strings.TrimSpace(value), `"'<>`))
 	return credentialShapedIdentifier(normalized)
 }
 
 func credentialShapedIdentifier(value string) bool {
+	return providerCredentialIdentifier(value)
+}
+
+func providerCredentialIdentifier(value string) bool {
+	value = strings.TrimSpace(value)
 	switch {
-	case strings.HasPrefix(value, "sk_live_"),
-		strings.HasPrefix(value, "sk_test_"),
-		strings.HasPrefix(value, "ghp_"),
-		strings.HasPrefix(value, "gho_"),
-		strings.HasPrefix(value, "ghu_"),
-		strings.HasPrefix(value, "github_pat_"),
-		strings.HasPrefix(value, "xoxb_"),
-		strings.HasPrefix(value, "xoxp_"),
-		strings.HasPrefix(value, "xoxa_"):
-		return true
-	case strings.HasPrefix(value, "real-") &&
-		(strings.Contains(value, "secret") ||
-			strings.Contains(value, "token") ||
-			strings.Contains(value, "key") ||
-			strings.Contains(value, "password")):
+	case providerTokenWithBody(value, "sk_live_", 16, ""),
+		providerTokenWithBody(value, "sk_test_", 16, ""),
+		providerTokenWithBody(value, "ghp_", 16, ""),
+		providerTokenWithBody(value, "gho_", 16, ""),
+		providerTokenWithBody(value, "ghu_", 16, ""),
+		providerTokenWithBody(value, "github_pat_", 16, "_"),
+		providerTokenWithBody(value, "xoxb_", 16, "-"),
+		providerTokenWithBody(value, "xoxp_", 16, "-"),
+		providerTokenWithBody(value, "xoxa_", 16, "-"),
+		providerTokenWithBody(value, "xoxb-", 16, "-"),
+		providerTokenWithBody(value, "xoxp-", 16, "-"),
+		providerTokenWithBody(value, "xoxa-", 16, "-"),
+		awsAccessKeyIdentifier(value):
 		return true
 	default:
 		return false
 	}
+}
+
+func providerTokenWithBody(value, prefix string, minBodyLength int, separators string) bool {
+	body, ok := strings.CutPrefix(value, prefix)
+	if !ok || len(body) < minBodyLength {
+		return false
+	}
+	for _, r := range body {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune(separators, r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func awsAccessKeyIdentifier(value string) bool {
+	if len(value) != 20 || (!strings.HasPrefix(value, "AKIA") && !strings.HasPrefix(value, "ASIA")) {
+		return false
+	}
+	for _, r := range value[4:] {
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func resourceTokenPlaceholderValue(value string) bool {

--- a/internal/qualitygate/publiccontent/scan.go
+++ b/internal/qualitygate/publiccontent/scan.go
@@ -47,15 +47,30 @@ func scanText(file, source, text string, detectorFile bool) []Finding {
 			out = append(out, newFinding("public_content_private_key_block", file, privateKeyLine, source, "private key block"))
 			inPrivateKey = false
 		}
-		for _, match := range credentialAssignmentRE.FindAllStringSubmatch(line, -1) {
-			if !isCredentialAssignmentMatch(match[0]) {
+		for _, location := range credentialAssignmentRE.FindAllStringIndex(line, -1) {
+			rawMatch := line[location[0]:location[1]]
+			if !validCredentialAssignmentStart(line, location[0], rawMatch) {
+				continue
+			}
+			match := credentialAssignmentRE.FindStringSubmatch(rawMatch)
+			if !isCredentialAssignmentMatch(rawMatch) {
 				continue
 			}
 			value := credentialAssignmentValue(match)
-			keyName, _ := normalizedCredentialAssignmentKey(match[0])
+			keyName, _ := normalizedCredentialAssignmentKey(rawMatch)
+			evidenceValue := value
+			if sourceCodeFile(file) {
+				if rhs, ok := sourceCodeTypedCredentialRHS(line, location[0], rawMatch); ok {
+					evidenceValue = rhs
+				}
+			}
+			if !(isWebhookCredentialKey(keyName) && webhookAssignmentValueLooksCredentialLike(value)) &&
+				!credentialValueHasStrongEvidence(keyName, evidenceValue) {
+				continue
+			}
 			if value == "" ||
 				isNonSecretLiteralValue(value) ||
-				isBenignCodeCredentialExpression(file, line, match[0], value) ||
+				isBenignCodeCredentialExpression(file, line, location[0], rawMatch, value) ||
 				isPlaceholderValue(value) ||
 				isPermissionScopeIdentifierAssignment(keyName, value) ||
 				isResourceTokenPlaceholderAssignment(keyName, value) {
@@ -64,7 +79,7 @@ func scanText(file, source, text string, detectorFile bool) []Finding {
 			if looksLikeEqualityComparison(value) {
 				continue
 			}
-			out = append(out, newFinding("public_content_generic_credential", file, lineNo, source, redactAssignment(match[0])))
+			out = append(out, newFinding("public_content_generic_credential", file, lineNo, source, redactAssignment(rawMatch)))
 		}
 		for _, match := range jwtLikeRE.FindAllString(line, -1) {
 			if !isJWTToken(match) {
@@ -123,21 +138,43 @@ func scanText(file, source, text string, detectorFile bool) []Finding {
 	return out
 }
 
+func validCredentialAssignmentStart(line string, start int, match string) bool {
+	if start <= 0 || credentialAssignmentOperator(match) != ":" {
+		return true
+	}
+	prefix := strings.TrimSpace(line[:start])
+	for _, arrow := range []string{"-->>", "->>", "-->", "->"} {
+		if strings.HasSuffix(prefix, arrow) {
+			return false
+		}
+	}
+	return true
+}
+
+func credentialAssignmentOperator(match string) string {
+	key, ok := credentialAssignmentKey(match)
+	if !ok {
+		return ""
+	}
+	rest := strings.TrimSpace(match[len(key):])
+	if strings.HasPrefix(rest, ":=") {
+		return ":="
+	}
+	if strings.HasPrefix(rest, ":") {
+		return ":"
+	}
+	if strings.HasPrefix(rest, "=") {
+		return "="
+	}
+	return ""
+}
+
 func isCredentialAssignmentMatch(match string) bool {
-	name, value, ok := normalizedCredentialAssignment(match)
+	name, _, ok := normalizedCredentialAssignment(match)
 	if !ok {
 		return false
 	}
-	if isWebhookCredentialKey(name) && webhookAssignmentValueLooksCredentialLike(value) {
-		return true
-	}
-	if isBenignTokenField(name) && !credentialShapedValue(value) {
-		return false
-	}
-	if isWeakTokenCredentialKey(name) && !weakTokenValueLooksCredentialLike(value) {
-		return false
-	}
-	return isExplicitCredentialKey(name)
+	return isExplicitCredentialKey(name) || isWebhookCredentialKey(name)
 }
 
 func normalizedCredentialAssignmentKey(match string) (string, bool) {
@@ -288,7 +325,7 @@ func tokenLikePlaceholderKey(key string) bool {
 
 func tokenLikePlaceholderValue(key, value string) bool {
 	normalized := strings.ToLower(strings.Trim(value, `"'`))
-	if normalized == "" || credentialShapedIdentifier(normalized) {
+	if normalized == "" || credentialShapedIdentifier(strings.Trim(value, `"'`)) {
 		return false
 	}
 	if authCredentialTokenKey(key) {
@@ -323,52 +360,8 @@ func maskedTokenFixturePlaceholderValue(key, value string) bool {
 	return stars >= 6 && alnum > 0
 }
 
-func isWeakTokenCredentialKey(key string) bool {
-	if authCredentialTokenKey(key) || isStrongTokenCredentialKey(key) {
-		return false
-	}
-	return key == "token" ||
-		strings.HasSuffix(key, "_token") ||
-		strings.HasSuffix(key, "-token")
-}
-
-func isStrongTokenCredentialKey(key string) bool {
-	parts := credentialKeyParts(strings.ReplaceAll(strings.ToLower(key), "-", "_"))
-	for _, phrase := range [][2]string{
-		{"access", "token"},
-		{"refresh", "token"},
-		{"auth", "token"},
-		{"bearer", "token"},
-		{"session", "token"},
-		{"service", "token"},
-		{"bot", "token"},
-		{"api", "token"},
-		{"secret", "token"},
-	} {
-		if hasAdjacentCredentialParts(parts, phrase[0], phrase[1]) {
-			return true
-		}
-	}
-	return false
-}
-
-func weakTokenValueLooksCredentialLike(value string) bool {
-	normalized := strings.ToLower(strings.Trim(value, `"'<>`))
-	if normalized == "" ||
-		isNonSecretLiteralValue(value) ||
-		isPlaceholderValue(value) {
-		return false
-	}
-	candidate := unwrapCredentialValue(normalized)
-	return credentialShapedIdentifier(candidate) ||
-		highEntropyCredentialValue(candidate) ||
-		commandSubstitutionLooksCredentialLike(normalized) ||
-		(strings.Contains(normalized, "://") &&
-			urlRemainderLooksCredentialLike(removeAnglePlaceholders(normalized)))
-}
-
 func unwrapCredentialValue(value string) string {
-	value = strings.TrimSpace(strings.Trim(value, `"'<>`))
+	value = strings.TrimSpace(strings.Trim(value, "\"'<>`"))
 	if strings.HasPrefix(value, "${{") && strings.HasSuffix(value, "}}") {
 		value = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "${{"), "}}"))
 	}
@@ -488,16 +481,19 @@ func numericStringPlaceholderValue(value string) bool {
 	return true
 }
 
-func isBenignCodeCredentialExpression(file, line, match, value string) bool {
+func isBenignCodeCredentialExpression(file, line string, matchStart int, match, value string) bool {
 	normalized := strings.TrimSpace(value)
 	if strings.HasPrefix(normalized, "regexp.MustCompile(") {
 		return true
 	}
-	if !sourceCodeFile(file) || credentialShapedValue(value) {
+	if !sourceCodeFile(file) {
 		return false
 	}
-	if rhs, ok := sourceCodeTypedCredentialRHS(line, match); ok {
+	if rhs, ok := sourceCodeTypedCredentialRHS(line, matchStart, match); ok {
 		return isBenignTypedCredentialRHS(rhs)
+	}
+	if credentialShapedValue(value) {
+		return false
 	}
 	rawValueQuoted := credentialAssignmentRawValueQuoted(match)
 	if sourceCodeLiteralLooksNonSecret(normalized, !rawValueQuoted) {
@@ -518,17 +514,16 @@ func isBenignCodeCredentialExpression(file, line, match, value string) bool {
 	return codeReferenceExpression(normalized)
 }
 
-func sourceCodeTypedCredentialRHS(line, match string) (string, bool) {
-	idx := strings.Index(line, match)
-	if idx < 0 {
+func sourceCodeTypedCredentialRHS(line string, matchStart int, match string) (string, bool) {
+	if matchStart < 0 || matchStart+len(match) > len(line) || line[matchStart:matchStart+len(match)] != match {
 		return "", false
 	}
 	key, ok := credentialAssignmentKey(match)
 	if !ok {
 		return "", false
 	}
-	rest := strings.TrimSpace(line[idx+len(key):])
-	if !strings.HasPrefix(rest, ":") {
+	rest := strings.TrimSpace(line[matchStart+len(key):])
+	if !strings.HasPrefix(rest, ":") || strings.HasPrefix(rest, ":=") {
 		return "", false
 	}
 	typeAndRHS := strings.TrimSpace(strings.TrimPrefix(rest, ":"))
@@ -536,7 +531,12 @@ func sourceCodeTypedCredentialRHS(line, match string) (string, bool) {
 	if assignmentIdx < 0 {
 		return "", false
 	}
-	return strings.TrimSpace(typeAndRHS[assignmentIdx+1:]), true
+	rhs := strings.TrimSpace(typeAndRHS[assignmentIdx+1:])
+	parsed := credentialAssignmentRE.FindStringSubmatch("client_secret=" + rhs)
+	if parsed == nil {
+		return rhs, true
+	}
+	return credentialAssignmentValue(parsed), true
 }
 
 func isBenignTypedCredentialRHS(value string) bool {
@@ -568,7 +568,7 @@ func credentialAssignmentRawValueQuoted(match string) bool {
 
 func sourceCodeFile(file string) bool {
 	switch filepath.Ext(file) {
-	case ".go", ".js", ".jsx", ".py", ".ts", ".tsx":
+	case ".go", ".js", ".jsx", ".py", ".sh", ".ts", ".tsx":
 		return true
 	default:
 		return false
@@ -593,6 +593,7 @@ func sourceCodeLiteralLooksNonSecret(value string, allowNumeric bool) bool {
 		sourceCodeFakeOrPlaceholderLiteral(literal) ||
 		sourceCodeCredentialTermLiteral(literal) ||
 		sourceCodeCredentialPrefixLiteral(literal) ||
+		sourceCodeStringExpressionLiteral(literal) ||
 		sourceCodeVocabularyLiteral(literal) ||
 		sourceCodeSchemaTypeLiteral(literal) ||
 		benignCredentialStatusLiteral(literal)
@@ -685,6 +686,18 @@ func sourceCodeCredentialPrefixLiteral(value string) bool {
 	}
 }
 
+func sourceCodeStringExpressionLiteral(value string) bool {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" ||
+		credentialShapedIdentifier(normalized) ||
+		highEntropyCredentialValue(strings.ToLower(normalized)) {
+		return false
+	}
+	return strings.Contains(normalized, "${") ||
+		strings.Contains(normalized, "$(") ||
+		(strings.Contains(normalized, `\b`) && strings.ContainsAny(normalized, "|[]{}()+*?"))
+}
+
 func sourceCodeVocabularyLiteral(value string) bool {
 	switch strings.ToLower(value) {
 	case "bot", "tenant", "user":
@@ -753,7 +766,7 @@ func codeIdentifier(value string) bool {
 
 func isNonSecretLiteralValue(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(strings.Trim(value, `"'`))) {
-	case "true", "false", "null", "nil", "{", "[":
+	case "true", "false", "null", "nil", "{", "[", `\`:
 		return true
 	default:
 		return false
@@ -980,6 +993,7 @@ func credentialURLPasswordFixture(password string) bool {
 	normalized := strings.ToLower(strings.Trim(password, `"'`))
 	switch normalized {
 	case "p",
+		"p%40ss",
 		"pass",
 		"password",
 		"pat_abc",

--- a/internal/qualitygate/publiccontent/scan_test.go
+++ b/internal/qualitygate/publiccontent/scan_test.go
@@ -251,26 +251,22 @@ func TestScanFileDoesNotTreatURLEncodedCredentialAsPlaceholder(t *testing.T) {
 	}
 }
 
-func TestScanFileDoesNotTreatPlaceholderMarkerSubstringsAsPlaceholders(t *testing.T) {
+func TestScanFileAllowsReadablePlaceholderMarkerSubstrings(t *testing.T) {
 	got := ScanFile("docs/config.md", []byte(strings.Join([]string{
 		"API_KEY=notredactedreal",
 		"API_KEY=notplaceholdersecret",
 		"API_KEY=abcxxxxreal",
 	}, "\n")+"\n"))
-	var count int
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("readable credential words should not be findings: %#v", got)
 		}
-	}
-	if count != 3 {
-		t.Fatalf("placeholder-marker substring findings = %d, want 3: %#v", count, got)
 	}
 }
 
 func TestScanFileDetectsBase64PaddedCredentialAssignments(t *testing.T) {
 	paddedSecretPrefix := "dGhpc2lz" + "YXNlY3JldA"
-	paddedTokenPrefix := "YWJj" + "ZGVmZ2g"
+	paddedTokenPrefix := "UTdrMm1O" + "OXBSNHZYOA"
 	paddedSecret := base64PaddedFixture(paddedSecretPrefix)
 	paddedToken := base64PaddedFixture(paddedTokenPrefix)
 	got := ScanFile("docs/config.md", []byte(strings.Join([]string{
@@ -294,17 +290,25 @@ func TestScanFileDetectsBase64PaddedCredentialAssignments(t *testing.T) {
 	}
 }
 
+func TestScanFileAllowsReadableBase64Lookalike(t *testing.T) {
+	got := ScanFile("docs/config.md", []byte("client_secret=placeholder=\n"))
+	if findingRules(got)["public_content_generic_credential"] {
+		t.Fatalf("readable base64 lookalike should not be a credential finding: %#v", got)
+	}
+}
+
 func TestScanFileDetectsQuotedJSONCredentialAssignments(t *testing.T) {
-	jsonToken := "real-json-token"
-	jsonSecret := "real " + "secret value"
-	jsonKey := "real-json-key"
-	jsonTenantToken := "real-tenant-json-token"
-	jsonAppSecret := "real-app-secret"
-	jsonPrefixedKey := "real-prefixed-key"
-	jsonTenantCamelToken := "real-tenant-camel-token"
-	jsonGithubToken := "real-github-token"
-	jsonVendorKey := "real-vendor-key"
-	jsonSlackBotToken := "xoxb-real-token"
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	jsonToken := providerValue
+	jsonSecret := providerValue
+	jsonKey := providerValue
+	jsonTenantToken := providerValue
+	jsonAppSecret := providerValue
+	jsonPrefixedKey := providerValue
+	jsonTenantCamelToken := providerValue
+	jsonGithubToken := providerValue
+	jsonVendorKey := providerValue
+	jsonSlackBotToken := "xoxb_" + "1234567890abcdef"
 	got := ScanFile("docs/public.json", []byte(strings.Join([]string{
 		`{"access_` + `token":"` + jsonToken + `"}`,
 		`{"client_` + `secret": "` + jsonSecret + `"}`,
@@ -334,12 +338,13 @@ func TestScanFileDetectsQuotedJSONCredentialAssignments(t *testing.T) {
 }
 
 func TestScanFileDetectsCredentialPhraseBeforeEnvironmentSuffix(t *testing.T) {
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
 	got := ScanFile("docs/config.yaml", []byte(strings.Join([]string{
-		"API_KEY_OPENAI: real-openai-key",
-		"TOKEN_GITHUB: real-github-token",
-		"CLIENT_SECRET_GOOGLE: real-google-secret",
-		"SECRET_KEY_BASE: real-secret-key-base",
-		"APP_PASSWORD_PROD: real-prod-password",
+		"API_KEY_OPENAI: " + providerValue,
+		"TOKEN_GITHUB: " + providerValue,
+		"CLIENT_SECRET_GOOGLE: " + providerValue,
+		"SECRET_KEY_BASE: " + providerValue,
+		"APP_PASSWORD_PROD: " + providerValue,
 	}, "\n")+"\n"))
 	var count int
 	for _, item := range got {
@@ -347,13 +352,7 @@ func TestScanFileDetectsCredentialPhraseBeforeEnvironmentSuffix(t *testing.T) {
 			continue
 		}
 		count++
-		for _, forbidden := range []string{
-			"real-openai-key",
-			"real-github-token",
-			"real-google-secret",
-			"real-secret-key-base",
-			"real-prod-password",
-		} {
+		for _, forbidden := range []string{providerValue} {
 			if strings.Contains(item.Excerpt, forbidden) {
 				t.Fatalf("credential finding leaked value %q in excerpt %q", forbidden, item.Excerpt)
 			}
@@ -364,85 +363,77 @@ func TestScanFileDetectsCredentialPhraseBeforeEnvironmentSuffix(t *testing.T) {
 	}
 }
 
-func TestScanFileDetectsCredentialValuesThatLookLikeBareIdentifiers(t *testing.T) {
+func TestScanFileAllowsCredentialValuesThatLookLikeBareIdentifiers(t *testing.T) {
 	got := ScanFile("docs/config.yaml", []byte(strings.Join([]string{
 		"API_KEY_OPENAI: prod_key",
 		"CLIENT_SECRET_GOOGLE: prod_secret",
 		"TOKEN_GITHUB: github_token",
 		"APP_PASSWORD_PROD: prod_password",
 	}, "\n")+"\n"))
-	var count int
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("readable identifiers should not be credential findings: %#v", got)
 		}
-	}
-	if count != 4 {
-		t.Fatalf("bare identifier credential findings = %d, want 4: %#v", count, got)
 	}
 }
 
 func TestScanFileDetectsAngleWrappedRealisticCredentialValues(t *testing.T) {
 	stripeLike := "sk_" + "live_1234567890abcdef"
 	patLike := "gh" + "p_1234567890abcdef1234567890abcdef1234"
-	got := ScanFile("docs/config.yaml", []byte(strings.Join([]string{
-		"API_KEY: <" + stripeLike + ">",
-		"SECRET_TOKEN: <" + patLike + ">",
-		"CLIENT_SECRET: <real-client-secret-value>",
-	}, "\n")+"\n"))
-	var count int
-	for _, item := range got {
-		if item.Rule == "public_content_generic_credential" {
-			count++
-		}
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "stripe", text: "API_KEY: <" + stripeLike + ">", want: true},
+		{name: "github", text: "SECRET_TOKEN: <" + patLike + ">", want: true},
+		{name: "readable", text: "CLIENT_SECRET: <real-client-secret-value>", want: false},
 	}
-	if count != 3 {
-		t.Fatalf("angle-wrapped realistic credential findings = %d, want 3: %#v", count, got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertGenericCredentialFinding(t, "docs/config.yaml", tc.text, tc.want)
+		})
 	}
 }
 
 func TestScanFileDetectsCredentialShapedValuesUnderBenignKeys(t *testing.T) {
 	stripeLike := "sk_" + "live_1234567890abcdef"
 	patLike := "gh" + "p_1234567890abcdef1234567890abcdef1234"
-	got := ScanFile("docs/public.json", []byte(strings.Join([]string{
-		`{"access_token_expires_in":"` + patLike + `"}`,
-		`{"refresh_token_expires_in":"` + stripeLike + `"}`,
-		`{"client_secret_status":"real-client-secret-value"}`,
-		`{"client_secret_name":"real-client-secret-value"}`,
-		`{"app_token":"` + patLike + `"}`,
-		`{"sync_token":"` + stripeLike + `"}`,
-		`{"target_token":"real-client-secret-value"}`,
-	}, "\n")+"\n"))
-	var count int
-	for _, item := range got {
-		if item.Rule == "public_content_generic_credential" {
-			count++
-		}
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "expiry provider token", text: `{"access_token_expires_in":"` + patLike + `"}`, want: true},
+		{name: "expiry provider secret", text: `{"refresh_token_expires_in":"` + stripeLike + `"}`, want: true},
+		{name: "status readable", text: `{"client_secret_status":"real-client-secret-value"}`, want: false},
+		{name: "name readable", text: `{"client_secret_name":"real-client-secret-value"}`, want: false},
+		{name: "app provider token", text: `{"app_token":"` + patLike + `"}`, want: true},
+		{name: "sync provider secret", text: `{"sync_token":"` + stripeLike + `"}`, want: true},
+		{name: "target readable", text: `{"target_token":"real-client-secret-value"}`, want: false},
 	}
-	if count != 7 {
-		t.Fatalf("credential-shaped benign-key findings = %d, want 7: %#v", count, got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertGenericCredentialFinding(t, "docs/public.json", tc.text, tc.want)
+		})
 	}
 }
 
-func TestScanFileDetectsBareIdentifierCredentialsWithMetadataSuffixes(t *testing.T) {
+func TestScanFileAllowsBareIdentifierCredentialsWithMetadataSuffixes(t *testing.T) {
 	got := ScanFile("docs/config.yaml", []byte(strings.Join([]string{
 		"API_KEY_NAME: prod_key",
 		"CLIENT_SECRET_NAME: prod_secret",
 		"SECRET_STATUS: prod_secret",
 	}, "\n")+"\n"))
-	var count int
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("readable metadata values should not be credential findings: %#v", got)
 		}
-	}
-	if count != 3 {
-		t.Fatalf("metadata-suffixed bare credential findings = %d, want 3: %#v", count, got)
 	}
 }
 
 func TestScanFileDetectsAccessKeyCredentials(t *testing.T) {
-	accessKey := "AK" + "IAIOSFODNN7EXAMPX"
+	accessKey := "AK" + "IAIOSFODNN7EXAMPXX"
 	got := ScanFile("docs/config.yaml", []byte(strings.Join([]string{
 		"AWS_ACCESS_KEY_ID: " + accessKey,
 		"ACCESS_KEY_ID: " + accessKey,
@@ -593,18 +584,18 @@ func TestScanFileAllowsCredentialReferenceValues(t *testing.T) {
 
 func TestScanFileDetectsMalformedGithubExpressionCredentialValues(t *testing.T) {
 	stripeLike := "sk_" + "live_1234567890abcdef"
-	got := ScanFile("docs/config.yaml", []byte(strings.Join([]string{
-		"API_KEY=${{" + stripeLike + "}}",
-		"TOKEN=${{real-secret-token-value}}",
-	}, "\n")+"\n"))
-	var count int
-	for _, item := range got {
-		if item.Rule == "public_content_generic_credential" {
-			count++
-		}
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "provider", text: "API_KEY=${{" + stripeLike + "}}", want: true},
+		{name: "readable", text: "TOKEN=${{real-secret-token-value}}", want: false},
 	}
-	if count != 2 {
-		t.Fatalf("malformed GitHub expression credential findings = %d, want 2: %#v", count, got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertGenericCredentialFinding(t, "docs/config.yaml", tc.text, tc.want)
+		})
 	}
 }
 
@@ -648,6 +639,7 @@ func TestScanFileAllowsCredentialURLPlaceholders(t *testing.T) {
 func TestScanFileAllowsCredentialURLFixtures(t *testing.T) {
 	got := ScanFile("fixtures/network_test.go", []byte(strings.Join([]string{
 		`proxy := "http://user:pass@proxy:8080"`,
+		`proxy := "http://user:p%40ss@proxy:8080/path"`,
 		`repo := "https://u:t@h/r.git"`,
 		`target := "https://attacker:pw@open.feishu.cn"`,
 		`proxy := "http://admin:s3cret@127.0.0.1:3128"`,
@@ -821,26 +813,36 @@ func TestScanFileDetectsWeakTokenFieldsWithHighConfidenceCredentialValues(t *tes
 	}
 }
 
-func TestScanFileDetectsStrongAuthTokenKeysWithFixtureLikeValues(t *testing.T) {
+func TestScanFileAllowsStrongAuthTokenKeysWithoutStrongValueEvidence(t *testing.T) {
 	got := ScanFile("docs/config.md", []byte(strings.Join([]string{
 		`{"access_token":"img_abc123"}`,
 		`{"api_token":"img_live_secret"}`,
 		`{"service_token":"ab********cd"}`,
 		`{"bot_token":"board_v3_example"}`,
 	}, "\n")+"\n"))
-	var count int
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("token field names alone should not produce findings: %#v", got)
 		}
-	}
-	if count != 4 {
-		t.Fatalf("strong auth token key findings = %d, want 4: %#v", count, got)
 	}
 }
 
 func TestScanFileAllowsTestFixtureSecretValues(t *testing.T) {
-	got := ScanFile("fixtures/calendar_meeting_test.go", []byte(`AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,`+"\n"))
+	got := ScanFile("fixtures/calendar_meeting_test.go", []byte(strings.Join([]string{
+		`AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,`,
+		`cfg := &core.CliConfig{AppID: "a", AppSecret: "s"}`,
+		`os.WriteFile(path, []byte("FEISHU_APP_ID=cli_abc\nFEISHU_APP_SECRET=secret\n"), 0600)`,
+		`rt := &stubRoundTripper{respBody: ` + "`" + `{"access_token":"t","token_type":"Bearer"}` + "`" + `}`,
+		`envContent := "FEISHU_APP_ID=cli_hermes_abc\nFEISHU_APP_SECRET=hermes_secret_123\nFEISHU_DOMAIN=lark\n"`,
+		`os.WriteFile(path, []byte("FEISHU_APP_ID=cli_auto\nFEISHU_APP_SECRET=auto_secret\n"), 0600)`,
+		`os.WriteFile(path, []byte("FEISHU_APP_ID=cli_new_app\nFEISHU_APP_SECRET=new_secret\n"), 0600)`,
+		`if got := out.String(); got != "username=x-access-token\npassword=valid-pat\n\n" {`,
+		`if got := out.String(); got != "username=x-access-token\npassword=restored-pat\n\n" {`,
+		`if got := stdout.String(); got != "username=x-access-token\npassword=pat-token\n\n" {`,
+		`return &core.CliConfig{AppID: "dummy", AppSecret: "dummy"}`,
+		`os.WriteFile(path, []byte("API_KEY=replace-me\n"), 0600)`,
+		`body := "APP_ID=\"cli_xxxxx\"\nAPP_SECRET=\"xxxxx\"\n"`,
+	}, "\n")+"\n"))
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
 			t.Fatalf("test fixture secret should not be credential finding: %#v", got)
@@ -848,8 +850,114 @@ func TestScanFileAllowsTestFixtureSecretValues(t *testing.T) {
 	}
 }
 
+func TestScanFileAllowsCredentialIdentifierFields(t *testing.T) {
+	got := ScanFile("fixtures/openapi_key_test.go", []byte(strings.Join([]string{
+		`"api_key_id": "k1",`,
+		`"secret_id": "s1",`,
+		`"token_id": "t1",`,
+		`"private_key_id": "pk1",`,
+	}, "\n")+"\n"))
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			t.Fatalf("credential identifier fields should not be credential findings: %#v", got)
+		}
+	}
+}
+
+func TestScanFileDetectsCredentialShapedIdentifierFieldValues(t *testing.T) {
+	stripeLike := "sk_" + "live_1234567890abcdef"
+	githubToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	got := ScanFile("fixtures/openapi_key_test.go", []byte(strings.Join([]string{
+		`"api_key_id": "` + stripeLike + `",`,
+		`"token_id": "` + githubToken + `",`,
+	}, "\n")+"\n"))
+	var count int
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("credential-shaped identifier field findings = %d, want 2: %#v", count, got)
+	}
+}
+
+func TestCredentialShapedValueTrimsWhitespaceBeforeDelimiters(t *testing.T) {
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	if !credentialShapedValue(` "` + providerValue + `" `) {
+		t.Fatal("space-padded quoted provider credential should be recognized")
+	}
+}
+
+func TestScanFileDetectsProviderCredentialsAcrossAssignmentSyntaxes(t *testing.T) {
+	providerValue := strings.Join([]string{"gh", "p_", "1234567890abcdef", "1234567890abcdef", "1234"}, "")
+	tests := []struct {
+		name string
+		path string
+		text string
+	}{
+		{name: "Go raw string", path: "pkg/config.go", text: "const clientSecret = `" + providerValue + "`"},
+		{name: "TypeScript template literal", path: "pkg/config.ts", text: "const clientSecret = `" + providerValue + "`;"},
+		{name: "shell backtick", path: "scripts/config.sh", text: "client_secret=`" + providerValue + "`"},
+		{name: "YAML string tag", path: "docs/config.yaml", text: "client_secret: !!str " + providerValue},
+		{name: "YAML string tag double quoted", path: "docs/config.yaml", text: `client_secret: !!str "` + providerValue + `"`},
+		{name: "YAML string tag single quoted", path: "docs/config.yaml", text: `client_secret: !!str '` + providerValue + `'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScanFile(tt.path, []byte(tt.text+"\n"))
+			if !findingRules(got)["public_content_generic_credential"] {
+				t.Fatalf("provider credential should be reported: %#v", got)
+			}
+		})
+	}
+}
+
+func TestScanFileDetectsPercentEncodedProviderCredential(t *testing.T) {
+	providerBody := strings.Join([]string{"1234567890abcdef", "1234567890abcdef", "1234"}, "")
+	tests := []string{
+		"access_token: ghp%" + "5F" + providerBody,
+		"access_token_hash: ghp%" + "255F" + providerBody,
+	}
+	for _, text := range tests {
+		got := ScanFile("docs/config.yaml", []byte(text+"\n"))
+		if !findingRules(got)["public_content_generic_credential"] {
+			t.Fatalf("percent-encoded provider credential should be reported: %#v", got)
+		}
+	}
+}
+
+func TestScanFileRequiresCompleteProviderCredentialFormats(t *testing.T) {
+	got := ScanFile("docs/config.yaml", []byte(strings.Join([]string{
+		"token_type: asian",
+		"token_prefix: ASIA",
+		"token_prefix: ghp_",
+		"api_key: sk_live_example",
+		"token_prefix: asianmarketsegment01",
+		"token_prefix: ghp_placeholder_value",
+	}, "\n")+"\n"))
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			t.Fatalf("incomplete provider prefixes should not be credential findings: %#v", got)
+		}
+	}
+}
+
+func TestScanFileAllowsEncodedTokenMetadataURL(t *testing.T) {
+	got := ScanFile("docs/config.yaml", []byte("token_url: https%3A%2F%2Fexample.invalid/oauth/token\n"))
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			t.Fatalf("encoded token metadata URL should not be credential finding: %#v", got)
+		}
+	}
+}
+
 func TestScanFileAllowsRegexpTokenValidators(t *testing.T) {
-	got := ScanFile("fixtures/minutes_detail.go", []byte("var validMinuteTokenDetail = regexp.MustCompile(`^[a-z0-9]+$`)\n"))
+	got := ScanFile("fixtures/minutes_detail.go", []byte(strings.Join([]string{
+		"var validMinuteTokenDetail = regexp.MustCompile(`^[a-z0-9]+$`)",
+		"REALISTIC_TOKEN_RE=\"\\\"${TOKEN_BODY}\\\"|\\`${TOKEN_BODY}\\`|\\\\b${TOKEN_BODY}\\\\b\"",
+	}, "\n")+"\n"))
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
 			t.Fatalf("regexp token validator should not be credential finding: %#v", got)
@@ -927,6 +1035,22 @@ func TestScanFileAllowsSourceCodeCredentialNonSecretLiterals(t *testing.T) {
 	}
 }
 
+func TestScanFileAllowsSourceCodeSyntheticCredentialIdentifiers(t *testing.T) {
+	got := ScanFile("fixtures/sheets_media.go", []byte(strings.Join([]string{
+		`const fakeOfficeTokenPrefix = "fake_office_"`,
+		`const localOfficeTokenPrefix = "local_office_"`,
+		`const imageLiveSecretMarker = "img_live_secret"`,
+		`const imageProdKeyMarker = "img_prod_key"`,
+		`if strings.HasPrefix(spreadsheetToken, fakeOfficeTokenPrefix) {`,
+		`if strings.HasPrefix(spreadsheetToken, localOfficeTokenPrefix) {`,
+	}, "\n")+"\n"))
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			t.Fatalf("source code token prefix references should not be credential findings: %#v", got)
+		}
+	}
+}
+
 func TestScanFileAllowsCredentialLikePublicPlaceholders(t *testing.T) {
 	got := ScanFile("fixtures/placeholders.md", []byte(strings.Join([]string{
 		`app_secret=***`,
@@ -941,21 +1065,17 @@ func TestScanFileAllowsCredentialLikePublicPlaceholders(t *testing.T) {
 	}
 }
 
-func TestScanFileDetectsPartiallyMaskedCredentialValues(t *testing.T) {
+func TestScanFileAllowsPartiallyMaskedCredentialValues(t *testing.T) {
 	got := ScanFile("fixtures/config.md", []byte(strings.Join([]string{
 		"client_secret=realprefix***realsuffix",
 		"client_secret=ab********cd",
 		"access_token=ab********cd",
 		"refresh_token=realprefix********realsuffix",
 	}, "\n")+"\n"))
-	var count int
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("partially masked values should not be credential findings: %#v", got)
 		}
-	}
-	if count != 4 {
-		t.Fatalf("partially masked credential findings = %d, want 4: %#v", count, got)
 	}
 }
 
@@ -972,6 +1092,7 @@ func TestScanFileAllowsDryRunCredentialPlaceholders(t *testing.T) {
 }
 
 func TestScanFileDetectsTypedCredentialAssignmentsWithSecretRHS(t *testing.T) {
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
 	cases := []struct {
 		name string
 		file string
@@ -980,32 +1101,47 @@ func TestScanFileDetectsTypedCredentialAssignmentsWithSecretRHS(t *testing.T) {
 		{
 			name: "typescript simple secret",
 			file: "fixtures/source_secret.ts",
-			text: `const clientSecret: string = "real-client-secret-value"`,
+			text: `const clientSecret: string = "` + providerValue + `"`,
 		},
 		{
-			name: "typescript numeric password",
+			name: "typescript terminated secret",
 			file: "fixtures/source_secret.ts",
-			text: `const password: string = "12345678901234567890"`,
+			text: `const clientSecret: string = "` + providerValue + `";`,
+		},
+		{
+			name: "typescript secret with trailing comment",
+			file: "fixtures/source_secret.ts",
+			text: `const clientSecret: string = "` + providerValue + `"; // production`,
+		},
+		{
+			name: "typescript asserted secret",
+			file: "fixtures/source_secret.ts",
+			text: `const clientSecret: string = "` + providerValue + `" as const;`,
+		},
+		{
+			name: "typescript provider password",
+			file: "fixtures/source_secret.ts",
+			text: `const password: string = "` + providerValue + `"`,
 		},
 		{
 			name: "typescript union secret",
 			file: "fixtures/source_secret.ts",
-			text: `const clientSecret: string | undefined = "real-client-secret-value"`,
+			text: `const clientSecret: string | undefined = "` + providerValue + `"`,
 		},
 		{
 			name: "python simple secret",
 			file: "fixtures/source_secret.py",
-			text: `self.client_secret: str = "real-client-secret-value"`,
+			text: `self.client_secret: str = "` + providerValue + `"`,
 		},
 		{
 			name: "python union secret",
 			file: "fixtures/source_secret.py",
-			text: `self.client_secret: str | None = "real-client-secret-value"`,
+			text: `self.client_secret: str | None = "` + providerValue + `"`,
 		},
 		{
 			name: "python optional secret",
 			file: "fixtures/source_secret.py",
-			text: `self.client_secret: Optional[str] = "real-client-secret-value"`,
+			text: `self.client_secret: Optional[str] = "` + providerValue + `"`,
 		},
 	}
 	for _, tc := range cases {
@@ -1018,24 +1154,154 @@ func TestScanFileDetectsTypedCredentialAssignmentsWithSecretRHS(t *testing.T) {
 	}
 }
 
-func TestScanFileDetectsCredentialShapedSourceCodeLiterals(t *testing.T) {
-	githubToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
-	got := ScanFile("fixtures/source_secret.go", []byte(strings.Join([]string{
-		`const ClientSecret = "real-client-secret-value"`,
-		`const GithubToken = "` + githubToken + `"`,
-		`const Password = "12345678901234567890"`,
-		`const ClientSecretNumber = "12345678901234567890"`,
-		`const ClientSecretFormat = "abc%sdefreal"`,
-		`fmt.Println("done"); const ClientSecret = "abc%sdefreal"`,
-	}, "\n")+"\n"))
+func TestScanFileDetectsRepeatedTypedCredentialAssignments(t *testing.T) {
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	assertGenericCredentialFinding(t, "fixtures/source_secret.ts", `const clientSecret: string = "placeholder";`, false)
+	assertGenericCredentialFinding(t, "fixtures/source_secret.ts", `const clientSecret: string = "`+providerValue+`";`, true)
+
+	got := ScanFile("fixtures/source_secret.ts", []byte(
+		`const clientSecret: string = "placeholder"; const clientSecret: string = "`+providerValue+`";`+"\n",
+	))
 	var count int
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
 			count++
 		}
 	}
-	if count != 6 {
-		t.Fatalf("source code credential-shaped literal findings = %d, want 6: %#v", count, got)
+	if count != 1 {
+		t.Fatalf("repeated typed credential findings = %d, want 1: %#v", count, got)
+	}
+}
+
+func TestScanFileDetectsCredentialShapedSourceCodeLiterals(t *testing.T) {
+	stripeLike := "sk_" + "live_1234567890abcdef"
+	githubToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "stripe", text: `const ClientSecret = "` + stripeLike + `"`, want: true},
+		{name: "github", text: `const GithubToken = "` + githubToken + `"`, want: true},
+		{name: "password number", text: `const Password = "12345678901234567890"`, want: false},
+		{name: "secret number", text: `const ClientSecretNumber = "12345678901234567890"`, want: false},
+		{name: "format literal", text: `const ClientSecretFormat = "abc%sdefreal"`, want: false},
+		{name: "inline format literal", text: `fmt.Println("done"); const ClientSecret = "abc%sdefreal"`, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertGenericCredentialFinding(t, "fixtures/source_secret.go", tc.text, tc.want)
+		})
+	}
+}
+
+func TestScanFileDetectsGoShortDeclarationCredentials(t *testing.T) {
+	providerSecret := "sk_" + "live_1234567890abcdef"
+	providerToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	got := ScanFile("fixtures/source_secret.go", []byte(strings.Join([]string{
+		`clientSecret := "` + providerSecret + `"`,
+		`accessToken := "` + providerToken + `"`,
+	}, "\n")+"\n"))
+
+	var count int
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("Go short declaration credential findings = %d, want 2: %#v", count, got)
+	}
+}
+
+func TestGenericCredentialDecisionMatrix(t *testing.T) {
+	providerToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	highEntropyValue := "Q7k2mN9pR4vX8cL3" + "sT6yU1aD5fG0hJ2z"
+	tokenHash := "6f1ed002ab559585" + "9014ebf0951522d9" +
+		"a0e3c1f4206254d" + "28a13efbbc8d56a30"
+	tests := []struct {
+		name    string
+		path    string
+		text    string
+		comment bool
+		want    bool
+	}{
+		{name: "source synthetic token prefix", path: "pkg/sheets.go", text: `const localOfficeTokenPrefix = "local_office_"`, want: false},
+		{name: "source token kind state", path: "pkg/client.py", text: `self._token_kind: TokenKind | None = None`, want: false},
+		{name: "documentation token prefix", path: "docs/config.yaml", text: `token_prefix: local_office_`, want: false},
+		{name: "documentation token kind", path: "docs/config.yaml", text: `token_kind: bearer`, want: false},
+		{name: "documentation token hash", path: "docs/config.yaml", text: `access_token_hash: ` + tokenHash, want: false},
+		{name: "comment fixture placeholder", text: `AppSecret: "fake-secret"`, comment: true, want: false},
+		{name: "test fixture placeholder", path: "pkg/config_test.go", text: `AppSecret: "fake-secret"`, want: false},
+		{name: "test real-labeled token", path: "pkg/config_test.go", text: `token: "real-tenant-access-token"`, want: false},
+		{name: "test ambiguous concrete secret word", path: "pkg/config_test.go", text: `AppSecret: "supersecret"`, want: false},
+		{name: "resource token placeholder", path: "docs/images.md", text: `"token": "img_abc123"`, want: false},
+		{name: "partially masked token", path: "docs/auth.md", text: `token=ab********cd`, want: false},
+		{name: "source readable secret words", path: "pkg/config.go", text: `const AppSecret = "customer-prod-secret"`, want: false},
+		{name: "documentation readable secret words", path: "docs/config.yaml", text: `client_secret: customer-prod-secret`, want: false},
+		{name: "comment middle fixture marker", text: `API_KEY=prod-fake-key`, comment: true, want: false},
+		{name: "comment negated fixture marker", text: `AppSecret: "not-fake-secret"`, comment: true, want: false},
+		{name: "source with credential words", path: "pkg/config.go", text: `secretWithPassword := "hunter2"`, want: false},
+		{name: "production filename containing sample", path: "pkg/sampler.go", text: `clientSecret := "customer-prod-secret"`, want: false},
+		{name: "provider token under weak key", path: "docs/config.yaml", text: `token: ` + providerToken, want: true},
+		{name: "provider token under hash key", path: "docs/config.yaml", text: `access_token_hash: ` + providerToken, want: true},
+		{name: "high entropy strong secret", path: "docs/config.yaml", text: `client_secret: ` + highEntropyValue, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []Finding
+			if tt.comment {
+				got = ScanComment("issue_comment", tt.text)
+			} else {
+				got = ScanFile(tt.path, []byte(tt.text+"\n"))
+			}
+			if actual := findingRules(got)["public_content_generic_credential"]; actual != tt.want {
+				t.Fatalf("generic credential finding = %v, want %v: %#v", actual, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestScanFileClassifiesLowEvidenceTestFixtureCredentials(t *testing.T) {
+	providerToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	highEntropyValue := "Q7k2mN9pR4vX8cL3" + "sT6yU1aD5fG0hJ2z"
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "human readable access token", value: "user-access-token", want: false},
+		{name: "delimited secret value", value: "secret-value", want: false},
+		{name: "underscored secret fixture", value: "plain_secret", want: false},
+		{name: "short delimited fixture", value: "t-abc", want: false},
+		{name: "embedded test marker", value: "perm-grant-test-secret-skip", want: false},
+		{name: "real labeled fixture", value: "real-token", want: false},
+		{name: "ambiguous concrete word", value: "supersecret", want: false},
+		{name: "provider token", value: providerToken, want: true},
+		{name: "high entropy secret", value: highEntropyValue, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScanFile("pkg/config_test.go", []byte(`AppSecret: "`+tt.value+`"`+"\n"))
+			if actual := findingRules(got)["public_content_generic_credential"]; actual != tt.want {
+				t.Fatalf("generic credential finding = %v, want %v: %#v", actual, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestScanFileAllowsLowEvidenceTestFixtureAssignmentSyntaxes(t *testing.T) {
+	got := ScanFile("pkg/config_test.go", []byte(strings.Join([]string{
+		`secret := "secret-value"`,
+		`samplePassword := "sample-password"`,
+		`bodyWithToken := "plain text body\\nDownload: https://example.com/file?token=tok_aaa\\n"`,
+	}, "\n")+"\n"))
+	for _, item := range got {
+		if item.Rule == "public_content_generic_credential" {
+			t.Fatalf("low-evidence test fixture assignment should not be reported: %#v", got)
+		}
 	}
 }
 
@@ -1116,9 +1382,10 @@ func TestScanFileAllowsClientTokenIdempotencyExamples(t *testing.T) {
 
 func TestScanFileDetectsCredentialShapedClientTokenValues(t *testing.T) {
 	stripeLike := "sk_" + "live_1234567890abcdef"
+	githubToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
 	got := ScanFile("fixtures/idempotency.md", []byte(strings.Join([]string{
 		`{"client_token":"` + stripeLike + `"}`,
-		`{"client_token":"real-client-secret-value"}`,
+		`{"client_token":"` + githubToken + `"}`,
 	}, "\n")+"\n"))
 	var count int
 	for _, item := range got {
@@ -1152,9 +1419,10 @@ func TestScanFileAllowsTokenLikePlaceholderExamples(t *testing.T) {
 
 func TestScanFileDetectsCredentialShapedTokenLikePlaceholderValues(t *testing.T) {
 	stripeLike := "sk_" + "live_1234567890abcdef"
+	githubToken := "ghp_" + "1234567890abcdef1234567890abcdef1234"
 	got := ScanFile("fixtures/placeholders.md", []byte(strings.Join([]string{
 		`{ "resource_token": "` + stripeLike + `" }`,
-		`{ "block_token": "real-client-secret-value" }`,
+		`{ "block_token": "` + githubToken + `" }`,
 	}, "\n")+"\n"))
 	var count int
 	for _, item := range got {
@@ -1368,39 +1636,43 @@ func TestScanFileAllowsConventionalCredentialPlaceholders(t *testing.T) {
 	}
 }
 
-func TestScanFileDetectsCredentialShapedPlaceholderLookalikes(t *testing.T) {
+func TestScanFileAllowsInvalidProviderPlaceholderLookalikes(t *testing.T) {
 	stripeLike := "sk_" + "live_1234567890abcdef"
 	got := ScanFile("docs/config.md", []byte(strings.Join([]string{
 		"client_secret: " + stripeLike + "_HERE",
 		"api_key: YOUR_" + stripeLike,
 	}, "\n")+"\n"))
-	var count int
 	for _, item := range got {
 		if item.Rule == "public_content_generic_credential" {
-			count++
+			t.Fatalf("invalid provider placeholder lookalike should not be blocked: %#v", got)
 		}
-	}
-	if count != 2 {
-		t.Fatalf("credential-shaped placeholder lookalike findings = %d, want 2: %#v", count, got)
 	}
 }
 
 func TestScanFileDetectsPercentWrappedCredentialValues(t *testing.T) {
 	stripeLike := "sk_" + "live_1234567890abcdef"
 	patLike := "gh" + "p_1234567890abcdef1234567890abcdef1234"
-	got := ScanFile("docs/config.md", []byte(strings.Join([]string{
-		"CLIENT_SECRET=%" + stripeLike + "%",
-		"GITHUB_TOKEN=%" + patLike + "%",
-		"TOKEN=%real-secret-token-value%",
-	}, "\n")+"\n"))
-	var count int
-	for _, item := range got {
-		if item.Rule == "public_content_generic_credential" {
-			count++
-		}
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "stripe", text: "CLIENT_SECRET=%" + stripeLike + "%", want: true},
+		{name: "github", text: "GITHUB_TOKEN=%" + patLike + "%", want: true},
+		{name: "readable", text: "TOKEN=%real-secret-token-value%", want: false},
 	}
-	if count != 3 {
-		t.Fatalf("percent-wrapped credential findings = %d, want 3: %#v", count, got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertGenericCredentialFinding(t, "docs/config.md", tc.text, tc.want)
+		})
+	}
+}
+
+func assertGenericCredentialFinding(t *testing.T, file, text string, want bool) {
+	t.Helper()
+	got := ScanFile(file, []byte(text+"\n"))
+	if actual := findingRules(got)["public_content_generic_credential"]; actual != want {
+		t.Fatalf("generic credential finding = %v, want %v: %#v", actual, want, got)
 	}
 }
 

--- a/internal/qualitygate/rules/run_test.go
+++ b/internal/qualitygate/rules/run_test.go
@@ -203,7 +203,8 @@ func TestRunCollectsPublicContentFindingsIntoDiagnosticsAndFacts(t *testing.T) {
 	if err := vfs.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	publicDoc := "api_" + "key = \"example-public-key\"\n" +
+	providerValue := "ghp_" + "1234567890abcdef1234567890abcdef1234"
+	publicDoc := "api_" + "key = \"" + providerValue + "\"\n" +
 		"Public docs describe a pri" + "vate request header and trust classification detail.\n"
 	if err := vfs.WriteFile(filepath.Join(repo, "docs", "public.md"), []byte(publicDoc), 0o644); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Reduce false positives in public-content credential detection while preserving detection of real credentials.

## Changes

- Require value evidence instead of blocking on credential-like field names alone.
- Recognize provider tokens, encoded credentials, high-entropy values, and typed assignments.
- Allow metadata fields, placeholders, synthetic prefixes, masked values, and security terminology.
- Preserve review-comment file paths for context-aware scanning.
- Add regression tests for reported false positives and real credential cases.

## Test Plan

- [x] Qualitygate tests and race tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential auditing for public comments by considering both the comment text and its contextual path, so findings are attributed to the correct location.
  * Reduced false positives by tightening credential-shape, evidence, and parsing logic across additional assignment syntaxes and encoded/provider formats.
  * Enhanced detection accuracy for credential-like content embedded in structured inputs (for example, diagrams).
* **Tests**
  * Expanded and strengthened scanning/auditing coverage with dynamic fixture values and broader allow/deny edge cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->