### PR TITLE
docs(calendar): clarify identity selection by event ownership

### DIFF
--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -16,14 +16,16 @@ metadata:
 
 ## 身份
 
-日程操作默认使用 `--as user`（查看和管理当前用户的日程）。`--as bot` 只能访问 bot 自己的（空）日历，会拿到空结果——不要用 bot 身份查用户日程。
+按**日程归属**选身份：
+
+- 查看/管理登录用户本人的日程 → `--as user`（默认，绝大多数场景）。
+- 查看/管理 bot 自己创建/拥有的日程 → `--as bot` 
 
 ```bash
-# BAD — bot 身份查用户日程，返回空列表
-lark-cli calendar +agenda --as bot
-
-# GOOD — user 身份查日程
+# 用户本人日程 → user
 lark-cli calendar +agenda --as user
+# bot 自建或参与的日程 → bot
+lark-cli calendar +agenda --as bot
 ```
 
 ## Shortcuts


### PR DESCRIPTION
## Summary
Reframe the calendar skill's identity section around **event ownership** instead of framing `--as bot` purely as a "wrong" choice that returns empty results. This gives agents clearer guidance on when each identity applies.

## Changes
- Replace the BAD/GOOD example pair with an ownership-based rule: `--as user` for the logged-in user's own events (default, most cases), `--as bot` for events the bot creates or participates in.
- Update the code examples so both use the same `+agenda` command, differing only by `--as user` / `--as bot`.

## Test Plan
- [x] Documentation-only change (no code affected)
- [ ] Rendered Markdown reviewed for correct formatting

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated calendar guidance to clarify how to choose the identity based on agenda ownership.
  * Added examples for using `--as user` and `--as bot`.
  * Removed outdated guidance about bot access returning empty calendar lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->