### PR TITLE
fix/task id handling

### DIFF
--- a/shortcuts/task/shortcuts.go
+++ b/shortcuts/task/shortcuts.go
@@ -105,7 +105,7 @@ var taskDisplayNumberPattern = regexp.MustCompile(`^t[0-9]+$`)
 
 func parseTaskGUID(input string) (string, error) {
 	input = strings.TrimSpace(input)
-	invalid := func(format string, args ...interface{}) error {
+	invalid := func(format string, args ...interface{}) *errs.ValidationError {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, format, args...).
 			WithParam("--task-id").
 			WithHint("provide the Task OpenAPI GUID or a task applink containing guid=")
@@ -119,7 +119,7 @@ func parseTaskGUID(input string) (string, error) {
 	if strings.HasPrefix(lowerInput, "http://") || strings.HasPrefix(lowerInput, "https://") {
 		u, err := url.Parse(input)
 		if err != nil {
-			return "", invalid("invalid task applink: %v", err)
+			return "", invalid("invalid task applink: %v", err).WithCause(err)
 		}
 		guid := strings.TrimSpace(u.Query().Get("guid"))
 		if guid == "" {

--- a/shortcuts/task/shortcuts.go
+++ b/shortcuts/task/shortcuts.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -98,6 +99,40 @@ func extractTasklistGuid(input string) string {
 // shared parsing logic.
 func extractTaskGuid(input string) string {
 	return extractTasklistGuid(input)
+}
+
+var taskDisplayNumberPattern = regexp.MustCompile(`^t[0-9]+$`)
+
+func parseTaskGUID(input string) (string, error) {
+	input = strings.TrimSpace(input)
+	invalid := func(format string, args ...interface{}) error {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, format, args...).
+			WithParam("--task-id").
+			WithHint("provide the Task OpenAPI GUID or a task applink containing guid=")
+	}
+
+	if input == "" {
+		return "", invalid("task ID is empty")
+	}
+
+	lowerInput := strings.ToLower(input)
+	if strings.HasPrefix(lowerInput, "http://") || strings.HasPrefix(lowerInput, "https://") {
+		u, err := url.Parse(input)
+		if err != nil {
+			return "", invalid("invalid task applink: %v", err)
+		}
+		guid := strings.TrimSpace(u.Query().Get("guid"))
+		if guid == "" {
+			return "", invalid("task applink is missing a non-empty guid query parameter")
+		}
+		return guid, nil
+	}
+
+	if taskDisplayNumberPattern.MatchString(input) {
+		return "", invalid("task display number %q is not a Task OpenAPI GUID", input)
+	}
+
+	return input, nil
 }
 
 func buildTaskCreateBody(runtime *common.RuntimeContext) (map[string]interface{}, error) {

--- a/shortcuts/task/shortcuts_test.go
+++ b/shortcuts/task/shortcuts_test.go
@@ -4,8 +4,10 @@
 package task
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/smartystreets/goconvey/convey"
 )
 
@@ -13,5 +15,70 @@ func TestShortcutsRegistration(t *testing.T) {
 	convey.Convey("Shortcuts() returns all commands", t, func() {
 		list := Shortcuts()
 		convey.So(len(list), convey.ShouldBeGreaterThan, 0)
+	})
+}
+
+func TestParseTaskGUID(t *testing.T) {
+	t.Run("accepts GUIDs and task applinks", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input string
+			want  string
+		}{
+			{name: "opaque GUID", input: "task-guid-123", want: "task-guid-123"},
+			{name: "trimmed GUID", input: "  task-guid-123  ", want: "task-guid-123"},
+			{
+				name:  "task applink",
+				input: "https://applink.larksuite.com/client/todo/detail?guid=task-guid-123",
+				want:  "task-guid-123",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := parseTaskGUID(tt.input)
+				if err != nil {
+					t.Fatalf("parseTaskGUID(%q) error = %v", tt.input, err)
+				}
+				if got != tt.want {
+					t.Fatalf("parseTaskGUID(%q) = %q, want %q", tt.input, got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("rejects unusable task identifiers", func(t *testing.T) {
+		for _, input := range []string{
+			"",
+			"https://applink.larksuite.com/client/todo/detail",
+			"https://%",
+			"t12345",
+		} {
+			t.Run(input, func(t *testing.T) {
+				_, err := parseTaskGUID(input)
+				if err == nil {
+					t.Fatalf("parseTaskGUID(%q) error = nil, want typed validation error", input)
+				}
+
+				problem, ok := errs.ProblemOf(err)
+				if !ok {
+					t.Fatalf("parseTaskGUID(%q) error type = %T, want typed error", input, err)
+				}
+				if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+					t.Fatalf("problem = %s/%s, want %s/%s", problem.Category, problem.Subtype, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+				}
+				if problem.Hint == "" {
+					t.Fatal("problem hint is empty")
+				}
+
+				var validationErr *errs.ValidationError
+				if !errors.As(err, &validationErr) {
+					t.Fatalf("error type = %T, want *errs.ValidationError", err)
+				}
+				if validationErr.Param != "--task-id" {
+					t.Fatalf("param = %q, want %q", validationErr.Param, "--task-id")
+				}
+			})
+		}
 	})
 }

--- a/shortcuts/task/shortcuts_test.go
+++ b/shortcuts/task/shortcuts_test.go
@@ -5,6 +5,7 @@ package task
 
 import (
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
@@ -79,6 +80,18 @@ func TestParseTaskGUID(t *testing.T) {
 					t.Fatalf("param = %q, want %q", validationErr.Param, "--task-id")
 				}
 			})
+		}
+	})
+
+	t.Run("preserves applink parse cause", func(t *testing.T) {
+		_, err := parseTaskGUID("https://%")
+		if err == nil {
+			t.Fatal("parseTaskGUID() error = nil, want URL parse error")
+		}
+
+		var urlErr *url.Error
+		if !errors.As(err, &urlErr) {
+			t.Fatalf("error chain = %T %v, want *url.Error cause", err, err)
 		}
 	})
 }

--- a/shortcuts/task/task_complete.go
+++ b/shortcuts/task/task_complete.go
@@ -25,45 +25,59 @@ var CompleteTask = common.Shortcut{
 	HasFormat:   true,
 
 	Flags: []common.Flag{
-		{Name: "task-id", Desc: "task id", Required: true},
+		{Name: "task-id", Desc: "task GUID or task applink URL", Required: true},
+	},
+
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := parseTaskGUID(runtime.Str("task-id"))
+		return err
 	},
 
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		body := buildCompleteBody()
-		taskId := url.PathEscape(runtime.Str("task-id"))
+		taskGUID, err := parseTaskGUID(runtime.Str("task-id"))
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		taskID := url.PathEscape(taskGUID)
 		return common.NewDryRunAPI().
-			GET("/open-apis/task/v2/tasks/" + taskId).
+			GET("/open-apis/task/v2/tasks/" + taskID).
 			Desc("get current task status").
 			Params(map[string]interface{}{"user_id_type": "open_id"}).
-			PATCH("/open-apis/task/v2/tasks/" + taskId).
+			PATCH("/open-apis/task/v2/tasks/" + taskID).
 			Desc("complete task if not completed").
 			Params(map[string]interface{}{"user_id_type": "open_id"}).
 			Body(body)
 	},
 
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		taskId := url.PathEscape(runtime.Str("task-id"))
+		taskGUID, err := parseTaskGUID(runtime.Str("task-id"))
+		if err != nil {
+			return err
+		}
+		taskID := url.PathEscape(taskGUID)
 
 		params := map[string]interface{}{"user_id_type": "open_id"}
 
 		var data map[string]interface{}
 
 		// 1. Get current task status
-		getData, err := callTaskAPITyped(runtime, http.MethodGet, "/open-apis/task/v2/tasks/"+taskId, params, nil)
+		getData, err := callTaskAPITyped(runtime, http.MethodGet, "/open-apis/task/v2/tasks/"+taskID, params, nil)
 		if err != nil {
 			return err
 		}
 
 		taskData, _ := getData["task"].(map[string]interface{})
 		completedAtStr, _ := taskData["completed_at"].(string)
+		alreadyCompleted := completedAtStr != "" && completedAtStr != "0"
 
 		// 2. If already completed, directly return success
-		if completedAtStr != "" && completedAtStr != "0" {
+		if alreadyCompleted {
 			data = getData
 		} else {
 			// 3. Complete the task
 			body := buildCompleteBody()
-			data, err = callTaskAPITyped(runtime, http.MethodPatch, "/open-apis/task/v2/tasks/"+taskId, params, body)
+			data, err = callTaskAPITyped(runtime, http.MethodPatch, "/open-apis/task/v2/tasks/"+taskID, params, body)
 			if err != nil {
 				return err
 			}
@@ -73,11 +87,19 @@ var CompleteTask = common.Shortcut{
 		guid, _ := task["guid"].(string)
 		urlVal, _ := task["url"].(string)
 		urlVal = truncateTaskURL(urlVal)
+		completedAt, _ := task["completed_at"].(string)
+		status := "todo"
+		if completedAt != "" && completedAt != "0" {
+			status = "done"
+		}
 
 		// Standardized write output: return resource identifiers
 		outData := map[string]interface{}{
-			"guid": guid,
-			"url":  urlVal,
+			"guid":              guid,
+			"url":               urlVal,
+			"status":            status,
+			"completed_at":      completedAt,
+			"already_completed": alreadyCompleted,
 		}
 
 		runtime.OutFormat(outData, nil, func(w io.Writer) {

--- a/shortcuts/task/task_complete_test.go
+++ b/shortcuts/task/task_complete_test.go
@@ -4,9 +4,12 @@
 package task
 
 import (
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
 )
 
@@ -45,6 +48,9 @@ func TestCompleteTask(t *testing.T) {
 			formatFlag:  "json",
 			expectedOutput: []string{
 				`"guid": "task-789"`,
+				`"status": "done"`,
+				`"completed_at": "1775174400000"`,
+				`"already_completed": false`,
 			},
 		},
 	}
@@ -107,5 +113,100 @@ func TestCompleteTask(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTaskCompleteAcceptsTaskApplink(t *testing.T) {
+	f, stdout, _, reg := taskShortcutTestFactory(t)
+	warmTenantToken(t, f, reg)
+
+	for _, method := range []string{"GET", "PATCH"} {
+		reg.Register(&httpmock.Stub{
+			Method: method,
+			URL:    "/open-apis/task/v2/tasks/task-guid-applink",
+			Body: map[string]interface{}{
+				"code": 0, "msg": "success",
+				"data": map[string]interface{}{
+					"task": map[string]interface{}{
+						"guid":         "task-guid-applink",
+						"summary":      "Applink task",
+						"completed_at": map[string]string{"GET": "0", "PATCH": "1775174400000"}[method],
+						"url":          "https://example.com/task-guid-applink",
+					},
+				},
+			},
+		})
+	}
+
+	err := runMountedTaskShortcut(t, CompleteTask, []string{
+		"+complete",
+		"--task-id", "https://applink.larksuite.com/client/todo/detail?guid=task-guid-applink",
+		"--format", "json",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("CompleteTask error = %v", err)
+	}
+	reg.Verify(t)
+	if !strings.Contains(stdout.String(), `"guid": "task-guid-applink"`) {
+		t.Fatalf("output = %s, want normalized task GUID", stdout.String())
+	}
+}
+
+func TestTaskCompleteAlreadyCompletedReturnsServerState(t *testing.T) {
+	f, stdout, _, reg := taskShortcutTestFactory(t)
+	warmTenantToken(t, f, reg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/task/v2/tasks/task-guid-done",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"task": map[string]interface{}{
+					"guid":         "task-guid-done",
+					"summary":      "Already done",
+					"completed_at": "1775174400000",
+					"url":          "https://example.com/task-guid-done",
+				},
+			},
+		},
+	})
+
+	err := runMountedTaskShortcut(t, CompleteTask, []string{
+		"+complete", "--task-id", "task-guid-done", "--format", "json", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("CompleteTask error = %v", err)
+	}
+	reg.Verify(t)
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	data, _ := envelope["data"].(map[string]interface{})
+	if data["status"] != "done" || data["completed_at"] != "1775174400000" || data["already_completed"] != true {
+		t.Fatalf("completion state = %#v, want done/already_completed server state", data)
+	}
+}
+
+func TestTaskCompleteRejectsDisplayNumberBeforeRead(t *testing.T) {
+	f, stdout, _, reg := taskShortcutTestFactory(t)
+	warmTenantToken(t, f, reg)
+
+	err := runMountedTaskShortcut(t, CompleteTask, []string{
+		"+complete", "--task-id", "t12345", "--format", "json", "--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("CompleteTask error = nil, want invalid task ID error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("error = %T %v, want typed invalid-argument error", err, err)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--task-id" {
+		t.Fatalf("error param = %#v, want --task-id", validationErr)
 	}
 }

--- a/shortcuts/task/task_update.go
+++ b/shortcuts/task/task_update.go
@@ -48,11 +48,13 @@ var UpdateTask = common.Shortcut{
 		if err != nil {
 			return common.NewDryRunAPI().Set("error", err.Error())
 		}
-		taskID := url.PathEscape(taskIDs[0])
-		return common.NewDryRunAPI().
-			PATCH("/open-apis/task/v2/tasks/" + taskID).
-			Params(map[string]interface{}{"user_id_type": "open_id"}).
-			Body(body)
+		preview := common.NewDryRunAPI()
+		for _, taskID := range taskIDs {
+			preview.PATCH("/open-apis/task/v2/tasks/" + url.PathEscape(taskID)).
+				Params(map[string]interface{}{"user_id_type": "open_id"}).
+				Body(body)
+		}
+		return preview
 	},
 
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/task/task_update.go
+++ b/shortcuts/task/task_update.go
@@ -27,11 +27,16 @@ var UpdateTask = common.Shortcut{
 	HasFormat:   true,
 
 	Flags: []common.Flag{
-		{Name: "task-id", Desc: "task id (comma-separated for multiple)", Required: true},
+		{Name: "task-id", Desc: "task GUID or task applink URL (comma-separated for multiple)", Required: true},
 		{Name: "summary", Desc: "task title"},
 		{Name: "description", Desc: "task description"},
 		{Name: "due", Desc: "due date (ISO 8601 / date:YYYY-MM-DD / relative:+2d / ms timestamp)"},
 		{Name: "data", Desc: "JSON payload for task object"},
+	},
+
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := parseTaskGUIDs(runtime.Str("task-id"))
+		return err
 	},
 
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
@@ -39,15 +44,23 @@ var UpdateTask = common.Shortcut{
 		if err != nil {
 			return common.NewDryRunAPI().Set("error", err.Error())
 		}
-		taskIds := strings.Split(runtime.Str("task-id"), ",")
-		taskId := url.PathEscape(strings.TrimSpace(taskIds[0]))
+		taskIDs, err := parseTaskGUIDs(runtime.Str("task-id"))
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		taskID := url.PathEscape(taskIDs[0])
 		return common.NewDryRunAPI().
-			PATCH("/open-apis/task/v2/tasks/" + taskId).
+			PATCH("/open-apis/task/v2/tasks/" + taskID).
 			Params(map[string]interface{}{"user_id_type": "open_id"}).
 			Body(body)
 	},
 
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		taskIDs, err := parseTaskGUIDs(runtime.Str("task-id"))
+		if err != nil {
+			return err
+		}
+
 		body, err := buildTaskUpdateBody(runtime)
 		if err != nil {
 			// buildTaskUpdateBody already returns a typed validation error;
@@ -55,17 +68,11 @@ var UpdateTask = common.Shortcut{
 			return err
 		}
 
-		taskIds := strings.Split(runtime.Str("task-id"), ",")
 		var updatedTasks []map[string]interface{}
 
-		for _, taskId := range taskIds {
-			taskId = strings.TrimSpace(taskId)
-			if taskId == "" {
-				continue
-			}
-
+		for _, taskID := range taskIDs {
 			params := map[string]interface{}{"user_id_type": "open_id"}
-			data, err := callTaskAPITyped(runtime, http.MethodPatch, "/open-apis/task/v2/tasks/"+url.PathEscape(taskId), params, body)
+			data, err := callTaskAPITyped(runtime, http.MethodPatch, "/open-apis/task/v2/tasks/"+url.PathEscape(taskID), params, body)
 			if err != nil {
 				return err
 			}
@@ -76,19 +83,28 @@ var UpdateTask = common.Shortcut{
 			}
 		}
 
+		updateFields, _ := body["update_fields"].([]string)
 		var tasks []map[string]interface{}
 		for _, task := range updatedTasks {
 			guid, _ := task["guid"].(string)
 			urlVal, _ := task["url"].(string)
 			urlVal = truncateTaskURL(urlVal)
+			confirmed := make(map[string]interface{})
+			for _, field := range updateFields {
+				if value, ok := task[field]; ok {
+					confirmed[field] = value
+				}
+			}
 			tasks = append(tasks, map[string]interface{}{
-				"guid": guid,
-				"url":  urlVal,
+				"guid":      guid,
+				"url":       urlVal,
+				"confirmed": confirmed,
 			})
 		}
 		// Standardized write output: return resource identifiers
 		outData := map[string]interface{}{
-			"tasks": tasks,
+			"updated_fields": updateFields,
+			"tasks":          tasks,
 		}
 
 		runtime.OutFormat(outData, &output.Meta{Count: len(updatedTasks)}, func(w io.Writer) {
@@ -110,6 +126,26 @@ var UpdateTask = common.Shortcut{
 		})
 		return nil
 	},
+}
+
+func parseTaskGUIDs(input string) ([]string, error) {
+	parts := strings.Split(input, ",")
+	taskGUIDs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		guid, err := parseTaskGUID(part)
+		if err != nil {
+			return nil, err
+		}
+		taskGUIDs = append(taskGUIDs, guid)
+	}
+	if len(taskGUIDs) == 0 {
+		_, err := parseTaskGUID("")
+		return nil, err
+	}
+	return taskGUIDs, nil
 }
 
 func buildTaskUpdateBody(runtime *common.RuntimeContext) (map[string]interface{}, error) {

--- a/shortcuts/task/task_update_test.go
+++ b/shortcuts/task/task_update_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestParseTaskGUIDs(t *testing.T) {
+	got, err := parseTaskGUIDs(" task-guid-1, https://applink.larksuite.com/client/todo/detail?guid=task-guid-2 ")
+	if err != nil {
+		t.Fatalf("parseTaskGUIDs() error = %v", err)
+	}
+	want := []string{"task-guid-1", "task-guid-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseTaskGUIDs() = %v, want %v", got, want)
+	}
+
+	_, err = parseTaskGUIDs("task-guid-1,t12345")
+	if err == nil {
+		t.Fatal("parseTaskGUIDs() error = nil, want invalid display-number error")
+	}
+}
+
+func TestTaskUpdateNormalizesAllIDsAndReturnsConfirmedFields(t *testing.T) {
+	f, stdout, _, reg := taskShortcutTestFactory(t)
+	warmTenantToken(t, f, reg)
+
+	first := &httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/task/v2/tasks/task-guid-1",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"task": map[string]interface{}{
+					"guid":        "task-guid-1",
+					"url":         "https://example.com/task-guid-1",
+					"summary":     "server summary one",
+					"description": "server description one",
+				},
+			},
+		},
+	}
+	second := &httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/task/v2/tasks/task-guid-2",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"task": map[string]interface{}{
+					"guid":    "task-guid-2",
+					"url":     "https://example.com/task-guid-2",
+					"summary": "server summary two",
+				},
+			},
+		},
+	}
+	reg.Register(first)
+	reg.Register(second)
+
+	err := runMountedTaskShortcut(t, UpdateTask, []string{
+		"+update",
+		"--task-id", "task-guid-1,https://applink.larksuite.com/client/todo/detail?guid=task-guid-2",
+		"--summary", "requested summary",
+		"--description", "requested description",
+		"--format", "json",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("UpdateTask error = %v", err)
+	}
+	reg.Verify(t)
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	data, ok := envelope["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data = %#v, want object", envelope["data"])
+	}
+	if got := stringSlice(data["updated_fields"]); !reflect.DeepEqual(got, []string{"summary", "description"}) {
+		t.Fatalf("updated_fields = %v, want [summary description]", got)
+	}
+
+	tasks, ok := data["tasks"].([]interface{})
+	if !ok || len(tasks) != 2 {
+		t.Fatalf("tasks = %#v, want two tasks", data["tasks"])
+	}
+	firstTask := tasks[0].(map[string]interface{})
+	if firstTask["guid"] != "task-guid-1" || firstTask["url"] != "https://example.com/task-guid-1" {
+		t.Fatalf("first task identifiers = %#v", firstTask)
+	}
+	if got := firstTask["confirmed"]; !reflect.DeepEqual(got, map[string]interface{}{
+		"summary": "server summary one", "description": "server description one",
+	}) {
+		t.Fatalf("first confirmed = %#v", got)
+	}
+
+	secondTask := tasks[1].(map[string]interface{})
+	if got := secondTask["confirmed"]; !reflect.DeepEqual(got, map[string]interface{}{
+		"summary": "server summary two",
+	}) {
+		t.Fatalf("second confirmed = %#v; omitted server fields must not be echoed from the request", got)
+	}
+}
+
+func TestTaskUpdateValidatesEveryIDBeforeFirstWrite(t *testing.T) {
+	f, stdout, _, reg := taskShortcutTestFactory(t)
+	warmTenantToken(t, f, reg)
+
+	err := runMountedTaskShortcut(t, UpdateTask, []string{
+		"+update",
+		"--task-id", "task-guid-1,t12345",
+		"--summary", "must not be written",
+		"--format", "json",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("UpdateTask error = nil, want invalid task ID error")
+	}
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("error = %T %v, want typed invalid-argument error", err, err)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--task-id" {
+		t.Fatalf("error param = %#v, want --task-id", validationErr)
+	}
+}
+
+func stringSlice(value interface{}) []string {
+	items, _ := value.([]interface{})
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if str, ok := item.(string); ok {
+			result = append(result, str)
+		}
+	}
+	return result
+}

--- a/shortcuts/task/task_update_test.go
+++ b/shortcuts/task/task_update_test.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
 )
 
 func TestParseTaskGUIDs(t *testing.T) {
@@ -26,6 +29,55 @@ func TestParseTaskGUIDs(t *testing.T) {
 	_, err = parseTaskGUIDs("task-guid-1,t12345")
 	if err == nil {
 		t.Fatal("parseTaskGUIDs() error = nil, want invalid display-number error")
+	}
+}
+
+func TestTaskUpdateDryRunPreviewsEveryTaskID(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("task-id", "task-guid-1,https://applink.larksuite.com/client/todo/detail?guid=task-guid-2", "")
+	cmd.Flags().String("summary", "updated", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("due", "", "")
+	cmd.Flags().String("data", "", "")
+
+	preview := UpdateTask.DryRun(context.Background(), &common.RuntimeContext{Cmd: cmd})
+	payload, err := json.Marshal(preview)
+	if err != nil {
+		t.Fatalf("marshal dry-run preview: %v", err)
+	}
+
+	var got struct {
+		API []struct {
+			Method string                 `json:"method"`
+			URL    string                 `json:"url"`
+			Params map[string]interface{} `json:"params"`
+			Body   map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("decode dry-run preview: %v", err)
+	}
+	if len(got.API) != 2 {
+		t.Fatalf("dry-run API calls = %d, want 2; payload: %s", len(got.API), payload)
+	}
+
+	wantURLs := []string{
+		"/open-apis/task/v2/tasks/task-guid-1",
+		"/open-apis/task/v2/tasks/task-guid-2",
+	}
+	for i, call := range got.API {
+		if call.Method != "PATCH" {
+			t.Errorf("api[%d].method = %q, want PATCH", i, call.Method)
+		}
+		if call.URL != wantURLs[i] {
+			t.Errorf("api[%d].url = %q, want %q", i, call.URL, wantURLs[i])
+		}
+		if !reflect.DeepEqual(call.Params, map[string]interface{}{"user_id_type": "open_id"}) {
+			t.Errorf("api[%d].params = %#v", i, call.Params)
+		}
+		if !reflect.DeepEqual(call.Body, got.API[0].Body) {
+			t.Errorf("api[%d].body = %#v, want same body as first call %#v", i, call.Body, got.API[0].Body)
+		}
 	}
 }
 

--- a/skills/lark-task/SKILL.md
+++ b/skills/lark-task/SKILL.md
@@ -38,6 +38,13 @@ metadata:
 > Task OpenAPI 中用于更新/操作任务的 `guid` 是任务的全局唯一标识（GUID），不是客户端展示的任务编号（例如 `t104121` / `suite_entity_num`）。
 > 对于 Feishu 的任务 applink（例如 `.../client/todo/task?guid=...`），必须使用 URL query 里的 `guid` 参数作为 task guid。
 
+> **从任务清单定位并修改任务的最短路径**：
+> 1. 已知任务清单 GUID 时直接使用，不要先搜索；已知任务清单 applink 时，取 URL query 中的 `guid` 作为 `tasklist_guid`。
+> 2. 只有清单名称或关键词、没有 GUID/applink 时，才调用一次 `+tasklist-search` 解析目标清单。
+> 3. 按原生 API 规则先执行 `lark-cli schema task.tasklists.tasks`，再执行 `lark-cli task tasklists tasks --params '{"tasklist_guid":"<tasklist_guid>"}' --as user`。
+> 4. 从清单任务结果中取任务的 `guid`，直接传给 `+update` 或 `+complete`；禁止传客户端展示编号（例如 `t104121`）。这两个 shortcut 也可直接接收包含 `guid=` 的任务 applink。
+> 5. `+update` 返回 `updated_fields` 和每个任务的服务端 `confirmed` 字段；`+complete` 返回 `status`、`completed_at`、`already_completed`。这些字段已确认目标状态时，不要例行追加 `tasks get`；仅在服务端未返回所需字段或用户明确要求完整复核时再查询详情。
+
 | Shortcut | 说明 |
 |----------|------|
 | [`+create`](references/lark-task-create.md) | create a task |

--- a/skills/lark-task/references/lark-task-complete.md
+++ b/skills/lark-task/references/lark-task-complete.md
@@ -9,19 +9,23 @@ Mark a task as completed.
 ```bash
 # Complete a task
 lark-cli task +complete --task-id "<task_guid>"
+
+# A task applink is accepted directly; the CLI extracts its guid query value
+lark-cli task +complete --task-id "https://applink.larksuite.com/client/todo/task?guid=<task_guid>"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <guid>` | Yes | The task GUID to complete. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
+| `--task-id <guid-or-applink>` | Yes | Task OpenAPI GUID or a task applink containing `guid=`. Display task IDs such as `t104121` / `suite_entity_num` are rejected. |
 
 ## Workflow
 
 1. Confirm the task to complete.
 2. Execute the command.
-3. Report success.
+3. Read `data.status`, `data.completed_at`, and `data.already_completed` from the result. `already_completed: true` means the shortcut observed an already-completed task and skipped the PATCH.
+4. Do not routinely call `task tasks get` when the result already reports `status: done` and a non-zero `completed_at`. Query details only if confirmation fields are absent or the user explicitly asks for a full verification.
 
 > [!CAUTION]
 > This is a **Write Operation** -- You must confirm the user's intent before executing.

--- a/skills/lark-task/references/lark-task-update.md
+++ b/skills/lark-task/references/lark-task-update.md
@@ -13,6 +13,9 @@ lark-cli task +update --task-id "<task_guid>" --summary "New Summary"
 # Update multiple tasks' due dates
 lark-cli task +update --task-id "<task_guid>,<another_task_guid>" --due "+2d"
 
+# A task applink is accepted directly; the CLI extracts its guid query value
+lark-cli task +update --task-id "https://applink.larksuite.com/client/todo/task?guid=<task_guid>" --summary "New Summary"
+
 # Update with JSON data
 lark-cli task +update --task-id "<task_guid>" --data '{"description": "New description"}'
 ```
@@ -21,7 +24,7 @@ lark-cli task +update --task-id "<task_guid>" --data '{"description": "New descr
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <guid>` | Yes | The task GUID to update. Comma-separated task GUIDs are supported for multiple tasks. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
+| `--task-id <guid-or-applink>` | Yes | Task OpenAPI GUID or a task applink containing `guid=`. Comma-separated GUIDs/applinks are supported for multiple tasks. Display task IDs such as `t104121` / `suite_entity_num` are rejected. |
 | `--summary <text>` | No | New summary/title for the task. |
 | `--description <text>` | No | New description for the task. |
 | `--due <time>` | No | New due date (supports relative time). |
@@ -31,7 +34,8 @@ lark-cli task +update --task-id "<task_guid>" --data '{"description": "New descr
 
 1. Confirm with the user the tasks to update and the fields.
 2. Execute `lark-cli task +update --task-id "..." ...`
-3. Report the successful updates.
+3. Read `data.updated_fields` and `data.tasks[].confirmed` from the result and report only the fields confirmed by the server.
+4. Do not routinely call `task tasks get` after the update when `confirmed` already contains the required state. Query details only if a required field is absent or the user explicitly asks for a full verification.
 
 > [!CAUTION]
 > This is a **Write Operation** -- You must confirm the user's intent before executing.

--- a/tests/cli_e2e/task/task_id_handling_dryrun_test.go
+++ b/tests/cli_e2e/task/task_id_handling_dryrun_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestTaskIDHandlingDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "task_id_dryrun_test")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "task_id_dryrun_secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	run := func(t *testing.T, args []string) *clie2e.Result {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: args, DefaultAs: "bot"})
+		require.NoError(t, err)
+		return result
+	}
+
+	t.Run("GUID and applink produce equivalent update requests", func(t *testing.T) {
+		guidResult := run(t, []string{
+			"task", "+update", "--task-id", "task-guid-123", "--summary", "updated", "--dry-run",
+		})
+		guidResult.AssertExitCode(t, 0)
+		applinkResult := run(t, []string{
+			"task", "+update", "--task-id", "https://applink.larksuite.com/client/todo/task?guid=task-guid-123", "--summary", "updated", "--dry-run",
+		})
+		applinkResult.AssertExitCode(t, 0)
+
+		wantURL := "/open-apis/task/v2/tasks/task-guid-123"
+		require.Equal(t, wantURL, clie2e.DryRunGet(guidResult.Stdout, "api.0.url").String())
+		require.Equal(t, wantURL, clie2e.DryRunGet(applinkResult.Stdout, "api.0.url").String())
+		require.Equal(t, clie2e.DryRunGet(guidResult.Stdout, "api.0.body").Raw, clie2e.DryRunGet(applinkResult.Stdout, "api.0.body").Raw)
+	})
+
+	t.Run("GUID and applink produce equivalent completion requests", func(t *testing.T) {
+		guidResult := run(t, []string{
+			"task", "+complete", "--task-id", "task-guid-456", "--dry-run",
+		})
+		guidResult.AssertExitCode(t, 0)
+		applinkResult := run(t, []string{
+			"task", "+complete", "--task-id", "https://applink.larksuite.com/client/todo/task?guid=task-guid-456", "--dry-run",
+		})
+		applinkResult.AssertExitCode(t, 0)
+
+		wantURL := "/open-apis/task/v2/tasks/task-guid-456"
+		for _, result := range []*clie2e.Result{guidResult, applinkResult} {
+			require.Equal(t, int64(2), clie2e.DryRunGet(result.Stdout, "api.#").Int())
+			require.Equal(t, wantURL, clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+			require.Equal(t, wantURL, clie2e.DryRunGet(result.Stdout, "api.1.url").String())
+		}
+	})
+
+	for _, shortcut := range []string{"+update", "+complete"} {
+		t.Run(shortcut+" rejects display numbers", func(t *testing.T) {
+			args := []string{"task", shortcut, "--task-id", "t12345", "--dry-run"}
+			if shortcut == "+update" {
+				args = append(args, "--summary", "must not be written")
+			}
+			result := run(t, args)
+			result.AssertExitCode(t, 2)
+
+			require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), "stderr:\n%s", result.Stderr)
+			require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), "stderr:\n%s", result.Stderr)
+			require.Equal(t, "--task-id", gjson.Get(result.Stderr, "error.param").String(), "stderr:\n%s", result.Stderr)
+			require.Contains(t, gjson.Get(result.Stderr, "error.hint").String(), "guid=", "stderr:\n%s", result.Stderr)
+			require.False(t, gjson.Get(result.Stdout, "data.api").Exists(), "invalid input must not emit a dry-run API request\nstdout:\n%s", result.Stdout)
+		})
+	}
+}

--- a/tests/cli_e2e/task/task_id_handling_dryrun_test.go
+++ b/tests/cli_e2e/task/task_id_handling_dryrun_test.go
@@ -44,6 +44,24 @@ func TestTaskIDHandlingDryRun(t *testing.T) {
 		require.Equal(t, clie2e.DryRunGet(guidResult.Stdout, "api.0.body").Raw, clie2e.DryRunGet(applinkResult.Stdout, "api.0.body").Raw)
 	})
 
+	t.Run("multi-ID update previews every mutation", func(t *testing.T) {
+		result := run(t, []string{
+			"task", "+update",
+			"--task-id", "task-guid-1,https://applink.larksuite.com/client/todo/task?guid=task-guid-2",
+			"--summary", "updated",
+			"--dry-run",
+		})
+		result.AssertExitCode(t, 0)
+
+		require.Equal(t, int64(2), clie2e.DryRunGet(result.Stdout, "api.#").Int())
+		require.Equal(t, "PATCH", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+		require.Equal(t, "/open-apis/task/v2/tasks/task-guid-1", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+		require.Equal(t, "PATCH", clie2e.DryRunGet(result.Stdout, "api.1.method").String())
+		require.Equal(t, "/open-apis/task/v2/tasks/task-guid-2", clie2e.DryRunGet(result.Stdout, "api.1.url").String())
+		require.Equal(t, clie2e.DryRunGet(result.Stdout, "api.0.params").Raw, clie2e.DryRunGet(result.Stdout, "api.1.params").Raw)
+		require.Equal(t, clie2e.DryRunGet(result.Stdout, "api.0.body").Raw, clie2e.DryRunGet(result.Stdout, "api.1.body").Raw)
+	})
+
 	t.Run("GUID and applink produce equivalent completion requests", func(t *testing.T) {
 		guidResult := run(t, []string{
 			"task", "+complete", "--task-id", "task-guid-456", "--dry-run",

--- a/tests/cli_e2e/task/task_id_handling_workflow_test.go
+++ b/tests/cli_e2e/task/task_id_handling_workflow_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestTaskIDHandlingWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	originalSummary := "lark-cli-e2e-task-id-original-" + suffix
+	updatedSummary := "lark-cli-e2e-task-id-updated-" + suffix
+	taskGUID := createTask(t, parentT, ctx, clie2e.Request{
+		Args:      []string{"task", "+create"},
+		DefaultAs: "bot",
+		Data: map[string]any{
+			"summary":     originalSummary,
+			"description": "created by task ID handling workflow",
+		},
+	})
+	taskApplink := "https://applink.larksuite.com/client/todo/task?guid=" + url.QueryEscape(taskGUID)
+
+	t.Run("update accepts task applink", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"task", "+update", "--task-id", taskApplink, "--summary", updatedSummary},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+		assert.Equal(t, taskGUID, gjson.Get(result.Stdout, "data.tasks.0.guid").String(), "stdout:\n%s", result.Stdout)
+		assert.Equal(t, updatedSummary, gjson.Get(result.Stdout, "data.tasks.0.confirmed.summary").String(), "stdout:\n%s", result.Stdout)
+	})
+
+	t.Run("display number is rejected without modifying task", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"task", "+update", "--task-id", "t12345", "--summary", "must-not-be-written-" + suffix},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+		assert.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), "stderr:\n%s", result.Stderr)
+		assert.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), "stderr:\n%s", result.Stderr)
+		assert.Equal(t, "--task-id", gjson.Get(result.Stderr, "error.param").String(), "stderr:\n%s", result.Stderr)
+
+		getResult, getErr := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"task", "tasks", "get"},
+			DefaultAs: "bot",
+			Params:    map[string]any{"task_guid": taskGUID},
+		})
+		require.NoError(t, getErr)
+		getResult.AssertExitCode(t, 0)
+		getResult.AssertStdoutStatus(t, true)
+		assert.Equal(t, updatedSummary, gjson.Get(getResult.Stdout, "data.task.summary").String(), "stdout:\n%s", getResult.Stdout)
+	})
+}


### PR DESCRIPTION
## Summary

Improve the existing Task `+update` and `+complete` shortcuts without adding a new shortcut. The change distinguishes Task OpenAPI GUIDs from client display IDs, accepts Task applinks directly, and returns server-confirmed mutation state to reduce redundant follow-up reads.

## Changes

- Add strict Task ID parsing:
  - Accept opaque Task OpenAPI GUIDs.
  - Extract `guid` from Task applinks.
  - Reject client display IDs such as `t104121` with a typed `invalid_argument` error.
- Validate every ID in a batch update before issuing the first PATCH, preventing partial updates caused by an invalid later ID.
- Extend `+update` output with:
  - `updated_fields`
  - Per-task `confirmed` values taken only from the server response.
- Preserve the idempotent pre-read in `+complete` and extend its output with:
  - `status`
  - `completed_at`
  - `already_completed`
- Update the Task skill workflow:
  - Use a known tasklist GUID directly.
  - Search only when only a tasklist name or keyword is available.
  - Keep the native `task tasklists tasks` command instead of adding a new shortcut.
  - Avoid routine `tasks get` calls when mutation output already confirms the required state.
- Add unit and dry-run E2E coverage for GUID/applink equivalence, invalid display IDs, batch pre-validation, and server-confirmed output.

## Test Plan

- [x] `go test -race -count=1 ./shortcuts/task`
- [x] `go test ./tests/cli_e2e/task -run TestTaskIDHandlingDryRun -count=1`
- [x] `go vet ./shortcuts/task ./tests/cli_e2e/task`
- [x] Dry-run verification confirms GUID and applink inputs generate the same Task API request paths.
- [x] Invalid display IDs fail before emitting a mutation request.

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task commands now accept task applinks as `--task-id`, extracting the GUID from `guid=` when provided.
  * Task completion output now includes `status`, `completed_at`, and `already_completed`.
  * Task update output now reports `updated_fields` and per-task server-confirmed values.
* **Bug Fixes**
  * Invalid or display-style task IDs are rejected with typed validation guidance before any requests.
  * Multiple `--task-id` values are validated up front to prevent partial updates.
* **Documentation**
  * Updated task v2 guidance and examples to reflect applink-based `--task-id` and the expanded result fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->