### PR TITLE
Feat/detect line text overlap

### DIFF
--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -60,6 +60,13 @@ GHOST_TEXT_MIN_FONT_SIZE = 96
 GHOST_TEXT_MAX_ALPHA = 0.5
 GHOST_TEXT_FAINT_MIN_FONT_SIZE = 36
 GHOST_TEXT_FAINT_MAX_ALPHA = 0.35
+# A <line> crossing text glyphs is a legibility defect (see line_crosses_text_glyphs). We erode the
+# glyph box by this margin before testing intersection so a line that only skims a glyph edge or the
+# padding-only text frame -- but does not actually cut through the letterforms -- is not flagged.
+LINE_TEXT_GRAZE_MIN_PX = 2.0
+LINE_TEXT_GRAZE_FONT_RATIO = 0.12
+# A line whose effective stroke alpha is below this is not visibly rendered, so it cannot occlude text.
+LINE_MIN_VISIBLE_ALPHA = 0.08
 # Sub-pixel canvas overflow is floating-point rounding noise (e.g. rotated-bbox math), not a
 # visible defect; keep this well under 1px so real overflow is still always caught.
 CANVAS_OVERFLOW_TOLERANCE = 0.5
@@ -1609,6 +1616,93 @@ def detect_table_layout_size_mismatches(elements: list[dict[str, Any]]) -> list[
     return issues
 
 
+def segment_intersects_rect(
+    x1: float, y1: float, x2: float, y2: float, rect: dict[str, int | float]
+) -> bool:
+    """True when segment (x1,y1)-(x2,y2) enters the axis-aligned rect (Liang-Barsky clip)."""
+    left = rect["x"]
+    top = rect["y"]
+    right = rect["x"] + rect["width"]
+    bottom = rect["y"] + rect["height"]
+    if right <= left or bottom <= top:
+        return False
+    dx = x2 - x1
+    dy = y2 - y1
+    if dx == 0 and dy == 0:
+        return left <= x1 <= right and top <= y1 <= bottom
+    t_enter, t_exit = 0.0, 1.0
+    for delta, distance in ((-dx, x1 - left), (dx, right - x1), (-dy, y1 - top), (dy, bottom - y1)):
+        if delta == 0:
+            if distance < 0:
+                return False
+            continue
+        t = distance / delta
+        if delta < 0:
+            t_enter = max(t_enter, t)
+        else:
+            t_exit = min(t_exit, t)
+        if t_enter > t_exit:
+            return False
+    return True
+
+
+def line_text_graze_margin(text_element: dict[str, Any]) -> float:
+    font_size = text_element["fontSize"] if isinstance(text_element.get("fontSize"), (int, float)) else 16
+    return max(font_size * LINE_TEXT_GRAZE_FONT_RATIO, LINE_TEXT_GRAZE_MIN_PX)
+
+
+def erode_rect(rect: dict[str, int | float], margin: float) -> dict[str, int | float] | None:
+    width = rect["width"] - 2 * margin
+    height = rect["height"] - 2 * margin
+    if width <= 0 or height <= 0:
+        return None
+    return {"x": rect["x"] + margin, "y": rect["y"] + margin, "width": width, "height": height}
+
+
+def line_crosses_text(line: dict[str, Any], text_element: dict[str, Any]) -> bool:
+    if not is_visually_rendered(line) or line.get("alpha", 1) < LINE_MIN_VISIBLE_ALPHA:
+        return False
+    if not is_text_element(text_element) or not has_text_content(text_element):
+        return False
+    if is_ghost_text(text_element) or is_decorative_text(text_element):
+        return False
+    glyph_bbox = estimate_text_visual_bbox(text_element)
+    if glyph_bbox is None:
+        return False
+    # Erode the glyph box so a line skimming the letter edge or only clipping the padding-only text
+    # frame is exempt; only a line that actually cuts through the letterforms is a crossing.
+    target = erode_rect(glyph_bbox, line_text_graze_margin(text_element))
+    if target is None:
+        return False
+    return segment_intersects_rect(
+        line["startX"], line["startY"], line["endX"], line["endY"], target
+    )
+
+
+def detect_line_text_crossings(
+    slide_xml: str, elements: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    lines = extract_line_elements(slide_xml)
+    if not lines:
+        return []
+    text_elements = [element for element in elements if is_text_element(element)]
+    issues: list[dict[str, Any]] = []
+    for line in lines:
+        for text_element in text_elements:
+            if not line_crosses_text(line, text_element):
+                continue
+            issues.append(
+                {
+                    "level": "error",
+                    "code": "bbox_overlap",
+                    "elements": [line["id"], text_element["id"]],
+                    "message": f'line {line["id"]} crosses text {text_element["id"]}',
+                    "hint": "Move the line off the text glyphs so it no longer cuts through the letterforms.",
+                }
+            )
+    return issues
+
+
 def lint_slide(
     slide_xml: str, slide_number: int, slide_width: int | float = 960, slide_height: int | float = 540
 ) -> dict[str, Any]:
@@ -1619,6 +1713,7 @@ def lint_slide(
         *detect_table_layout_size_mismatches(elements),
         *detect_text_may_overflow_shapes(elements),
         *detect_image_text_occlusions(elements),
+        *detect_line_text_crossings(slide_xml, elements),
     ]
 
     for index, left in enumerate(elements):
@@ -2224,7 +2319,7 @@ def related_object(element: dict[str, Any]) -> dict[str, Any]:
 
 def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
     elements: list[dict[str, Any]] = []
-    for match in re.finditer(r"<line\b([^>]*)>", slide_xml):
+    for match in re.finditer(r"<line\b([^>]*?)(/?)>", slide_xml):
         attrs = match.group(1)
         start_x = extract_numeric_attribute(attrs, "startX")
         start_y = extract_numeric_attribute(attrs, "startY")
@@ -2233,6 +2328,15 @@ def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
         if any(value is None for value in (start_x, start_y, end_x, end_y)):
             continue
         line_alpha = extract_numeric_attribute(attrs, "alpha")
+        base_alpha = line_alpha if line_alpha is not None else 1
+        border_alpha = 1
+        if match.group(2) != "/":
+            close_index = slide_xml.find("</line>", match.end())
+            body = slide_xml[match.end() : close_index] if close_index != -1 else ""
+            border_attrs = extract_tag_attributes(body, "border")
+            color_alpha = extract_color_alpha(extract_attribute(border_attrs, "color"))
+            if isinstance(color_alpha, (int, float)):
+                border_alpha = color_alpha
         elements.append(
             {
                 "id": extract_attribute(attrs, "id") or f"line-{len(elements) + 1}",
@@ -2242,8 +2346,12 @@ def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "y": min(start_y, end_y),
                 "width": abs(end_x - start_x),
                 "height": abs(end_y - start_y),
+                "startX": start_x,
+                "startY": start_y,
+                "endX": end_x,
+                "endY": end_y,
                 "rotation": 0,
-                "alpha": line_alpha if line_alpha is not None else 1,
+                "alpha": base_alpha * border_alpha,
                 "order": len(elements),
             }
         )

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -1500,8 +1500,6 @@ def detect_elements_out_of_canvas(
         if element["kind"] in {"table", "chart"}
         or (element["kind"] == "shape" and element["type"] in {"rect", "text"})
     ):
-        if is_ghost_text(element):
-            continue
         bbox = element_canvas_bbox(element)
         overflow = {
             "left": max(-bbox["x"], 0),

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -1457,6 +1457,187 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(result["summary"]["error_count"], 0)
         self.assertEqual(result["slides"][0]["issues"], [])
 
+    def test_lint_xml_reports_horizontal_line_crossing_headline_glyphs(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="title" type="text" topLeftX="80" topLeftY="200" width="500" height="90">
+                  <content fontSize="60"><p>测试文字 ABC</p></content>
+                </shape>
+                <line id="strike" startX="80" startY="245" endX="560" endY="245">
+                  <border color="rgb(255, 0, 0)" width="4"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        crossing = [
+            issue for issue in result["slides"][0]["errors"] if set(issue["elements"]) == {"strike", "title"}
+        ]
+        self.assertEqual(len(crossing), 1)
+        self.assertEqual(crossing[0]["code"], "bbox_overlap")
+
+    def test_lint_xml_reports_vertical_line_crossing_multiline_text(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="col" type="text" topLeftX="700" topLeftY="180" width="240" height="180">
+                  <content fontSize="20"><p>第一行文字内容</p><p>第二行文字内容</p><p>第三行文字内容</p></content>
+                </shape>
+                <line id="vbar" startX="740" startY="170" endX="740" endY="360">
+                  <border color="rgb(0, 0, 255)" width="3"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        crossing = [
+            issue for issue in result["slides"][0]["errors"] if set(issue["elements"]) == {"vbar", "col"}
+        ]
+        self.assertEqual(len(crossing), 1)
+
+    def test_lint_xml_reports_diagonal_line_crossing_text_block(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="para" type="text" topLeftX="80" topLeftY="400" width="420" height="140">
+                  <content fontSize="18"><p>这是一段测试文字用于验证线条穿过</p></content>
+                </shape>
+                <line id="diag" startX="80" startY="410" endX="500" endY="530">
+                  <border color="rgb(255, 0, 0)" width="3"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        crossing = [
+            issue for issue in result["slides"][0]["errors"] if set(issue["elements"]) == {"diag", "para"}
+        ]
+        self.assertEqual(len(crossing), 1)
+
+    def test_lint_xml_ignores_diagonal_line_whose_bbox_but_not_segment_crosses_text(self) -> None:
+        # The diagonal's axis-aligned bounding box overlaps the text, but the segment itself passes
+        # through empty space in the opposite corner -- a naive bbox test would false-positive here.
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="corner-text" type="text" topLeftX="80" topLeftY="80" width="120" height="40">
+                  <content fontSize="18"><p>corner</p></content>
+                </shape>
+                <line id="far-diag" startX="700" startY="80" endX="90" endY="500">
+                  <border color="rgb(255, 0, 0)" width="3"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        crossing = [
+            issue for issue in result["slides"][0]["errors"] if set(issue["elements"]) == {"far-diag", "corner-text"}
+        ]
+        self.assertEqual(crossing, [])
+
+    def test_lint_xml_ignores_line_touching_text_frame_but_not_glyphs(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="lbl" type="text" topLeftX="80" topLeftY="80" width="300" height="200">
+                  <content fontSize="18" verticalAlign="top"><p>短标签</p></content>
+                </shape>
+                <line id="below" startX="80" startY="270" endX="380" endY="270">
+                  <border color="rgb(255, 0, 0)" width="2"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        self.assertEqual(result["summary"]["error_count"], 0)
+
+    def test_lint_xml_ignores_invisible_line_crossing_text(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="title" type="text" topLeftX="80" topLeftY="200" width="500" height="90">
+                  <content fontSize="60"><p>测试文字 ABC</p></content>
+                </shape>
+                <line id="ghost-line" startX="80" startY="245" endX="560" endY="245">
+                  <border color="rgba(255, 0, 0, 0.03)" width="4"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        self.assertEqual(result["summary"]["error_count"], 0)
+
+    def test_lint_xml_ignores_vertical_line_grazing_text_left_edge(self) -> None:
+        # Verbatim from deck GpGusGCwplQyK8dFN9LczmBXnwQ slide 4: a vertical line sitting on the text
+        # frame's left edge renders before the first glyph, so it must not be flagged.
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape width="240" height="60" topLeftX="120" topLeftY="100" type="text" id="bmm">
+                  <content fontSize="20" fontFamily="Arial" color="rgba(31, 35, 41, 1)" lineSpacing="fixed:24">
+                    <p>Vertical edge graze</p>
+                  </content>
+                </shape>
+                <line id="bmX" startX="120.00000000000001" startY="90" endX="120.00000000000001" endY="150.00833275470998">
+                  <border color="rgba(0, 0, 0, 1)"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        self.assertEqual(result["summary"]["error_count"], 0)
+
+    def test_lint_xml_ignores_polyline_crossing_text(self) -> None:
+        # Verbatim from deck GpGusGCwplQyK8dFN9LczmBXnwQ slide 6: the crossing check is scoped to
+        # <line> only, so a <polyline> over text is not flagged.
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape width="240" height="60" topLeftX="120" topLeftY="100" type="text" id="bmr">
+                  <content fontSize="20" fontFamily="Arial" color="rgba(31, 35, 41, 1)" lineSpacing="fixed:24">
+                    <p>Polyline target</p>
+                  </content>
+                </shape>
+                <polyline id="bmH" width="270" height="55" topLeftX="110" topLeftY="95">
+                  <border color="rgba(0, 0, 0, 1)"/>
+                </polyline>
+              </data>
+            </slide>
+            """
+        )
+        self.assertEqual(result["summary"]["error_count"], 0)
+
+    def test_lint_xml_ignores_line_below_visual_glyph_height(self) -> None:
+        # Verbatim from deck GpGusGCwplQyK8dFN9LczmBXnwQ slide 7: the shape frame is 80px tall but the
+        # single 20px line of glyphs occupies only its top; a line at the frame's lower region grazes
+        # under the visual glyph box (underline look) and must not be flagged.
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape width="240" height="80" topLeftX="120" topLeftY="100" type="text" id="bmB">
+                  <content fontSize="20" fontFamily="Arial" color="rgba(31, 35, 41, 1)" lineSpacing="fixed:24">
+                    <p>Visual height target</p>
+                  </content>
+                </shape>
+                <line id="bmQ" startX="110" startY="150" endX="380.00185184550116" endY="150">
+                  <border color="rgba(0, 0, 0, 1)"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+        self.assertEqual(result["summary"]["error_count"], 0)
+
     def test_lint_xml_uses_rotated_text_and_chart_bounds_for_canvas_validation(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -1026,7 +1026,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(result["slides"][0]["infos"], [issues["bg-deco"]])
         self.assertIn("background decoration", issues["bg-deco"]["message"])
 
-    def test_lint_xml_allows_shape_alpha_ghost_text_out_of_canvas_and_overlap(self) -> None:
+    def test_lint_xml_reports_shape_alpha_ghost_text_out_of_canvas_but_allows_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <slide xmlns="http://www.larkoffice.com/sml/2.0">
@@ -1042,11 +1042,11 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             """
         )
         codes = [issue["code"] for issue in result["slides"][0]["issues"]]
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertNotIn("shape_out_of_canvas", codes)
+        self.assertEqual(result["summary"]["error_count"], 1)
+        self.assertIn("shape_out_of_canvas", codes)
         self.assertNotIn("bbox_overlap", codes)
 
-    def test_lint_xml_allows_content_color_alpha_ghost_text_out_of_canvas_and_overlap(self) -> None:
+    def test_lint_xml_reports_content_color_alpha_ghost_text_out_of_canvas_but_allows_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <slide xmlns="http://www.larkoffice.com/sml/2.0">
@@ -1062,11 +1062,11 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             """
         )
         codes = [issue["code"] for issue in result["slides"][0]["issues"]]
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertNotIn("shape_out_of_canvas", codes)
+        self.assertEqual(result["summary"]["error_count"], 1)
+        self.assertIn("shape_out_of_canvas", codes)
         self.assertNotIn("bbox_overlap", codes)
 
-    def test_lint_xml_allows_faint_medium_ghost_text_out_of_canvas_and_overlap(self) -> None:
+    def test_lint_xml_reports_faint_medium_ghost_text_out_of_canvas_but_allows_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <slide xmlns="http://www.larkoffice.com/sml/2.0">
@@ -1082,8 +1082,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             """
         )
         codes = [issue["code"] for issue in result["slides"][0]["issues"]]
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertNotIn("shape_out_of_canvas", codes)
+        self.assertEqual(result["summary"]["error_count"], 1)
+        self.assertIn("shape_out_of_canvas", codes)
         self.assertNotIn("bbox_overlap", codes)
 
     def test_lint_xml_allows_ghost_text_image_overlap(self) -> None:
@@ -1126,7 +1126,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         codes = [issue["code"] for issue in result["issues"]]
         self.assertNotIn("whiteboard_external_overlap", codes)
 
-    def test_lint_xml_allows_faint_ghost_text_without_area_threshold(self) -> None:
+    def test_lint_xml_reports_faint_ghost_text_out_of_canvas_without_area_threshold(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <slide xmlns="http://www.larkoffice.com/sml/2.0">
@@ -1138,8 +1138,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             </slide>
             """
         )
-        self.assertEqual(result["summary"]["error_count"], 0)
-        self.assertEqual(result["slides"][0]["issues"], [])
+        self.assertEqual(result["summary"]["error_count"], 1)
+        self.assertEqual(result["slides"][0]["issues"][0]["code"], "shape_out_of_canvas")
 
     def test_lint_xml_keeps_out_of_canvas_error_for_medium_text_without_faint_alpha(self) -> None:
         result = xml_text_overlap_lint.lint_xml(


### PR DESCRIPTION
## Summary
Improve the Slides XML layout lint gate by tightening canvas overflow reporting and adding detection for visible line elements that cross readable text glyphs.

## Changes
- Report ghost/faint text shapes when they overflow the slide canvas, while still allowing their intentional decorative overlaps.
- Detect `<line>` elements that cross text glyphs and report them as `bbox_overlap` errors.
- Use segment-level geometry for horizontal, vertical, and diagonal lines to avoid naive bounding-box false positives.
- Ignore non-actionable cases such as invisible lines, frame-edge grazing, padding-only intersections, polylines, and lines outside the actual visual glyph area.
- Add regression coverage for ghost text canvas overflow and line/text crossing edge cases.

## Test Plan
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli slides` lint flow works as expected

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lint checks that detect visible lines crossing text glyphs.
  * Improved detection accuracy by ignoring nearly invisible lines, frame-only contact, and near-edge grazes.
* **Bug Fixes**
  * Out-of-canvas text is now reported consistently, including low-opacity text.
  * Reduced false positives for diagonal lines and lines outside visible glyph areas.
* **Tests**
  * Expanded coverage for horizontal, vertical, diagonal, and exempt line/text scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->