### PR TITLE
docs(skills): clarify callout child rules

### DIFF
--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -13,7 +13,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 ## 容器标签
 |标签|说明|关键属性|
 |-|-|-|
-| `<callout>` | 高亮框，子块仅支持文本、标题、列表、待办、引用 | `emoji`(默认 bulb), `background-color`, `border-color`, `text-color` |
+| `<callout>` | 高亮框，子块仅支持文本块（如 `<p>`）、标题、列表、待办、引用；禁止裸文本及 `<table>`、`<img>`、`<pre>`、`<hr>`、`<grid>`、`<whiteboard>`、`<sheet>` 等其他块级标签或资源块 | `emoji`(默认 bulb), `background-color`, `border-color`, `text-color` |
 | `<grid>` + `<column>` | 分栏布局，各列 width-ratio 之和为 1 | `width-ratio` |
 | `<whiteboard>` | 嵌入画板 | `type`: `blank` \| `mermaid` \| `plantuml` \| `svg` |
 | `<pre>` | （代码块，内含 `code`）| `lang`, `caption` |


### PR DESCRIPTION
## Summary

Clarify the Lark Doc XML rules for `<callout>` so agents use text blocks and avoid nesting unsupported block and resource types.

## Changes

- Expand the existing callout table row to prohibit raw text and unsupported block or resource types.

## Test Plan

- [x] `node scripts/skill-format-check/index.js skills`
- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .` produces no output
- [x] `go mod tidy` produces no changes
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- [x] Manual live verification covered standalone callout writes and nested table round-tripping.

## Related Issues

- None
