### PR TITLE
docs(sheets): use English placeholder in table-get guidance

### DIFF
--- a/shortcuts/sheets/lark_sheet_table_io.go
+++ b/shortcuts/sheets/lark_sheet_table_io.go
@@ -1213,7 +1213,7 @@ var TableGet = common.Shortcut{
 	},
 	Tips: []string{
 		"Output is the same shape +table-put consumes — pipe it back in, or load sheets[].rows into a DataFrame keyed by columns[].name.",
-		"Column types are inferred per column, but only when every non-empty cell agrees; a column mixing types (e.g. numbers + \"暂无\") degrades to string — lossless and round-trips cleanly. Numeric coercion of dirty cells is the caller's job (pandas to_numeric(errors=\"coerce\") on the string column).",
+		"Column types are inferred per column, but only when every non-empty cell agrees; a column mixing types (e.g. numbers + \"N/A\") degrades to string — lossless and round-trips cleanly. Numeric coercion of dirty cells is the caller's job (pandas to_numeric(errors=\"coerce\") on the string column).",
 	},
 }
 
@@ -1522,7 +1522,7 @@ func readCellFormat(cell map[string]interface{}) string {
 // inferColumnType decides a column's type from its data cells: a date
 // number_format guides each cell's type, but a column is given a non-string type
 // only when EVERY non-empty cell agrees. Real sheet columns often mix types (a
-// number column with a stray "暂无", a date column with a bare count); declaring
+// number column with a stray "N/A", a date column with a bare count); declaring
 // number/date while a string value rides along makes the output inconsistent —
 // it breaks round-trip back into +table-put (which rejects a string in a number
 // column) and crashes pandas astype. So a mixed column degrades to string

--- a/shortcuts/sheets/lark_sheet_table_io_test.go
+++ b/shortcuts/sheets/lark_sheet_table_io_test.go
@@ -1140,7 +1140,7 @@ func TestTableGet_InferColumnType(t *testing.T) {
 	// Mixed number+text degrades to string (self-consistent: every value is then
 	// a string), so the column round-trips and pandas doesn't choke. Numeric
 	// coercion of the dirty cells is left to the caller (pandas to_numeric).
-	if typ, _ := inferColumnType(col(mk(100.0, ""), mk("暂无", ""), mk(200.0, "")), 0); typ != "string" {
+	if typ, _ := inferColumnType(col(mk(100.0, ""), mk("N/A", ""), mk(200.0, "")), 0); typ != "string" {
 		t.Errorf("mixed number+text col → %s, want string", typ)
 	}
 	// A bare number mixed into a date column must NOT stay date (would serial-


### PR DESCRIPTION
## Summary
- Replace the Chinese placeholder example in +table-get guidance with N/A.
- Keep the implementation comment and regression test aligned with the documented example.

## Validation
- go test ./shortcuts/sheets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated table shortcut examples to use “N/A” when describing mixed-type column values.
* **Tests**
  * Updated the corresponding mixed number-and-text test example to use “N/A”; expected behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->