### PR TITLE
fix: allow jq examples in quality gate dry-runs

### DIFF
--- a/internal/qualitygate/rules/dryrun.go
+++ b/internal/qualitygate/rules/dryrun.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/qualitygate/facts"
 	"github.com/larksuite/cli/internal/qualitygate/manifest"
 	"github.com/larksuite/cli/internal/qualitygate/report"
@@ -726,7 +727,11 @@ func appendDryRunArg(raw string) ([]string, error) {
 		return nil, fmt.Errorf("not a lark-cli command")
 	}
 	argv = truncateShellTail(argv)
-	argv = forceDryRunJSONFormat(argv)
+	var jqValid bool
+	argv, jqValid = stripDryRunJQFilter(argv)
+	if jqValid {
+		argv = forceDryRunJSONFormat(argv)
+	}
 	hasDryRunArg := false
 	dryRunEnabled := false
 	for _, arg := range argv[1:] {
@@ -773,6 +778,73 @@ func truncateShellTail(argv []string) []string {
 		}
 	}
 	return argv
+}
+
+// stripDryRunJQFilter removes valid output-only jq filters from the synthetic
+// dry-run invocation. Invalid jq syntax and incompatible output flags are left
+// untouched so the real CLI execution still rejects the documented command.
+// The bool reports whether other output normalization remains safe.
+func stripDryRunJQFilter(argv []string) ([]string, bool) {
+	jqExpr, outputPath, format, hasJQ, jqHasValue := dryRunOutputFlags(argv)
+	if !hasJQ {
+		return argv, true
+	}
+	if !jqHasValue || output.ValidateJqFlags(jqExpr, outputPath, format) != nil {
+		return argv, false
+	}
+
+	out := make([]string, 0, len(argv))
+	for i := 0; i < len(argv); i++ {
+		arg := argv[i]
+		switch {
+		case arg == "--":
+			return append(out, argv[i:]...), true
+		case arg == "--jq" || arg == "-q":
+			i++
+		case strings.HasPrefix(arg, "--jq=") || strings.HasPrefix(arg, "-q="):
+			continue
+		default:
+			out = append(out, arg)
+		}
+	}
+	return out, true
+}
+
+func dryRunOutputFlags(argv []string) (jqExpr, outputPath, format string, hasJQ, jqHasValue bool) {
+	for i := 1; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" {
+			break
+		}
+		switch {
+		case arg == "--jq" || arg == "-q":
+			hasJQ = true
+			jqHasValue = i+1 < len(argv)
+			if jqHasValue {
+				jqExpr = argv[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "--jq=") || strings.HasPrefix(arg, "-q="):
+			hasJQ = true
+			jqHasValue = true
+			jqExpr = arg[strings.IndexByte(arg, '=')+1:]
+		case arg == "--output":
+			if i+1 < len(argv) {
+				outputPath = argv[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "--output="):
+			outputPath = strings.TrimPrefix(arg, "--output=")
+		case arg == "--format":
+			if i+1 < len(argv) {
+				format = argv[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "--format="):
+			format = strings.TrimPrefix(arg, "--format=")
+		}
+	}
+	return jqExpr, outputPath, format, hasJQ, jqHasValue
 }
 
 func dryRunFlagExplicitlyTrue(arg string) bool {

--- a/internal/qualitygate/rules/dryrun_test.go
+++ b/internal/qualitygate/rules/dryrun_test.go
@@ -194,6 +194,38 @@ func TestRunDryRunsIgnoresTrailingShellComment(t *testing.T) {
 	}
 }
 
+func TestRunDryRunsIgnoresJQFilterWhenValidatingRequestPreview(t *testing.T) {
+	cliBin, argsPath := fakeDryRunCLI(t, `{"api":[{"method":"GET","url":"/open-apis/im/v1/flags"}]}`)
+	m := manifest.Manifest{Commands: []manifest.Command{{
+		Path:       "im +flag-list",
+		Runnable:   true,
+		Identities: []string{"user"},
+		Flags: []manifest.Flag{
+			{Name: "as", TakesValue: true},
+			{Name: "page-all"},
+			{Name: "jq", Shorthand: "q", TakesValue: true},
+			{Name: "dry-run"},
+		},
+	}}}
+	ex := skillscan.Example{
+		Raw:        `lark-cli im +flag-list --as user --page-all -q '.data.flag_items[-1]'`,
+		SourceFile: "skills/lark-im/references/lark-im-flag-list.md",
+		Line:       26,
+	}
+
+	diags, facts := RunDryRuns(context.Background(), cliBin, m, []skillscan.Example{ex})
+	if len(diags) != 0 {
+		t.Fatalf("RunDryRuns() diagnostics = %#v", diags)
+	}
+	if len(facts) != 1 || !facts[0].Executable || facts[0].SkipReason != "" {
+		t.Fatalf("jq example should remain executable: %#v", facts)
+	}
+	wantArgs := []string{"im", "+flag-list", "--as", "user", "--page-all", "--dry-run"}
+	if gotArgs := readArgs(t, argsPath); !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("fake CLI args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
 func TestRunDryRunsMaterializesPlaceholdersInsideJSONFlags(t *testing.T) {
 	cliBin, argsPath := fakeDryRunCLI(t, `{"api":[{"method":"GET","url":"/open-apis/im/v1/messages","params":{"chat_id":"oc_test123","page_token":"page_test123"}}]}`)
 	m := manifest.Manifest{Commands: []manifest.Command{{
@@ -792,6 +824,72 @@ func TestAppendDryRunArgForcesInlineJSONFormat(t *testing.T) {
 	want := []string{"vc", "+meeting-events", "--meeting-id", "400000000001", "--format=json", "--dry-run"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("appendDryRunArg() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppendDryRunArgRemovesJQFilter(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "short split",
+			raw:  `lark-cli im +flag-list --page-all -q '.data.flag_items[-1]'`,
+			want: []string{"im", "+flag-list", "--page-all", "--dry-run"},
+		},
+		{
+			name: "long split",
+			raw:  `lark-cli im +flag-list --jq '.data.flag_items[].item_id' --page-all`,
+			want: []string{"im", "+flag-list", "--page-all", "--dry-run"},
+		},
+		{
+			name: "short inline",
+			raw:  `lark-cli im +flag-list -q='.data.flag_items[-1]' --page-all`,
+			want: []string{"im", "+flag-list", "--page-all", "--dry-run"},
+		},
+		{
+			name: "long inline",
+			raw:  `lark-cli im +flag-list --jq='.data.flag_items[-1]' --page-all`,
+			want: []string{"im", "+flag-list", "--page-all", "--dry-run"},
+		},
+		{
+			name: "missing value remains invalid",
+			raw:  `lark-cli im +flag-list --page-all --jq`,
+			want: []string{"im", "+flag-list", "--page-all", "--jq", "--dry-run"},
+		},
+		{
+			name: "next flag is not accepted as jq expression",
+			raw:  `lark-cli im +flag-list --jq --page-all`,
+			want: []string{"im", "+flag-list", "--jq", "--page-all", "--dry-run"},
+		},
+		{
+			name: "invalid expression remains invalid",
+			raw:  `lark-cli im +flag-list --jq 'invalid[' --page-all`,
+			want: []string{"im", "+flag-list", "--jq", "invalid[", "--page-all", "--dry-run"},
+		},
+		{
+			name: "incompatible pretty format remains invalid",
+			raw:  `lark-cli im +flag-list --jq '.data' --format pretty`,
+			want: []string{"im", "+flag-list", "--jq", ".data", "--format", "pretty", "--dry-run"},
+		},
+		{
+			name: "compatible json format preserves request preview",
+			raw:  `lark-cli im +flag-list --jq '.data' --format json`,
+			want: []string{"im", "+flag-list", "--format", "json", "--dry-run"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := appendDryRunArg(tt.raw)
+			if err != nil {
+				t.Fatalf("appendDryRunArg() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("appendDryRunArg() = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

The deterministic quality gate executes documented CLI examples with `--dry-run` to validate their request previews. Examples using `-q` or `--jq` could filter the synthetic dry-run envelope into `null` or fail at runtime, causing valid examples such as those in PR #1906 to be rejected.

This change validates jq-related output flags first, then removes valid jq filters only from the synthetic dry-run invocation so the underlying request preview remains available for validation.

## Changes

- Validate jq syntax and its compatibility with `--format` and `--output` before normalizing dry-run examples.
- Remove valid `-q` and `--jq` filters from synthetic dry-run invocations while preserving the original documented command.
- Keep malformed jq expressions, missing values, and incompatible output combinations intact so the real CLI execution still rejects them.
- Add regression coverage for short, long, split, and inline jq forms, including malformed and conflicting cases.
- Add an end-to-end quality-gate test based on the `im +flag-list` example affected in PR #1906.

## Test Plan

- [x] `go test ./internal/qualitygate/... -count=1`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=upstream/main`
- [x] `QUALITY_GATE_CHANGED_FROM=upstream/main make quality-gate`
- [x] `go mod tidy` produced no changes
- [x] Full local stock-example scan harvested 1,849 examples and executed 207 dry-run previews
- [x] Both existing `im +flag-list -q ...` examples produced the expected `GET /open-apis/im/v1/flags` request preview

The full stock-example scan also reported pre-existing unrelated reference and placeholder-validation findings outside this PR's changed files.

## Related Issues

- Related PR: #1906


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dry-run request previews when commands include valid `jq` output filters.
  * Dry-run validation now ignores output-only filters while preserving the original command’s behavior.
  * Improved compatibility between JSON formatting and dry-run previews.
  * Invalid filters and incompatible output options continue to produce the expected CLI errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->