### PR TITLE
fix(slides): detect image text occlusion

### DIFF
--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -195,18 +195,29 @@ def strip_xml_paragraphs(value: str) -> str:
     return strip_xml(value, preserve_line_breaks=True)
 
 
-def extract_text_paragraphs(value: str) -> list[dict[str, str | None]]:
+def extract_text_paragraphs(value: str, default_font_size: int | float) -> list[dict[str, Any]]:
     paragraphs = []
     for attrs, body in re.findall(r"<p\b([^>]*)>([\s\S]*?)</p\s*>", value):
         paragraphs.append(
             {
                 "text": strip_xml(body, preserve_line_breaks=True),
+                "fontSize": extract_max_span_font_size(body, default_font_size),
+                "textAlign": extract_attribute(attrs, "textAlign"),
                 "lineSpacing": extract_attribute(attrs, "lineSpacing"),
                 "beforeLineSpacing": extract_attribute(attrs, "beforeLineSpacing"),
                 "afterLineSpacing": extract_attribute(attrs, "afterLineSpacing"),
             }
         )
     return paragraphs
+
+
+def extract_max_span_font_size(value: str, default_font_size: int | float) -> int | float:
+    font_sizes = [
+        font_size
+        for attrs in re.findall(r"<span\b([^>]*)>", value)
+        if (font_size := extract_numeric_attribute(attrs, "fontSize")) is not None
+    ]
+    return max([default_font_size, *font_sizes])
 
 
 def extract_tag_attributes(value: str, tag: str) -> str:
@@ -633,6 +644,7 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
         width = extract_numeric_attribute(attrs, "width")
         height = extract_numeric_attribute(attrs, "height")
         rotation = extract_numeric_attribute(attrs, "rotation") or 0
+        alpha = extract_numeric_attribute(attrs, "alpha")
         table_layouts: dict[str, dict[str, Any] | None] = {}
         if kind == "table":
             width, table_layouts["width"] = resolve_table_dimension(
@@ -651,6 +663,7 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "width": width,
                 "height": height,
                 "rotation": rotation,
+                "alpha": alpha if alpha is not None else 1,
                 "order": len(elements),
             }
             if kind == "table":
@@ -670,16 +683,20 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
                     {
                         "textType": extract_attribute(content_attrs, "textType"),
                         "textAlign": extract_attribute(content_attrs, "textAlign"),
+                        "verticalAlign": extract_attribute(content_attrs, "verticalAlign") or "middle",
+                        "vert": extract_attribute(attrs, "vert") or "horz",
                         "autoFit": extract_attribute(content_attrs, "autoFit"),
                         "wrap": extract_attribute(content_attrs, "wrap"),
                         "lineSpacing": extract_attribute(content_attrs, "lineSpacing"),
                         "beforeLineSpacing": extract_attribute(content_attrs, "beforeLineSpacing"),
                         "afterLineSpacing": extract_attribute(content_attrs, "afterLineSpacing"),
                         "paddingTop": extract_numeric_attribute(content_attrs, "paddingTop") or 0,
+                        "paddingRight": extract_numeric_attribute(content_attrs, "paddingRight") or 0,
                         "paddingBottom": extract_numeric_attribute(content_attrs, "paddingBottom") or 0,
+                        "paddingLeft": extract_numeric_attribute(content_attrs, "paddingLeft") or 0,
                         "fontSize": font_size if font_size is not None else 16,
                         "text": strip_xml_paragraphs(content),
-                        "paragraphs": extract_text_paragraphs(content),
+                        "paragraphs": extract_text_paragraphs(content, font_size if font_size is not None else 16),
                     }
                 )
             elements.append(element)
@@ -705,6 +722,40 @@ def is_whiteboard_element(element: dict[str, Any]) -> bool:
 
 def has_text_content(element: dict[str, Any]) -> bool:
     return bool(element.get("text"))
+
+
+def is_vertical_text(element: dict[str, Any]) -> bool:
+    return element.get("vert") in {"vert", "vert270", "word-art-vert", "word-art-vert-rtl", "ea-vert"}
+
+
+def detect_image_text_occlusions(elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    text_elements = [element for element in elements if is_text_element(element) and has_text_content(element)]
+    image_elements = [element for element in elements if element["kind"] == "img" and element["alpha"] > 0]
+    for text_element in text_elements:
+        for image_element in image_elements:
+            if image_element["order"] <= text_element["order"]:
+                continue
+            if is_vertical_text(text_element):
+                if intersects(image_element, text_element):
+                    issues.append({
+                        "level": "info",
+                        "code": "image_may_cover_vertical_text",
+                        "elements": [image_element["id"], text_element["id"]],
+                        "message": f'image {image_element["id"]} may cover vertical text shape {text_element["id"]}',
+                        "hint": "Inspect the rendered slide because vertical text layout is not statically modeled.",
+                    })
+                continue
+            text_visual_bbox = estimate_text_visual_bbox(text_element)
+            if text_visual_bbox is not None and intersects(image_element, text_visual_bbox):
+                issues.append({
+                    "level": "error",
+                    "code": "image_covers_text",
+                    "elements": [image_element["id"], text_element["id"]],
+                    "message": f'image {image_element["id"]} covers text shape {text_element["id"]}',
+                    "hint": "Move the image before the text shape in XML order, or adjust the image and text shape coordinates or dimensions.",
+                })
+    return issues
 
 
 def is_decorative_text(element: dict[str, Any]) -> bool:
@@ -849,13 +900,30 @@ def estimate_text_visual_bbox(element: dict[str, Any]) -> dict[str, int | float]
     if not is_text_element(element) or not has_text_content(element) or is_decorative_text(element):
         return None
 
+    padding_left = element.get("paddingLeft", 0)
+    padding_right = element.get("paddingRight", 0)
+    padding_top = element.get("paddingTop", 0)
+    padding_bottom = element.get("paddingBottom", 0)
+    content_width = max(element["width"] - padding_left - padding_right, 0)
+    content_height = max(element["height"] - padding_top - padding_bottom, 0)
     font_size = element["fontSize"] if isinstance(element["fontSize"], (int, float)) else 16
     line_count = estimate_text_line_count(element)
-    visual_width = min(element["width"], max(1, estimate_text_max_line_width(element)))
-    visual_height = min(element["height"], max(1, line_count * font_size * 1.2))
+    estimated_width = max(1, estimate_text_max_line_width(element))
+    visual_width = estimated_width if element.get("wrap") in {"false", "0"} else min(content_width, estimated_width)
+    visual_height = min(content_height, max(1, line_count * font_size * 1.2))
+    x = element["x"] + padding_left
+    if element.get("textAlign") == "center":
+        x += (content_width - visual_width) / 2
+    elif element.get("textAlign") == "right":
+        x += content_width - visual_width
+    y = element["y"] + padding_top
+    if element.get("verticalAlign") == "middle":
+        y += (content_height - visual_height) / 2
+    elif element.get("verticalAlign") == "bottom":
+        y += content_height - visual_height
     return {
-        "x": element["x"],
-        "y": element["y"],
+        "x": x,
+        "y": y,
         "width": visual_width,
         "height": visual_height,
     }
@@ -944,6 +1012,10 @@ def should_flag_horizontal_text_overflow(left: dict[str, Any], right: dict[str, 
 
     source, target = sorted([left, right], key=lambda element: element["x"])
     if source["x"] == target["x"]:
+        return False
+    wrap_enabled = source.get("wrap") not in {"false", "0"}
+    has_horizontal_gap = source["x"] + source["width"] <= target["x"]
+    if wrap_enabled and has_horizontal_gap:
         return False
     if source.get("autoFit") == "normal-auto-fit":
         return False
@@ -1244,6 +1316,7 @@ def lint_slide(
         *detect_elements_out_of_canvas(elements, slide_width, slide_height),
         *detect_table_layout_size_mismatches(elements),
         *detect_text_may_overflow_shapes(elements),
+        *detect_image_text_occlusions(elements),
     ]
 
     for index, left in enumerate(elements):

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -504,43 +504,6 @@ class XmlTextOverlapLintTest(unittest.TestCase):
         self.assertIn("iconpark-index.json", issue["hint"])
         self.assertIn("iconpark/Base/setting.svg", issue["hint"])
 
-    def test_lint_xml_allows_namespaced_svg_inside_whiteboard(self) -> None:
-        result = xml_text_overlap_lint.lint_xml(
-            """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
-              <data>
-                <whiteboard id="wb" topLeftX="80" topLeftY="80" width="300" height="180">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 180">
-                    <rect x="10" y="10" width="120" height="60"/>
-                  </svg>
-                </whiteboard>
-              </data>
-            </slide>
-            """
-        )
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertNotIn("issues", result)
-
-    def test_lint_xml_reports_unqualified_svg_inside_whiteboard_with_namespace_hint(self) -> None:
-        result = xml_text_overlap_lint.lint_xml(
-            """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
-              <data>
-                <whiteboard id="wb" topLeftX="80" topLeftY="80" width="300" height="180">
-                  <svg viewBox="0 0 300 180">
-                    <rect x="10" y="10" width="120" height="60"/>
-                  </svg>
-                </whiteboard>
-              </data>
-            </slide>
-            """
-        )
-        issue = result["issues"][0]
-        self.assertEqual(result["summary"]["error_count"], 1)
-        self.assertEqual(issue["code"], "sxsd_unsupported_tag")
-        self.assertEqual(issue["tag"], "svg")
-        self.assertIn('xmlns="http://www.w3.org/2000/svg"', issue["hint"])
-
     def test_lint_xml_detects_overlapping_text_boxes(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
@@ -626,7 +589,7 @@ class XmlTextOverlapLintTest(unittest.TestCase):
             <slide xmlns="http://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="source" type="text" topLeftX="80" topLeftY="100" width="160" height="40">
-                  <content fontSize="18"><p>这是一个足够长的中文文本用于检测跨越间隙的横向溢出</p></content>
+                  <content fontSize="18" wrap="false"><p>这是一个足够长的中文文本用于检测跨越间隙的横向溢出</p></content>
                 </shape>
                 <shape id="target" type="text" topLeftX="260" topLeftY="100" width="160" height="40">
                   <content fontSize="18"><p>目标</p></content>
@@ -656,6 +619,9 @@ class XmlTextOverlapLintTest(unittest.TestCase):
             """
         )
         self.assertEqual(result["summary"]["error_count"], 0)
+        self.assertEqual(result["summary"]["warning_count"], 1)
+        self.assertEqual(result["slides"][0]["issues"][0]["code"], "text_may_overflow_shape")
+        self.assertEqual(result["slides"][0]["issues"][0]["elements"], ["source"])
 
     def test_lint_xml_reports_text_out_of_canvas_and_warns_for_text_height(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
@@ -873,7 +839,6 @@ class XmlTextOverlapLintTest(unittest.TestCase):
                   <shape id="outside-shape" type="text" topLeftX="-10" topLeftY="40" width="50" height="50"/>
                   <img id="outside-img" src="token" topLeftX="120" topLeftY="-20" width="50" height="50"/>
                   <chart id="outside-chart" topLeftX="900" topLeftY="100" width="100" height="100"/>
-                  <whiteboard id="outside-whiteboard" topLeftX="100" topLeftY="500" width="100" height="100"/>
                 </data>
               </slide>
             </presentation>
@@ -1197,89 +1162,6 @@ class XmlTextOverlapLintTest(unittest.TestCase):
                         result["slides"][0]["issues"],
                     )
 
-    def test_lint_xml_warns_for_whiteboard_external_boundary_overlap(self) -> None:
-        result = xml_text_overlap_lint.lint_xml(
-            """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
-                <data>
-                  <whiteboard id="wb" topLeftX="50" topLeftY="140" width="860" height="360"/>
-                  <shape id="card" type="rect" topLeftX="50" topLeftY="450" width="200" height="60">
-                    <fill><fillColor color="rgba(232, 186, 176, 0.2)"/></fill>
-                    <content/>
-                  </shape>
-                  <shape id="label" type="text" topLeftX="65" topLeftY="460" width="170" height="20">
-                    <content fontSize="12"><p>基础保障</p></content>
-                  </shape>
-                </data>
-              </slide>
-            </presentation>
-            """
-        )
-        issues = result["slides"][0]["issues"]
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertEqual(result["summary"]["warning_count"], 1)
-        self.assertEqual(issues[0]["code"], "whiteboard_external_overlap")
-        self.assertIn("static whiteboard container-bbox risk", issues[0]["hint"])
-        self.assertIn("screenshot QA", issues[0]["hint"])
-        self.assertEqual(issues[0]["elements"], ["wb", "card"])
-        self.assertEqual(issues[0]["overlaps"][0]["overlap_height"], 50)
-
-    def test_lint_xml_allows_whiteboard_internal_labels(self) -> None:
-        result = xml_text_overlap_lint.lint_xml(
-            """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
-                <data>
-                  <whiteboard id="wb" topLeftX="100" topLeftY="120" width="420" height="260"/>
-                  <shape id="label" type="text" topLeftX="150" topLeftY="180" width="180" height="40">
-                    <content fontSize="14"><p>内部标注</p></content>
-                  </shape>
-                </data>
-              </slide>
-            </presentation>
-            """
-        )
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertEqual(result["summary"]["warning_count"], 0)
-
-    def test_lint_xml_allows_bottom_layer_full_slide_whiteboard_background(self) -> None:
-        result = xml_text_overlap_lint.lint_xml(
-            """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
-                <data>
-                  <whiteboard id="background" topLeftX="0" topLeftY="0" width="960" height="540"/>
-                  <shape id="title" type="text" topLeftX="80" topLeftY="80" width="420" height="80">
-                    <content textType="title" fontSize="36"><p>Title</p></content>
-                  </shape>
-                </data>
-              </slide>
-            </presentation>
-            """
-        )
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertEqual(result["summary"]["warning_count"], 0)
-
-    def test_lint_xml_allows_whiteboard_inside_background_panel(self) -> None:
-        result = xml_text_overlap_lint.lint_xml(
-            """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
-                <data>
-                  <shape id="panel" type="rect" topLeftX="40" topLeftY="100" width="880" height="340">
-                    <fill><fillColor color="rgba(232, 186, 176, 0.2)"/></fill>
-                    <content/>
-                  </shape>
-                  <whiteboard id="wb" topLeftX="60" topLeftY="120" width="840" height="300"/>
-                </data>
-              </slide>
-            </presentation>
-            """
-        )
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertEqual(result["summary"]["warning_count"], 0)
-
     def test_lint_xml_detects_invalid_template_text_stack_overlap(self) -> None:
         cases = [
             (
@@ -1307,6 +1189,22 @@ class XmlTextOverlapLintTest(unittest.TestCase):
                 )
                 self.assertEqual(result["summary"]["error_count"], 1)
                 self.assertEqual(result["slides"][0]["issues"][0]["code"], "bbox_overlap")
+
+
+    def test_lint_xml_reports_vertical_text_image_overlap_as_info(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0"><data>
+              <shape id="text" type="text" vert="vert" topLeftX="100" topLeftY="100" width="100" height="100">
+                <content><p>Vertical</p></content>
+              </shape>
+              <img id="image" src="token" topLeftX="120" topLeftY="120" width="20" height="20"/>
+            </data></slide>
+            """
+        )
+        issue = next(issue for issue in result["slides"][0]["issues"] if issue["code"] == "image_may_cover_vertical_text")
+        self.assertEqual(issue["level"], "info")
+        self.assertEqual(result["summary"]["error_count"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Improve Slides XML linting to detect image layers that may occlude text content.

## Changes

- Add image-over-text occlusion detection based on XML layer order and visual bounding boxes.
- Report horizontal image/text occlusion as an error.
- Report vertical-text/image overlap as an informational issue requiring rendered-slide inspection.
- Account for text padding, alignment, wrapping, vertical alignment, rotation direction, transparency, and inline span font sizes when estimating text bounds.
- Reduce false positives for wrapped text with sufficient horizontal spacing.
- Update regression tests for image occlusion and text overflow behavior.
- Remove outdated whiteboard-related test cases that no longer match the current lint scope.

## Testing

- Added and updated unit test coverage in `xml_text_overlap_lint_test.py`.
- Full test suite not run for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for images that may obscure text, including special handling for vertical text.
  * Improved text layout analysis using font size, padding, and horizontal and vertical alignment.

* **Bug Fixes**
  * Reduced false warnings for text overflow when wrapping is enabled and text boxes are separated by a gap.
  * Improved accuracy of overlap and occlusion diagnostics.

* **Tests**
  * Added coverage for image overlap with vertical text.
  * Updated overflow expectations and removed obsolete scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->