### PR TITLE
docs: make enterprise/embedded integration discoverable from the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The official [Lark/Feishu](https://www.larksuite.com/) CLI tool, maintained by the [larksuite](https://github.com/larksuite) team — built for humans and AI Agents. Covers core business domains including Messenger, Docs, Base, Sheets, Slides, Calendar, Mail, Tasks, Meetings, Markdown, and more, with 200+ commands and 26 AI Agent [Skills](./skills/).
 
-[Install](#installation--quick-start) · [AI Agent Skills](#agent-skills) · [Auth](#authentication) · [Commands](#three-layer-command-system) · [Advanced](#advanced-usage) · [Security](#security--risk-warnings-read-before-use) · [Contributing](#contributing)
+[Install](#installation--quick-start) · [AI Agent Skills](#agent-skills) · [Auth](#authentication) · [Commands](#three-layer-command-system) · [Advanced](#advanced-usage) · [Enterprise](#personal-or-enterprise) · [Security](#security--risk-warnings-read-before-use) · [Contributing](#contributing)
 
 ## Why lark-cli?
 
@@ -19,6 +19,15 @@ The official [Lark/Feishu](https://www.larksuite.com/) CLI tool, maintained by t
 - **Up and Running in 3 Minutes** — One-click app creation, interactive login, from install to first API call in just 3 steps
 - **Secure & Controllable** — Input injection protection, terminal output sanitization, OS-native keychain credential storage
 - **Three-Layer Architecture** — Shortcuts (human & AI friendly) → API Commands (platform-synced) → Raw API (full coverage), choose the right granularity
+
+## Personal or Enterprise?
+
+| You are... | Recommended path |
+| ---------- | ---------------- |
+| **An individual developer** — using lark-cli in your terminal or with your own AI Agent | Follow the [Quick Start](#installation--quick-start) below |
+| **Enterprise IT / ISV** — embedding lark-cli into your own Agent or platform, with centralized credentials (database / Vault / config center), unified audit logging, and a restricted command surface | Read [Embed lark-cli in your Agent](https://open.larksuite.com/document/mcp_open_tools/feishu-cli/embed-feishu-cli-in-agent) and the [`extension/`](./extension/) packages — extend via a wrapper `main`, no need to modify CLI source |
+
+> 💡 **For AI Agents:** append `.md` to any Open Platform doc URL to fetch it as raw Markdown, e.g. [`embed-feishu-cli-in-agent.md`](https://open.larksuite.com/document/mcp_open_tools/feishu-cli/embed-feishu-cli-in-agent.md).
 
 ## Features
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,7 @@
 
 飞书官方 CLI 工具，由 [larksuite](https://github.com/larksuite) 团队维护 — 让人类和 AI Agent 都能在终端中操作飞书。覆盖消息、文档、多维表格、电子表格、幻灯片、日历、邮箱、任务、会议、Markdown 等核心业务域，提供 200+ 命令及 26 个 AI Agent [Skills](./skills/)。
 
-[安装](#安装与快速开始) · [AI Agent Skills](#agent-skills) · [认证](#认证) · [命令](#三层命令调用) · [进阶用法](#进阶用法) · [安全](#安全与风险提示使用前必读) · [贡献](#贡献)
+[安装](#安装与快速开始) · [AI Agent Skills](#agent-skills) · [认证](#认证) · [命令](#三层命令调用) · [进阶用法](#进阶用法) · [企业接入](#个人使用还是企业集成) · [安全](#安全与风险提示使用前必读) · [贡献](#贡献)
 
 ## 为什么选 lark-cli？
 
@@ -19,6 +19,15 @@
 - **三分钟上手** — 一键创建应用、交互式登录授权，从安装到第一次 API 调用只需三步
 - **安全可控** — 输入防注入、终端输出净化、OS 原生密钥链存储凭证
 - **三层调用架构** — 快捷命令（人机友好）→ API 命令（平台同步）→ 通用调用（全 API 覆盖），按需选择粒度
+
+## 个人使用还是企业集成？
+
+| 你是... | 推荐路径 |
+| ------- | -------- |
+| **个人开发者** — 在终端里直接使用，或搭配自己的 AI Agent | 按下方[快速开始](#安装与快速开始)操作 |
+| **企业 IT / ISV** — 把 lark-cli 内嵌到自研 Agent 或平台中，需要中心化凭证管理（数据库 / Vault / 配置中心）、统一审计日志、命令能力裁剪 | 阅读[《自研 Agent 接入飞书 CLI》](https://open.larkoffice.com/document/mcp_open_tools/feishu-cli/embed-feishu-cli-in-agent)与 [`extension/`](./extension/) 扩展包 — 通过 wrapper `main` 扩展，无需修改 CLI 源码 |
+
+> 💡 **给 AI Agent：** 任意开放平台文档 URL 加 `.md` 后缀即可直接获取原始 Markdown，例如 [`embed-feishu-cli-in-agent.md`](https://open.larkoffice.com/document/mcp_open_tools/feishu-cli/embed-feishu-cli-in-agent.md)。
 
 ## 功能
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,13 @@
+# Extension
+
+Embed lark-cli into your own Agent or application — swap credential sources, audit every command, restrict the command surface — without modifying CLI source. Write a Go package against these interfaces, import it from a wrapper `main`, and build your own enhanced binary.
+
+Main extension points:
+
+| Package | Extension point | What it does |
+| ------- | --------------- | ------------ |
+| [`credential/`](./credential/) | **Credential** | Bring your own credential source: database, Vault, config center… |
+| [`transport/`](./transport/) | **Transport** | Intercept every HTTP request: inject headers, rewrite targets, logging & monitoring |
+| [`platform/`](./platform/) | **Restrict · Observer · Wrap · On** | Command allow/deny rules, audit hooks, onion-style middleware (approval gates, rate limiting), process lifecycle — see the [Plugin SDK README](./platform/README.md) |
+
+📖 Full guide: [Embed lark-cli in your Agent](https://open.larksuite.com/document/mcp_open_tools/feishu-cli/embed-feishu-cli-in-agent) ([中文](https://open.larkoffice.com/document/mcp_open_tools/feishu-cli/embed-feishu-cli-in-agent))


### PR DESCRIPTION
## Problem

Enterprise IT developers repeatedly report they don't know how to **centrally integrate lark-cli** into their own Agents/platforms. The capability exists and is documented — the extension mechanism (Credential / Transport / Restrict / Observer / Wrap / On) has a full guide on the Open Platform doc site ([Embed lark-cli in your Agent](https://open.larksuite.com/document/mcp_open_tools/feishu-cli/embed-feishu-cli-in-agent)) and the code is open-sourced under `extension/` — but the repo never mentions it. The README is written entirely from the individual-developer perspective (`config init` → `auth login`), so anyone evaluating the tool on GitHub cannot discover the enterprise path: neither `extension`, `enterprise` nor `embed` appears anywhere in the README.

## Changes

Content stays on the doc site (single source of truth); the repo only gains signposts:

- **README.md / README.zh.md** — add a small **"Personal or Enterprise?"** routing table right after *Why lark-cli?*: individual developers continue to Quick Start, enterprise IT / ISV get a direct link to the official embedding guide and `extension/`. Also adds an **Enterprise** entry to the nav bar, and a one-line tip that appending `.md` to any Open Platform doc URL returns raw Markdown (useful for AI Agents).
- **extension/README.md** (new, thin index) — maps the packages (`credential/`, `transport/`, `platform/`) to the six extension points and points to the existing `platform/README.md` Plugin SDK guide plus the official doc. Helps engineers who evaluate via source / pkg.go.dev.

No code changes; 3 files, +33/−2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated English and Chinese README navigation with a new section for choosing between personal use and enterprise integration.
  - Added guidance and a recommendation table for individual developers versus enterprise IT/ISVs.
  - Included a note for AI agents on fetching raw Markdown by appending `.md` to Open Platform documentation URLs.
  - Expanded the extension embedding guide, covering integration points and linking to full embedding documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
