### PR TITLE
fix(core): recognize env credentials in doctor config check

### DIFF
--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/larksuite/cli/internal/build"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/internal/identitydiag"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/transport"
@@ -87,23 +88,34 @@ func doctorRun(opts *DoctorOptions) error {
 	// ── 1. Config file ──
 	_, err := core.LoadMultiAppConfig()
 	if err != nil {
-		// For "config not present" cases, prefer the workspace-aware
-		// NotConfiguredError message + hint (e.g. "openclaw context
-		// detected but lark-cli is not bound to it" → bind --help) over
-		// the OS-level "open ... no such file or directory".
-		// For other errors (parse, perms), keep the raw error so the
-		// underlying problem is still visible.
-		msg, hint := err.Error(), ""
-		if errors.Is(err, os.ErrNotExist) {
-			var cfgErr *errs.ConfigError
-			if errors.As(core.NotConfiguredError(), &cfgErr) {
-				msg, hint = cfgErr.Message, cfgErr.Hint
+		// Credentials can also come from environment variables (the env
+		// credential provider), in which case there is legitimately no
+		// config.json on disk. Don't dead-end with a "run config init"
+		// hint here: skip the disk check and let step 2 resolve the account
+		// through the credential provider, which either succeeds from env
+		// or surfaces an actionable reason (e.g. "APP_ID is missing").
+		if errors.Is(err, os.ErrNotExist) && envvars.HasEnvCredentials() {
+			checks = append(checks, skip("config_file", "no config.json on disk; using environment credentials"))
+		} else {
+			// For "config not present" cases, prefer the workspace-aware
+			// NotConfiguredError message + hint (e.g. "openclaw context
+			// detected but lark-cli is not bound to it" → bind --help) over
+			// the OS-level "open ... no such file or directory".
+			// For other errors (parse, perms), keep the raw error so the
+			// underlying problem is still visible.
+			msg, hint := err.Error(), ""
+			if errors.Is(err, os.ErrNotExist) {
+				var cfgErr *errs.ConfigError
+				if errors.As(core.NotConfiguredError(), &cfgErr) {
+					msg, hint = cfgErr.Message, cfgErr.Hint
+				}
 			}
+			checks = append(checks, fail("config_file", msg, hint))
+			return finishDoctor(f, checks)
 		}
-		checks = append(checks, fail("config_file", msg, hint))
-		return finishDoctor(f, checks)
+	} else {
+		checks = append(checks, pass("config_file", "config.json found"))
 	}
-	checks = append(checks, pass("config_file", "config.json found"))
 
 	// ── 2. App resolved ──
 	cfg, err := f.Config()

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -144,6 +144,47 @@ func TestDoctorRun_SplitsBotAndMissingUserIdentity(t *testing.T) {
 	assertCheck(t, got.Checks, "identity_ready", "pass")
 }
 
+// With no config.json on disk but env credentials present, doctor must not
+// dead-end at the config_file check with a "run config init" hint. It should
+// skip that check and proceed to resolve the account from the environment.
+func TestDoctorRun_EnvCredentials_NoConfigFile_SkipsConfigCheck(t *testing.T) {
+	// Point config at an empty dir so LoadMultiAppConfig hits os.ErrNotExist,
+	// and supply credentials via the environment instead.
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "cli_env")
+	t.Setenv("LARKSUITE_CLI_TENANT_ACCESS_TOKEN", "t-env-token")
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "cli_env", Brand: core.BrandFeishu,
+	})
+	// Overall pass/fail depends on identity verification, which isn't the focus
+	// here; we only assert that step 1 no longer dead-ends the run.
+	_ = doctorRun(&DoctorOptions{
+		Factory: f,
+		Ctx:     context.Background(),
+		Offline: true,
+	})
+
+	var got struct {
+		Checks []checkResult `json:"checks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+
+	cfgCheck := findCheck(t, got.Checks, "config_file")
+	if cfgCheck.Status != "skip" {
+		t.Fatalf("config_file status = %q, want skip; check = %#v", cfgCheck.Status, cfgCheck)
+	}
+	// It must not hand back the "run config init" style hint that would send an
+	// env-only user in circles.
+	if strings.Contains(cfgCheck.Hint, "config init") {
+		t.Fatalf("config_file hint should not suggest config init for env credentials, got %q", cfgCheck.Hint)
+	}
+	// Doctor must have proceeded past step 1 to the identity checks.
+	findCheck(t, got.Checks, "app_resolved")
+}
+
 func assertCheck(t *testing.T, checks []checkResult, name, status string) {
 	t.Helper()
 	if got := findCheck(t, checks, name); got.Status != status {

--- a/internal/envvars/envvars.go
+++ b/internal/envvars/envvars.go
@@ -3,6 +3,8 @@
 
 package envvars
 
+import "os"
+
 const (
 	CliAppID             = "LARKSUITE_CLI_APP_ID"
 	CliAppSecret         = "LARKSUITE_CLI_APP_SECRET"
@@ -26,3 +28,18 @@ const (
 	CliProxyAddress = "LARKSUITE_CLI_PROXY_ADDRESS"
 	CliCAPath       = "LARKSUITE_CLI_CA_PATH"
 )
+
+// HasEnvCredentials reports whether any of the environment variables that feed
+// the env credential provider (app id/secret or an access token) are set. It
+// lets callers such as `doctor` distinguish "nothing configured at all" from
+// "credentials supplied via environment but no config.json on disk", so the
+// user isn't told to run `config init` when env credentials are the intended
+// setup.
+func HasEnvCredentials() bool {
+	for _, key := range []string{CliAppID, CliAppSecret, CliUserAccessToken, CliTenantAccessToken} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/envvars/envvars_test.go
+++ b/internal/envvars/envvars_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package envvars
+
+import "testing"
+
+func TestHasEnvCredentials(t *testing.T) {
+	// Ensure a clean slate: clear every credential env var, then set only the
+	// one under test. t.Setenv restores originals at test end.
+	credKeys := []string{CliAppID, CliAppSecret, CliUserAccessToken, CliTenantAccessToken}
+
+	tests := []struct {
+		name string
+		set  string // env var to set (empty = none set)
+		want bool
+	}{
+		{name: "nothing set", set: "", want: false},
+		{name: "app id set", set: CliAppID, want: true},
+		{name: "app secret set", set: CliAppSecret, want: true},
+		{name: "user access token set", set: CliUserAccessToken, want: true},
+		{name: "tenant access token set", set: CliTenantAccessToken, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, k := range credKeys {
+				t.Setenv(k, "")
+			}
+			if tt.set != "" {
+				t.Setenv(tt.set, "value")
+			}
+			if got := HasEnvCredentials(); got != tt.want {
+				t.Fatalf("HasEnvCredentials() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`lark-cli doctor` reported "not configured" (with a "run config init" hint) when credentials were supplied via `LARKSUITE_CLI_*` environment variables but no config.json existed on disk. The config_file check read disk directly and returned early, never reaching the credential-provider-backed identity checks.

## Changes
- Add `envvars.HasEnvCredentials()` to detect app id/secret or access-token env vars
- In `doctor`, when config.json is absent but env credentials are present, skip the config_file check instead of failing, letting account resolution proceed through the credential provider (which resolves env creds, or surfaces the actionable "APP_ID is missing" reason at app_resolved)
- Add unit tests for the helper and the env-only doctor path

## Test Plan
- [x] Unit tests pass (`go test ./cmd/doctor/... ./internal/envvars/...`)
- [x] `go build ./...` and `go vet ./...` pass

## Related Issues
- Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The doctor diagnostic now recognizes credentials provided through environment variables.
  - When no configuration file exists but environment credentials are available, the configuration check is skipped and diagnostics continue.

- **Bug Fixes**
  - Improved configuration guidance when credentials are unavailable, while preserving detailed error messages for other configuration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->