### PR TITLE
docs: update lark doc HTML size limit

### DIFF
--- a/skills/lark-doc/references/lark-doc-xml-extended-blocks.md
+++ b/skills/lark-doc/references/lark-doc-xml-extended-blocks.md
@@ -41,7 +41,7 @@
 
 ### 内容限制
 
-- HTML 总长度上限为 900000 字符。不要内联大图片、Base64、字体、长 JSON/CSV 或大量 mock 数据。
+- HTML 总长度上限为 500KB。不要内联大图片、Base64、字体、长 JSON/CSV 或大量 mock 数据。
 
 ## OKR block
 


### PR DESCRIPTION
## Summary
Update the Lark Doc extended-block reference to reflect the revised HTML total size limit.

## Changes
- Change the documented HTML total size limit from 900000 characters to 500KB.

## Test Plan
- [x] `git diff --check` passes.
- [ ] Unit tests pass (not run; documentation-only change).
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected (not applicable; documentation-only change).

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “内容限制” guidance to change the HTML total size limit from 900,000 characters to a maximum total size of 500 KB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->