### PR TITLE
test(e2e): declare request identities explicitly

### DIFF
--- a/tests/cli_e2e/base/base_record_batch_update_workflow_test.go
+++ b/tests/cli_e2e/base/base_record_batch_update_workflow_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestBaseRecordBatchUpdatePerRecordWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
 	parentT := t
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/docs/docs_create_fetch_test.go
+++ b/tests/cli_e2e/docs/docs_create_fetch_test.go
@@ -44,6 +44,7 @@ func TestDocs_CreateAndFetchWorkflowAsBot(t *testing.T) {
 				"--doc", docToken,
 				"--doc-format", "markdown",
 			},
+			DefaultAs: defaultAs,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/okr/okr_shortcuts_test.go
+++ b/tests/cli_e2e/okr/okr_shortcuts_test.go
@@ -366,6 +366,7 @@ func createTestObjectives(t *testing.T, ctx context.Context, cycleID string, suf
 			"--cycle-id", cycleID,
 			"--input", string(inputJSON),
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err, "failed to create test objectives")
 	result.AssertExitCode(t, 0)
@@ -411,6 +412,7 @@ func cleanupLiveTest(t *testing.T, created []liveTestCreated) {
 					"--key-result-id", krID,
 					"--yes",
 				},
+				DefaultAs: "user",
 			})
 			clie2e.ReportCleanupFailure(t, fmt.Sprintf("delete KR %s", krID), result, err)
 			select {
@@ -426,6 +428,7 @@ func cleanupLiveTest(t *testing.T, created []liveTestCreated) {
 				"--objective-id", obj.ObjectiveID,
 				"--yes",
 			},
+			DefaultAs: "user",
 		})
 		clie2e.ReportCleanupFailure(t, fmt.Sprintf("delete objective %s", obj.ObjectiveID), result, err)
 		if i > 0 {
@@ -447,6 +450,7 @@ func createLiveObjective(t *testing.T, ctx context.Context, cycleID string, suff
 			"--cycle-id", cycleID,
 			"--content", fmt.Sprintf(`{"text":"E2E Single Objective %s","mention":["ou_test"]}`, suffix),
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err, "failed to create live objective")
 	result.AssertExitCode(t, 0)
@@ -466,6 +470,7 @@ func createLiveKeyResult(t *testing.T, ctx context.Context, objectiveID string, 
 			"--objective-id", objectiveID,
 			"--content", fmt.Sprintf(`{"text":"E2E Single KR %s","mention":["ou_test"]}`, suffix),
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err, "failed to create live key result")
 	result.AssertExitCode(t, 0)
@@ -499,6 +504,7 @@ func TestOKR_BatchCreateLive(t *testing.T) {
 			"okr", "+cycle-detail",
 			"--cycle-id", cycleID,
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
@@ -544,6 +550,7 @@ func TestOKR_CreateLive_Objective(t *testing.T) {
 			"okr", "+cycle-detail",
 			"--cycle-id", cycleID,
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
@@ -581,6 +588,7 @@ func TestOKR_CreateLive_KeyResultUnderExistingObjective(t *testing.T) {
 			"okr", "+cycle-detail",
 			"--cycle-id", cycleID,
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
@@ -640,6 +648,7 @@ func TestOKR_ReorderLive(t *testing.T) {
 			"--level", "objective",
 			"--ops", string(opsJSON),
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
@@ -650,6 +659,7 @@ func TestOKR_ReorderLive(t *testing.T) {
 			"okr", "+cycle-detail",
 			"--cycle-id", cycleID,
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
@@ -702,6 +712,7 @@ func TestOKR_WeightLive(t *testing.T) {
 			"--level", "objective",
 			"--weights", string(weightsJSON),
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
@@ -712,6 +723,7 @@ func TestOKR_WeightLive(t *testing.T) {
 			"okr", "+cycle-detail",
 			"--cycle-id", cycleID,
 		},
+		DefaultAs: "user",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end test command requests to explicitly use the correct default execution context, aligning bot and user workflows.
  - Improved document-fetch coverage in the create-and-fetch workflow.
  - Expanded OKR end-to-end scenarios to consistently verify cycle details and operations like reordering and weighting.
  - Added a safety guard to skip a batch-update end-to-end test when the required tenant access token isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->