### PR TITLE
feat(config): add --output json/yaml to strict-mode/default-as

### DIFF
--- a/cmd/config/default_as.go
+++ b/cmd/config/default_as.go
@@ -5,15 +5,25 @@ package config
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
+// DefaultAsView is the structured (json/yaml) representation of `config
+// default-as`'s view-mode output.
+type DefaultAsView struct {
+	DefaultAs string `json:"default_as" yaml:"default_as"`
+}
+
 // NewCmdConfigDefaultAs creates the "config default-as" subcommand.
 func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
+	var outputFormat string
+
 	cmd := &cobra.Command{
 		Use:   "default-as [user|bot|auto]",
 		Short: "View or set default identity type",
@@ -31,12 +41,25 @@ func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(args) == 0 {
+				format, ok := output.ParseViewFormat(outputFormat)
+				if !ok {
+					return errs.NewValidationError(errs.SubtypeInvalidArgument,
+						"invalid output format %q, valid values: text | json | yaml", outputFormat).WithParam("--output")
+				}
 				current := app.DefaultAs
 				if current == "" {
 					current = "auto"
 				}
-				fmt.Fprintf(f.IOStreams.Out, "default-as: %s\n", current)
+				output.RenderView(f.IOStreams.Out, format, DefaultAsView{DefaultAs: string(current)}, func(w io.Writer) error {
+					_, err := fmt.Fprintf(w, "default-as: %s\n", current)
+					return err
+				})
 				return nil
+			}
+
+			if outputFormat != "text" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument,
+					"--output only applies when viewing (no value argument)").WithParam("--output")
 			}
 
 			value := args[0]
@@ -52,6 +75,10 @@ func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&outputFormat, "output", "text", "output format for viewing: text|json|yaml")
+	cmdutil.RegisterFlagCompletion(cmd, "output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"text", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	cmdutil.SetRisk(cmd, "write")
 	return cmd
 }

--- a/cmd/config/default_as_test.go
+++ b/cmd/config/default_as_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+)
+
+func TestDefaultAs_Show_Default(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != "default-as: auto\n" {
+		t.Errorf("stdout = %q, want %q", stdout.String(), "default-as: auto\n")
+	}
+}
+
+func TestDefaultAs_Show_JSON(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (output: %s)", err, stdout.String())
+	}
+	if got["default_as"] != "auto" {
+		t.Errorf("default_as = %q, want %q", got["default_as"], "auto")
+	}
+}
+
+func TestDefaultAs_Show_YAML_AfterSet(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"user"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	f2, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd2 := NewCmdConfigDefaultAs(f2)
+	cmd2.SetArgs([]string{"--output", "yaml"})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]string
+	if err := yaml.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid YAML: %v (output: %s)", err, stdout.String())
+	}
+	if got["default_as"] != "user" {
+		t.Errorf("default_as = %q, want %q", got["default_as"], "user")
+	}
+}
+
+func TestDefaultAs_Show_InvalidOutputValue(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"--output", "xml"})
+	err := cmd.Execute()
+	var verr *errs.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if verr.Param != "--output" {
+		t.Errorf("Param = %q, want %q", verr.Param, "--output")
+	}
+}
+
+func TestDefaultAs_Set_RejectsNonTextOutput(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"user", "--output", "json"})
+	err := cmd.Execute()
+	var verr *errs.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if verr.Param != "--output" {
+		t.Errorf("Param = %q, want %q", verr.Param, "--output")
+	}
+
+	multi, _ := core.LoadMultiAppConfig()
+	app := multi.CurrentAppConfig("")
+	if app.DefaultAs != "" {
+		t.Errorf("expected DefaultAs to remain unset, got %q", app.DefaultAs)
+	}
+}
+
+func TestDefaultAs_Set_InvalidIdentity(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigDefaultAs(f)
+	cmd.SetArgs([]string{"xml"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid identity type 'xml'")
+	}
+}

--- a/cmd/config/strict_mode.go
+++ b/cmd/config/strict_mode.go
@@ -6,10 +6,12 @@ package config
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +19,7 @@ import (
 func NewCmdConfigStrictMode(f *cmdutil.Factory) *cobra.Command {
 	var global bool
 	var reset bool
+	var outputFormat string
 
 	cmd := &cobra.Command{
 		Use:   "strict-mode [bot|user|off]",
@@ -32,6 +35,7 @@ No args: show current mode. Switching does NOT require re-bind.
 For AI agents: this is a security policy. DO NOT switch without
 explicit user confirmation — never run on your own initiative.`,
 		Example: `  lark-cli config strict-mode               # show current
+  lark-cli config strict-mode --output json # show current as JSON
   lark-cli config strict-mode user          # switch (after user confirms)
   lark-cli config strict-mode bot --global  # set globally
   lark-cli config strict-mode --reset       # clear profile override`,
@@ -42,6 +46,12 @@ explicit user confirmation — never run on your own initiative.`,
 				return err
 			}
 
+			isView := !reset && len(args) == 0
+			if !isView && outputFormat != "text" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument,
+					"--output only applies when viewing (no value argument, no --reset)").WithParam("--output")
+			}
+
 			if reset {
 				app := multi.CurrentAppConfig(f.Invocation.Profile)
 				if app == nil {
@@ -50,11 +60,16 @@ explicit user confirmation — never run on your own initiative.`,
 				return resetStrictMode(f, multi, app, global, args)
 			}
 			if len(args) == 0 {
+				format, ok := output.ParseViewFormat(outputFormat)
+				if !ok {
+					return errs.NewValidationError(errs.SubtypeInvalidArgument,
+						"invalid output format %q, valid values: text | json | yaml", outputFormat).WithParam("--output")
+				}
 				app := multi.CurrentAppConfig(f.Invocation.Profile)
 				if app == nil {
 					return core.NoActiveProfileError()
 				}
-				return showStrictMode(cmd.Context(), f, multi, app)
+				return showStrictMode(cmd.Context(), f, multi, app, format)
 			}
 			app := multi.CurrentAppConfig(f.Invocation.Profile)
 			if !global && app == nil {
@@ -66,6 +81,10 @@ explicit user confirmation — never run on your own initiative.`,
 
 	cmd.Flags().BoolVar(&global, "global", false, "set at global level (applies to all profiles)")
 	cmd.Flags().BoolVar(&reset, "reset", false, "reset profile setting to inherit global")
+	cmd.Flags().StringVar(&outputFormat, "output", "text", "output format for viewing: text|json|yaml")
+	cmdutil.RegisterFlagCompletion(cmd, "output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"text", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	cmdutil.SetRisk(cmd, "write")
 
 	return cmd
@@ -86,16 +105,27 @@ func resetStrictMode(f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.A
 	return nil
 }
 
-func showStrictMode(ctx context.Context, f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.AppConfig) error {
+// StrictModeView is the structured (json/yaml) representation of `config
+// strict-mode`'s view-mode output.
+type StrictModeView struct {
+	Mode   string `json:"mode" yaml:"mode"`
+	Source string `json:"source" yaml:"source"`
+}
+
+func showStrictMode(ctx context.Context, f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.AppConfig, format output.ViewFormat) error {
 	// Runtime effective mode from credential provider chain is the source of truth.
 	runtime := f.ResolveStrictMode(ctx)
 	configMode, configSource := resolveStrictModeStatus(multi, app)
 
+	mode, source := configMode, configSource
 	if runtime != configMode {
-		fmt.Fprintf(f.IOStreams.Out, "strict-mode: %s (source: credential provider)\n", runtime)
-		return nil
+		mode, source = runtime, "credential provider"
 	}
-	fmt.Fprintf(f.IOStreams.Out, "strict-mode: %s (source: %s)\n", configMode, configSource)
+
+	output.RenderView(f.IOStreams.Out, format, StrictModeView{Mode: string(mode), Source: source}, func(w io.Writer) error {
+		_, err := fmt.Fprintf(w, "strict-mode: %s (source: %s)\n", mode, source)
+		return err
+	})
 	return nil
 }
 

--- a/cmd/config/strict_mode_test.go
+++ b/cmd/config/strict_mode_test.go
@@ -4,9 +4,14 @@
 package config
 
 import (
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 )
@@ -160,5 +165,108 @@ func TestStrictMode_InvalidValue(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error for invalid value 'on'")
+	}
+}
+
+func TestStrictMode_Show_JSON(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (output: %s)", err, stdout.String())
+	}
+	if got["mode"] != "off" {
+		t.Errorf("mode = %q, want %q", got["mode"], "off")
+	}
+	if got["source"] != "global (default)" {
+		t.Errorf("source = %q, want %q", got["source"], "global (default)")
+	}
+}
+
+func TestStrictMode_Show_YAML(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--output", "yaml"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]string
+	if err := yaml.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid YAML: %v (output: %s)", err, stdout.String())
+	}
+	if got["mode"] != "off" {
+		t.Errorf("mode = %q, want %q", got["mode"], "off")
+	}
+	if got["source"] != "global (default)" {
+		t.Errorf("source = %q, want %q", got["source"], "global (default)")
+	}
+}
+
+func TestStrictMode_Show_InvalidOutputValue(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--output", "xml"})
+	err := cmd.Execute()
+	var verr *errs.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if verr.Param != "--output" {
+		t.Errorf("Param = %q, want %q", verr.Param, "--output")
+	}
+}
+
+func TestStrictMode_Set_RejectsNonTextOutput(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"bot", "--output", "json"})
+	err := cmd.Execute()
+	var verr *errs.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if verr.Param != "--output" {
+		t.Errorf("Param = %q, want %q", verr.Param, "--output")
+	}
+
+	multi, _ := core.LoadMultiAppConfig()
+	app := multi.CurrentAppConfig("")
+	if app.StrictMode != nil {
+		t.Errorf("expected StrictMode to remain unset, got %v", *app.StrictMode)
+	}
+}
+
+func TestStrictMode_Reset_RejectsNonTextOutput(t *testing.T) {
+	setupStrictModeTestConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "secret"})
+	cmd := NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"bot"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = NewCmdConfigStrictMode(f)
+	cmd.SetArgs([]string{"--reset", "--output", "yaml"})
+	err := cmd.Execute()
+	var verr *errs.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if verr.Param != "--output" {
+		t.Errorf("Param = %q, want %q", verr.Param, "--output")
+	}
+
+	multi, _ := core.LoadMultiAppConfig()
+	app := multi.CurrentAppConfig("")
+	if app.StrictMode == nil || *app.StrictMode != core.StrictModeBot {
+		t.Errorf("expected StrictMode to remain %q, got %v", core.StrictModeBot, app.StrictMode)
 	}
 }

--- a/cmd/config/strict_mode_test.go
+++ b/cmd/config/strict_mode_test.go
@@ -6,7 +6,6 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -40,8 +39,8 @@ func TestStrictMode_Show_Default(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(stdout.String(), "off") {
-		t.Errorf("expected 'off' in output, got: %s", stdout.String())
+	if stdout.String() != "strict-mode: off (source: global (default))\n" {
+		t.Errorf("stdout = %q, want %q", stdout.String(), "strict-mode: off (source: global (default))\n")
 	}
 }
 

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ViewFormat is the output format for single-object "view" commands
+// (config strict-mode / default-as, ...). It is distinct from Format,
+// which targets paginated API-result lists (json/ndjson/table/csv) and
+// has no yaml variant.
+type ViewFormat int
+
+const (
+	ViewFormatText ViewFormat = iota
+	ViewFormatJSON
+	ViewFormatYAML
+)
+
+// String returns the string representation of a ViewFormat.
+func (f ViewFormat) String() string {
+	switch f {
+	case ViewFormatJSON:
+		return "json"
+	case ViewFormatYAML:
+		return "yaml"
+	default:
+		return "text"
+	}
+}
+
+// ParseViewFormat parses "text"/"json"/"yaml" (case-insensitive; "" -> text).
+// The second return value is false if the string was not recognized, in
+// which case ViewFormatText is returned as default.
+func ParseViewFormat(s string) (ViewFormat, bool) {
+	switch strings.ToLower(s) {
+	case "", "text":
+		return ViewFormatText, true
+	case "json":
+		return ViewFormatJSON, true
+	case "yaml":
+		return ViewFormatYAML, true
+	default:
+		return ViewFormatText, false
+	}
+}
+
+// RenderView writes data in the requested format. For ViewFormatText it
+// calls textFn — the caller's existing human-readable rendering, unchanged.
+// For JSON/YAML it marshals data directly. Marshal/write failures are
+// reported to stderr and never fail the command, mirroring FormatValue.
+func RenderView(w io.Writer, format ViewFormat, data interface{}, textFn func(io.Writer) error) {
+	var err error
+	switch format {
+	case ViewFormatJSON:
+		err = WriteJSON(w, data)
+	case ViewFormatYAML:
+		err = WriteYAML(w, data)
+	default:
+		err = textFn(w)
+	}
+	if isOutputMarshalError(err) {
+		legacyStderrf("%s marshal error: %v\n", format, err)
+	}
+}
+
+// WriteYAML writes data as YAML to w and returns marshal or write errors.
+func WriteYAML(w io.Writer, data interface{}) error {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(data); err != nil {
+		_ = enc.Close()
+		return &outputMarshalError{err: err}
+	}
+	if err := enc.Close(); err != nil {
+		return &outputMarshalError{err: err}
+	}
+	_, err := w.Write(buf.Bytes())
+	return err
+}

--- a/internal/output/view.go
+++ b/internal/output/view.go
@@ -5,6 +5,7 @@ package output
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 
@@ -71,17 +72,23 @@ func RenderView(w io.Writer, format ViewFormat, data interface{}, textFn func(io
 }
 
 // WriteYAML writes data as YAML to w and returns marshal or write errors.
-func WriteYAML(w io.Writer, data interface{}) error {
+func WriteYAML(w io.Writer, data interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = &outputMarshalError{err: fmt.Errorf("yaml marshal panic: %v", r)}
+		}
+	}()
+
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
-	if err := enc.Encode(data); err != nil {
+	if encErr := enc.Encode(data); encErr != nil {
 		_ = enc.Close()
-		return &outputMarshalError{err: err}
+		return &outputMarshalError{err: encErr}
 	}
-	if err := enc.Close(); err != nil {
-		return &outputMarshalError{err: err}
+	if closeErr := enc.Close(); closeErr != nil {
+		return &outputMarshalError{err: closeErr}
 	}
-	_, err := w.Write(buf.Bytes())
-	return err
+	_, writeErr := w.Write(buf.Bytes())
+	return writeErr
 }

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -117,3 +117,43 @@ func TestRenderView_Text(t *testing.T) {
 		t.Errorf("got %q", buf.String())
 	}
 }
+
+// testUnmarshalable is a struct with a func field, which yaml.v3 cannot marshal.
+type testUnmarshalable struct {
+	Name string
+	Fn   func()
+}
+
+func TestWriteYAML_UnmarshalableValue(t *testing.T) {
+	var buf bytes.Buffer
+	data := testUnmarshalable{Name: "test", Fn: func() {}}
+
+	err := WriteYAML(&buf, data)
+
+	if err == nil {
+		t.Fatalf("WriteYAML with unmarshalalble value should return an error, got nil")
+	}
+
+	if !isOutputMarshalError(err) {
+		t.Fatalf("error should be outputMarshalError, got: %T", err)
+	}
+
+	if errMsg := err.Error(); len(errMsg) == 0 {
+		t.Fatalf("error message should not be empty")
+	}
+}
+
+func TestRenderView_YAML_UnmarshalableValue(t *testing.T) {
+	// This test verifies that RenderView does not panic when given an
+	// unmarshalalble value with ViewFormatYAML. The test passes if it
+	// completes without panicking.
+	var buf bytes.Buffer
+	data := testUnmarshalable{Name: "test", Fn: func() {}}
+
+	// RenderView has no return value, so if it panics, the test will fail.
+	// If it returns normally, the test passes (marshal error is logged to stderr).
+	RenderView(&buf, ViewFormatYAML, data, func(io.Writer) error {
+		t.Fatal("textFn must not be called for ViewFormatYAML")
+		return nil
+	})
+}

--- a/internal/output/view_test.go
+++ b/internal/output/view_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestParseViewFormat(t *testing.T) {
+	tests := []struct {
+		input  string
+		want   ViewFormat
+		wantOK bool
+	}{
+		{"", ViewFormatText, true},
+		{"text", ViewFormatText, true},
+		{"TEXT", ViewFormatText, true},
+		{"Text", ViewFormatText, true},
+		{"json", ViewFormatJSON, true},
+		{"JSON", ViewFormatJSON, true},
+		{"yaml", ViewFormatYAML, true},
+		{"YAML", ViewFormatYAML, true},
+		{"xml", ViewFormatText, false},
+		{"foobar", ViewFormatText, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := ParseViewFormat(tt.input)
+			if got != tt.want {
+				t.Errorf("ParseViewFormat(%q) format = %v, want %v", tt.input, got, tt.want)
+			}
+			if ok != tt.wantOK {
+				t.Errorf("ParseViewFormat(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestViewFormatString(t *testing.T) {
+	tests := []struct {
+		format ViewFormat
+		want   string
+	}{
+		{ViewFormatText, "text"},
+		{ViewFormatJSON, "json"},
+		{ViewFormatYAML, "yaml"},
+		{ViewFormat(99), "text"}, // unknown falls back
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.format.String()
+			if got != tt.want {
+				t.Errorf("ViewFormat(%d).String() = %q, want %q", tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
+type testView struct {
+	Mode   string `json:"mode" yaml:"mode"`
+	Source string `json:"source" yaml:"source"`
+}
+
+func TestRenderView_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	RenderView(&buf, ViewFormatJSON, testView{Mode: "bot", Source: "global"}, func(io.Writer) error {
+		t.Fatal("textFn must not be called for ViewFormatJSON")
+		return nil
+	})
+
+	var got testView
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (output: %s)", err, buf.String())
+	}
+	if got.Mode != "bot" || got.Source != "global" {
+		t.Errorf("got %+v, want {bot global}", got)
+	}
+}
+
+func TestRenderView_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	RenderView(&buf, ViewFormatYAML, testView{Mode: "user", Source: `profile "default"`}, func(io.Writer) error {
+		t.Fatal("textFn must not be called for ViewFormatYAML")
+		return nil
+	})
+
+	var got testView
+	if err := yaml.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid YAML: %v (output: %s)", err, buf.String())
+	}
+	if got.Mode != "user" || got.Source != `profile "default"` {
+		t.Errorf("got %+v, want {user profile \"default\"}", got)
+	}
+}
+
+func TestRenderView_Text(t *testing.T) {
+	var buf bytes.Buffer
+	called := false
+	RenderView(&buf, ViewFormatText, testView{Mode: "off"}, func(w io.Writer) error {
+		called = true
+		_, err := w.Write([]byte("strict-mode: off (source: global (default))\n"))
+		return err
+	})
+
+	if !called {
+		t.Fatal("textFn was not called for ViewFormatText")
+	}
+	if buf.String() != "strict-mode: off (source: global (default))\n" {
+		t.Errorf("got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--output {text,json,yaml}` to the view mode of `config strict-mode` and `config default-as`, backed by a new shared `internal/output` formatter
- Default (`text`) output stays byte-identical; `json`/`yaml` expose structured fields for AI agents/scripts to consume directly

## Changes
- New `internal/output/view.go`: `ViewFormat`, `ParseViewFormat`, `RenderView`, `WriteYAML` (reuses existing `WriteJSON`/error helpers; recovers from yaml.v3 encode panics)
- `cmd/config/strict_mode.go`: view mode renders `StrictModeView{mode, source}`; set-mode/`--reset` reject a non-`text` `--output` with a typed validation error and no side effect
- `cmd/config/default_as.go`: view mode renders `DefaultAsView{default_as}`; same set-mode rejection semantics
- Shell completion registered for `--output` on both commands
- Out of scope (unchanged): `config show`, `config policy show`, `config plugins show` (already default to JSON)

## Test Plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] Unit tests: `internal/output`, `cmd/config` (new + existing, including byte-exact default-text regression)
- [x] E2E sandbox: 7/7 passing (backward-compat, JSON/YAML field exposure, mutex validation, `--help` docs)
- [x] Human-proxy acceptance review: 5/5 scenarios, including a binary-diff regression check against the pre-change build

## Related Issues
N/A (verbal requirement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON and YAML output options to `config default-as` and `config strict-mode`.
  * Added structured strict-mode details, including the active mode and its source.
  * Added shell completion for supported output formats: `text`, `json`, and `yaml`.

* **Bug Fixes**
  * Added validation preventing structured output formats when setting or resetting configuration values.
  * Improved handling of output-format and configuration validation errors.

* **Tests**
  * Expanded coverage for text, JSON, YAML, invalid formats, and invalid configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->