### PR TITLE
feat: add chat member shortcut

### DIFF
--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -874,7 +874,8 @@ func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f
 }
 
 // runShortcut is the execution pipeline for a declarative shortcut.
-// Each step is a clear phase: identity → config → scopes → context → validate → execute.
+// Each step is a clear phase: identity → config → context → validate →
+// dry-run or confirmation → scopes → execute.
 func runShortcut(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, botOnly bool) error {
 	// --print-schema short-circuits everything below: it's pure local
 	// introspection, no identity / scope / network needed. The flag is
@@ -913,10 +914,6 @@ func runShortcut(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, botOnly bo
 	// Identity info is now included in the JSON envelope; skip stderr printing.
 	// cmdutil.PrintIdentity(f.IOStreams.ErrOut, as, config, false)
 
-	if err := checkShortcutScopes(f, cmd.Context(), as, config, s.ScopesForIdentity(string(as))); err != nil {
-		return err
-	}
-
 	rctx, err := newRuntimeContext(cmd, f, s, config, as, botOnly)
 	if err != nil {
 		return err
@@ -943,6 +940,10 @@ func runShortcut(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, botOnly bo
 
 	if s.Risk == "high-risk-write" && !rctx.Bool("yes") {
 		return cmdutil.RequireConfirmation(s.Service + " " + s.Command)
+	}
+
+	if err := checkShortcutScopes(f, rctx.ctx, as, config, s.ScopesForIdentity(string(as))); err != nil {
+		return err
 	}
 
 	if err := s.Execute(rctx.ctx, rctx); err != nil {

--- a/shortcuts/common/runner_scope_test.go
+++ b/shortcuts/common/runner_scope_test.go
@@ -4,11 +4,15 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -23,6 +27,194 @@ type scopeCheckTokenResolver struct {
 
 func (r *scopeCheckTokenResolver) ResolveToken(ctx context.Context, req credential.TokenSpec) (*credential.TokenResult, error) {
 	return r.result, r.err
+}
+
+type orderedScopeTokenResolver struct {
+	calls  int
+	events *[]string
+	result *credential.TokenResult
+}
+
+func (r *orderedScopeTokenResolver) ResolveToken(_ context.Context, req credential.TokenSpec) (*credential.TokenResult, error) {
+	r.calls++
+	if r.events != nil {
+		*r.events = append(*r.events, "resolve:"+string(req.Type))
+	}
+	return r.result, nil
+}
+
+func TestRunShortcut_HighRiskScopePreflightOrdering(t *testing.T) {
+	tests := []struct {
+		identity  core.Identity
+		tokenType credential.TokenType
+	}{
+		{identity: core.AsUser, tokenType: credential.TokenTypeUAT},
+		{identity: core.AsBot, tokenType: credential.TokenTypeTAT},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.identity), func(t *testing.T) {
+			t.Run("confirmation before scope preflight", func(t *testing.T) {
+				resolver := &orderedScopeTokenResolver{
+					result: &credential.TokenResult{Token: "token", Scopes: "test:write"},
+				}
+				executeCalls := 0
+				shortcut := scopeOrderingShortcut(&executeCalls, nil)
+				factory, cmd := scopeOrderingRuntime(t, shortcut, resolver, tt.identity)
+
+				err := runShortcut(cmd, factory, shortcut, false)
+				problem, ok := errs.ProblemOf(err)
+				if !ok || problem.Subtype != errs.SubtypeConfirmationRequired {
+					t.Fatalf("error = %T %v, want confirmation_required", err, err)
+				}
+				if resolver.calls != 0 {
+					t.Fatalf("token resolver calls = %d, want 0", resolver.calls)
+				}
+				if executeCalls != 0 {
+					t.Fatalf("Execute calls = %d, want 0", executeCalls)
+				}
+			})
+
+			t.Run("dry run before scope preflight", func(t *testing.T) {
+				resolver := &orderedScopeTokenResolver{
+					result: &credential.TokenResult{Token: "token", Scopes: "test:write"},
+				}
+				executeCalls := 0
+				shortcut := scopeOrderingShortcut(&executeCalls, nil)
+				factory, cmd := scopeOrderingRuntime(t, shortcut, resolver, tt.identity)
+				if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+					t.Fatalf("set dry-run: %v", err)
+				}
+
+				if err := runShortcut(cmd, factory, shortcut, false); err != nil {
+					t.Fatalf("runShortcut() error = %v", err)
+				}
+				if resolver.calls != 0 {
+					t.Fatalf("token resolver calls = %d, want 0", resolver.calls)
+				}
+				if executeCalls != 0 {
+					t.Fatalf("Execute calls = %d, want 0", executeCalls)
+				}
+				stdout := factory.IOStreams.Out.(*bytes.Buffer).String()
+				if !strings.Contains(stdout, "/open-apis/test/v1/items") {
+					t.Fatalf("dry-run output has no request preview: %s", stdout)
+				}
+			})
+
+			t.Run("confirmed execution checks scopes first", func(t *testing.T) {
+				events := []string{}
+				resolver := &orderedScopeTokenResolver{
+					events: &events,
+					result: &credential.TokenResult{Token: "token", Scopes: "test:write"},
+				}
+				executeCalls := 0
+				shortcut := scopeOrderingShortcut(&executeCalls, &events)
+				factory, cmd := scopeOrderingRuntime(t, shortcut, resolver, tt.identity)
+				if err := cmd.Flags().Set("yes", "true"); err != nil {
+					t.Fatalf("set yes: %v", err)
+				}
+
+				if err := runShortcut(cmd, factory, shortcut, false); err != nil {
+					t.Fatalf("runShortcut() error = %v", err)
+				}
+				if resolver.calls != 1 {
+					t.Fatalf("token resolver calls = %d, want 1", resolver.calls)
+				}
+				wantEvents := []string{"resolve:" + string(tt.tokenType), "execute"}
+				if !reflect.DeepEqual(events, wantEvents) {
+					t.Fatalf("events = %#v, want %#v", events, wantEvents)
+				}
+			})
+		})
+	}
+}
+
+func TestRunShortcut_LowRiskExecutionStillChecksScopes(t *testing.T) {
+	events := []string{}
+	resolver := &orderedScopeTokenResolver{
+		events: &events,
+		result: &credential.TokenResult{Token: "token", Scopes: "test:write"},
+	}
+	executeCalls := 0
+	shortcut := scopeOrderingShortcut(&executeCalls, &events)
+	shortcut.Risk = "read"
+	factory, cmd := scopeOrderingRuntime(t, shortcut, resolver, core.AsUser)
+
+	if err := runShortcut(cmd, factory, shortcut, false); err != nil {
+		t.Fatalf("runShortcut() error = %v", err)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("token resolver calls = %d, want 1", resolver.calls)
+	}
+	if want := []string{"resolve:uat", "execute"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestRunShortcut_LocalValidationPrecedesScopeAndConfirmation(t *testing.T) {
+	resolver := &orderedScopeTokenResolver{
+		result: &credential.TokenResult{Token: "token", Scopes: "test:write"},
+	}
+	executeCalls := 0
+	shortcut := scopeOrderingShortcut(&executeCalls, nil)
+	shortcut.Flags = append(shortcut.Flags, Flag{Name: "value"})
+	shortcut.Validate = func(_ context.Context, runtime *RuntimeContext) error {
+		if runtime.Str("value") == "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--value is required").WithParam("--value")
+		}
+		return nil
+	}
+	factory, cmd := scopeOrderingRuntime(t, shortcut, resolver, core.AsUser)
+
+	err := runShortcut(cmd, factory, shortcut, false)
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("error = %T %v, want validation invalid_argument", err, err)
+	}
+	if resolver.calls != 0 {
+		t.Fatalf("token resolver calls = %d, want 0", resolver.calls)
+	}
+	if executeCalls != 0 {
+		t.Fatalf("Execute calls = %d, want 0", executeCalls)
+	}
+}
+
+func scopeOrderingShortcut(executeCalls *int, events *[]string) *Shortcut {
+	return &Shortcut{
+		Service:     "test",
+		Command:     "+scope-order",
+		Risk:        "high-risk-write",
+		Scopes:      []string{"test:write"},
+		AuthTypes:   []string{"user", "bot"},
+		Description: "test scope ordering",
+		DryRun: func(_ context.Context, _ *RuntimeContext) *DryRunAPI {
+			return NewDryRunAPI().GET("/open-apis/test/v1/items")
+		},
+		Execute: func(_ context.Context, _ *RuntimeContext) error {
+			(*executeCalls)++
+			if events != nil {
+				*events = append(*events, "execute")
+			}
+			return nil
+		},
+	}
+}
+
+func scopeOrderingRuntime(
+	t *testing.T,
+	shortcut *Shortcut,
+	resolver *orderedScopeTokenResolver,
+	identity core.Identity,
+) (*cmdutil.Factory, *cobra.Command) {
+	t.Helper()
+
+	factory := newTestFactory()
+	factory.Credential = credential.NewCredentialProvider(nil, nil, resolver, nil)
+	cmd := newTestShortcutCmd(shortcut, factory)
+	if err := cmd.Flags().Set("as", string(identity)); err != nil {
+		t.Fatalf("set as: %v", err)
+	}
+	return factory, cmd
 }
 
 // TestEnhancePermissionError_TypedPermissionErrorRouted pins typed routing:

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -651,6 +651,7 @@ func TestShortcuts(t *testing.T) {
 	want := []string{
 		"+chat-create",
 		"+chat-list",
+		"+chat-members-add",
 		"+chat-members-list",
 		"+chat-messages-list",
 		"+chat-search",

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -68,6 +68,7 @@ var ImChatMembersAdd = common.Shortcut{
 	Tips: []string{
 		"At least one of --users or --bots is required; duplicate IDs are removed in first-seen order.",
 		"When both are present, user members are added before bot members in separate requests with succeed_type=1.",
+		"--as user uses the authenticated user's chat membership and invite permissions; --as bot uses the app bot's chat membership and invite permissions.",
 		"Partial member results return ok:false and exit 1; outcome_unknown requires listing current members before retrying.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
@@ -234,6 +235,19 @@ func dedupeChatMemberIDs(ids []string) []string {
 
 func validateChatMembersAddID(param, id, prefix string) error {
 	if !strings.HasPrefix(id, prefix) {
+		if param == "--users" {
+			return errs.NewValidationError(
+				errs.SubtypeInvalidArgument,
+				"invalid user ID format, should start with 'ou_' (e.g., ou_abc123)",
+			).WithParam(param)
+		}
+		if param == "--bots" {
+			return errs.NewValidationError(
+				errs.SubtypeInvalidArgument,
+				"invalid bot id %q: expected app ID (cli_xxx)",
+				id,
+			).WithParam(param)
+		}
 		return errs.NewValidationError(
 			errs.SubtypeInvalidArgument,
 			"invalid %s: identifier must start with %s",

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -4,10 +4,13 @@
 package im
 
 import (
+	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -24,6 +27,39 @@ type chatMembersAddSpec struct {
 	ChatID string
 	Users  []string
 	Bots   []string
+}
+
+type chatMembersAddResponse struct {
+	InvalidIDList         []interface{}
+	NotExistedIDList      []interface{}
+	PendingApprovalIDList []interface{}
+}
+
+type chatMembersAddResult struct {
+	ChatID                string               `json:"chat_id"`
+	SuccessCount          int                  `json:"success_count"`
+	InvalidIDList         []interface{}        `json:"invalid_id_list"`
+	NotExistedIDList      []interface{}        `json:"not_existed_id_list"`
+	PendingApprovalIDList []interface{}        `json:"pending_approval_id_list"`
+	FailedMemberType      string               `json:"failed_member_type,omitempty"`
+	OutcomeUnknown        bool                 `json:"outcome_unknown,omitempty"`
+	Error                 *chatMembersAddError `json:"error,omitempty"`
+}
+
+type chatMembersAddError struct {
+	Type            errs.Category `json:"type"`
+	Subtype         errs.Subtype  `json:"subtype,omitempty"`
+	Code            int           `json:"code,omitempty"`
+	Message         string        `json:"message"`
+	Hint            string        `json:"hint,omitempty"`
+	LogID           string        `json:"log_id,omitempty"`
+	Troubleshooter  string        `json:"troubleshooter,omitempty"`
+	Retryable       bool          `json:"retryable"`
+	MissingScopes   []string      `json:"missing_scopes,omitempty"`
+	RequestedScopes []string      `json:"requested_scopes,omitempty"`
+	GrantedScopes   []string      `json:"granted_scopes,omitempty"`
+	Identity        string        `json:"identity,omitempty"`
+	ConsoleURL      string        `json:"console_url,omitempty"`
 }
 
 func readChatMembersAddSpec(runtime *common.RuntimeContext) (chatMembersAddSpec, error) {
@@ -132,4 +168,126 @@ func validateChatMembersAddID(param, id, prefix string) error {
 		).WithParam(param)
 	}
 	return nil
+}
+
+func buildChatMembersAddDryRun(spec chatMembersAddSpec) *common.DryRunAPI {
+	dryRun := common.NewDryRunAPI()
+	path := fmt.Sprintf(imChatMembersAddPathFormat, validate.EncodePathSegment(spec.ChatID))
+	if len(spec.Users) > 0 {
+		dryRun.POST(path).
+			Params(chatMembersAddParams("open_id")).
+			Body(chatMembersAddBody(spec.Users))
+	}
+	if len(spec.Bots) > 0 {
+		dryRun.POST(path).
+			Params(chatMembersAddParams("app_id")).
+			Body(chatMembersAddBody(spec.Bots))
+	}
+	return dryRun
+}
+
+func executeChatMembersAdd(runtime *common.RuntimeContext, spec chatMembersAddSpec) error {
+	responses := make([]chatMembersAddResponse, 0, 2)
+	if len(spec.Users) > 0 {
+		response, err := callChatMembersAddBatch(runtime, spec.ChatID, "open_id", spec.Users)
+		if err != nil {
+			return err
+		}
+		responses = append(responses, response)
+	}
+	if len(spec.Bots) > 0 {
+		response, err := callChatMembersAddBatch(runtime, spec.ChatID, "app_id", spec.Bots)
+		if err != nil {
+			return err
+		}
+		responses = append(responses, response)
+	}
+
+	merged := mergeChatMembersAddResponse(responses...)
+	result := chatMembersAddResult{
+		ChatID:                spec.ChatID,
+		SuccessCount:          confirmedChatMembersAddCount(len(spec.Users)+len(spec.Bots), merged),
+		InvalidIDList:         merged.InvalidIDList,
+		NotExistedIDList:      merged.NotExistedIDList,
+		PendingApprovalIDList: merged.PendingApprovalIDList,
+	}
+	runtime.Out(result, nil)
+	return nil
+}
+
+func callChatMembersAddBatch(
+	runtime *common.RuntimeContext,
+	chatID string,
+	memberIDType string,
+	ids []string,
+) (chatMembersAddResponse, error) {
+	path := fmt.Sprintf(imChatMembersAddPathFormat, validate.EncodePathSegment(chatID))
+	data, err := runtime.CallAPITyped(
+		http.MethodPost,
+		path,
+		chatMembersAddParams(memberIDType),
+		chatMembersAddBody(ids),
+	)
+	if err != nil {
+		return chatMembersAddResponse{}, err
+	}
+	return projectChatMembersAddResponse(data), nil
+}
+
+func chatMembersAddParams(memberIDType string) map[string]interface{} {
+	return map[string]interface{}{
+		"member_id_type": memberIDType,
+		"succeed_type":   "1",
+	}
+}
+
+func chatMembersAddBody(ids []string) map[string]interface{} {
+	return map[string]interface{}{
+		"id_list": ids,
+	}
+}
+
+func projectChatMembersAddResponse(data map[string]interface{}) chatMembersAddResponse {
+	return chatMembersAddResponse{
+		InvalidIDList:         projectChatMembersAddList(data, "invalid_id_list"),
+		NotExistedIDList:      projectChatMembersAddList(data, "not_existed_id_list"),
+		PendingApprovalIDList: projectChatMembersAddList(data, "pending_approval_id_list"),
+	}
+}
+
+func projectChatMembersAddList(data map[string]interface{}, key string) []interface{} {
+	values, ok := data[key].([]interface{})
+	if !ok {
+		return []interface{}{}
+	}
+	return append([]interface{}{}, values...)
+}
+
+func mergeChatMembersAddResponse(responses ...chatMembersAddResponse) chatMembersAddResponse {
+	merged := chatMembersAddResponse{
+		InvalidIDList:         []interface{}{},
+		NotExistedIDList:      []interface{}{},
+		PendingApprovalIDList: []interface{}{},
+	}
+	for _, response := range responses {
+		merged.InvalidIDList = append(merged.InvalidIDList, response.InvalidIDList...)
+		merged.NotExistedIDList = append(merged.NotExistedIDList, response.NotExistedIDList...)
+		merged.PendingApprovalIDList = append(merged.PendingApprovalIDList, response.PendingApprovalIDList...)
+	}
+	return merged
+}
+
+func confirmedChatMembersAddCount(requested int, response chatMembersAddResponse) int {
+	if requested <= 0 {
+		return 0
+	}
+	unfinished := len(response.InvalidIDList) + len(response.NotExistedIDList) + len(response.PendingApprovalIDList)
+	confirmed := requested - unfinished
+	if confirmed < 0 {
+		return 0
+	}
+	if confirmed > requested {
+		return requested
+	}
+	return confirmed
 }

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -232,9 +232,7 @@ func executeChatMembersAdd(runtime *common.RuntimeContext, spec chatMembersAddSp
 			result.FailedMemberType = "bot"
 			result.OutcomeUnknown = isChatMembersAddOutcomeUnknown(err)
 			result.Error = projectChatMembersAddError(projectedErr, true)
-			if err := writeChatMembersAddProgressWarning(runtime, result.SuccessCount); err != nil {
-				return err
-			}
+			writeChatMembersAddProgressWarning(runtime, result.SuccessCount)
 			return runtime.OutPartialFailure(result, nil)
 		}
 		responses = append(responses, response)
@@ -349,19 +347,13 @@ func isChatMembersAddOutcomeUnknown(err error) bool {
 	return ok && problem.Subtype == errs.SubtypeInvalidResponse
 }
 
-func writeChatMembersAddProgressWarning(runtime *common.RuntimeContext, successCount int) error {
-	if _, err := fmt.Fprintf(
+func writeChatMembersAddProgressWarning(runtime *common.RuntimeContext, successCount int) {
+	// The stdout partial result is authoritative, so a stderr warning failure is best-effort only.
+	_, _ = fmt.Fprintf(
 		runtime.IO().ErrOut,
 		"Added %d user member(s) before the bot member request failed.\n",
 		successCount,
-	); err != nil {
-		return errs.NewInternalError(
-			errs.SubtypeFileIO,
-			"write chat member progress to stderr: %v",
-			err,
-		).WithCause(err)
-	}
-	return nil
+	)
 }
 
 func callChatMembersAddBatch(

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -25,14 +25,28 @@ const (
 	imChatMembersAddBotLimit   = 5
 	imChatMembersAddIDMaxBytes = 256
 
-	imChatMembersAddReadbackHint = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only members not confirmed present."
-	imChatBotsAddReadbackHint    = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only bots not confirmed present."
+	imChatMembersAddReadbackHint = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --member-types user --page-all --page-limit 0 --as <same-identity> before retrying. Treat a member not found as missing only when has_more:false and truncations has no entry for member_type user; otherwise do not retry the unknown batch. Retry only user members not confirmed present."
+	imChatBotsAddReadbackHint    = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --member-types bot --page-all --page-limit 0 --as <same-identity> before retrying. Treat a member not found as missing only when has_more:false and truncations has no entry for member_type bot; otherwise do not retry the unknown batch. Retry only bots not confirmed present."
 )
 
 var (
 	imChatMembersAddIDSuffix             = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
-	errChatMembersAddMissingResponseData = errors.New("chat member response data is missing or invalid")
+	errChatMembersAddMissingResponseData = chatMembersAddInvalidResponseCause{
+		reason: "chat member response data is missing or invalid",
+	}
 )
+
+type chatMembersAddInvalidResponseCause struct {
+	field  string
+	reason string
+}
+
+func (e chatMembersAddInvalidResponseCause) Error() string {
+	if e.field == "" {
+		return e.reason
+	}
+	return e.field + " " + e.reason
+}
 
 type chatMembersAddSpecContextKey struct{}
 
@@ -523,7 +537,7 @@ func projectChatMembersAddList(data map[string]interface{}, key string) ([]strin
 }
 
 func newInvalidChatMembersAddResponseError(field, reason string) error {
-	cause := fmt.Errorf("%s %s", field, reason)
+	cause := chatMembersAddInvalidResponseCause{field: field, reason: reason}
 	return errs.NewInternalError(
 		errs.SubtypeInvalidResponse,
 		"API returned invalid %s",

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -4,6 +4,7 @@
 package im
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,10 +31,64 @@ const (
 
 var imChatMembersAddIDSuffix = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
+type chatMembersAddSpecContextKey struct{}
+
+// ImChatMembersAdd is the +chat-members-add shortcut. User open IDs and bot
+// app IDs are sent in separate requests, with the user request first.
+var ImChatMembersAdd = common.Shortcut{
+	Service:     "im",
+	Command:     "+chat-members-add",
+	Description: "Add user open IDs and bot app IDs to a chat; users are processed first; partial results return ok:false",
+	Risk:        "high-risk-write",
+	Scopes:      []string{"im:chat.members:write_only"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "chat-id", Required: true, Desc: "chat ID or supported chat URL (oc_xxx)"},
+		{Name: "users", Desc: "comma-separated user open IDs (ou_xxx), max 50 unique IDs"},
+		{Name: "bots", Desc: "comma-separated bot app IDs (cli_xxx), max 5 unique IDs"},
+	},
+	Tips: []string{
+		"At least one of --users or --bots is required; duplicate IDs are removed in first-seen order.",
+		"When both are present, user members are added before bot members in separate requests with succeed_type=1.",
+		"Partial member results return ok:false and exit 1; outcome_unknown requires listing current members before retrying.",
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		spec, err := readChatMembersAddSpec(runtime)
+		if err != nil {
+			return err
+		}
+		runtime.Cmd.SetContext(context.WithValue(ctx, chatMembersAddSpecContextKey{}, spec))
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		spec, _ := validatedChatMembersAddSpec(runtime)
+		return buildChatMembersAddDryRun(spec)
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		spec, ok := validatedChatMembersAddSpec(runtime)
+		if !ok {
+			return errs.NewInternalError(
+				errs.SubtypeUnknown,
+				"validated chat member specification is unavailable",
+			)
+		}
+		return executeChatMembersAdd(runtime, spec)
+	},
+}
+
 type chatMembersAddSpec struct {
 	ChatID string
 	Users  []string
 	Bots   []string
+}
+
+func validatedChatMembersAddSpec(runtime *common.RuntimeContext) (chatMembersAddSpec, bool) {
+	if runtime == nil || runtime.Cmd == nil || runtime.Cmd.Context() == nil {
+		return chatMembersAddSpec{}, false
+	}
+	spec, ok := runtime.Cmd.Context().Value(chatMembersAddSpecContextKey{}).(chatMembersAddSpec)
+	return spec, ok
 }
 
 type chatMembersAddResponse struct {

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -29,7 +29,10 @@ const (
 	imChatBotsAddReadbackHint    = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only bots not confirmed present."
 )
 
-var imChatMembersAddIDSuffix = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+var (
+	imChatMembersAddIDSuffix             = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	errChatMembersAddMissingResponseData = errors.New("chat member response data is missing or invalid")
+)
 
 type chatMembersAddSpecContextKey struct{}
 
@@ -429,6 +432,12 @@ func callChatMembersAddBatch(
 	)
 	if err != nil {
 		return chatMembersAddResponse{}, err
+	}
+	if data == nil {
+		return chatMembersAddResponse{}, errs.NewInternalError(
+			errs.SubtypeInvalidResponse,
+			"API returned missing or invalid chat member response data",
+		).WithCause(errChatMembersAddMissingResponseData)
 	}
 	return projectChatMembersAddResponse(data, ids)
 }

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -62,7 +62,10 @@ var ImChatMembersAdd = common.Shortcut{
 		return nil
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		spec, _ := validatedChatMembersAddSpec(runtime)
+		spec, ok := validatedChatMembersAddSpec(runtime)
+		if !ok {
+			return nil
+		}
 		return buildChatMembersAddDryRun(spec)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -4,12 +4,16 @@
 package im
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -19,6 +23,9 @@ const (
 	imChatMembersAddUserLimit  = 50
 	imChatMembersAddBotLimit   = 5
 	imChatMembersAddIDMaxBytes = 256
+
+	imChatMembersAddReadbackHint = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only members not confirmed present."
+	imChatBotsAddReadbackHint    = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only bots not confirmed present."
 )
 
 var imChatMembersAddIDSuffix = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -42,7 +49,7 @@ type chatMembersAddResult struct {
 	NotExistedIDList      []string             `json:"not_existed_id_list"`
 	PendingApprovalIDList []string             `json:"pending_approval_id_list"`
 	FailedMemberType      string               `json:"failed_member_type,omitempty"`
-	OutcomeUnknown        bool                 `json:"outcome_unknown,omitempty"`
+	OutcomeUnknown        bool                 `json:"-"`
 	Error                 *chatMembersAddError `json:"error,omitempty"`
 }
 
@@ -60,6 +67,22 @@ type chatMembersAddError struct {
 	GrantedScopes   []string      `json:"granted_scopes,omitempty"`
 	Identity        string        `json:"identity,omitempty"`
 	ConsoleURL      string        `json:"console_url,omitempty"`
+}
+
+func (r chatMembersAddResult) MarshalJSON() ([]byte, error) {
+	type resultAlias chatMembersAddResult
+	var outcomeUnknown *bool
+	if r.FailedMemberType != "" {
+		value := r.OutcomeUnknown
+		outcomeUnknown = &value
+	}
+	return json.Marshal(struct {
+		resultAlias
+		OutcomeUnknown *bool `json:"outcome_unknown,omitempty"`
+	}{
+		resultAlias:    resultAlias(r),
+		OutcomeUnknown: outcomeUnknown,
+	})
 }
 
 func readChatMembersAddSpec(runtime *common.RuntimeContext) (chatMembersAddSpec, error) {
@@ -188,31 +211,123 @@ func buildChatMembersAddDryRun(spec chatMembersAddSpec) *common.DryRunAPI {
 
 func executeChatMembersAdd(runtime *common.RuntimeContext, spec chatMembersAddSpec) error {
 	responses := make([]chatMembersAddResponse, 0, 2)
+	completedCount := 0
 	if len(spec.Users) > 0 {
 		response, err := callChatMembersAddBatch(runtime, spec.ChatID, "open_id", spec.Users)
 		if err != nil {
-			return err
+			return withChatMembersAddUnknownOutcome(err, false)
 		}
 		responses = append(responses, response)
+		completedCount += len(spec.Users)
 	}
 	if len(spec.Bots) > 0 {
 		response, err := callChatMembersAddBatch(runtime, spec.ChatID, "app_id", spec.Bots)
 		if err != nil {
-			return err
+			if completedCount == 0 {
+				return withChatMembersAddUnknownOutcome(err, true)
+			}
+			projectedErr := withChatMembersAddUnknownOutcome(err, true)
+			merged := mergeChatMembersAddResponse(responses...)
+			result := newChatMembersAddResult(spec.ChatID, completedCount, merged)
+			result.FailedMemberType = "bot"
+			result.OutcomeUnknown = errs.IsNetwork(err)
+			result.Error = projectChatMembersAddError(projectedErr, true)
+			return runtime.OutPartialFailure(result, nil)
 		}
 		responses = append(responses, response)
+		completedCount += len(spec.Bots)
 	}
 
 	merged := mergeChatMembersAddResponse(responses...)
-	result := chatMembersAddResult{
-		ChatID:                spec.ChatID,
-		SuccessCount:          confirmedChatMembersAddCount(len(spec.Users)+len(spec.Bots), merged),
-		InvalidIDList:         merged.InvalidIDList,
-		NotExistedIDList:      merged.NotExistedIDList,
-		PendingApprovalIDList: merged.PendingApprovalIDList,
+	result := newChatMembersAddResult(spec.ChatID, completedCount, merged)
+	if hasUnfinishedChatMembersAdd(result) {
+		return runtime.OutPartialFailure(result, nil)
 	}
-	runtime.Out(result, nil)
+	runtime.OutFormat(result, &output.Meta{Count: result.SuccessCount}, func(w io.Writer) {
+		renderChatMembersAddPretty(w, result)
+	})
 	return nil
+}
+
+func newChatMembersAddResult(chatID string, completedCount int, response chatMembersAddResponse) chatMembersAddResult {
+	return chatMembersAddResult{
+		ChatID:                chatID,
+		SuccessCount:          confirmedChatMembersAddCount(completedCount, response),
+		InvalidIDList:         response.InvalidIDList,
+		NotExistedIDList:      response.NotExistedIDList,
+		PendingApprovalIDList: response.PendingApprovalIDList,
+	}
+}
+
+func hasUnfinishedChatMembersAdd(result chatMembersAddResult) bool {
+	return len(result.InvalidIDList) > 0 ||
+		len(result.NotExistedIDList) > 0 ||
+		len(result.PendingApprovalIDList) > 0
+}
+
+func renderChatMembersAddPretty(w io.Writer, result chatMembersAddResult) {
+	fmt.Fprintf(w, "Chat: %s\n", result.ChatID)
+	fmt.Fprintf(w, "Added members: %d\n", result.SuccessCount)
+}
+
+func withChatMembersAddUnknownOutcome(err error, botBatch bool) error {
+	var networkErr *errs.NetworkError
+	if !errors.As(err, &networkErr) {
+		return err
+	}
+
+	cloned := *networkErr
+	cloned.Problem = networkErr.Problem
+	cloned.Retryable = false
+	cloned.Hint = chatMembersAddUnknownOutcomeHint(botBatch)
+	return &cloned
+}
+
+func projectChatMembersAddError(err error, botBatch bool) *chatMembersAddError {
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		return &chatMembersAddError{
+			Type:      errs.CategoryInternal,
+			Subtype:   errs.SubtypeUnknown,
+			Message:   "member request failed",
+			Retryable: false,
+		}
+	}
+
+	projected := &chatMembersAddError{
+		Type:           problem.Category,
+		Subtype:        problem.Subtype,
+		Code:           problem.Code,
+		Message:        problem.Message,
+		Hint:           problem.Hint,
+		LogID:          problem.LogID,
+		Troubleshooter: problem.Troubleshooter,
+		Retryable:      problem.Retryable,
+	}
+
+	var networkErr *errs.NetworkError
+	if errors.As(err, &networkErr) {
+		projected.Retryable = false
+		projected.Hint = chatMembersAddUnknownOutcomeHint(botBatch)
+	}
+
+	var permissionErr *errs.PermissionError
+	if errors.As(err, &permissionErr) {
+		projected.MissingScopes = append([]string(nil), permissionErr.MissingScopes...)
+		projected.RequestedScopes = append([]string(nil), permissionErr.RequestedScopes...)
+		projected.GrantedScopes = append([]string(nil), permissionErr.GrantedScopes...)
+		projected.Identity = permissionErr.Identity
+		projected.ConsoleURL = permissionErr.ConsoleURL
+	}
+
+	return projected
+}
+
+func chatMembersAddUnknownOutcomeHint(botBatch bool) string {
+	if botBatch {
+		return imChatBotsAddReadbackHint
+	}
+	return imChatMembersAddReadbackHint
 }
 
 func callChatMembersAddBatch(

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -230,8 +230,11 @@ func executeChatMembersAdd(runtime *common.RuntimeContext, spec chatMembersAddSp
 			merged := mergeChatMembersAddResponse(responses...)
 			result := newChatMembersAddResult(spec.ChatID, completedCount, merged)
 			result.FailedMemberType = "bot"
-			result.OutcomeUnknown = errs.IsNetwork(err)
+			result.OutcomeUnknown = isChatMembersAddOutcomeUnknown(err)
 			result.Error = projectChatMembersAddError(projectedErr, true)
+			if err := writeChatMembersAddProgressWarning(runtime, result.SuccessCount); err != nil {
+				return err
+			}
 			return runtime.OutPartialFailure(result, nil)
 		}
 		responses = append(responses, response)
@@ -272,15 +275,24 @@ func renderChatMembersAddPretty(w io.Writer, result chatMembersAddResult) {
 
 func withChatMembersAddUnknownOutcome(err error, botBatch bool) error {
 	var networkErr *errs.NetworkError
-	if !errors.As(err, &networkErr) {
-		return err
+	if errors.As(err, &networkErr) {
+		cloned := *networkErr
+		cloned.Problem = networkErr.Problem
+		cloned.Retryable = false
+		cloned.Hint = chatMembersAddUnknownOutcomeHint(botBatch)
+		return &cloned
 	}
 
-	cloned := *networkErr
-	cloned.Problem = networkErr.Problem
-	cloned.Retryable = false
-	cloned.Hint = chatMembersAddUnknownOutcomeHint(botBatch)
-	return &cloned
+	var internalErr *errs.InternalError
+	if errors.As(err, &internalErr) && internalErr.Subtype == errs.SubtypeInvalidResponse {
+		cloned := *internalErr
+		cloned.Problem = internalErr.Problem
+		cloned.Retryable = false
+		cloned.Hint = chatMembersAddUnknownOutcomeHint(botBatch)
+		return &cloned
+	}
+
+	return err
 }
 
 func projectChatMembersAddError(err error, botBatch bool) *chatMembersAddError {
@@ -305,8 +317,7 @@ func projectChatMembersAddError(err error, botBatch bool) *chatMembersAddError {
 		Retryable:      problem.Retryable,
 	}
 
-	var networkErr *errs.NetworkError
-	if errors.As(err, &networkErr) {
+	if isChatMembersAddOutcomeUnknown(err) {
 		projected.Retryable = false
 		projected.Hint = chatMembersAddUnknownOutcomeHint(botBatch)
 	}
@@ -328,6 +339,29 @@ func chatMembersAddUnknownOutcomeHint(botBatch bool) string {
 		return imChatBotsAddReadbackHint
 	}
 	return imChatMembersAddReadbackHint
+}
+
+func isChatMembersAddOutcomeUnknown(err error) bool {
+	if errs.IsNetwork(err) {
+		return true
+	}
+	problem, ok := errs.ProblemOf(err)
+	return ok && problem.Subtype == errs.SubtypeInvalidResponse
+}
+
+func writeChatMembersAddProgressWarning(runtime *common.RuntimeContext, successCount int) error {
+	if _, err := fmt.Fprintf(
+		runtime.IO().ErrOut,
+		"Added %d user member(s) before the bot member request failed.\n",
+		successCount,
+	); err != nil {
+		return errs.NewInternalError(
+			errs.SubtypeFileIO,
+			"write chat member progress to stderr: %v",
+			err,
+		).WithCause(err)
+	}
+	return nil
 }
 
 func callChatMembersAddBatch(

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const (
+	imChatMembersAddPathFormat = "/open-apis/im/v1/chats/%s/members"
+	imChatMembersAddUserLimit  = 50
+	imChatMembersAddBotLimit   = 5
+	imChatMembersAddIDMaxBytes = 256
+)
+
+var imChatMembersAddIDSuffix = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+type chatMembersAddSpec struct {
+	ChatID string
+	Users  []string
+	Bots   []string
+}
+
+func readChatMembersAddSpec(runtime *common.RuntimeContext) (chatMembersAddSpec, error) {
+	chatID, err := common.ValidateChatIDTyped("--chat-id", runtime.Str("chat-id"))
+	if err != nil {
+		return chatMembersAddSpec{}, err
+	}
+
+	spec := chatMembersAddSpec{
+		ChatID: chatID,
+		Users:  dedupeChatMemberIDs(common.SplitCSV(runtime.Str("users"))),
+		Bots:   dedupeChatMemberIDs(common.SplitCSV(runtime.Str("bots"))),
+	}
+	if len(spec.Users) == 0 && len(spec.Bots) == 0 {
+		return chatMembersAddSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"specify at least one of --users or --bots",
+		).WithParams(
+			errs.InvalidParam{Name: "--users", Reason: "required; specify at least one"},
+			errs.InvalidParam{Name: "--bots", Reason: "required; specify at least one"},
+		)
+	}
+	if len(spec.Users) > imChatMembersAddUserLimit {
+		return chatMembersAddSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--users exceeds the maximum of %d (got %d)",
+			imChatMembersAddUserLimit,
+			len(spec.Users),
+		).WithParam("--users")
+	}
+	if len(spec.Bots) > imChatMembersAddBotLimit {
+		return chatMembersAddSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--bots exceeds the maximum of %d (got %d)",
+			imChatMembersAddBotLimit,
+			len(spec.Bots),
+		).WithParam("--bots")
+	}
+
+	for _, id := range spec.Users {
+		if _, err := common.ValidateUserIDTyped("--users", id); err != nil {
+			return chatMembersAddSpec{}, err
+		}
+		if err := validateChatMembersAddID("--users", id, "ou_"); err != nil {
+			return chatMembersAddSpec{}, err
+		}
+	}
+	for _, id := range spec.Bots {
+		if err := validateChatMembersAddID("--bots", id, "cli_"); err != nil {
+			return chatMembersAddSpec{}, err
+		}
+	}
+
+	return spec, nil
+}
+
+func dedupeChatMemberIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(ids))
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result
+}
+
+func validateChatMembersAddID(param, id, prefix string) error {
+	if !strings.HasPrefix(id, prefix) {
+		return errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"invalid %s value %q: must start with %s",
+			param,
+			id,
+			prefix,
+		).WithParam(param)
+	}
+	if len(id) > imChatMembersAddIDMaxBytes {
+		return errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"invalid %s value: identifier exceeds %d bytes",
+			param,
+			imChatMembersAddIDMaxBytes,
+		).WithParam(param)
+	}
+
+	suffix := strings.TrimPrefix(id, prefix)
+	if !imChatMembersAddIDSuffix.MatchString(suffix) {
+		return errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"invalid %s value %q: identifier suffix must contain only ASCII letters, digits, underscores, or hyphens",
+			param,
+			id,
+		).WithParam(param)
+	}
+	return nil
+}

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -31,6 +31,9 @@ func readChatMembersAddSpec(runtime *common.RuntimeContext) (chatMembersAddSpec,
 	if err != nil {
 		return chatMembersAddSpec{}, err
 	}
+	if err := validateChatMembersAddID("--chat-id", chatID, "oc_"); err != nil {
+		return chatMembersAddSpec{}, err
+	}
 
 	spec := chatMembersAddSpec{
 		ChatID: chatID,
@@ -49,25 +52,23 @@ func readChatMembersAddSpec(runtime *common.RuntimeContext) (chatMembersAddSpec,
 	if len(spec.Users) > imChatMembersAddUserLimit {
 		return chatMembersAddSpec{}, errs.NewValidationError(
 			errs.SubtypeInvalidArgument,
-			"--users exceeds the maximum of %d (got %d)",
+			"--users accepts at most %d unique IDs",
 			imChatMembersAddUserLimit,
-			len(spec.Users),
 		).WithParam("--users")
 	}
 	if len(spec.Bots) > imChatMembersAddBotLimit {
 		return chatMembersAddSpec{}, errs.NewValidationError(
 			errs.SubtypeInvalidArgument,
-			"--bots exceeds the maximum of %d (got %d)",
+			"--bots accepts at most %d unique IDs",
 			imChatMembersAddBotLimit,
-			len(spec.Bots),
 		).WithParam("--bots")
 	}
 
 	for _, id := range spec.Users {
-		if _, err := common.ValidateUserIDTyped("--users", id); err != nil {
+		if err := validateChatMembersAddID("--users", id, "ou_"); err != nil {
 			return chatMembersAddSpec{}, err
 		}
-		if err := validateChatMembersAddID("--users", id, "ou_"); err != nil {
+		if _, err := common.ValidateUserIDTyped("--users", id); err != nil {
 			return chatMembersAddSpec{}, err
 		}
 	}
@@ -101,28 +102,33 @@ func validateChatMembersAddID(param, id, prefix string) error {
 	if !strings.HasPrefix(id, prefix) {
 		return errs.NewValidationError(
 			errs.SubtypeInvalidArgument,
-			"invalid %s value %q: must start with %s",
+			"invalid %s: identifier must start with %s",
 			param,
-			id,
 			prefix,
 		).WithParam(param)
 	}
 	if len(id) > imChatMembersAddIDMaxBytes {
 		return errs.NewValidationError(
 			errs.SubtypeInvalidArgument,
-			"invalid %s value: identifier exceeds %d bytes",
+			"invalid %s: identifier must not exceed %d bytes",
 			param,
 			imChatMembersAddIDMaxBytes,
 		).WithParam(param)
 	}
 
 	suffix := strings.TrimPrefix(id, prefix)
+	if suffix == "" {
+		return errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"invalid %s: identifier suffix cannot be empty",
+			param,
+		).WithParam(param)
+	}
 	if !imChatMembersAddIDSuffix.MatchString(suffix) {
 		return errs.NewValidationError(
 			errs.SubtypeInvalidArgument,
-			"invalid %s value %q: identifier suffix must contain only ASCII letters, digits, underscores, or hyphens",
+			"invalid %s: identifier suffix must use only ASCII letters, digits, underscores, or hyphens",
 			param,
-			id,
 		).WithParam(param)
 	}
 	return nil

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -38,15 +38,15 @@ type chatMembersAddSpecContextKey struct{}
 var ImChatMembersAdd = common.Shortcut{
 	Service:     "im",
 	Command:     "+chat-members-add",
-	Description: "Add user open IDs and bot app IDs to a chat; users are processed first; partial results return ok:false",
+	Description: "Add user open_id values and bot app_id values to a chat; users are processed first; partial results return ok:false",
 	Risk:        "high-risk-write",
 	Scopes:      []string{"im:chat.members:write_only"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "chat-id", Required: true, Desc: "chat ID or supported chat URL (oc_xxx)"},
-		{Name: "users", Desc: "comma-separated user open IDs (ou_xxx), max 50 unique IDs"},
-		{Name: "bots", Desc: "comma-separated bot app IDs (cli_xxx), max 5 unique IDs"},
+		{Name: "users", Desc: "comma-separated user open_id values (ou_xxx), max 50 unique IDs"},
+		{Name: "bots", Desc: "comma-separated bot app_id values (cli_xxx), max 5 unique IDs"},
 	},
 	Tips: []string{
 		"At least one of --users or --bots is required; duplicate IDs are removed in first-seen order.",

--- a/shortcuts/im/im_chat_members_add.go
+++ b/shortcuts/im/im_chat_members_add.go
@@ -30,17 +30,17 @@ type chatMembersAddSpec struct {
 }
 
 type chatMembersAddResponse struct {
-	InvalidIDList         []interface{}
-	NotExistedIDList      []interface{}
-	PendingApprovalIDList []interface{}
+	InvalidIDList         []string
+	NotExistedIDList      []string
+	PendingApprovalIDList []string
 }
 
 type chatMembersAddResult struct {
 	ChatID                string               `json:"chat_id"`
 	SuccessCount          int                  `json:"success_count"`
-	InvalidIDList         []interface{}        `json:"invalid_id_list"`
-	NotExistedIDList      []interface{}        `json:"not_existed_id_list"`
-	PendingApprovalIDList []interface{}        `json:"pending_approval_id_list"`
+	InvalidIDList         []string             `json:"invalid_id_list"`
+	NotExistedIDList      []string             `json:"not_existed_id_list"`
+	PendingApprovalIDList []string             `json:"pending_approval_id_list"`
 	FailedMemberType      string               `json:"failed_member_type,omitempty"`
 	OutcomeUnknown        bool                 `json:"outcome_unknown,omitempty"`
 	Error                 *chatMembersAddError `json:"error,omitempty"`
@@ -231,7 +231,7 @@ func callChatMembersAddBatch(
 	if err != nil {
 		return chatMembersAddResponse{}, err
 	}
-	return projectChatMembersAddResponse(data), nil
+	return projectChatMembersAddResponse(data, ids)
 }
 
 func chatMembersAddParams(memberIDType string) map[string]interface{} {
@@ -247,27 +247,87 @@ func chatMembersAddBody(ids []string) map[string]interface{} {
 	}
 }
 
-func projectChatMembersAddResponse(data map[string]interface{}) chatMembersAddResponse {
-	return chatMembersAddResponse{
-		InvalidIDList:         projectChatMembersAddList(data, "invalid_id_list"),
-		NotExistedIDList:      projectChatMembersAddList(data, "not_existed_id_list"),
-		PendingApprovalIDList: projectChatMembersAddList(data, "pending_approval_id_list"),
+func projectChatMembersAddResponse(data map[string]interface{}, requestedIDs []string) (chatMembersAddResponse, error) {
+	response := chatMembersAddResponse{}
+	fields := []struct {
+		name   string
+		target *[]string
+	}{
+		{name: "invalid_id_list", target: &response.InvalidIDList},
+		{name: "not_existed_id_list", target: &response.NotExistedIDList},
+		{name: "pending_approval_id_list", target: &response.PendingApprovalIDList},
+	}
+
+	requested := make(map[string]struct{}, len(requestedIDs))
+	for _, id := range requestedIDs {
+		requested[id] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+
+	for _, field := range fields {
+		values, err := projectChatMembersAddList(data, field.name)
+		if err != nil {
+			return chatMembersAddResponse{}, err
+		}
+		for _, id := range values {
+			if _, ok := requested[id]; !ok {
+				return chatMembersAddResponse{}, newInvalidChatMembersAddResponseError(
+					field.name,
+					"contains an identifier outside the request",
+				)
+			}
+			if _, ok := seen[id]; ok {
+				return chatMembersAddResponse{}, newInvalidChatMembersAddResponseError(
+					field.name,
+					"contains a duplicate identifier",
+				)
+			}
+			seen[id] = struct{}{}
+		}
+		*field.target = values
+	}
+
+	return response, nil
+}
+
+func projectChatMembersAddList(data map[string]interface{}, key string) ([]string, error) {
+	raw, exists := data[key]
+	if !exists {
+		return []string{}, nil
+	}
+
+	switch values := raw.(type) {
+	case []string:
+		return append([]string{}, values...), nil
+	case []interface{}:
+		result := make([]string, 0, len(values))
+		for _, value := range values {
+			id, ok := value.(string)
+			if !ok {
+				return nil, newInvalidChatMembersAddResponseError(key, "contains a non-string element")
+			}
+			result = append(result, id)
+		}
+		return result, nil
+	default:
+		return nil, newInvalidChatMembersAddResponseError(key, "is not an array of strings")
 	}
 }
 
-func projectChatMembersAddList(data map[string]interface{}, key string) []interface{} {
-	values, ok := data[key].([]interface{})
-	if !ok {
-		return []interface{}{}
-	}
-	return append([]interface{}{}, values...)
+func newInvalidChatMembersAddResponseError(field, reason string) error {
+	cause := fmt.Errorf("%s %s", field, reason)
+	return errs.NewInternalError(
+		errs.SubtypeInvalidResponse,
+		"API returned invalid %s",
+		field,
+	).WithCause(cause)
 }
 
 func mergeChatMembersAddResponse(responses ...chatMembersAddResponse) chatMembersAddResponse {
 	merged := chatMembersAddResponse{
-		InvalidIDList:         []interface{}{},
-		NotExistedIDList:      []interface{}{},
-		PendingApprovalIDList: []interface{}{},
+		InvalidIDList:         []string{},
+		NotExistedIDList:      []string{},
+		PendingApprovalIDList: []string{},
 	}
 	for _, response := range responses {
 		merged.InvalidIDList = append(merged.InvalidIDList, response.InvalidIDList...)

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -37,6 +37,10 @@ func TestImChatMembersAddMetadata(t *testing.T) {
 	if ImChatMembersAdd.Command != "+chat-members-add" {
 		t.Fatalf("Command = %q, want +chat-members-add", ImChatMembersAdd.Command)
 	}
+	wantDescription := "Add user open_id values and bot app_id values to a chat; users are processed first; partial results return ok:false"
+	if ImChatMembersAdd.Description != wantDescription {
+		t.Fatalf("Description = %q, want %q", ImChatMembersAdd.Description, wantDescription)
+	}
 	if ImChatMembersAdd.Risk != "high-risk-write" {
 		t.Fatalf("Risk = %q, want high-risk-write", ImChatMembersAdd.Risk)
 	}
@@ -60,11 +64,19 @@ func TestImChatMembersAddMetadata(t *testing.T) {
 
 	wantFlags := []common.Flag{
 		{Name: "chat-id", Required: true, Desc: "chat ID or supported chat URL (oc_xxx)"},
-		{Name: "users", Desc: "comma-separated user open IDs (ou_xxx), max 50 unique IDs"},
-		{Name: "bots", Desc: "comma-separated bot app IDs (cli_xxx), max 5 unique IDs"},
+		{Name: "users", Desc: "comma-separated user open_id values (ou_xxx), max 50 unique IDs"},
+		{Name: "bots", Desc: "comma-separated bot app_id values (cli_xxx), max 5 unique IDs"},
 	}
 	if !reflect.DeepEqual(ImChatMembersAdd.Flags, wantFlags) {
 		t.Fatalf("Flags = %#v, want %#v", ImChatMembersAdd.Flags, wantFlags)
+	}
+	wantTips := []string{
+		"At least one of --users or --bots is required; duplicate IDs are removed in first-seen order.",
+		"When both are present, user members are added before bot members in separate requests with succeed_type=1.",
+		"Partial member results return ok:false and exit 1; outcome_unknown requires listing current members before retrying.",
+	}
+	if !reflect.DeepEqual(ImChatMembersAdd.Tips, wantTips) {
+		t.Fatalf("Tips = %#v, want %#v", ImChatMembersAdd.Tips, wantTips)
 	}
 }
 

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -733,6 +733,10 @@ func TestExecuteChatMembersAddReturnsPriorResultWhenBotRequestFails(t *testing.T
 		t.Fatal("error.message is empty")
 	}
 	errOut := chatMembersAddStderr(t, runtime)
+	wantErrOut := "Added 1 user member(s) before the bot member request failed.\n"
+	if errOut != wantErrOut {
+		t.Fatalf("stderr = %q, want %q", errOut, wantErrOut)
+	}
 	if strings.Contains(errOut, "ou_") || strings.Contains(errOut, "cli_") || strings.Contains(errOut, "PermissionError") {
 		t.Fatalf("stderr exposes member data or an error object: %q", errOut)
 	}
@@ -775,8 +779,8 @@ func TestExecuteChatMembersAddReturnsPriorResultWhenBotResponseIsInvalid(t *test
 	if data["chat_id"] != "oc_test" {
 		t.Fatalf("chat_id = %#v, want %q", data["chat_id"], "oc_test")
 	}
-	if data["failed_member_type"] != "bot" || data["outcome_unknown"] != false {
-		t.Fatalf("failure metadata = %#v, want failed bot with known outcome", data)
+	if data["failed_member_type"] != "bot" || data["outcome_unknown"] != true {
+		t.Fatalf("failure metadata = %#v, want failed bot with unknown outcome", data)
 	}
 	if got := int(data["success_count"].(float64)); got != 1 {
 		t.Fatalf("success_count = %d, want 1", got)
@@ -791,6 +795,185 @@ func TestExecuteChatMembersAddReturnsPriorResultWhenBotResponseIsInvalid(t *test
 	}
 	if got := errorData["subtype"]; got != string(errs.SubtypeInvalidResponse) {
 		t.Fatalf("error.subtype = %#v, want %q", got, errs.SubtypeInvalidResponse)
+	}
+	if retryable, ok := errorData["retryable"].(bool); !ok || retryable {
+		t.Fatalf("error.retryable = %#v, want false", errorData["retryable"])
+	}
+	hint, _ := errorData["hint"].(string)
+	assertChatMembersAddReadbackHint(t, hint, true)
+	wantErrOut := "Added 1 user member(s) before the bot member request failed.\n"
+	if got := chatMembersAddStderr(t, runtime); got != wantErrOut {
+		t.Fatalf("stderr = %q, want %q", got, wantErrOut)
+	}
+}
+
+func TestExecuteChatMembersAddMarksMalformedBotResponsesUnknown(t *testing.T) {
+	tests := []struct {
+		name     string
+		response func() *http.Response
+	}{
+		{
+			name: "invalid JSON",
+			response: func() *http.Response {
+				return shortcutRawResponse(http.StatusOK, []byte(`{"code":`), http.Header{
+					"Content-Type": []string{"application/json"},
+				})
+			},
+		},
+		{
+			name: "non-object JSON",
+			response: func() *http.Response {
+				return shortcutRawResponse(http.StatusOK, []byte(`[]`), http.Header{
+					"Content-Type": []string{"application/json"},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requestCount++
+				if requestCount == 1 {
+					return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+						"code": 0,
+						"data": map[string]interface{}{},
+					}), nil
+				}
+				return tt.response(), nil
+			}))
+			setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok", "cli_private")
+
+			err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+				ChatID: "oc_test",
+				Users:  []string{"ou_ok"},
+				Bots:   []string{"cli_private"},
+			})
+			assertChatMembersAddPartialFailure(t, err)
+			data := decodeChatMembersAddPartialOutput(t, runtime)
+			if data["failed_member_type"] != "bot" || data["outcome_unknown"] != true {
+				t.Fatalf("failure metadata = %#v, want failed bot with unknown outcome", data)
+			}
+			if got := int(data["success_count"].(float64)); got != 1 {
+				t.Fatalf("success_count = %d, want 1", got)
+			}
+			assertChatMembersAddOutputLists(t, data, []string{}, []string{}, []string{})
+			errorData := data["error"].(map[string]interface{})
+			if errorData["type"] != string(errs.CategoryInternal) || errorData["subtype"] != string(errs.SubtypeInvalidResponse) {
+				t.Fatalf("error projection = %#v, want internal/invalid_response", errorData)
+			}
+			if retryable, ok := errorData["retryable"].(bool); !ok || retryable {
+				t.Fatalf("error.retryable = %#v, want false", errorData["retryable"])
+			}
+			assertChatMembersAddReadbackHint(t, errorData["hint"].(string), true)
+			wantErrOut := "Added 1 user member(s) before the bot member request failed.\n"
+			if got := chatMembersAddStderr(t, runtime); got != wantErrOut {
+				t.Fatalf("stderr = %q, want %q", got, wantErrOut)
+			}
+		})
+	}
+}
+
+func TestExecuteChatMembersAddDisablesRetryForInvalidFirstResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		botBatch bool
+		response func() *http.Response
+	}{
+		{
+			name: "invalid user JSON",
+			response: func() *http.Response {
+				return shortcutRawResponse(http.StatusOK, []byte(`{"code":`), http.Header{
+					"Content-Type": []string{"application/json"},
+				})
+			},
+		},
+		{
+			name:     "non-object bot JSON",
+			botBatch: true,
+			response: func() *http.Response {
+				return shortcutRawResponse(http.StatusOK, []byte(`[]`), http.Header{
+					"Content-Type": []string{"application/json"},
+				})
+			},
+		},
+		{
+			name: "invalid user member list",
+			response: func() *http.Response {
+				return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+					"code": 0,
+					"data": map[string]interface{}{"invalid_id_list": "invalid-response-shape"},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return tt.response(), nil
+			})
+			spec := chatMembersAddSpec{ChatID: "oc_test", Users: []string{"ou_private"}}
+			runtime := newUserShortcutRuntime(t, transport)
+			if tt.botBatch {
+				spec = chatMembersAddSpec{ChatID: "oc_test", Bots: []string{"cli_private"}}
+				runtime = newBotShortcutRuntime(t, transport)
+			}
+			setChatMembersAddTestFlags(t, runtime, "oc_test", strings.Join(spec.Users, ","), strings.Join(spec.Bots, ","))
+
+			err := executeChatMembersAdd(runtime, spec)
+			var internalErr *errs.InternalError
+			if !errors.As(err, &internalErr) {
+				t.Fatalf("error = %T, want *errs.InternalError", err)
+			}
+			if internalErr.Subtype != errs.SubtypeInvalidResponse || internalErr.Retryable {
+				t.Fatalf("problem = %#v, want non-retryable invalid_response", internalErr.Problem)
+			}
+			assertChatMembersAddReadbackHint(t, internalErr.Hint, tt.botBatch)
+			if errors.Unwrap(internalErr) == nil {
+				t.Fatal("invalid response cause was not preserved")
+			}
+			if got := chatMembersAddStdout(t, runtime); got != "" {
+				t.Fatalf("stdout = %q, want empty", got)
+			}
+			if got := chatMembersAddStderr(t, runtime); got != "" {
+				t.Fatalf("stderr = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestWithChatMembersAddUnknownOutcomeCopiesInvalidResponseError(t *testing.T) {
+	cause := errors.New("invalid response cause")
+	source := errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid response").
+		WithHint("inspect raw response").
+		WithLogID("log-invalid-response").
+		WithCode(502).
+		WithRetryable().
+		WithCause(cause)
+	source.Troubleshooter = "https://example.invalid/invalid-response-help"
+
+	err := withChatMembersAddUnknownOutcome(source, false)
+	var got *errs.InternalError
+	if !errors.As(err, &got) {
+		t.Fatalf("error = %T, want *errs.InternalError", err)
+	}
+	if got == source {
+		t.Fatal("withChatMembersAddUnknownOutcome() returned the source pointer")
+	}
+	if got.Category != source.Category || got.Subtype != source.Subtype || got.Code != source.Code || got.Message != source.Message || got.LogID != source.LogID || got.Troubleshooter != source.Troubleshooter {
+		t.Fatalf("internal problem = %#v, want source metadata preserved", got.Problem)
+	}
+	if got.Retryable {
+		t.Fatal("invalid response Retryable = true, want false")
+	}
+	assertChatMembersAddReadbackHint(t, got.Hint, false)
+	if !errors.Is(got, cause) {
+		t.Fatal("invalid response cause was not preserved")
+	}
+	if source.Hint != "inspect raw response" || !source.Retryable {
+		t.Fatalf("source invalid response error was mutated: %#v", source.Problem)
 	}
 }
 
@@ -829,7 +1012,7 @@ func TestProjectChatMembersAddErrorCopiesPermissionFields(t *testing.T) {
 
 func TestWithChatMembersAddUnknownOutcomePreservesDeterministicError(t *testing.T) {
 	cause := errors.New("permission cause")
-	source := errs.NewPermissionError(errs.SubtypeMissingScope, "permission denied").WithCause(cause)
+	source := errs.NewPermissionError(errs.SubtypeMissingScope, "permission denied").WithRetryable().WithCause(cause)
 
 	got := withChatMembersAddUnknownOutcome(source, false)
 	if got != source {
@@ -837,6 +1020,9 @@ func TestWithChatMembersAddUnknownOutcomePreservesDeterministicError(t *testing.
 	}
 	if !errors.Is(got, cause) {
 		t.Fatal("deterministic error cause was not preserved")
+	}
+	if !source.Retryable {
+		t.Fatal("deterministic error retryable field changed")
 	}
 }
 
@@ -909,6 +1095,49 @@ func TestExecuteChatMembersAddMarksBotNetworkOutcomeUnknown(t *testing.T) {
 	assertChatMembersAddReadbackHint(t, hint, true)
 	if _, exists := errorData["cause"]; exists {
 		t.Fatal("serialized error projection contains cause")
+	}
+	wantErrOut := "Added 1 user member(s) before the bot member request failed.\n"
+	if got := chatMembersAddStderr(t, runtime); got != wantErrOut {
+		t.Fatalf("stderr = %q, want %q", got, wantErrOut)
+	}
+}
+
+func TestExecuteChatMembersAddReturnsTypedErrorWhenProgressWarningFails(t *testing.T) {
+	requestCount := 0
+	writeCause := errors.New("stderr write failed")
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{},
+			}), nil
+		}
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 99991672,
+			"msg":  "app scope not applied",
+		}), nil
+	}))
+	runtime.Factory.IOStreams.ErrOut = chatMembersAddFailingWriter{err: writeCause}
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_ok"},
+		Bots:   []string{"cli_private"},
+	})
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeFileIO {
+		t.Fatalf("error subtype = %q, want %q", internalErr.Subtype, errs.SubtypeFileIO)
+	}
+	if !errors.Is(err, writeCause) {
+		t.Fatal("stderr write error cause was not preserved")
+	}
+	if got := chatMembersAddStdout(t, runtime); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
 	}
 }
 
@@ -1092,6 +1321,14 @@ func chatMembersAddStderr(t *testing.T, runtime *common.RuntimeContext) string {
 		t.Fatalf("stderr buffer has type %T", runtime.Factory.IOStreams.ErrOut)
 	}
 	return errOut.String()
+}
+
+type chatMembersAddFailingWriter struct {
+	err error
+}
+
+func (w chatMembersAddFailingWriter) Write([]byte) (int, error) {
+	return 0, w.err
 }
 
 func TestProjectChatMembersAddResponseUsesEmptySlices(t *testing.T) {

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -1102,7 +1102,7 @@ func TestExecuteChatMembersAddMarksBotNetworkOutcomeUnknown(t *testing.T) {
 	}
 }
 
-func TestExecuteChatMembersAddReturnsTypedErrorWhenProgressWarningFails(t *testing.T) {
+func TestExecuteChatMembersAddPreservesPartialResultWhenProgressWarningFails(t *testing.T) {
 	requestCount := 0
 	writeCause := errors.New("stderr write failed")
 	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -1118,7 +1118,8 @@ func TestExecuteChatMembersAddReturnsTypedErrorWhenProgressWarningFails(t *testi
 			"msg":  "app scope not applied",
 		}), nil
 	}))
-	runtime.Factory.IOStreams.ErrOut = chatMembersAddFailingWriter{err: writeCause}
+	failingWriter := &chatMembersAddFailingWriter{err: writeCause}
+	runtime.Factory.IOStreams.ErrOut = failingWriter
 	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok", "cli_private")
 
 	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
@@ -1126,18 +1127,22 @@ func TestExecuteChatMembersAddReturnsTypedErrorWhenProgressWarningFails(t *testi
 		Users:  []string{"ou_ok"},
 		Bots:   []string{"cli_private"},
 	})
-	var internalErr *errs.InternalError
-	if !errors.As(err, &internalErr) {
-		t.Fatalf("error = %T, want *errs.InternalError", err)
+	assertChatMembersAddPartialFailure(t, err)
+	data := decodeChatMembersAddPartialOutput(t, runtime)
+	if data["chat_id"] != "oc_test" || int(data["success_count"].(float64)) != 1 {
+		t.Fatalf("partial result = %#v, want chat and one confirmed user", data)
 	}
-	if internalErr.Subtype != errs.SubtypeFileIO {
-		t.Fatalf("error subtype = %q, want %q", internalErr.Subtype, errs.SubtypeFileIO)
+	if data["failed_member_type"] != "bot" || data["outcome_unknown"] != false {
+		t.Fatalf("failure metadata = %#v, want deterministic bot failure", data)
 	}
-	if !errors.Is(err, writeCause) {
-		t.Fatal("stderr write error cause was not preserved")
+	assertChatMembersAddOutputLists(t, data, []string{}, []string{}, []string{})
+	errorData, ok := data["error"].(map[string]interface{})
+	if !ok || errorData["type"] != string(errs.CategoryAuthorization) {
+		t.Fatalf("error projection = %#v, want authorization error", data["error"])
 	}
-	if got := chatMembersAddStdout(t, runtime); got != "" {
-		t.Fatalf("stdout = %q, want empty", got)
+	wantWarning := "Added 1 user member(s) before the bot member request failed.\n"
+	if len(failingWriter.attempts) != 1 || failingWriter.attempts[0] != wantWarning {
+		t.Fatalf("stderr attempts = %#v, want one warning", failingWriter.attempts)
 	}
 }
 
@@ -1324,10 +1329,12 @@ func chatMembersAddStderr(t *testing.T, runtime *common.RuntimeContext) string {
 }
 
 type chatMembersAddFailingWriter struct {
-	err error
+	err      error
+	attempts []string
 }
 
-func (w chatMembersAddFailingWriter) Write([]byte) (int, error) {
+func (w *chatMembersAddFailingWriter) Write(p []byte) (int, error) {
+	w.attempts = append(w.attempts, string(p))
 	return 0, w.err
 }
 

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -1676,13 +1676,35 @@ func assertChatMembersAddOutputLists(t *testing.T, data map[string]interface{}, 
 
 func assertChatMembersAddReadbackHint(t *testing.T, hint string, botsOnly bool) {
 	t.Helper()
-	for _, want := range []string{"im +chat-members-list", "--chat-id <chat_id>", "--page-all", "only"} {
+	wantHint := "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --member-types user --page-all --page-limit 0 --as <same-identity> before retrying. Treat a member not found as missing only when has_more:false and truncations has no entry for member_type user; otherwise do not retry the unknown batch. Retry only user members not confirmed present."
+	wantMemberType := "user"
+	if botsOnly {
+		wantHint = "List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --member-types bot --page-all --page-limit 0 --as <same-identity> before retrying. Treat a member not found as missing only when has_more:false and truncations has no entry for member_type bot; otherwise do not retry the unknown batch. Retry only bots not confirmed present."
+		wantMemberType = "bot"
+	}
+	if hint != wantHint {
+		t.Errorf("hint = %q, want %q", hint, wantHint)
+	}
+	for _, want := range []string{
+		"im +chat-members-list",
+		"--chat-id <chat_id>",
+		"--member-types " + wantMemberType,
+		"--page-all",
+		"--page-limit 0",
+		"--as <same-identity>",
+		"has_more:false",
+		"truncations",
+		"member_type " + wantMemberType,
+		"only",
+	} {
 		if !strings.Contains(hint, want) {
 			t.Errorf("hint = %q, want substring %q", hint, want)
 		}
 	}
-	if botsOnly && !strings.Contains(strings.ToLower(hint), "bot") {
-		t.Errorf("hint = %q, want bot-specific retry guidance", hint)
+	for _, prohibited := range []string{"oc_test", "ou_", "cli_", "tenant-token", "test-secret", "invalid-data-shape"} {
+		if strings.Contains(hint, prohibited) {
+			t.Errorf("hint contains protected runtime data %q", prohibited)
+		}
 	}
 }
 

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -5,6 +5,7 @@ package im
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -25,12 +26,13 @@ func TestReadChatMembersAddSpec(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		chatID     string
-		users      string
-		bots       string
-		wantParam  string
-		wantParams []string
+		name        string
+		chatID      string
+		users       string
+		bots        string
+		wantParam   string
+		wantParams  []string
+		wantMessage string
 	}{
 		{
 			name:      "missing chat",
@@ -38,9 +40,40 @@ func TestReadChatMembersAddSpec(t *testing.T) {
 			wantParam: "--chat-id",
 		},
 		{
-			name:       "missing members",
-			chatID:     "oc_chat_a",
-			wantParams: []string{"--users", "--bots"},
+			name:        "missing members",
+			chatID:      "oc_chat_a",
+			wantParams:  []string{"--users", "--bots"},
+			wantMessage: "specify at least one of --users or --bots",
+		},
+		{
+			name:      "chat control character",
+			chatID:    "oc_chat\x00a",
+			users:     "ou_user_a",
+			wantParam: "--chat-id",
+		},
+		{
+			name:      "chat unicode suffix",
+			chatID:    "oc_群聊",
+			users:     "ou_user_a",
+			wantParam: "--chat-id",
+		},
+		{
+			name:      "chat URL metacharacter",
+			chatID:    "oc_chat?mode=admin",
+			users:     "ou_user_a",
+			wantParam: "--chat-id",
+		},
+		{
+			name:      "chat identifier too long",
+			chatID:    "oc_" + strings.Repeat("a", imChatMembersAddIDMaxBytes-2),
+			users:     "ou_user_a",
+			wantParam: "--chat-id",
+		},
+		{
+			name:      "chat URL token receives local validation",
+			chatID:    "https://tenant.feishu.cn/messenger/chat/oc_chat?mode=admin",
+			users:     "ou_user_a",
+			wantParam: "--chat-id",
 		},
 		{
 			name:      "invalid user prefix",
@@ -91,16 +124,18 @@ func TestReadChatMembersAddSpec(t *testing.T) {
 			wantParam: "--bots",
 		},
 		{
-			name:      "too many users",
-			chatID:    "oc_chat_a",
-			users:     strings.Join(userIDsOverLimit, ","),
-			wantParam: "--users",
+			name:        "too many users",
+			chatID:      "oc_chat_a",
+			users:       strings.Join(userIDsOverLimit, ","),
+			wantParam:   "--users",
+			wantMessage: "--users accepts at most 50 unique IDs",
 		},
 		{
-			name:      "too many bots",
-			chatID:    "oc_chat_a",
-			bots:      strings.Join(botIDsOverLimit, ","),
-			wantParam: "--bots",
+			name:        "too many bots",
+			chatID:      "oc_chat_a",
+			bots:        strings.Join(botIDsOverLimit, ","),
+			wantParam:   "--bots",
+			wantMessage: "--bots accepts at most 5 unique IDs",
 		},
 	}
 
@@ -108,7 +143,112 @@ func TestReadChatMembersAddSpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			runtime := newChatMembersAddTestRuntime(t, tt.chatID, tt.users, tt.bots)
 			_, err := readChatMembersAddSpec(runtime)
-			assertChatMembersAddValidationError(t, err, tt.wantParam, tt.wantParams)
+			assertChatMembersAddValidationError(t, err, tt.wantParam, tt.wantParams, tt.wantMessage)
+		})
+	}
+}
+
+func TestReadChatMembersAddSpecAcceptsNormalizedChatURL(t *testing.T) {
+	runtime := newChatMembersAddTestRuntime(
+		t,
+		"https://tenant.feishu.cn/messenger/chat/oc_chat_a",
+		"ou_user_a",
+		"",
+	)
+
+	got, err := readChatMembersAddSpec(runtime)
+	if err != nil {
+		t.Fatalf("readChatMembersAddSpec() error = %v", err)
+	}
+	if got.ChatID != "oc_chat_a" {
+		t.Fatalf("ChatID = %q, want %q", got.ChatID, "oc_chat_a")
+	}
+}
+
+func TestReadChatMembersAddSpecCountsUniqueIDs(t *testing.T) {
+	usersAtLimit := makeChatMembersAddIDs("ou_user_", imChatMembersAddUserLimit)
+	botsAtLimit := makeChatMembersAddIDs("cli_bot_", imChatMembersAddBotLimit)
+
+	tests := []struct {
+		name      string
+		users     []string
+		bots      []string
+		wantUsers int
+		wantBots  int
+	}{
+		{
+			name:      "51 user entries with one duplicate",
+			users:     append(append([]string(nil), usersAtLimit...), usersAtLimit[0]),
+			wantUsers: imChatMembersAddUserLimit,
+		},
+		{
+			name:     "6 bot entries with one duplicate",
+			bots:     append(append([]string(nil), botsAtLimit...), botsAtLimit[0]),
+			wantBots: imChatMembersAddBotLimit,
+		},
+		{
+			name:      "exact user and bot limits",
+			users:     usersAtLimit,
+			bots:      botsAtLimit,
+			wantUsers: imChatMembersAddUserLimit,
+			wantBots:  imChatMembersAddBotLimit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := newChatMembersAddTestRuntime(
+				t,
+				"oc_chat_a",
+				strings.Join(tt.users, ","),
+				strings.Join(tt.bots, ","),
+			)
+			got, err := readChatMembersAddSpec(runtime)
+			if err != nil {
+				t.Fatalf("readChatMembersAddSpec() error = %v", err)
+			}
+			if len(got.Users) != tt.wantUsers || len(got.Bots) != tt.wantBots {
+				t.Fatalf(
+					"member counts = users %d bots %d, want users %d bots %d",
+					len(got.Users),
+					len(got.Bots),
+					tt.wantUsers,
+					tt.wantBots,
+				)
+			}
+		})
+	}
+}
+
+func TestReadChatMembersAddSpecErrorsDoNotEchoMemberIDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		users string
+		bots  string
+		rawID string
+	}{
+		{
+			name:  "invalid user characters",
+			users: "ou_private@example.com",
+			rawID: "ou_private@example.com",
+		},
+		{
+			name:  "invalid bot characters",
+			bots:  "cli_private@example.com",
+			rawID: "cli_private@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := newChatMembersAddTestRuntime(t, "oc_chat_a", tt.users, tt.bots)
+			_, err := readChatMembersAddSpec(runtime)
+			if err == nil {
+				t.Fatal("readChatMembersAddSpec() error = nil, want validation error")
+			}
+			if strings.Contains(err.Error(), tt.rawID) {
+				t.Fatalf("error message contains the member identifier: %q", err.Error())
+			}
 		})
 	}
 }
@@ -163,7 +303,15 @@ func newChatMembersAddTestRuntime(t *testing.T, chatID, users, bots string) *com
 	return &common.RuntimeContext{Cmd: cmd}
 }
 
-func assertChatMembersAddValidationError(t *testing.T, err error, wantParam string, wantParams []string) {
+func makeChatMembersAddIDs(prefix string, count int) []string {
+	ids := make([]string, count)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%s%d", prefix, i)
+	}
+	return ids
+}
+
+func assertChatMembersAddValidationError(t *testing.T, err error, wantParam string, wantParams []string, wantMessage string) {
 	t.Helper()
 
 	var validationErr *errs.ValidationError
@@ -192,5 +340,8 @@ func assertChatMembersAddValidationError(t *testing.T, err error, wantParam stri
 	}
 	if !reflect.DeepEqual(gotParams, wantParams) {
 		t.Fatalf("Params = %#v, want %#v", gotParams, wantParams)
+	}
+	if wantMessage != "" && validationErr.Error() != wantMessage {
+		t.Fatalf("error message = %q, want %q", validationErr.Error(), wantMessage)
 	}
 }

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -4,6 +4,7 @@
 package im
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -570,7 +571,10 @@ func TestExecuteChatMembersAddPassesThroughUserAPIError(t *testing.T) {
 }
 
 func TestProjectChatMembersAddResponseUsesEmptySlices(t *testing.T) {
-	got := projectChatMembersAddResponse(map[string]interface{}{})
+	got, err := projectChatMembersAddResponse(map[string]interface{}{}, []string{"ou_a"})
+	if err != nil {
+		t.Fatalf("projectChatMembersAddResponse() error = %v", err)
+	}
 	if got.InvalidIDList == nil || got.NotExistedIDList == nil || got.PendingApprovalIDList == nil {
 		t.Fatalf("projectChatMembersAddResponse() = %#v, want non-nil empty slices", got)
 	}
@@ -581,48 +585,126 @@ func TestProjectChatMembersAddResponseUsesEmptySlices(t *testing.T) {
 
 func TestProjectChatMembersAddResponsePreservesAllLists(t *testing.T) {
 	data := map[string]interface{}{
-		"invalid_id_list": []interface{}{
-			map[string]interface{}{"id": "first-invalid", "reason": "invalid"},
-			map[string]interface{}{"id": "second-invalid", "reason": "invalid"},
-		},
-		"not_existed_id_list": []interface{}{
-			map[string]interface{}{"id": "first-missing", "reason": "not_existed"},
-			map[string]interface{}{"id": "second-missing", "reason": "not_existed"},
-		},
-		"pending_approval_id_list": []interface{}{
-			map[string]interface{}{"id": "first-pending", "reason": "pending"},
-			map[string]interface{}{"id": "second-pending", "reason": "pending"},
-		},
+		"invalid_id_list":          []interface{}{"ou_invalid_a", "ou_invalid_b"},
+		"not_existed_id_list":      []string{"ou_missing_a", "ou_missing_b"},
+		"pending_approval_id_list": []interface{}{"ou_pending_a", "ou_pending_b"},
+	}
+	requested := []string{
+		"ou_invalid_a", "ou_invalid_b",
+		"ou_missing_a", "ou_missing_b",
+		"ou_pending_a", "ou_pending_b",
 	}
 
-	got := projectChatMembersAddResponse(data)
+	got, err := projectChatMembersAddResponse(data, requested)
+	if err != nil {
+		t.Fatalf("projectChatMembersAddResponse() error = %v", err)
+	}
 	want := chatMembersAddResponse{
-		InvalidIDList:         data["invalid_id_list"].([]interface{}),
-		NotExistedIDList:      data["not_existed_id_list"].([]interface{}),
-		PendingApprovalIDList: data["pending_approval_id_list"].([]interface{}),
+		InvalidIDList:         []string{"ou_invalid_a", "ou_invalid_b"},
+		NotExistedIDList:      []string{"ou_missing_a", "ou_missing_b"},
+		PendingApprovalIDList: []string{"ou_pending_a", "ou_pending_b"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("projectChatMembersAddResponse() = %#v, want %#v", got, want)
 	}
 }
 
+func TestExecuteChatMembersAddRejectsInvalidResponseLists(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{
+			name: "field is not an array",
+			data: map[string]interface{}{"invalid_id_list": "invalid-shape"},
+		},
+		{
+			name: "array element is not a string",
+			data: map[string]interface{}{"invalid_id_list": []interface{}{"ou_a", float64(1)}},
+		},
+		{
+			name: "duplicate inside one list",
+			data: map[string]interface{}{"invalid_id_list": []interface{}{"ou_a", "ou_a"}},
+		},
+		{
+			name: "duplicate across lists",
+			data: map[string]interface{}{
+				"invalid_id_list":     []interface{}{"ou_a"},
+				"not_existed_id_list": []interface{}{"ou_a"},
+			},
+		},
+		{
+			name: "identifier was not requested",
+			data: map[string]interface{}{"pending_approval_id_list": []interface{}{"ou_unexpected"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+					"code": 0,
+					"data": tt.data,
+				}), nil
+			}))
+			setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_a,ou_b", "")
+
+			err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+				ChatID: "oc_test",
+				Users:  []string{"ou_a", "ou_b"},
+			})
+			if err == nil {
+				t.Fatal("executeChatMembersAdd() error = nil, want invalid response error")
+			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("ProblemOf(%v) returned ok=false", err)
+			}
+			if problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf(
+					"problem = category %q subtype %q, want category %q subtype %q",
+					problem.Category,
+					problem.Subtype,
+					errs.CategoryInternal,
+					errs.SubtypeInvalidResponse,
+				)
+			}
+			if errors.Unwrap(err) == nil {
+				t.Fatal("invalid response error has no cause")
+			}
+			for _, id := range []string{"ou_a", "ou_b", "ou_unexpected"} {
+				if strings.Contains(err.Error(), id) {
+					t.Fatalf("error message contains member identifier %q", id)
+				}
+			}
+			out, ok := runtime.Factory.IOStreams.Out.(*bytes.Buffer)
+			if !ok {
+				t.Fatalf("stdout buffer has type %T", runtime.Factory.IOStreams.Out)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("stdout = %q, want no success data", out.String())
+			}
+		})
+	}
+}
+
 func TestMergeChatMembersAddResponsesPreservesRequestOrder(t *testing.T) {
 	users := chatMembersAddResponse{
-		InvalidIDList:         []interface{}{"ou_invalid"},
-		NotExistedIDList:      []interface{}{"ou_missing"},
-		PendingApprovalIDList: []interface{}{"ou_pending"},
+		InvalidIDList:         []string{"ou_invalid"},
+		NotExistedIDList:      []string{"ou_missing"},
+		PendingApprovalIDList: []string{"ou_pending"},
 	}
 	bots := chatMembersAddResponse{
-		InvalidIDList:         []interface{}{"cli_invalid"},
-		NotExistedIDList:      []interface{}{"cli_missing"},
-		PendingApprovalIDList: []interface{}{"cli_pending"},
+		InvalidIDList:         []string{"cli_invalid"},
+		NotExistedIDList:      []string{"cli_missing"},
+		PendingApprovalIDList: []string{"cli_pending"},
 	}
 
 	got := mergeChatMembersAddResponse(users, bots)
 	want := chatMembersAddResponse{
-		InvalidIDList:         []interface{}{"ou_invalid", "cli_invalid"},
-		NotExistedIDList:      []interface{}{"ou_missing", "cli_missing"},
-		PendingApprovalIDList: []interface{}{"ou_pending", "cli_pending"},
+		InvalidIDList:         []string{"ou_invalid", "cli_invalid"},
+		NotExistedIDList:      []string{"ou_missing", "cli_missing"},
+		PendingApprovalIDList: []string{"ou_pending", "cli_pending"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("mergeChatMembersAddResponse() = %#v, want %#v", got, want)
@@ -641,9 +723,9 @@ func TestChatMembersAddResultSuccessCount(t *testing.T) {
 			name:      "subtracts all unfinished lists",
 			requested: 5,
 			response: chatMembersAddResponse{
-				InvalidIDList:         []interface{}{"invalid"},
-				NotExistedIDList:      []interface{}{"missing"},
-				PendingApprovalIDList: []interface{}{"pending"},
+				InvalidIDList:         []string{"invalid"},
+				NotExistedIDList:      []string{"missing"},
+				PendingApprovalIDList: []string{"pending"},
 			},
 			want: 2,
 		},
@@ -651,9 +733,9 @@ func TestChatMembersAddResultSuccessCount(t *testing.T) {
 			name:      "clamps excessive unfinished count to zero",
 			requested: 2,
 			response: chatMembersAddResponse{
-				InvalidIDList:         []interface{}{1, 2},
-				NotExistedIDList:      []interface{}{3},
-				PendingApprovalIDList: []interface{}{4},
+				InvalidIDList:         []string{"invalid-a", "invalid-b"},
+				NotExistedIDList:      []string{"missing"},
+				PendingApprovalIDList: []string{"pending"},
 			},
 			want: 0,
 		},

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -1176,6 +1176,150 @@ func TestExecuteChatMembersAddDisablesRetryForInvalidFirstResponse(t *testing.T)
 	}
 }
 
+func TestExecuteChatMembersAddRejectsMissingUserResponseData(t *testing.T) {
+	requestCount := 0
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount > 1 {
+			t.Fatal("bot request executed after missing user response data")
+		}
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_private", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_private"},
+		Bots:   []string{"cli_private"},
+	})
+	assertChatMembersAddInvalidFirstResponse(t, runtime, err, false)
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+}
+
+func TestExecuteChatMembersAddRejectsNullBotResponseData(t *testing.T) {
+	runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+			"data": nil,
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Bots:   []string{"cli_private"},
+	})
+	assertChatMembersAddInvalidFirstResponse(t, runtime, err, true)
+}
+
+func TestExecuteChatMembersAddPreservesUserResultWhenBotResponseDataIsNonObject(t *testing.T) {
+	requestCount := 0
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{},
+			}), nil
+		}
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+			"data": []interface{}{"invalid-data-shape"},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_ok"},
+		Bots:   []string{"cli_private"},
+	})
+	assertChatMembersAddPartialFailure(t, err)
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+	data := decodeChatMembersAddPartialOutput(t, runtime)
+	if data["chat_id"] != "oc_test" || int(data["success_count"].(float64)) != 1 {
+		t.Fatalf("partial result = %#v, want only one confirmed user", data)
+	}
+	if data["failed_member_type"] != "bot" || data["outcome_unknown"] != true {
+		t.Fatalf("failure metadata = %#v, want unknown bot outcome", data)
+	}
+	assertChatMembersAddOutputLists(t, data, []string{}, []string{}, []string{})
+	errorData, ok := data["error"].(map[string]interface{})
+	if !ok || errorData["type"] != string(errs.CategoryInternal) || errorData["subtype"] != string(errs.SubtypeInvalidResponse) {
+		t.Fatalf("error projection = %#v, want internal/invalid_response", data["error"])
+	}
+	if retryable, ok := errorData["retryable"].(bool); !ok || retryable {
+		t.Fatalf("error.retryable = %#v, want false", errorData["retryable"])
+	}
+	assertChatMembersAddReadbackHint(t, errorData["hint"].(string), true)
+	wantErrOut := "Added 1 user member(s) before the bot member request failed.\n"
+	if got := chatMembersAddStderr(t, runtime); got != wantErrOut {
+		t.Fatalf("stderr = %q, want %q", got, wantErrOut)
+	}
+}
+
+func TestExecuteChatMembersAddAcceptsEmptyResponseDataObject(t *testing.T) {
+	requestCount := 0
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok", "cli_ok")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_ok"},
+		Bots:   []string{"cli_ok"},
+	})
+	if err != nil {
+		t.Fatalf("executeChatMembersAdd() error = %v", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+	data, meta := decodeChatMembersAddSuccessOutput(t, runtime)
+	if int(data["success_count"].(float64)) != 2 || meta == nil || meta.Count != 2 {
+		t.Fatalf("success result = data %#v meta %#v, want count 2", data, meta)
+	}
+	assertChatMembersAddOutputLists(t, data, []string{}, []string{}, []string{})
+}
+
+func assertChatMembersAddInvalidFirstResponse(t *testing.T, runtime *common.RuntimeContext, err error, botBatch bool) {
+	t.Helper()
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Category != errs.CategoryInternal || internalErr.Subtype != errs.SubtypeInvalidResponse || internalErr.Retryable {
+		t.Fatalf("problem = %#v, want non-retryable internal/invalid_response", internalErr.Problem)
+	}
+	assertChatMembersAddReadbackHint(t, internalErr.Hint, botBatch)
+	cause := errors.Unwrap(internalErr)
+	if cause == nil || cause.Error() != "chat member response data is missing or invalid" {
+		t.Fatalf("missing response data cause = %v, want fixed safe cause", cause)
+	}
+	for _, sensitive := range []string{"ou_", "cli_"} {
+		if strings.Contains(internalErr.Error(), sensitive) {
+			t.Fatalf("error message contains member identifier prefix %q", sensitive)
+		}
+	}
+	if got := chatMembersAddStdout(t, runtime); got != "" {
+		t.Fatalf("stdout = %q, want no false success envelope", got)
+	}
+	if got := chatMembersAddStderr(t, runtime); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+}
+
 func TestWithChatMembersAddUnknownOutcomeCopiesInvalidResponseError(t *testing.T) {
 	cause := errors.New("invalid response cause")
 	source := errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid response").

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -185,6 +185,32 @@ func TestImChatMembersAddHooksShareNormalizedSpec(t *testing.T) {
 	}
 }
 
+func TestImChatMembersAddHooksRequireValidatedSpec(t *testing.T) {
+	runtime := newChatMembersAddTestRuntime(t, "oc_chat_a", "ou_user_a", "")
+
+	dryRun := ImChatMembersAdd.DryRun(context.Background(), runtime)
+	if dryRun != nil {
+		t.Fatalf("DryRun() = %#v, want nil without a validated spec", dryRun)
+	}
+	dryRunErr := cmdutil.WriteDryRun(dryRun, cmdutil.DryRunOutputOptions{
+		Format: "json",
+		Out:    io.Discard,
+	})
+	problem, ok := errs.ProblemOf(dryRunErr)
+	if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("WriteDryRun() error = %T %v, want internal unknown", dryRunErr, dryRunErr)
+	}
+	if !strings.Contains(dryRunErr.Error(), "dry-run produced no request preview") {
+		t.Fatalf("WriteDryRun() error = %q, want missing preview message", dryRunErr.Error())
+	}
+
+	executeErr := ImChatMembersAdd.Execute(context.Background(), runtime)
+	problem, ok = errs.ProblemOf(executeErr)
+	if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("Execute() error = %T %v, want internal unknown", executeErr, executeErr)
+	}
+}
+
 func newChatMembersAddMountedTestFactory(
 	t *testing.T,
 	registerSuccess bool,

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -586,6 +586,9 @@ func TestExecuteChatMembersAddReturnsPartialFailureForRejectedIDs(t *testing.T) 
 	assertChatMembersAddPartialFailure(t, err)
 
 	data := decodeChatMembersAddPartialOutput(t, runtime)
+	if got := data["chat_id"]; got != "oc_test" {
+		t.Fatalf("chat_id = %#v, want %q", got, "oc_test")
+	}
 	if got := int(data["success_count"].(float64)); got != 1 {
 		t.Fatalf("success_count = %d, want 1", got)
 	}
@@ -732,6 +735,62 @@ func TestExecuteChatMembersAddReturnsPriorResultWhenBotRequestFails(t *testing.T
 	errOut := chatMembersAddStderr(t, runtime)
 	if strings.Contains(errOut, "ou_") || strings.Contains(errOut, "cli_") || strings.Contains(errOut, "PermissionError") {
 		t.Fatalf("stderr exposes member data or an error object: %q", errOut)
+	}
+}
+
+func TestExecuteChatMembersAddReturnsPriorResultWhenBotResponseIsInvalid(t *testing.T) {
+	requestCount := 0
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"invalid_id_list":          []interface{}{"ou_invalid"},
+					"not_existed_id_list":      []interface{}{},
+					"pending_approval_id_list": []interface{}{},
+				},
+			}), nil
+		}
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"invalid_id_list": "invalid-response-shape",
+			},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok,ou_invalid", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_ok", "ou_invalid"},
+		Bots:   []string{"cli_private"},
+	})
+	assertChatMembersAddPartialFailure(t, err)
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+
+	data := decodeChatMembersAddPartialOutput(t, runtime)
+	if data["chat_id"] != "oc_test" {
+		t.Fatalf("chat_id = %#v, want %q", data["chat_id"], "oc_test")
+	}
+	if data["failed_member_type"] != "bot" || data["outcome_unknown"] != false {
+		t.Fatalf("failure metadata = %#v, want failed bot with known outcome", data)
+	}
+	if got := int(data["success_count"].(float64)); got != 1 {
+		t.Fatalf("success_count = %d, want 1", got)
+	}
+	assertChatMembersAddOutputLists(t, data, []string{"ou_invalid"}, []string{}, []string{})
+	errorData, ok := data["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("error projection = %T, want object", data["error"])
+	}
+	if got := errorData["type"]; got != string(errs.CategoryInternal) {
+		t.Fatalf("error.type = %#v, want %q", got, errs.CategoryInternal)
+	}
+	if got := errorData["subtype"]; got != string(errs.SubtypeInvalidResponse) {
+		t.Fatalf("error.subtype = %#v, want %q", got, errs.SubtypeInvalidResponse)
 	}
 }
 

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
@@ -568,6 +569,470 @@ func TestExecuteChatMembersAddPassesThroughUserAPIError(t *testing.T) {
 	if requestCount != 1 {
 		t.Fatalf("request count = %d, want 1; bot request must not execute", requestCount)
 	}
+}
+
+func TestExecuteChatMembersAddReturnsPartialFailureForRejectedIDs(t *testing.T) {
+	runtime := newUserShortcutRuntime(t, chatMembersAddSuccessTransport(t, map[string]interface{}{
+		"invalid_id_list":          []interface{}{"ou_invalid"},
+		"not_existed_id_list":      []interface{}{"ou_missing"},
+		"pending_approval_id_list": []interface{}{"ou_pending"},
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok,ou_invalid,ou_missing,ou_pending", "")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_ok", "ou_invalid", "ou_missing", "ou_pending"},
+	})
+	assertChatMembersAddPartialFailure(t, err)
+
+	data := decodeChatMembersAddPartialOutput(t, runtime)
+	if got := int(data["success_count"].(float64)); got != 1 {
+		t.Fatalf("success_count = %d, want 1", got)
+	}
+	assertChatMembersAddOutputLists(t, data,
+		[]string{"ou_invalid"}, []string{"ou_missing"}, []string{"ou_pending"})
+}
+
+func TestExecuteChatMembersAddStopsAfterUserAPIError(t *testing.T) {
+	causeMarker := "log-chat-members-add"
+	requestCount := 0
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 99991672,
+			"msg":  "app scope not applied",
+			"error": map[string]interface{}{
+				"log_id": causeMarker,
+				"permission_violations": []interface{}{
+					map[string]interface{}{"subject": "im:chat.members:write_only"},
+				},
+			},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_private", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_private"},
+		Bots:   []string{"cli_private"},
+	})
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("error = %T, want *errs.PermissionError", err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf() returned ok=false")
+	}
+	if problem.Category != errs.CategoryAuthorization || problem.Subtype != errs.SubtypeAppScopeNotApplied || problem.Code != 99991672 || problem.LogID != causeMarker {
+		t.Fatalf("problem = %#v, want preserved permission metadata", problem)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+	if got := chatMembersAddStdout(t, runtime); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+}
+
+func TestExecuteChatMembersAddDisablesRetryForUnknownUserOutcome(t *testing.T) {
+	transportCause := errors.New("transport marker")
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, transportCause
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_private", "")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{ChatID: "oc_test", Users: []string{"ou_private"}})
+	var networkErr *errs.NetworkError
+	if !errors.As(err, &networkErr) {
+		t.Fatalf("error = %T, want *errs.NetworkError", err)
+	}
+	if networkErr.Retryable {
+		t.Fatal("network error Retryable = true, want false")
+	}
+	assertChatMembersAddReadbackHint(t, networkErr.Hint, false)
+	if !errors.Is(err, transportCause) {
+		t.Fatalf("error does not preserve transport cause: %v", err)
+	}
+	if strings.Contains(networkErr.Hint, "ou_private") {
+		t.Fatal("network hint contains a member identifier")
+	}
+	if got := chatMembersAddStdout(t, runtime); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+}
+
+func TestExecuteChatMembersAddReturnsPriorResultWhenBotRequestFails(t *testing.T) {
+	requestCount := 0
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"invalid_id_list": []interface{}{"ou_invalid"},
+				},
+			}), nil
+		}
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 99991672,
+			"msg":  "app scope not applied",
+			"error": map[string]interface{}{
+				"log_id":         "log-bot-request",
+				"troubleshooter": "https://example.invalid/troubleshooter",
+				"permission_violations": []interface{}{
+					map[string]interface{}{"subject": "im:chat.members:write_only"},
+				},
+			},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok,ou_invalid", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_ok", "ou_invalid"},
+		Bots:   []string{"cli_private"},
+	})
+	assertChatMembersAddPartialFailure(t, err)
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+
+	data := decodeChatMembersAddPartialOutput(t, runtime)
+	if data["failed_member_type"] != "bot" || data["outcome_unknown"] != false {
+		t.Fatalf("failure metadata = %#v, want failed bot with known outcome", data)
+	}
+	if got := int(data["success_count"].(float64)); got != 1 {
+		t.Fatalf("success_count = %d, want 1", got)
+	}
+	assertChatMembersAddOutputLists(t, data, []string{"ou_invalid"}, []string{}, []string{})
+	errorData, ok := data["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("error projection = %T, want object", data["error"])
+	}
+	for key, want := range map[string]interface{}{
+		"type":           string(errs.CategoryAuthorization),
+		"subtype":        string(errs.SubtypeAppScopeNotApplied),
+		"code":           float64(99991672),
+		"log_id":         "log-bot-request",
+		"troubleshooter": "https://example.invalid/troubleshooter",
+		"retryable":      false,
+		"identity":       "user",
+	} {
+		if got := errorData[key]; got != want {
+			t.Errorf("error.%s = %#v, want %#v", key, got, want)
+		}
+	}
+	if _, ok := errorData["missing_scopes"].([]interface{}); !ok {
+		t.Fatalf("error.missing_scopes = %T, want array", errorData["missing_scopes"])
+	}
+	if message, _ := errorData["message"].(string); message == "" {
+		t.Fatal("error.message is empty")
+	}
+	errOut := chatMembersAddStderr(t, runtime)
+	if strings.Contains(errOut, "ou_") || strings.Contains(errOut, "cli_") || strings.Contains(errOut, "PermissionError") {
+		t.Fatalf("stderr exposes member data or an error object: %q", errOut)
+	}
+}
+
+func TestProjectChatMembersAddErrorCopiesPermissionFields(t *testing.T) {
+	cause := errors.New("permission cause")
+	source := errs.NewPermissionError(errs.SubtypeMissingScope, "permission denied").
+		WithHint("grant required scopes").
+		WithLogID("log-projection").
+		WithCode(99991679).
+		WithRetryable().
+		WithMissingScopes("scope.missing").
+		WithRequestedScopes("scope.requested").
+		WithGrantedScopes("scope.granted").
+		WithIdentity("bot").
+		WithConsoleURL("https://example.invalid/console").
+		WithCause(cause)
+	source.Troubleshooter = "https://example.invalid/help"
+
+	got := projectChatMembersAddError(source, false)
+	if got == nil {
+		t.Fatal("projectChatMembersAddError() = nil")
+	}
+	if got.Type != source.Category || got.Subtype != source.Subtype || got.Code != source.Code || got.Message != source.Message || got.Hint != source.Hint || got.LogID != source.LogID || got.Troubleshooter != source.Troubleshooter || !got.Retryable {
+		t.Fatalf("projected common fields = %#v, want %#v", got, source.Problem)
+	}
+	if !reflect.DeepEqual(got.MissingScopes, source.MissingScopes) || !reflect.DeepEqual(got.RequestedScopes, source.RequestedScopes) || !reflect.DeepEqual(got.GrantedScopes, source.GrantedScopes) || got.Identity != source.Identity || got.ConsoleURL != source.ConsoleURL {
+		t.Fatalf("projected permission fields = %#v, want copied fields", got)
+	}
+	source.MissingScopes[0] = "mutated"
+	source.RequestedScopes[0] = "mutated"
+	source.GrantedScopes[0] = "mutated"
+	if got.MissingScopes[0] == "mutated" || got.RequestedScopes[0] == "mutated" || got.GrantedScopes[0] == "mutated" {
+		t.Fatal("projected permission slices alias source slices")
+	}
+}
+
+func TestWithChatMembersAddUnknownOutcomePreservesDeterministicError(t *testing.T) {
+	cause := errors.New("permission cause")
+	source := errs.NewPermissionError(errs.SubtypeMissingScope, "permission denied").WithCause(cause)
+
+	got := withChatMembersAddUnknownOutcome(source, false)
+	if got != source {
+		t.Fatalf("deterministic error = %T, want original pointer", got)
+	}
+	if !errors.Is(got, cause) {
+		t.Fatal("deterministic error cause was not preserved")
+	}
+}
+
+func TestWithChatMembersAddUnknownOutcomeCopiesNetworkError(t *testing.T) {
+	cause := errors.New("network cause")
+	source := errs.NewNetworkError(errs.SubtypeNetworkTimeout, "request timed out").
+		WithHint("retry request").
+		WithLogID("log-network").
+		WithCode(504).
+		WithRetryable().
+		WithCause(cause)
+	source.Troubleshooter = "https://example.invalid/network-help"
+
+	err := withChatMembersAddUnknownOutcome(source, false)
+	var got *errs.NetworkError
+	if !errors.As(err, &got) {
+		t.Fatalf("error = %T, want *errs.NetworkError", err)
+	}
+	if got == source {
+		t.Fatal("withChatMembersAddUnknownOutcome() returned the source pointer")
+	}
+	if got.Category != source.Category || got.Subtype != source.Subtype || got.Code != source.Code || got.Message != source.Message || got.LogID != source.LogID || got.Troubleshooter != source.Troubleshooter {
+		t.Fatalf("network problem = %#v, want source metadata preserved", got.Problem)
+	}
+	if got.Retryable {
+		t.Fatal("network error Retryable = true, want false")
+	}
+	assertChatMembersAddReadbackHint(t, got.Hint, false)
+	if !errors.Is(got, cause) {
+		t.Fatal("network error cause was not preserved")
+	}
+	if source.Hint != "retry request" || !source.Retryable {
+		t.Fatalf("source network error was mutated: %#v", source.Problem)
+	}
+}
+
+func TestExecuteChatMembersAddMarksBotNetworkOutcomeUnknown(t *testing.T) {
+	requestCount := 0
+	transportCause := errors.New("bot transport marker")
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if requestCount == 1 {
+			return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{},
+			}), nil
+		}
+		return nil, transportCause
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_ok", "cli_private")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_ok"},
+		Bots:   []string{"cli_private"},
+	})
+	assertChatMembersAddPartialFailure(t, err)
+	data := decodeChatMembersAddPartialOutput(t, runtime)
+	if data["failed_member_type"] != "bot" || data["outcome_unknown"] != true {
+		t.Fatalf("failure metadata = %#v, want failed bot with unknown outcome", data)
+	}
+	if got := int(data["success_count"].(float64)); got != 1 {
+		t.Fatalf("success_count = %d, want 1", got)
+	}
+	errorData := data["error"].(map[string]interface{})
+	if retryable, ok := errorData["retryable"].(bool); !ok || retryable {
+		t.Fatalf("error.retryable = %#v, want false", errorData["retryable"])
+	}
+	hint, _ := errorData["hint"].(string)
+	assertChatMembersAddReadbackHint(t, hint, true)
+	if _, exists := errorData["cause"]; exists {
+		t.Fatal("serialized error projection contains cause")
+	}
+}
+
+func TestExecuteChatMembersAddBotOnlyFailureBehavior(t *testing.T) {
+	t.Run("deterministic error passes through", func(t *testing.T) {
+		runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+				"code": 99991672,
+				"msg":  "app scope not applied",
+			}), nil
+		}))
+		setChatMembersAddTestFlags(t, runtime, "oc_test", "", "cli_private")
+		err := executeChatMembersAdd(runtime, chatMembersAddSpec{ChatID: "oc_test", Bots: []string{"cli_private"}})
+		var permissionErr *errs.PermissionError
+		if !errors.As(err, &permissionErr) {
+			t.Fatalf("error = %T, want *errs.PermissionError", err)
+		}
+		if got := chatMembersAddStdout(t, runtime); got != "" {
+			t.Fatalf("stdout = %q, want empty", got)
+		}
+	})
+
+	t.Run("network error disables retry", func(t *testing.T) {
+		transportCause := errors.New("bot-only transport marker")
+		runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, transportCause
+		}))
+		setChatMembersAddTestFlags(t, runtime, "oc_test", "", "cli_private")
+		err := executeChatMembersAdd(runtime, chatMembersAddSpec{ChatID: "oc_test", Bots: []string{"cli_private"}})
+		var networkErr *errs.NetworkError
+		if !errors.As(err, &networkErr) {
+			t.Fatalf("error = %T, want *errs.NetworkError", err)
+		}
+		if networkErr.Retryable {
+			t.Fatal("network error Retryable = true, want false")
+		}
+		assertChatMembersAddReadbackHint(t, networkErr.Hint, true)
+		if got := chatMembersAddStdout(t, runtime); got != "" {
+			t.Fatalf("stdout = %q, want empty", got)
+		}
+	})
+}
+
+func TestExecuteChatMembersAddSuccessOutput(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		runtime := newUserShortcutRuntime(t, chatMembersAddSuccessTransport(t, map[string]interface{}{}))
+		setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_a,ou_b", "")
+		err := executeChatMembersAdd(runtime, chatMembersAddSpec{ChatID: "oc_test", Users: []string{"ou_a", "ou_b"}})
+		if err != nil {
+			t.Fatalf("executeChatMembersAdd() error = %v", err)
+		}
+		data, meta := decodeChatMembersAddSuccessOutput(t, runtime)
+		if data["chat_id"] != "oc_test" || int(data["success_count"].(float64)) != 2 {
+			t.Fatalf("success data = %#v", data)
+		}
+		for _, key := range []string{"failed_member_type", "outcome_unknown", "error"} {
+			if _, exists := data[key]; exists {
+				t.Errorf("success data contains failure-only field %q", key)
+			}
+		}
+		if meta == nil || meta.Count != 2 {
+			t.Fatalf("meta = %#v, want count 2", meta)
+		}
+		assertChatMembersAddOutputLists(t, data, []string{}, []string{}, []string{})
+	})
+
+	t.Run("pretty", func(t *testing.T) {
+		runtime := newUserShortcutRuntime(t, chatMembersAddSuccessTransport(t, map[string]interface{}{}))
+		runtime.Format = "pretty"
+		setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_private", "")
+		err := executeChatMembersAdd(runtime, chatMembersAddSpec{ChatID: "oc_test", Users: []string{"ou_private"}})
+		if err != nil {
+			t.Fatalf("executeChatMembersAdd() error = %v", err)
+		}
+		got := chatMembersAddStdout(t, runtime)
+		want := "Chat: oc_test\nAdded members: 1\n"
+		if got != want {
+			t.Fatalf("pretty output = %q, want %q", got, want)
+		}
+		if strings.Contains(got, "ou_private") {
+			t.Fatal("pretty output contains a member identifier")
+		}
+	})
+}
+
+func chatMembersAddSuccessTransport(t *testing.T, data map[string]interface{}) shortcutRoundTripFunc {
+	t.Helper()
+	return shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{"code": 0, "data": data}), nil
+	})
+}
+
+func assertChatMembersAddPartialFailure(t *testing.T, err error) {
+	t.Helper()
+	var partialErr *output.PartialFailureError
+	if !errors.As(err, &partialErr) {
+		t.Fatalf("error = %T (%v), want *output.PartialFailureError", err, err)
+	}
+	if partialErr.Code != output.ExitAPI || output.ExitCodeOf(err) != output.ExitAPI {
+		t.Fatalf("partial failure exit = %d/%d, want %d", partialErr.Code, output.ExitCodeOf(err), output.ExitAPI)
+	}
+}
+
+func decodeChatMembersAddEnvelope(t *testing.T, runtime *common.RuntimeContext) (bool, map[string]interface{}, *output.Meta) {
+	t.Helper()
+	var envelope struct {
+		OK   bool                   `json:"ok"`
+		Data map[string]interface{} `json:"data"`
+		Meta *output.Meta           `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(chatMembersAddStdout(t, runtime)), &envelope); err != nil {
+		t.Fatalf("decode stdout: %v", err)
+	}
+	return envelope.OK, envelope.Data, envelope.Meta
+}
+
+func decodeChatMembersAddPartialOutput(t *testing.T, runtime *common.RuntimeContext) map[string]interface{} {
+	t.Helper()
+	ok, data, _ := decodeChatMembersAddEnvelope(t, runtime)
+	if ok {
+		t.Fatal("stdout envelope ok = true, want false")
+	}
+	return data
+}
+
+func decodeChatMembersAddSuccessOutput(t *testing.T, runtime *common.RuntimeContext) (map[string]interface{}, *output.Meta) {
+	t.Helper()
+	ok, data, meta := decodeChatMembersAddEnvelope(t, runtime)
+	if !ok {
+		t.Fatal("stdout envelope ok = false, want true")
+	}
+	return data, meta
+}
+
+func assertChatMembersAddOutputLists(t *testing.T, data map[string]interface{}, invalid, notExisted, pending []string) {
+	t.Helper()
+	for key, want := range map[string][]string{
+		"invalid_id_list":          invalid,
+		"not_existed_id_list":      notExisted,
+		"pending_approval_id_list": pending,
+	} {
+		raw, ok := data[key].([]interface{})
+		if !ok {
+			t.Fatalf("%s = %T, want non-nil array", key, data[key])
+		}
+		got := make([]string, len(raw))
+		for i := range raw {
+			got[i], _ = raw[i].(string)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
+func assertChatMembersAddReadbackHint(t *testing.T, hint string, botsOnly bool) {
+	t.Helper()
+	for _, want := range []string{"im +chat-members-list", "--chat-id <chat_id>", "--page-all", "only"} {
+		if !strings.Contains(hint, want) {
+			t.Errorf("hint = %q, want substring %q", hint, want)
+		}
+	}
+	if botsOnly && !strings.Contains(strings.ToLower(hint), "bot") {
+		t.Errorf("hint = %q, want bot-specific retry guidance", hint)
+	}
+}
+
+func chatMembersAddStdout(t *testing.T, runtime *common.RuntimeContext) string {
+	t.Helper()
+	out, ok := runtime.Factory.IOStreams.Out.(*bytes.Buffer)
+	if !ok {
+		t.Fatalf("stdout buffer has type %T", runtime.Factory.IOStreams.Out)
+	}
+	return out.String()
+}
+
+func chatMembersAddStderr(t *testing.T, runtime *common.RuntimeContext) string {
+	t.Helper()
+	errOut, ok := runtime.Factory.IOStreams.ErrOut.(*bytes.Buffer)
+	if !ok {
+		t.Fatalf("stderr buffer has type %T", runtime.Factory.IOStreams.ErrOut)
+	}
+	return errOut.String()
 }
 
 func TestProjectChatMembersAddResponseUsesEmptySlices(t *testing.T) {

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -73,6 +73,7 @@ func TestImChatMembersAddMetadata(t *testing.T) {
 	wantTips := []string{
 		"At least one of --users or --bots is required; duplicate IDs are removed in first-seen order.",
 		"When both are present, user members are added before bot members in separate requests with succeed_type=1.",
+		"--as user uses the authenticated user's chat membership and invite permissions; --as bot uses the app bot's chat membership and invite permissions.",
 		"Partial member results return ok:false and exit 1; outcome_unknown requires listing current members before retrying.",
 	}
 	if !reflect.DeepEqual(ImChatMembersAdd.Tips, wantTips) {
@@ -313,10 +314,11 @@ func TestReadChatMembersAddSpec(t *testing.T) {
 			wantParam: "--chat-id",
 		},
 		{
-			name:      "invalid user prefix",
-			chatID:    "oc_chat_a",
-			users:     "user_a",
-			wantParam: "--users",
+			name:        "invalid user prefix",
+			chatID:      "oc_chat_a",
+			users:       "user_a",
+			wantParam:   "--users",
+			wantMessage: "invalid user ID format, should start with 'ou_' (e.g., ou_abc123)",
 		},
 		{
 			name:      "empty user suffix",
@@ -325,10 +327,11 @@ func TestReadChatMembersAddSpec(t *testing.T) {
 			wantParam: "--users",
 		},
 		{
-			name:      "invalid bot prefix",
-			chatID:    "oc_chat_a",
-			bots:      "bot_a",
-			wantParam: "--bots",
+			name:        "invalid bot prefix",
+			chatID:      "oc_chat_a",
+			bots:        "bot_a",
+			wantParam:   "--bots",
+			wantMessage: `invalid bot id "bot_a": expected app ID (cli_xxx)`,
 		},
 		{
 			name:      "empty bot suffix",

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -434,6 +434,141 @@ func TestExecuteChatMembersAddUsersBeforeBots(t *testing.T) {
 	}
 }
 
+func TestExecuteChatMembersAddUsersOnly(t *testing.T) {
+	got := executeSingleChatMembersAddRequest(t, "user", chatMembersAddSpec{
+		ChatID: "oc_test/slash",
+		Users:  []string{"ou_b", "ou_a"},
+	})
+	assertSingleChatMembersAddRequest(t, got, "open_id", []string{"ou_b", "ou_a"})
+}
+
+func TestExecuteChatMembersAddBotsOnly(t *testing.T) {
+	got := executeSingleChatMembersAddRequest(t, "bot", chatMembersAddSpec{
+		ChatID: "oc_test/slash",
+		Bots:   []string{"cli_b", "cli_a"},
+	})
+	assertSingleChatMembersAddRequest(t, got, "app_id", []string{"cli_b", "cli_a"})
+}
+
+type chatMembersAddRequestRecord struct {
+	method       string
+	escapedPath  string
+	memberIDType string
+	succeedType  string
+	idList       []string
+}
+
+func executeSingleChatMembersAddRequest(t *testing.T, identity string, spec chatMembersAddSpec) chatMembersAddRequestRecord {
+	t.Helper()
+
+	var requests []chatMembersAddRequestRecord
+	transport := shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body struct {
+			IDList []string `json:"id_list"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Fatalf("json.Decode() error = %v", err)
+		}
+		requests = append(requests, chatMembersAddRequestRecord{
+			method:       req.Method,
+			escapedPath:  req.URL.EscapedPath(),
+			memberIDType: req.URL.Query().Get("member_id_type"),
+			succeedType:  req.URL.Query().Get("succeed_type"),
+			idList:       body.IDList,
+		})
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		}), nil
+	})
+
+	var runtime *common.RuntimeContext
+	switch identity {
+	case "user":
+		runtime = newUserShortcutRuntime(t, transport)
+	case "bot":
+		runtime = newBotShortcutRuntime(t, transport)
+	default:
+		t.Fatalf("unsupported test identity %q", identity)
+	}
+	setChatMembersAddTestFlags(t, runtime, spec.ChatID, strings.Join(spec.Users, ","), strings.Join(spec.Bots, ","))
+
+	if err := executeChatMembersAdd(runtime, spec); err != nil {
+		t.Fatalf("executeChatMembersAdd() error = %v", err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(requests))
+	}
+	return requests[0]
+}
+
+func assertSingleChatMembersAddRequest(t *testing.T, got chatMembersAddRequestRecord, wantMemberIDType string, wantIDs []string) {
+	t.Helper()
+
+	if got.method != http.MethodPost {
+		t.Errorf("method = %q, want %q", got.method, http.MethodPost)
+	}
+	if got.escapedPath != "/open-apis/im/v1/chats/oc_test%2Fslash/members" {
+		t.Errorf("escaped path = %q, want encoded chat ID", got.escapedPath)
+	}
+	if got.memberIDType != wantMemberIDType {
+		t.Errorf("member_id_type = %q, want %q", got.memberIDType, wantMemberIDType)
+	}
+	if got.succeedType != "1" {
+		t.Errorf("succeed_type = %q, want %q", got.succeedType, "1")
+	}
+	if !reflect.DeepEqual(got.idList, wantIDs) {
+		t.Errorf("id_list = %#v, want %#v", got.idList, wantIDs)
+	}
+}
+
+func TestExecuteChatMembersAddPassesThroughUserAPIError(t *testing.T) {
+	requestCount := 0
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount++
+		if got := req.URL.Query().Get("member_id_type"); got != "open_id" {
+			t.Fatalf("member_id_type = %q, want first request to use open_id", got)
+		}
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 123456789,
+			"msg":  "member request rejected",
+			"error": map[string]interface{}{
+				"log_id": "log-chat-members-add",
+			},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_a", "cli_a")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_a"},
+		Bots:   []string{"cli_a"},
+	})
+	if err == nil {
+		t.Fatal("executeChatMembersAdd() error = nil, want typed API error")
+	}
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("executeChatMembersAdd() error = %T, want *errs.APIError", err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf(%v) returned ok=false", err)
+	}
+	if problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeUnknown {
+		t.Errorf("problem category/subtype = %q/%q, want %q/%q", problem.Category, problem.Subtype, errs.CategoryAPI, errs.SubtypeUnknown)
+	}
+	if problem.Code != 123456789 {
+		t.Errorf("problem code = %d, want %d", problem.Code, 123456789)
+	}
+	if problem.LogID != "log-chat-members-add" {
+		t.Errorf("problem log_id = %q, want %q", problem.LogID, "log-chat-members-add")
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1; bot request must not execute", requestCount)
+	}
+}
+
 func TestProjectChatMembersAddResponseUsesEmptySlices(t *testing.T) {
 	got := projectChatMembersAddResponse(map[string]interface{}{})
 	if got.InvalidIDList == nil || got.NotExistedIDList == nil || got.PendingApprovalIDList == nil {
@@ -441,6 +576,33 @@ func TestProjectChatMembersAddResponseUsesEmptySlices(t *testing.T) {
 	}
 	if len(got.InvalidIDList) != 0 || len(got.NotExistedIDList) != 0 || len(got.PendingApprovalIDList) != 0 {
 		t.Fatalf("projectChatMembersAddResponse() = %#v, want empty slices", got)
+	}
+}
+
+func TestProjectChatMembersAddResponsePreservesAllLists(t *testing.T) {
+	data := map[string]interface{}{
+		"invalid_id_list": []interface{}{
+			map[string]interface{}{"id": "first-invalid", "reason": "invalid"},
+			map[string]interface{}{"id": "second-invalid", "reason": "invalid"},
+		},
+		"not_existed_id_list": []interface{}{
+			map[string]interface{}{"id": "first-missing", "reason": "not_existed"},
+			map[string]interface{}{"id": "second-missing", "reason": "not_existed"},
+		},
+		"pending_approval_id_list": []interface{}{
+			map[string]interface{}{"id": "first-pending", "reason": "pending"},
+			map[string]interface{}{"id": "second-pending", "reason": "pending"},
+		},
+	}
+
+	got := projectChatMembersAddResponse(data)
+	want := chatMembersAddResponse{
+		InvalidIDList:         data["invalid_id_list"].([]interface{}),
+		NotExistedIDList:      data["not_existed_id_list"].([]interface{}),
+		PendingApprovalIDList: data["pending_approval_id_list"].([]interface{}),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projectChatMembersAddResponse() = %#v, want %#v", got, want)
 	}
 }
 

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -5,6 +5,7 @@ package im
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,13 +13,206 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
+
+func TestImChatMembersAddMetadata(t *testing.T) {
+	t.Parallel()
+
+	if ImChatMembersAdd.Service != "im" {
+		t.Fatalf("Service = %q, want im", ImChatMembersAdd.Service)
+	}
+	if ImChatMembersAdd.Command != "+chat-members-add" {
+		t.Fatalf("Command = %q, want +chat-members-add", ImChatMembersAdd.Command)
+	}
+	if ImChatMembersAdd.Risk != "high-risk-write" {
+		t.Fatalf("Risk = %q, want high-risk-write", ImChatMembersAdd.Risk)
+	}
+	if want := []string{"im:chat.members:write_only"}; !reflect.DeepEqual(ImChatMembersAdd.Scopes, want) {
+		t.Fatalf("Scopes = %#v, want %#v", ImChatMembersAdd.Scopes, want)
+	}
+	if want := []string{"user", "bot"}; !reflect.DeepEqual(ImChatMembersAdd.AuthTypes, want) {
+		t.Fatalf("AuthTypes = %#v, want %#v", ImChatMembersAdd.AuthTypes, want)
+	}
+	if !ImChatMembersAdd.HasFormat {
+		t.Fatal("HasFormat = false, want true")
+	}
+	if ImChatMembersAdd.Validate == nil || ImChatMembersAdd.DryRun == nil || ImChatMembersAdd.Execute == nil {
+		t.Fatalf(
+			"hooks = Validate:%t DryRun:%t Execute:%t, want all configured",
+			ImChatMembersAdd.Validate != nil,
+			ImChatMembersAdd.DryRun != nil,
+			ImChatMembersAdd.Execute != nil,
+		)
+	}
+
+	wantFlags := []common.Flag{
+		{Name: "chat-id", Required: true, Desc: "chat ID or supported chat URL (oc_xxx)"},
+		{Name: "users", Desc: "comma-separated user open IDs (ou_xxx), max 50 unique IDs"},
+		{Name: "bots", Desc: "comma-separated bot app IDs (cli_xxx), max 5 unique IDs"},
+	}
+	if !reflect.DeepEqual(ImChatMembersAdd.Flags, wantFlags) {
+		t.Fatalf("Flags = %#v, want %#v", ImChatMembersAdd.Flags, wantFlags)
+	}
+}
+
+func TestImChatMembersAddConfirmation(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantCalls int32
+		wantCode  int
+	}{
+		{
+			name: "missing yes is rejected before transport",
+			args: []string{
+				"+chat-members-add", "--chat-id", "oc_chat_a", "--users", "ou_user_a", "--as", "user",
+			},
+			wantCode: output.ExitConfirmationRequired,
+		},
+		{
+			name: "yes allows transport",
+			args: []string{
+				"+chat-members-add", "--chat-id", "oc_chat_a", "--users", "ou_user_a", "--as", "user", "--yes",
+			},
+			wantCalls: 1,
+		},
+		{
+			name: "dry run bypasses confirmation and transport",
+			args: []string{
+				"+chat-members-add", "--chat-id", "oc_chat_a", "--users", "ou_user_a", "--as", "user", "--dry-run",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, stdout, calls := newChatMembersAddMountedTestFactory(t, tt.wantCalls > 0)
+			parent := &cobra.Command{Use: "im", SilenceErrors: true, SilenceUsage: true}
+			ImChatMembersAdd.Mount(parent, factory)
+			parent.SetArgs(tt.args)
+
+			err := parent.Execute()
+			if tt.wantCode != 0 {
+				problem, ok := errs.ProblemOf(err)
+				if !ok || problem.Subtype != errs.SubtypeConfirmationRequired {
+					t.Fatalf("error = %T %v, want subtype %q", err, err, errs.SubtypeConfirmationRequired)
+				}
+				if code := output.ExitCodeOf(err); code != tt.wantCode {
+					t.Fatalf("exit code = %d, want %d", code, tt.wantCode)
+				}
+			} else if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if got := calls.Load(); got != tt.wantCalls {
+				t.Fatalf("transport calls = %d, want %d", got, tt.wantCalls)
+			}
+			if strings.Contains(tt.name, "dry run") && !strings.Contains(stdout.String(), "/open-apis/im/v1/chats/oc_chat_a/members") {
+				t.Fatalf("dry-run output does not contain members API path: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestImChatMembersAddHooksShareNormalizedSpec(t *testing.T) {
+	var requestPath string
+	var requestBody struct {
+		IDList []string `json:"id_list"`
+	}
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestPath = req.URL.Path
+		if err := json.NewDecoder(req.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_original", "ou_b,ou_a,ou_b", "")
+
+	if err := ImChatMembersAdd.Validate(context.Background(), runtime); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if err := runtime.Cmd.Flags().Set("chat-id", "oc_changed"); err != nil {
+		t.Fatalf("set chat-id: %v", err)
+	}
+	if err := runtime.Cmd.Flags().Set("users", "ou_changed"); err != nil {
+		t.Fatalf("set users: %v", err)
+	}
+
+	dryRunJSON, err := json.Marshal(ImChatMembersAdd.DryRun(context.Background(), runtime))
+	if err != nil {
+		t.Fatalf("marshal DryRun() result: %v", err)
+	}
+	if !strings.Contains(string(dryRunJSON), "/open-apis/im/v1/chats/oc_original/members") ||
+		!strings.Contains(string(dryRunJSON), `"id_list":["ou_b","ou_a"]`) {
+		t.Fatalf("DryRun() did not use normalized spec: %s", dryRunJSON)
+	}
+
+	if err := ImChatMembersAdd.Execute(context.Background(), runtime); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if requestPath != "/open-apis/im/v1/chats/oc_original/members" {
+		t.Fatalf("request path = %q, want normalized chat path", requestPath)
+	}
+	if want := []string{"ou_b", "ou_a"}; !reflect.DeepEqual(requestBody.IDList, want) {
+		t.Fatalf("request IDs = %#v, want %#v", requestBody.IDList, want)
+	}
+}
+
+func newChatMembersAddMountedTestFactory(
+	t *testing.T,
+	registerSuccess bool,
+) (*cmdutil.Factory, *bytes.Buffer, *atomic.Int32) {
+	t.Helper()
+
+	config := &core.CliConfig{
+		AppID:      "test-app",
+		AppSecret:  "test-secret",
+		Brand:      core.BrandFeishu,
+		UserOpenId: "ou_test_user",
+	}
+	factory, stdout, _, registry := cmdutil.TestFactory(t, config)
+	if registerSuccess {
+		registry.Register(&httpmock.Stub{
+			Method: http.MethodPost,
+			URL:    "/open-apis/im/v1/chats/oc_chat_a/members",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{},
+			},
+		})
+	}
+
+	var calls atomic.Int32
+	transport := shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return registry.RoundTrip(req)
+	})
+	sdk := lark.NewClient(
+		config.AppID,
+		config.AppSecret,
+		lark.WithEnableTokenCache(false),
+		lark.WithLogLevel(larkcore.LogLevelError),
+		lark.WithOpenBaseUrl(core.ResolveOpenBaseURL(config.Brand)),
+		lark.WithHttpClient(&http.Client{Transport: transport}),
+	)
+	factory.LarkClient = func() (*lark.Client, error) { return sdk, nil }
+	return factory, stdout, &calls
+}
 
 func TestReadChatMembersAddSpec(t *testing.T) {
 	userIDsOverLimit := make([]string, imChatMembersAddUserLimit+1)

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+func TestReadChatMembersAddSpec(t *testing.T) {
+	userIDsOverLimit := make([]string, imChatMembersAddUserLimit+1)
+	for i := range userIDsOverLimit {
+		userIDsOverLimit[i] = "ou_user_" + strings.Repeat("a", i+1)
+	}
+	botIDsOverLimit := make([]string, imChatMembersAddBotLimit+1)
+	for i := range botIDsOverLimit {
+		botIDsOverLimit[i] = "cli_bot_" + strings.Repeat("a", i+1)
+	}
+
+	tests := []struct {
+		name       string
+		chatID     string
+		users      string
+		bots       string
+		wantParam  string
+		wantParams []string
+	}{
+		{
+			name:      "missing chat",
+			users:     "ou_user_a",
+			wantParam: "--chat-id",
+		},
+		{
+			name:       "missing members",
+			chatID:     "oc_chat_a",
+			wantParams: []string{"--users", "--bots"},
+		},
+		{
+			name:      "invalid user prefix",
+			chatID:    "oc_chat_a",
+			users:     "user_a",
+			wantParam: "--users",
+		},
+		{
+			name:      "empty user suffix",
+			chatID:    "oc_chat_a",
+			users:     "ou_",
+			wantParam: "--users",
+		},
+		{
+			name:      "invalid bot prefix",
+			chatID:    "oc_chat_a",
+			bots:      "bot_a",
+			wantParam: "--bots",
+		},
+		{
+			name:      "empty bot suffix",
+			chatID:    "oc_chat_a",
+			bots:      "cli_",
+			wantParam: "--bots",
+		},
+		{
+			name:      "user control character",
+			chatID:    "oc_chat_a",
+			users:     "ou_user\x00a",
+			wantParam: "--users",
+		},
+		{
+			name:      "bot control character",
+			chatID:    "oc_chat_a",
+			bots:      "cli_bot\x1fa",
+			wantParam: "--bots",
+		},
+		{
+			name:      "user identifier too long",
+			chatID:    "oc_chat_a",
+			users:     "ou_" + strings.Repeat("a", imChatMembersAddIDMaxBytes-2),
+			wantParam: "--users",
+		},
+		{
+			name:      "bot identifier too long",
+			chatID:    "oc_chat_a",
+			bots:      "cli_" + strings.Repeat("a", imChatMembersAddIDMaxBytes-3),
+			wantParam: "--bots",
+		},
+		{
+			name:      "too many users",
+			chatID:    "oc_chat_a",
+			users:     strings.Join(userIDsOverLimit, ","),
+			wantParam: "--users",
+		},
+		{
+			name:      "too many bots",
+			chatID:    "oc_chat_a",
+			bots:      strings.Join(botIDsOverLimit, ","),
+			wantParam: "--bots",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := newChatMembersAddTestRuntime(t, tt.chatID, tt.users, tt.bots)
+			_, err := readChatMembersAddSpec(runtime)
+			assertChatMembersAddValidationError(t, err, tt.wantParam, tt.wantParams)
+		})
+	}
+}
+
+func TestReadChatMembersAddSpecDeduplicatesInFirstSeenOrder(t *testing.T) {
+	runtime := newChatMembersAddTestRuntime(
+		t,
+		"oc_chat_a",
+		"ou_b,ou_a,ou_b",
+		"cli_b,cli_a,cli_b",
+	)
+
+	got, err := readChatMembersAddSpec(runtime)
+	if err != nil {
+		t.Fatalf("readChatMembersAddSpec() error = %v", err)
+	}
+
+	want := chatMembersAddSpec{
+		ChatID: "oc_chat_a",
+		Users:  []string{"ou_b", "ou_a"},
+		Bots:   []string{"cli_b", "cli_a"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("readChatMembersAddSpec() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDedupeChatMemberIDs(t *testing.T) {
+	got := dedupeChatMemberIDs([]string{"ou_b", "ou_a", "ou_b", "ou_a", "ou_c"})
+	want := []string{"ou_b", "ou_a", "ou_c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dedupeChatMemberIDs() = %#v, want %#v", got, want)
+	}
+}
+
+func newChatMembersAddTestRuntime(t *testing.T, chatID, users, bots string) *common.RuntimeContext {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("chat-id", "", "")
+	cmd.Flags().String("users", "", "")
+	cmd.Flags().String("bots", "", "")
+	for name, value := range map[string]string{
+		"chat-id": chatID,
+		"users":   users,
+		"bots":    bots,
+	} {
+		if err := cmd.Flags().Set(name, value); err != nil {
+			t.Fatalf("set %s: %v", name, err)
+		}
+	}
+	return &common.RuntimeContext{Cmd: cmd}
+}
+
+func assertChatMembersAddValidationError(t *testing.T, err error, wantParam string, wantParams []string) {
+	t.Helper()
+
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T (%v), want *errs.ValidationError", err, err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf(%v) returned ok=false", err)
+	}
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf(
+			"problem = category %q subtype %q, want category %q subtype %q",
+			problem.Category,
+			problem.Subtype,
+			errs.CategoryValidation,
+			errs.SubtypeInvalidArgument,
+		)
+	}
+	if validationErr.Param != wantParam {
+		t.Fatalf("Param = %q, want %q", validationErr.Param, wantParam)
+	}
+	var gotParams []string
+	for _, param := range validationErr.Params {
+		gotParams = append(gotParams, param.Name)
+	}
+	if !reflect.DeepEqual(gotParams, wantParams) {
+		t.Fatalf("Params = %#v, want %#v", gotParams, wantParams)
+	}
+}

--- a/shortcuts/im/im_chat_members_add_test.go
+++ b/shortcuts/im/im_chat_members_add_test.go
@@ -4,8 +4,11 @@
 package im
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -284,7 +287,233 @@ func TestDedupeChatMemberIDs(t *testing.T) {
 	}
 }
 
+func TestBuildChatMembersAddDryRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       chatMembersAddSpec
+		wantTypes  []string
+		wantBodies [][]string
+	}{
+		{
+			name: "users only",
+			spec: chatMembersAddSpec{
+				ChatID: "oc_test/slash",
+				Users:  []string{"ou_b", "ou_a"},
+			},
+			wantTypes:  []string{"open_id"},
+			wantBodies: [][]string{{"ou_b", "ou_a"}},
+		},
+		{
+			name: "bots only",
+			spec: chatMembersAddSpec{
+				ChatID: "oc_test/slash",
+				Bots:   []string{"cli_b", "cli_a"},
+			},
+			wantTypes:  []string{"app_id"},
+			wantBodies: [][]string{{"cli_b", "cli_a"}},
+		},
+		{
+			name: "users before bots",
+			spec: chatMembersAddSpec{
+				ChatID: "oc_test/slash",
+				Users:  []string{"ou_b", "ou_a"},
+				Bots:   []string{"cli_b", "cli_a"},
+			},
+			wantTypes:  []string{"open_id", "app_id"},
+			wantBodies: [][]string{{"ou_b", "ou_a"}, {"cli_b", "cli_a"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dryRun := buildChatMembersAddDryRun(tt.spec)
+			encoded, err := json.Marshal(dryRun)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			var payload struct {
+				API []struct {
+					Method string                 `json:"method"`
+					URL    string                 `json:"url"`
+					Params map[string]interface{} `json:"params"`
+					Body   struct {
+						IDList []string `json:"id_list"`
+					} `json:"body"`
+				} `json:"api"`
+			}
+			if err := json.Unmarshal(encoded, &payload); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if len(payload.API) != len(tt.wantTypes) {
+				t.Fatalf("api call count = %d, want %d", len(payload.API), len(tt.wantTypes))
+			}
+			for i, call := range payload.API {
+				if call.Method != http.MethodPost {
+					t.Errorf("api[%d].method = %q, want %q", i, call.Method, http.MethodPost)
+				}
+				if call.URL != "/open-apis/im/v1/chats/oc_test%2Fslash/members" {
+					t.Errorf("api[%d].url = %q, want safely encoded chat ID", i, call.URL)
+				}
+				if got := call.Params["member_id_type"]; got != tt.wantTypes[i] {
+					t.Errorf("api[%d].params.member_id_type = %#v, want %q", i, got, tt.wantTypes[i])
+				}
+				if got := call.Params["succeed_type"]; got != "1" {
+					t.Errorf("api[%d].params.succeed_type = %#v, want %q", i, got, "1")
+				}
+				if !reflect.DeepEqual(call.Body.IDList, tt.wantBodies[i]) {
+					t.Errorf("api[%d].body.id_list = %#v, want %#v", i, call.Body.IDList, tt.wantBodies[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteChatMembersAddUsersBeforeBots(t *testing.T) {
+	type recordedCall struct {
+		method       string
+		escapedPath  string
+		memberIDType string
+		succeedType  string
+		body         struct {
+			IDList []string `json:"id_list"`
+		}
+	}
+	var calls []recordedCall
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var call recordedCall
+		call.method = req.Method
+		call.escapedPath = req.URL.EscapedPath()
+		call.memberIDType = req.URL.Query().Get("member_id_type")
+		call.succeedType = req.URL.Query().Get("succeed_type")
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("io.ReadAll() error = %v", err)
+		}
+		if err := json.Unmarshal(body, &call.body); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		calls = append(calls, call)
+		return shortcutJSONResponse(http.StatusOK, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		}), nil
+	}))
+	setChatMembersAddTestFlags(t, runtime, "oc_test", "ou_b,ou_a,ou_b", "cli_b,cli_a,cli_b")
+
+	err := executeChatMembersAdd(runtime, chatMembersAddSpec{
+		ChatID: "oc_test",
+		Users:  []string{"ou_b", "ou_a"},
+		Bots:   []string{"cli_b", "cli_a"},
+	})
+	if err != nil {
+		t.Fatalf("executeChatMembersAdd() error = %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("call count = %d, want 2", len(calls))
+	}
+	for i, call := range calls {
+		if call.method != http.MethodPost {
+			t.Errorf("calls[%d].method = %q, want %q", i, call.method, http.MethodPost)
+		}
+		if call.escapedPath != "/open-apis/im/v1/chats/oc_test/members" {
+			t.Errorf("calls[%d].escapedPath = %q", i, call.escapedPath)
+		}
+		if got := call.succeedType; got != "1" {
+			t.Errorf("calls[%d].succeed_type = %q, want %q", i, got, "1")
+		}
+	}
+	if got, want := []string{calls[0].memberIDType, calls[1].memberIDType}, []string{"open_id", "app_id"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("member_id_type order = %#v, want %#v", got, want)
+	}
+	if got, want := calls[0].body.IDList, []string{"ou_b", "ou_a"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("user id_list = %#v, want %#v", got, want)
+	}
+	if got, want := calls[1].body.IDList, []string{"cli_b", "cli_a"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("bot id_list = %#v, want %#v", got, want)
+	}
+}
+
+func TestProjectChatMembersAddResponseUsesEmptySlices(t *testing.T) {
+	got := projectChatMembersAddResponse(map[string]interface{}{})
+	if got.InvalidIDList == nil || got.NotExistedIDList == nil || got.PendingApprovalIDList == nil {
+		t.Fatalf("projectChatMembersAddResponse() = %#v, want non-nil empty slices", got)
+	}
+	if len(got.InvalidIDList) != 0 || len(got.NotExistedIDList) != 0 || len(got.PendingApprovalIDList) != 0 {
+		t.Fatalf("projectChatMembersAddResponse() = %#v, want empty slices", got)
+	}
+}
+
+func TestMergeChatMembersAddResponsesPreservesRequestOrder(t *testing.T) {
+	users := chatMembersAddResponse{
+		InvalidIDList:         []interface{}{"ou_invalid"},
+		NotExistedIDList:      []interface{}{"ou_missing"},
+		PendingApprovalIDList: []interface{}{"ou_pending"},
+	}
+	bots := chatMembersAddResponse{
+		InvalidIDList:         []interface{}{"cli_invalid"},
+		NotExistedIDList:      []interface{}{"cli_missing"},
+		PendingApprovalIDList: []interface{}{"cli_pending"},
+	}
+
+	got := mergeChatMembersAddResponse(users, bots)
+	want := chatMembersAddResponse{
+		InvalidIDList:         []interface{}{"ou_invalid", "cli_invalid"},
+		NotExistedIDList:      []interface{}{"ou_missing", "cli_missing"},
+		PendingApprovalIDList: []interface{}{"ou_pending", "cli_pending"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mergeChatMembersAddResponse() = %#v, want %#v", got, want)
+	}
+}
+
+func TestChatMembersAddResultSuccessCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested int
+		response  chatMembersAddResponse
+		want      int
+	}{
+		{name: "all confirmed", requested: 4, response: chatMembersAddResponse{}, want: 4},
+		{
+			name:      "subtracts all unfinished lists",
+			requested: 5,
+			response: chatMembersAddResponse{
+				InvalidIDList:         []interface{}{"invalid"},
+				NotExistedIDList:      []interface{}{"missing"},
+				PendingApprovalIDList: []interface{}{"pending"},
+			},
+			want: 2,
+		},
+		{
+			name:      "clamps excessive unfinished count to zero",
+			requested: 2,
+			response: chatMembersAddResponse{
+				InvalidIDList:         []interface{}{1, 2},
+				NotExistedIDList:      []interface{}{3},
+				PendingApprovalIDList: []interface{}{4},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := confirmedChatMembersAddCount(tt.requested, tt.response); got != tt.want {
+				t.Fatalf("confirmedChatMembersAddCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func newChatMembersAddTestRuntime(t *testing.T, chatID, users, bots string) *common.RuntimeContext {
+	t.Helper()
+	runtime := &common.RuntimeContext{}
+	setChatMembersAddTestFlags(t, runtime, chatID, users, bots)
+	return runtime
+}
+
+func setChatMembersAddTestFlags(t *testing.T, runtime *common.RuntimeContext, chatID, users, bots string) {
 	t.Helper()
 
 	cmd := &cobra.Command{Use: "test"}
@@ -300,7 +529,7 @@ func newChatMembersAddTestRuntime(t *testing.T, chatID, users, bots string) *com
 			t.Fatalf("set %s: %v", name, err)
 		}
 	}
-	return &common.RuntimeContext{Cmd: cmd}
+	runtime.Cmd = cmd
 }
 
 func makeChatMembersAddIDs(prefix string, count int) []string {

--- a/shortcuts/im/shortcuts.go
+++ b/shortcuts/im/shortcuts.go
@@ -10,6 +10,7 @@ func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{
 		ImChatCreate,
 		ImChatList,
+		ImChatMembersAdd,
 		ImChatMembersList,
 		ImChatMessageList,
 		ImChatSearch,

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-im
 version: 1.0.0
-description: "飞书即时通讯：收发消息和管理群聊。发送和回复消息、搜索聊天记录、管理群聊成员、上传下载图片和文件（支持大文件分片下载）、管理表情回复、发送应用内/短信/电话加急、发送和处理交互卡片（Interactive Card）、监听卡片按钮回调（card.action.trigger）。当用户需要发消息、查看或搜索聊天记录、下载聊天中的文件、查看群成员、搜索群、创建群聊或话题群、管理标记数据、管理 Feed 置顶（添加/移除/查询置顶会话）、管理标签数据、处理卡片回调时使用。"
+description: "飞书即时通讯：收发消息和管理群聊。发送和回复消息、搜索聊天记录、添加或查看群聊成员、将用户或应用机器人加入群聊、上传下载图片和文件（支持大文件分片下载）、管理表情回复、发送应用内/短信/电话加急、发送和处理交互卡片（Interactive Card）、监听卡片按钮回调（card.action.trigger）。当用户需要发消息、查看或搜索聊天记录、下载聊天中的文件、群聊加人、添加用户或机器人、查看群成员、搜索群、创建群聊或话题群、管理标记数据、管理 Feed 置顶（添加/移除/查询置顶会话）、管理标签数据、处理卡片回调时使用。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -40,6 +40,10 @@ Chat (oc_xxx)
 - `--as user` means **user identity** and uses `user_access_token`. Calls run as the authorized end user, so permissions depend on both the app scopes and that user's own access to the target chat/message/resource.
 - `--as bot` means **bot identity** and uses `tenant_access_token`. Calls run as the app bot, so behavior depends on the bot's membership, app visibility, availability range, and bot-specific scopes.
 - If an IM API says it supports both `user` and `bot`, the token type changes who the operator is. The same API can succeed with one identity and fail with the other because owner/admin status, chat membership, tenant boundary, or app availability are checked against the current caller.
+
+### Chat Member Addition and Recovery
+
+Before adding user or bot members, or recovering from a member request with `outcome_unknown:true`, you MUST read [`references/lark-im-chat-members-add.md`](references/lark-im-chat-members-add.md). Follow its identifier-source rules and retry checklist. In particular, keep the original target chat and identity, preserve every confirmed batch, and retry only members whose absence is proven by a complete member listing.
 
 ### Sender Name Resolution
 

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -105,6 +105,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。
 |----------|------|
 | [`+chat-create`](references/lark-im-chat-create.md) | Create a group chat or topic chat; user/bot; --chat-mode group|topic; private/public; invites users/bots; optionally sets bot manager |
 | [`+chat-list`](references/lark-im-chat-list.md) | List chats the current user/bot is a member of; defaults to groups; pass --types=p2p,group to include p2p single chats (user-only); user/bot; supports sorting, pagination, --exclude-muted (user-only) |
+| [`+chat-members-add`](references/lark-im-chat-members-add.md) | Add user open_id values and bot app_id values to a chat; user/bot; sends users first in separate requests; returns one total success count and member-level failure arrays |
 | [`+chat-members-list`](references/lark-im-chat-members-list.md) | List members of a chat; returns separate users[] / bots[] buckets; callable as user or bot; --member-types filters which kinds to return; --page-all pagination; surfaces truncations[] when the server caps a bucket |
 | [`+chat-messages-list`](references/lark-im-chat-messages-list.md) | List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range/sort/pagination |
 | [`+chat-search`](references/lark-im-chat-search.md) | Search visible group chats by --query keyword and/or --member-ids; user/bot; e.g. look up chat_id by group name; supports type filters, sorting, pagination, and --exclude-muted (user identity only) |
@@ -143,7 +144,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 
 ### chat.members
 
-  - `create` — 将用户或机器人拉入群聊。Identity: supports `user` and `bot`; the caller must be in the target chat; for `bot` calls, added users must be within the app's availability; for internal chats the operator must belong to the same tenant; if only owners/admins can add members, the caller must be an owner/admin, or a chat-creator bot with `im:chat:operate_as_owner`.
+  - `create` — 将用户或机器人拉入群聊。群成员新增优先使用 [`+chat-members-add`](references/lark-im-chat-members-add.md)，由 Shortcut 处理用户与机器人的分批请求及合并输出。Identity: supports `user` and `bot`; the caller must be in the target chat; for `bot` calls, added users must be within the app's availability; for internal chats the operator must belong to the same tenant; if only owners/admins can add members, the caller must be an owner/admin, or a chat-creator bot with `im:chat:operate_as_owner`.
   - `delete` — 将用户或机器人移出群聊。Identity: supports `user` and `bot`; only group owner, admin, or creator bot can remove others; max 50 users or 5 bots per request.
 
 ### chat.user_setting
@@ -215,7 +216,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `chats.get` | `im:chat:read` |
 | `chats.link` | `im:chat:read` |
 | `chats.update` | `im:chat:update` |
-| `chat.members.create` | `im:chat.members:write_only` |
+| `chat.members.create`, `+chat-members-add` | `im:chat.members:write_only` |
 | `chat.members.delete` | `im:chat.members:write_only` |
 | `chat.members.get` | `im:chat.members:read` |
 | `+chat-members-list` | `im:chat.members:read` |

--- a/skills/lark-im/references/lark-im-chat-create.md
+++ b/skills/lark-im/references/lark-im-chat-create.md
@@ -85,6 +85,8 @@ Bot may fail to invite users who are mutually invisible to it during group creat
 
 3. **Add other members via user identity** (requires the current user to be in the group):
 
+   Add `--yes` only after the operator has explicitly confirmed these member changes. Before confirmation, use the same command with `--dry-run` instead of `--yes` to inspect the request, or omit `--yes` to receive `confirmation_required` and exit code `10`. After confirmation, execute the command shown below.
+
    ```bash
    lark-cli im +chat-members-add \
      --chat-id "<chat_id from step 2>" \

--- a/skills/lark-im/references/lark-im-chat-create.md
+++ b/skills/lark-im/references/lark-im-chat-create.md
@@ -86,15 +86,16 @@ Bot may fail to invite users who are mutually invisible to it during group creat
 3. **Add other members via user identity** (requires the current user to be in the group):
 
    ```bash
-   lark-cli im chat.members create \
-     --params '{"chat_id":"<chat_id from step 2>","member_id_type":"open_id","succeed_type":1}' \
-     --data '{"id_list":["ou_aaa","ou_bbb"]}' \
-     --as user
+   lark-cli im +chat-members-add \
+     --chat-id "<chat_id from step 2>" \
+     --users "ou_aaa,ou_bbb" \
+     --as user \
+     --yes
    ```
 
-   `succeed_type=1` ensures reachable users are added successfully; unreachable ones are returned in `invalid_id_list` instead of failing the whole request.
+   Read `success_count`, `invalid_id_list`, `not_existed_id_list`, and `pending_approval_id_list` from the response. The shortcut fixes `succeed_type=1`, so members that can be added continue to be added while the three arrays report members that were not confirmed as added.
 
-4. **Check `invalid_id_list`** in the response. If non-empty, report to the user which members could not be added.
+4. **Include bots when requested:** Add `--bots "cli_aaa,cli_bbb"` using bot application `app_id` values. When both `--users` and `--bots` are present, the shortcut sends the user request first and the bot request second, then returns one combined result. Follow [`+chat-members-add`](lark-im-chat-members-add.md) when `outcome_unknown` is present.
 
 ### When using `--as user`
 

--- a/skills/lark-im/references/lark-im-chat-members-add.md
+++ b/skills/lark-im/references/lark-im-chat-members-add.md
@@ -1,0 +1,95 @@
+# im +chat-members-add
+
+> **Prerequisite:** Read [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) first to understand authentication, global parameters, and safety rules.
+
+Add user and bot members to an existing group chat. User members are identified by `open_id`; bot members are identified by application `app_id`.
+
+This skill maps to the shortcut: `lark-cli im +chat-members-add` (internally calls `POST /open-apis/im/v1/chats/{chat_id}/members`). Prefer this shortcut over the native Meta API command because it validates identifiers, separates user and bot requests, and returns one stable result.
+
+## Command
+
+```bash
+lark-cli im +chat-members-add \
+  --chat-id oc_xxx \
+  --users ou_a,ou_b \
+  --bots cli_a \
+  --as user \
+  --yes
+```
+
+To preview both requests without changing the chat, replace `--yes` with `--dry-run`. Dry-run does not require `--yes`.
+
+## Parameters
+
+| Parameter | Required | Limits | Description |
+|------|------|------|------|
+| `--chat-id <id-or-url>` | Yes | `oc_xxx` or a supported chat link | Target group ID or supported group link |
+| `--users <ids>` | At least one member type is required | Up to 50 unique values | Comma-separated user `open_id` values in `ou_xxx` form |
+| `--bots <ids>` | At least one member type is required | Up to 5 unique values | Comma-separated bot application `app_id` values in `cli_xxx` form |
+| `--as <identity>` | No | `user` or `bot` | Identity used for both requests |
+| `--yes` | Required for execution | - | Confirms the high-impact write operation |
+| `--dry-run` | No | - | Prints the request preview without executing it or requiring `--yes` |
+
+At least one of `--users` or `--bots` must be present. Duplicate values are removed automatically while preserving first-seen order. Limits are applied after deduplication.
+
+Both `--as user` and `--as bot` are supported. The selected identity requires the `im:chat.members:write_only` scope and sufficient permission to add members to the target chat.
+
+## Request Behavior
+
+User and bot members are always sent in separate requests because they use different identifier types. The user request runs first with `member_id_type=open_id`; the bot request follows with `member_id_type=app_id`. Every request fixes `succeed_type=1`, so members that can be added continue to be added while member-level failures are returned in the response.
+
+If the user request fails for any reason, execution stops immediately and the bot request is not sent. A network, transport, or invalid-response failure in this first request is non-retryable until the current user members have been read back with `+chat-members-list`; retry only users that are not confirmed present. If the user request succeeds and the bot request fails, confirmed user results remain in the output and in the chat. The operation has no transaction or automatic rollback.
+
+## Output
+
+The `data` object contains one combined result. It reports only the chat identifier, the total `success_count`, and three member-level failure arrays; counts are not separated by user and bot type.
+
+| Field | Description |
+|------|------|
+| `chat_id` | Target chat ID |
+| `success_count` | Total number of members confirmed as added after deduplication |
+| `invalid_id_list` | Identifiers rejected as invalid |
+| `not_existed_id_list` | Identifiers that do not exist |
+| `pending_approval_id_list` | Identifiers awaiting approval and not yet confirmed as added |
+
+A successful response exits `0` with `ok:true`:
+
+```json
+{"ok":true,"data":{"chat_id":"oc_xxx","success_count":3,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[]},"meta":{"count":3}}
+```
+
+If any member-level failure array is non-empty, stdout carries `ok:false` with the complete result and the process exits `1`. Members already accepted by the service remain in the chat:
+
+```json
+{"ok":false,"data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":["ou_invalid"],"not_existed_id_list":["cli_missing"],"pending_approval_id_list":["ou_pending"]}}
+```
+
+Scripts and agents must read `success_count` and all three arrays even when the process exits `1`.
+
+## Bot Request Failure
+
+When the user request has completed and the bot request returns an error, the partial result also contains `failed_member_type:"bot"`, `outcome_unknown`, and a structured `error` object. `success_count` and the three arrays describe only the confirmed user request result; the shortcut does not guess the bot outcome.
+
+```json
+{"ok":false,"data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[],"failed_member_type":"bot","outcome_unknown":true,"error":{"type":"network","subtype":"network_transport","message":"member request failed","hint":"List current chat members before retrying; retry only bots not confirmed present.","retryable":false}}}
+```
+
+`outcome_unknown:true` covers network or transport failures and responses that cannot be parsed or validated. First read the current members with the same identity:
+
+```bash
+lark-cli im +chat-members-list \
+  --chat-id oc_xxx \
+  --page-all \
+  --as <same-identity>
+```
+
+After the readback, process only bots that are not confirmed present. Do not repeat the complete `+chat-members-add` command, because the service may have accepted the bot request before the response became unavailable.
+
+Deterministic permission, authentication, and API errors use `outcome_unknown:false`. Handle these through the structured `error` fields. The confirmed user additions remain in the chat.
+
+## References
+
+- [List chat members](lark-im-chat-members-list.md)
+- [Create a chat](lark-im-chat-create.md)
+- [lark-im](../SKILL.md)
+- [lark-shared](../../lark-shared/SKILL.md)

--- a/skills/lark-im/references/lark-im-chat-members-add.md
+++ b/skills/lark-im/references/lark-im-chat-members-add.md
@@ -38,7 +38,18 @@ Both `--as user` and `--as bot` are supported. The selected identity requires th
 
 User and bot members are always sent in separate requests because they use different identifier types. The user request runs first with `member_id_type=open_id`; the bot request follows with `member_id_type=app_id`. Every request fixes `succeed_type=1`, so members that can be added continue to be added while member-level failures are returned in the response.
 
-If the user request fails for any reason, execution stops immediately and the bot request is not sent. A network, transport, or invalid-response failure in this first request is non-retryable until the current user members have been read back with `+chat-members-list`; retry only users that are not confirmed present. If the user request succeeds and the bot request fails, confirmed user results remain in the output and in the chat. The operation has no transaction or automatic rollback.
+If the user request fails for any reason, execution stops immediately and the bot request is not sent. For a network, transport, or invalid-response failure in this first request, read back every visible user member with the same identity before considering a retry:
+
+```bash
+lark-cli im +chat-members-list \
+  --chat-id oc_xxx \
+  --member-types user \
+  --page-all \
+  --page-limit 0 \
+  --as <same-identity>
+```
+
+The user list is sufficient for an absence check only when `has_more:false` and `truncations` contains no entry for `member_type:"user"`. If `has_more:true` or user truncation is present, a missing identifier does not prove that the user was not added; do not retry the unknown user batch. When the list is complete, retry only users that are not confirmed present. If the user request succeeds and the bot request fails, confirmed user results remain in the output and in the chat. The operation has no transaction or automatic rollback. See [List chat members](lark-im-chat-members-list.md) for pagination and truncation details.
 
 ## Output
 
@@ -74,20 +85,22 @@ The partial-result fields described in this section appear only when the user ba
 {"ok":false,"identity":"user","data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[],"failed_member_type":"bot","outcome_unknown":true,"error":{"type":"network","subtype":"network_transport","message":"member request failed","hint":"List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only bots not confirmed present.","retryable":false}}}
 ```
 
-`outcome_unknown:true` covers network or transport failures and responses that cannot be parsed or validated. First read the current members with the same identity:
+`outcome_unknown:true` covers network or transport failures and responses that cannot be parsed or validated. The JSON example preserves the implementation's exact fixed `error.hint`. For a safe absence check, add the bot filter and unlimited page count to the basic command named by that hint, then read the members with the same identity:
 
 ```bash
 lark-cli im +chat-members-list \
   --chat-id oc_xxx \
+  --member-types bot \
   --page-all \
+  --page-limit 0 \
   --as <same-identity>
 ```
 
-After the readback, process only bots that are not confirmed present. Do not repeat the complete `+chat-members-add` command, because the service may have accepted the bot request before the response became unavailable.
+The bot list is sufficient for an absence check only when `has_more:false` and `truncations` contains no entry for `member_type:"bot"`. If `has_more:true` or bot truncation is present, a missing identifier does not prove that the bot was not added; do not retry the unknown bot batch. When the list is complete, process only bots that are not confirmed present. Do not repeat the complete `+chat-members-add` command, because the service may have accepted the bot request before the response became unavailable.
 
 Deterministic permission, authentication, and API errors use `outcome_unknown:false`. Handle these through the structured `error` fields. The confirmed user additions remain in the chat.
 
-When only `--bots` is supplied, the bot request is the first batch and there is no preceding user result. A deterministic failure returns the standard typed error envelope with top-level `ok:false`, `identity`, and `error`; it does not include `data.failed_member_type`, `data.outcome_unknown`, or any preceding result. A network or transport failure, or a response that cannot be parsed or validated, also remains a top-level typed error. Automatic retry is disabled and `error.hint` requires a `+chat-members-list` readback, but the failure still has no partial-result fields. Use the same identity for readback and retry only bots that are not confirmed present.
+When only `--bots` is supplied, the bot request is the first batch and there is no preceding user result. A deterministic failure returns the standard typed error envelope with top-level `ok:false`, `identity`, and `error`; it does not include `data.failed_member_type`, `data.outcome_unknown`, or any preceding result. A network or transport failure, or a response that cannot be parsed or validated, also remains a top-level typed error. Automatic retry is disabled and `error.hint` requires a `+chat-members-list` readback, but the failure still has no partial-result fields. Apply the same complete bot readback conditions above, use the same identity, and retry only bots that are not confirmed present.
 
 ## References
 

--- a/skills/lark-im/references/lark-im-chat-members-add.md
+++ b/skills/lark-im/references/lark-im-chat-members-add.md
@@ -17,7 +17,7 @@ lark-cli im +chat-members-add \
   --yes
 ```
 
-To preview both requests without changing the chat, replace `--yes` with `--dry-run`. Dry-run does not require `--yes`.
+Append `--yes` only after the operator has explicitly confirmed the requested member changes. Before confirmation, replace `--yes` with `--dry-run` to inspect both requests without changing the chat, or omit `--yes` to receive the `confirmation_required` error and exit code `10`. After confirmation, execute the command with `--yes` to perform the write.
 
 ## Parameters
 
@@ -27,7 +27,7 @@ To preview both requests without changing the chat, replace `--yes` with `--dry-
 | `--users <ids>` | At least one member type is required | Up to 50 unique values | Comma-separated user `open_id` values in `ou_xxx` form |
 | `--bots <ids>` | At least one member type is required | Up to 5 unique values | Comma-separated bot application `app_id` values in `cli_xxx` form |
 | `--as <identity>` | No | `user` or `bot` | Identity used for both requests |
-| `--yes` | Required for execution | - | Confirms the high-impact write operation |
+| `--yes` | Required for execution | - | Performs the write only after explicit operator confirmation |
 | `--dry-run` | No | - | Prints the request preview without executing it or requiring `--yes` |
 
 At least one of `--users` or `--bots` must be present. Duplicate values are removed automatically while preserving first-seen order. Limits are applied after deduplication.
@@ -55,23 +55,23 @@ The `data` object contains one combined result. It reports only the chat identif
 A successful response exits `0` with `ok:true`:
 
 ```json
-{"ok":true,"data":{"chat_id":"oc_xxx","success_count":3,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[]},"meta":{"count":3}}
+{"ok":true,"identity":"user","data":{"chat_id":"oc_xxx","success_count":3,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[]},"meta":{"count":3}}
 ```
 
 If any member-level failure array is non-empty, stdout carries `ok:false` with the complete result and the process exits `1`. Members already accepted by the service remain in the chat:
 
 ```json
-{"ok":false,"data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":["ou_invalid"],"not_existed_id_list":["cli_missing"],"pending_approval_id_list":["ou_pending"]}}
+{"ok":false,"identity":"user","data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":["ou_invalid"],"not_existed_id_list":["cli_missing"],"pending_approval_id_list":["ou_pending"]}}
 ```
 
 Scripts and agents must read `success_count` and all three arrays even when the process exits `1`.
 
 ## Bot Request Failure
 
-When the user request has completed and the bot request returns an error, the partial result also contains `failed_member_type:"bot"`, `outcome_unknown`, and a structured `error` object. `success_count` and the three arrays describe only the confirmed user request result; the shortcut does not guess the bot outcome.
+The partial-result fields described in this section appear only when the user batch has already returned a normal API response with `code=0`, including a response with member-level failure arrays, and the following bot batch fails. In that case, `data` also contains `failed_member_type:"bot"`, `outcome_unknown`, and a structured `error` object. `success_count` and the three arrays describe only the confirmed user response; the shortcut does not guess the bot outcome.
 
 ```json
-{"ok":false,"data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[],"failed_member_type":"bot","outcome_unknown":true,"error":{"type":"network","subtype":"network_transport","message":"member request failed","hint":"List current chat members before retrying; retry only bots not confirmed present.","retryable":false}}}
+{"ok":false,"identity":"user","data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[],"failed_member_type":"bot","outcome_unknown":true,"error":{"type":"network","subtype":"network_transport","message":"member request failed","hint":"List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only bots not confirmed present.","retryable":false}}}
 ```
 
 `outcome_unknown:true` covers network or transport failures and responses that cannot be parsed or validated. First read the current members with the same identity:
@@ -86,6 +86,8 @@ lark-cli im +chat-members-list \
 After the readback, process only bots that are not confirmed present. Do not repeat the complete `+chat-members-add` command, because the service may have accepted the bot request before the response became unavailable.
 
 Deterministic permission, authentication, and API errors use `outcome_unknown:false`. Handle these through the structured `error` fields. The confirmed user additions remain in the chat.
+
+When only `--bots` is supplied, the bot request is the first batch and there is no preceding user result. A deterministic failure returns the standard typed error envelope with top-level `ok:false`, `identity`, and `error`; it does not include `data.failed_member_type`, `data.outcome_unknown`, or any preceding result. A network or transport failure, or a response that cannot be parsed or validated, also remains a top-level typed error. Automatic retry is disabled and `error.hint` requires a `+chat-members-list` readback, but the failure still has no partial-result fields. Use the same identity for readback and retry only bots that are not confirmed present.
 
 ## References
 

--- a/skills/lark-im/references/lark-im-chat-members-add.md
+++ b/skills/lark-im/references/lark-im-chat-members-add.md
@@ -34,6 +34,16 @@ At least one of `--users` or `--bots` must be present. Duplicate values are remo
 
 Both `--as user` and `--as bot` are supported. The selected identity requires the `im:chat.members:write_only` scope and sufficient permission to add members to the target chat.
 
+## Resolve Member Identifiers
+
+Use only identifiers obtained from a verified command response:
+
+- For the currently authorized user, use either `contact +get-user --as user` or `auth status --json --verify` and read `identities.user.openId`.
+- For the current configured application bot, use `auth status --json --verify` and read the top-level `appId`.
+- For any other bot, list a chat that contains that bot and read `bots[].app_id` from a complete `+chat-members-list` result. If the lookup fails, `has_more:true`, or bot truncation is present, stop before the write instead of substituting the current application ID or guessing an ID.
+
+Keep identifier lookup chats separate from the write target. A chat used only to discover `bots[].app_id` must never replace the original `--chat-id`.
+
 ## Request Behavior
 
 User and bot members are always sent in separate requests because they use different identifier types. The user request runs first with `member_id_type=open_id`; the bot request follows with `member_id_type=app_id`. Every request fixes `succeed_type=1`, so members that can be added continue to be added while member-level failures are returned in the response.
@@ -97,6 +107,16 @@ lark-cli im +chat-members-list \
 ```
 
 The bot list is sufficient for an absence check only when `has_more:false` and `truncations` contains no entry for `member_type:"bot"`. If `has_more:true` or bot truncation is present, a missing identifier does not prove that the bot was not added; do not retry the unknown bot batch. When the list is complete, process only bots that are not confirmed present. Do not repeat the complete `+chat-members-add` command, because the service may have accepted the bot request before the response became unavailable.
+
+For `outcome_unknown:true` after a confirmed user batch, apply this checklist in order:
+
+1. Preserve the original target `chat_id` and the original `--as` identity.
+2. Treat the confirmed user batch as complete. Every recovery command must omit `--users`.
+3. Resolve each bot `app_id` from a verified source as described above. Do not replace an unverified bot with `auth status.appId` unless the requested bot is explicitly the current configured application bot.
+4. List the original target chat's bot members with `--member-types bot --page-all --page-limit 0` and the same identity.
+5. If the listing is incomplete or fails, stop and report that error. If the list is complete, omit bots already present and retry only missing bots with `--bots <unconfirmed-app-ids> --yes` against the original target chat.
+
+The confirmed user count is never rolled back by a later bot failure. Replaying `--users`, changing the target chat, changing identity, or retrying a bot already present can duplicate or misdirect a high-impact write.
 
 Deterministic permission, authentication, and API errors use `outcome_unknown:false`. Handle these through the structured `error` fields. The confirmed user additions remain in the chat.
 

--- a/skills/lark-im/references/lark-im-chat-members-add.md
+++ b/skills/lark-im/references/lark-im-chat-members-add.md
@@ -38,7 +38,7 @@ Both `--as user` and `--as bot` are supported. The selected identity requires th
 
 User and bot members are always sent in separate requests because they use different identifier types. The user request runs first with `member_id_type=open_id`; the bot request follows with `member_id_type=app_id`. Every request fixes `succeed_type=1`, so members that can be added continue to be added while member-level failures are returned in the response.
 
-If the user request fails for any reason, execution stops immediately and the bot request is not sent. For a network, transport, or invalid-response failure in this first request, read back every visible user member with the same identity before considering a retry:
+If the user request fails for any reason, execution stops immediately and the bot request is not sent. For a network, transport, or invalid-response failure in this first request, the typed error's fixed hint already contains the complete user readback command and completeness conditions. Read back every visible user member with the same identity before considering a retry:
 
 ```bash
 lark-cli im +chat-members-list \
@@ -82,10 +82,10 @@ Scripts and agents must read `success_count` and all three arrays even when the 
 The partial-result fields described in this section appear only when the user batch has already returned a normal API response with `code=0`, including a response with member-level failure arrays, and the following bot batch fails. In that case, `data` also contains `failed_member_type:"bot"`, `outcome_unknown`, and a structured `error` object. `success_count` and the three arrays describe only the confirmed user response; the shortcut does not guess the bot outcome.
 
 ```json
-{"ok":false,"identity":"user","data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[],"failed_member_type":"bot","outcome_unknown":true,"error":{"type":"network","subtype":"network_transport","message":"member request failed","hint":"List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --page-all before retrying; retry only bots not confirmed present.","retryable":false}}}
+{"ok":false,"identity":"user","data":{"chat_id":"oc_xxx","success_count":1,"invalid_id_list":[],"not_existed_id_list":[],"pending_approval_id_list":[],"failed_member_type":"bot","outcome_unknown":true,"error":{"type":"network","subtype":"network_transport","message":"member request failed","hint":"List current chat members with lark-cli im +chat-members-list --chat-id <chat_id> --member-types bot --page-all --page-limit 0 --as <same-identity> before retrying. Treat a member not found as missing only when has_more:false and truncations has no entry for member_type bot; otherwise do not retry the unknown batch. Retry only bots not confirmed present.","retryable":false}}}
 ```
 
-`outcome_unknown:true` covers network or transport failures and responses that cannot be parsed or validated. The JSON example preserves the implementation's exact fixed `error.hint`. For a safe absence check, add the bot filter and unlimited page count to the basic command named by that hint, then read the members with the same identity:
+`outcome_unknown:true` covers network or transport failures and responses that cannot be parsed or validated. The JSON example preserves the implementation's exact fixed `error.hint`. The hint already contains the bot filter, unlimited page count, same-identity placeholder, completeness conditions, and retry rule. The standalone command is shown here for readability:
 
 ```bash
 lark-cli im +chat-members-list \
@@ -100,7 +100,7 @@ The bot list is sufficient for an absence check only when `has_more:false` and `
 
 Deterministic permission, authentication, and API errors use `outcome_unknown:false`. Handle these through the structured `error` fields. The confirmed user additions remain in the chat.
 
-When only `--bots` is supplied, the bot request is the first batch and there is no preceding user result. A deterministic failure returns the standard typed error envelope with top-level `ok:false`, `identity`, and `error`; it does not include `data.failed_member_type`, `data.outcome_unknown`, or any preceding result. A network or transport failure, or a response that cannot be parsed or validated, also remains a top-level typed error. Automatic retry is disabled and `error.hint` requires a `+chat-members-list` readback, but the failure still has no partial-result fields. Apply the same complete bot readback conditions above, use the same identity, and retry only bots that are not confirmed present.
+When only `--bots` is supplied, the bot request is the first batch and there is no preceding user result. A deterministic failure returns the standard typed error envelope with top-level `ok:false`, `identity`, and `error`; it does not include `data.failed_member_type`, `data.outcome_unknown`, or any preceding result. A network or transport failure, or a response that cannot be parsed or validated, also remains a top-level typed error. Automatic retry is disabled, and the fixed `error.hint` already includes the complete bot readback command and completeness conditions, but the failure still has no partial-result fields. Apply the same complete bot readback conditions above, use the same identity, and retry only bots that are not confirmed present.
 
 ## References
 

--- a/tests/cli_e2e/im/chat_members_add_dryrun_test.go
+++ b/tests/cli_e2e/im/chat_members_add_dryrun_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestIM_ChatMembersAddDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	tests := []struct {
+		name     string
+		args     []string
+		requests []chatMembersAddDryRunRequest
+	}{
+		{
+			name: "users only",
+			args: []string{"--users", "ou_user_b,ou_user_a,ou_user_b"},
+			requests: []chatMembersAddDryRunRequest{
+				{memberIDType: "open_id", ids: []string{"ou_user_b", "ou_user_a"}},
+			},
+		},
+		{
+			name: "bots only",
+			args: []string{"--bots", "cli_bot_b,cli_bot_a,cli_bot_b"},
+			requests: []chatMembersAddDryRunRequest{
+				{memberIDType: "app_id", ids: []string{"cli_bot_b", "cli_bot_a"}},
+			},
+		},
+		{
+			name: "users before bots",
+			args: []string{
+				"--users", "ou_user_b,ou_user_a,ou_user_b",
+				"--bots", "cli_bot_b,cli_bot_a,cli_bot_b",
+			},
+			requests: []chatMembersAddDryRunRequest{
+				{memberIDType: "open_id", ids: []string{"ou_user_b", "ou_user_a"}},
+				{memberIDType: "app_id", ids: []string{"cli_bot_b", "cli_bot_a"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{
+				"im", "+chat-members-add",
+				"--chat-id", "oc_e2e_chat",
+			}
+			args = append(args, tt.args...)
+			args = append(args, "--dry-run")
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      args,
+				DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+			result.AssertStdoutStatus(t, true)
+			require.True(t, gjson.Get(result.Stdout, "dry_run").Bool(), "expected a dry-run response")
+
+			requests := clie2e.DryRunGet(result.Stdout, "api").Array()
+			require.Len(t, requests, len(tt.requests), "unexpected dry-run request count")
+			for i, expected := range tt.requests {
+				assertChatMembersAddDryRunRequest(t, requests[i], expected)
+			}
+		})
+	}
+}
+
+type chatMembersAddDryRunRequest struct {
+	memberIDType string
+	ids          []string
+}
+
+func assertChatMembersAddDryRunRequest(t *testing.T, request gjson.Result, expected chatMembersAddDryRunRequest) {
+	t.Helper()
+
+	require.Equal(t, "POST", request.Get("method").String())
+	require.Equal(t, "/open-apis/im/v1/chats/oc_e2e_chat/members", request.Get("url").String())
+	require.Equal(t, expected.memberIDType, request.Get("params.member_id_type").String())
+	require.Equal(t, "1", request.Get("params.succeed_type").String())
+
+	actualIDs := make([]string, 0, len(request.Get("body.id_list").Array()))
+	for _, item := range request.Get("body.id_list").Array() {
+		actualIDs = append(actualIDs, item.String())
+	}
+	require.Equal(t, expected.ids, actualIDs)
+}

--- a/tests/cli_e2e/im/chat_members_add_workflow_test.go
+++ b/tests/cli_e2e/im/chat_members_add_workflow_test.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const chatMembersAddWriteScope = "im:chat.members:write_only"
+
+func TestIM_ChatMembersAddWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+	clie2e.SkipWithoutUserToken(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	t.Cleanup(cancel)
+	parentT := t
+	suffix := clie2e.GenerateSuffix()
+
+	selfOpenID := getSelfOpenIDForChatMembersAdd(t, ctx)
+	botChatID := createChatAs(t, parentT, ctx, "lark-cli-e2e-member-add-bot-"+suffix, "bot")
+	botAppID := getBotAppIDFromChat(t, ctx, botChatID)
+	userChatID := createChatAs(t, parentT, ctx, "lark-cli-e2e-member-add-user-"+suffix, "user")
+
+	t.Run("add user as bot and read back", func(t *testing.T) {
+		baseline := listChatMembers(t, ctx, botChatID, "user", "bot")
+		assertCompleteChatMemberList(t, baseline)
+		require.False(t, chatMemberListContains(baseline, "users", "member_id", selfOpenID), "target user must be absent before add")
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+chat-members-add",
+				"--chat-id", botChatID,
+				"--users", selfOpenID,
+			},
+			DefaultAs: "bot",
+			Yes:       true,
+		})
+		require.NoError(t, err)
+		skipIfMissingChatMemberPermission(t, result)
+		assertChatMembersAddSuccess(t, result)
+
+		readback := waitForChatMember(t, ctx, botChatID, "user", "bot", "users", "member_id", selfOpenID)
+		assertCompleteChatMemberList(t, readback)
+	})
+
+	t.Run("add bot as user and read back", func(t *testing.T) {
+		baseline := listChatMembers(t, ctx, userChatID, "bot", "user")
+		assertCompleteChatMemberList(t, baseline)
+		require.False(t, chatMemberListContains(baseline, "bots", "app_id", botAppID), "target bot must be absent before add")
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+chat-members-add",
+				"--chat-id", userChatID,
+				"--bots", botAppID,
+			},
+			DefaultAs: "user",
+			Yes:       true,
+		})
+		require.NoError(t, err)
+		skipIfMissingChatMemberPermission(t, result)
+		assertChatMembersAddSuccess(t, result)
+
+		readback := waitForChatMember(t, ctx, userChatID, "bot", "user", "bots", "app_id", botAppID)
+		assertCompleteChatMemberList(t, readback)
+	})
+}
+
+func getSelfOpenIDForChatMembersAdd(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"contact", "+get-user"},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.ExitCode, "contact lookup failed: %s", resultErrorSummary(result))
+	require.True(t, gjson.Get(result.Stdout, "ok").Bool(), "contact lookup returned ok=false")
+
+	openID := gjson.Get(result.Stdout, "data.user.open_id").String()
+	require.NotEmpty(t, openID, "contact lookup returned an empty open_id")
+	return openID
+}
+
+func getBotAppIDFromChat(t *testing.T, ctx context.Context, chatID string) string {
+	t.Helper()
+
+	result, err := clie2e.RunCmdWithRetry(ctx, chatMembersListRequest(chatID, "bot", "bot"), clie2e.RetryOptions{
+		Attempts:     6,
+		InitialDelay: time.Second,
+		MaxDelay:     4 * time.Second,
+		ShouldRetry: func(result *clie2e.Result) bool {
+			if result == nil {
+				return true
+			}
+			if result.ExitCode != 0 {
+				return clie2e.ResultHasRetryableError(result)
+			}
+			for _, bot := range gjson.Get(result.Stdout, "data.bots").Array() {
+				if bot.Get("app_id").String() != "" {
+					return false
+				}
+			}
+			return true
+		},
+	})
+	require.NoError(t, err)
+	skipIfMissingChatMemberPermission(t, result)
+	require.Equal(t, 0, result.ExitCode, "bot member discovery failed: %s", resultErrorSummary(result))
+	require.True(t, gjson.Get(result.Stdout, "ok").Bool(), "bot member discovery returned ok=false")
+	assertCompleteChatMemberList(t, result)
+
+	for _, bot := range gjson.Get(result.Stdout, "data.bots").Array() {
+		if appID := bot.Get("app_id").String(); appID != "" {
+			return appID
+		}
+	}
+	t.Fatal("bot member discovery returned no app_id")
+	return ""
+}
+
+func chatMembersListRequest(chatID, memberType, defaultAs string) clie2e.Request {
+	return clie2e.Request{
+		Args: []string{
+			"im", "+chat-members-list",
+			"--chat-id", chatID,
+			"--member-types", memberType,
+			"--page-all",
+			"--page-limit", "0",
+		},
+		DefaultAs: defaultAs,
+	}
+}
+
+func listChatMembers(t *testing.T, ctx context.Context, chatID, memberType, defaultAs string) *clie2e.Result {
+	t.Helper()
+
+	result, err := clie2e.RunCmd(ctx, chatMembersListRequest(chatID, memberType, defaultAs))
+	require.NoError(t, err)
+	skipIfMissingChatMemberPermission(t, result)
+	require.Equal(t, 0, result.ExitCode, "member list failed: %s", resultErrorSummary(result))
+	require.True(t, gjson.Get(result.Stdout, "ok").Bool(), "member list returned ok=false")
+	return result
+}
+
+func waitForChatMember(
+	t *testing.T,
+	ctx context.Context,
+	chatID string,
+	memberType string,
+	defaultAs string,
+	bucket string,
+	idField string,
+	id string,
+) *clie2e.Result {
+	t.Helper()
+
+	result, err := clie2e.RunCmdWithRetry(ctx, chatMembersListRequest(chatID, memberType, defaultAs), clie2e.RetryOptions{
+		Attempts:     8,
+		InitialDelay: time.Second,
+		MaxDelay:     5 * time.Second,
+		ShouldRetry: func(result *clie2e.Result) bool {
+			if result == nil {
+				return true
+			}
+			if result.ExitCode != 0 {
+				return clie2e.ResultHasRetryableError(result)
+			}
+			return !chatMemberListContains(result, bucket, idField, id)
+		},
+	})
+	require.NoError(t, err)
+	skipIfMissingChatMemberPermission(t, result)
+	require.Equal(t, 0, result.ExitCode, "member readback failed: %s", resultErrorSummary(result))
+	require.True(t, gjson.Get(result.Stdout, "ok").Bool(), "member readback returned ok=false")
+	require.True(t, chatMemberListContains(result, bucket, idField, id), "added member was absent after bounded readback")
+	return result
+}
+
+func chatMemberListContains(result *clie2e.Result, bucket, idField, id string) bool {
+	if result == nil {
+		return false
+	}
+	for _, member := range gjson.Get(result.Stdout, "data."+bucket).Array() {
+		if member.Get(idField).String() == id {
+			return true
+		}
+	}
+	return false
+}
+
+func assertCompleteChatMemberList(t *testing.T, result *clie2e.Result) {
+	t.Helper()
+	require.False(t, gjson.Get(result.Stdout, "data.has_more").Bool(), "member list must include all pages")
+	require.Empty(t, gjson.Get(result.Stdout, "data.truncations").Array(), "member list must not contain truncation markers")
+}
+
+func assertChatMembersAddSuccess(t *testing.T, result *clie2e.Result) {
+	t.Helper()
+	require.Equal(t, 0, result.ExitCode, "member add failed: %s", resultErrorSummary(result))
+	require.True(t, gjson.Get(result.Stdout, "ok").Bool(), "member add returned ok=false")
+	require.Equal(t, int64(1), gjson.Get(result.Stdout, "data.success_count").Int())
+
+	for _, field := range []string{"invalid_id_list", "not_existed_id_list", "pending_approval_id_list"} {
+		value := gjson.Get(result.Stdout, "data."+field)
+		require.True(t, value.Exists(), "%s must be present", field)
+		require.True(t, value.IsArray(), "%s must be an array", field)
+		require.Empty(t, value.Array(), "%s must be empty", field)
+	}
+}
+
+func skipIfMissingChatMemberPermission(t *testing.T, result *clie2e.Result) {
+	t.Helper()
+	if result == nil || result.ExitCode == 0 {
+		return
+	}
+
+	scopes := missingPermissionNames(result)
+	if len(scopes) == 0 {
+		return
+	}
+	t.Skipf("skipped: missing IM member permissions: %s", strings.Join(scopes, ", "))
+}
+
+func missingPermissionNames(result *clie2e.Result) []string {
+	if result == nil {
+		return nil
+	}
+
+	names := map[string]struct{}{}
+	permissionFailure := false
+	for _, raw := range []string{result.Stdout, result.Stderr} {
+		payload := strings.TrimSpace(raw)
+		if !gjson.Valid(payload) {
+			continue
+		}
+		category := gjson.Get(payload, "error.type").String()
+		subtype := gjson.Get(payload, "error.subtype").String()
+		if category == "authorization" || strings.Contains(subtype, "scope") || subtype == "permission_denied" {
+			permissionFailure = true
+		}
+		for _, scope := range gjson.Get(payload, "error.missing_scopes").Array() {
+			if name := scope.String(); name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+
+	combined := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	if strings.Contains(combined, "missing_scope") ||
+		strings.Contains(combined, "permission denied") ||
+		strings.Contains(combined, "99991672") ||
+		strings.Contains(combined, "99991676") ||
+		strings.Contains(combined, "99991679") {
+		permissionFailure = true
+	}
+	for _, scope := range []string{chatMembersAddWriteScope, "im:chat.members:read"} {
+		if strings.Contains(combined, scope) {
+			names[scope] = struct{}{}
+		}
+	}
+	if !permissionFailure {
+		return nil
+	}
+	if len(names) == 0 {
+		names["IM chat member permission"] = struct{}{}
+	}
+
+	resultNames := make([]string, 0, len(names))
+	for name := range names {
+		resultNames = append(resultNames, name)
+	}
+	sort.Strings(resultNames)
+	return resultNames
+}
+
+func resultErrorSummary(result *clie2e.Result) string {
+	if result == nil {
+		return "result=nil"
+	}
+	for _, raw := range []string{result.Stderr, result.Stdout} {
+		payload := strings.TrimSpace(raw)
+		if !gjson.Valid(payload) {
+			continue
+		}
+		return "type=" + gjson.Get(payload, "error.type").String() +
+			" subtype=" + gjson.Get(payload, "error.subtype").String()
+	}
+	return "structured error unavailable"
+}

--- a/tests/cli_e2e/im/chat_members_add_workflow_test.go
+++ b/tests/cli_e2e/im/chat_members_add_workflow_test.go
@@ -242,8 +242,8 @@ func missingPermissionNames(result *clie2e.Result) []string {
 	fallbackNames := map[string]struct{}{}
 	missingScopeFailure := false
 	for _, raw := range []string{result.Stdout, result.Stderr} {
-		payload := strings.TrimSpace(raw)
-		if !gjson.Valid(payload) {
+		payload := extractTrailingJSONEnvelope(raw)
+		if payload == "" {
 			continue
 		}
 		subtype := gjson.Get(payload, "error.subtype").String()
@@ -280,6 +280,30 @@ func missingPermissionNames(result *clie2e.Result) []string {
 	}
 	sort.Strings(resultNames)
 	return resultNames
+}
+
+func extractTrailingJSONEnvelope(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "{") && gjson.Valid(trimmed) {
+		return trimmed
+	}
+
+	searchEnd := len(trimmed)
+	for searchEnd > 0 {
+		candidateStart := strings.LastIndex(trimmed[:searchEnd], "{")
+		if candidateStart < 0 {
+			return ""
+		}
+		candidate := strings.TrimSpace(trimmed[candidateStart:])
+		if gjson.Valid(candidate) {
+			return candidate
+		}
+		searchEnd = candidateStart
+	}
+	return ""
 }
 
 func isMissingIMMemberScope(subtype string, code int64) bool {
@@ -338,6 +362,22 @@ func TestMissingIMMemberPermissionNames(t *testing.T) {
 			want:   []string{"scope code 99991679"},
 		},
 		{
+			name:   "page progress before missing scope",
+			stderr: "[page 1] fetching...\n{\"error\":{\"type\":\"authorization\",\"subtype\":\"missing_scope\",\"missing_scopes\":[\"im:chat.members:read\"]}}",
+			want:   []string{"im:chat.members:read"},
+		},
+		{
+			name: "page progress before multiline scope envelope",
+			stderr: "[page 1] fetching...\n{\n" +
+				"  \"error\": {\n" +
+				"    \"type\": \"authorization\",\n" +
+				"    \"subtype\": \"app_scope_not_applied\",\n" +
+				"    \"missing_scopes\": [\"im:chat.members:write_only\"]\n" +
+				"  }\n" +
+				"}\n",
+			want: []string{chatMembersAddWriteScope},
+		},
+		{
 			name:   "authorization category alone",
 			stderr: `{"error":{"type":"authorization","subtype":"unknown"}}`,
 		},
@@ -346,8 +386,16 @@ func TestMissingIMMemberPermissionNames(t *testing.T) {
 			stderr: `{"error":{"type":"authorization","subtype":"permission_denied"}}`,
 		},
 		{
+			name:   "page progress before permission denied",
+			stderr: "[page 1] fetching...\n{\"error\":{\"type\":\"authorization\",\"subtype\":\"permission_denied\"}}",
+		},
+		{
 			name:   "not in chat resource state",
 			stderr: `{"error":{"type":"validation","subtype":"failed_precondition","message":"not in chat"}}`,
+		},
+		{
+			name:   "page progress before resource state error",
+			stderr: "[page 1] fetching...\n{\"error\":{\"type\":\"validation\",\"subtype\":\"failed_precondition\",\"message\":\"not in chat\"}}",
 		},
 		{
 			name:   "no invite permission",
@@ -360,6 +408,14 @@ func TestMissingIMMemberPermissionNames(t *testing.T) {
 		{
 			name:   "unknown error",
 			stderr: `{"error":{"type":"internal","subtype":"unknown"}}`,
+		},
+		{
+			name:   "non JSON progress text",
+			stderr: "[page 1] fetching...\nrequest failed",
+		},
+		{
+			name:   "embedded JSON does not cover text end",
+			stderr: `[page {"error":{"subtype":"missing_scope"}}] fetching...`,
 		},
 	}
 
@@ -380,8 +436,8 @@ func resultErrorSummary(result *clie2e.Result) string {
 		return "result=nil"
 	}
 	for _, raw := range []string{result.Stderr, result.Stdout} {
-		payload := strings.TrimSpace(raw)
-		if !gjson.Valid(payload) {
+		payload := extractTrailingJSONEnvelope(raw)
+		if payload == "" {
 			continue
 		}
 		return "type=" + gjson.Get(payload, "error.type").String() +

--- a/tests/cli_e2e/im/chat_members_add_workflow_test.go
+++ b/tests/cli_e2e/im/chat_members_add_workflow_test.go
@@ -6,6 +6,7 @@ package im
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -238,16 +239,24 @@ func missingPermissionNames(result *clie2e.Result) []string {
 	}
 
 	names := map[string]struct{}{}
-	permissionFailure := false
+	fallbackNames := map[string]struct{}{}
+	missingScopeFailure := false
 	for _, raw := range []string{result.Stdout, result.Stderr} {
 		payload := strings.TrimSpace(raw)
 		if !gjson.Valid(payload) {
 			continue
 		}
-		category := gjson.Get(payload, "error.type").String()
 		subtype := gjson.Get(payload, "error.subtype").String()
-		if category == "authorization" || strings.Contains(subtype, "scope") || subtype == "permission_denied" {
-			permissionFailure = true
+		code := gjson.Get(payload, "error.code").Int()
+		if !isMissingIMMemberScope(subtype, code) {
+			continue
+		}
+
+		missingScopeFailure = true
+		if isMissingIMMemberScopeCode(code) {
+			fallbackNames["scope code "+strconv.FormatInt(code, 10)] = struct{}{}
+		} else {
+			fallbackNames["IM chat member scope"] = struct{}{}
 		}
 		for _, scope := range gjson.Get(payload, "error.missing_scopes").Array() {
 			if name := scope.String(); name != "" {
@@ -256,24 +265,13 @@ func missingPermissionNames(result *clie2e.Result) []string {
 		}
 	}
 
-	combined := strings.ToLower(result.Stdout + "\n" + result.Stderr)
-	if strings.Contains(combined, "missing_scope") ||
-		strings.Contains(combined, "permission denied") ||
-		strings.Contains(combined, "99991672") ||
-		strings.Contains(combined, "99991676") ||
-		strings.Contains(combined, "99991679") {
-		permissionFailure = true
-	}
-	for _, scope := range []string{chatMembersAddWriteScope, "im:chat.members:read"} {
-		if strings.Contains(combined, scope) {
-			names[scope] = struct{}{}
-		}
-	}
-	if !permissionFailure {
+	if !missingScopeFailure {
 		return nil
 	}
 	if len(names) == 0 {
-		names["IM chat member permission"] = struct{}{}
+		for name := range fallbackNames {
+			names[name] = struct{}{}
+		}
 	}
 
 	resultNames := make([]string, 0, len(names))
@@ -282,6 +280,99 @@ func missingPermissionNames(result *clie2e.Result) []string {
 	}
 	sort.Strings(resultNames)
 	return resultNames
+}
+
+func isMissingIMMemberScope(subtype string, code int64) bool {
+	switch subtype {
+	case "missing_scope", "app_scope_not_applied", "token_scope_insufficient":
+		return true
+	default:
+		return isMissingIMMemberScopeCode(code)
+	}
+}
+
+func isMissingIMMemberScopeCode(code int64) bool {
+	switch code {
+	case 99991672, 99991676, 99991679:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestMissingIMMemberPermissionNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		stdout string
+		want   []string
+	}{
+		{
+			name:   "missing scope subtype",
+			stderr: `{"error":{"type":"authorization","subtype":"missing_scope","missing_scopes":["im:chat.members:read"]}}`,
+			want:   []string{"im:chat.members:read"},
+		},
+		{
+			name:   "app scope not applied subtype",
+			stderr: `{"error":{"type":"authorization","subtype":"app_scope_not_applied","missing_scopes":["im:chat.members:write_only"]}}`,
+			want:   []string{chatMembersAddWriteScope},
+		},
+		{
+			name:   "token scope insufficient subtype",
+			stderr: `{"error":{"type":"authorization","subtype":"token_scope_insufficient"}}`,
+			want:   []string{"IM chat member scope"},
+		},
+		{
+			name:   "app scope not applied code",
+			stderr: `{"error":{"type":"api_error","code":99991672}}`,
+			want:   []string{"scope code 99991672"},
+		},
+		{
+			name:   "token scope insufficient code",
+			stderr: `{"error":{"type":"api_error","code":99991676}}`,
+			want:   []string{"scope code 99991676"},
+		},
+		{
+			name:   "missing scope code on stdout",
+			stdout: `{"error":{"type":"api_error","code":99991679}}`,
+			want:   []string{"scope code 99991679"},
+		},
+		{
+			name:   "authorization category alone",
+			stderr: `{"error":{"type":"authorization","subtype":"unknown"}}`,
+		},
+		{
+			name:   "ordinary permission denied",
+			stderr: `{"error":{"type":"authorization","subtype":"permission_denied"}}`,
+		},
+		{
+			name:   "not in chat resource state",
+			stderr: `{"error":{"type":"validation","subtype":"failed_precondition","message":"not in chat"}}`,
+		},
+		{
+			name:   "no invite permission",
+			stderr: `{"error":{"type":"authorization","subtype":"permission_denied","message":"no invite permission"}}`,
+		},
+		{
+			name:   "scope substring is not accepted",
+			stderr: `{"error":{"type":"authorization","subtype":"unknown_scope_state"}}`,
+		},
+		{
+			name:   "unknown error",
+			stderr: `{"error":{"type":"internal","subtype":"unknown"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &clie2e.Result{
+				ExitCode: 3,
+				Stdout:   tt.stdout,
+				Stderr:   tt.stderr,
+			}
+			require.Equal(t, tt.want, missingPermissionNames(result))
+		})
+	}
 }
 
 func resultErrorSummary(result *clie2e.Result) string {

--- a/tests/cli_e2e/im/coverage.md
+++ b/tests/cli_e2e/im/coverage.md
@@ -1,9 +1,9 @@
 # IM CLI E2E Coverage
 
 ## Metrics
-- Denominator: 30 leaf commands
-- Covered: 11
-- Coverage: 36.7%
+- Denominator: 31 leaf commands
+- Covered: 12
+- Coverage: 38.7%
 
 ## Summary
 - TestIM_ChatUpdateWorkflow: proves `im +chat-create`, `im +chat-update`, and `im chats get`; key `t.Run(...)` proof points are `update chat name as bot`, `update chat description as bot`, and `get updated chat as bot`.
@@ -14,6 +14,8 @@
 - TestIM_MessageReplyWorkflowAsBot: proves threaded reply flow through `reply to message in thread as bot` and `list thread replies as bot`, reading back the reply from `im +threads-messages-list`.
 - TestIM_MessagesSendAudioDryRunRejectsNonOpus: proves the `im +messages-send --audio` dry-run validation rejects non-Opus local audio before upload, with typed validation metadata and recovery guidance.
 - TestIM_MessageForwardWorkflowAsUser: proves UAT-backed API forwarding through `im messages forward` and `im threads forward` using a fresh message/thread fixture; skips the forward assertions when the current test app/UAT lacks IM forward permission.
+- TestIM_ChatMembersAddDryRun: proves `im +chat-members-add` builds users-only, bots-only, and users-before-bots requests with fixed `succeed_type=1`, preserved first-seen order, duplicate removal, and no `--yes` requirement during dry-run.
+- TestIM_ChatMembersAddWorkflow: proves live user and bot member additions through two isolated private chats, checks each target member is initially absent, and reads the added `open_id` or `app_id` back from `im +chat-members-list`.
 - Blocked area: `im +chat-search` did not reliably return freshly created private chats in UAT, and `im +messages-search` did not reliably index freshly sent messages in time for a deterministic read-after-write assertion, so both remain uncovered.
 
 ## Command Table
@@ -21,6 +23,7 @@
 | Status | Cmd | Type | Testcase | Key parameter shapes | Notes / uncovered reason |
 | --- | --- | --- | --- | --- | --- |
 | ✓ | im +chat-create | shortcut | im/chat_message_workflow_test.go::TestIM_ChatMessageWorkflowAsUser/create chat as user; im/chat_workflow_test.go::TestIM_ChatUpdateWorkflow; im/chat_workflow_test.go::TestIM_ChatsGetWorkflow; im/chat_workflow_test.go::TestIM_ChatsLinkWorkflow; im/message_get_workflow_test.go::TestIM_MessageGetWorkflowAsUser; im/message_reply_workflow_test.go::TestIM_MessageReplyWorkflowAsBot | `--name`; `--type private` | covered via workflow setup with created chat IDs asserted |
+| ✓ | im +chat-members-add | shortcut | im/chat_members_add_dryrun_test.go::TestIM_ChatMembersAddDryRun; im/chat_members_add_workflow_test.go::TestIM_ChatMembersAddWorkflow/add user as bot and read back; im/chat_members_add_workflow_test.go::TestIM_ChatMembersAddWorkflow/add bot as user and read back | dry-run: users only, bots only, users then bots; live: `--users <open_id> --as bot --yes`, `--bots <app_id> --as user --yes` | dry-run proves request count, request order, fixed parameters, and duplicate removal; live tests confirm absence before add and presence after add |
 | ✓ | im +chat-messages-list | shortcut | im/chat_message_workflow_test.go::TestIM_ChatMessageWorkflowAsUser/list chat messages as user; im/message_reply_workflow_test.go::TestIM_MessageReplyWorkflowAsBot/list thread replies as bot | `--chat-id`; `--start`; `--end` | reads back created message and discovers thread ID |
 | ✕ | im +chat-search | shortcut |  | none | UAT did not reliably return freshly created private chats, so it is left uncovered |
 | ✓ | im +chat-update | shortcut | im/chat_workflow_test.go::TestIM_ChatUpdateWorkflow/update chat name as bot; im/chat_workflow_test.go::TestIM_ChatUpdateWorkflow/update chat description as bot | `--chat-id`; `--name`; `--description` | |


### PR DESCRIPTION
## Summary

Add a dedicated `im +chat-members-add` shortcut so callers can add user `open_id` and bot `app_id` values without constructing Meta API JSON. The shortcut preserves partial results, processes users before bots, and provides explicit recovery guidance for unknown outcomes.

## Changes

- Add `ImChatMembersAdd` request validation, dry-run previews, two-request execution, and stable combined output in `shortcuts/im/im_chat_members_add.go`
- Run shortcut validation and confirmation before scope preflight in `shortcuts/common/runner.go`
- Add unit, dry-run, and live workflow coverage under `shortcuts/im/` and `tests/cli_e2e/im/`
- Document identity selection, result fields, and safe retry behavior in `skills/lark-im/`

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed
- [x] local-eval passed (E2E 2/2; the bot-identity case used a scope-specific environment skip)
- [ ] skillave completed 3/4; the remaining `outcome_unknown` recovery case was accepted by explicit human approval
- [x] acceptance-reviewer passed (5/5 cases)
- [x] manual verification: `lark-cli im +chat-members-add --help` and `lark-cli im +chat-members-add --chat-id oc_review123 --bots bot_123 --as user --dry-run`

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `im +chat-members-add` to add users and bots to group chats.
  * Supports validation, deduplication, dry-run previews, confirmation, combined results, and partial-failure reporting.
  * Added recovery guidance for uncertain bot-addition outcomes.

* **Bug Fixes**
  * Scope checks now occur after validation, dry-run handling, and confirmation gates.

* **Documentation**
  * Updated IM shortcut guidance, permissions, usage examples, and recovery procedures.

* **Tests**
  * Added comprehensive unit and end-to-end coverage for chat-member additions and dry-run workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->