### PR TITLE
feat: add --output text/json/yaml to config view commands

### DIFF
--- a/cmd/config/default_as.go
+++ b/cmd/config/default_as.go
@@ -5,15 +5,23 @@ package config
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
+type defaultAsView struct {
+	DefaultAs string `json:"default_as" yaml:"default_as"`
+}
+
 // NewCmdConfigDefaultAs creates the "config default-as" subcommand.
 func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
+	var outputFlag string
+
 	cmd := &cobra.Command{
 		Use:   "default-as [user|bot|auto]",
 		Short: "View or set default identity type",
@@ -31,12 +39,18 @@ func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(args) == 0 {
+				format, err := output.ParseViewFormat(outputFlag)
+				if err != nil {
+					return err
+				}
 				current := app.DefaultAs
 				if current == "" {
 					current = "auto"
 				}
-				fmt.Fprintf(f.IOStreams.Out, "default-as: %s\n", current)
-				return nil
+				return output.WriteView(f.IOStreams.Out, format, defaultAsView{DefaultAs: string(current)}, func(w io.Writer) error {
+					_, err := fmt.Fprintf(w, "default-as: %s\n", current)
+					return err
+				})
 			}
 
 			value := args[0]
@@ -52,6 +66,7 @@ func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&outputFlag, "output", "text", "output format: text | json | yaml")
 	cmdutil.SetRisk(cmd, "write")
 	return cmd
 }

--- a/cmd/config/default_as_test.go
+++ b/cmd/config/default_as_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+)
+
+func setupDefaultAsTestConfig(t *testing.T, defaultAs core.Identity) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", dir)
+	multi := &core.MultiAppConfig{
+		Apps: []core.AppConfig{{
+			AppId:     "test-app",
+			AppSecret: core.PlainSecret("secret"),
+			Brand:     core.BrandFeishu,
+			DefaultAs: defaultAs,
+		}},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDefaultAs_Show_TextDefault(t *testing.T) {
+	setupDefaultAsTestConfig(t, "")
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stdout.String(), "default-as: auto\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultAs_Show_ExplicitText(t *testing.T) {
+	setupDefaultAsTestConfig(t, core.Identity("bot"))
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"--output", "text"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stdout.String(), "default-as: bot\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultAs_Show_JSON(t *testing.T) {
+	setupDefaultAsTestConfig(t, core.Identity("bot"))
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stdout.String(), "{\n  \"default_as\": \"bot\"\n}\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultAs_Show_YAML(t *testing.T) {
+	setupDefaultAsTestConfig(t, core.Identity("user"))
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"--output", "yaml"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stdout.String(), "default_as: user\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultAs_Show_InvalidOutput(t *testing.T) {
+	setupDefaultAsTestConfig(t, "")
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"--output", "xml"})
+	err := cmd.Execute()
+	var valErr *errs.ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if valErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("Subtype = %q, want %q", valErr.Subtype, errs.SubtypeInvalidArgument)
+	}
+}
+
+func TestDefaultAs_Set_OutputIsNoop(t *testing.T) {
+	setupDefaultAsTestConfig(t, "")
+	f, _, stderr, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"bot", "--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stderr.String(), "Default identity set to: bot\n"; got != want {
+		t.Errorf("stderr got %q, want %q (--output must not change the set path's plain-text message)", got, want)
+	}
+	multi, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if app := multi.CurrentAppConfig(""); app.DefaultAs != core.Identity("bot") {
+		t.Errorf("expected DefaultAs=bot, got %v", app.DefaultAs)
+	}
+}

--- a/cmd/config/default_as_test.go
+++ b/cmd/config/default_as_test.go
@@ -97,6 +97,9 @@ func TestDefaultAs_Show_InvalidOutput(t *testing.T) {
 	if valErr.Param != "output" {
 		t.Errorf("Param = %q, want %q", valErr.Param, "output")
 	}
+	if p, ok := errs.ProblemOf(err); !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("ProblemOf = %+v (ok=%v), want Category=%q Subtype=%q", p, ok, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+	}
 }
 
 func TestDefaultAs_Set_OutputIsNoop(t *testing.T) {

--- a/cmd/config/default_as_test.go
+++ b/cmd/config/default_as_test.go
@@ -94,6 +94,9 @@ func TestDefaultAs_Show_InvalidOutput(t *testing.T) {
 	if valErr.Subtype != errs.SubtypeInvalidArgument {
 		t.Errorf("Subtype = %q, want %q", valErr.Subtype, errs.SubtypeInvalidArgument)
 	}
+	if valErr.Param != "output" {
+		t.Errorf("Param = %q, want %q", valErr.Param, "output")
+	}
 }
 
 func TestDefaultAs_Set_OutputIsNoop(t *testing.T) {

--- a/cmd/config/strict_mode.go
+++ b/cmd/config/strict_mode.go
@@ -6,17 +6,25 @@ package config
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+type strictModeView struct {
+	StrictMode string `json:"strict_mode" yaml:"strict_mode"`
+	Source     string `json:"source" yaml:"source"`
+}
 
 // NewCmdConfigStrictMode creates the "config strict-mode" subcommand.
 func NewCmdConfigStrictMode(f *cmdutil.Factory) *cobra.Command {
 	var global bool
 	var reset bool
+	var outputFlag string
 
 	cmd := &cobra.Command{
 		Use:   "strict-mode [bot|user|off]",
@@ -54,7 +62,7 @@ explicit user confirmation — never run on your own initiative.`,
 				if app == nil {
 					return core.NoActiveProfileError()
 				}
-				return showStrictMode(cmd.Context(), f, multi, app)
+				return showStrictMode(cmd.Context(), f, multi, app, outputFlag)
 			}
 			app := multi.CurrentAppConfig(f.Invocation.Profile)
 			if !global && app == nil {
@@ -66,6 +74,7 @@ explicit user confirmation — never run on your own initiative.`,
 
 	cmd.Flags().BoolVar(&global, "global", false, "set at global level (applies to all profiles)")
 	cmd.Flags().BoolVar(&reset, "reset", false, "reset profile setting to inherit global")
+	cmd.Flags().StringVar(&outputFlag, "output", "text", "output format: text | json | yaml")
 	cmdutil.SetRisk(cmd, "write")
 
 	return cmd
@@ -86,17 +95,27 @@ func resetStrictMode(f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.A
 	return nil
 }
 
-func showStrictMode(ctx context.Context, f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.AppConfig) error {
+func showStrictMode(ctx context.Context, f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.AppConfig, outputFlag string) error {
+	format, err := output.ParseViewFormat(outputFlag)
+	if err != nil {
+		return err
+	}
+
 	// Runtime effective mode from credential provider chain is the source of truth.
 	runtime := f.ResolveStrictMode(ctx)
 	configMode, configSource := resolveStrictModeStatus(multi, app)
 
+	mode, source := configMode, configSource
 	if runtime != configMode {
-		fmt.Fprintf(f.IOStreams.Out, "strict-mode: %s (source: credential provider)\n", runtime)
-		return nil
+		mode, source = runtime, "credential provider"
 	}
-	fmt.Fprintf(f.IOStreams.Out, "strict-mode: %s (source: %s)\n", configMode, configSource)
-	return nil
+
+	return output.WriteView(f.IOStreams.Out, format,
+		strictModeView{StrictMode: string(mode), Source: source},
+		func(w io.Writer) error {
+			_, err := fmt.Fprintf(w, "strict-mode: %s (source: %s)\n", mode, source)
+			return err
+		})
 }
 
 func setStrictMode(f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.AppConfig, value string, global bool) error {

--- a/cmd/config/strict_mode_test.go
+++ b/cmd/config/strict_mode_test.go
@@ -224,4 +224,7 @@ func TestStrictMode_Show_InvalidOutput(t *testing.T) {
 	if valErr.Subtype != errs.SubtypeInvalidArgument {
 		t.Errorf("Subtype = %q, want %q", valErr.Subtype, errs.SubtypeInvalidArgument)
 	}
+	if valErr.Param != "output" {
+		t.Errorf("Param = %q, want %q", valErr.Param, "output")
+	}
 }

--- a/cmd/config/strict_mode_test.go
+++ b/cmd/config/strict_mode_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
@@ -37,8 +36,9 @@ func TestStrictMode_Show_Default(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout.String(), "off") {
-		t.Errorf("expected 'off' in output, got: %s", stdout.String())
+	want := "strict-mode: off (source: global (default))\n"
+	if got := stdout.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 

--- a/cmd/config/strict_mode_test.go
+++ b/cmd/config/strict_mode_test.go
@@ -227,4 +227,7 @@ func TestStrictMode_Show_InvalidOutput(t *testing.T) {
 	if valErr.Param != "output" {
 		t.Errorf("Param = %q, want %q", valErr.Param, "output")
 	}
+	if p, ok := errs.ProblemOf(err); !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("ProblemOf = %+v (ok=%v), want Category=%q Subtype=%q", p, ok, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+	}
 }

--- a/cmd/config/strict_mode_test.go
+++ b/cmd/config/strict_mode_test.go
@@ -4,9 +4,11 @@
 package config
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 )
@@ -160,5 +162,66 @@ func TestStrictMode_InvalidValue(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error for invalid value 'on'")
+	}
+}
+
+func TestStrictMode_Show_JSON(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	want := "{\n  \"strict_mode\": \"off\",\n  \"source\": \"global (default)\"\n}\n"
+	if got := stdout.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStrictMode_Show_YAML(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--output", "yaml"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	// "off" collides with a YAML 1.1 boolean literal; yaml.v3 quotes it.
+	want := "strict_mode: \"off\"\nsource: global (default)\n"
+	if got := stdout.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStrictMode_Show_CredentialProviderSource(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	// SupportedIdentities: 2 makes the runtime credential chain resolve to
+	// "bot", diverging from the persisted profile's default "off" — this
+	// exercises the runtime != configMode branch in showStrictMode.
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret", SupportedIdentities: 2})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	want := "{\n  \"strict_mode\": \"bot\",\n  \"source\": \"credential provider\"\n}\n"
+	if got := stdout.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestStrictMode_Show_InvalidOutput(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--output", "xml"})
+	err := cmd.Execute()
+	var valErr *errs.ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if valErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("Subtype = %q, want %q", valErr.Subtype, errs.SubtypeInvalidArgument)
 	}
 }

--- a/internal/output/view_format.go
+++ b/internal/output/view_format.go
@@ -39,7 +39,7 @@ func ParseViewFormat(raw string) (ViewFormat, error) {
 		return ViewFormatYAML, nil
 	default:
 		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
-			"invalid --output value %q, valid values: text | json | yaml", raw)
+			"invalid --output value %q, valid values: text | json | yaml", raw).WithParam("output")
 	}
 }
 
@@ -55,15 +55,27 @@ func WriteView(w io.Writer, format ViewFormat, data interface{}, renderText func
 	case ViewFormatJSON:
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		return enc.Encode(data)
+		return wrapWriteViewErr(enc.Encode(data), "failed to render json: %v")
 	case ViewFormatYAML:
 		out, err := yaml.Marshal(data)
 		if err != nil {
 			return errs.NewInternalError(errs.SubtypeUnknown, "failed to render yaml: %v", err).WithCause(err)
 		}
 		_, err = w.Write(out)
-		return err
+		return wrapWriteViewErr(err, "failed to write yaml output: %v")
 	default:
-		return renderText(w)
+		return wrapWriteViewErr(renderText(w), "failed to render text: %v")
 	}
+}
+
+// wrapWriteViewErr preserves already-typed errs errors (e.g. from a caller's
+// renderText closure) and wraps everything else as an internal error.
+func wrapWriteViewErr(err error, format string) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := errs.ProblemOf(err); ok {
+		return err
+	}
+	return errs.NewInternalError(errs.SubtypeUnknown, format, err).WithCause(err)
 }

--- a/internal/output/view_format.go
+++ b/internal/output/view_format.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"encoding/json"
+	"io"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// ViewFormat is the output format for simple read-only "view" commands
+// (e.g. `config default-as`, `config strict-mode`). It is intentionally
+// separate from Format/ParseFormat/Emitter, which serve a different set
+// of commands and already use the string "yaml" in tests as a stand-in
+// for an unrecognized format.
+type ViewFormat string
+
+const (
+	ViewFormatText ViewFormat = "text"
+	ViewFormatJSON ViewFormat = "json"
+	ViewFormatYAML ViewFormat = "yaml"
+)
+
+// ParseViewFormat validates the raw --output flag value. Empty string is
+// treated as the default ("text"). Unknown values are a hard validation
+// error (not a silent fallback) — this flag is new, so there is no legacy
+// leniency to preserve, and silent fallback would hide typos from AI agents.
+func ParseViewFormat(raw string) (ViewFormat, error) {
+	switch ViewFormat(raw) {
+	case "", ViewFormatText:
+		return ViewFormatText, nil
+	case ViewFormatJSON:
+		return ViewFormatJSON, nil
+	case ViewFormatYAML:
+		return ViewFormatYAML, nil
+	default:
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"invalid --output value %q, valid values: text | json | yaml", raw)
+	}
+}
+
+// WriteView renders data according to format. For ViewFormatText, it
+// delegates to renderText (the command's existing fmt.Fprintf logic,
+// unchanged). For JSON/YAML, it marshals data directly — callers pass a
+// struct with json/yaml tags (snake_case, matching config's other
+// structured output in policy.go/plugins.go). Use a struct, not a map:
+// encoding/json sorts map keys alphabetically, which would silently
+// reorder fields.
+func WriteView(w io.Writer, format ViewFormat, data interface{}, renderText func(io.Writer) error) error {
+	switch format {
+	case ViewFormatJSON:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
+	case ViewFormatYAML:
+		out, err := yaml.Marshal(data)
+		if err != nil {
+			return errs.NewInternalError(errs.SubtypeUnknown, "failed to render yaml: %v", err).WithCause(err)
+		}
+		_, err = w.Write(out)
+		return err
+	default:
+		return renderText(w)
+	}
+}

--- a/internal/output/view_format_test.go
+++ b/internal/output/view_format_test.go
@@ -49,6 +49,9 @@ func TestParseViewFormat_Invalid(t *testing.T) {
 	if valErr.Param != "output" {
 		t.Errorf("Param = %q, want %q", valErr.Param, "output")
 	}
+	if p, ok := errs.ProblemOf(err); !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("ProblemOf = %+v (ok=%v), want Category=%q Subtype=%q", p, ok, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+	}
 }
 
 type testView struct {

--- a/internal/output/view_format_test.go
+++ b/internal/output/view_format_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func TestParseViewFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want ViewFormat
+	}{
+		{"empty defaults to text", "", ViewFormatText},
+		{"explicit text", "text", ViewFormatText},
+		{"json", "json", ViewFormatJSON},
+		{"yaml", "yaml", ViewFormatYAML},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseViewFormat(tc.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseViewFormat_Invalid(t *testing.T) {
+	_, err := ParseViewFormat("xml")
+	var valErr *errs.ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if valErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("Subtype = %q, want %q", valErr.Subtype, errs.SubtypeInvalidArgument)
+	}
+}
+
+type testView struct {
+	Foo string `json:"foo" yaml:"foo"`
+}
+
+func TestWriteView_Text(t *testing.T) {
+	var buf bytes.Buffer
+	called := false
+	err := WriteView(&buf, ViewFormatText, testView{Foo: "bar"}, func(w io.Writer) error {
+		called = true
+		_, err := fmt.Fprint(w, "plain text\n")
+		return err
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected renderText to be invoked for ViewFormatText")
+	}
+	if got, want := buf.String(), "plain text\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteView_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteView(&buf, ViewFormatJSON, testView{Foo: "bar"}, func(w io.Writer) error {
+		t.Fatal("renderText must not be invoked for ViewFormatJSON")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := buf.String(), "{\n  \"foo\": \"bar\"\n}\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteView_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteView(&buf, ViewFormatYAML, testView{Foo: "off"}, func(w io.Writer) error {
+		t.Fatal("renderText must not be invoked for ViewFormatYAML")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "off" collides with a YAML 1.1 boolean literal; yaml.v3 quotes it to
+	// preserve string semantics — verified against the real dependency in
+	// the design spec, not assumed.
+	if got, want := buf.String(), "foo: \"off\"\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/output/view_format_test.go
+++ b/internal/output/view_format_test.go
@@ -46,6 +46,9 @@ func TestParseViewFormat_Invalid(t *testing.T) {
 	if valErr.Subtype != errs.SubtypeInvalidArgument {
 		t.Errorf("Subtype = %q, want %q", valErr.Subtype, errs.SubtypeInvalidArgument)
 	}
+	if valErr.Param != "output" {
+		t.Errorf("Param = %q, want %q", valErr.Param, "output")
+	}
 }
 
 type testView struct {


### PR DESCRIPTION
## Summary

`config default-as` and `config strict-mode` currently only print human-readable text with no structured output option, making them hard for AI agents to consume reliably. This PR adds a unified `--output {text,json,yaml}` flag to both commands' view (no-argument) branches, backed by a new shared formatter. Default (no-flag) output is unchanged.

## Changes

- Add `internal/output/view_format.go`: `ViewFormat` enum + `ParseViewFormat` + `WriteView`, deliberately isolated from the existing `Format`/`ParseFormat`/`Emitter` machinery (whose tests use the string `"yaml"` as a stand-in for "unrecognized format")
- Add `--output` flag to `cmd/config/default_as.go`'s view branch; set branch is unaffected (no-op)
- Add `--output` flag to `cmd/config/strict_mode.go`'s view branch (`showStrictMode`), covering both the config-mode and credential-provider-source cases; set/reset/global branches are unaffected
- Invalid `--output` values return a structured validation error (exit code 2), consistent with existing `cmd/config` validation errors
- `config show` / `config policy show` / `config plugins show` (already unconditional JSON) and all mutating config commands are out of scope and untouched

## Test Plan

- [x] `go build ./...` passed
- [x] `go test ./internal/output/... ./cmd/config/...` passed, including byte-exact regression assertions for unflagged output
- [x] Manual verification: `config default-as --output json`, `config strict-mode --output yaml`, `config default-as --output xml` (confirms invalid-value error), `config default-as bot --output json` (confirms no-op on set path)

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added formatted `--output` support for `config default-as` and `config strict-mode` view output, with `text`, `json`, and `yaml`.
  * When `--output` is omitted, output defaults to `text`.
* **Bug Fixes**
  * `strict-mode` view output now consistently includes the active setting source and resolved value across output formats.
* **Tests**
  * Expanded CLI and unit tests to verify exact rendering for `text/json/yaml` and to confirm invalid `--output` values return proper validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->