### PR TITLE
docs(doc): clarify history edit time format

### DIFF
--- a/shortcuts/doc/docs_history_test.go
+++ b/shortcuts/doc/docs_history_test.go
@@ -175,7 +175,7 @@ func TestDocsHistoryExecuteList(t *testing.T) {
 					map[string]interface{}{
 						"revision_id":        float64(42),
 						"history_version_id": "11",
-						"edit_time":          "1780000000",
+						"edit_time":          "2026-06-22T12:24:45Z",
 						"type":               float64(1),
 						"editor_ids":         []interface{}{"ou_1"},
 					},
@@ -205,6 +205,13 @@ func TestDocsHistoryExecuteList(t *testing.T) {
 	entries, _ := data["entries"].([]interface{})
 	if len(entries) != 1 {
 		t.Fatalf("entries = %#v, want one entry", data["entries"])
+	}
+	entry, ok := entries[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("entry = %T, want object", entries[0])
+	}
+	if got := entry["edit_time"]; got != "2026-06-22T12:24:45Z" {
+		t.Fatalf("edit_time = %#v, want RFC3339 value preserved", got)
 	}
 }
 

--- a/skills/lark-doc/references/lark-doc-history.md
+++ b/skills/lark-doc/references/lark-doc-history.md
@@ -2,6 +2,8 @@
 
 用于查看 Docx 历史版本、按 `history_version_id` 回滚，以及查询回滚任务状态。
 
+`entries[].edit_time` 是 RFC3339 时间字符串（例如 `2026-06-22T12:24:45Z`）。按时间匹配时先将其解析为时间值，再比较先后关系或时间差。
+
 ## 安全约束
 
 - `overwrite` 会重建正文和 block ID，且无法保证保留评论等非正文对象。用户要求保留这些对象时，应先说明限制并确认。
@@ -70,7 +72,7 @@ lark-cli docs +history-revert-status --doc "<docx_url_or_token>" --task-id "<tas
     {
       "revision_id": 42,
       "history_version_id": "11",
-      "edit_time": "1780000000",
+      "edit_time": "2026-06-22T12:24:45Z",
       "type": 1,
       "name": "版本名",
       "description": "版本说明",


### PR DESCRIPTION
## Summary
Clarify the actual `edit_time` wire format returned by the Docs history OpenAPI so time-based history selection does not rely on the stale Unix timestamp example.

The CLI does not normalize this field: `DocsHistoryList.Execute` returns the successful API `data` object through `OutRaw` unchanged. The documentation and execution test should therefore match the upstream RFC3339 wire value.

## Changes
- Document `entries[].edit_time` as an RFC3339 string.
- Update the history-list response example to use RFC3339.
- Align the `DocsHistoryList` response fixture with the wire format and assert that the CLI preserves `edit_time` unchanged.

## Test Plan
- [x] `git diff --check origin/main...HEAD`
- [x] `go test ./shortcuts/doc -run '^TestDocsHistoryExecuteList$' -count=1`
- [x] `node scripts/skill-format-check/index.js`
- [x] Confirmed `CallAPITyped` returns the successful response `data` object untouched and `DocsHistoryList.Execute` emits it through `OutRaw`.
- [x] Confirmed the upstream `ai_edit` OpenAPI layer formats `edit_time` with `time.RFC3339` and a live `docs +history-list` response returns RFC3339.

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that history edit times use RFC3339 UTC timestamp strings.
  * Updated the example response to show the correct timestamp format.
  * Added guidance to parse timestamps before comparing them.
  * Updated the history example to reflect the format returned by the history list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->