### PR TITLE
chore: release v1.0.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.72] - 2026-07-17
+
+### Features
+
+- **slides**: lint table out of canvas
+- **slides**: report resolved table size mismatches
+- **approval**: support approval event consumption (#1924)
+
+### Bug Fixes
+
+- **vc**: don't fail +detail for in-progress meetings (#1930)
+- stabilize drive delete E2E terminal-state checks (#1939)
+
+### Documentation
+
+- **slides**: document table dimensions
+- document base field default values (#1500)
+- **sheets**: use English placeholder in table-get guidance (#1936)
+
+### Tests
+
+- stabilize live e2e auth retries (#1904)
+- use tri-state wiki node identity in delete verification (#1931)
+- fix drive cover download retries (#1934)
+
 ## [v1.0.71] - 2026-07-16
 
 ### Features
@@ -1527,6 +1552,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.72]: https://github.com/larksuite/cli/releases/tag/v1.0.72
 [v1.0.71]: https://github.com/larksuite/cli/releases/tag/v1.0.71
 [v1.0.70]: https://github.com/larksuite/cli/releases/tag/v1.0.70
 [v1.0.69]: https://github.com/larksuite/cli/releases/tag/v1.0.69

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.71` |
| Release version | `1.0.72` |
| Tag | `v1.0.72` |
| Branch | `release/v1.0.72` |
| Date | `2026-07-17` |

## Changes

- docs(slides): document table dimensions
- docs: document base field default values (#1500)
- fix(vc): don't fail +detail for in-progress meetings (#1930)
- docs(sheets): use English placeholder in table-get guidance (#1936)
- test: stabilize live e2e auth retries (#1904)
- feat(slides):lint table out of canvas
- feat(slides): report resolved table size mismatches
- test: use tri-state wiki node identity in delete verification (#1931)
- test: fix drive cover download retries (#1934)
- fix: stabilize drive delete E2E terminal-state checks (#1939)
- feat(approval): support approval event consumption (#1924)

## Files Changed

- `package.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.0.72, covering new features, bug fixes, documentation updates, and test improvements.
  * Updated the changelog with the release date and version reference.

* **Chores**
  * Incremented the package version to 1.0.72.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->