### PR TITLE
docs: add known note_id query example to lark-note skill

### DIFF
--- a/skills/lark-note/SKILL.md
+++ b/skills/lark-note/SKILL.md
@@ -92,3 +92,28 @@ lark-cli note +detail --note-id <note_id>
 # 3. 读取纪要文档内容
 lark-cli docs +fetch --doc <note_doc_token> --doc-format markdown
 ```
+
+### 2. 已知 note_id 直接查询纪要详情
+
+已经持有 `note_id`（用户直接给出，或从 `docs +fetch` 的 `<vc-transcribe-tab vc-node-id="...">` 取得）时，跳过 vc / minutes / calendar 定位步骤，直接 `note +detail`：
+
+```bash
+lark-cli note +detail --note-id <note_id>
+```
+
+返回 `note` 对象（`shared_doc_tokens` 为空时省略该字段）：
+
+```json
+{
+  "note": {
+    "note_id": "7412345678901234567",
+    "note_display_type": "normal",
+    "creator_id": "ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "create_time": "2026-07-18 15:04",
+    "note_doc_token": "Xy1zAbCdEfGhIjKlMnOpQrStUv",
+    "verbatim_doc_token": "Pq2rStUvWxYzAbCdEfGhIjKlMn"
+  }
+}
+```
+
+拿到结果后按 `note_display_type` 路由（见上方「`note_display_type` 路由」表）：`normal` 用 `docs +fetch --doc <verbatim_doc_token>` 读逐字稿，`unified` 转 `note +transcript --note-id <note_id>`。


### PR DESCRIPTION
## Summary

Add a "known note_id" worked example to the lark-note skill doc. The skill's
primary use case is querying note detail when you already hold a note_id, but the
only existing example starts from a meeting_id. This documents the direct
`note +detail --note-id` path with a concrete output sample.

## Changes

- `skills/lark-note/SKILL.md`: add a new "direct query by known note_id" section
  right after the existing first scenario. It shows the direct
  `note +detail --note-id <note_id>` command, a concrete `{"note": {...}}` output
  sample (fields aligned to `shortcuts/note` `ToMap()`, `create_time` in the
  no-seconds `FormatTime` format, `shared_doc_tokens` omitted when empty), and a
  one-line `note_display_type` routing hint pointing at the existing routing table.

## Test Plan

- [x] Docs-only change: no Go code, flags, output, or command behavior modified
- [x] Output-sample fields verified against source (`shortcuts/note/note.go` `ToMap()`,
      `shortcuts/note/note_detail.go` output envelope, `shortcuts/common/common.go` `FormatTime`)
- [x] `go build`, `go vet`, unit and integration tests pass (unchanged by a docs edit)
- [x] Structural acceptance review via `note +detail --help` and `--dry-run` (no real API calls)

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for directly retrieving meeting note details when a note ID is available.
  * Documented the returned note information, including timestamps, creator details, and document tokens.
  * Added instructions for handling normal and unified note types and accessing their transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->