### PR TITLE
docs(base): clarify complete and partial updates

### DIFF
--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -29,7 +29,7 @@ metadata:
 ## 使用边界
 
 - Base 业务操作只使用 `lark-cli base +...` shortcut，不使用旧聚合式 `+table / +field / +record / +view / +history / +workspace`。
-- 本轮 Base 不依赖 `lark-cli schema`。SKILL 只保留路由、风险和复杂 JSON/DSL；简单命令由命令自身的参数、tips 和错误恢复承接。
+- 执行 update 前先查当前 shortcut 的 `--help` 或对应 reference。若契约要求完整配置，首次实际请求须基于可信当前配置执行 read-modify-write，只改用户指定内容、保留必需可写属性，并按命令要求的结构提交；已有完整配置可复用，否则先读取。若命令支持局部／delta update，按其契约提交最小合法 payload；若命令要求完整配置，不得先提交局部配置再根据报错补参。
 - 用户要把 Excel / CSV / `.base` 导入成 Base 时，先转 `lark-cli drive +import --type bitable`，导入完成后再回到 Base 命令。
 - 认证、初始化、scope、身份切换、权限不足恢复属于 `lark-shared`；Base 文档只保留会影响 Base 路径选择的权限规则。
 
@@ -104,7 +104,6 @@ metadata:
 
 ## 写入前置规则
 
-- 更新前先看命令说明：需要完整提交时，先读取并补齐当前配置，只改用户指定的内容，再按命令要求提交；支持局部修改时，按命令说明和 reference 提交最小合法 payload。
 - 优先用写入返回确认结果；返回信息不足或任务明确要求核验时，再读回。
 - 写记录前先读字段结构；只写存储字段。系统字段、附件字段、`formula`、`lookup` 不作为普通记录写入目标。
 - 附件上传、下载、删除走专用 `+record-*-attachment` 命令。

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -29,7 +29,7 @@ metadata:
 ## 使用边界
 
 - Base 业务操作只使用 `lark-cli base +...` shortcut，不使用旧聚合式 `+table / +field / +record / +view / +history / +workspace`。
-- 执行 update 前先查当前 shortcut 的 `--help` 或对应 reference。若契约要求完整配置，首次实际请求须基于可信当前配置执行 read-modify-write，只改用户指定内容、保留必需可写属性，并按命令要求的结构提交；已有完整配置可复用，否则先读取。若命令支持局部／delta update，按其契约提交最小合法 payload；若命令要求完整配置，不得先提交局部配置再根据报错补参。
+- 执行 update 前先查当前 shortcut 的 `--help` 或对应 reference。若命令要求完整配置，首次请求应基于当前配置执行 read-modify-write：只修改用户明确指定的内容，其他可写配置保持不变；因本次修改而不再适用的配置除外。若命令支持局部／delta update，按其契约提交最小合法 payload；若命令要求完整配置，不得先提交局部配置再根据报错补参。
 - 用户要把 Excel / CSV / `.base` 导入成 Base 时，先转 `lark-cli drive +import --type bitable`，导入完成后再回到 Base 命令。
 - 认证、初始化、scope、身份切换、权限不足恢复属于 `lark-shared`；Base 文档只保留会影响 Base 路径选择的权限规则。
 

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -29,7 +29,7 @@ metadata:
 ## 使用边界
 
 - Base 业务操作只使用 `lark-cli base +...` shortcut，不使用旧聚合式 `+table / +field / +record / +view / +history / +workspace`。
-- 执行 update 前先查当前 shortcut 的 `--help` 或对应 reference。若命令要求完整配置，首次请求应基于当前配置执行 read-modify-write：只修改用户明确指定的内容，其他可写配置保持不变；因本次修改而不再适用的配置除外。若命令支持局部／delta update，按其契约提交最小合法 payload；若命令要求完整配置，不得先提交局部配置再根据报错补参。
+- 执行 update 前必须先查当前 shortcut 的 `--help` 或对应 reference。若命令要求完整配置，首次请求必须基于可信的当前配置执行 read-modify-write：只修改用户明确指定的内容，保留其他仍适用的可写配置，并按命令要求的结构提交。若命令支持局部／delta update，按其契约提交最小合法 payload；不得以不完整请求试错补参。
 - 用户要把 Excel / CSV / `.base` 导入成 Base 时，先转 `lark-cli drive +import --type bitable`，导入完成后再回到 Base 命令。
 - 认证、初始化、scope、身份切换、权限不足恢复属于 `lark-shared`；Base 文档只保留会影响 Base 路径选择的权限规则。
 


### PR DESCRIPTION
## Summary

Clarify the command-contract boundary for Base updates. This is a focused follow-up to #1879: full-update commands must start from trusted current configuration, while true partial/delta commands should use the smallest legal payload.

## Changes

- Replace the obsolete schema-routing statement with a command-aware update boundary.
- Require the first actual request to a full-update command to be derived from trusted complete configuration; reuse it when already available, otherwise read first.
- Separate valid delta updates from fail-first partial probes for full-update commands, and consolidate the shorter rule introduced in #1879.

## Test Plan

- [x] `node scripts/skill-format-check/index.js`
- [x] `go test ./internal/qualitygate/skillscan/...`
- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no output)
- [x] `go mod tidy` (no changes)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main` (0 issues)
- [x] `git diff --check`

## Related Issues

- Follow-up to #1879


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 更新了“使用边界/写入前置规则”，执行更新前需先查对应快捷命令的 `--help`/参考文档。
  * 若命令要求完整配置：首次更新必须基于可信的当前配置执行读-改-写，仅变更用户明确指定内容，并保留其他仍适用的可写配置。
  * 若支持局部/增量：提交最小合法 payload。
  * 禁止通过“不完整请求试错补参”来完成更新；并调整了原有前置规则表述衔接方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->