### PR TITLE
feat(slides): add layout density lint for sparse/empty containers 

### DIFF
--- a/skills/lark-slides/references/validation-checklist.md
+++ b/skills/lark-slides/references/validation-checklist.md
@@ -39,6 +39,34 @@ python3 skills/lark-slides/scripts/xml_text_overlap_lint.py --input <presentatio
 - 当前工具只检查 XML well-formed 和文本元素之间的明显重叠；它不检查越界、文本高度不足、图文压盖、表格/图表压盖或底部拥挤。
 - 该工具不能替代页数核对、关键内容核对或真实视觉验收。
 
+## Automated Layout Density Lint
+
+在 XML 结构检查通过后、截图视觉验收前，可运行布局密度静态检查：
+
+```bash
+python3 skills/lark-slides/scripts/xml_layout_density_lint.py --input <presentation.xml>
+```
+
+它的用途是找出大型 `rect` 容器内的可见内容面积偏小的候选区域，常见于大卡片只放少量文字、空图片占位卡、单字符伪主视觉或目录卡内容过空。
+
+调用顺序：
+
+```text
+slides +xml-get 回读 XML
+→ xml_text_overlap_lint.py 检查 XML / 重叠等结构风险
+→ xml_layout_density_lint.py 输出内容覆盖率事实
+→ 截图 QA 判断留白是否有意设计
+```
+
+`xml_layout_density_lint.py` 的 warning 只陈述可复算的几何事实：
+
+- `target`：页码、容器 ID、坐标和尺寸；
+- `rule`：阈值与比较条件；
+- `measurement`：容器面积、可见内容面积、覆盖率和参与元素数量；
+- `elements`：容器及参与计算的 XML 元素 ID。
+
+当 `measurement.content_coverage_ratio < rule.threshold` 时输出 `code = sparse_container_content`。这只是静态几何命中，不自动说明页面难看、留白错误或必须修改；必须结合同页截图进行视觉判断。
+
 常见 code 的处理方向：
 
 | code | 含义 | 处理方式 |

--- a/skills/lark-slides/references/validation-checklist.md
+++ b/skills/lark-slides/references/validation-checklist.md
@@ -29,8 +29,10 @@ lark-cli slides +xml-get --as user \
 
 `slides +xml-get` 保存 XML 到本地文件后，优先运行 XML 语法和文本重叠静态检查：
 
+先取得当前已加载 `lark-slides/SKILL.md` 的父目录，记为 `<lark-slides-skill-dir>`；不要猜测全局安装路径。下面命令中的脚本路径相对于该目录。
+
 ```bash
-python3 skills/lark-slides/scripts/xml_text_overlap_lint.py --input <presentation.xml>
+python3 "<lark-slides-skill-dir>/scripts/xml_text_overlap_lint.py" --input <presentation.xml>
 ```
 
 通过标准：
@@ -44,7 +46,7 @@ python3 skills/lark-slides/scripts/xml_text_overlap_lint.py --input <presentatio
 在 XML 结构检查通过后、截图视觉验收前，可运行布局密度静态检查：
 
 ```bash
-python3 skills/lark-slides/scripts/xml_layout_density_lint.py --input <presentation.xml>
+python3 "<lark-slides-skill-dir>/scripts/xml_layout_density_lint.py" --input <presentation.xml>
 ```
 
 它的用途是找出大型 `rect` 容器内的可见内容面积偏小的候选区域，常见于大卡片只放少量文字、空图片占位卡、单字符伪主视觉或目录卡内容过空。

--- a/skills/lark-slides/scripts/xml_layout_density_lint.py
+++ b/skills/lark-slides/scripts/xml_layout_density_lint.py
@@ -17,8 +17,13 @@ import xml_text_overlap_lint as xml_lint
 
 MIN_CONTAINER_WIDTH = 140
 MIN_CONTAINER_HEIGHT = 160
+MIN_SHORT_CARD_HEIGHT = 80
 MIN_CONTAINER_AREA = 20_000
 MIN_CONTENT_COVERAGE_RATIO = 0.15
+MIN_SLIDE_CONTENT_COVERAGE_RATIO = 0.035
+MIN_SLIDE_CONTENT_ELEMENT_COUNT = 4
+SHORT_CARD_SIZE_TOLERANCE_RATIO = 0.10
+MIN_SIMILAR_SHORT_CARD_COUNT = 2
 LARGE_VISUAL_CHILD_RATIO = 0.35
 LAYOUT_PANEL_SPAN_RATIO = 0.90
 IMAGE_OVERLAY_MATCH_RATIO = 0.90
@@ -57,12 +62,37 @@ def rectangle_union_area(rectangles: list[dict[str, int | float]]) -> int | floa
     return area
 
 
-def is_layout_container(element: dict[str, Any], slide_width: int | float, slide_height: int | float) -> bool:
+def has_similar_short_card_peer(element: dict[str, Any], elements: list[dict[str, Any]]) -> bool:
+    return sum(
+        other["kind"] == "shape"
+        and other["type"] == "rect"
+        and other["width"] >= MIN_CONTAINER_WIDTH
+        and other["height"] >= MIN_SHORT_CARD_HEIGHT
+        and xml_lint.element_area(other) >= MIN_CONTAINER_AREA
+        and abs(other["width"] - element["width"]) / max(other["width"], element["width"])
+        <= SHORT_CARD_SIZE_TOLERANCE_RATIO
+        and abs(other["height"] - element["height"]) / max(other["height"], element["height"])
+        <= SHORT_CARD_SIZE_TOLERANCE_RATIO
+        for other in elements
+    ) >= MIN_SIMILAR_SHORT_CARD_COUNT
+
+
+def is_layout_container(
+    element: dict[str, Any],
+    slide_width: int | float,
+    slide_height: int | float,
+    elements: list[dict[str, Any]] | None = None,
+) -> bool:
+    has_supported_height = element["height"] >= MIN_CONTAINER_HEIGHT or (
+        elements is not None
+        and element["height"] >= MIN_SHORT_CARD_HEIGHT
+        and has_similar_short_card_peer(element, elements)
+    )
     return (
         element["kind"] == "shape"
         and element["type"] == "rect"
         and element["width"] >= MIN_CONTAINER_WIDTH
-        and element["height"] >= MIN_CONTAINER_HEIGHT
+        and has_supported_height
         and xml_lint.element_area(element) >= MIN_CONTAINER_AREA
         and not (
             element["x"] <= 2
@@ -194,6 +224,20 @@ def own_text_visual_bbox(container: dict[str, Any]) -> dict[str, int | float] | 
     return clipped_bbox(estimated, container) if estimated else None
 
 
+def slide_content_visual_bbox(
+    element: dict[str, Any], slide_bbox: dict[str, int | float]
+) -> dict[str, int | float] | None:
+    if xml_lint.is_text_element(element):
+        estimated = xml_lint.estimate_text_visual_bbox(element)
+        return clipped_bbox(estimated, slide_bbox) if estimated else None
+    if element["kind"] == "shape" and xml_lint.has_text_content(element):
+        estimated = own_text_visual_bbox(element)
+        return clipped_bbox(estimated, slide_bbox) if estimated else None
+    if element["kind"] in {"img", "chart", "table", "whiteboard", "icon"}:
+        return clipped_bbox(element, slide_bbox)
+    return None
+
+
 def is_large_visual_child(element: dict[str, Any], container: dict[str, Any]) -> bool:
     if element["kind"] not in {"img", "chart", "table", "whiteboard"}:
         return False
@@ -204,7 +248,9 @@ def detect_sparse_container_content(
     elements: list[dict[str, Any]], slide_number: int, slide_width: int | float, slide_height: int | float
 ) -> list[dict[str, Any]]:
     issues: list[dict[str, Any]] = []
-    for container in (element for element in elements if is_layout_container(element, slide_width, slide_height)):
+    for container in (
+        element for element in elements if is_layout_container(element, slide_width, slide_height, elements)
+    ):
         if (
             is_edge_spanning_layout_panel(container, slide_width, slide_height)
             or is_nested_in_layout_panel(container, elements, slide_width, slide_height)
@@ -255,6 +301,47 @@ def detect_sparse_container_content(
     return issues
 
 
+def detect_sparse_slide_content(
+    elements: list[dict[str, Any]], slide_number: int, slide_width: int | float, slide_height: int | float
+) -> list[dict[str, Any]]:
+    slide_bbox = {"x": 0, "y": 0, "width": slide_width, "height": slide_height}
+    content = [
+        (element, bbox)
+        for element in elements
+        if (bbox := slide_content_visual_bbox(element, slide_bbox)) is not None
+    ]
+    if len(content) < MIN_SLIDE_CONTENT_ELEMENT_COUNT:
+        return []
+    content_area = rectangle_union_area([bbox for _, bbox in content])
+    slide_area = slide_width * slide_height
+    coverage_ratio = content_area / slide_area
+    if coverage_ratio >= MIN_SLIDE_CONTENT_COVERAGE_RATIO:
+        return []
+    return [
+        {
+            "level": "warning",
+            "code": "sparse_slide_content",
+            "schema_version": "1.0",
+            "target": {
+                "slide_number": slide_number,
+                "bbox": slide_bbox,
+            },
+            "rule": {
+                "name": "slide_visible_content_coverage",
+                "threshold": MIN_SLIDE_CONTENT_COVERAGE_RATIO,
+                "comparison": "content_coverage_ratio < threshold",
+            },
+            "measurement": {
+                "slide_area": slide_area,
+                "visible_content_area": round(content_area, 3),
+                "content_coverage_ratio": round(coverage_ratio, 3),
+                "content_element_count": len(content),
+            },
+            "elements": [element["id"] for element, _ in content],
+        }
+    ]
+
+
 def detect_blank_slide(elements: list[dict[str, Any]], slide_number: int) -> list[dict[str, Any]]:
     if elements:
         return []
@@ -295,7 +382,8 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
                 "slide_number": slide_number,
                 "element_count": len(elements),
                 "issues": detect_blank_slide(elements, slide_number)
-                + detect_sparse_container_content(elements, slide_number, presentation["width"], presentation["height"]),
+                + detect_sparse_container_content(elements, slide_number, presentation["width"], presentation["height"])
+                + detect_sparse_slide_content(elements, slide_number, presentation["width"], presentation["height"]),
             }
         )
     warning_count = sum(len(slide["issues"]) for slide in slides)

--- a/skills/lark-slides/scripts/xml_layout_density_lint.py
+++ b/skills/lark-slides/scripts/xml_layout_density_lint.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from xml.etree import ElementTree as ET
 from pathlib import Path
 from typing import Any
 
@@ -17,10 +18,11 @@ import xml_text_overlap_lint as xml_lint
 MIN_CONTAINER_WIDTH = 140
 MIN_CONTAINER_HEIGHT = 160
 MIN_CONTAINER_AREA = 20_000
-MIN_CONTENT_COVERAGE_RATIO = 0.10
+MIN_CONTENT_COVERAGE_RATIO = 0.15
 LARGE_VISUAL_CHILD_RATIO = 0.35
 LAYOUT_PANEL_SPAN_RATIO = 0.90
 IMAGE_OVERLAY_MATCH_RATIO = 0.90
+DENSITY_CONTAINMENT_TOLERANCE = 8
 
 
 def clipped_bbox(element: dict[str, Any], container: dict[str, Any]) -> dict[str, int | float] | None:
@@ -100,13 +102,59 @@ def is_nested_in_layout_panel(
         and element["kind"] == "shape"
         and element["type"] == "rect"
         and is_edge_spanning_layout_panel(element, slide_width, slide_height)
-        and xml_lint.contains(element, container)
+        and xml_lint.contains(element, container, tolerance=DENSITY_CONTAINMENT_TOLERANCE)
         for element in elements
     )
 
 
 def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
     elements = xml_lint.extract_elements(slide_xml)
+    elements_by_id = {element["id"]: element for element in elements}
+    root = ET.fromstring(slide_xml)
+    for node in root.iter():
+        if xml_lint.xml_local_name(node.tag) != "shape":
+            continue
+        element = elements_by_id.get(node.attrib.get("id", ""))
+        if element is None:
+            continue
+        content_node = next(
+            (child for child in node if xml_lint.xml_local_name(child.tag) == "content"),
+            None,
+        )
+        paragraphs = (
+            [
+                " ".join("".join(paragraph.itertext()).split())
+                for paragraph in content_node.iter()
+                if xml_lint.xml_local_name(paragraph.tag) == "p"
+            ]
+            if content_node is not None
+            else []
+        )
+        raw_font_size = (
+            content_node.attrib.get("fontSize") if content_node is not None else None
+        ) or node.attrib.get("fontSize")
+        try:
+            base_font_size = float(raw_font_size or 16)
+        except ValueError:
+            base_font_size = 16.0
+        element.update(
+            {
+                "textType": content_node.attrib.get("textType") if content_node is not None else None,
+                "textAlign": content_node.attrib.get("textAlign") if content_node is not None else None,
+                "autoFit": content_node.attrib.get("autoFit") if content_node is not None else None,
+                "fontSize": base_font_size,
+                "text": "\n".join(paragraph for paragraph in paragraphs if paragraph),
+            }
+        )
+        if not xml_lint.has_text_content(element):
+            continue
+        declared_font_sizes = [
+            float(descendant.attrib["fontSize"])
+            for descendant in node.iter()
+            if descendant.attrib.get("fontSize") is not None
+        ]
+        if declared_font_sizes:
+            element["fontSize"] = max(declared_font_sizes)
     for match in re.finditer(r"<icon\b([^>]*)>", slide_xml):
         attrs = match.group(1)
         x = xml_lint.extract_numeric_attribute(attrs, "topLeftX")
@@ -138,6 +186,14 @@ def visual_bbox(element: dict[str, Any], container: dict[str, Any]) -> dict[str,
     return clipped_bbox(element, container)
 
 
+def own_text_visual_bbox(container: dict[str, Any]) -> dict[str, int | float] | None:
+    if container["kind"] != "shape" or not xml_lint.has_text_content(container):
+        return None
+    text_proxy = {**container, "type": "text"}
+    estimated = xml_lint.estimate_text_visual_bbox(text_proxy)
+    return clipped_bbox(estimated, container) if estimated else None
+
+
 def is_large_visual_child(element: dict[str, Any], container: dict[str, Any]) -> bool:
     if element["kind"] not in {"img", "chart", "table", "whiteboard"}:
         return False
@@ -158,11 +214,15 @@ def detect_sparse_container_content(
         children = [
             element
             for element in elements
-            if element is not container and xml_lint.contains(container, element)
+            if element is not container
+            and xml_lint.contains(container, element, tolerance=DENSITY_CONTAINMENT_TOLERANCE)
         ]
         if any(is_large_visual_child(child, container) for child in children):
             continue
-        rectangles = [bbox for child in children if (bbox := visual_bbox(child, container)) is not None]
+        own_text_bbox = own_text_visual_bbox(container)
+        rectangles = ([own_text_bbox] if own_text_bbox else []) + [
+            bbox for child in children if (bbox := visual_bbox(child, container)) is not None
+        ]
         content_area = rectangle_union_area(rectangles) if rectangles else 0
         coverage_ratio = content_area / xml_lint.element_area(container)
         if coverage_ratio >= MIN_CONTENT_COVERAGE_RATIO:
@@ -187,12 +247,31 @@ def detect_sparse_container_content(
                     "container_area": xml_lint.element_area(container),
                     "visible_content_area": round(content_area, 3),
                     "content_coverage_ratio": round(coverage_ratio, 3),
-                    "content_element_count": len(children),
+                    "content_element_count": len(children) + (1 if own_text_bbox else 0),
                 },
                 "elements": [container["id"], *[child["id"] for child in children]],
             }
         )
     return issues
+
+
+def detect_blank_slide(elements: list[dict[str, Any]], slide_number: int) -> list[dict[str, Any]]:
+    if elements:
+        return []
+    return [
+        {
+            "level": "warning",
+            "code": "blank_slide",
+            "schema_version": "1.0",
+            "target": {"slide_number": slide_number},
+            "rule": {
+                "name": "slide_has_visible_content",
+                "comparison": "visible_element_count == 0",
+            },
+            "measurement": {"visible_element_count": 0},
+            "elements": [],
+        }
+    ]
 
 
 def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
@@ -210,13 +289,13 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
     slides = []
     for index, slide_xml in enumerate(presentation["slides"]):
         elements = extract_density_elements(slide_xml)
+        slide_number = index + 1
         slides.append(
             {
-                "slide_number": index + 1,
+                "slide_number": slide_number,
                 "element_count": len(elements),
-                "issues": detect_sparse_container_content(
-                    elements, index + 1, presentation["width"], presentation["height"]
-                ),
+                "issues": detect_blank_slide(elements, slide_number)
+                + detect_sparse_container_content(elements, slide_number, presentation["width"], presentation["height"]),
             }
         )
     warning_count = sum(len(slide["issues"]) for slide in slides)

--- a/skills/lark-slides/scripts/xml_layout_density_lint.py
+++ b/skills/lark-slides/scripts/xml_layout_density_lint.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+"""Warn when a large layout container has too little visible content inside it."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import xml_text_overlap_lint as xml_lint
+
+
+MIN_CONTAINER_WIDTH = 140
+MIN_CONTAINER_HEIGHT = 160
+MIN_CONTAINER_AREA = 20_000
+MIN_CONTENT_COVERAGE_RATIO = 0.10
+LARGE_VISUAL_CHILD_RATIO = 0.35
+LAYOUT_PANEL_SPAN_RATIO = 0.90
+IMAGE_OVERLAY_MATCH_RATIO = 0.90
+
+
+def clipped_bbox(element: dict[str, Any], container: dict[str, Any]) -> dict[str, int | float] | None:
+    left = max(element["x"], container["x"])
+    top = max(element["y"], container["y"])
+    right = min(element["x"] + element["width"], container["x"] + container["width"])
+    bottom = min(element["y"] + element["height"], container["y"] + container["height"])
+    if right <= left or bottom <= top:
+        return None
+    return {"x": left, "y": top, "width": right - left, "height": bottom - top}
+
+
+def rectangle_union_area(rectangles: list[dict[str, int | float]]) -> int | float:
+    x_coordinates = sorted({coordinate for rect in rectangles for coordinate in (rect["x"], rect["x"] + rect["width"])})
+    area = 0
+    for left, right in zip(x_coordinates, x_coordinates[1:]):
+        intervals = sorted(
+            (rect["y"], rect["y"] + rect["height"])
+            for rect in rectangles
+            if rect["x"] < right and rect["x"] + rect["width"] > left
+        )
+        covered_height = 0
+        interval_end: int | float | None = None
+        for top, bottom in intervals:
+            if interval_end is None:
+                covered_height += bottom - top
+                interval_end = bottom
+            elif bottom > interval_end:
+                covered_height += bottom - max(top, interval_end)
+                interval_end = bottom
+        area += (right - left) * covered_height
+    return area
+
+
+def is_layout_container(element: dict[str, Any], slide_width: int | float, slide_height: int | float) -> bool:
+    return (
+        element["kind"] == "shape"
+        and element["type"] == "rect"
+        and element["width"] >= MIN_CONTAINER_WIDTH
+        and element["height"] >= MIN_CONTAINER_HEIGHT
+        and xml_lint.element_area(element) >= MIN_CONTAINER_AREA
+        and not (
+            element["x"] <= 2
+            and element["y"] <= 2
+            and element["width"] >= slide_width - 4
+            and element["height"] >= slide_height - 4
+        )
+    )
+
+
+def is_edge_spanning_layout_panel(
+    element: dict[str, Any], slide_width: int | float, slide_height: int | float
+) -> bool:
+    touches_horizontal_edge = element["x"] <= 2 or element["x"] + element["width"] >= slide_width - 2
+    touches_vertical_edge = element["y"] <= 2 or element["y"] + element["height"] >= slide_height - 2
+    return (touches_horizontal_edge and element["height"] >= slide_height * LAYOUT_PANEL_SPAN_RATIO) or (
+        touches_vertical_edge and element["width"] >= slide_width * LAYOUT_PANEL_SPAN_RATIO
+    )
+
+
+def has_matching_image_overlay(container: dict[str, Any], elements: list[dict[str, Any]]) -> bool:
+    container_area = xml_lint.element_area(container)
+    return any(
+        element["kind"] == "img"
+        and xml_lint.intersection_area(container, element)
+        / max(1, min(container_area, xml_lint.element_area(element)))
+        >= IMAGE_OVERLAY_MATCH_RATIO
+        for element in elements
+    )
+
+
+def is_nested_in_layout_panel(
+    container: dict[str, Any], elements: list[dict[str, Any]], slide_width: int | float, slide_height: int | float
+) -> bool:
+    return any(
+        element is not container
+        and element["kind"] == "shape"
+        and element["type"] == "rect"
+        and is_edge_spanning_layout_panel(element, slide_width, slide_height)
+        and xml_lint.contains(element, container)
+        for element in elements
+    )
+
+
+def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
+    elements = xml_lint.extract_elements(slide_xml)
+    for match in re.finditer(r"<icon\b([^>]*)>", slide_xml):
+        attrs = match.group(1)
+        x = xml_lint.extract_numeric_attribute(attrs, "topLeftX")
+        y = xml_lint.extract_numeric_attribute(attrs, "topLeftY")
+        width = xml_lint.extract_numeric_attribute(attrs, "width")
+        height = xml_lint.extract_numeric_attribute(attrs, "height")
+        if any(value is None for value in (x, y, width, height)):
+            continue
+        elements.append(
+            {
+                "id": xml_lint.extract_attribute(attrs, "id") or f"icon-{len(elements) + 1}",
+                "kind": "icon",
+                "type": "icon",
+                "x": x,
+                "y": y,
+                "width": width,
+                "height": height,
+                "rotation": xml_lint.extract_numeric_attribute(attrs, "rotation") or 0,
+                "order": len(elements),
+            }
+        )
+    return elements
+
+
+def visual_bbox(element: dict[str, Any], container: dict[str, Any]) -> dict[str, int | float] | None:
+    if xml_lint.is_text_element(element):
+        estimated = xml_lint.estimate_text_visual_bbox(element)
+        return clipped_bbox(estimated, container) if estimated else None
+    return clipped_bbox(element, container)
+
+
+def is_large_visual_child(element: dict[str, Any], container: dict[str, Any]) -> bool:
+    if element["kind"] not in {"img", "chart", "table", "whiteboard"}:
+        return False
+    return xml_lint.element_area(element) / xml_lint.element_area(container) >= LARGE_VISUAL_CHILD_RATIO
+
+
+def detect_sparse_container_content(
+    elements: list[dict[str, Any]], slide_number: int, slide_width: int | float, slide_height: int | float
+) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    for container in (element for element in elements if is_layout_container(element, slide_width, slide_height)):
+        if (
+            is_edge_spanning_layout_panel(container, slide_width, slide_height)
+            or is_nested_in_layout_panel(container, elements, slide_width, slide_height)
+            or has_matching_image_overlay(container, elements)
+        ):
+            continue
+        children = [
+            element
+            for element in elements
+            if element is not container and xml_lint.contains(container, element)
+        ]
+        if any(is_large_visual_child(child, container) for child in children):
+            continue
+        rectangles = [bbox for child in children if (bbox := visual_bbox(child, container)) is not None]
+        content_area = rectangle_union_area(rectangles) if rectangles else 0
+        coverage_ratio = content_area / xml_lint.element_area(container)
+        if coverage_ratio >= MIN_CONTENT_COVERAGE_RATIO:
+            continue
+        issues.append(
+            {
+                "level": "warning",
+                "code": "sparse_container_content",
+                "schema_version": "1.0",
+                "target": {
+                    "slide_number": slide_number,
+                    "container_id": container["id"],
+                    "container_type": container["type"],
+                    "bbox": {key: container[key] for key in ("x", "y", "width", "height")},
+                },
+                "rule": {
+                    "name": "large_container_visible_content_coverage",
+                    "threshold": MIN_CONTENT_COVERAGE_RATIO,
+                    "comparison": "content_coverage_ratio < threshold",
+                },
+                "measurement": {
+                    "container_area": xml_lint.element_area(container),
+                    "visible_content_area": round(content_area, 3),
+                    "content_coverage_ratio": round(coverage_ratio, 3),
+                    "content_element_count": len(children),
+                },
+                "elements": [container["id"], *[child["id"] for child in children]],
+            }
+        )
+    return issues
+
+
+def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
+    root, xml_error = xml_lint.parse_xml_root(xml)
+    if xml_error:
+        return {
+            "file": source_path,
+            "summary": {"slide_count": 0, "warning_count": 0, "error_count": 1},
+            "issues": [xml_error],
+            "slides": [],
+        }
+    if root is None:
+        raise AssertionError("parse_xml_root must return a root or error")
+    presentation = xml_lint.parse_presentation(xml)
+    slides = []
+    for index, slide_xml in enumerate(presentation["slides"]):
+        elements = extract_density_elements(slide_xml)
+        slides.append(
+            {
+                "slide_number": index + 1,
+                "element_count": len(elements),
+                "issues": detect_sparse_container_content(
+                    elements, index + 1, presentation["width"], presentation["height"]
+                ),
+            }
+        )
+    warning_count = sum(len(slide["issues"]) for slide in slides)
+    return {
+        "file": source_path,
+        "slide_size": {"width": presentation["width"], "height": presentation["height"]},
+        "summary": {"slide_count": len(slides), "warning_count": warning_count, "error_count": 0},
+        "slides": slides,
+    }
+
+
+def print_usage() -> None:
+    print("Usage:\n  python3 xml_layout_density_lint.py --input <presentation.xml>", file=sys.stderr)
+
+
+def run_cli(argv: list[str] | None = None) -> None:
+    options = xml_lint.parse_args(argv or sys.argv[1:])
+    if options.get("help") or options.get("--help"):
+        print_usage()
+        raise SystemExit(0)
+    if not options.get("input"):
+        print_usage()
+        raise xml_lint.XmlTextOverlapLintError("--input is required")
+    input_path = Path(options["input"]).resolve()
+    print(json.dumps(lint_xml(xml_lint.read_file(input_path), str(input_path)), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        run_cli()
+    except xml_lint.XmlTextOverlapLintError as error:
+        print(f"xml-layout-density-lint error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/skills/lark-slides/scripts/xml_layout_density_lint_test.py
+++ b/skills/lark-slides/scripts/xml_layout_density_lint_test.py
@@ -86,6 +86,100 @@ class XmlLayoutDensityLintTest(unittest.TestCase):
         self.assertEqual(issue["elements"], ["trend-card", "trend-title", "trend-copy"])
         self.assertEqual(set(issue), {"level", "code", "schema_version", "target", "rule", "measurement", "elements"})
 
+    def test_lint_xml_warns_for_sparse_short_cards(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card-1" type="rect" topLeftX="60" topLeftY="180" width="400" height="105"/>
+                <shape id="text-1" type="text" topLeftX="80" topLeftY="220" width="360" height="30">
+                  <content fontSize="14"><p>期待认识大家</p></content>
+                </shape>
+                <shape id="card-2" type="rect" topLeftX="490" topLeftY="180" width="400" height="105"/>
+                <shape id="text-2" type="text" topLeftX="510" topLeftY="220" width="360" height="30">
+                  <content fontSize="14"><p>化学一起讨论</p></content>
+                </shape>
+                <shape id="card-3" type="rect" topLeftX="60" topLeftY="310" width="400" height="105"/>
+                <shape id="text-3" type="text" topLeftX="80" topLeftY="350" width="360" height="30">
+                  <content fontSize="14"><p>吉他随时交流</p></content>
+                </shape>
+                <shape id="card-4" type="rect" topLeftX="490" topLeftY="310" width="400" height="105"/>
+                <shape id="text-4" type="text" topLeftX="510" topLeftY="350" width="360" height="30">
+                  <content fontSize="14"><p>共度美好四年</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        container_issues = [
+            issue for issue in result["slides"][0]["issues"] if issue["code"] == "sparse_container_content"
+        ]
+        self.assertEqual(
+            [issue["target"]["container_id"] for issue in container_issues],
+            ["card-1", "card-2", "card-3", "card-4"],
+        )
+        self.assertTrue(all(issue["target"]["bbox"]["height"] == 105 for issue in container_issues))
+        self.assertTrue(all(issue["measurement"]["content_coverage_ratio"] < 0.15 for issue in container_issues))
+        self.assertEqual(
+            [issue["code"] for issue in result["slides"][0]["issues"]],
+            [
+                "sparse_container_content",
+                "sparse_container_content",
+                "sparse_container_content",
+                "sparse_container_content",
+                "sparse_slide_content",
+            ],
+        )
+
+    def test_lint_xml_warns_when_whole_slide_has_too_little_effective_content(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="background" type="rect" topLeftX="0" topLeftY="0" width="960" height="540"/>
+                <shape id="text-1" type="text" topLeftX="60" topLeftY="80" width="200" height="30">
+                  <content fontSize="14"><p>One short line</p></content>
+                </shape>
+                <shape id="text-2" type="text" topLeftX="500" topLeftY="180" width="200" height="30">
+                  <content fontSize="14"><p>Another line</p></content>
+                </shape>
+                <shape id="text-3" type="text" topLeftX="60" topLeftY="310" width="200" height="30">
+                  <content fontSize="14"><p>Third line</p></content>
+                </shape>
+                <shape id="text-4" type="text" topLeftX="500" topLeftY="410" width="200" height="30">
+                  <content fontSize="14"><p>Fourth line</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        issues = [issue for issue in result["slides"][0]["issues"] if issue["code"] == "sparse_slide_content"]
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue["target"]["bbox"], {"x": 0, "y": 0, "width": 960, "height": 540})
+        self.assertEqual(issue["rule"]["threshold"], 0.035)
+        self.assertLess(issue["measurement"]["content_coverage_ratio"], 0.035)
+        self.assertEqual(issue["measurement"]["content_element_count"], 4)
+        self.assertNotIn("background", issue["elements"])
+
+    def test_lint_xml_ignores_isolated_short_layout_bar(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="summary-bar" type="rect" topLeftX="52" topLeftY="82" width="856" height="105"/>
+                <shape id="summary" type="text" topLeftX="72" topLeftY="115" width="816" height="30">
+                  <content fontSize="14"><p>One concise summary</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["slides"][0]["issues"], [])
+
     def test_lint_xml_counts_rect_own_content_as_visible_content(self) -> None:
         result = xml_layout_density_lint.lint_xml(
             """

--- a/skills/lark-slides/scripts/xml_layout_density_lint_test.py
+++ b/skills/lark-slides/scripts/xml_layout_density_lint_test.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import unittest
+
+import xml_layout_density_lint
+
+
+class XmlLayoutDensityLintTest(unittest.TestCase):
+    def test_lint_xml_warns_when_large_container_is_mostly_empty(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="trend-card" type="rect" topLeftX="500" topLeftY="135" width="410" height="370"/>
+                <shape id="trend-title" type="text" topLeftX="515" topLeftY="147" width="380" height="28">
+                  <content fontSize="15"><p>Core trends</p></content>
+                </shape>
+                <shape id="trend-copy" type="text" topLeftX="515" topLeftY="177" width="380" height="315">
+                  <content fontSize="12"><p>First point</p><p>Second point</p><p>Third point</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = result["slides"][0]["issues"][0]
+        self.assertEqual(issue["code"], "sparse_container_content")
+        self.assertEqual(issue["target"]["container_id"], "trend-card")
+        self.assertEqual(issue["target"], {
+            "slide_number": 1,
+            "container_id": "trend-card",
+            "container_type": "rect",
+            "bbox": {"x": 500, "y": 135, "width": 410, "height": 370},
+        })
+        self.assertLess(issue["measurement"]["content_coverage_ratio"], 0.10)
+        self.assertEqual(issue["rule"], {
+            "name": "large_container_visible_content_coverage",
+            "threshold": 0.10,
+            "comparison": "content_coverage_ratio < threshold",
+        })
+        self.assertEqual(issue["measurement"]["container_area"], 151700)
+        self.assertEqual(issue["measurement"]["content_coverage_ratio"], 0.032)
+        self.assertEqual(issue["elements"], ["trend-card", "trend-title", "trend-copy"])
+        self.assertEqual(set(issue), {"level", "code", "schema_version", "target", "rule", "measurement", "elements"})
+
+    def test_lint_xml_allows_container_with_large_visual_child(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="chart-card" type="rect" topLeftX="500" topLeftY="135" width="410" height="300"/>
+                <chart id="chart" topLeftX="525" topLeftY="170" width="350" height="220"/>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["summary"]["warning_count"], 0)
+
+    def test_lint_xml_warns_for_small_empty_visual_placeholder_cards(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="letter-placeholder" type="rect" topLeftX="520" topLeftY="180" width="200" height="200"/>
+                <shape id="letter" type="text" topLeftX="540" topLeftY="250" width="160" height="70">
+                  <content fontSize="46"><p>Z</p></content>
+                </shape>
+                <shape id="empty-placeholder" type="rect" topLeftX="744" topLeftY="180" width="144" height="200"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issues = result["slides"][0]["issues"]
+        self.assertEqual(
+            [issue["target"]["container_id"] for issue in issues],
+            ["letter-placeholder", "empty-placeholder"],
+        )
+        self.assertEqual(issues[1]["measurement"]["content_element_count"], 0)
+
+    def test_lint_xml_allows_normal_card_below_legacy_threshold(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="70" topLeftY="184" width="260" height="288"/>
+                <shape id="title" type="text" topLeftX="90" topLeftY="215" width="220" height="30">
+                  <content fontSize="18"><p>梦境与现实</p></content>
+                </shape>
+                <shape id="copy" type="text" topLeftX="90" topLeftY="330" width="220" height="70">
+                  <content fontSize="13"><p>边界溶解，逻辑失效。观众被拽入潜意识的迷宫。</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["summary"]["warning_count"], 0)
+
+    def test_lint_xml_allows_image_overlay_rect(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <img id="hero" topLeftX="560" topLeftY="0" width="400" height="540"/>
+                <shape id="tint" type="rect" topLeftX="560" topLeftY="0" width="400" height="540"/>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["summary"]["warning_count"], 0)
+
+    def test_lint_xml_allows_edge_spanning_layout_panel_and_nested_decoration(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="panel" type="rect" topLeftX="600" topLeftY="0" width="360" height="540"/>
+                <shape id="decoration" type="rect" topLeftX="660" topLeftY="150" width="240" height="240"/>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["summary"]["warning_count"], 0)
+
+    def test_lint_xml_counts_icons_as_visible_content(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="80" topLeftY="140" width="320" height="240"/>
+                <icon id="visual" iconType="shield" topLeftX="100" topLeftY="160" width="180" height="180"/>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["summary"]["warning_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/lark-slides/scripts/xml_layout_density_lint_test.py
+++ b/skills/lark-slides/scripts/xml_layout_density_lint_test.py
@@ -8,6 +8,47 @@ import xml_layout_density_lint
 
 
 class XmlLayoutDensityLintTest(unittest.TestCase):
+    def test_lint_xml_warns_for_blank_slide(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide id="content-slide">
+                <data>
+                  <shape id="title" type="text" topLeftX="60" topLeftY="60" width="400" height="50">
+                    <content fontSize="28"><p>Investment report</p></content>
+                  </shape>
+                </data>
+              </slide>
+              <slide id="blank-slide">
+                <style><fill><fillColor color="rgba(255, 255, 255, 1)"/></fill></style>
+                <data/>
+                <note><content/></note>
+              </slide>
+            </presentation>
+            """
+        )
+
+        self.assertEqual(result["summary"], {"slide_count": 2, "warning_count": 1, "error_count": 0})
+        self.assertEqual(result["slides"][0]["issues"], [])
+        self.assertEqual(result["slides"][1]["element_count"], 0)
+        self.assertEqual(
+            result["slides"][1]["issues"],
+            [
+                {
+                    "level": "warning",
+                    "code": "blank_slide",
+                    "schema_version": "1.0",
+                    "target": {"slide_number": 2},
+                    "rule": {
+                        "name": "slide_has_visible_content",
+                        "comparison": "visible_element_count == 0",
+                    },
+                    "measurement": {"visible_element_count": 0},
+                    "elements": [],
+                }
+            ],
+        )
+
     def test_lint_xml_warns_when_large_container_is_mostly_empty(self) -> None:
         result = xml_layout_density_lint.lint_xml(
             """
@@ -34,16 +75,143 @@ class XmlLayoutDensityLintTest(unittest.TestCase):
             "container_type": "rect",
             "bbox": {"x": 500, "y": 135, "width": 410, "height": 370},
         })
-        self.assertLess(issue["measurement"]["content_coverage_ratio"], 0.10)
+        self.assertLess(issue["measurement"]["content_coverage_ratio"], 0.15)
         self.assertEqual(issue["rule"], {
             "name": "large_container_visible_content_coverage",
-            "threshold": 0.10,
+            "threshold": 0.15,
             "comparison": "content_coverage_ratio < threshold",
         })
         self.assertEqual(issue["measurement"]["container_area"], 151700)
         self.assertEqual(issue["measurement"]["content_coverage_ratio"], 0.032)
         self.assertEqual(issue["elements"], ["trend-card", "trend-title", "trend-copy"])
         self.assertEqual(set(issue), {"level", "code", "schema_version", "target", "rule", "measurement", "elements"})
+
+    def test_lint_xml_counts_rect_own_content_as_visible_content(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="load-card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
+                  <content fontSize="18">
+                    <p>被吊物</p>
+                    <p><span fontSize="36">32.0 t</span></p>
+                    <p>钢结构模块</p>
+                  </content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["slides"][0]["issues"], [])
+
+    def test_lint_xml_reports_nonzero_coverage_for_rect_own_content_reproduction(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="load-card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
+                  <content fontSize="18">
+                    <p>被吊物</p>
+                    <p>32.0 t</p>
+                    <p>钢结构模块</p>
+                  </content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = result["slides"][0]["issues"][0]
+        self.assertGreater(issue["measurement"]["visible_content_area"], 0)
+        self.assertEqual(issue["measurement"]["content_element_count"], 1)
+        self.assertGreater(issue["measurement"]["content_coverage_ratio"], 0)
+
+    def test_lint_xml_still_warns_for_sparse_rect_own_content(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="sparse-card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
+                  <content fontSize="12"><p>A</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = result["slides"][0]["issues"][0]
+        self.assertEqual(issue["target"]["container_id"], "sparse-card")
+        self.assertGreater(issue["measurement"]["visible_content_area"], 0)
+        self.assertEqual(issue["measurement"]["content_element_count"], 1)
+        self.assertEqual(issue["elements"], ["sparse-card"])
+
+    def test_lint_xml_unions_rect_own_content_with_child_content(self) -> None:
+        self_only = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
+                  <content fontSize="12"><p>A</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+        with_overlapping_child = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
+                  <content fontSize="12"><p>A</p></content>
+                </shape>
+                <shape id="child" type="text" topLeftX="60" topLeftY="140" width="220" height="184">
+                  <content fontSize="12"><p>A</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        self_issue = self_only["slides"][0]["issues"][0]
+        mixed_issue = with_overlapping_child["slides"][0]["issues"][0]
+        self.assertEqual(
+            mixed_issue["measurement"]["visible_content_area"],
+            self_issue["measurement"]["visible_content_area"],
+        )
+        self.assertEqual(mixed_issue["measurement"]["content_element_count"], 2)
+
+    def test_extract_density_elements_reads_nested_font_size_from_rect_content(self) -> None:
+        elements = xml_layout_density_lint.extract_density_elements(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
+                  <content fontSize="12"><p><span fontSize="36">32.0 t</span></p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(elements[0]["fontSize"], 36)
+
+    def test_extract_density_elements_does_not_attach_following_text_to_self_closing_rect(self) -> None:
+        elements = xml_layout_density_lint.extract_density_elements(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184"/>
+                <shape id="title" type="text" topLeftX="80" topLeftY="160" width="180" height="30">
+                  <content fontSize="18"><p>Following title</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(elements[0]["text"], "")
+        self.assertEqual(elements[1]["text"], "Following title")
 
     def test_lint_xml_allows_container_with_large_visual_child(self) -> None:
         result = xml_layout_density_lint.lint_xml(
@@ -81,7 +249,7 @@ class XmlLayoutDensityLintTest(unittest.TestCase):
         )
         self.assertEqual(issues[1]["measurement"]["content_element_count"], 0)
 
-    def test_lint_xml_allows_normal_card_below_legacy_threshold(self) -> None:
+    def test_lint_xml_applies_global_threshold_to_normal_text_card(self) -> None:
         result = xml_layout_density_lint.lint_xml(
             """
             <slide xmlns="http://www.larkoffice.com/sml/2.0">
@@ -98,7 +266,9 @@ class XmlLayoutDensityLintTest(unittest.TestCase):
             """
         )
 
-        self.assertEqual(result["summary"]["warning_count"], 0)
+        issue = result["slides"][0]["issues"][0]
+        self.assertEqual(issue["target"]["container_id"], "card")
+        self.assertEqual(issue["rule"]["threshold"], 0.15)
 
     def test_lint_xml_allows_image_overlay_rect(self) -> None:
         result = xml_layout_density_lint.lint_xml(
@@ -141,6 +311,53 @@ class XmlLayoutDensityLintTest(unittest.TestCase):
         )
 
         self.assertEqual(result["summary"]["warning_count"], 0)
+
+    def test_lint_xml_warns_when_coverage_is_below_global_threshold(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="80" topLeftY="140" width="200" height="200"/>
+                <icon id="visual" iconType="shield" topLeftX="100" topLeftY="160" width="70" height="70"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = result["slides"][0]["issues"][0]
+        self.assertEqual(issue["target"]["container_id"], "card")
+        self.assertEqual(issue["measurement"]["content_coverage_ratio"], 0.122)
+        self.assertEqual(issue["rule"]["threshold"], 0.15)
+
+    def test_lint_xml_allows_quarter_coverage_under_lower_threshold(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="80" topLeftY="140" width="200" height="200"/>
+                <icon id="visual" iconType="shield" topLeftX="100" topLeftY="160" width="100" height="100"/>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["slides"][0]["issues"], [])
+
+    def test_lint_xml_allows_large_metric_card_above_lower_threshold(self) -> None:
+        result = xml_layout_density_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="metric-card" type="rect" topLeftX="80" topLeftY="140" width="360" height="300"/>
+                <shape id="metric" type="text" topLeftX="104" topLeftY="190" width="340" height="90">
+                  <content fontSize="12.4"><p><strong><span fontSize="62">400</span></strong>+ 项</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["slides"][0]["issues"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 Description：                                                                                                                                                                                                      
  ## Summary                                                                                                                                                                                                         
  - 新增 xml_layout_density_lint.py 静态检查脚本，识别大型 rect                                                                                                                                                      
  容器内可见内容面积偏低的候选区域（大卡片配少量文字、空图片占位、单字符伪主视觉、目录卡内容过空等场景），输出可复算的几何事实（target/rule/measurement/elements），不做视觉主观判断                                 
  - 补充对应单元测试 xml_layout_density_lint_test.py                                                                                                                                                                 
  - 更新 validation-checklist.md，明确脚本路径解析方式（相对已加载 SKILL.md 的父目录，不猜测全局安装路径）及调用顺序：xml-get → xml_text_overlap_lint（结构） → xml_layout_density_lint（密度） → 截图视觉验收       
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
  - [x] python3 skills/lark-slides/scripts/xml_layout_density_lint_test.py 通过                                                                                                                                      
  - [x] 对已知稀疏容器样例 XML 跑 xml_layout_density_lint.py，确认 sparse_container_content 命中                                                                                                                     
  - [x] 对正常密度页面跑同一脚本，确认无误报                     