### PR TITLE
fix(slides): normalize presentation flag aliases

### DIFF
--- a/shortcuts/slides/shortcuts.go
+++ b/shortcuts/slides/shortcuts.go
@@ -3,11 +3,24 @@
 
 package slides
 
-import "github.com/larksuite/cli/shortcuts/common"
+import (
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var presentationFlagAliases = []string{
+	"presentation-id",
+	"presentation-token",
+	"token",
+	"presentation_id",
+	"xml-presentation-id",
+	"url",
+}
 
 // Shortcuts returns all slides shortcuts.
 func Shortcuts() []common.Shortcut {
-	return []common.Shortcut{
+	all := []common.Shortcut{
 		SlidesCreate,
 		SlidesMediaUpload,
 		SlidesReplaceSlide,
@@ -17,5 +30,40 @@ func Shortcuts() []common.Shortcut {
 		SlidesHistoryList,
 		SlidesHistoryRevert,
 		SlidesHistoryRevertStatus,
+	}
+	for i := range all {
+		if hasPresentationFlag(all[i].Flags) {
+			all[i].PostMount = withPresentationFlagAliases(all[i].PostMount)
+		}
+	}
+	return all
+}
+
+func hasPresentationFlag(flags []common.Flag) bool {
+	for _, flag := range flags {
+		if flag.Name == "presentation" {
+			return true
+		}
+	}
+	return false
+}
+
+// withPresentationFlagAliases accepts common agent-generated spellings for
+// --presentation without registering extra flags. The aliases therefore stay
+// out of help and completion while resolving to the canonical flag at parse
+// time, matching the zero-round-trip compatibility used by Sheets.
+func withPresentationFlagAliases(prev func(cmd *cobra.Command)) func(cmd *cobra.Command) {
+	return func(cmd *cobra.Command) {
+		if prev != nil {
+			prev(cmd)
+		}
+		cmd.Flags().SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+			for _, alias := range presentationFlagAliases {
+				if name == alias {
+					return pflag.NormalizedName("presentation")
+				}
+			}
+			return pflag.NormalizedName(name)
+		})
 	}
 }

--- a/shortcuts/slides/shortcuts_alias_test.go
+++ b/shortcuts/slides/shortcuts_alias_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package slides
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestWithPresentationFlagAliases(t *testing.T) {
+	for _, alias := range presentationFlagAliases {
+		t.Run(alias, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().String("presentation", "", "presentation reference")
+			withPresentationFlagAliases(nil)(cmd)
+
+			if err := cmd.Flags().Parse([]string{"--" + alias, "presABC"}); err != nil {
+				t.Fatalf("--%s should resolve to --presentation: %v", alias, err)
+			}
+			got, err := cmd.Flags().GetString("presentation")
+			if err != nil {
+				t.Fatalf("read --presentation: %v", err)
+			}
+			if got != "presABC" {
+				t.Fatalf("--%s set --presentation to %q, want presABC", alias, got)
+			}
+			if usage := cmd.Flags().FlagUsages(); strings.Contains(usage, "--"+alias) {
+				t.Fatalf("hidden compatibility alias --%s leaked into help:\n%s", alias, usage)
+			}
+		})
+	}
+}
+
+func TestShortcutsAttachPresentationFlagAliases(t *testing.T) {
+	count := 0
+	for _, shortcut := range Shortcuts() {
+		if !hasPresentationFlag(shortcut.Flags) {
+			continue
+		}
+		count++
+		if shortcut.PostMount == nil {
+			t.Errorf("%s has --presentation but no compatibility normalizer", shortcut.Command)
+			continue
+		}
+
+		cmd := &cobra.Command{Use: shortcut.Command}
+		cmd.Flags().String("presentation", "", "presentation reference")
+		shortcut.PostMount(cmd)
+		if err := cmd.Flags().Parse([]string{"--token", "presABC"}); err != nil {
+			t.Errorf("%s did not normalize --token: %v", shortcut.Command, err)
+			continue
+		}
+		got, err := cmd.Flags().GetString("presentation")
+		if err != nil {
+			t.Errorf("%s could not read --presentation: %v", shortcut.Command, err)
+			continue
+		}
+		if got != "presABC" {
+			t.Errorf("%s normalized --token to %q, want presABC", shortcut.Command, got)
+		}
+	}
+	if count == 0 {
+		t.Fatal("expected at least one slides shortcut with --presentation")
+	}
+}

--- a/tests/cli_e2e/slides/slides_presentation_alias_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_presentation_alias_dryrun_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package slides
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestSlidesPresentationAliasesDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	aliases := []string{
+		"presentation-id",
+		"presentation-token",
+		"token",
+		"presentation_id",
+		"xml-presentation-id",
+		"url",
+	}
+	for _, alias := range aliases {
+		t.Run(alias, func(t *testing.T) {
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args: []string{
+					"slides", "+xml-get",
+					"--" + alias, "presAliasDryRun",
+					"--dry-run",
+				},
+				DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+
+			require.Equal(t, "GET", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
+			require.Equal(t,
+				"/open-apis/slides_ai/v1/xml_presentations/presAliasDryRun",
+				gjson.Get(result.Stdout, "data.api.0.url").String(),
+				result.Stdout,
+			)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Normalize common agent-generated presentation flag spellings to the canonical `--presentation` flag across Slides shortcuts. The compatibility aliases are parse-time only, so they stay out of help and completion while avoiding an error/retry round trip.

## Changes

- Normalize `--presentation-id`, `--presentation-token`, `--token`, `--presentation_id`, `--xml-presentation-id`, and `--url` to `--presentation` on every Slides shortcut that declares the canonical flag.
- Keep compatibility aliases implicit: no additional flags are registered or shown in `--help`.
- Add unit coverage for normalization, help visibility, and automatic attachment to all matching Slides shortcuts.
- Add dry-run E2E coverage that verifies every alias reaches the same `+xml-get` API request.

## Test Plan

- [x] Unit tests pass: `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 make unit-test`
- [x] Slides unit and E2E tests pass: `go test ./shortcuts/slides ./tests/cli_e2e/slides`
- [x] `go vet ./...`
- [x] `gofmt -l` produces no output for changed Go files
- [x] `go mod tidy` produces no changes
- [x] `golangci-lint` reports 0 issues
- [x] Manual local verification confirms aliases work while `lark-cli slides +xml-get --help` only exposes `--presentation`

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for presentation-related flag aliases, including token, ID, and URL variants.
  * Aliases now resolve to the standard presentation value without adding duplicate flags to command help.

* **Bug Fixes**
  * Slide commands using presentation aliases now correctly generate the intended presentation API request during dry runs.

* **Tests**
  * Added coverage for alias parsing and end-to-end slide command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->