### PR TITLE
docs(task): document create data passthrough

### DIFF
--- a/skills/lark-task/references/lark-task-create.md
+++ b/skills/lark-task/references/lark-task-create.md
@@ -24,6 +24,12 @@ lark-cli task +create \
 lark-cli task +create \
   --summary "Buy milk"
 
+# Create a milestone by passing an API field without a named flag
+lark-cli task +create \
+  --summary "Release v2.0" \
+  --due "2026-08-15" \
+  --data '{"is_milestone":true}'
+
 # Preview the API call without executing
 lark-cli task +create --summary "Test Task" --dry-run
 ```
@@ -39,7 +45,10 @@ lark-cli task +create --summary "Test Task" --dry-run
 | `--due <time>` | No | Due date. Supports ISO 8601, `YYYY-MM-DD`, relative time (e.g., `+2d`), or ms timestamp. `YYYY-MM-DD` and relative time will automatically set it as an all-day task. |
 | `--tasklist-id <id>` | No | The GUID of the tasklist, or a full AppLink URL (the CLI will automatically extract the `guid` parameter from the URL). |
 | `--idempotency-key <key>` | No | Client token to ensure idempotency of the request. |
+| `--data <json>` | No | JSON object merged into the task create request for API fields without dedicated flags, such as `{"is_milestone":true}`. Explicit named flags override same-named fields in this object. |
 | `--dry-run` | No | Preview the API call (JSON payload) without actually creating the task. |
+
+Use `lark-cli schema task.tasks.create` to confirm that an extra field is supported before passing it through `--data`. Prefer this shortcut over the raw `tasks create` command when `--data` can express the request. Do not assume that other shortcuts support `--data`; check each shortcut's `--help` output first.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Document the existing `--data` passthrough capability of `task +create` so agents can use supported Task API fields without unnecessarily falling back to the raw API command.

## Changes

- Add `--data <json>` to the `task +create` skill reference, including named-flag precedence.
- Add a milestone-task example using `is_milestone`.
- Clarify that extra fields must be checked against `task.tasks.create` schema and that `--data` is not universally supported by all shortcuts.

## Test Plan

- [x] `go test -count=1 ./shortcuts/task`
- [x] `node scripts/skill-format-check/index.js`
- [x] `git diff --check`

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `--data` option when creating Lark tasks.
  * Included an example for creating milestone tasks using `is_milestone`.
  * Clarified how JSON fields interact with explicit command-line options and how to validate additional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->