### PR TITLE
0728 fix url

### DIFF
--- a/shortcuts/calendar/description_rich_images.go
+++ b/shortcuts/calendar/description_rich_images.go
@@ -157,7 +157,7 @@ func localImagePath(src string) string {
 }
 
 func buildCalendarImagePreviewURL(brand core.LarkBrand, fileToken string, width, height int, size int64) string {
-	host := "internal-api-drive-stream.larkoffice.com"
+	host := "internal-api-drive-stream.feishu.cn"
 	if brand == core.BrandLark {
 		host = "internal-api-drive-stream.larksuite.com"
 	}

--- a/shortcuts/calendar/description_rich_images_test.go
+++ b/shortcuts/calendar/description_rich_images_test.go
@@ -68,7 +68,7 @@ func TestBuildCalendarImagePreviewURL(t *testing.T) {
 		brand    core.LarkBrand
 		hostFrag string
 	}{
-		{core.BrandFeishu, "larkoffice"},
+		{core.BrandFeishu, "feishu.cn"},
 		{core.BrandLark, "larksuite"},
 	} {
 		raw := buildCalendarImagePreviewURL(tc.brand, "boxcnTOKEN123", 416, 306, 142568)


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated calendar image preview links to use the correct default download host for Feishu.
  * Preserved existing Lark-specific preview routing and retained current image sizing options (including width/height and optional sizing parameters).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->