### PR TITLE
fix(sheets): recognize OFL0X local office tokens

### DIFF
--- a/shortcuts/sheets/backward/lark_sheets_float_images.go
+++ b/shortcuts/sheets/backward/lark_sheets_float_images.go
@@ -17,9 +17,10 @@ import (
 )
 
 // Drive media parent_type values for uploading an image into a spreadsheet.
-// Native spreadsheets use "sheet_image"; imported "office" spreadsheets carry a
-// synthetic token prefixed with "fake_office_" (being renamed to
-// "local_office_") and the backend requires "office_sheet_file" instead.
+// Native spreadsheets use "sheet_image"; imported "office" spreadsheets use a
+// legacy synthetic-token prefix or a 28-character token whose interleaved
+// product/region marker is "OFL0X". The backend requires
+// "office_sheet_file" for those imported spreadsheets.
 const (
 	sheetImageParentType      = "sheet_image"
 	officeSheetFileParentType = "office_sheet_file"
@@ -27,21 +28,36 @@ const (
 	localOfficePrefix         = "local_office_"
 )
 
-// officePrefixes are the synthetic token prefixes an imported "office"
-// spreadsheet may carry. The prefix is being renamed from "fake_office_" to
-// "local_office_"; accept either so image uploads keep working across the
-// rename.
+// officePrefixes are the legacy synthetic token prefixes an imported "office"
+// spreadsheet may carry.
 var officePrefixes = []string{fakeOfficePrefix, localOfficePrefix}
 
-// sheetMediaParentType returns the drive media parent_type to use when
-// uploading an image whose parent_node is spreadsheetToken, mapping either the
-// "fake_office_" or "local_office_" imported-spreadsheet token prefix to
-// "office_sheet_file".
-func sheetMediaParentType(spreadsheetToken string) string {
+func isOfficeSpreadsheet(spreadsheetToken string) bool {
 	for _, prefix := range officePrefixes {
 		if strings.HasPrefix(spreadsheetToken, prefix) {
-			return officeSheetFileParentType
+			return true
 		}
+	}
+	if len(spreadsheetToken) != 28 {
+		return false
+	}
+	// The five-character marker occupies positions 5, 10, 15, 20, and 25
+	// (1-based) in the interleaved token.
+	marker := []byte{
+		spreadsheetToken[4],
+		spreadsheetToken[9],
+		spreadsheetToken[14],
+		spreadsheetToken[19],
+		spreadsheetToken[24],
+	}
+	return string(marker) == "OFL0X"
+}
+
+// sheetMediaParentType returns the drive media parent_type to use when
+// uploading an image whose parent_node is spreadsheetToken.
+func sheetMediaParentType(spreadsheetToken string) string {
+	if isOfficeSpreadsheet(spreadsheetToken) {
+		return officeSheetFileParentType
 	}
 	return sheetImageParentType
 }

--- a/shortcuts/sheets/backward/lark_sheets_sheet_media_upload_test.go
+++ b/shortcuts/sheets/backward/lark_sheets_sheet_media_upload_test.go
@@ -105,7 +105,7 @@ func TestSheetMediaUploadDryRunSmallFileOfficeParentType(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
 	err := mountAndRunSheets(t, SheetMediaUpload, []string{
 		"+media-upload",
-		"--spreadsheet-token", "fake_office_abc123",
+		"--spreadsheet-token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa",
 		"--file", "img.png",
 		"--dry-run", "--as", "user",
 	}, f, stdout)
@@ -117,10 +117,10 @@ func TestSheetMediaUploadDryRunSmallFileOfficeParentType(t *testing.T) {
 		t.Fatalf("dry-run should use upload_all for small file, got: %s", out)
 	}
 	if !strings.Contains(out, `"office_sheet_file"`) {
-		t.Fatalf("dry-run should include parent_type=office_sheet_file for fake_office_ token, got: %s", out)
+		t.Fatalf("dry-run should include parent_type=office_sheet_file for interleaved OFL0X token, got: %s", out)
 	}
 	if strings.Contains(out, `"sheet_image"`) {
-		t.Fatalf("dry-run must not emit sheet_image for fake_office_ token, got: %s", out)
+		t.Fatalf("dry-run must not emit sheet_image for interleaved OFL0X token, got: %s", out)
 	}
 }
 
@@ -239,7 +239,7 @@ func TestSheetMediaUploadExecuteSuccess(t *testing.T) {
 }
 
 // TestSheetMediaUploadExecuteOfficeParentType confirms that an imported
-// "office" spreadsheet (token prefixed with "fake_office_") uploads with
+// "office" spreadsheet (token carrying the interleaved "OFL0X" marker) uploads with
 // parent_type=office_sheet_file instead of the native sheet_image.
 func TestSheetMediaUploadExecuteOfficeParentType(t *testing.T) {
 	dir := t.TempDir()
@@ -259,7 +259,7 @@ func TestSheetMediaUploadExecuteOfficeParentType(t *testing.T) {
 	}
 	reg.Register(stub)
 
-	const officeToken = "fake_office_abc123"
+	const officeToken = "aaaaOaaaaFaaaaLaaaa0aaaaXaaa"
 	err := mountAndRunSheets(t, SheetMediaUpload, []string{
 		"+media-upload",
 		"--spreadsheet-token", officeToken,

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -53,9 +53,10 @@ func sheetsInputStatError(flag string, err error) error {
 }
 
 // Drive media parent_type values for uploading an image into a spreadsheet.
-// Native spreadsheets use "sheet_image"; imported "office" spreadsheets carry a
-// synthetic token prefixed with "fake_office_" (being renamed to
-// "local_office_") and the backend requires "office_sheet_file" instead.
+// Native spreadsheets use "sheet_image"; imported "office" spreadsheets use a
+// legacy synthetic-token prefix or a 28-character token whose interleaved
+// product/region marker is "OFL0X". The backend requires
+// "office_sheet_file" for those imported spreadsheets.
 const (
 	sheetImageParentType      = "sheet_image"
 	officeSheetFileParentType = "office_sheet_file"
@@ -63,21 +64,38 @@ const (
 	localOfficePrefix         = "local_office_"
 )
 
-// officePrefixes are the synthetic token prefixes an imported "office"
-// spreadsheet may carry. The prefix is being renamed from "fake_office_" to
-// "local_office_"; accept either so image uploads keep working across the
-// rename.
+// officePrefixes are the legacy synthetic token prefixes an imported "office"
+// spreadsheet may carry.
 var officePrefixes = []string{fakeOfficePrefix, localOfficePrefix}
+
+func isOfficeSpreadsheet(spreadsheetToken string) bool {
+	for _, prefix := range officePrefixes {
+		if strings.HasPrefix(spreadsheetToken, prefix) {
+			return true
+		}
+	}
+	if len(spreadsheetToken) != 28 {
+		return false
+	}
+	// The five-character marker occupies positions 5, 10, 15, 20, and 25
+	// (1-based) in the interleaved token.
+	marker := []byte{
+		spreadsheetToken[4],
+		spreadsheetToken[9],
+		spreadsheetToken[14],
+		spreadsheetToken[19],
+		spreadsheetToken[24],
+	}
+	return string(marker) == "OFL0X"
+}
 
 // sheetMediaParentType returns the drive media parent_type to use when
 // uploading an image whose parent_node is spreadsheetToken. It is the single
 // place that maps a spreadsheet token to its parent_type so every image-upload
 // entry point (and its dry-run preview) stays consistent.
 func sheetMediaParentType(spreadsheetToken string) string {
-	for _, prefix := range officePrefixes {
-		if strings.HasPrefix(spreadsheetToken, prefix) {
-			return officeSheetFileParentType
-		}
+	if isOfficeSpreadsheet(spreadsheetToken) {
+		return officeSheetFileParentType
 	}
 	return sheetImageParentType
 }

--- a/shortcuts/sheets/sheet_media_parent_type_test.go
+++ b/shortcuts/sheets/sheet_media_parent_type_test.go
@@ -25,8 +25,9 @@ import (
 
 // TestSheetMediaParentType pins the token→parent_type mapping that every
 // sheets image-upload entry point funnels through. Native spreadsheet tokens
-// use "sheet_image"; imported "office" spreadsheets carry a "fake_office_" or
-// "local_office_" synthetic token and must upload with "office_sheet_file".
+// use "sheet_image"; imported "office" spreadsheets use either a legacy
+// prefix or the interleaved "OFL0X" marker and must upload with
+// "office_sheet_file".
 func TestSheetMediaParentType(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -40,6 +41,13 @@ func TestSheetMediaParentType(t *testing.T) {
 		{"fake_office token, only the prefix", fakeOfficePrefix, officeSheetFileParentType},
 		{"local_office imported token", "local_office_abc123", officeSheetFileParentType},
 		{"local_office token, only the prefix", localOfficePrefix, officeSheetFileParentType},
+		{"interleaved OFL0X office token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa", officeSheetFileParentType},
+		{"interleaved exlcn token", "abcdeefghxijkllmnopcqrstnuv", sheetImageParentType},
+		{"interleaved shtcn native token", "abcdsefghhijkltmnopcqrstnuv", sheetImageParentType},
+		{"interleaved pptcn token", "abcdpefghpijkltmnopcqrstnuv", sheetImageParentType},
+		{"interleaved wodcn token", "abcdwefghoijkldmnopcqrstnuv", sheetImageParentType},
+		{"interleaved OFL0X marker with short length", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", sheetImageParentType},
+		{"interleaved OFL0X marker with long length", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", sheetImageParentType},
 		{"fake_office prefix mid-string is not matched", "shtfake_office_abc", sheetImageParentType},
 		{"local_office prefix mid-string is not matched", "shtlocal_office_abc", sheetImageParentType},
 	}
@@ -57,7 +65,7 @@ func TestSheetMediaParentType(t *testing.T) {
 // to end (the Execute path the dry-run tests don't reach), asserting the
 // parent_type that actually goes out on the wire is derived from the token: a
 // native spreadsheet uploads as sheet_image, an imported "office" spreadsheet
-// (fake_office_-prefixed token) as office_sheet_file.
+// (legacy prefix or interleaved OFL0X marker) as office_sheet_file.
 func TestUploadSheetImage_ParentType(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -67,6 +75,7 @@ func TestUploadSheetImage_ParentType(t *testing.T) {
 		{"native spreadsheet", "shtcnTOK123", sheetImageParentType},
 		{"fake_office imported spreadsheet", "fake_office_abc123", officeSheetFileParentType},
 		{"local_office imported spreadsheet", "local_office_abc123", officeSheetFileParentType},
+		{"interleaved OFL0X imported spreadsheet", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa", officeSheetFileParentType},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tests/cli_e2e/sheets/sheets_image_upload_dryrun_test.go
+++ b/tests/cli_e2e/sheets/sheets_image_upload_dryrun_test.go
@@ -17,11 +17,10 @@ import (
 // TestSheets_ImageUploadDryRunParentType pins the parent_type the sheets
 // image-upload shortcuts emit in --dry-run output for native vs. imported
 // "office" spreadsheets. For native tokens parent_type must be "sheet_image";
-// for tokens prefixed with "fake_office_" (the synthetic token an imported
-// office spreadsheet carries) the backend requires "office_sheet_file". The
-// three covered entries — sheets +media-upload (backward), sheets
-// +cells-set-image, and sheets +create-float-image — are every image-upload
-// surface that the office/native split fans out to.
+// for tokens carrying the interleaved "OFL0X" marker the backend requires
+// "office_sheet_file". The covered entries — sheets +media-upload (backward),
+// sheets +cells-set-image, and sheets +float-image-create — are every
+// image-upload surface that the office/native split fans out to.
 func TestSheets_ImageUploadDryRunParentType(t *testing.T) {
 	setSheetsDryRunEnv(t)
 
@@ -50,11 +49,11 @@ func TestSheets_ImageUploadDryRunParentType(t *testing.T) {
 			name: "media-upload office",
 			args: []string{
 				"sheets", "+media-upload",
-				"--spreadsheet-token", "fake_office_dryrun",
+				"--spreadsheet-token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa",
 				"--file", "img.png",
 				"--dry-run",
 			},
-			token:          "fake_office_dryrun",
+			token:          "aaaaOaaaaFaaaaLaaaa0aaaaXaaa",
 			wantParentType: "office_sheet_file",
 		},
 		{
@@ -74,13 +73,30 @@ func TestSheets_ImageUploadDryRunParentType(t *testing.T) {
 			name: "cells-set-image office",
 			args: []string{
 				"sheets", "+cells-set-image",
-				"--spreadsheet-token", "fake_office_dryrun",
+				"--spreadsheet-token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa",
 				"--sheet-id", "sheet1",
 				"--range", "A1",
 				"--image", "img.png",
 				"--dry-run",
 			},
-			token:          "fake_office_dryrun",
+			token:          "aaaaOaaaaFaaaaLaaaa0aaaaXaaa",
+			wantParentType: "office_sheet_file",
+		},
+		{
+			name: "float-image-create office",
+			args: []string{
+				"sheets", "+float-image-create",
+				"--spreadsheet-token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa",
+				"--sheet-id", "sheet1",
+				"--image-name", "img.png",
+				"--image", "img.png",
+				"--position-row", "0",
+				"--position-col", "A",
+				"--size-width", "100",
+				"--size-height", "100",
+				"--dry-run",
+			},
+			token:          "aaaaOaaaaFaaaaLaaaa0aaaaXaaa",
 			wantParentType: "office_sheet_file",
 		},
 	}


### PR DESCRIPTION
## Problem

Local Office spreadsheet tokens now use a 28-character interleaved format. The CLI only recognized the legacy `fake_office_` and `local_office_` prefixes, so local-image uploads for the new tokens selected `parent_type=sheet_image` instead of the required `office_sheet_file`.

## Changes

- Recognize a 28-character token as a local Office spreadsheet when positions 5, 10, 15, 20, and 25 form `OFL0X`.
- Keep the legacy prefix checks for compatibility.
- Apply the same classification to the current sheets shortcuts and the backward-compatible media upload path.
- Cover `+media-upload`, `+cells-set-image`, and `+float-image-create`, including native and malformed-token negative cases.

## Validation

- `go test -count=1 ./shortcuts/sheets/...`
- `go vet ./shortcuts/sheets/...`
- `./build.sh`
- `go test -count=1 ./tests/cli_e2e/sheets -run TestSheets_ImageUploadDryRunParentType`
- `make quality-gate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload parent-type handling for imported Office spreadsheets by expanding detection of legacy synthetic tokens and the newer interleaved `OFL0X` marker, ensuring uploads map to `office_sheet_file` (while non-Office/natively handled sheets continue to use `sheet_image`).

* **Tests**
  * Updated unit and end-to-end dry-run cases to use the new `OFL0X` office token and revised expectations across media-upload, cells-set-image, and float-image-create flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->