### PR TITLE
test: fix drive cover download retries

### DIFF
--- a/tests/cli_e2e/drive/drive_preview_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_preview_workflow_test.go
@@ -125,15 +125,7 @@ func TestDrive_PreviewAndCoverWorkflow(t *testing.T) {
 			InitialDelay:    2 * time.Second,
 			MaxDelay:        8 * time.Second,
 			BackoffMultiple: 2,
-			ShouldRetry: func(result *clie2e.Result) bool {
-				if result == nil {
-					return true
-				}
-				if result.ExitCode == 0 {
-					return false
-				}
-				return false
-			},
+			ShouldRetry:     shouldRetryCoverDownload,
 		})
 		require.NoError(t, err)
 		coverResult.AssertExitCode(t, 0)
@@ -154,6 +146,80 @@ func TestDrive_PreviewAndCoverWorkflow(t *testing.T) {
 			t.Fatalf("cover artifact should not be empty: %s", outputPath)
 		}
 	})
+}
+
+func shouldRetryCoverDownload(result *clie2e.Result) bool {
+	return result == nil || result.ExitCode != 0
+}
+
+func TestShouldRetryCoverDownload(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		result *clie2e.Result
+		want   bool
+	}{
+		{name: "nil result", result: nil, want: true},
+		{name: "successful result", result: &clie2e.Result{ExitCode: 0}, want: false},
+		{name: "failed result", result: &clie2e.Result{ExitCode: 1}, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldRetryCoverDownload(tt.result))
+		})
+	}
+
+	fakeCLI := writeCoverDownloadRetryFakeCLI(t)
+	for _, tt := range []struct {
+		name         string
+		succeedAfter string
+		wantCount    string
+		wantExitCode int
+	}{
+		{name: "retries after failure", succeedAfter: "2", wantCount: "2\n", wantExitCode: 0},
+		{name: "stops after success", succeedAfter: "1", wantCount: "1\n", wantExitCode: 0},
+		{name: "stops after eight failures", succeedAfter: "9", wantCount: "8\n", wantExitCode: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			statePath := filepath.Join(t.TempDir(), "attempt-count")
+			result, err := clie2e.RunCmdWithRetry(context.Background(), clie2e.Request{
+				BinaryPath: fakeCLI,
+				Args:       []string{statePath, tt.succeedAfter},
+			}, clie2e.RetryOptions{
+				Attempts:        8,
+				InitialDelay:    time.Millisecond,
+				MaxDelay:        time.Millisecond,
+				BackoffMultiple: 2,
+				ShouldRetry:     shouldRetryCoverDownload,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantExitCode, result.ExitCode)
+
+			count, err := os.ReadFile(statePath)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCount, string(count))
+		})
+	}
+}
+
+func writeCoverDownloadRetryFakeCLI(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "fake-lark-cli")
+	script := `#!/bin/sh
+state="$1"
+succeed_after="$2"
+count=0
+if [ -f "$state" ]; then
+  count="$(cat "$state")"
+fi
+count=$((count + 1))
+echo "$count" > "$state"
+if [ "$count" -lt "$succeed_after" ]; then
+  exit 1
+fi
+exit 0
+`
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
 }
 
 // writePreviewFixture writes a local fixture file used by the live workflow.


### PR DESCRIPTION
## Summary

The Drive Cover live E2E configured eight attempts but stopped after the first non-zero exit code. This PR fixes the local retry condition so transient Cover download failures retry within the existing bounded backoff and timeout.

## Changes

- Add `shouldRetryCoverDownload` to `tests/cli_e2e/drive/drive_preview_workflow_test.go` for nil, success, and non-zero exit results.
- Add credential-free regression coverage for actual invocation counts, immediate success, and the eight-attempt limit.
- Preserve the existing retry delays, four-minute workflow timeout, and global `RunCmdWithRetry` behavior.

## Test Plan

- [x] `make unit-test` passed through Harness validate.
- [x] Harness validate passed build, vet, unit, and integration checks.
- [x] Existing E2E regressions passed (2/2); skill eval is N/A.
- [x] Acceptance reviewer passed (2/2 cases).
- [x] Manual verification: `go test ./tests/cli_e2e/drive -run 'TestShouldRetryCoverDownload' -count=1` and `go test ./tests/cli_e2e -run 'TestRunCmdWithRetry' -count=1`.
- [ ] Live Drive workflow skipped because credentials are unavailable in the current environment.

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for Drive cover downloads when CLI commands fail.
  * Increased reliability of cover download workflows by retrying failed or unavailable command results.

* **Tests**
  * Added coverage to verify retry behavior across repeated failures and eventual success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->