### PR TITLE
feat(drive): add +member-remove shortcut

### DIFF
--- a/shortcuts/drive/drive_member_remove.go
+++ b/shortcuts/drive/drive_member_remove.go
@@ -1,0 +1,393 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var driveMemberRemoveIDTypes = []string{
+	"email", "openid", "openchat", "opendepartmentid",
+	"userid", "unionid", "groupid", "wikispaceid",
+}
+
+// DriveMemberRemove removes one collaborator/member permission from a Drive resource.
+var DriveMemberRemove = common.Shortcut{
+	Service:     "drive",
+	Command:     "+member-remove",
+	Description: "Remove one collaborator/member permission from a Drive resource",
+	Risk:        "high-risk-write",
+	Scopes:      []string{"docs:permission.member:delete"},
+	AuthTypes:   []string{"user", "bot"},
+	Flags: []common.Flag{
+		{Name: "token", Desc: "target token or document URL; type is auto-inferred from URL path when omitted", Required: true},
+		{Name: "type", Desc: "target resource type; required when --token is a bare token"},
+		{Name: "member-id", Desc: "single collaborator ID to remove; comma-separated values are rejected", Required: true},
+		{Name: "member-type", Desc: "ID type for --member-id; supported: email|openid|openchat|opendepartmentid|userid|unionid|groupid|wikispaceid", Required: true},
+		{Name: "member-kind", Desc: "request body type when --member-type=wikispaceid; one of wiki_space_member|wiki_space_viewer|wiki_space_editor"},
+		{Name: "perm-type", Desc: "wiki permission scope; defaults to container; rejected for non-wiki types and wiki-space members"},
+	},
+	Tips: []string{
+		"This command removes exactly one collaborator; run separate commands for multiple members.",
+		"Resource type is auto-inferred from URL paths; pass --type when --token is a bare token.",
+		"When --member-type=wikispaceid, pass --member-kind wiki_space_member, wiki_space_viewer, or wiki_space_editor.",
+		"For ordinary wiki collaborators, --perm-type defaults to container; use single_page to remove only the current-page permission.",
+		"Department collaborator removal (--member-type=opendepartmentid) requires --as user; bot identity is not supported.",
+		"A successful response confirms that the removal request completed; it does not prove the permission previously existed.",
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := readDriveMemberRemoveSpec(runtime)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		spec, err := readDriveMemberRemoveSpec(runtime)
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		return buildDriveMemberRemoveDryRun(spec)
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		spec, err := readDriveMemberRemoveSpec(runtime)
+		if err != nil {
+			return err
+		}
+		return executeDriveMemberRemove(runtime, spec)
+	},
+}
+
+type driveMemberRemoveSpec struct {
+	Token        string
+	ResourceType string
+	MemberID     string
+	MemberType   string
+	MemberKind   string
+	PermType     string
+}
+
+// APIQueryParams returns the query parameters sent with the member-remove DELETE request.
+func (spec driveMemberRemoveSpec) APIQueryParams() map[string]interface{} {
+	return map[string]interface{}{
+		"type":        spec.ResourceType,
+		"member_type": spec.MemberType,
+	}
+}
+
+// Body builds the request body, carrying the wiki member kind and permission scope only when set.
+func (spec driveMemberRemoveSpec) Body() map[string]interface{} {
+	body := make(map[string]interface{}, 2)
+	if memberKind := driveMemberAddBodyType(spec.MemberType, spec.MemberKind); memberKind != "" {
+		body["type"] = memberKind
+	}
+	if spec.PermType != "" {
+		body["perm_type"] = spec.PermType
+	}
+	return body
+}
+
+// readDriveMemberRemoveSpec reads and validates the command flags into a driveMemberRemoveSpec,
+// enforcing single-member, member-type, wiki, and identity constraints before any request is issued.
+// rejectDriveMemberRemoveDotSegment rejects a value that is an RFC 3986 dot
+// segment ("." or "..") in any "/"-split part. validate.ResourceName only stops
+// "..", but a lone "." (or an encoded "%2e" that PathUnescape decodes to ".")
+// survives EncodePathSegment unchanged and can be normalized away by an HTTP
+// stack or proxy, redirecting this high-risk DELETE to a different route. This
+// is a local, remove-only guard so the shared validate.ResourceName behavior is
+// left untouched for its many other callers.
+func rejectDriveMemberRemoveDotSegment(value, flagName string) error {
+	for _, seg := range strings.Split(value, "/") {
+		if seg == "." || seg == ".." {
+			return errs.NewValidationError(
+				errs.SubtypeInvalidArgument,
+				"%s must not contain '.' or '..' path segments",
+				flagName,
+			).WithParam(flagName)
+		}
+	}
+	return nil
+}
+
+func readDriveMemberRemoveSpec(runtime *common.RuntimeContext) (driveMemberRemoveSpec, error) {
+	token, resourceType, err := resolveDriveMemberRemoveTarget(runtime.Str("token"), runtime.Str("type"))
+	if err != nil {
+		return driveMemberRemoveSpec{}, err
+	}
+	// The resolver already rejects separators, but not "." or "..". Validate the
+	// resolved (decoded) token so a bare ".", "..", or an encoded "%2e"/"%2e%2e"
+	// in a URL path cannot reach the DELETE path as a dot segment.
+	if err := validate.ResourceName(token, "--token"); err != nil {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument, "%s", err.Error(),
+		).WithParam("--token")
+	}
+	if err := rejectDriveMemberRemoveDotSegment(token, "--token"); err != nil {
+		return driveMemberRemoveSpec{}, err
+	}
+
+	memberID := strings.TrimSpace(runtime.Str("member-id"))
+	if memberID == "" {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--member-id is required and cannot be blank",
+		).WithParam("--member-id")
+	}
+	if strings.Contains(memberID, "/") {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--member-id must be a single collaborator ID and cannot contain '/'",
+		).WithParam("--member-id")
+	}
+	if strings.Contains(memberID, ",") {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--member-id accepts exactly one collaborator ID; run one +member-remove command per member",
+		).WithParam("--member-id")
+	}
+	// Reject path-traversal and other unsafe patterns (e.g. "..", "%2e%2e" decoded
+	// to "..") before this value is interpolated into the DELETE path. The
+	// single-segment checks above stop separators, but not "." or "..", which
+	// EncodePathSegment leaves intact and an HTTP stack/proxy could normalize into
+	// a different route. This is a high-risk delete, so validate defensively.
+	if err := validate.ResourceName(memberID, "--member-id"); err != nil {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument, "%s", err.Error(),
+		).WithParam("--member-id")
+	}
+	if err := rejectDriveMemberRemoveDotSegment(memberID, "--member-id"); err != nil {
+		return driveMemberRemoveSpec{}, err
+	}
+
+	memberType, err := resolveDriveMemberRemoveMemberType(memberID, runtime.Str("member-type"))
+	if err != nil {
+		return driveMemberRemoveSpec{}, err
+	}
+	if memberType == "wikispaceid" && resourceType != "wiki" {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--member-type=wikispaceid only applies when resource type is wiki; got %q",
+			resourceType,
+		).WithParam("--member-type")
+	}
+	memberKind, err := resolveDriveMemberAddMemberKind(memberType, runtime.Str("member-kind"))
+	if err != nil {
+		return driveMemberRemoveSpec{}, err
+	}
+
+	permType, err := normalizeDriveMemberAddEnumValue(runtime.Str("perm-type"), driveMemberAddPermTypes, "--perm-type")
+	if err != nil {
+		return driveMemberRemoveSpec{}, err
+	}
+	if resourceType == "wiki" && memberType == "wikispaceid" {
+		if runtime.Changed("perm-type") {
+			return driveMemberRemoveSpec{}, errs.NewValidationError(
+				errs.SubtypeInvalidArgument,
+				"--perm-type is not supported when --member-type=wikispaceid; use --member-kind wiki_space_member|wiki_space_viewer|wiki_space_editor",
+			).WithParam("--perm-type")
+		}
+		permType = ""
+	} else if resourceType == "wiki" && permType == "" {
+		permType = driveMemberAddDefaultPermType(resourceType)
+	} else if resourceType != "wiki" && runtime.Changed("perm-type") {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--perm-type only applies when resource type is wiki; got %q",
+			resourceType,
+		).WithParam("--perm-type")
+	} else if resourceType != "wiki" {
+		permType = ""
+	}
+
+	spec := driveMemberRemoveSpec{
+		Token:        token,
+		ResourceType: resourceType,
+		MemberID:     memberID,
+		MemberType:   memberType,
+		MemberKind:   memberKind,
+		PermType:     permType,
+	}
+	if runtime.As().IsBot() && spec.MemberType == "opendepartmentid" {
+		return driveMemberRemoveSpec{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--member-type=opendepartmentid requires --as user; bot identity does not support removing department collaborators",
+		).WithParam("--member-type")
+	}
+	return spec, nil
+}
+
+// resolveDriveMemberRemoveMemberType normalizes and requires --member-type, rejecting a value
+// that conflicts with the prefix implied by memberID (except tenant-defined userid).
+func resolveDriveMemberRemoveMemberType(memberID, explicit string) (string, error) {
+	memberType, err := normalizeDriveMemberAddEnumValue(explicit, driveMemberRemoveIDTypes, "--member-type")
+	if err != nil {
+		return "", err
+	}
+	if memberType == "" {
+		return "", errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--member-type is required; accepted values: %s",
+			strings.Join(driveMemberRemoveIDTypes, ", "),
+		).WithParam("--member-type")
+	}
+
+	// User IDs are tenant-defined and may resemble another supported ID format.
+	if memberType != "userid" {
+		if expected := inferMemberTypeFromID(memberID); expected != "" && expected != memberType {
+			return "", errs.NewValidationError(
+				errs.SubtypeInvalidArgument,
+				"member-id %q prefix implies --member-type %s, but --member-type %s was provided; fix the ID or use the matching member type",
+				memberID,
+				expected,
+				memberType,
+			).WithParam("--member-id")
+		}
+	}
+	return memberType, nil
+}
+
+// buildDriveMemberRemoveDryRun renders the spec as a dry-run description of the DELETE request.
+func buildDriveMemberRemoveDryRun(spec driveMemberRemoveSpec) *common.DryRunAPI {
+	return common.NewDryRunAPI().
+		Desc("Remove Drive collaborator/member permission").
+		DELETE(driveMemberRemovePath(spec)).
+		Params(spec.APIQueryParams()).
+		Body(spec.Body())
+}
+
+// driveMemberRemovePath builds the permissions member DELETE path with each segment escaped.
+func driveMemberRemovePath(spec driveMemberRemoveSpec) string {
+	return fmt.Sprintf(
+		"/open-apis/drive/v1/permissions/%s/members/%s",
+		validate.EncodePathSegment(spec.Token),
+		validate.EncodePathSegment(spec.MemberID),
+	)
+}
+
+// executeDriveMemberRemove issues the typed DELETE request and emits the structured removal result.
+func executeDriveMemberRemove(runtime *common.RuntimeContext, spec driveMemberRemoveSpec) error {
+	fmt.Fprintf(
+		runtime.IO().ErrOut,
+		"Removing Drive member %s (type=%s) from %s %s...\n",
+		common.MaskToken(spec.MemberID),
+		spec.MemberType,
+		spec.ResourceType,
+		common.MaskToken(spec.Token),
+	)
+
+	if _, err := runtime.CallAPITyped(
+		"DELETE",
+		driveMemberRemovePath(spec),
+		spec.APIQueryParams(),
+		spec.Body(),
+	); err != nil {
+		return err
+	}
+
+	out := driveMemberRemoveOutput(spec)
+
+	fmt.Fprintf(runtime.IO().ErrOut, "Removed Drive member %s\n", common.MaskToken(spec.MemberID))
+	runtime.Out(out, nil)
+	return nil
+}
+
+// driveMemberRemoveOutput assembles the structured output map, including optional member kind and perm type.
+func driveMemberRemoveOutput(spec driveMemberRemoveSpec) map[string]interface{} {
+	out := map[string]interface{}{
+		"removed":        true,
+		"resource_token": spec.Token,
+		"resource_type":  spec.ResourceType,
+		"member_id":      spec.MemberID,
+		"member_type":    spec.MemberType,
+	}
+	if memberKind := driveMemberAddBodyType(spec.MemberType, spec.MemberKind); memberKind != "" {
+		out["member_kind"] = memberKind
+	}
+	if spec.PermType != "" {
+		out["perm_type"] = spec.PermType
+	}
+	return out
+}
+
+// resolveDriveMemberRemoveTarget resolves (token, type) from a --token that may
+// be a bare token or a resource URL, plus an optional explicit --type. Because
+// +member-remove is a high-risk delete, it parses URLs strictly: the escaped
+// path must be a supported prefix followed by exactly one segment, and a
+// --type that conflicts with the URL path type is rejected. This deliberately
+// does not reuse the more permissive +member-add resolver, so an ambiguous or
+// encoded URL can never delete a collaborator from an unintended resource.
+func resolveDriveMemberRemoveTarget(raw, explicitType string) (token, resourceType string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--token is required").WithParam("--token")
+	}
+	explicitType = strings.ToLower(strings.TrimSpace(explicitType))
+
+	if explicitType != "" && !isSupportedDriveMemberAddResourceType(explicitType) {
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--type must be one of: %s", strings.Join(driveMemberAddResourceTypes, ", "),
+		).WithParam("--type")
+	}
+
+	if strings.Contains(raw, "://") {
+		parsed, parseErr := url.Parse(raw)
+		if parseErr != nil || parsed.Hostname() == "" {
+			return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--token URL is malformed: %q", raw).WithParam("--token")
+		}
+		urlToken, urlType, ok := parseDriveMemberRemoveResourceURLPath(parsed.EscapedPath())
+		if !ok {
+			return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"unsupported URL path %q: expected one of %s followed by a single token segment",
+				parsed.EscapedPath(), strings.Join(driveMemberAddSupportedURLPaths(), ", "),
+			).WithParam("--token")
+		}
+		if explicitType != "" && explicitType != urlType {
+			return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--type %q conflicts with URL path type %q; remove --type or use a matching value",
+				explicitType, urlType,
+			).WithParam("--type")
+		}
+		return urlToken, urlType, nil
+	}
+
+	if explicitType == "" {
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--type is required when --token is a bare token; accepted values: %s",
+			strings.Join(driveMemberAddResourceTypes, ", "),
+		).WithParam("--type")
+	}
+	if strings.Contains(raw, "/") {
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--token must resolve to a single resource token and cannot contain '/'",
+		).WithParam("--token")
+	}
+	return raw, explicitType, nil
+}
+
+// parseDriveMemberRemoveResourceURLPath resolves (token, type) from a URL path
+// with strict exact-segment matching: the escaped path must be a supported
+// prefix followed by exactly one path segment. Extra segments or encoded
+// separators (%2F) are rejected rather than truncated, so a URL can never
+// silently address a different resource than the one it spells out.
+func parseDriveMemberRemoveResourceURLPath(escapedPath string) (token, resourceType string, ok bool) {
+	for _, mapping := range driveMemberAddURLPathToType {
+		if !strings.HasPrefix(escapedPath, mapping.Prefix) {
+			continue
+		}
+		escapedToken := strings.TrimSuffix(strings.TrimPrefix(escapedPath, mapping.Prefix), "/")
+		if escapedToken == "" || strings.Contains(escapedToken, "/") {
+			return "", "", false
+		}
+		decoded, decodeErr := url.PathUnescape(escapedToken)
+		if decodeErr != nil || decoded == "" || strings.Contains(decoded, "/") {
+			return "", "", false
+		}
+		return decoded, mapping.Type, true
+	}
+	return "", "", false
+}

--- a/shortcuts/drive/drive_member_remove_test.go
+++ b/shortcuts/drive/drive_member_remove_test.go
@@ -1,0 +1,473 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func TestDriveMemberRemoveMetadata(t *testing.T) {
+	t.Parallel()
+
+	if DriveMemberRemove.Service != "drive" || DriveMemberRemove.Command != "+member-remove" {
+		t.Fatalf("shortcut identity = %s %s", DriveMemberRemove.Service, DriveMemberRemove.Command)
+	}
+	if DriveMemberRemove.Risk != "high-risk-write" {
+		t.Fatalf("risk = %q, want high-risk-write", DriveMemberRemove.Risk)
+	}
+	if !reflect.DeepEqual(DriveMemberRemove.Scopes, []string{"docs:permission.member:delete"}) {
+		t.Fatalf("scopes = %#v", DriveMemberRemove.Scopes)
+	}
+	if !reflect.DeepEqual(DriveMemberRemove.AuthTypes, []string{"user", "bot"}) {
+		t.Fatalf("auth types = %#v", DriveMemberRemove.AuthTypes)
+	}
+	wantIDTypes := []string{
+		"email", "openid", "openchat", "opendepartmentid",
+		"userid", "unionid", "groupid", "wikispaceid",
+	}
+	if !reflect.DeepEqual(driveMemberRemoveIDTypes, wantIDTypes) {
+		t.Fatalf("member types = %#v, want %#v", driveMemberRemoveIDTypes, wantIDTypes)
+	}
+}
+
+func TestDriveMemberRemoveSpecRequestShape(t *testing.T) {
+	t.Parallel()
+
+	spec := driveMemberRemoveSpec{
+		Token:        "wikcnTok",
+		ResourceType: "wiki",
+		MemberID:     "ou_member",
+		MemberType:   "openid",
+		PermType:     "single_page",
+	}
+	wantParams := map[string]interface{}{"type": "wiki", "member_type": "openid"}
+	if got := spec.APIQueryParams(); !reflect.DeepEqual(got, wantParams) {
+		t.Fatalf("params = %#v, want %#v", got, wantParams)
+	}
+	wantBody := map[string]interface{}{"type": "user", "perm_type": "single_page"}
+	if got := spec.Body(); !reflect.DeepEqual(got, wantBody) {
+		t.Fatalf("body = %#v, want %#v", got, wantBody)
+	}
+
+	wikiSpaceSpec := driveMemberRemoveSpec{
+		Token:        "wikcnTok",
+		ResourceType: "wiki",
+		MemberID:     "space_member",
+		MemberType:   "wikispaceid",
+		MemberKind:   "wiki_space_viewer",
+	}
+	if got := wikiSpaceSpec.Body(); !reflect.DeepEqual(got, map[string]interface{}{"type": "wiki_space_viewer"}) {
+		t.Fatalf("wiki-space body = %#v", got)
+	}
+}
+
+func TestDriveMemberRemoveOutputConditionalFields(t *testing.T) {
+	t.Parallel()
+
+	wikiSpace := driveMemberRemoveOutput(driveMemberRemoveSpec{
+		Token:        "wikTok",
+		ResourceType: "wiki",
+		MemberID:     "space_member",
+		MemberType:   "wikispaceid",
+		MemberKind:   "wiki_space_editor",
+	})
+	if wikiSpace["removed"] != true || wikiSpace["member_kind"] != "wiki_space_editor" {
+		t.Fatalf("wiki-space output = %#v", wikiSpace)
+	}
+	if _, ok := wikiSpace["perm_type"]; ok {
+		t.Fatalf("wiki-space output must omit perm_type: %#v", wikiSpace)
+	}
+
+	userID := driveMemberRemoveOutput(driveMemberRemoveSpec{
+		Token:        "doxTok",
+		ResourceType: "docx",
+		MemberID:     "custom_user",
+		MemberType:   "userid",
+	})
+	if userID["member_kind"] != "user" {
+		t.Fatalf("userid output = %#v, want member_kind user", userID)
+	}
+}
+
+func TestDriveMemberRemoveDryRunInfersURLAndDefaultsWikiPermType(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveMemberRemove, []string{
+		"+member-remove",
+		"--token", "https://example.feishu.cn/wiki/wikcnTok?from=share",
+		"--member-id", "ou_member",
+		"--member-type", "openid",
+		"--dry-run",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got struct {
+		Data struct {
+			API []struct {
+				Method string                 `json:"method"`
+				URL    string                 `json:"url"`
+				Params map[string]interface{} `json:"params"`
+				Body   map[string]interface{} `json:"body"`
+			} `json:"api"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
+	}
+	if len(got.Data.API) != 1 {
+		t.Fatalf("api count = %d, want 1", len(got.Data.API))
+	}
+	call := got.Data.API[0]
+	if call.Method != "DELETE" || call.URL != "/open-apis/drive/v1/permissions/wikcnTok/members/ou_member" {
+		t.Fatalf("call = %#v", call)
+	}
+	if call.Params["type"] != "wiki" || call.Params["member_type"] != "openid" {
+		t.Fatalf("params = %#v", call.Params)
+	}
+	if call.Body["type"] != "user" || call.Body["perm_type"] != "container" {
+		t.Fatalf("body = %#v", call.Body)
+	}
+}
+
+func TestDriveMemberRemoveDryRunInfersAppsFromPageURLAndBareToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		typ   string
+	}{
+		{name: "page URL infers apps", token: "https://example.feishu.cn/page/appRemoveTok?from=share"},
+		{name: "bare token with explicit type", token: "appRemoveTok", typ: "apps"},
+	}
+
+	for _, temp := range tests {
+		tt := temp
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+			f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+			args := []string{
+				"+member-remove",
+				"--token", tt.token,
+				"--member-id", "ou_member",
+				"--member-type", "openid",
+				"--dry-run",
+				"--as", "user",
+			}
+			if tt.typ != "" {
+				args = append(args, "--type", tt.typ)
+			}
+			if err := mountAndRunDrive(t, DriveMemberRemove, args, f, stdout); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var got struct {
+				Data struct {
+					API []struct {
+						Method string                 `json:"method"`
+						URL    string                 `json:"url"`
+						Params map[string]interface{} `json:"params"`
+						Body   map[string]interface{} `json:"body"`
+					} `json:"api"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
+			}
+			if len(got.Data.API) != 1 {
+				t.Fatalf("api count = %d, want 1", len(got.Data.API))
+			}
+			call := got.Data.API[0]
+			if call.Method != "DELETE" || call.URL != "/open-apis/drive/v1/permissions/appRemoveTok/members/ou_member" {
+				t.Fatalf("call = %#v", call)
+			}
+			if call.Params["type"] != "apps" || call.Params["member_type"] != "openid" {
+				t.Fatalf("params = %#v", call.Params)
+			}
+			if call.Body["type"] != "user" {
+				t.Fatalf("body = %#v", call.Body)
+			}
+			if _, ok := call.Body["perm_type"]; ok {
+				t.Fatalf("apps must not carry perm_type, body = %#v", call.Body)
+			}
+		})
+	}
+}
+
+func TestDriveMemberRemoveValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		defaultAs string
+		wantParam string
+		wantText  string
+	}{
+		{
+			name:      "rejects slash in normalized token",
+			args:      []string{"--token", "token/with/slash", "--type", "docx", "--member-id", "ou_user", "--member-type", "openid"},
+			wantParam: "--token",
+			wantText:  "cannot contain '/'",
+		},
+		{
+			name:      "rejects slash in member ID",
+			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "userid/with/slash", "--member-type", "userid"},
+			wantParam: "--member-id",
+			wantText:  "cannot contain '/'",
+		},
+		{
+			name:      "rejects multiple members",
+			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "ou_a,ou_b", "--member-type", "openid"},
+			wantParam: "--member-id",
+			wantText:  "exactly one collaborator ID",
+		},
+		{
+			name:      "rejects member prefix mismatch",
+			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "oc_chat", "--member-type", "openid"},
+			wantParam: "--member-id",
+			wantText:  "implies --member-type openchat",
+		},
+		{
+			name:      "rejects app ID",
+			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "cli_app", "--member-type", "appid"},
+			wantParam: "--member-type",
+			wantText:  `invalid value "appid"`,
+		},
+		{
+			name:      "rejects wiki-space ID outside wiki",
+			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "space_x", "--member-type", "wikispaceid", "--member-kind", "wiki_space_member"},
+			wantParam: "--member-type",
+			wantText:  "only applies when resource type is wiki",
+		},
+		{
+			name:      "requires member kind for wiki space ID",
+			args:      []string{"--token", "wikTok", "--type", "wiki", "--member-id", "space_x", "--member-type", "wikispaceid"},
+			wantParam: "--member-kind",
+			wantText:  "--member-kind is required",
+		},
+		{
+			name:      "rejects member kind for ordinary member",
+			args:      []string{"--token", "wikTok", "--type", "wiki", "--member-id", "ou_x", "--member-type", "openid", "--member-kind", "wiki_space_member"},
+			wantParam: "--member-kind",
+			wantText:  "only applies",
+		},
+		{
+			name:      "rejects perm type outside wiki",
+			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "ou_x", "--member-type", "openid", "--perm-type", "single_page"},
+			wantParam: "--perm-type",
+			wantText:  "only applies when resource type is wiki",
+		},
+		{
+			name:      "rejects perm type on apps",
+			args:      []string{"--token", "appRemoveTok", "--type", "apps", "--member-id", "ou_x", "--member-type", "openid", "--perm-type", "single_page"},
+			wantParam: "--perm-type",
+			wantText:  `--perm-type only applies when resource type is wiki; got "apps"`,
+		},
+		{
+			name:      "rejects perm type for wiki space member",
+			args:      []string{"--token", "wikTok", "--type", "wiki", "--member-id", "space_x", "--member-type", "wikispaceid", "--member-kind", "wiki_space_member", "--perm-type", "container"},
+			wantParam: "--perm-type",
+			wantText:  "not supported when --member-type=wikispaceid",
+		},
+		{
+			name:      "rejects department with bot",
+			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "od_dept", "--member-type", "opendepartmentid"},
+			defaultAs: "bot",
+			wantParam: "--member-type",
+			wantText:  "requires --as user",
+		},
+	}
+
+	for _, temp := range tests {
+		tt := temp
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+			f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+			args := append([]string{"+member-remove"}, tt.args...)
+			args = append(args, "--dry-run", "--as", tt.defaultAs)
+			if tt.defaultAs == "" {
+				args[len(args)-1] = "user"
+			}
+			err := mountAndRunDrive(t, DriveMemberRemove, args, f, stdout)
+			if err == nil || !strings.Contains(err.Error(), tt.wantText) {
+				t.Fatalf("error = %v, want text %q", err, tt.wantText)
+			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed validation error, got %T: %v", err, err)
+			}
+			if problem.Category != errs.CategoryValidation {
+				t.Fatalf("problem = %#v", problem)
+			}
+			if problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem subtype = %q, want %q", problem.Subtype, errs.SubtypeInvalidArgument)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) || validationErr.Param != tt.wantParam {
+				t.Fatalf("validation error = %#v, want param %q", validationErr, tt.wantParam)
+			}
+		})
+	}
+}
+
+func TestDriveMemberRemoveAcceptsUserID(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveMemberRemove, []string{
+		"+member-remove",
+		"--token", "doxTok",
+		"--type", "docx",
+		"--member-id", "ou_tenant_defined_user",
+		"--member-type", "userid",
+		"--dry-run",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got struct {
+		Data struct {
+			API []struct {
+				Params map[string]interface{} `json:"params"`
+				Body   map[string]interface{} `json:"body"`
+			} `json:"api"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
+	}
+	if len(got.Data.API) != 1 {
+		t.Fatalf("api count = %d, want 1", len(got.Data.API))
+	}
+	if got.Data.API[0].Params["member_type"] != "userid" {
+		t.Fatalf("params = %#v", got.Data.API[0].Params)
+	}
+	if got.Data.API[0].Body["type"] != "user" {
+		t.Fatalf("body = %#v", got.Data.API[0].Body)
+	}
+}
+
+func TestDriveMemberRemoveExecuteSuccess(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, driveTestConfig())
+	var capturedQuery string
+	stub := &httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/drive/v1/permissions/wikcnSecretToken/members/ou_secret_member",
+		OnMatch: func(req *http.Request) {
+			capturedQuery = req.URL.RawQuery
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{},
+		},
+	}
+	reg.Register(stub)
+
+	err := mountAndRunDrive(t, DriveMemberRemove, []string{
+		"+member-remove",
+		"--token", "wikcnSecretToken",
+		"--type", "wiki",
+		"--member-id", "ou_secret_member",
+		"--member-type", "openid",
+		"--perm-type", "single_page",
+		"--as", "user",
+		"--yes",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(capturedQuery, "type=wiki") || !strings.Contains(capturedQuery, "member_type=openid") {
+		t.Fatalf("query = %q", capturedQuery)
+	}
+	var capturedBody map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &capturedBody); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	wantBody := map[string]interface{}{"type": "user", "perm_type": "single_page"}
+	if !reflect.DeepEqual(capturedBody, wantBody) {
+		t.Fatalf("body = %#v, want %#v", capturedBody, wantBody)
+	}
+
+	data := decodeDriveEnvelope(t, stdout)
+	if data["removed"] != true || data["resource_token"] != "wikcnSecretToken" || data["resource_type"] != "wiki" ||
+		data["member_id"] != "ou_secret_member" || data["member_type"] != "openid" ||
+		data["member_kind"] != "user" || data["perm_type"] != "single_page" {
+		t.Fatalf("output = %#v", data)
+	}
+	if strings.Contains(stderr.String(), "wikcnSecretToken") || strings.Contains(stderr.String(), "ou_secret_member") {
+		t.Fatalf("stderr exposes unmasked identifiers: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), common.MaskToken("wikcnSecretToken")) || !strings.Contains(stderr.String(), common.MaskToken("ou_secret_member")) {
+		t.Fatalf("stderr missing masked identifiers: %q", stderr.String())
+	}
+}
+
+func TestDriveMemberRemoveTypedPermissionErrorPassesThrough(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/drive/v1/permissions/doxTok/members/ou_member",
+		Body: map[string]interface{}{
+			"code": 1063002,
+			"msg":  "Permission denied",
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveMemberRemove, []string{
+		"+member-remove",
+		"--token", "doxTok",
+		"--type", "docx",
+		"--member-id", "ou_member",
+		"--member-type", "openid",
+		"--as", "user",
+		"--yes",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("expected *errs.PermissionError, got %T: %v", err, err)
+	}
+	if permissionErr.Code != 1063002 {
+		t.Fatalf("code = %d, want 1063002", permissionErr.Code)
+	}
+}
+
+func TestDriveMemberRemoveRequiresConfirmation(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveMemberRemove, []string{
+		"+member-remove",
+		"--token", "doxTok",
+		"--type", "docx",
+		"--member-id", "ou_member",
+		"--member-type", "openid",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "requires confirmation") {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+}

--- a/shortcuts/drive/shortcuts.go
+++ b/shortcuts/drive/shortcuts.go
@@ -43,6 +43,7 @@ func Shortcuts() []common.Shortcut {
 		DriveApplyPermission,
 		DriveMemberAdd,
 		DriveMemberList,
+		DriveMemberRemove,
 		DrivePermissionGetSetting,
 		DriveSecureLabelList,
 		DriveSecureLabelUpdate,

--- a/shortcuts/drive/shortcuts_test.go
+++ b/shortcuts/drive/shortcuts_test.go
@@ -50,6 +50,7 @@ func TestShortcutsIncludesExpectedCommands(t *testing.T) {
 		"+apply-permission",
 		"+member-add",
 		"+member-list",
+		"+member-remove",
 		"+permission-get-setting",
 		"+secure-label-list",
 		"+secure-label-update",

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -25,6 +25,7 @@ metadata:
 - 用户要**识别飞书 / doubao 云空间 URL 的类型和 token**时，可以先按 URL 路径形态做轻量判断；当路径已明确指向 docx / sheet / bitable / slides / file / folder 等资源时，可直接提取对应 token/type。传入 wiki URL、需要识别标题或 canonical URL、URL/token 有歧义，或后续操作依赖底层真实资源时，再使用 `lark-cli drive +inspect --url '<url>'` 进行识别；具体用法、失败处理和边界见 [`references/lark-drive-inspect.md`](references/lark-drive-inspect.md)。
 - 高风险写操作（删除、公开权限修改、owner 转移、版本删除/回滚、批量移动/覆盖/同步）必须同时满足三个条件才执行：目标已解析为该操作可直接使用的执行对象，执行细节已明确到可直接调用命令（例如删除的 file-token/type、公开权限修改的共享范围、owner 转移的目标 owner、版本删除/回滚的 version id、移动/覆盖/同步的目标位置和冲突策略），且用户在本轮明确确认执行这些具体目标和执行细节。用户只说“删除没用的文件”“开放/共享给大家”“改成开放”“覆盖/移动这些”只表示目标状态；先只读发现并列出候选、权限档位或执行方案，停止等待用户确认。
 - 用户要**检查 / 治理文档权限、公开范围、链接分享、外部访问、复制下载权限、密级标签、owner 转移**，或要”权限风险报告、收紧权限、申请查看 / 编辑权限、转移 / 批量转移 owner”，必须先阅读 [`references/lark-drive-workflow.md`](references/lark-drive-workflow.md)，再按其中 `Workflow Registry` 进入 [`permission_governance`](references/lark-drive-workflow-permission-governance.md) workflow。
+- 用户明确要**移除单个云文档协作者权限**时，使用 `lark-cli drive +member-remove`；先阅读 [`references/lark-drive-member-remove.md`](references/lark-drive-member-remove.md)。这是高风险写操作，真实执行必须确认准确的资源、成员 ID/type 和 wiki 权限范围，并显式传 `--yes`。
 - 用户要为指定飞书文档**设置 / 修改密级标签（secure label）**，或查询当前用户可用的密级标签，直接读取 [`references/lark-drive-secure-label.md`](references/lark-drive-secure-label.md)；这是 Drive 文件治理能力。
 - 用户要**检查 / 治理文档权限、公开范围、链接分享、外部访问、复制下载权限、密级标签、owner 转移**，或要“权限风险报告、收紧权限、申请查看 / 编辑权限、转移 / 批量转移 owner”，必须先阅读 [`references/lark-drive-workflow.md`](references/lark-drive-workflow.md)，再按其中 `Workflow Registry` 进入 [`permission_governance`](references/lark-drive-workflow-permission-governance.md) workflow。
 - 用户要**查询文件、文件夹或云文档自身的公开访问、分享、协作者管理、安全与评论权限设置**，优先使用 `lark-cli drive +permission-get-setting`；它只读取目标自身设置，不递归审计文件夹子文档权限。裸 token 必须显式传 `--type`。
@@ -154,6 +155,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli drive +<verb> [flags]`）
 | [`+apply-permission`](references/lark-drive-apply-permission.md) | 以 user 身份向文档 owner 申请访问权限。 |
 | [`+member-add`](references/lark-drive-member-add.md) | 添加一个或最多 10 个 Drive 文档、文件、文件夹或 wiki 节点协作者/授权成员；封装 Drive permission member create/batch_create，真实写入需要 `--yes`。 |
 | [`+member-list`](references/lark-drive-member-list.md) | 查询 Drive 文档、文件、文件夹或 wiki 节点的协作者/授权成员列表。 |
+| [`+member-remove`](references/lark-drive-member-remove.md) | 移除一个 Drive 文档、文件、文件夹或 wiki 节点协作者；封装 Drive permission member delete，真实写入需要 `--yes`。 |
 | [`+permission-get-setting`](references/lark-drive-permission-get-setting.md) | 查询文件、文件夹或云文档自身的公开访问、分享、协作者管理、安全与评论权限设置；支持 URL 或裸 token + `--type`；不递归读取文件夹子文档权限。 |
 | [`+secure-label-list`](references/lark-drive-secure-label.md) | 列出当前用户可用的密级标签。 |
 | [`+secure-label-update`](references/lark-drive-secure-label.md) | 更新 Drive 文件或文档的密级标签。 |

--- a/skills/lark-drive/references/lark-drive-member-remove.md
+++ b/skills/lark-drive/references/lark-drive-member-remove.md
@@ -1,0 +1,59 @@
+# drive +member-remove（移除协作者权限）
+
+> 这是高风险写操作。真实执行会移除权限，需要核对资源和成员后显式加 `--yes`。
+
+## 命令
+
+```bash
+lark-cli drive +member-remove \
+  --token "<bare_token_or_url>" \
+  --type docx \
+  --member-id "ou_xxx" \
+  --member-type openid \
+  --yes
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--token` | 是 | 裸 token 或完整 URL。路径支持 `/drive/folder/`、`/docx/`、`/doc/`、`/sheets/`、`/base/`、`/bitable/`、`/wiki/`、`/file/`、`/mindnotes/`、`/slides/`、`/minutes/`、`/page/`；URL 可从路径推断类型，裸 token 必须同时传 `--type`。 |
+| `--type` | 条件必填 | 资源类型：`docx` / `doc` / `sheet` / `bitable` / `file` / `folder` / `wiki` / `mindnote` / `slides` / `minutes` / `apps`。完整 URL 可省略。 |
+| `--member-id` | 是 | 要移除的单个协作者 ID。逗号分隔的多成员输入会被拒绝；批量场景应逐个调用。 |
+| `--member-type` | 是 | ID 类型：`email` / `openid` / `openchat` / `opendepartmentid` / `userid` / `unionid` / `groupid` / `wikispaceid`。 |
+| `--member-kind` | 条件必填 | 仅 `--member-type=wikispaceid` 使用：未启用知识库成员分组时传 `wiki_space_member`，启用后根据权限传 `wiki_space_viewer` 或 `wiki_space_editor`。 |
+| `--perm-type` | 否 | 仅 wiki 协作者使用：`container`（默认，当前页面及子页面）或 `single_page`（仅当前页面）。 |
+| `--dry-run` | 否 | 只预览 DELETE URL、query 和 body，不调用接口。 |
+| `--yes` | 真实执行时是 | 确认高风险权限移除操作。 |
+
+## 输出
+
+以移除 `openid` 类型的用户协作者为例，成功后返回：
+
+```json
+{
+  "ok": true,
+  "identity": "user",
+  "data": {
+    "removed": true,
+    "resource_token": "doxcnxxx",
+    "resource_type": "docx",
+    "member_id": "ou_xxx",
+    "member_type": "openid",
+    "member_kind": "user"
+  }
+}
+```
+
+Wiki 普通协作者还会返回 `perm_type`；`wikispaceid` 返回所传的 `member_kind`。
+
+`removed: true` 表示删除请求成功完成，不保证该权限此前一定存在。
+
+## 行为说明
+
+- **身份支持**：支持 `--as user` 和 `--as bot`。
+- **部门协作者**：`--member-type=opendepartmentid` 只能配合 `--as user`；bot 身份会在客户端提前拒绝。
+- **安全编码**：资源 token 和 member ID 都作为独立 path segment 编码。
+- **Wiki 范围**：普通 wiki 协作者默认删除 `container` 权限；只删除当前页面权限时显式传 `single_page`。
+- **Wiki 空间成员**：`--member-type=wikispaceid` 仅支持 `--type=wiki`；必须用 `--member-kind` 指明成员角色，并且不能同时传 `--perm-type`。
+- **错误处理**：OpenAPI 返回的 typed error 原样透传，可根据错误信封中的 subtype、code、hint 和权限信息处理。

--- a/tests/cli_e2e/drive/drive_member_remove_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_member_remove_dryrun_test.go
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrive_MemberRemoveDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	tests := []struct {
+		name             string
+		args             []string
+		wantURL          string
+		wantResourceType string
+		wantMemberType   string
+		wantMemberKind   string
+		wantPermType     string
+	}{
+		{
+			name: "docx URL infers resource type",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "https://example.feishu.cn/docx/doxcnRemove001?from=share",
+				"--member-id", "ou_remove_user",
+				"--member-type", "openid",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/doxcnRemove001/members/ou_remove_user",
+			wantResourceType: "docx",
+			wantMemberType:   "openid",
+			wantMemberKind:   "user",
+		},
+		{
+			name: "user ID is accepted",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "doxcnRemoveUserID",
+				"--type", "docx",
+				"--member-id", "tenant_defined_user",
+				"--member-type", "userid",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/doxcnRemoveUserID/members/tenant_defined_user",
+			wantResourceType: "docx",
+			wantMemberType:   "userid",
+			wantMemberKind:   "user",
+		},
+		{
+			name: "ordinary wiki member defaults container scope",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "wikcnE2E002",
+				"--type", "wiki",
+				"--member-id", "oc_remove_chat",
+				"--member-type", "openchat",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/wikcnE2E002/members/oc_remove_chat",
+			wantResourceType: "wiki",
+			wantMemberType:   "openchat",
+			wantMemberKind:   "chat",
+			wantPermType:     "container",
+		},
+		{
+			name: "wiki single-page scope",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "wikcnE2E003",
+				"--type", "wiki",
+				"--member-id", "ou_remove_user",
+				"--member-type", "openid",
+				"--perm-type", "single_page",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/wikcnE2E003/members/ou_remove_user",
+			wantResourceType: "wiki",
+			wantMemberType:   "openid",
+			wantMemberKind:   "user",
+			wantPermType:     "single_page",
+		},
+		{
+			name: "wiki-space member uses explicit kind without perm type",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "wikcnE2E004",
+				"--type", "wiki",
+				"--member-id", "space_remove_member",
+				"--member-type", "wikispaceid",
+				"--member-kind", "wiki_space_editor",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/wikcnE2E004/members/space_remove_member",
+			wantResourceType: "wiki",
+			wantMemberType:   "wikispaceid",
+			wantMemberKind:   "wiki_space_editor",
+		},
+		{
+			name: "apps page URL infers resource type",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "https://example.feishu.cn/page/appRemovePageTok?from=share",
+				"--member-id", "ou_remove_user",
+				"--member-type", "openid",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/appRemovePageTok/members/ou_remove_user",
+			wantResourceType: "apps",
+			wantMemberType:   "openid",
+			wantMemberKind:   "user",
+		},
+		{
+			name: "apps bare token with explicit type",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "appRemoveTok",
+				"--type", "apps",
+				"--member-id", "ou_remove_user",
+				"--member-type", "openid",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/appRemoveTok/members/ou_remove_user",
+			wantResourceType: "apps",
+			wantMemberType:   "openid",
+			wantMemberKind:   "user",
+		},
+	}
+
+	for _, temp := range tests {
+		tt := temp
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: tt.args, DefaultAs: "user"})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+
+			out := result.Stdout
+			require.Equal(t, "DELETE", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+			require.Equal(t, tt.wantURL, clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+			require.Equal(t, tt.wantResourceType, clie2e.DryRunGet(out, "api.0.params.type").String(), "stdout:\n%s", out)
+			require.Equal(t, tt.wantMemberType, clie2e.DryRunGet(out, "api.0.params.member_type").String(), "stdout:\n%s", out)
+			require.Equal(t, tt.wantMemberKind, clie2e.DryRunGet(out, "api.0.body.type").String(), "stdout:\n%s", out)
+
+			permType := clie2e.DryRunGet(out, "api.0.body.perm_type")
+			if tt.wantPermType == "" {
+				require.False(t, permType.Exists(), "perm_type should be omitted\nstdout:\n%s", out)
+			} else {
+				require.Equal(t, tt.wantPermType, permType.String(), "stdout:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestDrive_MemberRemoveDryRunRejectsInvalidInputs(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	tests := []struct {
+		name      string
+		args      []string
+		defaultAs string
+		wantErr   string
+	}{
+		{
+			name:    "slash in normalized token is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "token/with/slash", "--type", "docx", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "--token must resolve to a single resource token and cannot contain '/'",
+		},
+		{
+			name:    "slash in member ID is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "userid/with/slash", "--member-type", "userid", "--dry-run"},
+			wantErr: "--member-id must be a single collaborator ID and cannot contain '/'",
+		},
+		{
+			name:    "blank member ID is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "   ", "--member-type", "openid", "--dry-run"},
+			wantErr: "--member-id is required and cannot be blank",
+		},
+		{
+			name:    "bare token requires type",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "--type is required when --token is a bare token",
+		},
+		{
+			name:    "multiple members are rejected",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "ou_a,ou_b", "--member-type", "openid", "--dry-run"},
+			wantErr: "exactly one collaborator ID",
+		},
+		{
+			name:    "wiki-space ID requires member kind",
+			args:    []string{"drive", "+member-remove", "--token", "wikcnRemove", "--type", "wiki", "--member-id", "space_member", "--member-type", "wikispaceid", "--dry-run"},
+			wantErr: "--member-kind is required",
+		},
+		{
+			name:    "app ID is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "cli_app", "--member-type", "appid", "--dry-run"},
+			wantErr: "allowed: email, openid, openchat, opendepartmentid, userid, unionid, groupid, wikispaceid",
+		},
+		{
+			name:    "wiki-space ID is rejected outside wiki",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "space_member", "--member-type", "wikispaceid", "--member-kind", "wiki_space_member", "--dry-run"},
+			wantErr: "only applies when resource type is wiki",
+		},
+		{
+			name:    "non-wiki rejects perm type",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "ou_user", "--member-type", "openid", "--perm-type", "single_page", "--dry-run"},
+			wantErr: "only applies when resource type is wiki",
+		},
+		{
+			name:    "apps rejects perm type",
+			args:    []string{"drive", "+member-remove", "--token", "appRemoveBadTok", "--type", "apps", "--member-id", "ou_user", "--member-type", "openid", "--perm-type", "single_page", "--dry-run"},
+			wantErr: `resource type is wiki; got \"apps\"`,
+		},
+		{
+			name:      "bot rejects department member",
+			args:      []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "od_department", "--member-type", "opendepartmentid", "--dry-run"},
+			defaultAs: "bot",
+			wantErr:   "requires --as user",
+		},
+		{
+			name:    "url with extra path segment is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "https://example.feishu.cn/docx/doxReal/other", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "unsupported URL path",
+		},
+		{
+			name:    "url with encoded separator is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "https://example.feishu.cn/docx/doxReal%2Fother", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "unsupported URL path",
+		},
+		{
+			// Double-encoded separator: PathUnescape decodes one level to the
+			// single literal token "doxReal%2Fother" (still holding a '%', no
+			// real '/'), so it survives the URL segment check but is then
+			// rejected by validate.ResourceName's unsafe-character rule before any
+			// request is shaped. This pins that the '%' can never reach the DELETE
+			// path, so the token cannot silently address a different resource.
+			name:    "url with double-encoded separator is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "https://example.feishu.cn/docx/doxReal%252Fother", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "--token contains invalid characters",
+		},
+		{
+			name:    "type conflicting with url path is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "https://example.feishu.cn/docx/doxReal", "--type", "wiki", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "conflicts with URL path type",
+		},
+		{
+			name:    "bare dot-dot token is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "..", "--type", "docx", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "--token must not contain '..' path traversal",
+		},
+		{
+			name:    "encoded dot-dot in url path is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "https://example.feishu.cn/docx/%2e%2e", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "--token must not contain '..' path traversal",
+		},
+		{
+			name:    "dot-dot member ID is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "..", "--member-type", "openid", "--dry-run"},
+			wantErr: "--member-id must not contain '..' path traversal",
+		},
+		{
+			name:    "bare single-dot token is rejected",
+			args:    []string{"drive", "+member-remove", "--token", ".", "--type", "docx", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "--token must not contain '.' or '..' path segments",
+		},
+		{
+			name:    "encoded single-dot in url path is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "https://example.feishu.cn/docx/%2e", "--member-id", "ou_user", "--member-type", "openid", "--dry-run"},
+			wantErr: "--token must not contain '.' or '..' path segments",
+		},
+		{
+			name:    "single-dot member ID is rejected",
+			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", ".", "--member-type", "openid", "--dry-run"},
+			wantErr: "--member-id must not contain '.' or '..' path segments",
+		},
+	}
+
+	for _, temp := range tests {
+		tt := temp
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+			defaultAs := tt.defaultAs
+			if defaultAs == "" {
+				defaultAs = "user"
+			}
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: tt.args, DefaultAs: defaultAs})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 2)
+			require.Contains(t, result.Stdout+result.Stderr, tt.wantErr, "stdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
+		})
+	}
+}
+
+func TestDrive_MemberRemoveRequiresConfirmation(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+member-remove",
+			"--token", "doxcnRemove",
+			"--type", "docx",
+			"--member-id", "ou_user",
+			"--member-type", "openid",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 10)
+	require.Contains(t, result.Stderr, "confirmation_required", "stderr:\n%s", result.Stderr)
+}

--- a/tests/cli_e2e/drive/drive_member_remove_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_member_remove_workflow_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestDrive_MemberRemoveWorkflowAsUser(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+	clie2e.SkipWithoutUserToken(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	folderToken := CreateDriveFolder(t, t, ctx, "lark-cli-e2e-member-remove-"+suffix, "user", "")
+	docToken := createMemberRemoveWorkflowDoc(t, ctx, folderToken, suffix)
+	memberOpenID := requireDriveMemberFixture(t)
+
+	// The doc is freshly created by this run, so the fixture user cannot be a
+	// pre-existing collaborator; a user member is also observable via member-list
+	// (unlike a bot, which the permission backend never returns), so this round
+	// trip can verify real state rather than only the synthesized receipt.
+	addResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+member-add",
+			"--token", docToken,
+			"--type", "docx",
+			"--member-id", memberOpenID,
+			"--member-type", "openid",
+			"--perm", "view",
+			"--yes",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	addResult.AssertExitCode(t, 0)
+	addResult.AssertStdoutStatus(t, true)
+	require.Equal(t, memberOpenID, gjson.Get(addResult.Stdout, "data.member_id").String(), "stdout:\n%s", addResult.Stdout)
+
+	// Prove the add actually granted access; the add receipt echoes request fields
+	// and cannot by itself prove the collaborator was created.
+	requireDriveMemberListMembership(t, ctx, docToken, "docx", memberOpenID, true)
+
+	removeResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+member-remove",
+			"--token", docToken,
+			"--type", "docx",
+			"--member-id", memberOpenID,
+			"--member-type", "openid",
+			"--yes",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	removeResult.AssertExitCode(t, 0)
+	removeResult.AssertStdoutStatus(t, true)
+	require.True(t, gjson.Get(removeResult.Stdout, "data.removed").Bool(), "stdout:\n%s", removeResult.Stdout)
+	require.Equal(t, docToken, gjson.Get(removeResult.Stdout, "data.resource_token").String(), "stdout:\n%s", removeResult.Stdout)
+	require.Equal(t, "docx", gjson.Get(removeResult.Stdout, "data.resource_type").String(), "stdout:\n%s", removeResult.Stdout)
+	require.Equal(t, memberOpenID, gjson.Get(removeResult.Stdout, "data.member_id").String(), "stdout:\n%s", removeResult.Stdout)
+	require.Equal(t, "openid", gjson.Get(removeResult.Stdout, "data.member_type").String(), "stdout:\n%s", removeResult.Stdout)
+
+	// Prove the removal changed observable state, not just that the call exited 0.
+	requireDriveMemberListMembership(t, ctx, docToken, "docx", memberOpenID, false)
+}
+
+// TestDrive_MemberRemoveAppsWorkflowAsUser exercises the Miaoda apps branch of
+// drive +member-remove against a real backend. The docx workflow above never
+// touches --type=apps, so this is the only live proof that the server accepts
+// DELETE /permissions/{token}/members/{id}?type=apps; the dry-run tests only
+// cover client-side URL inference and request shaping.
+//
+// The collaborator is a USER (not a bot): the permission member-list backend
+// only returns supported member types and deliberately excludes app/bot owners,
+// so a bot collaborator can never be observed there and its membership can never
+// be verified. A user member is observable, which lets this test use an
+// authoritative baseline and a real add -> verify -> remove -> verify round
+// trip. Both the app and the collaborator user are injected via fixture env vars
+// (never real tokens in source); the test only mutates that one collaborator and
+// cleans it up. The app's existing collaborators are never touched.
+func TestDrive_MemberRemoveAppsWorkflowAsUser(t *testing.T) {
+	clie2e.SkipWithoutUserToken(t)
+	appToken := requireDriveAppsFixture(t)
+	memberOpenID := requireDriveMemberFixture(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	// Authoritative baseline: the collaborator must be a supported (user) member
+	// type that member-list actually returns, and it must be absent before the
+	// run. If it is already present, skip rather than risk deleting a pre-existing
+	// collaborator during cleanup. Because user members ARE observable, absence
+	// here is authoritative (unlike a bot, which is never listed).
+	baselineResult, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"drive", "+member-list", "--token", appToken, "--type", "apps"},
+		DefaultAs: "user",
+	}, clie2e.RetryOptions{})
+	require.NoError(t, err)
+	baselineResult.AssertExitCode(t, 0)
+	baselineResult.AssertStdoutStatus(t, true)
+	if driveMemberListContains(baselineResult.Stdout, memberOpenID) {
+		t.Skipf("FIXTURE: user %s already collaborates on the fixture app; refusing to mutate pre-existing state", memberOpenID)
+	}
+
+	// Arm cleanup only for the membership this run creates. needsCleanup is set
+	// true just before the add write, so a transport failure after a committed
+	// request still triggers cleanup, while an early skip/failure never removes a
+	// collaborator this run did not add. Cleanup failures are reported, not
+	// discarded.
+	needsCleanup := false
+	t.Cleanup(func() {
+		if !needsCleanup {
+			return
+		}
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+
+		removeResult, removeErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+			Args: []string{
+				"drive", "+member-remove",
+				"--token", appToken,
+				"--type", "apps",
+				"--member-id", memberOpenID,
+				"--member-type", "openid",
+				"--yes",
+			},
+			DefaultAs: "user",
+		})
+		clie2e.ReportCleanupFailure(t, "remove added apps collaborator "+memberOpenID, removeResult, removeErr)
+	})
+
+	needsCleanup = true
+	addResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+member-add",
+			"--token", appToken,
+			"--type", "apps",
+			"--member-id", memberOpenID,
+			"--member-type", "openid",
+			"--perm", "view",
+			"--yes",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	addResult.AssertExitCode(t, 0)
+	addResult.AssertStdoutStatus(t, true)
+	require.Equal(t, "apps", gjson.Get(addResult.Stdout, "data.resource_type").String(), "stdout:\n%s", addResult.Stdout)
+	require.Equal(t, memberOpenID, gjson.Get(addResult.Stdout, "data.member_id").String(), "stdout:\n%s", addResult.Stdout)
+
+	// Prove the add is observable (user members are returned by member-list), so
+	// the round trip verifies real state rather than just an exit code.
+	requireDriveMemberListMembership(t, ctx, appToken, "apps", memberOpenID, true)
+
+	removeResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+member-remove",
+			"--token", appToken,
+			"--type", "apps",
+			"--member-id", memberOpenID,
+			"--member-type", "openid",
+			"--yes",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	removeResult.AssertExitCode(t, 0)
+	removeResult.AssertStdoutStatus(t, true)
+	require.True(t, gjson.Get(removeResult.Stdout, "data.removed").Bool(), "stdout:\n%s", removeResult.Stdout)
+	require.Equal(t, "apps", gjson.Get(removeResult.Stdout, "data.resource_type").String(), "stdout:\n%s", removeResult.Stdout)
+	require.Equal(t, memberOpenID, gjson.Get(removeResult.Stdout, "data.member_id").String(), "stdout:\n%s", removeResult.Stdout)
+	require.Equal(t, "openid", gjson.Get(removeResult.Stdout, "data.member_type").String(), "stdout:\n%s", removeResult.Stdout)
+
+	// Prove the removal changed observable state (the user we just confirmed
+	// present is now gone), not merely that the call exited 0.
+	requireDriveMemberListMembership(t, ctx, appToken, "apps", memberOpenID, false)
+
+	// The explicit remove above already deleted the membership; a redundant
+	// cleanup delete is unnecessary and would only add noise.
+	needsCleanup = false
+}
+
+// driveMemberListContains reports whether a +member-list response includes a
+// collaborator with the given member id.
+func driveMemberListContains(stdout, memberID string) bool {
+	for _, item := range gjson.Get(stdout, "data.items").Array() {
+		if item.Get("member_id").String() == memberID {
+			return true
+		}
+	}
+	return false
+}
+
+// requireDriveMemberListMembership polls +member-list until the member's
+// presence matches want, tolerating eventual consistency. It fails the test if
+// the expected state is not reached before the deadline, so a removal that did
+// not actually change server state cannot pass silently.
+func requireDriveMemberListMembership(t *testing.T, ctx context.Context, token, resourceType, memberID string, want bool) {
+	t.Helper()
+	err := clie2e.WaitForCondition(ctx, clie2e.WaitOptions{
+		Timeout:  30 * time.Second,
+		Interval: 2 * time.Second,
+		TimeoutError: func() error {
+			return fmt.Errorf("member %s presence in %s member-list never became %v", memberID, resourceType, want)
+		},
+	}, func() (bool, error) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"drive", "+member-list", "--token", token, "--type", resourceType},
+			DefaultAs: "user",
+		})
+		if err != nil {
+			return false, err
+		}
+		if result.ExitCode != 0 {
+			return false, fmt.Errorf("member-list failed: exit=%d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+		}
+		return driveMemberListContains(result.Stdout, memberID) == want, nil
+	})
+	require.NoError(t, err)
+}
+
+// requireDriveAppsFixture returns the Miaoda app token/URL used as the live
+// apps target, or skips when it is unset. The token is never hard-coded in
+// source: it identifies a real tenant resource and must be supplied by the
+// runner. Accepts either a /page/ URL or a bare app token (both resolve to
+// --type=apps).
+func requireDriveAppsFixture(t *testing.T) string {
+	t.Helper()
+	appToken := strings.TrimSpace(os.Getenv("LARK_CLI_E2E_DRIVE_APPS_TOKEN"))
+	if appToken == "" {
+		t.Skip("FIXTURE: Set LARK_CLI_E2E_DRIVE_APPS_TOKEN to a Miaoda app /page/ URL or bare app token whose collaborators the test user can manage")
+	}
+	return appToken
+}
+
+// requireDriveMemberFixture returns the open id of a USER collaborator to add and
+// remove in the live workflows, or skips when unset. A user (not a bot) is
+// required because the permission member-list backend only returns supported
+// member types and excludes app/bot owners, so only a user member can be
+// verified via member-list. The id must be a disposable test user that is NOT a
+// pre-existing collaborator of the target resource. Shared by the docx and apps
+// workflows; mirrors the LARK_CLI_E2E_APPS_ROLE_USER_OPEN_ID fixture used by the
+// apps role live test.
+func requireDriveMemberFixture(t *testing.T) string {
+	t.Helper()
+	memberOpenID := strings.TrimSpace(os.Getenv("LARK_CLI_E2E_DRIVE_MEMBER_OPEN_ID"))
+	if memberOpenID == "" {
+		t.Skip("FIXTURE: Set LARK_CLI_E2E_DRIVE_MEMBER_OPEN_ID to a disposable test user's open id (ou_...) that is not already a collaborator on the target resource")
+	}
+	return memberOpenID
+}
+
+func createMemberRemoveWorkflowDoc(t *testing.T, ctx context.Context, folderToken, suffix string) string {
+	t.Helper()
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+create",
+			"--parent-token", folderToken,
+			"--doc-format", "markdown",
+			"--content", "# member-remove-" + suffix + "\n\nTemporary permission workflow fixture.",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+
+	docToken := gjson.Get(result.Stdout, "data.document.document_id").String()
+	require.NotEmpty(t, docToken, "stdout:\n%s", result.Stdout)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+
+		deleteResult, deleteErr := DeleteDriveResourceAndVerify(cleanupCtx, docToken, "docx", "user")
+		clie2e.ReportCleanupFailure(t, "delete member-remove workflow doc "+docToken, deleteResult, deleteErr)
+	})
+	return docToken
+}


### PR DESCRIPTION
Add a high-risk Drive shortcut for removing one collaborator permission through the permission member delete API. The command validates resource and member combinations, previews the exact DELETE request, and returns an auditable success receipt.

Key features:

- Reuse existing Drive member target, member type, and wiki permission helpers without changing +member-add

- Require explicit confirmation and reject unsupported bot department removal before the API call

- Cover request shaping, typed errors, dry-run behavior, and the live add/remove workflow

## Test Plan

- Unit (`shortcuts/drive/drive_member_remove_test.go`): request construction, query/body shaping, conditional output fields, typed validation errors, and API-error passthrough.
- Dry-run E2E (`tests/cli_e2e/drive/drive_member_remove_dryrun_test.go`): exact DELETE method/URL/params/body per resource type, plus regression cases rejecting ambiguous multi-segment URLs, %2F-encoded separators, `--type` conflicts, and slash/comma-containing member IDs.
- Live workflow E2E (`tests/cli_e2e/drive/drive_member_remove_workflow_test.go`): docx add→remove round trip, and a fixture-gated apps (Miaoda) add→remove round trip (`LARK_CLI_E2E_DRIVE_APPS_TOKEN`, skipped when unset) that only mutates a transient bot collaborator and reports cleanup failures via `clie2e.ReportCleanupFailure`.
- Targeted package check: `go test ./shortcuts/drive/ -run MemberRemove` (pass), `go vet ./shortcuts/drive/`, `gofmt -l` (clean).

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `drive +member-remove` to remove exactly one collaborator’s Drive permission, with wiki-specific handling and structured progress/output.
  * Enforces strict validation and requires confirmation for real deletions.
* **Documentation**
  * Added command reference and skill guidance for safe usage (`--dry-run`, parameter rules, and returned field meanings).
* **Tests**
  * Added unit tests for request construction, conditional output fields, validation, and typed permission error passthrough.
  * Added CLI end-to-end coverage for dry-run and a successful user workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
