### PR TITLE
feat(apps): support absolute and relative upload paths

### DIFF
--- a/internal/cmdutil/localfile.go
+++ b/internal/cmdutil/localfile.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// OpenLocalFile opens a regular file in the process filesystem namespace.
+// Absolute and relative paths are accepted. It is the shared replacement for
+// direct os.Open/os.ReadFile use in commands that intentionally read local
+// paths outside the workspace sandbox.
+func OpenLocalFile(path string) (fs.File, error) {
+	localPath, err := validate.LocalInputPath(path)
+	if err != nil {
+		return nil, &fileio.PathValidationError{Err: err}
+	}
+
+	info, err := vfs.Stat(localPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, &fileio.PathValidationError{Err: fmt.Errorf("%q is not a regular file", path)}
+	}
+
+	f, err := vfs.Open(localPath)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !openedInfo.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, &fileio.PathValidationError{Err: fmt.Errorf("%q is not a regular file", path)}
+	}
+	return f, nil
+}

--- a/internal/cmdutil/localfile.go
+++ b/internal/cmdutil/localfile.go
@@ -4,7 +4,6 @@
 package cmdutil
 
 import (
-	"fmt"
 	"io/fs"
 
 	"github.com/larksuite/cli/extension/fileio"
@@ -12,36 +11,26 @@ import (
 	"github.com/larksuite/cli/internal/vfs"
 )
 
-// OpenLocalFile opens a regular file in the process filesystem namespace.
+// StatLocalFile returns metadata for a path in the process filesystem namespace.
+// It is intended for advisory validation; callers must validate the opened file
+// again before using its contents.
+func StatLocalFile(path string) (fs.FileInfo, error) {
+	localPath, err := validate.LocalInputPath(path)
+	if err != nil {
+		return nil, &fileio.PathValidationError{Err: err}
+	}
+	return vfs.Stat(localPath)
+}
+
+// OpenLocalFile opens a path in the process filesystem namespace.
 // Absolute and relative paths are accepted. It is the shared replacement for
 // direct os.Open/os.ReadFile use in commands that intentionally read local
-// paths outside the workspace sandbox.
+// paths outside the workspace sandbox. Callers inspect the returned descriptor
+// before reading so validation and use apply to the same opened file.
 func OpenLocalFile(path string) (fs.File, error) {
 	localPath, err := validate.LocalInputPath(path)
 	if err != nil {
 		return nil, &fileio.PathValidationError{Err: err}
 	}
-
-	info, err := vfs.Stat(localPath)
-	if err != nil {
-		return nil, err
-	}
-	if !info.Mode().IsRegular() {
-		return nil, &fileio.PathValidationError{Err: fmt.Errorf("%q is not a regular file", path)}
-	}
-
-	f, err := vfs.Open(localPath)
-	if err != nil {
-		return nil, err
-	}
-	openedInfo, err := f.Stat()
-	if err != nil {
-		_ = f.Close()
-		return nil, err
-	}
-	if !openedInfo.Mode().IsRegular() {
-		_ = f.Close()
-		return nil, &fileio.PathValidationError{Err: fmt.Errorf("%q is not a regular file", path)}
-	}
-	return f, nil
+	return vfs.Open(localPath)
 }

--- a/internal/cmdutil/localfile_test.go
+++ b/internal/cmdutil/localfile_test.go
@@ -6,11 +6,13 @@ package cmdutil
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/vfs"
 )
 
 func TestOpenLocalFile_AcceptsAbsoluteAndParentRelativePaths(t *testing.T) {
@@ -38,10 +40,57 @@ func TestOpenLocalFile_AcceptsAbsoluteAndParentRelativePaths(t *testing.T) {
 	}
 }
 
-func TestOpenLocalFile_RejectsInvalidAndNonRegularInputs(t *testing.T) {
-	for _, input := range []string{"input\n.txt", t.TempDir()} {
-		if _, err := OpenLocalFile(input); !errors.Is(err, fileio.ErrPathValidation) {
-			t.Fatalf("OpenLocalFile(%q) error = %v, want ErrPathValidation", input, err)
-		}
+func TestOpenLocalFile_RejectsInvalidInput(t *testing.T) {
+	if _, err := OpenLocalFile("input\n.txt"); !errors.Is(err, fileio.ErrPathValidation) {
+		t.Fatalf("OpenLocalFile() error = %v, want ErrPathValidation", err)
 	}
+}
+
+func TestStatLocalFile_ReturnsMetadata(t *testing.T) {
+	info, err := StatLocalFile(t.TempDir())
+	if err != nil {
+		t.Fatalf("StatLocalFile() error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("StatLocalFile() mode = %v, want directory", info.Mode())
+	}
+}
+
+func TestOpenLocalFile_DoesNotStatBeforeOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input.txt")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := vfs.DefaultFS
+	counting := &countingLocalFileFS{FS: previous}
+	vfs.DefaultFS = counting
+	t.Cleanup(func() { vfs.DefaultFS = previous })
+
+	f, err := OpenLocalFile(path)
+	if err != nil {
+		t.Fatalf("OpenLocalFile() error = %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if counting.openCalls != 1 || counting.statCalls != 0 {
+		t.Fatalf("OpenLocalFile() calls: Open=%d Stat=%d, want Open=1 Stat=0", counting.openCalls, counting.statCalls)
+	}
+}
+
+type countingLocalFileFS struct {
+	vfs.FS
+	openCalls int
+	statCalls int
+}
+
+func (f *countingLocalFileFS) Open(name string) (*os.File, error) {
+	f.openCalls++
+	return f.FS.Open(name)
+}
+
+func (f *countingLocalFileFS) Stat(name string) (fs.FileInfo, error) {
+	f.statCalls++
+	return f.FS.Stat(name)
 }

--- a/internal/cmdutil/localfile_test.go
+++ b/internal/cmdutil/localfile_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+func TestOpenLocalFile_AcceptsAbsoluteAndParentRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "input.txt")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	TestChdir(t, workDir)
+
+	for _, input := range []string{path, filepath.Join("..", "input.txt")} {
+		f, err := OpenLocalFile(input)
+		if err != nil {
+			t.Fatalf("OpenLocalFile(%q) error = %v", input, err)
+		}
+		got, readErr := io.ReadAll(f)
+		closeErr := f.Close()
+		if readErr != nil || closeErr != nil || string(got) != "content" {
+			t.Fatalf("OpenLocalFile(%q) content=%q read=%v close=%v", input, got, readErr, closeErr)
+		}
+	}
+}
+
+func TestOpenLocalFile_RejectsInvalidAndNonRegularInputs(t *testing.T) {
+	for _, input := range []string{"input\n.txt", t.TempDir()} {
+		if _, err := OpenLocalFile(input); !errors.Is(err, fileio.ErrPathValidation) {
+			t.Fatalf("OpenLocalFile(%q) error = %v, want ErrPathValidation", input, err)
+		}
+	}
+}

--- a/internal/validate/path.go
+++ b/internal/validate/path.go
@@ -17,6 +17,13 @@ func SafeInputPath(path string) (string, error) {
 	return localfileio.SafeInputPath(path)
 }
 
+// LocalInputPath validates a local input path without restricting it to the
+// current working directory. It delegates to localfileio.LocalInputPath so
+// command validation and shared local-file readers use one policy.
+func LocalInputPath(path string) (string, error) {
+	return localfileio.LocalInputPath(path)
+}
+
 // SafeEnvDirPath validates an environment-provided application directory path.
 // Delegates to localfileio.SafeEnvDirPath.
 func SafeEnvDirPath(path, envName string) (string, error) {

--- a/internal/validate/path_test.go
+++ b/internal/validate/path_test.go
@@ -211,6 +211,18 @@ func TestSafeLocalFlagPath(t *testing.T) {
 	}
 }
 
+func TestLocalInputPath_AllowsLocalPathsAndRejectsUnsafeCharacters(t *testing.T) {
+	for _, path := range []string{"/tmp/report.pdf", "../report.pdf"} {
+		got, err := LocalInputPath(path)
+		if err != nil || got != path {
+			t.Fatalf("LocalInputPath(%q) = %q, %v; want unchanged path", path, got, err)
+		}
+	}
+	if _, err := LocalInputPath("report\n.pdf"); err == nil {
+		t.Fatal("LocalInputPath() unexpectedly accepted a control character")
+	}
+}
+
 func TestSafeUploadPath_AllowsTempFileAbsolutePath(t *testing.T) {
 	// GIVEN: a real temp file (absolute path under os.TempDir())
 	f, err := os.CreateTemp("", "upload-test-*.bin")

--- a/internal/vfs/localfileio/path.go
+++ b/internal/vfs/localfileio/path.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/larksuite/cli/internal/charcheck"
 	"github.com/larksuite/cli/internal/vfs"
@@ -20,6 +21,24 @@ func SafeOutputPath(path string) (string, error) {
 // SafeInputPath validates an upload/read source path for --file flags.
 func SafeInputPath(path string) (string, error) {
 	return safePath(path, "--file")
+}
+
+// LocalInputPath validates an input path in the process local filesystem
+// namespace. It intentionally does not impose cwd containment or canonicalize
+// the path: absolute paths, parent-relative paths, and symlink traversal retain
+// their normal OS semantics. Character validation remains mandatory because
+// paths are user-controlled and may appear in errors or progress output.
+func LocalInputPath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("local input path must not be empty")
+	}
+	if strings.IndexFunc(path, unicode.IsControl) >= 0 {
+		return "", fmt.Errorf("local input path must not contain control characters")
+	}
+	if err := charcheck.RejectControlChars(path, "local input path"); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // SafeLocalFlagPath validates a flag value as a local file path.

--- a/internal/vfs/localfileio/path.go
+++ b/internal/vfs/localfileio/path.go
@@ -38,7 +38,15 @@ func LocalInputPath(path string) (string, error) {
 	if err := charcheck.RejectControlChars(path, "local input path"); err != nil {
 		return "", err
 	}
+	if err := validateLocalInputPlatform(path); err != nil {
+		return "", err
+	}
 	return path, nil
+}
+
+func isWindowsNonLocalNamespace(path string) bool {
+	normalized := strings.ReplaceAll(path, "/", `\`)
+	return strings.HasPrefix(normalized, `\\`) || strings.HasPrefix(normalized, `\??\`)
 }
 
 // SafeLocalFlagPath validates a flag value as a local file path.
@@ -48,7 +56,7 @@ func SafeLocalFlagPath(flagName, value string) (string, error) {
 		return value, nil
 	}
 	if _, err := SafeInputPath(value); err != nil {
-		return "", fmt.Errorf("%s: %v", flagName, err)
+		return "", fmt.Errorf("%s: %w", flagName, err)
 	}
 	return value, nil
 }

--- a/internal/vfs/localfileio/path_local_other.go
+++ b/internal/vfs/localfileio/path_local_other.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package localfileio
+
+func validateLocalInputPlatform(string) error { return nil }

--- a/internal/vfs/localfileio/path_local_windows.go
+++ b/internal/vfs/localfileio/path_local_windows.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package localfileio
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func validateLocalInputPlatform(path string) error {
+	if isWindowsNonLocalNamespace(path) {
+		return fmt.Errorf("local input path must not use a Windows network or device namespace")
+	}
+
+	cleaned := filepath.Clean(path)
+	volume := filepath.VolumeName(cleaned)
+	remainder := strings.TrimLeft(cleaned[len(volume):], `\/`)
+	for _, component := range strings.FieldsFunc(remainder, func(r rune) bool {
+		return r == '\\' || r == '/'
+	}) {
+		if component == "." || component == ".." {
+			continue
+		}
+		if !filepath.IsLocal(component) {
+			return fmt.Errorf("local input path contains a reserved Windows path component %q", component)
+		}
+	}
+	return nil
+}

--- a/internal/vfs/localfileio/path_local_windows_test.go
+++ b/internal/vfs/localfileio/path_local_windows_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package localfileio
+
+import "testing"
+
+func TestLocalInputPath_RejectsWindowsNetworkDeviceAndReservedPaths(t *testing.T) {
+	for _, input := range []string{
+		`\\server\share\report.pdf`,
+		`//server/share/report.pdf`,
+		`\\.\pipe\upload`,
+		`\\?\C:\Users\agent\report.pdf`,
+		`\\?\UNC\server\share\report.pdf`,
+		`\??\C:\Users\agent\report.pdf`,
+		`C:\Users\agent\NUL.txt`,
+		`CON`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := LocalInputPath(input); err == nil {
+				t.Fatalf("LocalInputPath(%q) unexpectedly succeeded", input)
+			}
+		})
+	}
+}

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -4,6 +4,7 @@
 package localfileio
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,6 +67,47 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 			// THEN: error matches expectation
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SafeOutputPath(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLocalInputPath_AllowsLocalNamespaceWithoutRewriting(t *testing.T) {
+	for _, input := range []string{
+		"/tmp/report.pdf",
+		"../outside/report.pdf",
+		"./report.pdf",
+		"nested/../report.pdf",
+		`C:\Users\agent\report.pdf`,
+		`\\server\share\report.pdf`,
+		"报告.pdf",
+	} {
+		t.Run(input, func(t *testing.T) {
+			got, err := LocalInputPath(input)
+			if err != nil {
+				t.Fatalf("LocalInputPath(%q) error = %v", input, err)
+			}
+			if got != input {
+				t.Fatalf("LocalInputPath(%q) = %q, want path preserved verbatim", input, got)
+			}
+		})
+	}
+}
+
+func TestLocalInputPath_RejectsEmptyControlAndDangerousUnicode(t *testing.T) {
+	for _, input := range []string{
+		"",
+		"   ",
+		"file\x00.txt",
+		"file\tname.txt",
+		"file\nname.txt",
+		"file\rname.txt",
+		"file\u202Ename.txt",
+		"file\u200Bname.txt",
+	} {
+		t.Run(fmt.Sprintf("%q", input), func(t *testing.T) {
+			if _, err := LocalInputPath(input); err == nil {
+				t.Fatalf("LocalInputPath(%q) unexpectedly succeeded", input)
 			}
 		})
 	}

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -79,7 +79,6 @@ func TestLocalInputPath_AllowsLocalNamespaceWithoutRewriting(t *testing.T) {
 		"./report.pdf",
 		"nested/../report.pdf",
 		`C:\Users\agent\report.pdf`,
-		`\\server\share\report.pdf`,
 		"报告.pdf",
 	} {
 		t.Run(input, func(t *testing.T) {
@@ -91,6 +90,32 @@ func TestLocalInputPath_AllowsLocalNamespaceWithoutRewriting(t *testing.T) {
 				t.Fatalf("LocalInputPath(%q) = %q, want path preserved verbatim", input, got)
 			}
 		})
+	}
+}
+
+func TestWindowsNonLocalNamespace(t *testing.T) {
+	for _, input := range []string{
+		`\\server\share\report.pdf`,
+		`//server/share/report.pdf`,
+		`\\.\pipe\upload`,
+		`\\?\C:\Users\agent\report.pdf`,
+		`\\?\UNC\server\share\report.pdf`,
+		`\??\C:\Users\agent\report.pdf`,
+	} {
+		if !isWindowsNonLocalNamespace(input) {
+			t.Errorf("isWindowsNonLocalNamespace(%q) = false, want true", input)
+		}
+	}
+
+	for _, input := range []string{
+		`C:\Users\agent\report.pdf`,
+		`C:/Users/agent/report.pdf`,
+		`..\outside\report.pdf`,
+		`.\report.pdf`,
+	} {
+		if isWindowsNonLocalNamespace(input) {
+			t.Errorf("isWindowsNonLocalNamespace(%q) = true, want false", input)
+		}
 	}
 }
 

--- a/shortcuts/apps/apps_file_upload.go
+++ b/shortcuts/apps/apps_file_upload.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/larksuite/cli/errs"
-	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -47,21 +46,7 @@ var AppsFileUpload = common.Shortcut{
 		if _, err := requireAppID(rctx.Str("app-id")); err != nil {
 			return err
 		}
-		f := strings.TrimSpace(rctx.Str("file"))
-		if f == "" {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file is required").WithParam("--file")
-		}
-		st, err := rctx.FileIO().Stat(f)
-		if err != nil {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file: %v", err).WithParam("--file").WithCause(err)
-		}
-		if st.IsDir() {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file must be a file, not a directory").WithParam("--file")
-		}
-		if st.Size() > fileUploadMaxBytes {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "file size %d bytes exceeds the 100 MB upload limit", st.Size()).WithParam("--file")
-		}
-		return nil
+		return rctx.ValidateLocalFileFlag("file", fileUploadMaxBytes)
 	},
 	DryRun: func(ctx context.Context, rctx *common.RuntimeContext) *common.DryRunAPI {
 		appID, _ := requireAppID(rctx.Str("app-id"))
@@ -76,9 +61,9 @@ var AppsFileUpload = common.Shortcut{
 			return err
 		}
 		localPath := strings.TrimSpace(rctx.Str("file"))
-		content, err := cmdutil.ReadInputFile(rctx.FileIO(), localPath)
+		content, err := rctx.ReadLocalFileFlag("file", fileUploadMaxBytes)
 		if err != nil {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file: %v", err).WithParam("--file").WithCause(err)
+			return err
 		}
 		fileName := filepath.Base(localPath)
 		contentType := mimeByExt(fileName)

--- a/shortcuts/apps/apps_file_upload_test.go
+++ b/shortcuts/apps/apps_file_upload_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -58,22 +59,17 @@ func TestAppsFileUpload_RejectsDirectory(t *testing.T) {
 	}
 }
 
-// TestAppsFileUpload_DryRunPreUpload 验证 dry-run 输出 POST file_pre_upload，body.file_name 取文件 basename。
+// TestAppsFileUpload_DryRunPreUpload verifies that dry-run validates the local
+// file and previews the pre-upload request without reading or uploading it.
 func TestAppsFileUpload_DryRunPreUpload(t *testing.T) {
-	// Validate 会 Stat --file（在 DryRun 之前），故 dry-run 也需要真实存在的文件。
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "logo.png"), []byte("x"), 0o600); err != nil {
+	absolutePath := filepath.Join(t.TempDir(), "logo.png")
+	if err := os.WriteFile(absolutePath, []byte("not-read-by-dry-run"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	oldWD, _ := os.Getwd()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 
 	factory, stdout, _ := newAppsExecuteFactory(t)
 	if err := runAppsShortcut(t, AppsFileUpload,
-		[]string{"+file-upload", "--app-id", "app_x", "--file", "logo.png", "--dry-run", "--as", "user"}, factory, stdout); err != nil {
+		[]string{"+file-upload", "--app-id", "app_x", "--file", absolutePath, "--dry-run", "--as", "user"}, factory, stdout); err != nil {
 		t.Fatalf("dry-run err=%v", err)
 	}
 	var env dryRunAPIEnvelope
@@ -84,6 +80,18 @@ func TestAppsFileUpload_DryRunPreUpload(t *testing.T) {
 	}
 	if a.Body["file_name"] != "logo.png" {
 		t.Fatalf("dry-run body.file_name = %v, want logo.png (basename)", a.Body["file_name"])
+	}
+}
+
+func TestAppsFileUpload_DryRunRejectsMissingFile(t *testing.T) {
+	missingAbsolutePath := filepath.Join(t.TempDir(), "does-not-exist", "logo.png")
+
+	factory, stdout, _ := newAppsExecuteFactory(t)
+	err := runAppsShortcut(t, AppsFileUpload,
+		[]string{"+file-upload", "--app-id", "app_x", "--file", missingAbsolutePath, "--dry-run", "--as", "user"}, factory, stdout)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--file" {
+		t.Fatalf("error = %T %v, want invalid_argument for --file", err, err)
 	}
 }
 
@@ -146,6 +154,142 @@ func TestAppsFileUpload_EndToEnd(t *testing.T) {
 	got := stdout.String()
 	if !strings.Contains(got, `"path": "/1858537546760216.png"`) {
 		t.Errorf("output missing uploaded path:\n%s", got)
+	}
+}
+
+// TestAppsFileUpload_AcceptsAbsolutePath verifies that file-upload can read an
+// absolute path outside the current working directory.
+func TestAppsFileUpload_AcceptsAbsolutePath(t *testing.T) {
+	var putBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		putBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("ETag", `"etag-abs"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Keep the process cwd unchanged so the temporary file is outside it.
+	dir := t.TempDir()
+	absFile := filepath.Join(dir, "report.pdf")
+	if !filepath.IsAbs(absFile) {
+		t.Fatalf("test setup: %q is not absolute", absFile)
+	}
+	if err := os.WriteFile(absFile, []byte("PDFBYTES"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/spark/v1/apps/app_x/storage/file_pre_upload",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"upload_url": srv.URL, "upload_id": "up-abs"}},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/spark/v1/apps/app_x/storage/file_upload_callback",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"file_name": "report.pdf", "path": "/1858537546760999.pdf", "size_bytes": 8,
+		}},
+	})
+
+	if err := runAppsShortcut(t, AppsFileUpload,
+		[]string{"+file-upload", "--app-id", "app_x", "--file", absFile, "--as", "user"}, factory, stdout); err != nil {
+		t.Fatalf("execute with absolute path err=%v", err)
+	}
+	if string(putBody) != "PDFBYTES" {
+		t.Fatalf("PUT body = %q, want file bytes", putBody)
+	}
+}
+
+func TestAppsFileUpload_AcceptsParentRelativePathOutsideCWD(t *testing.T) {
+	var putBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		putBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("ETag", `"etag-parent"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "report.pdf"), []byte("PARENT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/spark/v1/apps/app_x/storage/file_pre_upload",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"upload_url": srv.URL, "upload_id": "up-parent"}},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/spark/v1/apps/app_x/storage/file_upload_callback",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"file_name": "report.pdf", "path": "/parent.pdf", "size_bytes": 6,
+		}},
+	})
+
+	if err := runAppsShortcut(t, AppsFileUpload,
+		[]string{"+file-upload", "--app-id", "app_x", "--file", filepath.Join("..", "report.pdf"), "--as", "user"}, factory, stdout); err != nil {
+		t.Fatalf("execute with parent-relative path err=%v", err)
+	}
+	if string(putBody) != "PARENT" {
+		t.Fatalf("PUT body = %q, want PARENT", putBody)
+	}
+}
+
+func TestAppsFileUpload_RejectsFileAboveLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "too-large.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(fileUploadMaxBytes + 1); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	factory, stdout, _ := newAppsExecuteFactory(t)
+	err = runAppsShortcut(t, AppsFileUpload,
+		[]string{"+file-upload", "--app-id", "app_x", "--file", path, "--as", "user"}, factory, stdout)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--file" {
+		t.Fatalf("error = %T %v, want --file ValidationError", err, err)
+	}
+	if !strings.Contains(validationErr.Error(), "limit") {
+		t.Fatalf("error = %v, want size limit context", validationErr)
+	}
+}
+
+func TestAppsFileUpload_RejectsDeviceWithoutReadingIt(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/dev/zero is unavailable on Windows")
+	}
+	if _, err := os.Stat("/dev/zero"); err != nil {
+		t.Skipf("/dev/zero unavailable: %v", err)
+	}
+
+	factory, stdout, _ := newAppsExecuteFactory(t)
+	err := runAppsShortcut(t, AppsFileUpload,
+		[]string{"+file-upload", "--app-id", "app_x", "--file", "/dev/zero", "--as", "user"}, factory, stdout)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--file" {
+		t.Fatalf("error = %T %v, want --file ValidationError", err, err)
+	}
+	if !strings.Contains(validationErr.Error(), "regular file") {
+		t.Fatalf("error = %v, want non-regular-file context", validationErr)
 	}
 }
 

--- a/shortcuts/common/localfile.go
+++ b/shortcuts/common/localfile.go
@@ -17,43 +17,20 @@ import (
 )
 
 // ValidateLocalFileFlag validates that a local input path exists, is a regular
-// readable file, and does not exceed maxBytes. Absolute and relative paths use
+// file, and does not exceed maxBytes. Absolute and relative paths use
 // the process filesystem namespace.
-func (ctx *RuntimeContext) ValidateLocalFileFlag(flagName string, maxBytes int64) (retErr error) {
-	name, param, err := localFileFlagNames(flagName)
+func (ctx *RuntimeContext) ValidateLocalFileFlag(flagName string, maxBytes int64) error {
+	path, param, err := ctx.localFileFlag(flagName, maxBytes)
 	if err != nil {
 		return err
 	}
-	if ctx == nil || ctx.Cmd == nil {
-		return errs.NewInternalError(errs.SubtypeUnknown, "cannot read %s: runtime command is unavailable", param)
-	}
 
-	path := strings.TrimSpace(ctx.Str(name))
-	if path == "" {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s is required", param).WithParam(param)
-	}
-	if _, err := validate.LocalInputPath(path); err != nil {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid %s path: %v", param, err).
-			WithParam(param).
-			WithCause(err)
-	}
-	if maxBytes < 0 {
-		return errs.NewInternalError(errs.SubtypeUnknown, "invalid read limit configured for %s", param)
-	}
-
-	f, err := cmdutil.OpenLocalFile(path)
+	info, err := cmdutil.StatLocalFile(path)
 	if err != nil {
-		return localFileReadError(param, path, "open", err)
+		return localFileReadError(param, path, "inspect", err)
 	}
-	defer func() {
-		if err := f.Close(); err != nil && retErr == nil {
-			retErr = errs.NewInternalError(errs.SubtypeFileIO, "cannot close %s %q: %v", param, path, err).WithCause(err)
-		}
-	}()
-
-	info, err := f.Stat()
-	if err != nil {
-		return localFileReadError(param, path, "inspect opened", err)
+	if err := localFileRegularError(param, path, info.Mode()); err != nil {
+		return err
 	}
 	if info.Size() > maxBytes {
 		return localFileSizeError(param, path, info.Size(), maxBytes)
@@ -65,15 +42,10 @@ func (ctx *RuntimeContext) ValidateLocalFileFlag(flagName string, maxBytes int64
 // shortcuts. It accepts absolute and relative paths, enforces a hard size
 // limit, and returns command-facing typed errors.
 func (ctx *RuntimeContext) ReadLocalFileFlag(flagName string, maxBytes int64) (data []byte, retErr error) {
-	name, param, err := localFileFlagNames(flagName)
+	path, param, err := ctx.localFileFlag(flagName, maxBytes)
 	if err != nil {
 		return nil, err
 	}
-	if err := ctx.ValidateLocalFileFlag(name, maxBytes); err != nil {
-		return nil, err
-	}
-
-	path := strings.TrimSpace(ctx.Str(name))
 	f, err := cmdutil.OpenLocalFile(path)
 	if err != nil {
 		return nil, localFileReadError(param, path, "open", err)
@@ -88,6 +60,9 @@ func (ctx *RuntimeContext) ReadLocalFileFlag(flagName string, maxBytes int64) (d
 	openedInfo, err := f.Stat()
 	if err != nil {
 		return nil, localFileReadError(param, path, "inspect opened", err)
+	}
+	if err := localFileRegularError(param, path, openedInfo.Mode()); err != nil {
+		return nil, err
 	}
 	if openedInfo.Size() > maxBytes {
 		return nil, localFileSizeError(param, path, openedInfo.Size(), maxBytes)
@@ -107,6 +82,39 @@ func (ctx *RuntimeContext) ReadLocalFileFlag(flagName string, maxBytes int64) (d
 			WithParam(param)
 	}
 	return data, nil
+}
+
+func (ctx *RuntimeContext) localFileFlag(flagName string, maxBytes int64) (path, param string, err error) {
+	name, param, err := localFileFlagNames(flagName)
+	if err != nil {
+		return "", "", err
+	}
+	if ctx == nil || ctx.Cmd == nil {
+		return "", param, errs.NewInternalError(errs.SubtypeUnknown, "cannot read %s: runtime command is unavailable", param)
+	}
+
+	path = strings.TrimSpace(ctx.Str(name))
+	if path == "" {
+		return "", param, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s is required", param).WithParam(param)
+	}
+	if _, err := validate.LocalInputPath(path); err != nil {
+		return "", param, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid %s path: %v", param, err).
+			WithParam(param).
+			WithCause(err)
+	}
+	if maxBytes < 0 {
+		return "", param, errs.NewInternalError(errs.SubtypeUnknown, "invalid read limit configured for %s", param)
+	}
+	return path, param, nil
+}
+
+func localFileRegularError(param, path string, mode fs.FileMode) error {
+	if mode.IsRegular() {
+		return nil
+	}
+	return errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"%s %q is not a regular file", param, path).
+		WithParam(param)
 }
 
 func localFileReadError(param, path, op string, cause error) error {

--- a/shortcuts/common/localfile.go
+++ b/shortcuts/common/localfile.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"math"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/validate"
+)
+
+// ValidateLocalFileFlag validates that a local input path exists, is a regular
+// readable file, and does not exceed maxBytes. Absolute and relative paths use
+// the process filesystem namespace.
+func (ctx *RuntimeContext) ValidateLocalFileFlag(flagName string, maxBytes int64) (retErr error) {
+	name, param, err := localFileFlagNames(flagName)
+	if err != nil {
+		return err
+	}
+	if ctx == nil || ctx.Cmd == nil {
+		return errs.NewInternalError(errs.SubtypeUnknown, "cannot read %s: runtime command is unavailable", param)
+	}
+
+	path := strings.TrimSpace(ctx.Str(name))
+	if path == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s is required", param).WithParam(param)
+	}
+	if _, err := validate.LocalInputPath(path); err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid %s path: %v", param, err).
+			WithParam(param).
+			WithCause(err)
+	}
+	if maxBytes < 0 {
+		return errs.NewInternalError(errs.SubtypeUnknown, "invalid read limit configured for %s", param)
+	}
+
+	f, err := cmdutil.OpenLocalFile(path)
+	if err != nil {
+		return localFileReadError(param, path, "open", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil && retErr == nil {
+			retErr = errs.NewInternalError(errs.SubtypeFileIO, "cannot close %s %q: %v", param, path, err).WithCause(err)
+		}
+	}()
+
+	info, err := f.Stat()
+	if err != nil {
+		return localFileReadError(param, path, "inspect opened", err)
+	}
+	if info.Size() > maxBytes {
+		return localFileSizeError(param, path, info.Size(), maxBytes)
+	}
+	return nil
+}
+
+// ReadLocalFileFlag is the shared replacement for direct os.ReadFile calls in
+// shortcuts. It accepts absolute and relative paths, enforces a hard size
+// limit, and returns command-facing typed errors.
+func (ctx *RuntimeContext) ReadLocalFileFlag(flagName string, maxBytes int64) (data []byte, retErr error) {
+	name, param, err := localFileFlagNames(flagName)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.ValidateLocalFileFlag(name, maxBytes); err != nil {
+		return nil, err
+	}
+
+	path := strings.TrimSpace(ctx.Str(name))
+	f, err := cmdutil.OpenLocalFile(path)
+	if err != nil {
+		return nil, localFileReadError(param, path, "open", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil && retErr == nil {
+			data = nil
+			retErr = errs.NewInternalError(errs.SubtypeFileIO, "cannot close %s %q: %v", param, path, err).WithCause(err)
+		}
+	}()
+
+	openedInfo, err := f.Stat()
+	if err != nil {
+		return nil, localFileReadError(param, path, "inspect opened", err)
+	}
+	if openedInfo.Size() > maxBytes {
+		return nil, localFileSizeError(param, path, openedInfo.Size(), maxBytes)
+	}
+
+	readLimit := maxBytes + 1
+	if maxBytes == math.MaxInt64 {
+		readLimit = maxBytes
+	}
+	data, err = io.ReadAll(io.LimitReader(f, readLimit))
+	if err != nil {
+		return nil, localFileReadError(param, path, "read", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"%s %q grew beyond the %d-byte limit while being read", param, path, maxBytes).
+			WithParam(param)
+	}
+	return data, nil
+}
+
+func localFileReadError(param, path, op string, cause error) error {
+	if errors.Is(cause, fileio.ErrPathValidation) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid %s %q: %v", param, path, cause).
+			WithParam(param).
+			WithCause(cause)
+	}
+	if errors.Is(cause, fs.ErrNotExist) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s %q does not exist", param, path).
+			WithParam(param).
+			WithCause(cause)
+	}
+	return errs.NewInternalError(errs.SubtypeFileIO, "cannot %s %s %q: %v", op, param, path, cause).WithCause(cause)
+}
+
+func localFileSizeError(param, path string, size, limit int64) error {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"%s %q is %d bytes; limit is %d bytes", param, path, size, limit).
+		WithParam(param)
+}
+
+func localFileFlagNames(flagName string) (name, param string, err error) {
+	name = strings.TrimLeft(strings.TrimSpace(flagName), "-")
+	if name == "" {
+		return "", "", errs.NewInternalError(errs.SubtypeUnknown, "local file flag name must not be empty")
+	}
+	return name, "--" + name, nil
+}

--- a/shortcuts/common/localfile_test.go
+++ b/shortcuts/common/localfile_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/spf13/cobra"
+)
+
+func TestReadLocalFileFlag_AcceptsAbsolutePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input.txt")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rctx := localFileTestRuntime(t, path)
+
+	if err := rctx.ValidateLocalFileFlag("file", 7); err != nil {
+		t.Fatalf("ValidateLocalFileFlag() error = %v", err)
+	}
+	got, err := rctx.ReadLocalFileFlag("file", 7)
+	if err != nil || string(got) != "content" {
+		t.Fatalf("ReadLocalFileFlag() = %q, %v; want content", got, err)
+	}
+}
+
+func TestValidateLocalFileFlag_ReturnsTypedInputErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path func(t *testing.T) string
+		max  int64
+	}{
+		{name: "invalid characters", path: func(*testing.T) string { return "input\n.txt" }, max: 10},
+		{name: "missing file", path: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing") }, max: 10},
+		{name: "directory", path: func(t *testing.T) string { return t.TempDir() }, max: 10},
+		{name: "too large", path: func(t *testing.T) string {
+			path := filepath.Join(t.TempDir(), "large")
+			if err := os.WriteFile(path, []byte("123456"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		}, max: 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := localFileTestRuntime(t, tc.path(t)).ValidateLocalFileFlag("file", tc.max)
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--file" {
+				t.Fatalf("error = %T %v, want invalid_argument for --file", err, err)
+			}
+		})
+	}
+}
+
+func TestReadLocalFileFlag_ReturnsTypedInputErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path func(t *testing.T) string
+		max  int64
+	}{
+		{name: "invalid characters", path: func(*testing.T) string { return "input\n.txt" }, max: 10},
+		{name: "missing file", path: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing") }, max: 10},
+		{name: "directory", path: func(t *testing.T) string { return t.TempDir() }, max: 10},
+		{name: "too large", path: func(t *testing.T) string {
+			path := filepath.Join(t.TempDir(), "large")
+			if err := os.WriteFile(path, []byte("123456"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		}, max: 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := localFileTestRuntime(t, tc.path(t)).ReadLocalFileFlag("file", tc.max)
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--file" {
+				t.Fatalf("error = %T %v, want invalid_argument for --file", err, err)
+			}
+		})
+	}
+}
+
+func localFileTestRuntime(t *testing.T, path string) *RuntimeContext {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("file", "", "")
+	if err := cmd.Flags().Set("file", path); err != nil {
+		t.Fatal(err)
+	}
+	return &RuntimeContext{ctx: context.Background(), Cmd: cmd}
+}

--- a/tests/cli_e2e/apps/apps_file_upload_dryrun_test.go
+++ b/tests/cli_e2e/apps/apps_file_upload_dryrun_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package apps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestAppsFileUploadDryRun_AcceptsAbsoluteHostPath(t *testing.T) {
+	setAppsDryRunEnv(t)
+	absolutePath := filepath.Join(t.TempDir(), "report.pdf")
+	require.NoError(t, os.WriteFile(absolutePath, []byte("dry-run-input"), 0o600))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"apps", "+file-upload",
+			"--app-id", "app_x",
+			"--file", absolutePath,
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	assert.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	assert.Equal(t, "/open-apis/spark/v1/apps/app_x/storage/file_pre_upload", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	assert.Equal(t, "report.pdf", clie2e.DryRunGet(result.Stdout, "api.0.body.file_name").String())
+}
+
+func TestAppsFileUploadDryRun_RejectsMissingHostPath(t *testing.T) {
+	setAppsDryRunEnv(t)
+	missingAbsolutePath := filepath.Join(t.TempDir(), "does-not-exist", "report.pdf")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"apps", "+file-upload",
+			"--app-id", "app_x",
+			"--file", missingAbsolutePath,
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Equal(t, "--file", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+}

--- a/tests/cli_e2e/apps/apps_file_upload_live_test.go
+++ b/tests/cli_e2e/apps/apps_file_upload_live_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package apps
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestAppsFileUploadLiveWorkflow(t *testing.T) {
+	if strings.TrimSpace(os.Getenv("LARKSUITE_CLI_CONFIG_DIR")) == "" {
+		t.Skip("FIXTURE: Set LARKSUITE_CLI_CONFIG_DIR to an isolated live-test config")
+	}
+	appID := strings.TrimSpace(os.Getenv("LARK_CLI_E2E_APPS_FILE_APP_ID"))
+	if appID == "" {
+		t.Skip("FIXTURE: Set LARK_CLI_E2E_APPS_FILE_APP_ID to a dedicated app for upload/delete testing")
+	}
+
+	fileName := fmt.Sprintf("lark-cli-host-path-e2e-%d.txt", time.Now().UnixNano())
+	absolutePath := filepath.Join(t.TempDir(), fileName)
+	content := []byte("host-path-live-e2e")
+	require.NoError(t, os.WriteFile(absolutePath, content, 0o600))
+
+	remotePath := ""
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+
+		if remotePath == "" {
+			listResult, listErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+				Args:      []string{"apps", "+file-list", "--app-id", appID, "--name", fileName},
+				DefaultAs: "user",
+			})
+			if listErr != nil || listResult.ExitCode != 0 {
+				clie2e.ReportCleanupFailure(t, "find uploaded file "+fileName, listResult, listErr)
+				return
+			}
+			for _, item := range gjson.Get(listResult.Stdout, "data.items").Array() {
+				if item.Get("file_name").String() == fileName {
+					remotePath = item.Get("path").String()
+					break
+				}
+			}
+		}
+		if remotePath == "" {
+			return
+		}
+
+		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+			Args:      []string{"apps", "+file-delete", "--app-id", appID, "--path", remotePath},
+			DefaultAs: "user",
+			Yes:       true,
+		})
+		clie2e.ReportCleanupFailure(t, "delete uploaded file "+remotePath, deleteResult, deleteErr)
+		if deleteErr == nil && deleteResult != nil && gjson.Get(deleteResult.Stdout, "data.results.0.status").String() != "ok" {
+			t.Errorf("cleanup delete did not report success: %s", deleteResult.Stdout)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+	uploadResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"apps", "+file-upload", "--app-id", appID, "--file", absolutePath},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	uploadResult.AssertExitCode(t, 0)
+	uploadResult.AssertStdoutStatus(t, true)
+	remotePath = gjson.Get(uploadResult.Stdout, "data.path").String()
+	require.NotEmpty(t, remotePath, "stdout:\n%s", uploadResult.Stdout)
+	assert.Equal(t, fileName, gjson.Get(uploadResult.Stdout, "data.file_name").String(), "stdout:\n%s", uploadResult.Stdout)
+
+	getResult, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"apps", "+file-get", "--app-id", appID, "--path", remotePath},
+		DefaultAs: "user",
+	}, clie2e.RetryOptions{
+		ShouldRetry: func(result *clie2e.Result) bool {
+			return result == nil || result.ExitCode != 0 || gjson.Get(result.Stdout, "data.path").String() != remotePath
+		},
+	})
+	require.NoError(t, err)
+	getResult.AssertExitCode(t, 0)
+	getResult.AssertStdoutStatus(t, true)
+	assert.Equal(t, int64(len(content)), gjson.Get(getResult.Stdout, "data.size_bytes").Int(), "stdout:\n%s", getResult.Stdout)
+}

--- a/tests/cli_e2e/apps/coverage.md
+++ b/tests/cli_e2e/apps/coverage.md
@@ -1,11 +1,11 @@
 # Apps CLI E2E Coverage
 
 ## Metrics
-- Denominator: 18 leaf commands in the selected apps E2E coverage set (not all 79 apps shortcuts)
-- Selected command coverage: 100% (18/18)
-- API dry-run coverage: 100% (16/16 API-backed commands)
+- Denominator: 19 leaf commands in the selected apps E2E coverage set (not all 79 apps shortcuts)
+- Selected command coverage: 100% (19/19)
+- API dry-run coverage: 100% (17/17 API-backed commands)
 - Local E2E coverage: 100% (2/2 local-only commands)
-- Live coverage: tracked role workflows are intentionally fixture-gated and skipped by default CI. When run manually with dedicated fixtures, a transient-role lifecycle covers create/get/update, member add/list/`--all` clear, role-presence readback, delete, and target-ID absence readback; shared-fixture workflows separately cover explicit member removal and `+role-match-list`.
+- Live coverage: file and role workflows are fixture-gated and skipped by default CI. File upload covers absolute-path upload, metadata readback, and cleanup; role workflows cover role lifecycle and member mutations with cleanup.
 
 ## Summary
 - `TestAppsCreateDryRun`: happy path with `--app-type html`, all-fields shape, rejection paths (missing name, missing app-type, invalid app-type, legacy uppercase `HTML`). `--app-type` is a strict lowercase enum (`html`/`full_stack`); the CLI does not normalize case — legacy uppercase compatibility is a server concern.
@@ -14,6 +14,8 @@
 - `TestAppsAccessScopeSetDryRun`: CLI input `specific`/`public`/`tenant` -> server enum `Range`/`All`/`Tenant`; `apply_config.approvers` shape; four mutex rejection paths.
 - `TestAppsAccessScopeGetDryRun`: URL shape; no body/params on GET; `--app-id` required.
 - `TestAppsHTMLPublishDryRun`: walker manifest for directory + single file; hidden files intentionally included (design decision); empty dir / missing `index.html` produce envelope `validation_error` field (dry-run exits 0 advisory, not blocking); both required-flag rejections.
+- `TestAppsFileUploadDryRun_AcceptsAbsoluteHostPath`: dry-run validates an absolute local file and derives its basename without uploading it; a missing source path is rejected before preview.
+- `TestAppsFileUploadLiveWorkflow`: fixture-gated absolute-path upload, `+file-get` readback, and `+file-delete` cleanup in a dedicated app.
 - `TestAppsGitCredentialInitDryRun`: URL shape for issuing an app Git PAT; no body; `app_id` query metadata included.
 - `TestAppsGitCredentialListLocalE2E`: local-only command scans every app storage directory and reports repository URL and status without exposing PAT or expiry details.
 - `TestAppsGitCredentialRemoveLocalE2E`: local cleanup command removes app-scoped metadata under an isolated config dir.
@@ -23,7 +25,7 @@
 - `TestAppsRoleLifecycleLiveWorkflow`: creates a uniquely named transient role, independently reads it back, updates and re-reads it, adds a fixture member, clears all members and proves the role still exists, then deletes it and verifies the target `role_id` is absent. Cleanup is armed before creation and uses only environment-provided test identifiers.
 - `TestAppsRoleMatchListLiveWorkflow`: separately fixture-gated live `+role-match-list` proof against the same isolated fixture role. It also requires the selected user to be absent at baseline and removes only the user it added.
 
-Blocked: General app create live E2E is intentionally not implemented yet. Apps has no `+delete` endpoint (OAPI doc explicitly defers archive/delete), so a create-and-cleanup workflow would leak tenant state. Selected role read/member/match live flows intentionally remain fixture-gated and skipped by default because they mutate app role members.
+Blocked: General app create live E2E is intentionally not implemented yet. Apps has no `+delete` endpoint, so a create-and-cleanup workflow would leak tenant state. File upload and selected role live workflows remain fixture-gated; each uses dedicated fixtures and cleans up the resources it mutates.
 
 ## Command Table
 
@@ -35,6 +37,7 @@ Blocked: General app create live E2E is intentionally not implemented yet. Apps 
 | ✓ | apps +access-scope-set | shortcut | apps_access_scope_set_dryrun_test.go::TestAppsAccessScopeSetDryRun | `--scope specific/public/tenant`; `--targets` JSON; `--apply-enabled --approver`; `--require-login` | live blocked: needs real open_ids |
 | ✓ | apps +access-scope-get | shortcut | apps_access_scope_get_dryrun_test.go::TestAppsAccessScopeGetDryRun | `--app-id` | live blocked: depends on +access-scope-set state |
 | ✓ | apps +html-publish | shortcut | apps_html_publish_dryrun_test.go::TestAppsHTMLPublishDryRun | `--app-id`, `--path` (file or directory containing `index.html`) | live blocked: real upload has side effects; no rollback API |
+| ✓ | apps +file-upload | shortcut | apps_file_upload_dryrun_test.go::TestAppsFileUploadDryRun_AcceptsAbsoluteHostPath; apps_file_upload_dryrun_test.go::TestAppsFileUploadDryRun_RejectsMissingHostPath; apps_file_upload_live_test.go::TestAppsFileUploadLiveWorkflow | `--app-id`, `--file` (absolute or relative local path) | live workflow uses `LARK_CLI_E2E_APPS_FILE_APP_ID`, reads metadata back, and deletes the uploaded file |
 | ✓ | apps +git-credential-init | shortcut | apps_git_credential_dryrun_test.go::TestAppsGitCredentialInitDryRun | `--app-id`; dry-run `GET /open-apis/spark/v1/apps/{app_id}/git_info` | live blocked: issues short-lived repository PAT |
 | ✓ | apps +git-credential-list | shortcut | apps_git_credential_local_test.go::TestAppsGitCredentialListLocalE2E | no `--app-id`; scans all local app storage directories and reports `app_id`, repository URL, and status without PAT or expiry | local E2E only: no dry-run API because command is local read only |
 | ✓ | apps +git-credential-remove | shortcut | apps_git_credential_local_test.go::TestAppsGitCredentialRemoveLocalE2E | `--app-id`; deletes local metadata, keychain PAT, and Git config | local E2E only: no dry-run API because command is local cleanup only |


### PR DESCRIPTION
## Summary

Allow `apps +file-upload --file` to read absolute and parent-relative local paths without weakening the existing workspace-confined `FileIO` behavior used by other commands.

## Changes

- Add a shared local-file path validator and regular-file opener under `internal/`.
- Add lightweight `RuntimeContext.ValidateLocalFileFlag` and `ReadLocalFileFlag` helpers for gradual shortcut adoption.
- Validate file existence, readability, regular-file type, and size before dry-run or execution; re-check and bound reads during execution.
- Migrate `apps +file-upload` to the shared helper.
- Add unit, dry-run E2E, and fixture-gated live E2E coverage for absolute paths, parent-relative paths, missing files, non-regular files, and size limits.

## Test Plan

- [x] `go test ./shortcuts/common ./shortcuts/apps`
- [x] `go test -race ./shortcuts/common ./shortcuts/apps`
- [x] `go vet ./internal/cmdutil ./internal/validate ./internal/vfs/localfileio ./shortcuts/common ./shortcuts/apps`
- [x] `golangci-lint run --new-from-rev=origin/main` for the affected packages
- [x] File-upload dry-run E2E validates an existing absolute path and rejects a missing path
- [x] Live E2E is fixture-gated and skips when no dedicated app fixture is configured

## Related Issues

- Follow-up to #1978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File uploads now support absolute paths and parent-relative paths outside the current directory.
  * Added consistent local-file validation and reading for CLI commands.

* **Bug Fixes**
  * Invalid, missing, oversized, directory, and unsafe paths now produce clear validation errors.
  * File uploads avoid reading unsupported device files.
  * Windows network, device, and reserved paths are rejected.

* **Documentation**
  * Expanded file-upload command coverage and dry-run behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->