### PR TITLE
mail +triage: Extract and preserve mailbox_id from batch_get response

### DIFF
--- a/shortcuts/mail/mail_triage.go
+++ b/shortcuts/mail/mail_triage.go
@@ -272,9 +272,12 @@ var MailTriage = common.Shortcut{
 
 		// Inject mailbox_id into every message so downstream consumers
 		// (e.g. mail +message) can preserve the mailbox context for
-		// public/shared mailbox scenarios.
+		// public/shared mailbox scenarios. Only inject if not already set
+		// by buildTriageMessageMeta (which extracts it from backend response).
 		for _, msg := range messages {
-			msg["mailbox_id"] = mailbox
+			if _, hasMailboxID := msg["mailbox_id"]; !hasMailboxID {
+				msg["mailbox_id"] = mailbox
+			}
 		}
 
 		switch outFormat {
@@ -569,6 +572,10 @@ func buildTriageMessageMeta(msg map[string]interface{}, fallbackMessageID string
 		}
 	}
 	item["labels"] = strings.Join(labelIDs, ",")
+	// Extract mailbox_id from response if present (backend returns it for public/shared mailbox scenarios)
+	if v := strVal(msg["mailbox_id"]); v != "" {
+		item["mailbox_id"] = v
+	}
 	return item
 }
 


### PR DESCRIPTION
Generated by the harness-coding skill (recovery run — original attempt crashed before MR open).

- **Task ID**: 01KXQGDWRPXM4K66MHHZCAXR1F-12
- **Branch**: feat/1813b76
- **Target**: main

> The commits below were produced by a prior coding run on this branch. The current resume run regenerated the sprint plan from tech-specs and confirmed those commits already implement the work.

## Commits on branch (ahead of main)

| Commit | Subject |
|--------|---------|
| eafc316 | mail +triage: Extract and preserve mailbox_id from batch_get response |

## Source specs

- /home/zenghuansheng/.local/state/harness-agent/envs/env-63732045c1d5/generic-workers/generic-n199-204-183-dbed6e/coding/claude-code/01KXQGDWRPXM4K66MHHZCAXR1F/01KXQGDWRPXM4K66MHHZCAXR1F-12/input/deploy-report.md

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `mail +triage` handling for public and shared mailboxes.
  - Preserves mailbox context supplied by the server when available.
  - Prevents existing mailbox identifiers from being overwritten during message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->