### PR TITLE
feat: card_icon

### DIFF
--- a/skills/lark-im/references/card/card-2.0-schema.md
+++ b/skills/lark-im/references/card/card-2.0-schema.md
@@ -29,7 +29,7 @@ Card 2.0 组件按**容器 / 展示 / 交互**三类，均通过 `tag` 字段声
     "title":    { "tag": "plain_text", "content": "卡片标题" },
     "subtitle": { "tag": "plain_text", "content": "副标题：一句上下文（时间/来源/状态）" },
     "template": "blue",
-    "icon": { "tag": "standard_icon", "token": "notice_colorful" },
+    "icon": { "tag": "standard_icon", "token": "lark-logo_colorful" },
     "text_tag_list": [
       { "tag": "text_tag", "text": { "tag": "plain_text", "content": "状态标签" }, "color": "blue" }
     ]

--- a/skills/lark-im/references/card/lark-im-card-style.md
+++ b/skills/lark-im/references/card/lark-im-card-style.md
@@ -105,12 +105,12 @@
 "header": {
   "title": { "tag": "plain_text", "content": "卡片标题" },
   "template": "blue",
-  "icon": { "tag": "standard_icon", "token": "mail_colorful" }
+  "icon": { "tag": "standard_icon", "token": "calendar_colorful" }
 }
 ```
 
-- `token` 从 `resource/icons.md` 按场景选取；彩色图标用 `*_colorful` 后缀，单色用普通名称。
-- 常用速查：通知 `notice_colorful`、告警 `warning_colorful`、审批 `approve_colorful`、日历 `calendar_colorful`、数据 `chart_colorful`、任务 `todo_colorful`、AI `myai_colorful`。
+- `token` 必须从 `resource/icons.md` 的精确枚举中选择；禁止根据名称规律自行拼接 token。没有合适的 token 时省略 icon。
+- 场景速查：日历 `calendar_colorful`、待办 `todo_colorful`、投票 `vote_colorful`、妙记 `file-lark-minutes_colorful`、多维表格 `wiki-bitable_colorful`、表单 `file-form_colorful`、社区 `larkcommunity_colorful`、招聘 `hirelogo_colorful`、飞书品牌 `lark-logo_colorful`、Meego `meego_colorful`、AI `myai_colorful`、aPaaS `apaas_colorful`、审批 `approval_colorful`、通用 AI `ai-common_colorful`。
 
 ### 1. 配色纪律（服务 P6 语义一致）
 
@@ -212,7 +212,7 @@ header 有三层能力，**尽量用满**（至少用 `title` + `icon`；`subtit
   "title":    { "tag": "plain_text", "content": "发版审批" },
   "subtitle": { "tag": "plain_text", "content": "2026-06-25 · 后端服务" },
   "template": "blue",
-  "icon": { "tag": "standard_icon", "token": "approve_colorful" },
+  "icon": { "tag": "standard_icon", "token": "approval_colorful" },
   "text_tag_list": [
     { "tag": "text_tag", "text": { "tag": "plain_text", "content": "待审批" }, "color": "yellow" }
   ]

--- a/skills/lark-im/references/card/resource/icons.md
+++ b/skills/lark-im/references/card/resource/icons.md
@@ -34,5 +34,19 @@
 | 通知/铃铛 | `bell_outlined` | 定位 | `pin_outlined` |
 | 附件 | `attachment_outlined` | 审批 | `approval_outlined` |
 
+## 彩色图标（精确 token）
+
+彩色图标必须从下表按**完整字符串**选择，禁止根据名称规律自行拼接。彩色 token 自带颜色，不要再推导其他后缀或变体。
+
+| 含义 | token | 含义 | token |
+|---|---|---|---|
+| 日历 | `calendar_colorful` | 待办 | `todo_colorful` |
+| 投票 | `vote_colorful` | 飞书妙记 | `file-lark-minutes_colorful` |
+| 多维表格 | `wiki-bitable_colorful` | 表单 | `file-form_colorful` |
+| 飞书社区 | `larkcommunity_colorful` | 招聘 | `hirelogo_colorful` |
+| 飞书品牌 | `lark-logo_colorful` | Meego | `meego_colorful` |
+| AI | `myai_colorful` | aPaaS | `apaas_colorful` |
+| 审批 | `approval_colorful` | 通用 AI | `ai-common_colorful` |
+
 > token 必须与官方完全一致，否则图标不渲染。上表为常用项，全量（数百个，分系统/商务/沟通/用户/媒体/文档等类目）以官方图标库为准：
 > https://open.larkoffice.com/document/feishu-cards/enumerations-for-icons


### PR DESCRIPTION
  ### Summary                                                                                                                                                                                                                                
                                                                                                                                                                                                                                         
  Card header icon documentation contained invalid tokens (e.g., mail_colorful, approve_colorful) that do not render, and icon guidance lacked precise token enumeration, causing LLM to guess or fabricate icon tokens. This PR replaces
  examples with valid tokens and adds a definitive colorful icon reference table.                                                                                                                                                        
                                                                                                                                                                                                                                         
  ### Changes                                                                                                                                                                                                                                
                                                                                                                                                                                                                                         
  - Add a resource/icons.md colorful icon reference table with 14 exact token strings (calendar_colorful, todo_colorful, vote_colorful, etc.) and a hard rule prohibiting pattern-based guessing                                         
  - Fix invalid icon tokens in lark-im-card-style.md: mail_colorful → calendar_colorful, approve_colorful → approval_colorful; rewrite guidance to require exact selection from icons.md                                                 
  - Fix stale icon token in card-2.0-schema.md example: notice_colorful → lark-logo_colorful                                                                                                                                               
                                                                                                                                                                                                                                         
   ### Test Plan                                                                                                                                                                                                                              
                                                                                                                                                                                                                                         
  - [x] make unit-test passed                                                                                                                                                                                                            
  - [x] Manual verification: confirmed each icon token in examples matches the exact value listed in resource/icons.md                                                                                                                   
  - [x] Manual verification: confirmed no invalid/guessed tokens (e.g., mail_colorful, approve_colorful, notice_colorful) remain in card-related docs                                                                                    
                                                                                                                                                                                                                                         
 ###  Related Issues                                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  - None        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the Card 2.0 root structure JSON example to change `header.icon.token` from `notice_colorful` to `lark-logo_colorful`.
  * Tightened Card 2.0 “Header 图标” guidance: `header.icon.token` must use the exact colorful tokens from the approved list only; omit `icon` when no matching token exists.
  * Refreshed quick-scan scenario examples (e.g., `mail_colorful` → `calendar_colorful`) and updated the “发版审批” header icon (`approve_colorful` → `approval_colorful`).
  * Added “彩色图标（精确 token）” reference with a full token mapping table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->