### PR TITLE
fix(slides): detect visual elements outside canvas

### DIFF
--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -605,6 +605,7 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
         y = extract_numeric_attribute(attrs, "topLeftY")
         width = extract_numeric_attribute(attrs, "width")
         height = extract_numeric_attribute(attrs, "height")
+        rotation = extract_numeric_attribute(attrs, "rotation") or 0
         table_layouts: dict[str, dict[str, Any] | None] = {}
         if kind == "table":
             width, table_layouts["width"] = resolve_table_dimension(
@@ -622,6 +623,7 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "y": y,
                 "width": width,
                 "height": height,
+                "rotation": rotation,
                 "order": len(elements),
             }
             if kind == "table":
@@ -963,16 +965,48 @@ def detect_whiteboard_external_overlaps(
     return issues
 
 
-def detect_table_out_of_canvas(
+def element_canvas_bbox(element: dict[str, Any]) -> dict[str, int | float]:
+    bbox = {key: element[key] for key in ("x", "y", "width", "height")}
+    if element["kind"] != "chart" and not (element["kind"] == "shape" and element["type"] == "text"):
+        return bbox
+
+    rotation = element["rotation"]
+    if not isinstance(rotation, (int, float)) or not math.isfinite(rotation):
+        rotation = 0
+    rotation %= 360
+    if math.isclose(rotation, 0, abs_tol=1e-9):
+        return bbox
+    radians = math.radians(rotation)
+    sine = abs(math.sin(radians))
+    cosine = abs(math.cos(radians))
+    sine = 0 if math.isclose(sine, 0, abs_tol=1e-12) else sine
+    cosine = 0 if math.isclose(cosine, 0, abs_tol=1e-12) else cosine
+    rotated_width = element["width"] * cosine + element["height"] * sine
+    rotated_height = element["width"] * sine + element["height"] * cosine
+    return {
+        "x": element["x"] - (rotated_width - element["width"]) / 2,
+        "y": element["y"] - (rotated_height - element["height"]) / 2,
+        "width": rotated_width,
+        "height": rotated_height,
+    }
+
+
+def detect_elements_out_of_canvas(
     elements: list[dict[str, Any]], slide_width: int | float, slide_height: int | float
 ) -> list[dict[str, Any]]:
     issues: list[dict[str, Any]] = []
-    for table in (element for element in elements if element["kind"] == "table"):
+    for element in (
+        element
+        for element in elements
+        if element["kind"] in {"table", "chart"}
+        or (element["kind"] == "shape" and element["type"] == "text")
+    ):
+        bbox = element_canvas_bbox(element)
         overflow = {
-            "left": max(-table["x"], 0),
-            "top": max(-table["y"], 0),
-            "right": max(table["x"] + table["width"] - slide_width, 0),
-            "bottom": max(table["y"] + table["height"] - slide_height, 0),
+            "left": max(-bbox["x"], 0),
+            "top": max(-bbox["y"], 0),
+            "right": max(bbox["x"] + bbox["width"] - slide_width, 0),
+            "bottom": max(bbox["y"] + bbox["height"] - slide_height, 0),
         }
         overflow_details = [
             f"{side} by {amount:g}px" for side, amount in overflow.items() if amount > 0
@@ -982,23 +1016,20 @@ def detect_table_out_of_canvas(
         issues.append(
             {
                 "level": "error",
-                "code": "table_out_of_canvas",
-                "elements": [table["id"]],
+                "code": f'{element["kind"]}_out_of_canvas',
+                "elements": [element["id"]],
                 "canvas": {"width": slide_width, "height": slide_height},
-                "bbox": {
-                    "x": table["x"],
-                    "y": table["y"],
-                    "width": table["width"],
-                    "height": table["height"],
-                },
+                "bbox": bbox,
                 "overflow": overflow,
                 "message": (
-                    f'table {table["id"]} exceeds the {slide_width:g}x{slide_height:g} canvas '
+                    f'{element["kind"]} {element["id"]} exceeds the {slide_width:g}x{slide_height:g} canvas '
                     f'({", ".join(overflow_details)})'
                 ),
                 "hint": (
                     "Move the table inside the canvas, reduce table.width/table.height, or split the table across "
                     "slides."
+                    if element["kind"] == "table"
+                    else f'Move the {element["kind"]} inside the canvas or reduce its width/height.'
                 ),
             }
         )
@@ -1083,7 +1114,7 @@ def lint_slide(
     elements = extract_elements(slide_xml)
     issues: list[dict[str, Any]] = [
         *detect_whiteboard_external_overlaps(elements, slide_width, slide_height),
-        *detect_table_out_of_canvas(elements, slide_width, slide_height),
+        *detect_elements_out_of_canvas(elements, slide_width, slide_height),
         *detect_table_layout_size_mismatches(elements),
     ]
 

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -217,7 +217,8 @@ class XmlTextOverlapLintTest(unittest.TestCase):
         )
         self.assertEqual(result["slide_size"], {"width": 960, "height": 540})
         self.assertEqual(result["summary"]["slide_count"], 1)
-        self.assertEqual(result["summary"]["error_count"], 0)
+        self.assertEqual(result["summary"]["error_count"], 1)
+        self.assertEqual(result["slides"][0]["issues"][0]["code"], "shape_out_of_canvas")
 
     def test_lint_xml_preserves_presentation_canvas_and_slide_order(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
@@ -601,7 +602,7 @@ class XmlTextOverlapLintTest(unittest.TestCase):
         self.assertEqual(result["slides"][0]["issues"][0]["code"], "bbox_overlap")
         self.assertEqual(result["slides"][0]["issues"][0]["elements"], ["source", "target"])
 
-    def test_lint_xml_does_not_check_bounds_or_text_height(self) -> None:
+    def test_lint_xml_reports_text_out_of_canvas_but_not_text_height(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
@@ -618,8 +619,11 @@ class XmlTextOverlapLintTest(unittest.TestCase):
             </presentation>
             """
         )
-        self.assertEqual(result["summary"]["error_count"], 0)
+        issue = result["slides"][0]["issues"][0]
+        self.assertEqual(result["summary"]["error_count"], 1)
         self.assertEqual(result["summary"]["warning_count"], 0)
+        self.assertEqual(issue["code"], "shape_out_of_canvas")
+        self.assertEqual(issue["overflow"], {"left": 0, "top": 0, "right": 160, "bottom": 40})
 
     def test_lint_xml_allows_template_style_bleed_and_text_over_images(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
@@ -674,7 +678,7 @@ class XmlTextOverlapLintTest(unittest.TestCase):
         self.assertEqual(elements[1]["fontSize"], 28)
         self.assertEqual(elements[1]["text"], "Growth & scale\nFocused execution")
 
-    def test_lint_xml_does_not_check_small_out_of_bounds_elements(self) -> None:
+    def test_lint_xml_allows_small_out_of_bounds_images(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
@@ -688,7 +692,7 @@ class XmlTextOverlapLintTest(unittest.TestCase):
         )
         self.assertEqual(result["summary"]["error_count"], 0)
 
-    def test_lint_xml_ignores_obviously_misplaced_large_visuals(self) -> None:
+    def test_lint_xml_allows_out_of_canvas_images(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
@@ -703,7 +707,7 @@ class XmlTextOverlapLintTest(unittest.TestCase):
         )
         self.assertEqual(result["summary"]["error_count"], 0)
 
-    def test_lint_xml_allows_reasonable_large_visual_bleed(self) -> None:
+    def test_lint_xml_allows_full_bleed_images(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
@@ -716,6 +720,72 @@ class XmlTextOverlapLintTest(unittest.TestCase):
             """
         )
         self.assertEqual(result["summary"]["error_count"], 0)
+
+    def test_lint_xml_reports_text_and_chart_out_of_canvas(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <data>
+                  <shape id="outside-shape" type="text" topLeftX="-10" topLeftY="40" width="50" height="50"/>
+                  <img id="outside-img" src="token" topLeftX="120" topLeftY="-20" width="50" height="50"/>
+                  <chart id="outside-chart" topLeftX="900" topLeftY="100" width="100" height="100"/>
+                  <whiteboard id="outside-whiteboard" topLeftX="100" topLeftY="500" width="100" height="100"/>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+        issues = result["slides"][0]["issues"]
+        self.assertEqual(result["summary"]["error_count"], 2)
+        self.assertEqual(
+            [(issue["code"], issue["elements"], issue["overflow"]) for issue in issues],
+            [
+                ("shape_out_of_canvas", ["outside-shape"], {"left": 10, "top": 0, "right": 0, "bottom": 0}),
+                ("chart_out_of_canvas", ["outside-chart"], {"left": 0, "top": 0, "right": 40, "bottom": 0}),
+            ],
+        )
+
+    def test_lint_xml_uses_rotated_text_and_chart_bounds_for_canvas_validation(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <data>
+                  <shape id="rotated-text" type="text" topLeftX="0" topLeftY="0" width="100" height="100" rotation="45"/>
+                  <chart id="rotated-chart" topLeftX="860" topLeftY="200" width="100" height="100" rotation="45"/>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+        issues_by_element = {issue["elements"][0]: issue for issue in result["slides"][0]["issues"]}
+        self.assertEqual(result["summary"]["error_count"], 2)
+        self.assertEqual(issues_by_element["rotated-text"]["code"], "shape_out_of_canvas")
+        self.assertAlmostEqual(issues_by_element["rotated-text"]["overflow"]["left"], 20.710678, places=5)
+        self.assertAlmostEqual(issues_by_element["rotated-text"]["overflow"]["top"], 20.710678, places=5)
+        self.assertEqual(issues_by_element["rotated-chart"]["code"], "chart_out_of_canvas")
+        self.assertAlmostEqual(issues_by_element["rotated-chart"]["overflow"]["right"], 20.710678, places=5)
+
+    def test_lint_xml_treats_non_finite_rotations_as_zero(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <data>
+                  <shape id="infinite" type="text" topLeftX="-10" topLeftY="0" width="20" height="20" rotation="inf"/>
+                  <shape id="negative-infinite" type="text" topLeftX="0" topLeftY="-10" width="20" height="20" rotation="-inf"/>
+                  <chart id="not-a-number" topLeftX="950" topLeftY="0" width="20" height="20" rotation="nan"/>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+        issues_by_element = {issue["elements"][0]: issue for issue in result["slides"][0]["issues"]}
+        self.assertEqual(result["summary"]["error_count"], 3)
+        self.assertEqual(issues_by_element["infinite"]["overflow"], {"left": 10, "top": 0, "right": 0, "bottom": 0})
+        self.assertEqual(issues_by_element["negative-infinite"]["overflow"], {"left": 0, "top": 10, "right": 0, "bottom": 0})
+        self.assertEqual(issues_by_element["not-a-number"]["overflow"], {"left": 0, "top": 0, "right": 10, "bottom": 0})
 
     def test_lint_xml_reports_table_bottom_overflow_from_declared_bounds(self) -> None:
         result = xml_text_overlap_lint.lint_xml(


### PR DESCRIPTION
## Summary
Extend the Slides XML lint to report text shapes and charts that exceed the canvas. The reported bounds account for rotation while images and whiteboards continue to permit intentional bleed.

## Changes
- Generalize canvas-bound validation from tables to tables, text shapes, and charts.
- Add rotation-aware bounds and regression coverage for in-canvas and out-of-canvas elements.

## Test Plan
- [ ] Unit tests pass (not run; tests were not requested in this turn)
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected (not run; this change only updates the lint script and its unit tests)

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slide validation now flags text, chart, and table elements that extend beyond the slide canvas.
  * Canvas boundary checks are now rotation-aware and handle non-finite rotations as unrotated.
  * Overflow diagnostics now provide more specific per-element details, including overflow distances and more tailored guidance.

* **Tests**
  * Updated and expanded test coverage for canvas overflow reporting, including rotated text and charts and revised expectations for default-canvas bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->