### PR TITLE
fix: preserve slides schema issues

### DIFF
--- a/shortcuts/slides/slides_create.go
+++ b/shortcuts/slides/slides_create.go
@@ -154,6 +154,9 @@ var SlidesCreate = common.Shortcut{
 		if revisionID := common.GetFloat(data, "revision_id"); revisionID > 0 {
 			result["revision_id"] = int(revisionID)
 		}
+		if issues, ok := data["issues"]; ok {
+			result["issues"] = issues
+		}
 
 		// Step 2: Add slides if provided
 		if slidesStr != "" {
@@ -182,6 +185,7 @@ var SlidesCreate = common.Shortcut{
 				)
 
 				var slideIDs []string
+				var slideIssues []map[string]interface{}
 				for i, slideXML := range slides {
 					slideData, err := runtime.CallAPITyped(
 						"POST",
@@ -194,13 +198,24 @@ var SlidesCreate = common.Shortcut{
 					if err != nil {
 						return appendSlidesProgressHint(err, fmt.Sprintf("adding slide %d/%d failed; presentation %s was created, %d slide(s) added before failure", i+1, len(slides), presentationID, i))
 					}
-					if sid := common.GetString(slideData, "slide_id"); sid != "" {
+					sid := common.GetString(slideData, "slide_id")
+					if sid != "" {
 						slideIDs = append(slideIDs, sid)
+					}
+					if issues, ok := slideData["issues"]; ok {
+						slideIssues = append(slideIssues, map[string]interface{}{
+							"slide_index": i + 1,
+							"slide_id":    sid,
+							"issues":      issues,
+						})
 					}
 				}
 
 				result["slide_ids"] = slideIDs
 				result["slides_added"] = len(slideIDs)
+				if len(slideIssues) > 0 {
+					result["slide_issues"] = slideIssues
+				}
 			}
 		}
 

--- a/shortcuts/slides/slides_create_test.go
+++ b/shortcuts/slides/slides_create_test.go
@@ -351,6 +351,56 @@ func TestSlidesCreateWithSlides(t *testing.T) {
 	}
 }
 
+func TestSlidesCreatePreservesSchemaIssues(t *testing.T) {
+	t.Parallel()
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"xml_presentation_id": "pres_issues",
+				"issues":              "presentation schema issue",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_issues/slide",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_id": "slide_001",
+				"issues":   "slide schema issue",
+			},
+		},
+	})
+
+	err := runSlidesCreateShortcut(t, f, stdout, []string{
+		"+create",
+		"--slides", `["<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data/></slide>"]`,
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeSlidesCreateEnvelope(t, stdout)
+	if data["issues"] != "presentation schema issue" {
+		t.Fatalf("issues = %v, want presentation schema issue", data["issues"])
+	}
+	slideIssues, ok := data["slide_issues"].([]interface{})
+	if !ok || len(slideIssues) != 1 {
+		t.Fatalf("slide_issues = %#v, want one entry", data["slide_issues"])
+	}
+	issue, _ := slideIssues[0].(map[string]interface{})
+	if issue["slide_index"] != float64(1) || issue["slide_id"] != "slide_001" || issue["issues"] != "slide schema issue" {
+		t.Fatalf("slide_issues[0] = %#v", issue)
+	}
+}
+
 // TestSlidesCreateWithSlidesPartialFailure verifies error reporting when a slide fails to create.
 func TestSlidesCreateWithSlidesPartialFailure(t *testing.T) {
 	t.Parallel()

--- a/shortcuts/slides/slides_replace_pages.go
+++ b/shortcuts/slides/slides_replace_pages.go
@@ -139,6 +139,7 @@ type replacePageResult struct {
 	NewSlideID string
 	Status     string
 	Error      string
+	Issues     interface{}
 	RevisionID *int
 }
 
@@ -330,6 +331,9 @@ func replaceOnePage(runtime *common.RuntimeContext, presentationID string, item 
 		return result, err
 	}
 	result.NewSlideID = newSlideID
+	if issues, ok := createData["issues"]; ok {
+		result.Issues = issues
+	}
 	if rev, ok := revisionFromData(createData); ok {
 		revisionID = rev
 		result.RevisionID = &rev
@@ -388,6 +392,9 @@ func replacePageResultsOutput(results []replacePageResult) []map[string]interfac
 		}
 		if result.Error != "" {
 			m["error"] = result.Error
+		}
+		if result.Issues != nil {
+			m["issues"] = result.Issues
 		}
 		if result.RevisionID != nil {
 			m["revision_id"] = *result.RevisionID

--- a/shortcuts/slides/slides_replace_pages_test.go
+++ b/shortcuts/slides/slides_replace_pages_test.go
@@ -42,7 +42,7 @@ func TestReplacePagesCreatesBeforeThenDeletesOld(t *testing.T) {
 		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide",
 		Body: map[string]interface{}{
 			"code": 0,
-			"data": map[string]interface{}{"slide_id": "new2", "revision_id": 11},
+			"data": map[string]interface{}{"slide_id": "new2", "revision_id": 11, "issues": "slide schema issue"},
 		},
 		OnMatch: func(req *http.Request) {
 			requestOrder = append(requestOrder, req.Method)
@@ -122,6 +122,9 @@ func TestReplacePagesCreatesBeforeThenDeletesOld(t *testing.T) {
 	first, _ := results[0].(map[string]interface{})
 	if first["old_slide_id"] != "old2" || first["new_slide_id"] != "new2" || first["status"] != "replaced" {
 		t.Fatalf("result = %#v", first)
+	}
+	if first["issues"] != "slide schema issue" {
+		t.Fatalf("result.issues = %v, want slide schema issue", first["issues"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Expose non-fatal Slides XML schema issues through the shortcut output, so callers can see server-side validation warnings.

## Changes

- Preserve presentation and per-slide issues in `slides +create`.
- Preserve per-page slide-create issues in `slides +replace-pages`.
- Add unit coverage for both output paths.

## Test Plan

- [ ] Unit tests pass (not run; not requested in this turn).
- [ ] Manual local verification (not run; not requested in this turn).

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slide creation now reports presentation-level and per-slide API issues in command output.
  * Slide replacement now includes any issues returned while creating replacement slides.
  * Results continue to include slide IDs, counts, and replacement status alongside issue details.

* **Tests**
  * Added coverage to verify issue details are preserved for slide creation and page replacement workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->