### PR TITLE
chore: release v1.0.76

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larksuite/cli",
-      "version": "1.0.75",
+      "version": "1.0.76",
       "cpu": [
         "x64",
         "arm64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Bump the package version to v1.0.76.

## Changes

- Update `package.json` from `1.0.75` to `1.0.76`.
- Synchronize both package version fields in `package-lock.json` to `1.0.76`.

## Test Plan

- [x] `make unit-test`
- [x] `npm run release:check -- --tag v1.0.76`
- [x] `node --test scripts/release-preflight.test.js`

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 1.0.76.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->