### PR TITLE
chore: release v1.0.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.74] - 2026-07-21
+
+### Features
+
+- **slides**: add history rollback shortcuts (#1714)
+- **base**: support per-record batch updates (#1889)
+
+### Bug Fixes
+
+- preserve slides schema issues
+- allow jq examples in quality gate dry-runs
+- **im**: warn when flag pagination is truncated (#1906)
+- **slides**: warn on text shape overflow
+- **slides**: exempt chart roundtrip attributes from lint
+- **slides**: detect image text occlusion
+- **slides**: clarify xml-text-overlap-lint error for positional argument (#1986)
+
+### Documentation
+
+- clarify drive upload overwrite guidance (#1982)
+
+### Tests
+
+- isolate unit tests from user state (#1883)
+
+### Refactoring
+
+- converge success output through a single Emitter that owns the write (#1899)
+
 ## [v1.0.73] - 2026-07-20
 
 ### Features
@@ -1579,6 +1608,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.74]: https://github.com/larksuite/cli/releases/tag/v1.0.74
 [v1.0.73]: https://github.com/larksuite/cli/releases/tag/v1.0.73
 [v1.0.72]: https://github.com/larksuite/cli/releases/tag/v1.0.72
 [v1.0.71]: https://github.com/larksuite/cli/releases/tag/v1.0.71

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.73",
+  "version": "1.0.74",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.73` |
| Release version | `1.0.74` |
| Tag | `v1.0.74` |
| Branch | `release/v1.0.74` |
| Date | `2026-07-21` |

## Changes

- test: isolate unit tests from user state (#1883)
- feat(slides): add history rollback shortcuts (#1714)
- fix: preserve slides schema issues
- fix: allow jq examples in quality gate dry-runs
- refactor: converge success output through a single Emitter that owns the write (#1899)
- fix(im): warn when flag pagination is truncated (#1906)
- fix(slides): warn on text shape overflow
- fix(slides): exempt chart roundtrip attributes from lint
- fix(slides): detect image text occlusion
- docs: clarify drive upload overwrite guidance (#1982)
- feat(base): support per-record batch updates (#1889)
- fix(slides): clarify xml-text-overlap-lint error for positional argument (#1986)

## Files Changed

- `package.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shortcuts to roll back slide history.
  * Added base per-record batch updates.

* **Bug Fixes**
  * Improved slide warnings, linting, occlusion handling, and schema preservation.
  * Fixed image pagination truncation warnings.
  * Clarified XML text overlap lint errors.

* **Documentation**
  * Added guidance for overwriting files during drive uploads.

* **Tests**
  * Improved test isolation from user state.

* **Release**
  * Updated the CLI to version 1.0.74.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->