### PR TITLE
fix: remove legacy shortcut

### DIFF
--- a/skills/lark-doc/references/lark-doc-whiteboard.md
+++ b/skills/lark-doc/references/lark-doc-whiteboard.md
@@ -125,9 +125,9 @@ Sub Agent 需要携带以下的最小上下文，以及后续的 [SVG 设计 Wor
 `../../lark-whiteboard/SKILL.md`](../../lark-whiteboard/SKILL.md) 编辑。
 
 ```bash
-lark-cli whiteboard +query \
+lark-cli whiteboard +export \
   --whiteboard-token "wbcnxxxxxxxx" \
-  --output_as image \
+  --output-type preview \
   --output ./preview.png
 ```
 

--- a/skills/lark-drive/references/lark-drive-comment-location.md
+++ b/skills/lark-drive/references/lark-drive-comment-location.md
@@ -190,9 +190,9 @@ lark-cli base +record-list --base-token '<base_token>' --table-id '<table_id>' -
 - 若要定位画板内部节点，切到 `lark-whiteboard` 读取 raw 节点结构：
 
 ```bash
-lark-cli whiteboard +query \
+lark-cli whiteboard +export \
   --whiteboard-token '<whiteboard_token>' \
-  --output_as raw
+  --output-type raw
 ```
 
 - 如果 raw 节点中存在唯一匹配 `quote` 的文本节点，可定位到该节点；如果有多个相同文本节点，仍然是弱匹配，需要结合位置、样式、用户描述或人工确认。


### PR DESCRIPTION
## Summary
After whiteboard +query shortcut renamed whiteboard +export, change remaining  `+query` quotes in lark-doc and lark-drive skill. 

## Changes
<!-- List the main changes in this PR. -->
`whiteboard +query` shortcut quotes in lark-doc-whiteboard.md and lark-drive-comment-location.md

## Test Plan
- [ ] Unit tests pass

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新画板 SVG 处理示例，改用导出命令生成预览图片。
  - 更新画板内部评论定位示例，采用新的 raw 节点导出参数。
  - 统一相关命令示例格式，提升操作指引的准确性与可用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->