### PR TITLE
fix: sanitize complete ANSI escape sequences

### DIFF
--- a/internal/validate/sanitize.go
+++ b/internal/validate/sanitize.go
@@ -10,9 +10,10 @@ import (
 	"github.com/larksuite/cli/internal/charcheck"
 )
 
-// ansiEscape matches ANSI CSI sequences (ESC[ ... letter) and OSC sequences (ESC] ... BEL).
-// Private CSI sequences (e.g. ESC[?25l) use the extended parameter byte range [0-9;?>=!].
-var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?>=!]*[a-zA-Z]|\x1b\][^\x07]*\x07`)
+// ansiEscape matches ANSI CSI sequences and OSC sequences terminated by BEL or ST.
+var ansiEscape = regexp.MustCompile(
+	`\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(\x07|\x1b\\)`,
+)
 
 // SanitizeForTerminal strips ANSI escape sequences, C0 control characters
 // (except \n and \t), and dangerous Unicode from text, preserving the actual

--- a/internal/validate/sanitize_test.go
+++ b/internal/validate/sanitize_test.go
@@ -29,11 +29,14 @@ func TestSanitizeForTerminal_StripsEscapesAndDangerousChars(t *testing.T) {
 		{"red color", "before\x1b[31mred\x1b[0mafter", "beforeredafter"},
 		{"bold", "before\x1b[1mbold\x1b[0mafter", "beforeboldafter"},
 		{"cursor move", "before\x1b[10;20Hafter", "beforeafter"},
+		{"tilde final byte", "before\x1b[3~after", "beforeafter"},
+		{"intermediate byte", "before\x1b[1 qafter", "beforeafter"},
 		{"multiple sequences", "\x1b[31m\x1b[1mhello\x1b[0m", "hello"},
 
 		// ── GIVEN: ANSI OSC sequences → THEN: stripped ──
 		{"OSC title change", "before\x1b]0;evil title\x07after", "beforeafter"},
 		{"OSC with text", "text\x1b]2;new title\x07more", "textmore"},
+		{"OSC ST terminator", "before\x1b]0;evil title\x1b\\after", "beforeafter"},
 
 		// ── GIVEN: C0 control characters → THEN: stripped ──
 		{"null byte", "hello\x00world", "helloworld"},


### PR DESCRIPTION
## Summary

The terminal sanitizer only recognized CSI sequences ending in letters and OSC sequences ending in BEL. Valid CSI final/intermediate bytes and ST-terminated OSC sequences therefore leaked their payload text into human-readable CLI output.

## Changes

- Match the complete ANSI CSI parameter, intermediate, and final byte ranges.
- Strip OSC sequences terminated by either BEL or ST, with regression coverage for each previously missed form.

## Test Plan

- [x] `go test ./internal/validate -count=1`
- [x] `go test -race ./internal/validate -count=1`
- [x] `go vet ./...`
- [x] `gofmt -l .` produced no output
- [x] `go mod tidy` produced no changes

`make unit-test` could not pass its `fetch_meta` prerequisite locally because the remote endpoint presented a self-signed certificate chain. Running the same full race package matrix without the Go 1.26-incompatible debug `-gcflags` passed all packages except the two that require the unavailable generated metadata (`internal/qualitygate/cmd/manifest-export` and `internal/schema`).

## Related Issues

- None
