### PR TITLE
feat(qualitygate): enforce six-layer package dependency boundaries

### DIFF
--- a/.github/workflows/arch-audit.yml
+++ b/.github/workflows/arch-audit.yml
@@ -62,19 +62,6 @@ jobs:
           go list -m -u all 2>/dev/null | grep '\[' >> report.md || echo "All dependencies up to date" >> report.md
           echo '```' >> report.md
 
-      - name: Circular dependency check
-        run: |
-          echo "## Circular Dependencies" >> report.md
-          go list -f '{{.ImportPath}} {{join .Imports " "}}' ./... | \
-            go run golang.org/x/tools/cmd/digraph@v0.31.0 scc 2>&1 | tee cycles.txt
-          if [ -s cycles.txt ]; then
-            echo '```' >> report.md
-            cat cycles.txt >> report.md
-            echo '```' >> report.md
-          else
-            echo "No circular dependencies detected." >> report.md
-          fi
-
       - name: E2E coverage gaps
         run: |
           echo "## E2E Coverage Gaps" >> report.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,19 +120,7 @@ jobs:
           QUALITY_GATE_CHANGED_FROM: ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: echo "QUALITY_GATE_CHANGED_FROM=$(bash scripts/resolve-changed-from.sh)" >> "$GITHUB_ENV"
       - name: Enforce layering ratchet
-        run: |
-          ratchet_file=internal/qualitygate/deptest/layering-edges.txt
-          initial_count=39
-          if git cat-file -e "$QUALITY_GATE_CHANGED_FROM:$ratchet_file" 2>/dev/null; then
-            base_count=$(git show "$QUALITY_GATE_CHANGED_FROM:$ratchet_file" | grep -vcE '^\s*(#|$)' || true)
-          else
-            base_count=$initial_count
-          fi
-          current_count=$(grep -vcE '^\s*(#|$)' "$ratchet_file" || true)
-          if [ "$current_count" -gt "$base_count" ]; then
-            echo "::error::Layering ratchet grew from $base_count to $current_count effective rows. Fix the dependency instead of adding a row."
-            exit 1
-          fi
+        run: bash scripts/check-layering-ratchet.sh "$QUALITY_GATE_CHANGED_FROM"
       - name: Run golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev="$QUALITY_GATE_CHANGED_FROM"
       - name: Run source-contract lint guards (lintcheck)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,20 @@ jobs:
         env:
           QUALITY_GATE_CHANGED_FROM: ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: echo "QUALITY_GATE_CHANGED_FROM=$(bash scripts/resolve-changed-from.sh)" >> "$GITHUB_ENV"
+      - name: Enforce layering ratchet
+        run: |
+          ratchet_file=internal/qualitygate/deptest/layering-edges.txt
+          initial_count=39
+          if git cat-file -e "$QUALITY_GATE_CHANGED_FROM:$ratchet_file" 2>/dev/null; then
+            base_count=$(git show "$QUALITY_GATE_CHANGED_FROM:$ratchet_file" | grep -vcE '^\s*(#|$)' || true)
+          else
+            base_count=$initial_count
+          fi
+          current_count=$(grep -vcE '^\s*(#|$)' "$ratchet_file" || true)
+          if [ "$current_count" -gt "$base_count" ]; then
+            echo "::error::Layering ratchet grew from $base_count to $current_count effective rows. Fix the dependency instead of adding a row."
+            exit 1
+          fi
       - name: Run golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev="$QUALITY_GATE_CHANGED_FROM"
       - name: Run source-contract lint guards (lintcheck)

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ fmt-check:
 
 script-test:
 	bash scripts/resolve-changed-from.test.sh
+	bash scripts/check-layering-ratchet.test.sh
 	bash scripts/ci-workflow.test.sh
 	bash scripts/semantic-review-workflow.test.sh
 	$(NODE) --test scripts/e2e_domains.test.js scripts/fetch_e2e_tat.test.js scripts/install.test.js scripts/release-preflight.test.js scripts/semantic-review-verify-artifact.test.js scripts/pr-quality-summary.test.js scripts/semantic-review-publish.test.js scripts/ci-quality-summary-publish.test.js

--- a/internal/qualitygate/deptest/layering-edges.txt
+++ b/internal/qualitygate/deptest/layering-edges.txt
@@ -16,6 +16,8 @@ github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/i
 github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/vfs	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
 github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/vfs/localfileio	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
 github.com/larksuite/cli/extension/transport/sidecar	github.com/larksuite/cli/internal/envvars	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/events	github.com/larksuite/cli/shortcuts/im/convert_lib	arch-migration	events root aggregates the existing im conversion dependency	2026-07-24
+github.com/larksuite/cli/events	github.com/larksuite/cli/shortcuts/common	arch-migration	events root aggregates the existing im conversion dependency	2026-07-24
 github.com/larksuite/cli/events/im	github.com/larksuite/cli/shortcuts/im/convert_lib	arch-migration	events->shortcuts inversion via convert_lib	2026-07-24
 github.com/larksuite/cli/events/im	github.com/larksuite/cli/shortcuts/common	arch-migration	events->shortcuts inversion via convert_lib	2026-07-24
 github.com/larksuite/cli/shortcuts/im	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24

--- a/internal/qualitygate/deptest/layering-edges.txt
+++ b/internal/qualitygate/deptest/layering-edges.txt
@@ -1,0 +1,40 @@
+# from	denied	owner	reason	added_at
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/charcheck	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/core	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/envvars	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/i18n	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/keychain	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/validate	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/vfs	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/env	github.com/larksuite/cli/internal/vfs/localfileio	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/charcheck	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/core	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/envvars	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/i18n	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/keychain	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/validate	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/vfs	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/internal/vfs/localfileio	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/extension/transport/sidecar	github.com/larksuite/cli/internal/envvars	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
+github.com/larksuite/cli/events/im	github.com/larksuite/cli/shortcuts/im/convert_lib	arch-migration	events->shortcuts inversion via convert_lib	2026-07-24
+github.com/larksuite/cli/events/im	github.com/larksuite/cli/shortcuts/common	arch-migration	events->shortcuts inversion via convert_lib	2026-07-24
+github.com/larksuite/cli/events	github.com/larksuite/cli/shortcuts/common	arch-migration	events register aggregates events/im (transitive)	2026-07-24
+github.com/larksuite/cli/events	github.com/larksuite/cli/shortcuts/im/convert_lib	arch-migration	events register aggregates events/im (transitive)	2026-07-24
+github.com/larksuite/cli/shortcuts/im	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/mail	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/minutes	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/vc	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/apps	github.com/larksuite/cli/internal/keychain	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/drive	github.com/larksuite/cli/internal/credential	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/im	github.com/larksuite/cli/internal/credential	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/minutes	github.com/larksuite/cli/internal/credential	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/vc	github.com/larksuite/cli/internal/credential	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/apps	github.com/larksuite/cli/internal/client	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/drive	github.com/larksuite/cli/internal/client	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/im	github.com/larksuite/cli/internal/client	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/mail	github.com/larksuite/cli/internal/client	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/markdown	github.com/larksuite/cli/internal/client	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/task	github.com/larksuite/cli/internal/client	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/apps	github.com/larksuite/cli/internal/vfs	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/event	github.com/larksuite/cli/internal/vfs	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
+github.com/larksuite/cli/shortcuts/mail	github.com/larksuite/cli/internal/vfs	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24

--- a/internal/qualitygate/deptest/layering-edges.txt
+++ b/internal/qualitygate/deptest/layering-edges.txt
@@ -18,8 +18,6 @@ github.com/larksuite/cli/extension/credential/sidecar	github.com/larksuite/cli/i
 github.com/larksuite/cli/extension/transport/sidecar	github.com/larksuite/cli/internal/envvars	arch-migration	extension pre-module-split (via core/envvars)	2026-07-24
 github.com/larksuite/cli/events/im	github.com/larksuite/cli/shortcuts/im/convert_lib	arch-migration	events->shortcuts inversion via convert_lib	2026-07-24
 github.com/larksuite/cli/events/im	github.com/larksuite/cli/shortcuts/common	arch-migration	events->shortcuts inversion via convert_lib	2026-07-24
-github.com/larksuite/cli/events	github.com/larksuite/cli/shortcuts/common	arch-migration	events register aggregates events/im (transitive)	2026-07-24
-github.com/larksuite/cli/events	github.com/larksuite/cli/shortcuts/im/convert_lib	arch-migration	events register aggregates events/im (transitive)	2026-07-24
 github.com/larksuite/cli/shortcuts/im	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
 github.com/larksuite/cli/shortcuts/mail	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24
 github.com/larksuite/cli/shortcuts/minutes	github.com/larksuite/cli/internal/auth	arch-migration	shortcut bypasses RuntimeContext gate	2026-07-24

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -120,11 +121,22 @@ type goListTarget struct {
 type commandFactory func(name string, args ...string) *exec.Cmd
 
 type goReleaserConfig struct {
-	Builds []struct {
-		GOOS   []string       `yaml:"goos"`
-		GOARCH []string       `yaml:"goarch"`
-		Ignore []goListTarget `yaml:"ignore"`
-	} `yaml:"builds"`
+	Builds []goReleaserBuild `yaml:"builds"`
+}
+
+type goReleaserBuild struct {
+	Builder string           `yaml:"builder"`
+	GOOS    []string         `yaml:"goos"`
+	GOARCH  []string         `yaml:"goarch"`
+	Targets []string         `yaml:"targets"`
+	Ignore  []map[string]any `yaml:"ignore"`
+	Skip    bool             `yaml:"skip"`
+}
+
+type distTarget struct {
+	GOOS       string
+	GOARCH     string
+	FirstClass bool
 }
 
 var layeringBuildTargets = []goListTarget{
@@ -602,32 +614,27 @@ func TestLayeringBuildTargetsMatchGoReleaser(t *testing.T) {
 		t.Fatal(".goreleaser.yml has no builds")
 	}
 
-	output, err := exec.Command("go", "tool", "dist", "list").Output()
+	output, err := exec.Command("go", "tool", "dist", "list", "-json").Output()
 	if err != nil {
 		t.Fatalf("go tool dist list: %v", err)
 	}
-	supported := make(map[string]struct{})
-	for _, target := range strings.Fields(string(output)) {
-		supported[target] = struct{}{}
+	var distTargets []distTarget
+	if err := json.Unmarshal(output, &distTargets); err != nil {
+		t.Fatalf("parse go tool dist list: %v", err)
+	}
+	supported := make(map[string]distTarget, len(distTargets))
+	for _, target := range distTargets {
+		supported[target.GOOS+"/"+target.GOARCH] = target
 	}
 
 	want := make(map[string]struct{})
-	for _, build := range config.Builds {
-		ignored := make(map[string]struct{}, len(build.Ignore))
-		for _, target := range build.Ignore {
-			ignored[target.GOOS+"/"+target.GOARCH] = struct{}{}
+	for index, build := range config.Builds {
+		targets, err := goReleaserBuildTargets(build, supported)
+		if err != nil {
+			t.Fatalf(".goreleaser.yml build %d: %v", index, err)
 		}
-		for _, goos := range build.GOOS {
-			for _, goarch := range build.GOARCH {
-				target := goos + "/" + goarch
-				if _, ok := supported[target]; !ok {
-					continue
-				}
-				if _, ok := ignored[target]; ok {
-					continue
-				}
-				want[target] = struct{}{}
-			}
+		for target := range targets {
+			want[target] = struct{}{}
 		}
 	}
 
@@ -642,6 +649,246 @@ func TestLayeringBuildTargetsMatchGoReleaser(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("layering build targets = %v, want GoReleaser targets %v", sortedKeys(got), sortedKeys(want))
 	}
+}
+
+func TestReleaseGoVersionMatchesModule(t *testing.T) {
+	root := repoRoot(t)
+	moduleContent, err := vfs.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	releaseContent, err := vfs.ReadFile(filepath.Join(root, ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+
+	moduleVersion := findVersion(t, string(moduleContent), `(?m)^go\s+([0-9]+\.[0-9]+)(?:\.[0-9]+)?\s*$`, "go.mod")
+	releaseVersion := findVersion(
+		t,
+		string(releaseContent),
+		`(?m)^\s+go-version:\s*['"]?([0-9]+\.[0-9]+)(?:\.[0-9]+)?['"]?\s*$`,
+		"release workflow",
+	)
+	if releaseVersion != moduleVersion {
+		t.Fatalf("release Go version = %q, want module Go version %q", releaseVersion, moduleVersion)
+	}
+}
+
+func TestGoReleaserBuildTargets(t *testing.T) {
+	supported := map[string]distTarget{
+		"darwin/arm64":  {GOOS: "darwin", GOARCH: "arm64", FirstClass: true},
+		"freebsd/amd64": {GOOS: "freebsd", GOARCH: "amd64"},
+		"linux/amd64":   {GOOS: "linux", GOARCH: "amd64", FirstClass: true},
+		"windows/amd64": {GOOS: "windows", GOARCH: "amd64", FirstClass: true},
+		"windows/arm64": {GOOS: "windows", GOARCH: "arm64"},
+	}
+	tests := []struct {
+		name    string
+		build   goReleaserBuild
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "explicit targets override the matrix",
+			build: goReleaserBuild{
+				GOOS:    []string{"linux"},
+				GOARCH:  []string{"amd64"},
+				Targets: []string{"freebsd_amd64"},
+			},
+			want: []string{"freebsd/amd64"},
+		},
+		{
+			name: "target suffixes preserve the base platform",
+			build: goReleaserBuild{
+				Targets: []string{"linux_amd64_v1"},
+			},
+			want: []string{"linux/amd64"},
+		},
+		{
+			name: "first class selector expands from the toolchain",
+			build: goReleaserBuild{
+				Targets: []string{"go_first_class"},
+			},
+			want: []string{"darwin/arm64", "linux/amd64", "windows/amd64"},
+		},
+		{
+			name: "partial ignore matches every architecture",
+			build: goReleaserBuild{
+				GOOS:   []string{"windows"},
+				GOARCH: []string{"amd64", "arm64"},
+				Ignore: []map[string]any{{"goos": "windows"}},
+			},
+			want: []string{},
+		},
+		{
+			name: "skipped build has no targets",
+			build: goReleaserBuild{
+				Skip: true,
+			},
+			want: []string{},
+		},
+		{
+			name: "microarchitecture ignore fails closed",
+			build: goReleaserBuild{
+				GOOS:   []string{"linux"},
+				GOARCH: []string{"amd64"},
+				Ignore: []map[string]any{{"goamd64": "v1"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "fixed first class selector fails closed",
+			build: goReleaserBuild{
+				Targets: []string{"go_118_first_class"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-Go builder fails closed",
+			build: goReleaserBuild{
+				Builder: "rust",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := goReleaserBuildTargets(tt.build, supported)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("goReleaserBuildTargets returned no error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("goReleaserBuildTargets returned an error: %v", err)
+			}
+			if keys := sortedKeys(got); !slices.Equal(keys, tt.want) {
+				t.Fatalf("goReleaserBuildTargets = %v, want %v", keys, tt.want)
+			}
+		})
+	}
+}
+
+func goReleaserBuildTargets(
+	build goReleaserBuild,
+	supported map[string]distTarget,
+) (map[string]struct{}, error) {
+	if build.Skip {
+		return map[string]struct{}{}, nil
+	}
+	if build.Builder != "" && build.Builder != "go" {
+		return nil, fmt.Errorf("unsupported builder %q", build.Builder)
+	}
+	if len(build.Targets) > 0 {
+		return explicitGoReleaserTargets(build.Targets, supported)
+	}
+
+	gooses := build.GOOS
+	if len(gooses) == 0 {
+		gooses = []string{"darwin", "linux", "windows"}
+	}
+	goarches := build.GOARCH
+	if len(goarches) == 0 {
+		goarches = []string{"386", "amd64", "arm64"}
+	}
+
+	targets := make(map[string]struct{})
+	for _, goos := range gooses {
+		for _, goarch := range goarches {
+			target := goos + "/" + goarch
+			if _, ok := supported[target]; !ok {
+				continue
+			}
+			ignored, err := goReleaserTargetIgnored(goos, goarch, build.Ignore)
+			if err != nil {
+				return nil, err
+			}
+			if !ignored {
+				targets[target] = struct{}{}
+			}
+		}
+	}
+	return targets, nil
+}
+
+func explicitGoReleaserTargets(
+	configured []string,
+	supported map[string]distTarget,
+) (map[string]struct{}, error) {
+	targets := make(map[string]struct{})
+	for _, configuredTarget := range configured {
+		if configuredTarget == "go_first_class" {
+			for key, target := range supported {
+				if target.FirstClass {
+					targets[key] = struct{}{}
+				}
+			}
+			continue
+		}
+		if configuredTarget == "go_118_first_class" {
+			return nil, fmt.Errorf("unsupported target selector %q", configuredTarget)
+		}
+		if strings.Contains(configuredTarget, "{{") {
+			return nil, fmt.Errorf("templated target %q is unsupported", configuredTarget)
+		}
+
+		parts := strings.Split(configuredTarget, "_")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("malformed target %q", configuredTarget)
+		}
+		target := parts[0] + "/" + parts[1]
+		if _, ok := supported[target]; !ok {
+			return nil, fmt.Errorf("unsupported Go target %q", configuredTarget)
+		}
+		targets[target] = struct{}{}
+	}
+	return targets, nil
+}
+
+func goReleaserTargetIgnored(goos, goarch string, ignored []map[string]any) (bool, error) {
+	for _, entry := range ignored {
+		for key := range entry {
+			if key != "goos" && key != "goarch" {
+				return false, fmt.Errorf("unsupported ignore selector %q", key)
+			}
+		}
+		ignoredGOOS, err := optionalString(entry, "goos")
+		if err != nil {
+			return false, err
+		}
+		ignoredGOARCH, err := optionalString(entry, "goarch")
+		if err != nil {
+			return false, err
+		}
+		if (ignoredGOOS == "" || ignoredGOOS == goos) &&
+			(ignoredGOARCH == "" || ignoredGOARCH == goarch) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func optionalString(values map[string]any, key string) (string, error) {
+	value, ok := values[key]
+	if !ok {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("ignore selector %q must be a string", key)
+	}
+	return text, nil
+}
+
+func findVersion(t *testing.T, content, pattern, source string) string {
+	t.Helper()
+	match := regexp.MustCompile(pattern).FindStringSubmatch(content)
+	if len(match) != 2 {
+		t.Fatalf("find Go version in %s", source)
+	}
+	return match[1]
 }
 
 func TestDecodeAndMergeListedPackages(t *testing.T) {

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/larksuite/cli/internal/vfs"
+	"gopkg.in/yaml.v3"
 )
 
 const modulePath = "github.com/larksuite/cli"
@@ -112,11 +113,19 @@ type listedPackage struct {
 }
 
 type goListTarget struct {
-	GOOS   string
-	GOARCH string
+	GOOS   string `yaml:"goos"`
+	GOARCH string `yaml:"goarch"`
 }
 
 type commandFactory func(name string, args ...string) *exec.Cmd
+
+type goReleaserConfig struct {
+	Builds []struct {
+		GOOS   []string       `yaml:"goos"`
+		GOARCH []string       `yaml:"goarch"`
+		Ignore []goListTarget `yaml:"ignore"`
+	} `yaml:"builds"`
+}
 
 var layeringBuildTargets = []goListTarget{
 	{GOOS: "linux", GOARCH: "amd64"},
@@ -578,6 +587,63 @@ func TestLayeringBuildTargets(t *testing.T) {
 	}
 }
 
+func TestLayeringBuildTargetsMatchGoReleaser(t *testing.T) {
+	root := repoRoot(t)
+	content, err := vfs.ReadFile(filepath.Join(root, ".goreleaser.yml"))
+	if err != nil {
+		t.Fatalf("read .goreleaser.yml: %v", err)
+	}
+
+	var config goReleaserConfig
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		t.Fatalf("parse .goreleaser.yml: %v", err)
+	}
+	if len(config.Builds) == 0 {
+		t.Fatal(".goreleaser.yml has no builds")
+	}
+
+	output, err := exec.Command("go", "tool", "dist", "list").Output()
+	if err != nil {
+		t.Fatalf("go tool dist list: %v", err)
+	}
+	supported := make(map[string]struct{})
+	for _, target := range strings.Fields(string(output)) {
+		supported[target] = struct{}{}
+	}
+
+	want := make(map[string]struct{})
+	for _, build := range config.Builds {
+		ignored := make(map[string]struct{}, len(build.Ignore))
+		for _, target := range build.Ignore {
+			ignored[target.GOOS+"/"+target.GOARCH] = struct{}{}
+		}
+		for _, goos := range build.GOOS {
+			for _, goarch := range build.GOARCH {
+				target := goos + "/" + goarch
+				if _, ok := supported[target]; !ok {
+					continue
+				}
+				if _, ok := ignored[target]; ok {
+					continue
+				}
+				want[target] = struct{}{}
+			}
+		}
+	}
+
+	got := make(map[string]struct{}, len(layeringBuildTargets))
+	for _, target := range layeringBuildTargets {
+		key := target.GOOS + "/" + target.GOARCH
+		if _, duplicate := got[key]; duplicate {
+			t.Fatalf("layering build target %q is duplicated", key)
+		}
+		got[key] = struct{}{}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("layering build targets = %v, want GoReleaser targets %v", sortedKeys(got), sortedKeys(want))
+	}
+}
+
 func TestDecodeAndMergeListedPackages(t *testing.T) {
 	input := strings.NewReader(
 		`{"ImportPath":"example.com/a","Imports":["example.com/b"],"Deps":["example.com/c"]}` + "\n" +
@@ -727,6 +793,15 @@ func mergeStrings(left, right []string) []string {
 	}
 	sort.Strings(merged)
 	return merged
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func evaluateLayeringRule(packages []listedPackage, rule Rule) []layeringViolation {

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -44,6 +44,13 @@ type Rule struct {
 	Denied     []string
 	// ExceptFrom exempts import paths matched exactly.
 	ExceptFrom []string
+	// AllowedRepoDeps inverts the check. When set, every dependency inside this
+	// module that is not listed here (matched exactly) is a violation and Denied
+	// is unused. Dependencies outside the module - standard library and
+	// third-party packages - are never considered. Prefer this over Denied
+	// whenever the rule name promises a surface rather than a blocklist, so the
+	// guarantee cannot drift as the repository grows new top-level trees.
+	AllowedRepoDeps []string
 }
 
 // examplesPrefix is the plugin-SDK example tree. Each subdirectory is a
@@ -74,15 +81,19 @@ var rules = []Rule{
 		},
 	},
 	{
-		// Demos may consume the assembled CLI (cmd) and the public SDK
-		// (extension/platform); reaching past those into internals or
-		// business commands would teach plugin authors the wrong entry point.
+		// Demos exist to show the wrapper-main pattern, so the assembled CLI and
+		// the public plugin SDK are the only repository packages they may reach
+		// for. This is an allowlist rather than a few denied prefixes because
+		// extension-zero-internal exempts these packages from the transitive
+		// check: pinning the direct surface is the only thing that keeps the
+		// inherited chain bounded, and a blocklist would silently permit every
+		// tree nobody thought to deny (events, errs, cmd subpackages).
 		Name:       "examples-surface-only",
 		Mode:       Direct,
 		FromPrefix: examplesPrefix,
-		Denied: []string{
-			modulePath + "/internal",
-			modulePath + "/shortcuts",
+		AllowedRepoDeps: []string{
+			modulePath + "/cmd",
+			modulePath + "/extension/platform",
 		},
 	},
 	{
@@ -451,9 +462,9 @@ func TestLayeringRuleContracts(t *testing.T) {
 			Name:       "examples-surface-only",
 			Mode:       Direct,
 			FromPrefix: examplesPrefix,
-			Denied: []string{
-				modulePath + "/internal",
-				modulePath + "/shortcuts",
+			AllowedRepoDeps: []string{
+				modulePath + "/cmd",
+				modulePath + "/extension/platform",
 			},
 		},
 		{
@@ -550,14 +561,17 @@ func TestLayeringRuleContracts(t *testing.T) {
 			wantDenied: modulePath + "/internal/core",
 		},
 		{
-			// cmd is the demo's whole point and stays legal; reaching past it
-			// into internals does not.
+			// cmd and the plugin SDK are the demo's whole point and stay legal.
+			// Standard library and third-party imports are outside the rule,
+			// including a same-organisation module that is not this one.
 			name:     "examples-may-wrap-cmd-but-not-reach-internals",
 			ruleName: "examples-surface-only",
 			packages: []listedPackage{
 				{
 					ImportPath: examplesPrefix + "/audit-observer",
 					Imports: []string{
+						"context",
+						"github.com/larksuite/oapi-sdk-go/v3",
 						modulePath + "/cmd",
 						modulePath + "/extension/platform",
 						modulePath + "/internal/keychain",
@@ -566,6 +580,57 @@ func TestLayeringRuleContracts(t *testing.T) {
 			},
 			wantFrom:   examplesPrefix + "/audit-observer",
 			wantDenied: modulePath + "/internal/keychain",
+		},
+		{
+			// The allowlist covers trees nobody thought to deny; a blocklist of
+			// internal and shortcuts would have let this through.
+			name:     "examples-reject-other-repository-trees",
+			ruleName: "examples-surface-only",
+			packages: []listedPackage{
+				{
+					ImportPath: examplesPrefix + "/audit-observer",
+					Imports:    []string{modulePath + "/cmd", modulePath + "/events"},
+				},
+			},
+			wantFrom:   examplesPrefix + "/audit-observer",
+			wantDenied: modulePath + "/events",
+		},
+		{
+			// Only the assembly root is public surface, not its subpackages.
+			name:     "examples-reject-cmd-subpackages",
+			ruleName: "examples-surface-only",
+			packages: []listedPackage{
+				{
+					ImportPath: examplesPrefix + "/audit-observer",
+					Imports:    []string{modulePath + "/cmd", modulePath + "/cmd/api"},
+				},
+			},
+			wantFrom:   examplesPrefix + "/audit-observer",
+			wantDenied: modulePath + "/cmd/api",
+		},
+		{
+			name:     "examples-reject-other-extension-subtrees",
+			ruleName: "examples-surface-only",
+			packages: []listedPackage{
+				{
+					ImportPath: examplesPrefix + "/audit-observer",
+					Imports:    []string{modulePath + "/extension/fileio"},
+				},
+			},
+			wantFrom:   examplesPrefix + "/audit-observer",
+			wantDenied: modulePath + "/extension/fileio",
+		},
+		{
+			name:     "examples-reject-the-module-root",
+			ruleName: "examples-surface-only",
+			packages: []listedPackage{
+				{
+					ImportPath: examplesPrefix + "/audit-observer",
+					Imports:    []string{modulePath},
+				},
+			},
+			wantFrom:   examplesPrefix + "/audit-observer",
+			wantDenied: modulePath,
 		},
 		{
 			name:     "events-transitive-denial",
@@ -1482,7 +1547,7 @@ func evaluateLayeringRule(packages []listedPackage, rule Rule) []layeringViolati
 			dependencies = pkg.Deps
 		}
 		for _, dependency := range dependencies {
-			if !matchesAnyPackagePrefix(rule.Denied, dependency) {
+			if !ruleRejectsDependency(rule, dependency) {
 				continue
 			}
 			violations = append(violations, layeringViolation{
@@ -1501,6 +1566,24 @@ func evaluateLayeringRule(packages []listedPackage, rule Rule) []layeringViolati
 		return violations[i].Denied < violations[j].Denied
 	})
 	return violations
+}
+
+// ruleRejectsDependency reports whether dependency breaks rule, reading the
+// allowlist when the rule declares one and the denied prefixes otherwise.
+func ruleRejectsDependency(rule Rule, dependency string) bool {
+	if len(rule.AllowedRepoDeps) == 0 {
+		return matchesAnyPackagePrefix(rule.Denied, dependency)
+	}
+	if !isRepoPackage(dependency) {
+		return false
+	}
+	return !slices.Contains(rule.AllowedRepoDeps, dependency)
+}
+
+// isRepoPackage reports whether importPath belongs to this module rather than
+// the standard library or a third-party dependency.
+func isRepoPackage(importPath string) bool {
+	return importPath == modulePath || matchesPackagePrefix(modulePath+"/", importPath)
 }
 
 func matchesPackagePrefix(prefix, importPath string) bool {

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -138,15 +138,17 @@ type goReleaserBuild struct {
 	GORISCV64 []any            `yaml:"goriscv64"`
 	Tool      string           `yaml:"tool"`
 	GoBinary  string           `yaml:"gobinary"`
+	Tags      []string         `yaml:"tags"`
+	Flags     []string         `yaml:"flags"`
+	Env       []string         `yaml:"env"`
 	Targets   []string         `yaml:"targets"`
 	Ignore    []map[string]any `yaml:"ignore"`
 	Skip      bool             `yaml:"skip"`
 }
 
 type distTarget struct {
-	GOOS       string
-	GOARCH     string
-	FirstClass bool
+	GOOS   string
+	GOARCH string
 }
 
 var layeringBuildTargets = []goListTarget{
@@ -158,6 +160,8 @@ var layeringBuildTargets = []goListTarget{
 	{GOOS: "windows", GOARCH: "amd64"},
 	{GOOS: "windows", GOARCH: "arm64"},
 }
+
+var layeringBuildTags = []string{"", "authsidecar"}
 
 type layeringEdge struct {
 	From   string
@@ -609,6 +613,13 @@ func TestLayeringBuildTargets(t *testing.T) {
 	}
 }
 
+func TestLayeringBuildTags(t *testing.T) {
+	want := []string{"", "authsidecar"}
+	if !slices.Equal(layeringBuildTags, want) {
+		t.Fatalf("layering build tags = %q, want %q", layeringBuildTags, want)
+	}
+}
+
 func TestLayeringBuildTargetsMatchGoReleaser(t *testing.T) {
 	root := repoRoot(t)
 	content, err := vfs.ReadFile(filepath.Join(root, ".goreleaser.yml"))
@@ -686,10 +697,10 @@ func TestReleaseGoVersionMatchesModule(t *testing.T) {
 
 func TestGoReleaserBuildTargets(t *testing.T) {
 	supported := map[string]distTarget{
-		"darwin/arm64":  {GOOS: "darwin", GOARCH: "arm64", FirstClass: true},
+		"darwin/arm64":  {GOOS: "darwin", GOARCH: "arm64"},
 		"freebsd/amd64": {GOOS: "freebsd", GOARCH: "amd64"},
-		"linux/amd64":   {GOOS: "linux", GOARCH: "amd64", FirstClass: true},
-		"windows/amd64": {GOOS: "windows", GOARCH: "amd64", FirstClass: true},
+		"linux/amd64":   {GOOS: "linux", GOARCH: "amd64"},
+		"windows/amd64": {GOOS: "windows", GOARCH: "amd64"},
 		"windows/arm64": {GOOS: "windows", GOARCH: "arm64"},
 	}
 	tests := []struct {
@@ -715,11 +726,11 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "first class selector expands from the toolchain",
+			name: "first class selector fails closed",
 			build: goReleaserBuild{
 				Targets: []string{"go_first_class"},
 			},
-			want: []string{"darwin/arm64", "linux/amd64", "windows/amd64"},
+			wantErr: true,
 		},
 		{
 			name: "partial ignore matches every architecture",
@@ -736,6 +747,14 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 				Skip: true,
 			},
 			want: []string{},
+		},
+		{
+			name: "arm target fails closed",
+			build: goReleaserBuild{
+				GOOS:   []string{"linux"},
+				GOARCH: []string{"arm"},
+			},
+			wantErr: true,
 		},
 		{
 			name: "microarchitecture matrix fails closed",
@@ -783,6 +802,34 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "release build tags fail closed",
+			build: goReleaserBuild{
+				Tags: []string{"feature"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "build flag tags fail closed",
+			build: goReleaserBuild{
+				Flags: []string{"-tags=feature"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "environment build tags fail closed",
+			build: goReleaserBuild{
+				Env: []string{"GOFLAGS=-tags=feature"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "enabled cgo fails closed",
+			build: goReleaserBuild{
+				Env: []string{"CGO_ENABLED=1"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -817,6 +864,12 @@ func goReleaserBuildTargets(
 	if build.Tool != "" || build.GoBinary != "" {
 		return nil, fmt.Errorf("custom Go tools are unsupported")
 	}
+	if len(build.Tags) > 0 || buildFlagsSetTags(build.Flags) {
+		return nil, fmt.Errorf("release build tags are unsupported")
+	}
+	if err := validateGoReleaserBuildEnv(build.Env); err != nil {
+		return nil, err
+	}
 	if buildHasMicroarchitectureMatrix(build) {
 		return nil, fmt.Errorf("microarchitecture matrices are unsupported")
 	}
@@ -836,6 +889,9 @@ func goReleaserBuildTargets(
 	targets := make(map[string]struct{})
 	for _, goos := range gooses {
 		for _, goarch := range goarches {
+			if goarch == "arm" {
+				return nil, fmt.Errorf("GOARCH=arm requires explicit GOARM support")
+			}
 			target := goos + "/" + goarch
 			if _, ok := supported[target]; !ok {
 				continue
@@ -858,15 +914,7 @@ func explicitGoReleaserTargets(
 ) (map[string]struct{}, error) {
 	targets := make(map[string]struct{})
 	for _, configuredTarget := range configured {
-		if configuredTarget == "go_first_class" {
-			for key, target := range supported {
-				if target.FirstClass {
-					targets[key] = struct{}{}
-				}
-			}
-			continue
-		}
-		if configuredTarget == "go_118_first_class" {
+		if configuredTarget == "go_first_class" || configuredTarget == "go_118_first_class" {
 			return nil, fmt.Errorf("unsupported target selector %q", configuredTarget)
 		}
 		if strings.Contains(configuredTarget, "{{") {
@@ -877,6 +925,9 @@ func explicitGoReleaserTargets(
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("malformed target %q", configuredTarget)
 		}
+		if parts[1] == "arm" {
+			return nil, fmt.Errorf("target %q requires explicit GOARM support", configuredTarget)
+		}
 		target := parts[0] + "/" + parts[1]
 		if _, ok := supported[target]; !ok {
 			return nil, fmt.Errorf("unsupported Go target %q", configuredTarget)
@@ -884,6 +935,38 @@ func explicitGoReleaserTargets(
 		targets[target] = struct{}{}
 	}
 	return targets, nil
+}
+
+func buildFlagsSetTags(flags []string) bool {
+	for _, flag := range flags {
+		if flag == "-tags" || strings.HasPrefix(flag, "-tags=") {
+			return true
+		}
+	}
+	return false
+}
+
+func validateGoReleaserBuildEnv(env []string) error {
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		switch name {
+		case "CGO_ENABLED":
+			if value != "0" {
+				return fmt.Errorf("CGO_ENABLED=%s is unsupported", value)
+			}
+		case "GOFLAGS":
+			if strings.Contains(value, "-tags") {
+				return fmt.Errorf("GOFLAGS build tags are unsupported")
+			}
+		case "GOEXPERIMENT", "GOOS", "GOARCH", "GOARM", "GOAMD64", "GOARM64",
+			"GOMIPS", "GOMIPS64", "GO386", "GOPPC64", "GORISCV64":
+			return fmt.Errorf("build environment variable %q is unsupported", name)
+		}
+	}
+	return nil
 }
 
 func buildHasMicroarchitectureMatrix(build goReleaserBuild) bool {
@@ -963,7 +1046,7 @@ func TestDecodeAndMergeListedPackages(t *testing.T) {
 
 func TestGoListPackagesSeparatesStderr(t *testing.T) {
 	target := goListTarget{GOOS: "linux", GOARCH: "amd64"}
-	packages, stderr, err := loadPackagesForTarget("", target, func(_ string, _ ...string) *exec.Cmd {
+	packages, stderr, err := loadPackagesForTarget("", target, "authsidecar", func(_ string, _ ...string) *exec.Cmd {
 		cmd := exec.Command(os.Args[0], "-test.run=^TestGoListCommandHelperProcess$")
 		cmd.Env = append(os.Environ(), "GO_LIST_COMMAND_HELPER=1")
 		return cmd
@@ -992,12 +1075,14 @@ func goListPackageGraph(t *testing.T, root string) []listedPackage {
 	t.Helper()
 	packagesByPath := make(map[string]listedPackage)
 	for _, target := range layeringBuildTargets {
-		for _, pkg := range goListPackages(t, root, target) {
-			merged := packagesByPath[pkg.ImportPath]
-			merged.ImportPath = pkg.ImportPath
-			merged.Imports = mergeStrings(merged.Imports, pkg.Imports)
-			merged.Deps = mergeStrings(merged.Deps, pkg.Deps)
-			packagesByPath[pkg.ImportPath] = merged
+		for _, tags := range layeringBuildTags {
+			for _, pkg := range goListPackages(t, root, target, tags) {
+				merged := packagesByPath[pkg.ImportPath]
+				merged.ImportPath = pkg.ImportPath
+				merged.Imports = mergeStrings(merged.Imports, pkg.Imports)
+				merged.Deps = mergeStrings(merged.Deps, pkg.Deps)
+				packagesByPath[pkg.ImportPath] = merged
+			}
 		}
 	}
 
@@ -1011,14 +1096,15 @@ func goListPackageGraph(t *testing.T, root string) []listedPackage {
 	return packages
 }
 
-func goListPackages(t *testing.T, root string, target goListTarget) []listedPackage {
+func goListPackages(t *testing.T, root string, target goListTarget, tags string) []listedPackage {
 	t.Helper()
-	packages, stderr, err := loadPackagesForTarget(root, target, exec.Command)
+	packages, stderr, err := loadPackagesForTarget(root, target, tags, exec.Command)
 	if err != nil {
 		t.Fatalf(
-			"GOOS=%s GOARCH=%s go list -json -tags authsidecar ./... failed: %v\n%s",
+			"GOOS=%s GOARCH=%s tags=%q go list -json ./... failed: %v\n%s",
 			target.GOOS,
 			target.GOARCH,
+			tags,
 			err,
 			stderr,
 		)
@@ -1029,9 +1115,14 @@ func goListPackages(t *testing.T, root string, target goListTarget) []listedPack
 func loadPackagesForTarget(
 	root string,
 	target goListTarget,
+	tags string,
 	newCommand commandFactory,
 ) ([]listedPackage, string, error) {
-	args := []string{"list", "-json", "-tags", "authsidecar", "./..."}
+	args := []string{"list", "-json"}
+	if tags != "" {
+		args = append(args, "-tags", tags)
+	}
+	args = append(args, "./...")
 	cmd := newCommand("go", args...)
 	cmd.Dir = root
 	env := cmd.Env

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -116,10 +116,16 @@ type goListTarget struct {
 	GOARCH string
 }
 
+type commandFactory func(name string, args ...string) *exec.Cmd
+
 var layeringBuildTargets = []goListTarget{
 	{GOOS: "linux", GOARCH: "amd64"},
+	{GOOS: "linux", GOARCH: "arm64"},
+	{GOOS: "linux", GOARCH: "riscv64"},
 	{GOOS: "darwin", GOARCH: "amd64"},
+	{GOOS: "darwin", GOARCH: "arm64"},
 	{GOOS: "windows", GOARCH: "amd64"},
+	{GOOS: "windows", GOARCH: "arm64"},
 }
 
 type layeringEdge struct {
@@ -560,8 +566,12 @@ func TestLayeringRuleContracts(t *testing.T) {
 func TestLayeringBuildTargets(t *testing.T) {
 	want := []goListTarget{
 		{GOOS: "linux", GOARCH: "amd64"},
+		{GOOS: "linux", GOARCH: "arm64"},
+		{GOOS: "linux", GOARCH: "riscv64"},
 		{GOOS: "darwin", GOARCH: "amd64"},
+		{GOOS: "darwin", GOARCH: "arm64"},
 		{GOOS: "windows", GOARCH: "amd64"},
+		{GOOS: "windows", GOARCH: "arm64"},
 	}
 	if !reflect.DeepEqual(layeringBuildTargets, want) {
 		t.Fatalf("layering build targets = %#v, want %#v", layeringBuildTargets, want)
@@ -586,6 +596,33 @@ func TestDecodeAndMergeListedPackages(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Fatalf("mergeStrings returned %q, want %q", got, want)
 	}
+}
+
+func TestGoListPackagesSeparatesStderr(t *testing.T) {
+	target := goListTarget{GOOS: "linux", GOARCH: "amd64"}
+	packages, stderr, err := loadPackagesForTarget("", target, func(_ string, _ ...string) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestGoListCommandHelperProcess$")
+		cmd.Env = append(os.Environ(), "GO_LIST_COMMAND_HELPER=1")
+		return cmd
+	})
+	if err != nil {
+		t.Fatalf("loadPackagesForTarget returned an error: %v", err)
+	}
+	if stderr != "go: downloading example.com/module\n" {
+		t.Fatalf("loadPackagesForTarget stderr = %q, want module download diagnostic", stderr)
+	}
+	if len(packages) != 1 || packages[0].ImportPath != "example.com/package" {
+		t.Fatalf("loadPackagesForTarget returned unexpected packages: %+v", packages)
+	}
+}
+
+func TestGoListCommandHelperProcess(t *testing.T) {
+	if os.Getenv("GO_LIST_COMMAND_HELPER") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stdout, `{"ImportPath":"example.com/package","Imports":[],"Deps":[]}`)
+	fmt.Fprintln(os.Stderr, "go: downloading example.com/module")
+	os.Exit(0)
 }
 
 func goListPackageGraph(t *testing.T, root string) []listedPackage {
@@ -613,32 +650,51 @@ func goListPackageGraph(t *testing.T, root string) []listedPackage {
 
 func goListPackages(t *testing.T, root string, target goListTarget) []listedPackage {
 	t.Helper()
+	packages, stderr, err := loadPackagesForTarget(root, target, exec.Command)
+	if err != nil {
+		t.Fatalf(
+			"GOOS=%s GOARCH=%s go list -json -tags authsidecar ./... failed: %v\n%s",
+			target.GOOS,
+			target.GOARCH,
+			err,
+			stderr,
+		)
+	}
+	return packages
+}
+
+func loadPackagesForTarget(
+	root string,
+	target goListTarget,
+	newCommand commandFactory,
+) ([]listedPackage, string, error) {
 	args := []string{"list", "-json", "-tags", "authsidecar", "./..."}
-	cmd := exec.Command("go", args...)
+	cmd := newCommand("go", args...)
 	cmd.Dir = root
+	env := cmd.Env
+	if env == nil {
+		env = os.Environ()
+	}
 	cmd.Env = append(
-		os.Environ(),
+		env,
 		"GOOS="+target.GOOS,
 		"GOARCH="+target.GOARCH,
 		"CGO_ENABLED=0",
 	)
-	out, err := cmd.CombinedOutput()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
 	if err != nil {
-		t.Fatalf(
-			"GOOS=%s GOARCH=%s go %s failed: %v\n%s",
-			target.GOOS,
-			target.GOARCH,
-			strings.Join(args, " "),
-			err,
-			out,
-		)
+		return nil, stderr.String(), err
 	}
 
-	packages, err := decodeListedPackages(bytes.NewReader(out))
+	packages, err := decodeListedPackages(&stdout)
 	if err != nil {
-		t.Fatalf("decode GOOS=%s GOARCH=%s go list output: %v", target.GOOS, target.GOARCH, err)
+		return nil, stderr.String(), fmt.Errorf("decode go list output: %w", err)
 	}
-	return packages
+	return packages, stderr.String(), nil
 }
 
 func decodeListedPackages(r io.Reader) ([]listedPackage, error) {

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -1,0 +1,508 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package deptest
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+const modulePath = "github.com/larksuite/cli"
+
+// Mode selects whether a rule checks direct or transitive dependencies.
+type Mode int
+
+const (
+	// Direct checks package imports.
+	Direct Mode = iota
+	// Transitive checks the complete dependency set.
+	Transitive
+)
+
+// Rule defines one package-layer dependency restriction.
+type Rule struct {
+	Name       string
+	Mode       Mode
+	FromPrefix string
+	Denied     []string
+	ExceptFrom []string
+	SkipFrom   []string
+}
+
+var rules = []Rule{
+	{
+		Name:       "extension-zero-internal",
+		Mode:       Transitive,
+		FromPrefix: modulePath + "/extension",
+		Denied:     []string{modulePath + "/internal/"},
+		SkipFrom:   []string{"/examples/"},
+	},
+	{
+		Name:       "events-no-shortcuts",
+		Mode:       Transitive,
+		FromPrefix: modulePath + "/events",
+		Denied:     []string{modulePath + "/shortcuts/"},
+	},
+	{
+		Name:       "shortcuts-runtime-gate",
+		Mode:       Direct,
+		FromPrefix: modulePath + "/shortcuts",
+		Denied: []string{
+			modulePath + "/internal/auth",
+			modulePath + "/internal/keychain",
+			modulePath + "/internal/credential",
+			modulePath + "/internal/client",
+			modulePath + "/internal/vfs",
+		},
+		ExceptFrom: []string{
+			modulePath + "/shortcuts/common",
+			modulePath + "/shortcuts/apps/gitcred",
+		},
+	},
+	{
+		Name:       "cmd-assembly-only",
+		Mode:       Direct,
+		FromPrefix: modulePath + "/cmd",
+		Denied:     []string{modulePath + "/shortcuts"},
+		ExceptFrom: []string{
+			modulePath + "/cmd",
+			modulePath + "/cmd/auth",
+		},
+	},
+	{
+		Name:       "errs-leaf",
+		Mode:       Direct,
+		FromPrefix: modulePath + "/errs",
+		Denied:     []string{modulePath + "/"},
+	},
+	{
+		Name:       "internal-no-upper",
+		Mode:       Direct,
+		FromPrefix: modulePath + "/internal",
+		Denied: []string{
+			modulePath + "/cmd",
+			modulePath + "/shortcuts",
+			modulePath + "/events",
+		},
+		ExceptFrom: []string{
+			modulePath + "/internal/qualitygate/cmd/manifest-export",
+		},
+	},
+}
+
+type listedPackage struct {
+	ImportPath string
+	Imports    []string
+	Deps       []string
+}
+
+type layeringEdge struct {
+	From   string
+	Denied string
+}
+
+type layeringViolation struct {
+	layeringEdge
+	Rule string
+}
+
+type seededLayeringEdge struct {
+	layeringEdge
+	Owner   string
+	Reason  string
+	AddedAt time.Time
+	Line    int
+}
+
+func TestPackageLayering(t *testing.T) {
+	root := repoRoot(t)
+	packages := goListPackageGraph(t, root)
+	seeded := readLayeringEdges(t, filepath.Join(root, "internal/qualitygate/deptest/layering-edges.txt"))
+	seededByEdge := indexSeededLayeringEdges(t, seeded)
+
+	actualByRule := make(map[string][]layeringViolation, len(rules))
+	actualEdges := make(map[layeringEdge]struct{})
+	for _, rule := range rules {
+		violations := evaluateLayeringRule(packages, rule)
+		actualByRule[rule.Name] = violations
+		for _, violation := range violations {
+			actualEdges[violation.layeringEdge] = struct{}{}
+		}
+	}
+
+	for _, rule := range rules {
+		t.Run(rule.Name, func(t *testing.T) {
+			for _, violation := range actualByRule[rule.Name] {
+				if _, ok := seededByEdge[violation.layeringEdge]; ok {
+					continue
+				}
+				t.Errorf(
+					"new layering violation: from=%s denied=%s rule=%s; use the approved dependency gate or fix the dependency; do not add rows to layering-edges.txt",
+					violation.From,
+					violation.Denied,
+					violation.Rule,
+				)
+			}
+		})
+	}
+
+	t.Run("stale-layering-edges", func(t *testing.T) {
+		for _, edge := range seeded {
+			if _, ok := actualEdges[edge.layeringEdge]; ok {
+				continue
+			}
+			t.Errorf(
+				"stale layering edge: from=%s denied=%s line=%d; this violation has been removed; delete this row from layering-edges.txt",
+				edge.From,
+				edge.Denied,
+				edge.Line,
+			)
+		}
+	})
+}
+
+func TestParseLayeringEdges(t *testing.T) {
+	t.Run("valid-rows", func(t *testing.T) {
+		input := strings.NewReader(
+			"# from\tdenied\towner\treason\tadded_at\n" +
+				"\n" +
+				"example.com/from\texample.com/denied\towner\tlegacy dependency\t2026-07-24\r\n",
+		)
+		edges, err := parseLayeringEdges(input)
+		if err != nil {
+			t.Fatalf("parseLayeringEdges returned an error: %v", err)
+		}
+		if len(edges) != 1 {
+			t.Fatalf("parseLayeringEdges returned %d rows, want 1", len(edges))
+		}
+		edge := edges[0]
+		if edge.From != "example.com/from" || edge.Denied != "example.com/denied" {
+			t.Fatalf("parseLayeringEdges returned unexpected edge: %+v", edge)
+		}
+		if edge.Owner != "owner" || edge.Reason != "legacy dependency" {
+			t.Fatalf("parseLayeringEdges returned unexpected metadata: %+v", edge)
+		}
+		if got := edge.AddedAt.Format(time.DateOnly); got != "2026-07-24" {
+			t.Fatalf("parseLayeringEdges returned added_at %q, want 2026-07-24", got)
+		}
+		if edge.Line != 3 {
+			t.Fatalf("parseLayeringEdges returned line %d, want 3", edge.Line)
+		}
+	})
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "wrong-field-count",
+			input: "from\tdenied\towner\treason\n",
+		},
+		{
+			name:  "blank-field",
+			input: "from\tdenied\t\treason\t2026-07-24\n",
+		},
+		{
+			name:  "invalid-date",
+			input: "from\tdenied\towner\treason\t2026-02-30\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseLayeringEdges(strings.NewReader(tt.input))
+			if err == nil {
+				t.Fatal("parseLayeringEdges returned nil error for a malformed row")
+			}
+			if !strings.Contains(err.Error(), "line 1") {
+				t.Fatalf("parseLayeringEdges error %q does not identify line 1", err)
+			}
+		})
+	}
+}
+
+func TestMatchesPackagePrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		prefix     string
+		importPath string
+		want       bool
+	}{
+		{
+			name:       "exact-package",
+			prefix:     modulePath + "/errs",
+			importPath: modulePath + "/errs",
+			want:       true,
+		},
+		{
+			name:       "child-package",
+			prefix:     modulePath + "/internal/vfs",
+			importPath: modulePath + "/internal/vfs/localfileio",
+			want:       true,
+		},
+		{
+			name:       "trailing-slash-prefix",
+			prefix:     modulePath + "/internal/",
+			importPath: modulePath + "/internal/vfs",
+			want:       true,
+		},
+		{
+			name:       "adjacent-package-name",
+			prefix:     modulePath + "/errs",
+			importPath: modulePath + "/errclass",
+			want:       false,
+		},
+		{
+			name:       "unrelated-package",
+			prefix:     modulePath + "/events/",
+			importPath: modulePath + "/shortcuts/im",
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesPackagePrefix(tt.prefix, tt.importPath); got != tt.want {
+				t.Fatalf(
+					"matchesPackagePrefix(%q, %q) = %t, want %t",
+					tt.prefix,
+					tt.importPath,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestEvaluateLayeringRuleUsesExactExceptions(t *testing.T) {
+	rule := Rule{
+		Name:       "exact-exception",
+		Mode:       Direct,
+		FromPrefix: modulePath + "/cmd",
+		Denied:     []string{modulePath + "/shortcuts"},
+		ExceptFrom: []string{modulePath + "/cmd"},
+	}
+	packages := []listedPackage{
+		{
+			ImportPath: modulePath + "/cmd",
+			Imports:    []string{modulePath + "/shortcuts"},
+		},
+		{
+			ImportPath: modulePath + "/cmd/service",
+			Imports:    []string{modulePath + "/shortcuts"},
+		},
+	}
+
+	violations := evaluateLayeringRule(packages, rule)
+	if len(violations) != 1 {
+		t.Fatalf("evaluateLayeringRule returned %d violations, want 1", len(violations))
+	}
+	if got := violations[0].From; got != modulePath+"/cmd/service" {
+		t.Fatalf("evaluateLayeringRule returned source %q, want %q", got, modulePath+"/cmd/service")
+	}
+}
+
+func goListPackageGraph(t *testing.T, root string) []listedPackage {
+	t.Helper()
+	args := []string{"list", "-json", "-tags", "authsidecar", "./..."}
+	cmd := exec.Command("go", args...)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(out))
+	var packages []listedPackage
+	for {
+		var pkg listedPackage
+		err := decoder.Decode(&pkg)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode go list output: %v", err)
+		}
+		packages = append(packages, pkg)
+	}
+	return packages
+}
+
+func evaluateLayeringRule(packages []listedPackage, rule Rule) []layeringViolation {
+	var violations []layeringViolation
+	for _, pkg := range packages {
+		if !matchesPackagePrefix(rule.FromPrefix, pkg.ImportPath) {
+			continue
+		}
+		if slices.Contains(rule.ExceptFrom, pkg.ImportPath) {
+			continue
+		}
+		if containsAny(pkg.ImportPath, rule.SkipFrom) {
+			continue
+		}
+
+		dependencies := pkg.Imports
+		if rule.Mode == Transitive {
+			dependencies = pkg.Deps
+		}
+		for _, dependency := range dependencies {
+			if !matchesAnyPackagePrefix(rule.Denied, dependency) {
+				continue
+			}
+			violations = append(violations, layeringViolation{
+				layeringEdge: layeringEdge{
+					From:   pkg.ImportPath,
+					Denied: dependency,
+				},
+				Rule: rule.Name,
+			})
+		}
+	}
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].From != violations[j].From {
+			return violations[i].From < violations[j].From
+		}
+		return violations[i].Denied < violations[j].Denied
+	})
+	return violations
+}
+
+func matchesPackagePrefix(prefix, importPath string) bool {
+	if importPath == prefix {
+		return true
+	}
+	if !strings.HasPrefix(importPath, prefix) {
+		return false
+	}
+	return strings.HasSuffix(prefix, "/") || importPath[len(prefix)] == '/'
+}
+
+func matchesAnyPackagePrefix(prefixes []string, importPath string) bool {
+	for _, prefix := range prefixes {
+		if matchesPackagePrefix(prefix, importPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(value string, substrings []string) bool {
+	for _, substring := range substrings {
+		if strings.Contains(value, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func readLayeringEdges(t *testing.T, path string) []seededLayeringEdge {
+	t.Helper()
+	file, err := vfs.Open(path)
+	if err != nil {
+		t.Fatalf("open layering edges: %v", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			t.Errorf("close layering edges: %v", err)
+		}
+	}()
+
+	edges, err := parseLayeringEdges(file)
+	if err != nil {
+		t.Fatalf("parse layering edges: %v", err)
+	}
+	return edges
+}
+
+func parseLayeringEdges(r io.Reader) ([]seededLayeringEdge, error) {
+	scanner := bufio.NewScanner(r)
+	var edges []seededLayeringEdge
+	var problems []string
+	for line := 1; scanner.Scan(); line++ {
+		text := strings.TrimRight(scanner.Text(), "\r")
+		if skipLayeringEdgeLine(text) {
+			continue
+		}
+		parts := strings.Split(text, "\t")
+		if len(parts) != 5 {
+			problems = append(problems, malformedLayeringEdge(line))
+			continue
+		}
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		addedAt, dateErr := time.Parse(time.DateOnly, parts[4])
+		if hasBlank(parts...) || dateErr != nil {
+			problems = append(problems, malformedLayeringEdge(line))
+			continue
+		}
+		edges = append(edges, seededLayeringEdge{
+			layeringEdge: layeringEdge{
+				From:   parts[0],
+				Denied: parts[1],
+			},
+			Owner:   parts[2],
+			Reason:  parts[3],
+			AddedAt: addedAt,
+			Line:    line,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		problems = append(problems, "failed to scan layering edges: "+err.Error())
+	}
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("%s", strings.Join(problems, "\n"))
+	}
+	return edges, nil
+}
+
+func skipLayeringEdgeLine(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	return trimmed == "" || strings.HasPrefix(trimmed, "#")
+}
+
+func hasBlank(values ...string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func malformedLayeringEdge(line int) string {
+	return fmt.Sprintf(
+		"line %d: layering edge row must have five tab-separated non-empty fields with added_at in YYYY-MM-DD format",
+		line,
+	)
+}
+
+func indexSeededLayeringEdges(t *testing.T, edges []seededLayeringEdge) map[layeringEdge]seededLayeringEdge {
+	t.Helper()
+	indexed := make(map[layeringEdge]seededLayeringEdge, len(edges))
+	for _, edge := range edges {
+		if previous, ok := indexed[edge.layeringEdge]; ok {
+			t.Fatalf(
+				"duplicate layering edge at lines %d and %d: from=%s denied=%s",
+				previous.Line,
+				edge.Line,
+				edge.From,
+				edge.Denied,
+			)
+		}
+		indexed[edge.layeringEdge] = edge
+	}
+	return indexed
+}

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -46,20 +48,20 @@ var rules = []Rule{
 	{
 		Name:       "extension-zero-internal",
 		Mode:       Transitive,
-		FromPrefix: modulePath + "/extension",
+		FromPrefix: modulePath + "/extension/",
 		Denied:     []string{modulePath + "/internal/"},
 		SkipFrom:   []string{"/examples/"},
 	},
 	{
 		Name:       "events-no-shortcuts",
 		Mode:       Transitive,
-		FromPrefix: modulePath + "/events",
+		FromPrefix: modulePath + "/events/",
 		Denied:     []string{modulePath + "/shortcuts/"},
 	},
 	{
 		Name:       "shortcuts-runtime-gate",
 		Mode:       Direct,
-		FromPrefix: modulePath + "/shortcuts",
+		FromPrefix: modulePath + "/shortcuts/",
 		Denied: []string{
 			modulePath + "/internal/auth",
 			modulePath + "/internal/keychain",
@@ -91,7 +93,7 @@ var rules = []Rule{
 	{
 		Name:       "internal-no-upper",
 		Mode:       Direct,
-		FromPrefix: modulePath + "/internal",
+		FromPrefix: modulePath + "/internal/",
 		Denied: []string{
 			modulePath + "/cmd",
 			modulePath + "/shortcuts",
@@ -107,6 +109,17 @@ type listedPackage struct {
 	ImportPath string
 	Imports    []string
 	Deps       []string
+}
+
+type goListTarget struct {
+	GOOS   string
+	GOARCH string
+}
+
+var layeringBuildTargets = []goListTarget{
+	{GOOS: "linux", GOARCH: "amd64"},
+	{GOOS: "darwin", GOARCH: "amd64"},
+	{GOOS: "windows", GOARCH: "amd64"},
 }
 
 type layeringEdge struct {
@@ -145,10 +158,7 @@ func TestPackageLayering(t *testing.T) {
 
 	for _, rule := range rules {
 		t.Run(rule.Name, func(t *testing.T) {
-			for _, violation := range actualByRule[rule.Name] {
-				if _, ok := seededByEdge[violation.layeringEdge]; ok {
-					continue
-				}
+			for _, violation := range findUnseededLayeringViolations(actualByRule[rule.Name], seededByEdge) {
 				t.Errorf(
 					"new layering violation: from=%s denied=%s rule=%s; use the approved dependency gate or fix the dependency; do not add rows to layering-edges.txt",
 					violation.From,
@@ -160,10 +170,7 @@ func TestPackageLayering(t *testing.T) {
 	}
 
 	t.Run("stale-layering-edges", func(t *testing.T) {
-		for _, edge := range seeded {
-			if _, ok := actualEdges[edge.layeringEdge]; ok {
-				continue
-			}
+		for _, edge := range findStaleLayeringEdges(seeded, actualEdges) {
 			t.Errorf(
 				"stale layering edge: from=%s denied=%s line=%d; this violation has been removed; delete this row from layering-edges.txt",
 				edge.From,
@@ -172,6 +179,37 @@ func TestPackageLayering(t *testing.T) {
 			)
 		}
 	})
+}
+
+func TestLayeringEdgeClassification(t *testing.T) {
+	known := layeringEdge{From: "example.com/from", Denied: "example.com/denied"}
+	added := layeringEdge{From: "example.com/new", Denied: "example.com/upper"}
+	removed := layeringEdge{From: "example.com/old", Denied: "example.com/legacy"}
+	seeded := []seededLayeringEdge{
+		{layeringEdge: known, Line: 1},
+		{layeringEdge: removed, Line: 2},
+	}
+	seededByEdge := map[layeringEdge]seededLayeringEdge{
+		known:   seeded[0],
+		removed: seeded[1],
+	}
+	actual := []layeringViolation{
+		{layeringEdge: known, Rule: "rule"},
+		{layeringEdge: added, Rule: "rule"},
+	}
+	actualEdges := map[layeringEdge]struct{}{
+		known: {},
+		added: {},
+	}
+
+	unseeded := findUnseededLayeringViolations(actual, seededByEdge)
+	if len(unseeded) != 1 || unseeded[0].layeringEdge != added {
+		t.Fatalf("findUnseededLayeringViolations returned %+v, want only %+v", unseeded, added)
+	}
+	stale := findStaleLayeringEdges(seeded, actualEdges)
+	if len(stale) != 1 || stale[0].layeringEdge != removed {
+		t.Fatalf("findStaleLayeringEdges returned %+v, want only %+v", stale, removed)
+	}
 }
 
 func TestParseLayeringEdges(t *testing.T) {
@@ -314,30 +352,325 @@ func TestEvaluateLayeringRuleUsesExactExceptions(t *testing.T) {
 	}
 }
 
+func TestLayeringRuleContracts(t *testing.T) {
+	wantRules := []Rule{
+		{
+			Name:       "extension-zero-internal",
+			Mode:       Transitive,
+			FromPrefix: modulePath + "/extension/",
+			Denied:     []string{modulePath + "/internal/"},
+			SkipFrom:   []string{"/examples/"},
+		},
+		{
+			Name:       "events-no-shortcuts",
+			Mode:       Transitive,
+			FromPrefix: modulePath + "/events/",
+			Denied:     []string{modulePath + "/shortcuts/"},
+		},
+		{
+			Name:       "shortcuts-runtime-gate",
+			Mode:       Direct,
+			FromPrefix: modulePath + "/shortcuts/",
+			Denied: []string{
+				modulePath + "/internal/auth",
+				modulePath + "/internal/keychain",
+				modulePath + "/internal/credential",
+				modulePath + "/internal/client",
+				modulePath + "/internal/vfs",
+			},
+			ExceptFrom: []string{
+				modulePath + "/shortcuts/common",
+				modulePath + "/shortcuts/apps/gitcred",
+			},
+		},
+		{
+			Name:       "cmd-assembly-only",
+			Mode:       Direct,
+			FromPrefix: modulePath + "/cmd",
+			Denied:     []string{modulePath + "/shortcuts"},
+			ExceptFrom: []string{
+				modulePath + "/cmd",
+				modulePath + "/cmd/auth",
+			},
+		},
+		{
+			Name:       "errs-leaf",
+			Mode:       Direct,
+			FromPrefix: modulePath + "/errs",
+			Denied:     []string{modulePath + "/"},
+		},
+		{
+			Name:       "internal-no-upper",
+			Mode:       Direct,
+			FromPrefix: modulePath + "/internal/",
+			Denied: []string{
+				modulePath + "/cmd",
+				modulePath + "/shortcuts",
+				modulePath + "/events",
+			},
+			ExceptFrom: []string{
+				modulePath + "/internal/qualitygate/cmd/manifest-export",
+			},
+		},
+	}
+	if !reflect.DeepEqual(rules, wantRules) {
+		t.Fatalf("layering rules differ from the enforced contract:\ngot:  %#v\nwant: %#v", rules, wantRules)
+	}
+
+	tests := []struct {
+		name       string
+		ruleName   string
+		packages   []listedPackage
+		wantFrom   string
+		wantDenied string
+	}{
+		{
+			name:     "extension-transitive-denial-and-example-scope-out",
+			ruleName: "extension-zero-internal",
+			packages: []listedPackage{
+				{
+					ImportPath: modulePath + "/extension/sdk",
+					Deps:       []string{modulePath + "/internal/core"},
+				},
+				{
+					ImportPath: modulePath + "/extension/platform/examples/demo",
+					Deps:       []string{modulePath + "/internal/core"},
+				},
+			},
+			wantFrom:   modulePath + "/extension/sdk",
+			wantDenied: modulePath + "/internal/core",
+		},
+		{
+			name:     "events-transitive-denial",
+			ruleName: "events-no-shortcuts",
+			packages: []listedPackage{
+				{
+					ImportPath: modulePath + "/events/im",
+					Deps:       []string{modulePath + "/shortcuts/common"},
+				},
+				{
+					ImportPath: modulePath + "/events/calendar",
+					Deps:       []string{modulePath + "/internal/core"},
+				},
+			},
+			wantFrom:   modulePath + "/events/im",
+			wantDenied: modulePath + "/shortcuts/common",
+		},
+		{
+			name:     "shortcuts-direct-denial-and-exceptions",
+			ruleName: "shortcuts-runtime-gate",
+			packages: []listedPackage{
+				{
+					ImportPath: modulePath + "/shortcuts/im",
+					Imports:    []string{modulePath + "/internal/auth"},
+				},
+				{
+					ImportPath: modulePath + "/shortcuts/common",
+					Imports:    []string{modulePath + "/internal/auth"},
+				},
+				{
+					ImportPath: modulePath + "/shortcuts/apps/gitcred",
+					Imports:    []string{modulePath + "/internal/keychain"},
+				},
+			},
+			wantFrom:   modulePath + "/shortcuts/im",
+			wantDenied: modulePath + "/internal/auth",
+		},
+		{
+			name:     "cmd-direct-denial-and-assembly-exceptions",
+			ruleName: "cmd-assembly-only",
+			packages: []listedPackage{
+				{
+					ImportPath: modulePath + "/cmd/service",
+					Imports:    []string{modulePath + "/shortcuts/im"},
+				},
+				{
+					ImportPath: modulePath + "/cmd",
+					Imports:    []string{modulePath + "/shortcuts"},
+				},
+				{
+					ImportPath: modulePath + "/cmd/auth",
+					Imports:    []string{modulePath + "/shortcuts/auth"},
+				},
+			},
+			wantFrom:   modulePath + "/cmd/service",
+			wantDenied: modulePath + "/shortcuts/im",
+		},
+		{
+			name:     "errs-direct-denial",
+			ruleName: "errs-leaf",
+			packages: []listedPackage{
+				{
+					ImportPath: modulePath + "/errs",
+					Imports:    []string{modulePath + "/internal/core"},
+				},
+				{
+					ImportPath: modulePath + "/errclass",
+					Imports:    []string{modulePath + "/internal/core"},
+				},
+			},
+			wantFrom:   modulePath + "/errs",
+			wantDenied: modulePath + "/internal/core",
+		},
+		{
+			name:     "internal-direct-denial-and-collector-exception",
+			ruleName: "internal-no-upper",
+			packages: []listedPackage{
+				{
+					ImportPath: modulePath + "/internal/core",
+					Imports:    []string{modulePath + "/events/im"},
+				},
+				{
+					ImportPath: modulePath + "/internal/qualitygate/cmd/manifest-export",
+					Imports:    []string{modulePath + "/cmd"},
+				},
+			},
+			wantFrom:   modulePath + "/internal/core",
+			wantDenied: modulePath + "/events/im",
+		},
+	}
+
+	rulesByName := make(map[string]Rule, len(rules))
+	for _, rule := range rules {
+		rulesByName[rule.Name] = rule
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule, ok := rulesByName[tt.ruleName]
+			if !ok {
+				t.Fatalf("missing rule %q", tt.ruleName)
+			}
+			violations := evaluateLayeringRule(tt.packages, rule)
+			if len(violations) != 1 {
+				t.Fatalf("evaluateLayeringRule returned %d violations, want 1: %+v", len(violations), violations)
+			}
+			if violations[0].From != tt.wantFrom || violations[0].Denied != tt.wantDenied {
+				t.Fatalf(
+					"evaluateLayeringRule returned edge (%q, %q), want (%q, %q)",
+					violations[0].From,
+					violations[0].Denied,
+					tt.wantFrom,
+					tt.wantDenied,
+				)
+			}
+		})
+	}
+}
+
+func TestLayeringBuildTargets(t *testing.T) {
+	want := []goListTarget{
+		{GOOS: "linux", GOARCH: "amd64"},
+		{GOOS: "darwin", GOARCH: "amd64"},
+		{GOOS: "windows", GOARCH: "amd64"},
+	}
+	if !reflect.DeepEqual(layeringBuildTargets, want) {
+		t.Fatalf("layering build targets = %#v, want %#v", layeringBuildTargets, want)
+	}
+}
+
+func TestDecodeAndMergeListedPackages(t *testing.T) {
+	input := strings.NewReader(
+		`{"ImportPath":"example.com/a","Imports":["example.com/b"],"Deps":["example.com/c"]}` + "\n" +
+			`{"ImportPath":"example.com/d","Imports":[],"Deps":[]}` + "\n",
+	)
+	packages, err := decodeListedPackages(input)
+	if err != nil {
+		t.Fatalf("decodeListedPackages returned an error: %v", err)
+	}
+	if len(packages) != 2 || packages[0].ImportPath != "example.com/a" || packages[1].ImportPath != "example.com/d" {
+		t.Fatalf("decodeListedPackages returned unexpected packages: %+v", packages)
+	}
+
+	got := mergeStrings([]string{"example.com/b", "example.com/c"}, []string{"example.com/a", "example.com/b"})
+	want := []string{"example.com/a", "example.com/b", "example.com/c"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("mergeStrings returned %q, want %q", got, want)
+	}
+}
+
 func goListPackageGraph(t *testing.T, root string) []listedPackage {
+	t.Helper()
+	packagesByPath := make(map[string]listedPackage)
+	for _, target := range layeringBuildTargets {
+		for _, pkg := range goListPackages(t, root, target) {
+			merged := packagesByPath[pkg.ImportPath]
+			merged.ImportPath = pkg.ImportPath
+			merged.Imports = mergeStrings(merged.Imports, pkg.Imports)
+			merged.Deps = mergeStrings(merged.Deps, pkg.Deps)
+			packagesByPath[pkg.ImportPath] = merged
+		}
+	}
+
+	packages := make([]listedPackage, 0, len(packagesByPath))
+	for _, pkg := range packagesByPath {
+		packages = append(packages, pkg)
+	}
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].ImportPath < packages[j].ImportPath
+	})
+	return packages
+}
+
+func goListPackages(t *testing.T, root string, target goListTarget) []listedPackage {
 	t.Helper()
 	args := []string{"list", "-json", "-tags", "authsidecar", "./..."}
 	cmd := exec.Command("go", args...)
 	cmd.Dir = root
+	cmd.Env = append(
+		os.Environ(),
+		"GOOS="+target.GOOS,
+		"GOARCH="+target.GOARCH,
+		"CGO_ENABLED=0",
+	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("go %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		t.Fatalf(
+			"GOOS=%s GOARCH=%s go %s failed: %v\n%s",
+			target.GOOS,
+			target.GOARCH,
+			strings.Join(args, " "),
+			err,
+			out,
+		)
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader(out))
+	packages, err := decodeListedPackages(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("decode GOOS=%s GOARCH=%s go list output: %v", target.GOOS, target.GOARCH, err)
+	}
+	return packages
+}
+
+func decodeListedPackages(r io.Reader) ([]listedPackage, error) {
+	decoder := json.NewDecoder(r)
 	var packages []listedPackage
 	for {
 		var pkg listedPackage
 		err := decoder.Decode(&pkg)
 		if err == io.EOF {
-			break
+			return packages, nil
 		}
 		if err != nil {
-			t.Fatalf("decode go list output: %v", err)
+			return nil, err
 		}
 		packages = append(packages, pkg)
 	}
-	return packages
+}
+
+func mergeStrings(left, right []string) []string {
+	values := make(map[string]struct{}, len(left)+len(right))
+	for _, value := range left {
+		values[value] = struct{}{}
+	}
+	for _, value := range right {
+		values[value] = struct{}{}
+	}
+	merged := make([]string, 0, len(values))
+	for value := range values {
+		merged = append(merged, value)
+	}
+	sort.Strings(merged)
+	return merged
 }
 
 func evaluateLayeringRule(packages []listedPackage, rule Rule) []layeringViolation {
@@ -405,6 +738,32 @@ func containsAny(value string, substrings []string) bool {
 		}
 	}
 	return false
+}
+
+func findUnseededLayeringViolations(
+	actual []layeringViolation,
+	seeded map[layeringEdge]seededLayeringEdge,
+) []layeringViolation {
+	var unseeded []layeringViolation
+	for _, violation := range actual {
+		if _, ok := seeded[violation.layeringEdge]; !ok {
+			unseeded = append(unseeded, violation)
+		}
+	}
+	return unseeded
+}
+
+func findStaleLayeringEdges(
+	seeded []seededLayeringEdge,
+	actual map[layeringEdge]struct{},
+) []seededLayeringEdge {
+	var stale []seededLayeringEdge
+	for _, edge := range seeded {
+		if _, ok := actual[edge.layeringEdge]; !ok {
+			stale = append(stale, edge)
+		}
+	}
+	return stale
 }
 
 func readLayeringEdges(t *testing.T, path string) []seededLayeringEdge {

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -54,20 +54,20 @@ var rules = []Rule{
 	{
 		Name:       "extension-zero-internal",
 		Mode:       Transitive,
-		FromPrefix: modulePath + "/extension/",
-		Denied:     []string{modulePath + "/internal/"},
+		FromPrefix: modulePath + "/extension",
+		Denied:     []string{modulePath + "/internal"},
 		SkipFrom:   []string{"/examples/"},
 	},
 	{
 		Name:       "events-no-shortcuts",
 		Mode:       Transitive,
-		FromPrefix: modulePath + "/events/",
-		Denied:     []string{modulePath + "/shortcuts/"},
+		FromPrefix: modulePath + "/events",
+		Denied:     []string{modulePath + "/shortcuts"},
 	},
 	{
 		Name:       "shortcuts-runtime-gate",
 		Mode:       Direct,
-		FromPrefix: modulePath + "/shortcuts/",
+		FromPrefix: modulePath + "/shortcuts",
 		Denied: []string{
 			modulePath + "/internal/auth",
 			modulePath + "/internal/keychain",
@@ -99,7 +99,7 @@ var rules = []Rule{
 	{
 		Name:       "internal-no-upper",
 		Mode:       Direct,
-		FromPrefix: modulePath + "/internal/",
+		FromPrefix: modulePath + "/internal",
 		Denied: []string{
 			modulePath + "/cmd",
 			modulePath + "/shortcuts",
@@ -413,20 +413,20 @@ func TestLayeringRuleContracts(t *testing.T) {
 		{
 			Name:       "extension-zero-internal",
 			Mode:       Transitive,
-			FromPrefix: modulePath + "/extension/",
-			Denied:     []string{modulePath + "/internal/"},
+			FromPrefix: modulePath + "/extension",
+			Denied:     []string{modulePath + "/internal"},
 			SkipFrom:   []string{"/examples/"},
 		},
 		{
 			Name:       "events-no-shortcuts",
 			Mode:       Transitive,
-			FromPrefix: modulePath + "/events/",
-			Denied:     []string{modulePath + "/shortcuts/"},
+			FromPrefix: modulePath + "/events",
+			Denied:     []string{modulePath + "/shortcuts"},
 		},
 		{
 			Name:       "shortcuts-runtime-gate",
 			Mode:       Direct,
-			FromPrefix: modulePath + "/shortcuts/",
+			FromPrefix: modulePath + "/shortcuts",
 			Denied: []string{
 				modulePath + "/internal/auth",
 				modulePath + "/internal/keychain",
@@ -458,7 +458,7 @@ func TestLayeringRuleContracts(t *testing.T) {
 		{
 			Name:       "internal-no-upper",
 			Mode:       Direct,
-			FromPrefix: modulePath + "/internal/",
+			FromPrefix: modulePath + "/internal",
 			Denied: []string{
 				modulePath + "/cmd",
 				modulePath + "/shortcuts",
@@ -606,6 +606,78 @@ func TestLayeringRuleContracts(t *testing.T) {
 					violations[0].From,
 					violations[0].Denied,
 					tt.wantFrom,
+					tt.wantDenied,
+				)
+			}
+		})
+	}
+}
+
+func TestLayeringRulesCoverRootPackages(t *testing.T) {
+	tests := []struct {
+		name       string
+		ruleName   string
+		pkg        listedPackage
+		wantDenied string
+	}{
+		{
+			name:     "extension-root",
+			ruleName: "extension-zero-internal",
+			pkg: listedPackage{
+				ImportPath: modulePath + "/extension",
+				Deps:       []string{modulePath + "/internal"},
+			},
+			wantDenied: modulePath + "/internal",
+		},
+		{
+			name:     "events-root",
+			ruleName: "events-no-shortcuts",
+			pkg: listedPackage{
+				ImportPath: modulePath + "/events",
+				Deps:       []string{modulePath + "/shortcuts"},
+			},
+			wantDenied: modulePath + "/shortcuts",
+		},
+		{
+			name:     "shortcuts-root",
+			ruleName: "shortcuts-runtime-gate",
+			pkg: listedPackage{
+				ImportPath: modulePath + "/shortcuts",
+				Imports:    []string{modulePath + "/internal/client"},
+			},
+			wantDenied: modulePath + "/internal/client",
+		},
+		{
+			name:     "internal-root",
+			ruleName: "internal-no-upper",
+			pkg: listedPackage{
+				ImportPath: modulePath + "/internal",
+				Imports:    []string{modulePath + "/events"},
+			},
+			wantDenied: modulePath + "/events",
+		},
+	}
+
+	rulesByName := make(map[string]Rule, len(rules))
+	for _, rule := range rules {
+		rulesByName[rule.Name] = rule
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule, ok := rulesByName[tt.ruleName]
+			if !ok {
+				t.Fatalf("missing rule %q", tt.ruleName)
+			}
+			violations := evaluateLayeringRule([]listedPackage{tt.pkg}, rule)
+			if len(violations) != 1 {
+				t.Fatalf("evaluateLayeringRule returned %d violations, want 1: %+v", len(violations), violations)
+			}
+			if violations[0].From != tt.pkg.ImportPath || violations[0].Denied != tt.wantDenied {
+				t.Fatalf(
+					"evaluateLayeringRule returned edge (%q, %q), want (%q, %q)",
+					violations[0].From,
+					violations[0].Denied,
+					tt.pkg.ImportPath,
 					tt.wantDenied,
 				)
 			}
@@ -846,6 +918,37 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "templated build environment fails closed",
+			build: goReleaserBuild{
+				Env: []string{`{{- if eq .Os "linux" }}GOFLAGS=-tags=feature{{- end }}`},
+			},
+			wantErr: true,
+		},
+		{
+			name: "templated build flags fail closed",
+			build: goReleaserBuild{
+				Flags: []string{`{{- if eq .Os "linux" }}-tags=feature{{- end }}`},
+			},
+			wantErr: true,
+		},
+		{
+			name: "templated target matrix fails closed",
+			build: goReleaserBuild{
+				GOOS:   []string{`{{ .Env.GOOS }}`},
+				GOARCH: []string{"amd64"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "templated ignore fails closed",
+			build: goReleaserBuild{
+				GOOS:   []string{"linux"},
+				GOARCH: []string{"amd64"},
+				Ignore: []map[string]any{{"goos": `{{ .Env.GOOS }}`}},
+			},
+			wantErr: true,
+		},
+		{
 			name: "custom build command fails closed",
 			build: goReleaserBuild{
 				Command: "test",
@@ -906,6 +1009,12 @@ func goReleaserBuildTargets(
 	if build.Overrides.Kind != 0 {
 		return nil, fmt.Errorf("target overrides are unsupported")
 	}
+	if containsGoReleaserTemplate(build.GOOS) || containsGoReleaserTemplate(build.GOARCH) {
+		return nil, fmt.Errorf("templated release target matrices are unsupported")
+	}
+	if containsGoReleaserTemplate(build.Flags) {
+		return nil, fmt.Errorf("templated release build flags are unsupported")
+	}
 	if len(build.Tags) > 0 || buildFlagsSetTags(build.Flags) {
 		return nil, fmt.Errorf("release build tags are unsupported")
 	}
@@ -959,7 +1068,7 @@ func explicitGoReleaserTargets(
 		if configuredTarget == "go_first_class" || configuredTarget == "go_118_first_class" {
 			return nil, fmt.Errorf("unsupported target selector %q", configuredTarget)
 		}
-		if strings.Contains(configuredTarget, "{{") {
+		if hasGoReleaserTemplate(configuredTarget) {
 			return nil, fmt.Errorf("templated target %q is unsupported", configuredTarget)
 		}
 
@@ -989,8 +1098,24 @@ func buildFlagsSetTags(flags []string) bool {
 	return false
 }
 
+func containsGoReleaserTemplate(values []string) bool {
+	for _, value := range values {
+		if hasGoReleaserTemplate(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasGoReleaserTemplate(value string) bool {
+	return strings.Contains(value, "{{") || strings.Contains(value, "}}")
+}
+
 func validateGoReleaserBuildEnv(env []string) error {
 	for _, entry := range env {
+		if hasGoReleaserTemplate(entry) {
+			return fmt.Errorf("templated build environment entries are unsupported")
+		}
 		name, value, ok := strings.Cut(entry, "=")
 		if !ok {
 			continue
@@ -1052,6 +1177,9 @@ func optionalString(values map[string]any, key string) (string, error) {
 	text, ok := value.(string)
 	if !ok {
 		return "", fmt.Errorf("ignore selector %q must be a string", key)
+	}
+	if hasGoReleaserTemplate(text) {
+		return "", fmt.Errorf("templated ignore selector %q is unsupported", key)
 	}
 	return text, nil
 }

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -44,11 +44,13 @@ type Rule struct {
 	Denied     []string
 	// ExceptFrom exempts import paths matched exactly.
 	ExceptFrom []string
-	// SkipFrom exempts any package whose import path contains one of these
-	// substrings (e.g. "/examples/" to skip demo code anywhere in the tree),
-	// deliberately looser than the prefix matching used for the other fields.
-	SkipFrom []string
 }
+
+// examplesPrefix is the plugin-SDK example tree. Each subdirectory is a
+// standalone main package demonstrating the sanctioned wrapper-main pattern:
+// register a plugin from init, then hand the process to cmd.Execute. The
+// customer forks built by tests/plugin_e2e/harness.go have the same shape.
+const examplesPrefix = modulePath + "/extension/platform/examples"
 
 var rules = []Rule{
 	{
@@ -56,7 +58,32 @@ var rules = []Rule{
 		Mode:       Transitive,
 		FromPrefix: modulePath + "/extension",
 		Denied:     []string{modulePath + "/internal"},
-		SkipFrom:   []string{"/examples/"},
+		// The wrapper-main demos import cmd deliberately — that fork is the
+		// thing they exist to show — so every internal package they reach is
+		// inherited through cmd rather than chosen by the demo. Exempting
+		// them by exact path (never by directory name) keeps two properties:
+		// a future examples/ subdirectory inherits no exemption, and
+		// examples-surface-only still stops a demo from reaching down on its
+		// own. Listing these edges in layering-edges.txt instead would also
+		// wedge the ratchet: they track cmd's transitive set, so any new
+		// internal package under cmd would demand a new row, which
+		// check-layering-ratchet.sh refuses by design.
+		ExceptFrom: []string{
+			examplesPrefix + "/audit-observer",
+			examplesPrefix + "/readonly-policy",
+		},
+	},
+	{
+		// Demos may consume the assembled CLI (cmd) and the public SDK
+		// (extension/platform); reaching past those into internals or
+		// business commands would teach plugin authors the wrong entry point.
+		Name:       "examples-surface-only",
+		Mode:       Direct,
+		FromPrefix: examplesPrefix,
+		Denied: []string{
+			modulePath + "/internal",
+			modulePath + "/shortcuts",
+		},
 	},
 	{
 		Name:       "events-no-shortcuts",
@@ -415,7 +442,19 @@ func TestLayeringRuleContracts(t *testing.T) {
 			Mode:       Transitive,
 			FromPrefix: modulePath + "/extension",
 			Denied:     []string{modulePath + "/internal"},
-			SkipFrom:   []string{"/examples/"},
+			ExceptFrom: []string{
+				examplesPrefix + "/audit-observer",
+				examplesPrefix + "/readonly-policy",
+			},
+		},
+		{
+			Name:       "examples-surface-only",
+			Mode:       Direct,
+			FromPrefix: examplesPrefix,
+			Denied: []string{
+				modulePath + "/internal",
+				modulePath + "/shortcuts",
+			},
 		},
 		{
 			Name:       "events-no-shortcuts",
@@ -481,7 +520,7 @@ func TestLayeringRuleContracts(t *testing.T) {
 		wantDenied string
 	}{
 		{
-			name:     "extension-transitive-denial-and-example-scope-out",
+			name:     "extension-transitive-denial-and-wrapper-main-exemption",
 			ruleName: "extension-zero-internal",
 			packages: []listedPackage{
 				{
@@ -489,12 +528,44 @@ func TestLayeringRuleContracts(t *testing.T) {
 					Deps:       []string{modulePath + "/internal/core"},
 				},
 				{
-					ImportPath: modulePath + "/extension/platform/examples/demo",
+					ImportPath: examplesPrefix + "/audit-observer",
 					Deps:       []string{modulePath + "/internal/core"},
 				},
 			},
 			wantFrom:   modulePath + "/extension/sdk",
 			wantDenied: modulePath + "/internal/core",
+		},
+		{
+			// The exemption is per exact path, so parking code in a new
+			// directory under examples/ buys no cover.
+			name:     "extension-still-covers-unlisted-example-directories",
+			ruleName: "extension-zero-internal",
+			packages: []listedPackage{
+				{
+					ImportPath: examplesPrefix + "/demo",
+					Deps:       []string{modulePath + "/internal/core"},
+				},
+			},
+			wantFrom:   examplesPrefix + "/demo",
+			wantDenied: modulePath + "/internal/core",
+		},
+		{
+			// cmd is the demo's whole point and stays legal; reaching past it
+			// into internals does not.
+			name:     "examples-may-wrap-cmd-but-not-reach-internals",
+			ruleName: "examples-surface-only",
+			packages: []listedPackage{
+				{
+					ImportPath: examplesPrefix + "/audit-observer",
+					Imports: []string{
+						modulePath + "/cmd",
+						modulePath + "/extension/platform",
+						modulePath + "/internal/keychain",
+					},
+				},
+			},
+			wantFrom:   examplesPrefix + "/audit-observer",
+			wantDenied: modulePath + "/internal/keychain",
 		},
 		{
 			name:     "events-transitive-denial",
@@ -1405,9 +1476,6 @@ func evaluateLayeringRule(packages []listedPackage, rule Rule) []layeringViolati
 		if slices.Contains(rule.ExceptFrom, pkg.ImportPath) {
 			continue
 		}
-		if containsAny(pkg.ImportPath, rule.SkipFrom) {
-			continue
-		}
 
 		dependencies := pkg.Imports
 		if rule.Mode == Transitive {
@@ -1448,15 +1516,6 @@ func matchesPackagePrefix(prefix, importPath string) bool {
 func matchesAnyPackagePrefix(prefixes []string, importPath string) bool {
 	for _, prefix := range prefixes {
 		if matchesPackagePrefix(prefix, importPath) {
-			return true
-		}
-	}
-	return false
-}
-
-func containsAny(value string, substrings []string) bool {
-	for _, substring := range substrings {
-		if strings.Contains(value, substring) {
 			return true
 		}
 	}

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -608,7 +608,7 @@ func TestGoListPackagesSeparatesStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadPackagesForTarget returned an error: %v", err)
 	}
-	if stderr != "go: downloading example.com/module\n" {
+	if !strings.Contains(stderr, "go: downloading example.com/module\n") {
 		t.Fatalf("loadPackagesForTarget stderr = %q, want module download diagnostic", stderr)
 	}
 	if len(packages) != 1 || packages[0].ImportPath != "example.com/package" {

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -42,8 +42,12 @@ type Rule struct {
 	Mode       Mode
 	FromPrefix string
 	Denied     []string
+	// ExceptFrom exempts import paths matched exactly.
 	ExceptFrom []string
-	SkipFrom   []string
+	// SkipFrom exempts any package whose import path contains one of these
+	// substrings (e.g. "/examples/" to skip demo code anywhere in the tree),
+	// deliberately looser than the prefix matching used for the other fields.
+	SkipFrom []string
 }
 
 var rules = []Rule{
@@ -121,6 +125,7 @@ type goListTarget struct {
 type commandFactory func(name string, args ...string) *exec.Cmd
 
 type goReleaserConfig struct {
+	Env    []string          `yaml:"env"`
 	Builds []goReleaserBuild `yaml:"builds"`
 }
 
@@ -141,6 +146,8 @@ type goReleaserBuild struct {
 	Tags      []string         `yaml:"tags"`
 	Flags     []string         `yaml:"flags"`
 	Env       []string         `yaml:"env"`
+	Command   string           `yaml:"command"`
+	Overrides yaml.Node        `yaml:"overrides"`
 	Targets   []string         `yaml:"targets"`
 	Ignore    []map[string]any `yaml:"ignore"`
 	Skip      bool             `yaml:"skip"`
@@ -161,6 +168,10 @@ var layeringBuildTargets = []goListTarget{
 	{GOOS: "windows", GOARCH: "arm64"},
 }
 
+// layeringBuildTags is the set of build tags whose import graphs are unioned
+// before evaluating the rules. Demo-only tags (authsidecar_demo,
+// authsidecar_multi_tenant_demo) are intentionally excluded: that code lives
+// under sidecar/server-demo*/ and never sits in a layer any rule governs.
 var layeringBuildTags = []string{"", "authsidecar"}
 
 type layeringEdge struct {
@@ -297,6 +308,10 @@ func TestParseLayeringEdges(t *testing.T) {
 		{
 			name:  "invalid-date",
 			input: "from\tdenied\towner\treason\t2026-02-30\n",
+		},
+		{
+			name:  "whitespace-padded-field",
+			input: "from\t denied \towner\treason\t2026-07-24\n",
 		},
 	}
 	for _, tt := range tests {
@@ -634,7 +649,14 @@ func TestLayeringBuildTargetsMatchGoReleaser(t *testing.T) {
 	if len(config.Builds) == 0 {
 		t.Fatal(".goreleaser.yml has no builds")
 	}
+	if err := validateGoReleaserBuildEnv(config.Env); err != nil {
+		t.Fatalf(".goreleaser.yml global environment: %v", err)
+	}
 
+	// The supported set is derived from the toolchain running this test.
+	// TestReleaseGoVersionMatchesModule pins the release Go to the go.mod floor,
+	// so a runner older than the release toolchain (which could omit a
+	// release-buildable target and under-compute want) is caught there first.
 	output, err := exec.Command("go", "tool", "dist", "list", "-json").Output()
 	if err != nil {
 		t.Fatalf("go tool dist list: %v", err)
@@ -812,7 +834,7 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 		{
 			name: "build flag tags fail closed",
 			build: goReleaserBuild{
-				Flags: []string{"-tags=feature"},
+				Flags: []string{"--tags=feature"},
 			},
 			wantErr: true,
 		},
@@ -820,6 +842,20 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 			name: "environment build tags fail closed",
 			build: goReleaserBuild{
 				Env: []string{"GOFLAGS=-tags=feature"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom build command fails closed",
+			build: goReleaserBuild{
+				Command: "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "target overrides fail closed",
+			build: goReleaserBuild{
+				Overrides: yaml.Node{Kind: yaml.MappingNode},
 			},
 			wantErr: true,
 		},
@@ -863,6 +899,12 @@ func goReleaserBuildTargets(
 	}
 	if build.Tool != "" || build.GoBinary != "" {
 		return nil, fmt.Errorf("custom Go tools are unsupported")
+	}
+	if build.Command != "" && build.Command != "build" {
+		return nil, fmt.Errorf("unsupported Go command %q", build.Command)
+	}
+	if build.Overrides.Kind != 0 {
+		return nil, fmt.Errorf("target overrides are unsupported")
 	}
 	if len(build.Tags) > 0 || buildFlagsSetTags(build.Flags) {
 		return nil, fmt.Errorf("release build tags are unsupported")
@@ -939,7 +981,8 @@ func explicitGoReleaserTargets(
 
 func buildFlagsSetTags(flags []string) bool {
 	for _, flag := range flags {
-		if flag == "-tags" || strings.HasPrefix(flag, "-tags=") {
+		if flag == "-tags" || strings.HasPrefix(flag, "-tags=") ||
+			flag == "--tags" || strings.HasPrefix(flag, "--tags=") {
 			return true
 		}
 	}
@@ -957,12 +1000,10 @@ func validateGoReleaserBuildEnv(env []string) error {
 			if value != "0" {
 				return fmt.Errorf("CGO_ENABLED=%s is unsupported", value)
 			}
-		case "GOFLAGS":
-			if strings.Contains(value, "-tags") {
-				return fmt.Errorf("GOFLAGS build tags are unsupported")
+		default:
+			if !strings.HasPrefix(name, "GO") {
+				continue
 			}
-		case "GOEXPERIMENT", "GOOS", "GOARCH", "GOARM", "GOAMD64", "GOARM64",
-			"GOMIPS", "GOMIPS64", "GO386", "GOPPC64", "GORISCV64":
 			return fmt.Errorf("build environment variable %q is unsupported", name)
 		}
 	}
@@ -1046,19 +1087,45 @@ func TestDecodeAndMergeListedPackages(t *testing.T) {
 
 func TestGoListPackagesSeparatesStderr(t *testing.T) {
 	target := goListTarget{GOOS: "linux", GOARCH: "amd64"}
-	packages, stderr, err := loadPackagesForTarget("", target, "authsidecar", func(_ string, _ ...string) *exec.Cmd {
-		cmd := exec.Command(os.Args[0], "-test.run=^TestGoListCommandHelperProcess$")
-		cmd.Env = append(os.Environ(), "GO_LIST_COMMAND_HELPER=1")
-		return cmd
-	})
-	if err != nil {
-		t.Fatalf("loadPackagesForTarget returned an error: %v", err)
+	tests := []struct {
+		name     string
+		tags     string
+		wantArgs []string
+	}{
+		{
+			name:     "default graph",
+			wantArgs: []string{"list", "-json", "./..."},
+		},
+		{
+			name:     "authsidecar graph",
+			tags:     "authsidecar",
+			wantArgs: []string{"list", "-json", "-tags", "authsidecar", "./..."},
+		},
 	}
-	if !strings.Contains(stderr, "go: downloading example.com/module\n") {
-		t.Fatalf("loadPackagesForTarget stderr = %q, want module download diagnostic", stderr)
-	}
-	if len(packages) != 1 || packages[0].ImportPath != "example.com/package" {
-		t.Fatalf("loadPackagesForTarget returned unexpected packages: %+v", packages)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotName string
+			var gotArgs []string
+			packages, stderr, err := loadPackagesForTarget("", target, tt.tags, func(name string, args ...string) *exec.Cmd {
+				gotName = name
+				gotArgs = slices.Clone(args)
+				cmd := exec.Command(os.Args[0], "-test.run=^TestGoListCommandHelperProcess$")
+				cmd.Env = append(os.Environ(), "GO_LIST_COMMAND_HELPER=1")
+				return cmd
+			})
+			if err != nil {
+				t.Fatalf("loadPackagesForTarget returned an error: %v", err)
+			}
+			if gotName != "go" || !slices.Equal(gotArgs, tt.wantArgs) {
+				t.Fatalf("command = %q %q, want go %q", gotName, gotArgs, tt.wantArgs)
+			}
+			if !strings.Contains(stderr, "go: downloading example.com/module\n") {
+				t.Fatalf("loadPackagesForTarget stderr = %q, want module download diagnostic", stderr)
+			}
+			if len(packages) != 1 || packages[0].ImportPath != "example.com/package" {
+				t.Fatalf("loadPackagesForTarget returned unexpected packages: %+v", packages)
+			}
+		})
 	}
 }
 
@@ -1076,7 +1143,16 @@ func goListPackageGraph(t *testing.T, root string) []listedPackage {
 	packagesByPath := make(map[string]listedPackage)
 	for _, target := range layeringBuildTargets {
 		for _, tags := range layeringBuildTags {
-			for _, pkg := range goListPackages(t, root, target, tags) {
+			listed := goListPackages(t, root, target, tags)
+			if len(listed) == 0 {
+				t.Fatalf(
+					"GOOS=%s GOARCH=%s tags=%q go list -json ./... returned no packages; the layering graph would silently under-cover",
+					target.GOOS,
+					target.GOARCH,
+					tags,
+				)
+			}
+			for _, pkg := range listed {
 				merged := packagesByPath[pkg.ImportPath]
 				merged.ImportPath = pkg.ImportPath
 				merged.Imports = mergeStrings(merged.Imports, pkg.Imports)
@@ -1318,11 +1394,15 @@ func parseLayeringEdges(r io.Reader) ([]seededLayeringEdge, error) {
 			problems = append(problems, malformedLayeringEdge(line))
 			continue
 		}
-		for i := range parts {
-			parts[i] = strings.TrimSpace(parts[i])
+		// Reject rather than trim: an import path never carries surrounding
+		// whitespace, so a padded field is a malformed row, not one to
+		// silently normalize into a different identity.
+		if hasBlank(parts...) || hasSurroundingWhitespace(parts...) {
+			problems = append(problems, malformedLayeringEdge(line))
+			continue
 		}
 		addedAt, dateErr := time.Parse(time.DateOnly, parts[4])
-		if hasBlank(parts...) || dateErr != nil {
+		if dateErr != nil {
 			problems = append(problems, malformedLayeringEdge(line))
 			continue
 		}
@@ -1354,6 +1434,15 @@ func skipLayeringEdgeLine(text string) bool {
 func hasBlank(values ...string) bool {
 	for _, value := range values {
 		if strings.TrimSpace(value) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSurroundingWhitespace(values ...string) bool {
+	for _, value := range values {
+		if value != strings.TrimSpace(value) {
 			return true
 		}
 	}

--- a/internal/qualitygate/deptest/layering_test.go
+++ b/internal/qualitygate/deptest/layering_test.go
@@ -125,12 +125,22 @@ type goReleaserConfig struct {
 }
 
 type goReleaserBuild struct {
-	Builder string           `yaml:"builder"`
-	GOOS    []string         `yaml:"goos"`
-	GOARCH  []string         `yaml:"goarch"`
-	Targets []string         `yaml:"targets"`
-	Ignore  []map[string]any `yaml:"ignore"`
-	Skip    bool             `yaml:"skip"`
+	Builder   string           `yaml:"builder"`
+	GOOS      []string         `yaml:"goos"`
+	GOARCH    []string         `yaml:"goarch"`
+	GOARM     []any            `yaml:"goarm"`
+	GOAMD64   []any            `yaml:"goamd64"`
+	GOARM64   []any            `yaml:"goarm64"`
+	GOMIPS    []any            `yaml:"gomips"`
+	GOMIPS64  []any            `yaml:"gomips64"`
+	GO386     []any            `yaml:"go386"`
+	GOPPC64   []any            `yaml:"goppc64"`
+	GORISCV64 []any            `yaml:"goriscv64"`
+	Tool      string           `yaml:"tool"`
+	GoBinary  string           `yaml:"gobinary"`
+	Targets   []string         `yaml:"targets"`
+	Ignore    []map[string]any `yaml:"ignore"`
+	Skip      bool             `yaml:"skip"`
 }
 
 type distTarget struct {
@@ -698,11 +708,11 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 			want: []string{"freebsd/amd64"},
 		},
 		{
-			name: "target suffixes preserve the base platform",
+			name: "target suffixes fail closed",
 			build: goReleaserBuild{
 				Targets: []string{"linux_amd64_v1"},
 			},
-			want: []string{"linux/amd64"},
+			wantErr: true,
 		},
 		{
 			name: "first class selector expands from the toolchain",
@@ -728,6 +738,15 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 			want: []string{},
 		},
 		{
+			name: "microarchitecture matrix fails closed",
+			build: goReleaserBuild{
+				GOOS:    []string{"linux"},
+				GOARCH:  []string{"amd64"},
+				GOAMD64: []any{"v3"},
+			},
+			wantErr: true,
+		},
+		{
 			name: "microarchitecture ignore fails closed",
 			build: goReleaserBuild{
 				GOOS:   []string{"linux"},
@@ -747,6 +766,20 @@ func TestGoReleaserBuildTargets(t *testing.T) {
 			name: "non-Go builder fails closed",
 			build: goReleaserBuild{
 				Builder: "rust",
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom Go tool fails closed",
+			build: goReleaserBuild{
+				Tool: "go1.24.0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "legacy custom Go binary fails closed",
+			build: goReleaserBuild{
+				GoBinary: "go1.24.0",
 			},
 			wantErr: true,
 		},
@@ -780,6 +813,12 @@ func goReleaserBuildTargets(
 	}
 	if build.Builder != "" && build.Builder != "go" {
 		return nil, fmt.Errorf("unsupported builder %q", build.Builder)
+	}
+	if build.Tool != "" || build.GoBinary != "" {
+		return nil, fmt.Errorf("custom Go tools are unsupported")
+	}
+	if buildHasMicroarchitectureMatrix(build) {
+		return nil, fmt.Errorf("microarchitecture matrices are unsupported")
 	}
 	if len(build.Targets) > 0 {
 		return explicitGoReleaserTargets(build.Targets, supported)
@@ -835,7 +874,7 @@ func explicitGoReleaserTargets(
 		}
 
 		parts := strings.Split(configuredTarget, "_")
-		if len(parts) < 2 {
+		if len(parts) != 2 {
 			return nil, fmt.Errorf("malformed target %q", configuredTarget)
 		}
 		target := parts[0] + "/" + parts[1]
@@ -845,6 +884,17 @@ func explicitGoReleaserTargets(
 		targets[target] = struct{}{}
 	}
 	return targets, nil
+}
+
+func buildHasMicroarchitectureMatrix(build goReleaserBuild) bool {
+	return len(build.GOARM) > 0 ||
+		len(build.GOAMD64) > 0 ||
+		len(build.GOARM64) > 0 ||
+		len(build.GOMIPS) > 0 ||
+		len(build.GOMIPS64) > 0 ||
+		len(build.GO386) > 0 ||
+		len(build.GOPPC64) > 0 ||
+		len(build.GORISCV64) > 0
 }
 
 func goReleaserTargetIgnored(goos, goarch string, ignored []map[string]any) (bool, error) {

--- a/scripts/check-layering-ratchet.sh
+++ b/scripts/check-layering-ratchet.sh
@@ -2,46 +2,7 @@
 # Copyright (c) 2026 Lark Technologies Pte. Ltd.
 # SPDX-License-Identifier: MIT
 
-set -euo pipefail
-
-if root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-  cd "$root"
-else
-  echo "Layering ratchet must run inside a Git worktree." >&2
-  exit 1
-fi
-
-base_revision="${1:-${QUALITY_GATE_CHANGED_FROM:-}}"
-ratchet_file="internal/qualitygate/deptest/layering-edges.txt"
-initial_count="${LAYERING_RATCHET_INITIAL_COUNT:-37}"
-initial_hash="${LAYERING_RATCHET_INITIAL_HASH:-cf61e4149cb4d539a1430f4a4266b91f972c253cedd300830c94e35dda1f0265}"
-
-if [[ -z "$base_revision" ]]; then
-  echo "Layering ratchet requires a base revision." >&2
-  exit 1
-fi
-if ! git cat-file -e "$base_revision^{commit}" 2>/dev/null; then
-  echo "Layering ratchet base revision does not exist: $base_revision" >&2
-  exit 1
-fi
-if [[ ! -f "$ratchet_file" ]]; then
-  echo "Layering ratchet file is missing: $ratchet_file" >&2
-  exit 1
-fi
-
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/layering-ratchet.XXXXXX")"
-base_file="$tmp_dir/base.txt"
-base_keys="$tmp_dir/base.keys"
-current_keys="$tmp_dir/current.keys"
-additions="$tmp_dir/additions.keys"
-
-cleanup_tmp() {
-  rm -f "$base_file" "$base_keys" "$current_keys" "$additions"
-  rmdir "$tmp_dir"
-}
-trap cleanup_tmp EXIT
-
-extract_keys() {
+layering_ratchet_extract_keys() {
   local source_file="$1"
   local output_file="$2"
   awk -F '\t' '
@@ -70,49 +31,105 @@ extract_keys() {
       }
       print from "\t" denied
     }
-  ' "$source_file" | LC_ALL=C sort >"$output_file"
+  ' "$source_file" | LC_ALL=C sort >"$output_file" || return
 
-  if [[ -n "$(uniq -d "$output_file")" ]]; then
+  local duplicates
+  duplicates="$(uniq -d "$output_file")" || return
+  if [[ -n "$duplicates" ]]; then
     echo "Layering ratchet contains duplicate (from, denied) keys: $source_file" >&2
-    uniq -d "$output_file" >&2
+    printf '%s\n' "$duplicates" >&2
     return 1
   fi
 }
 
-hash_keys() {
+layering_ratchet_hash_keys() {
   local source_file="$1"
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$source_file" | awk '{ print $1 }'
+    sha256sum "$source_file" | awk '{ print $1 }' || return
     return
   fi
   if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$source_file" | awk '{ print $1 }'
+    shasum -a 256 "$source_file" | awk '{ print $1 }' || return
     return
   fi
   echo "Layering ratchet requires sha256sum or shasum." >&2
   return 1
 }
 
-extract_keys "$ratchet_file" "$current_keys"
-
-if ! git cat-file -e "$base_revision:$ratchet_file" 2>/dev/null; then
-  current_count="$(wc -l <"$current_keys" | tr -d '[:space:]')"
-  current_hash="$(hash_keys "$current_keys")"
-  if [[ "$current_count" != "$initial_count" || "$current_hash" != "$initial_hash" ]]; then
-    echo "::error::Layering ratchet bootstrap differs from the approved $initial_count-edge snapshot." >&2
-    exit 1
+layering_ratchet_validate_bootstrap_snapshot() {
+  local current_keys="$1"
+  local expected_count="$2"
+  local expected_hash="$3"
+  local current_count
+  local current_hash
+  current_count="$(wc -l <"$current_keys" | tr -d '[:space:]')" || return
+  current_hash="$(layering_ratchet_hash_keys "$current_keys")" || return
+  if [[ "$current_count" != "$expected_count" || "$current_hash" != "$expected_hash" ]]; then
+    echo "::error::Layering ratchet bootstrap differs from the approved $expected_count-edge snapshot." >&2
+    return 1
   fi
-  exit 0
-fi
+}
 
-git show "$base_revision:$ratchet_file" >"$base_file"
-extract_keys "$base_file" "$base_keys"
-LC_ALL=C comm -13 "$base_keys" "$current_keys" >"$additions"
+layering_ratchet_main() (
+  set -euo pipefail
 
-if [[ -s "$additions" ]]; then
-  echo "::error::Layering ratchet contains new (from, denied) keys. Fix the dependency instead of adding rows." >&2
-  while IFS=$'\t' read -r from denied; do
-    printf 'from=%s denied=%s\n' "$from" "$denied" >&2
-  done <"$additions"
-  exit 1
+  local ratchet_file="internal/qualitygate/deptest/layering-edges.txt"
+  if root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    cd "$root" || return
+  else
+    echo "Layering ratchet must run inside a Git worktree." >&2
+    return 1
+  fi
+
+  local base_revision="${1:-${QUALITY_GATE_CHANGED_FROM:-}}"
+  local approved_initial_count="${2:-37}"
+  local approved_initial_hash="${3:-cf61e4149cb4d539a1430f4a4266b91f972c253cedd300830c94e35dda1f0265}"
+  if [[ -z "$base_revision" ]]; then
+    echo "Layering ratchet requires a base revision." >&2
+    return 1
+  fi
+  if ! git cat-file -e "$base_revision^{commit}" 2>/dev/null; then
+    echo "Layering ratchet base revision does not exist: $base_revision" >&2
+    return 1
+  fi
+  if [[ ! -f "$ratchet_file" ]]; then
+    echo "Layering ratchet file is missing: $ratchet_file" >&2
+    return 1
+  fi
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/layering-ratchet.XXXXXX")" || return
+  local base_file="$tmp_dir/base.txt"
+  local base_keys="$tmp_dir/base.keys"
+  local current_keys="$tmp_dir/current.keys"
+  local additions="$tmp_dir/additions.keys"
+
+  layering_ratchet_cleanup_current_run() {
+    rm -f "$base_file" "$base_keys" "$current_keys" "$additions"
+    rmdir "$tmp_dir"
+  }
+  trap layering_ratchet_cleanup_current_run EXIT
+
+  layering_ratchet_extract_keys "$ratchet_file" "$current_keys" || return
+
+  if ! git cat-file -e "$base_revision:$ratchet_file" 2>/dev/null; then
+    layering_ratchet_validate_bootstrap_snapshot "$current_keys" "$approved_initial_count" "$approved_initial_hash" || return
+    return
+  fi
+
+  git show "$base_revision:$ratchet_file" >"$base_file" || return
+  layering_ratchet_extract_keys "$base_file" "$base_keys" || return
+  LC_ALL=C comm -13 "$base_keys" "$current_keys" >"$additions" || return
+
+  if [[ -s "$additions" ]]; then
+    echo "::error::Layering ratchet contains new (from, denied) keys. Fix the dependency instead of adding rows." >&2
+    while IFS=$'\t' read -r from denied; do
+      printf 'from=%s denied=%s\n' "$from" "$denied" >&2
+    done <"$additions"
+    return 1
+  fi
+)
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  layering_ratchet_main "${1:-${QUALITY_GATE_CHANGED_FROM:-}}"
 fi

--- a/scripts/check-layering-ratchet.sh
+++ b/scripts/check-layering-ratchet.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+if root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  cd "$root"
+else
+  echo "Layering ratchet must run inside a Git worktree." >&2
+  exit 1
+fi
+
+base_revision="${1:-${QUALITY_GATE_CHANGED_FROM:-}}"
+ratchet_file="internal/qualitygate/deptest/layering-edges.txt"
+initial_count="${LAYERING_RATCHET_INITIAL_COUNT:-37}"
+initial_hash="${LAYERING_RATCHET_INITIAL_HASH:-cf61e4149cb4d539a1430f4a4266b91f972c253cedd300830c94e35dda1f0265}"
+
+if [[ -z "$base_revision" ]]; then
+  echo "Layering ratchet requires a base revision." >&2
+  exit 1
+fi
+if ! git cat-file -e "$base_revision^{commit}" 2>/dev/null; then
+  echo "Layering ratchet base revision does not exist: $base_revision" >&2
+  exit 1
+fi
+if [[ ! -f "$ratchet_file" ]]; then
+  echo "Layering ratchet file is missing: $ratchet_file" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/layering-ratchet.XXXXXX")"
+base_file="$tmp_dir/base.txt"
+base_keys="$tmp_dir/base.keys"
+current_keys="$tmp_dir/current.keys"
+additions="$tmp_dir/additions.keys"
+
+cleanup_tmp() {
+  rm -f "$base_file" "$base_keys" "$current_keys" "$additions"
+  rmdir "$tmp_dir"
+}
+trap cleanup_tmp EXIT
+
+extract_keys() {
+  local source_file="$1"
+  local output_file="$2"
+  awk -F '\t' '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    {
+      content = trim($0)
+      if (content == "" || substr(content, 1, 1) == "#") {
+        next
+      }
+      if (NF != 5) {
+        printf "Malformed layering ratchet row at %s:%d: expected five tab-separated fields.\n", FILENAME, FNR > "/dev/stderr"
+        exit 2
+      }
+      from = trim($1)
+      denied = trim($2)
+      owner = trim($3)
+      reason = trim($4)
+      added_at = trim($5)
+      if (from == "" || denied == "" || owner == "" || reason == "" || added_at !~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/) {
+        printf "Malformed layering ratchet row at %s:%d: fields must be non-empty and added_at must use YYYY-MM-DD.\n", FILENAME, FNR > "/dev/stderr"
+        exit 2
+      }
+      print from "\t" denied
+    }
+  ' "$source_file" | LC_ALL=C sort >"$output_file"
+
+  if [[ -n "$(uniq -d "$output_file")" ]]; then
+    echo "Layering ratchet contains duplicate (from, denied) keys: $source_file" >&2
+    uniq -d "$output_file" >&2
+    return 1
+  fi
+}
+
+hash_keys() {
+  local source_file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$source_file" | awk '{ print $1 }'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$source_file" | awk '{ print $1 }'
+    return
+  fi
+  echo "Layering ratchet requires sha256sum or shasum." >&2
+  return 1
+}
+
+extract_keys "$ratchet_file" "$current_keys"
+
+if ! git cat-file -e "$base_revision:$ratchet_file" 2>/dev/null; then
+  current_count="$(wc -l <"$current_keys" | tr -d '[:space:]')"
+  current_hash="$(hash_keys "$current_keys")"
+  if [[ "$current_count" != "$initial_count" || "$current_hash" != "$initial_hash" ]]; then
+    echo "::error::Layering ratchet bootstrap differs from the approved $initial_count-edge snapshot." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+git show "$base_revision:$ratchet_file" >"$base_file"
+extract_keys "$base_file" "$base_keys"
+LC_ALL=C comm -13 "$base_keys" "$current_keys" >"$additions"
+
+if [[ -s "$additions" ]]; then
+  echo "::error::Layering ratchet contains new (from, denied) keys. Fix the dependency instead of adding rows." >&2
+  while IFS=$'\t' read -r from denied; do
+    printf 'from=%s denied=%s\n' "$from" "$denied" >&2
+  done <"$additions"
+  exit 1
+fi

--- a/scripts/check-layering-ratchet.sh
+++ b/scripts/check-layering-ratchet.sh
@@ -20,11 +20,16 @@ layering_ratchet_extract_keys() {
         printf "Malformed layering ratchet row at %s:%d: expected five tab-separated fields.\n", FILENAME, FNR > "/dev/stderr"
         exit 2
       }
-      from = trim($1)
-      denied = trim($2)
-      owner = trim($3)
-      reason = trim($4)
-      added_at = trim($5)
+      from = $1
+      denied = $2
+      owner = $3
+      reason = $4
+      added_at = $5
+      sub(/\r+$/, "", added_at)
+      if (from != trim(from) || denied != trim(denied) || owner != trim(owner) || reason != trim(reason) || added_at != trim(added_at)) {
+        printf "Malformed layering ratchet row at %s:%d: fields must not have surrounding whitespace.\n", FILENAME, FNR > "/dev/stderr"
+        exit 2
+      }
       if (from == "" || denied == "" || owner == "" || reason == "" || added_at !~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/) {
         printf "Malformed layering ratchet row at %s:%d: fields must be non-empty and added_at must use YYYY-MM-DD.\n", FILENAME, FNR > "/dev/stderr"
         exit 2
@@ -82,8 +87,8 @@ layering_ratchet_main() (
   fi
 
   local base_revision="${1:-${QUALITY_GATE_CHANGED_FROM:-}}"
-  local approved_initial_count="${2:-37}"
-  local approved_initial_hash="${3:-cf61e4149cb4d539a1430f4a4266b91f972c253cedd300830c94e35dda1f0265}"
+  local approved_initial_count="${2:-39}"
+  local approved_initial_hash="${3:-5636d50d10b9de1e08dc9f06cd66671b3f438650fa5b7f28b95aa7d5a69a1c21}"
   if [[ -z "$base_revision" ]]; then
     echo "Layering ratchet requires a base revision." >&2
     return 1

--- a/scripts/check-layering-ratchet.test.sh
+++ b/scripts/check-layering-ratchet.test.sh
@@ -190,6 +190,31 @@ test_malformed_and_missing_current_file_fail() {
   expect_fail "$dir" "$base" "Layering ratchet file is missing"
 }
 
+test_surrounding_whitespace_fails() {
+  local dir="$tmp/surrounding-whitespace"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  printf '# from\tdenied\towner\treason\tadded_at\nfrom/a\t denied/a \towner\treason\t2026-07-24\n' >"$dir/$ratchet_file"
+  expect_fail "$dir" "$base" "fields must not have surrounding whitespace"
+  expect_sourced_main_fail "$dir" "$base" "fields must not have surrounding whitespace"
+}
+
+test_crlf_rows_pass() {
+  local dir="$tmp/crlf"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  printf '# from\tdenied\towner\treason\tadded_at\r\nfrom/a\tdenied/a\towner\treason\t2026-07-24\r\n' >"$dir/$ratchet_file"
+  expect_pass "$dir" "$base"
+}
+
 test_duplicate_key_fails() {
   local dir="$tmp/duplicate"
   git_init "$dir"
@@ -213,7 +238,7 @@ test_bootstrap_requires_the_approved_snapshot() {
 
   local args=()
   local index
-  for index in $(seq 1 37); do
+  for index in $(seq 1 39); do
     args+=("from/$index" "denied/$index")
   done
   write_rows "$dir" "${args[@]}"
@@ -221,16 +246,16 @@ test_bootstrap_requires_the_approved_snapshot() {
   bootstrap_keys "$dir/$ratchet_file" >"$keys_file"
   local expected_hash
   expected_hash="$(hash_file "$keys_file")"
-  expect_bootstrap_pass "$dir" "$base" 37 "$expected_hash"
+  expect_bootstrap_pass "$dir" "$base" 39 "$expected_hash"
 
-  args[72]="from/replacement"
+  args[76]="from/replacement"
   write_rows "$dir" "${args[@]}"
-  expect_bootstrap_fail "$dir" "$base" 37 "$expected_hash"
+  expect_bootstrap_fail "$dir" "$base" 39 "$expected_hash"
 
-  args[72]="from/37"
-  args+=("from/38" "denied/38")
+  args[76]="from/39"
+  args+=("from/40" "denied/40")
   write_rows "$dir" "${args[@]}"
-  expect_bootstrap_fail "$dir" "$base" 37 "$expected_hash"
+  expect_bootstrap_fail "$dir" "$base" 39 "$expected_hash"
 }
 
 test_invalid_base_fails() {
@@ -246,6 +271,8 @@ test_deletion_passes
 test_addition_fails
 test_equal_count_replacement_fails
 test_malformed_and_missing_current_file_fail
+test_surrounding_whitespace_fails
+test_crlf_rows_pass
 test_duplicate_key_fails
 test_bootstrap_requires_the_approved_snapshot
 test_invalid_base_fails

--- a/scripts/check-layering-ratchet.test.sh
+++ b/scripts/check-layering-ratchet.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$repo_root/scripts/check-layering-ratchet.sh"
+ratchet_file="internal/qualitygate/deptest/layering-edges.txt"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/check-layering-ratchet-test.XXXXXX")"
+
+cleanup_tmp() {
+  rm -rf "$tmp"
+}
+trap cleanup_tmp EXIT
+
+row() {
+  printf '%s\t%s\towner\treason\t2026-07-24\n' "$1" "$2"
+}
+
+git_init() {
+  local dir="$1"
+  git init -q -b main "$dir"
+  git -C "$dir" config user.name test
+  git -C "$dir" config user.email test@example.com
+  mkdir -p "$dir/$(dirname "$ratchet_file")"
+}
+
+write_rows() {
+  local dir="$1"
+  shift
+  {
+    printf '# from\tdenied\towner\treason\tadded_at\n'
+    while (( $# > 0 )); do
+      row "$1" "$2"
+      shift 2
+    done
+  } >"$dir/$ratchet_file"
+}
+
+commit_ratchet() {
+  local dir="$1"
+  git -C "$dir" add "$ratchet_file"
+  git -C "$dir" commit -q -m "ratchet"
+}
+
+expect_pass() {
+  local dir="$1"
+  local base="$2"
+  if ! (cd "$dir" && bash "$script" "$base"); then
+    echo "Expected layering ratchet check to pass in $dir." >&2
+    return 1
+  fi
+}
+
+expect_fail() {
+  local dir="$1"
+  local base="$2"
+  if (cd "$dir" && bash "$script" "$base" >/dev/null 2>&1); then
+    echo "Expected layering ratchet check to fail in $dir." >&2
+    return 1
+  fi
+}
+
+hash_file() {
+  local source_file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$source_file" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$source_file" | awk '{ print $1 }'
+  fi
+}
+
+bootstrap_keys() {
+  local source_file="$1"
+  awk -F '\t' 'NF == 5 && $1 !~ /^[[:space:]]*#/ { print $1 "\t" $2 }' "$source_file" | LC_ALL=C sort
+}
+
+expect_bootstrap_pass() {
+  local dir="$1"
+  local base="$2"
+  local count="$3"
+  local hash="$4"
+  if ! (
+    cd "$dir"
+    LAYERING_RATCHET_INITIAL_COUNT="$count" \
+      LAYERING_RATCHET_INITIAL_HASH="$hash" \
+      bash "$script" "$base"
+  ); then
+    echo "Expected layering ratchet bootstrap check to pass in $dir." >&2
+    return 1
+  fi
+}
+
+expect_bootstrap_fail() {
+  local dir="$1"
+  local base="$2"
+  local count="$3"
+  local hash="$4"
+  if (
+    cd "$dir"
+    LAYERING_RATCHET_INITIAL_COUNT="$count" \
+      LAYERING_RATCHET_INITIAL_HASH="$hash" \
+      bash "$script" "$base" >/dev/null 2>&1
+  ); then
+    echo "Expected layering ratchet bootstrap check to fail in $dir." >&2
+    return 1
+  fi
+}
+
+test_unchanged_and_metadata_changes_pass() {
+  local dir="$tmp/unchanged"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a from/b denied/b
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  expect_pass "$dir" "$base"
+  sed -i.bak 's/\towner\treason\t/\tnew-owner\tnew-reason\t/' "$dir/$ratchet_file"
+  rm -f "$dir/$ratchet_file.bak"
+  expect_pass "$dir" "$base"
+}
+
+test_deletion_passes() {
+  local dir="$tmp/deletion"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a from/b denied/b
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  write_rows "$dir" from/a denied/a
+  expect_pass "$dir" "$base"
+}
+
+test_addition_fails() {
+  local dir="$tmp/addition"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  write_rows "$dir" from/a denied/a from/b denied/b
+  expect_fail "$dir" "$base"
+}
+
+test_equal_count_replacement_fails() {
+  local dir="$tmp/replacement"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a from/b denied/b
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  write_rows "$dir" from/a denied/a from/c denied/c
+  expect_fail "$dir" "$base"
+}
+
+test_malformed_and_missing_current_file_fail() {
+  local dir="$tmp/malformed"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  printf 'from/a\tdenied/a\towner\treason\n' >"$dir/$ratchet_file"
+  expect_fail "$dir" "$base"
+  rm -f "$dir/$ratchet_file"
+  expect_fail "$dir" "$base"
+}
+
+test_bootstrap_requires_the_approved_snapshot() {
+  local dir="$tmp/bootstrap"
+  git_init "$dir"
+  printf 'base\n' >"$dir/base.txt"
+  git -C "$dir" add base.txt
+  git -C "$dir" commit -q -m "base"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  local args=()
+  local index
+  for index in $(seq 1 37); do
+    args+=("from/$index" "denied/$index")
+  done
+  write_rows "$dir" "${args[@]}"
+  local keys_file="$dir/initial.keys"
+  bootstrap_keys "$dir/$ratchet_file" >"$keys_file"
+  local initial_hash
+  initial_hash="$(hash_file "$keys_file")"
+  expect_bootstrap_pass "$dir" "$base" 37 "$initial_hash"
+
+  args[72]="from/replacement"
+  write_rows "$dir" "${args[@]}"
+  expect_bootstrap_fail "$dir" "$base" 37 "$initial_hash"
+
+  args[72]="from/37"
+  args+=("from/38" "denied/38")
+  write_rows "$dir" "${args[@]}"
+  expect_bootstrap_fail "$dir" "$base" 37 "$initial_hash"
+}
+
+test_invalid_base_fails() {
+  local dir="$tmp/invalid-base"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a
+  commit_ratchet "$dir"
+  expect_fail "$dir" missing-revision
+}
+
+test_unchanged_and_metadata_changes_pass
+test_deletion_passes
+test_addition_fails
+test_equal_count_replacement_fails
+test_malformed_and_missing_current_file_fail
+test_bootstrap_requires_the_approved_snapshot
+test_invalid_base_fails

--- a/scripts/check-layering-ratchet.test.sh
+++ b/scripts/check-layering-ratchet.test.sh
@@ -8,6 +8,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 script="$repo_root/scripts/check-layering-ratchet.sh"
 ratchet_file="internal/qualitygate/deptest/layering-edges.txt"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/check-layering-ratchet-test.XXXXXX")"
+source "$script"
 
 cleanup_tmp() {
   rm -rf "$tmp"
@@ -56,8 +57,14 @@ expect_pass() {
 expect_fail() {
   local dir="$1"
   local base="$2"
-  if (cd "$dir" && bash "$script" "$base" >/dev/null 2>&1); then
+  local expected="$3"
+  local output
+  if output="$(cd "$dir" && bash "$script" "$base" 2>&1)"; then
     echo "Expected layering ratchet check to fail in $dir." >&2
+    return 1
+  fi
+  if ! grep -Fq "$expected" <<<"$output"; then
+    printf 'Layering ratchet failure did not include %q:\n%s\n' "$expected" "$output" >&2
     return 1
   fi
 }
@@ -81,12 +88,7 @@ expect_bootstrap_pass() {
   local base="$2"
   local count="$3"
   local hash="$4"
-  if ! (
-    cd "$dir"
-    LAYERING_RATCHET_INITIAL_COUNT="$count" \
-      LAYERING_RATCHET_INITIAL_HASH="$hash" \
-      bash "$script" "$base"
-  ); then
+  if ! (cd "$dir" && layering_ratchet_main "$base" "$count" "$hash"); then
     echo "Expected layering ratchet bootstrap check to pass in $dir." >&2
     return 1
   fi
@@ -97,13 +99,28 @@ expect_bootstrap_fail() {
   local base="$2"
   local count="$3"
   local hash="$4"
-  if (
-    cd "$dir"
-    LAYERING_RATCHET_INITIAL_COUNT="$count" \
-      LAYERING_RATCHET_INITIAL_HASH="$hash" \
-      bash "$script" "$base" >/dev/null 2>&1
-  ); then
+  local output
+  if output="$(cd "$dir" && layering_ratchet_main "$base" "$count" "$hash" 2>&1)"; then
     echo "Expected layering ratchet bootstrap check to fail in $dir." >&2
+    return 1
+  fi
+  if ! grep -Fq "bootstrap differs from the approved" <<<"$output"; then
+    printf 'Unexpected layering ratchet bootstrap failure:\n%s\n' "$output" >&2
+    return 1
+  fi
+}
+
+expect_sourced_main_fail() {
+  local dir="$1"
+  local base="$2"
+  local expected="$3"
+  local output
+  if output="$(cd "$dir" && layering_ratchet_main "$base" 2>&1)"; then
+    echo "Expected sourced layering ratchet main to fail in $dir." >&2
+    return 1
+  fi
+  if ! grep -Fq "$expected" <<<"$output"; then
+    printf 'Sourced layering ratchet failure did not include %q:\n%s\n' "$expected" "$output" >&2
     return 1
   fi
 }
@@ -143,7 +160,7 @@ test_addition_fails() {
   base="$(git -C "$dir" rev-parse HEAD)"
 
   write_rows "$dir" from/a denied/a from/b denied/b
-  expect_fail "$dir" "$base"
+  expect_fail "$dir" "$base" "from=from/b denied=denied/b"
 }
 
 test_equal_count_replacement_fails() {
@@ -155,7 +172,7 @@ test_equal_count_replacement_fails() {
   base="$(git -C "$dir" rev-parse HEAD)"
 
   write_rows "$dir" from/a denied/a from/c denied/c
-  expect_fail "$dir" "$base"
+  expect_fail "$dir" "$base" "from=from/c denied=denied/c"
 }
 
 test_malformed_and_missing_current_file_fail() {
@@ -167,9 +184,22 @@ test_malformed_and_missing_current_file_fail() {
   base="$(git -C "$dir" rev-parse HEAD)"
 
   printf 'from/a\tdenied/a\towner\treason\n' >"$dir/$ratchet_file"
-  expect_fail "$dir" "$base"
+  expect_fail "$dir" "$base" "expected five tab-separated fields"
+  expect_sourced_main_fail "$dir" "$base" "expected five tab-separated fields"
   rm -f "$dir/$ratchet_file"
-  expect_fail "$dir" "$base"
+  expect_fail "$dir" "$base" "Layering ratchet file is missing"
+}
+
+test_duplicate_key_fails() {
+  local dir="$tmp/duplicate"
+  git_init "$dir"
+  write_rows "$dir" from/a denied/a
+  commit_ratchet "$dir"
+  local base
+  base="$(git -C "$dir" rev-parse HEAD)"
+
+  write_rows "$dir" from/a denied/a from/a denied/a
+  expect_fail "$dir" "$base" "duplicate (from, denied) keys"
 }
 
 test_bootstrap_requires_the_approved_snapshot() {
@@ -189,18 +219,18 @@ test_bootstrap_requires_the_approved_snapshot() {
   write_rows "$dir" "${args[@]}"
   local keys_file="$dir/initial.keys"
   bootstrap_keys "$dir/$ratchet_file" >"$keys_file"
-  local initial_hash
-  initial_hash="$(hash_file "$keys_file")"
-  expect_bootstrap_pass "$dir" "$base" 37 "$initial_hash"
+  local expected_hash
+  expected_hash="$(hash_file "$keys_file")"
+  expect_bootstrap_pass "$dir" "$base" 37 "$expected_hash"
 
   args[72]="from/replacement"
   write_rows "$dir" "${args[@]}"
-  expect_bootstrap_fail "$dir" "$base" 37 "$initial_hash"
+  expect_bootstrap_fail "$dir" "$base" 37 "$expected_hash"
 
   args[72]="from/37"
   args+=("from/38" "denied/38")
   write_rows "$dir" "${args[@]}"
-  expect_bootstrap_fail "$dir" "$base" 37 "$initial_hash"
+  expect_bootstrap_fail "$dir" "$base" 37 "$expected_hash"
 }
 
 test_invalid_base_fails() {
@@ -208,7 +238,7 @@ test_invalid_base_fails() {
   git_init "$dir"
   write_rows "$dir" from/a denied/a
   commit_ratchet "$dir"
-  expect_fail "$dir" missing-revision
+  expect_fail "$dir" missing-revision "base revision does not exist"
 }
 
 test_unchanged_and_metadata_changes_pass
@@ -216,5 +246,6 @@ test_deletion_passes
 test_addition_fails
 test_equal_count_replacement_fails
 test_malformed_and_missing_current_file_fail
+test_duplicate_key_fails
 test_bootstrap_requires_the_approved_snapshot
 test_invalid_base_fails

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -170,6 +170,21 @@ if grep -Fq '${{ secrets.' <<<"$script_test_section"; then
   exit 1
 fi
 
+if ! grep -Fq 'bash scripts/check-layering-ratchet.sh "$QUALITY_GATE_CHANGED_FROM"' <<<"$lint_section"; then
+  echo "lint should enforce the layering ratchet with the tested key-set checker"
+  exit 1
+fi
+
+if grep -Fq "grep -vcE" <<<"$lint_section"; then
+  echo "lint should not enforce the layering ratchet by row count alone"
+  exit 1
+fi
+
+if grep -Fq "LAYERING_RATCHET_INITIAL_" <<<"$lint_section"; then
+  echo "lint must use the checked-in layering bootstrap snapshot"
+  exit 1
+fi
+
 if grep -Fq "metadata-gate:" "$workflow"; then
   echo "metadata-gate should not run alongside deterministic-gate because both would upload the same facts artifact"
   exit 1

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -180,8 +180,8 @@ if grep -Fq "grep -vcE" <<<"$lint_section"; then
   exit 1
 fi
 
-if grep -Fq "LAYERING_RATCHET_INITIAL_" <<<"$lint_section"; then
-  echo "lint must use the checked-in layering bootstrap snapshot"
+if grep -Fq "LAYERING_RATCHET_INITIAL_" "$workflow"; then
+  echo "CI must use the immutable checked-in layering bootstrap snapshot"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Adds machine enforcement for six package dependency layers. This PR installs enforcement only; no business packages are moved, and follow-up changes can remove the registered legacy edges.

## Changes

- Add a data-driven layering test in `internal/qualitygate/deptest/layering_test.go`. It runs `go list -json ./...` twice for each of the seven published Linux, Darwin, and Windows `GOOS/GOARCH` combinations - once untagged and once with `-tags authsidecar` - and unions the resulting non-test production dependency graphs (14 invocations). The union matters: `extension/credential/sidecar` and its 8 denied edges only exist under the tag. Standard error remains separate from JSON output so cold-cache module download messages cannot corrupt decoding. The test reads only `.Imports` and `.Deps`, so test-only imports stay outside this phase.
- Enforce seven rules:

  | Rule | Mode | Restriction |
  |---|---|---|
  | extension-zero-internal | Transitive | Packages under `extension/` must not depend on `internal/**`; the two wrapper-main demos (`examples/audit-observer`, `examples/readonly-policy`) are exempt by exact import path, because their `cmd` import is the pattern they exist to demonstrate and every internal package they reach is inherited through `cmd` |
  | examples-surface-only | Direct | Packages under `extension/platform/examples/` may directly import only `cmd` and `extension/platform` from this module; every other repository package is rejected, while standard library and third-party imports stay outside the rule |
  | events-no-shortcuts | Transitive | Packages under `events/` must not depend on `shortcuts/**` |
  | shortcuts-runtime-gate | Direct | Packages under `shortcuts/` must use the `shortcuts/common` runtime gate instead of importing sensitive runtime packages; `shortcuts/common` and `shortcuts/apps/gitcred` are exempt |
  | cmd-assembly-only | Direct | Only the `cmd` assembly root and `cmd/auth` may import `shortcuts/**` |
  | errs-leaf | Direct | `errs` must remain a repository leaf |
  | internal-no-upper | Direct | Packages under `internal/` must not import `cmd`, `shortcuts`, or `events`; the `manifest-export` command collector is exempt |

- Exempt packages by exact import path only. An earlier revision skipped any package whose path contained `/examples/`, which meant a directory named `examples` anywhere under `extension/` escaped the rule outright, and the sanctioned demos were exempt from every denial rather than only from the internal packages they inherit through `cmd`. That substring mechanism is gone, and `examples-surface-only` now covers the demo tree as an allowlist rather than a few denied prefixes: because the transitive rule no longer inspects these packages, pinning their direct surface to two packages is what keeps the inherited chain bounded. Seeding those inherited edges instead would wedge the ratchet: they track `cmd`'s transitive set, so a new `internal` package under `cmd` would demand a new row that `check-layering-ratchet.sh` refuses by design.
- Register 39 existing `(from, denied)` edges in `layering-edges.txt`. The Go test rejects new unregistered edges and stale rows. CI compares the current key set with the base revision, so keys may only be removed; equal-count replacement also fails. The first-run bootstrap is locked to the exact approved 39-edge snapshot.
- Add contract tests for unchanged metadata, deletion, addition, equal-count replacement, malformed input, missing files, duplicate keys, bootstrap replacement, invalid base revisions, conditional Shell execution, and separated `go list` output streams.
- Remove the circular-dependency report step from `arch-audit.yml`; Go already rejects import cycles during compilation.

## Test Plan

- [x] `make script-test`
- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `golangci-lint` reports zero issues
- [x] Fresh `GOMODCACHE` and `GOCACHE` run passes all seven package graph targets
- [x] A temporary forbidden `events` import fails with `from`, `denied`, and `rule` diagnostics
- [x] Removing an active seed row fails as a new violation
- [x] Adding a stale seed row fails with deletion guidance
- [x] Adding a violation together with a matching seed row passes the Go test but fails the CI ratchet
- [x] A forbidden `internal` import inside `examples/audit-observer` fails `examples-surface-only`
- [x] `events`, `errs` and a `cmd` subpackage imported from `examples/audit-observer` all fail `examples-surface-only`
- [x] A new package under any `examples/` directory in `extension/` fails `extension-zero-internal`
- [x] `make examples-build` still builds both wrapper-main demos
- [ ] Manual local verification - N/A because runtime command behavior is unchanged

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Quality Improvements**
  - Strengthened dependency layering enforcement using an approved ratchet of denied dependency edges, including strict TSV validation, duplicate detection, and detection of newly added vs stale entries.
  - Added automated coverage to parse, evaluate, and reconcile layering violations against the approved edges list.

- **CI / Automation**
  - Lint now enforces the layering ratchet relative to a baseline, failing the build if new violations are introduced.
  - Architecture Audit workflow no longer generates circular-dependency reporting artifacts.
  - Expanded the `script-test` target to include layering ratchet checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

