### PR TITLE
chore: release v1.0.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.75] - 2026-07-22
+
+### Features
+
+- add okr single create shortcut & skill text opti (#1941)
+- **calendar**: auto-add bot self as attendee and note user-only search (#1991)
+
+### Bug Fixes
+
+- **base**: improve table shortcut behavior & guidance (#1803)
+- issue#1935 & whiteboard shortcut reformat (#1980)
+- remove legacy shortcut (#1997)
+- **e2e**: inject shared credentials by identity (#1995)
+
+### Documentation
+
+- **skill**: describe html5 block xml usage (#1380)
+- clarify fetch metadata and user cites (#1981)
+- add topic move collector workflow (#1473)
+- update lark doc HTML size limit (#2001)
+- **base**: align record write schema guidance (#2000)
+
+### Tests
+
+- **e2e**: declare request identities explicitly (#2004)
+
+### Misc
+
+- harden npm release publishing (#1918)
+
 ## [v1.0.74] - 2026-07-21
 
 ### Features
@@ -1608,6 +1638,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.75]: https://github.com/larksuite/cli/releases/tag/v1.0.75
 [v1.0.74]: https://github.com/larksuite/cli/releases/tag/v1.0.74
 [v1.0.73]: https://github.com/larksuite/cli/releases/tag/v1.0.73
 [v1.0.72]: https://github.com/larksuite/cli/releases/tag/v1.0.72

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.11",
+  "version": "1.0.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larksuite/cli",
-      "version": "1.0.11",
+      "version": "1.0.75",
       "cpu": [
         "x64",
-        "arm64"
+        "arm64",
+        "riscv64"
       ],
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Prepare the v1.0.75 release by updating package metadata and the changelog.

## Changes

- Bump `package.json` from `1.0.74` to `1.0.75`.
- Synchronize both `package-lock.json` package version fields to `1.0.75` and refresh the root CPU metadata from `package.json`.
- Add the v1.0.75 changelog entry and release link.

## Test Plan

- [x] `make unit-test`
- [x] `npm run release:check -- --tag v1.0.75`
- [x] `node --test scripts/release-preflight.test.js`
- [x] `go vet ./...`
- [x] `gofmt -l .` produces no output
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`

## Related Issues

- None
