### PR TITLE
feat: add mail sender service commands

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func TestBuildWithoutPluginsStillBuildsBuiltinCommands(t *testing.T) {
+	root := Build(context.Background(), cmdutil.InvocationContext{}, WithoutPlugins())
+
+	if root == nil {
+		t.Fatal("Build returned nil root")
+	}
+	if findCommand(root, "api") == nil {
+		t.Fatal("builtin api command missing")
+	}
+	if findCommand(root, "docs +fetch") == nil {
+		t.Fatal("builtin docs +fetch shortcut missing")
+	}
+	if findCommand(root, "mail user_mailbox.allow_senders batch_create") == nil {
+		t.Fatal("mail allow_senders batch_create service command missing")
+	}
+	if findCommand(root, "mail user_mailbox.blocked_senders batch_remove") == nil {
+		t.Fatal("mail blocked_senders batch_remove service command missing")
+	}
+}
+
+func findCommand(root *cobra.Command, path string) *cobra.Command {
+	parts := strings.Fields(path)
+	cmd := root
+	for _, part := range parts {
+		var next *cobra.Command
+		for _, child := range cmd.Commands() {
+			if child.Name() == part {
+				next = child
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		cmd = next
+	}
+	return cmd
+}

--- a/cmd/service/mail_sender_output.go
+++ b/cmd/service/mail_sender_output.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import "strings"
+
+func serviceSuccessTransformer(schemaPath string) func(interface{}) interface{} {
+	if !isMailSenderSchema(schemaPath) {
+		return nil
+	}
+	return func(result interface{}) interface{} {
+		switch {
+		case strings.HasSuffix(schemaPath, ".list"):
+			return projectMailSenderList(result)
+		case strings.HasSuffix(schemaPath, ".batch_create"), strings.HasSuffix(schemaPath, ".batch_remove"):
+			return projectMailSenderBatch(result)
+		default:
+			return result
+		}
+	}
+}
+
+func isMailSenderSchema(schemaPath string) bool {
+	return strings.HasPrefix(schemaPath, "mail.user_mailbox.allow_senders.") ||
+		strings.HasPrefix(schemaPath, "mail.user_mailbox.blocked_senders.")
+}
+
+func projectMailSenderList(result interface{}) interface{} {
+	data, ok := responseData(result)
+	if !ok {
+		return result
+	}
+	out := map[string]interface{}{}
+	if items, ok := data["items"].([]interface{}); ok {
+		projected := make([]interface{}, 0, len(items))
+		for _, item := range items {
+			if m, ok := item.(map[string]interface{}); ok {
+				projected = append(projected, map[string]interface{}{"address": m["address"]})
+			}
+		}
+		out["items"] = projected
+	}
+	if token, ok := data["next_page_token"]; ok {
+		out["next_page_token"] = token
+	}
+	return successResponseWithData(result, out)
+}
+
+func projectMailSenderBatch(result interface{}) interface{} {
+	data, ok := responseData(result)
+	if !ok {
+		return result
+	}
+	out := map[string]interface{}{}
+	if v, ok := data["submitted_count"]; ok {
+		out["submitted_count"] = v
+	}
+	if v, ok := data["deduplicated_count"]; ok {
+		out["deduplicated_count"] = v
+	}
+	return successResponseWithData(result, out)
+}
+
+func responseData(result interface{}) (map[string]interface{}, bool) {
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	data, ok := m["data"].(map[string]interface{})
+	return data, ok
+}
+
+func successResponseWithData(result interface{}, data map[string]interface{}) interface{} {
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		return result
+	}
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	out["data"] = data
+	return out
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -7,98 +7,129 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/apicatalog"
 	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdmeta"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/errclass"
+	"github.com/larksuite/cli/internal/meta"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/registry"
-	"github.com/larksuite/cli/internal/util"
 	"github.com/larksuite/cli/internal/validate"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // RegisterServiceCommands registers all service commands from from_meta specs.
 func RegisterServiceCommands(parent *cobra.Command, f *cmdutil.Factory) {
-	for _, project := range registry.ListFromMetaProjects() {
-		spec := registry.LoadFromMeta(project)
-		if spec == nil {
+	RegisterServiceCommandsWithContext(context.Background(), parent, f)
+}
+
+func RegisterServiceCommandsWithContext(ctx context.Context, parent *cobra.Command, f *cmdutil.Factory) {
+	RegisterServiceCommandsFromCatalog(ctx, parent, f, registry.RuntimeCatalog())
+}
+
+func RegisterServiceCommandsFromCatalog(ctx context.Context, parent *cobra.Command, f *cmdutil.Factory, catalog apicatalog.Catalog) {
+	// Drive the service list from the same navigation catalog the method walk
+	// uses, so registration is catalog-sourced end to end. Kept as a per-service
+	// loop rather than a flat WalkMethods(nil) drive precisely so a service with
+	// no methods still gets its bare command (WalkMethods yields one ref per
+	// method, so empty services would vanish).
+	for _, svc := range catalog.Services() {
+		if svc.Name == "" || svc.ServicePath == "" {
 			continue
 		}
-		specName := registry.GetStrFromMap(spec, "name")
-		servicePath := registry.GetStrFromMap(spec, "servicePath")
-		if specName == "" || servicePath == "" {
-			continue
-		}
-		resources, _ := spec["resources"].(map[string]interface{})
-		if resources == nil {
-			continue
-		}
-		registerService(parent, spec, resources, f)
+		registerServiceWithContext(ctx, parent, svc, f)
 	}
 }
 
-func registerService(parent *cobra.Command, spec map[string]interface{}, resources map[string]interface{}, f *cmdutil.Factory) {
-	specName := registry.GetStrFromMap(spec, "name")
-	specDesc := registry.GetServiceDescription(specName, "en")
-	if specDesc == "" {
-		specDesc = registry.GetStrFromMap(spec, "description")
+func registerService(parent *cobra.Command, svc meta.Service, f *cmdutil.Factory) {
+	registerServiceWithContext(context.Background(), parent, svc, f)
+}
+
+func registerServiceWithContext(ctx context.Context, parent *cobra.Command, svc meta.Service, f *cmdutil.Factory) {
+	svcCmd := ensureChildCommand(parent, svc.Name, serviceShort(svc))
+
+	// Build the service's subtree from the catalog's method walk
+	// (apicatalog.ServiceMethods recurses nested resources), so the command tree
+	// is sourced from the same navigation Module as schema/scope rather than a
+	// hand-rolled resource/method walk. Each ref's ResourcePath becomes the
+	// resource-command chain — one level for a flat dotted resource like
+	// "chat.members", deeper for genuinely nested resources. A service with no
+	// methods keeps its bare command (svcCmd is created above regardless).
+	refs := apicatalog.ServiceMethods(svc, nil)
+
+	// Collect each resource's verbs up front so resourceShort can summarize a
+	// resource as its verb list from the first ensureChildCommand call.
+	verbs := map[string][]string{}
+	for _, ref := range refs {
+		key := strings.Join(ref.ResourcePath, ".")
+		verbs[key] = append(verbs[key], ref.Method.Name)
 	}
 
-	// Find existing service command or create one
-	var svc *cobra.Command
+	for _, ref := range refs {
+		resCmd := svcCmd
+		var path []string
+		for _, seg := range ref.ResourcePath {
+			path = append(path, seg)
+			resCmd = ensureChildCommand(resCmd, seg, resourceShort(seg, verbs[strings.Join(path, ".")]))
+		}
+		resCmd.AddCommand(buildMethodCommand(ctx, f, newMethodCommandSpec(ref), nil, parent.PersistentFlags()))
+	}
+}
+
+// resourceShort summarizes a resource as its sorted verb list, or the
+// "<name> operations" placeholder for an intermediate group with no methods.
+func resourceShort(seg string, verbs []string) string {
+	if len(verbs) == 0 {
+		return seg + " operations"
+	}
+	sorted := append([]string(nil), verbs...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ", ")
+}
+
+// serviceShort is the service command's help summary: the localized description
+// from the registry, falling back to the metadata's own description.
+func serviceShort(svc meta.Service) string {
+	if d := registry.GetServiceDescription(svc.Name, "en"); d != "" {
+		return d
+	}
+	return svc.Description
+}
+
+// ensureChildCommand returns the child of parent named name, creating it (with
+// short) when absent — so re-registration merges into an existing command tree
+// instead of duplicating a level.
+func ensureChildCommand(parent *cobra.Command, name, short string) *cobra.Command {
 	for _, c := range parent.Commands() {
-		if c.Name() == specName {
-			svc = c
-			break
+		if c.Name() == name {
+			cmdmeta.SetSource(c, cmdmeta.SourceService, true)
+			return c
 		}
 	}
-	if svc == nil {
-		svc = &cobra.Command{
-			Use:   specName,
-			Short: specDesc,
-		}
-		parent.AddCommand(svc)
-	}
-
-	for resName, resource := range resources {
-		resMap, _ := resource.(map[string]interface{})
-		if resMap == nil {
-			continue
-		}
-		registerResource(svc, spec, resName, resMap, f)
-	}
-}
-
-func registerResource(parent *cobra.Command, spec map[string]interface{}, name string, resource map[string]interface{}, f *cmdutil.Factory) {
-	res := &cobra.Command{
-		Use:   name,
-		Short: name + " operations",
-	}
-	parent.AddCommand(res)
-
-	methods, _ := resource["methods"].(map[string]interface{})
-	for methodName, method := range methods {
-		methodMap, _ := method.(map[string]interface{})
-		if methodMap == nil {
-			continue
-		}
-		registerMethod(res, spec, methodMap, methodName, name, f)
-	}
+	cmd := &cobra.Command{Use: name, Short: short}
+	cmdmeta.SetSource(cmd, cmdmeta.SourceService, true)
+	parent.AddCommand(cmd)
+	return cmd
 }
 
 // ServiceMethodOptions holds all inputs for a dynamically registered service method command.
 type ServiceMethodOptions struct {
-	Factory    *cmdutil.Factory
-	Cmd        *cobra.Command
-	Ctx        context.Context
-	Spec       map[string]interface{}
-	Method     map[string]interface{}
-	SchemaPath string
+	Factory     *cmdutil.Factory
+	Cmd         *cobra.Command
+	Ctx         context.Context
+	ServicePath string
+	Method      meta.Method
+	SchemaPath  string
 
 	// Flags
 	Params     string
@@ -113,36 +144,126 @@ type ServiceMethodOptions struct {
 	DryRun     bool
 	File       string   // --file flag value
 	FileFields []string // auto-detected file field names from metadata
+
+	// binder owns the generated typed param flags — registration and the
+	// --params overlay — replacing the raw paramFlags side-channel.
+	binder *paramFlagBinder
 }
 
-// detectFileFields delegates to the shared cmdutil.DetectFileFields helper.
-func detectFileFields(method map[string]interface{}) []string {
-	return cmdutil.DetectFileFields(method)
-}
-
-func registerMethod(parent *cobra.Command, spec map[string]interface{}, method map[string]interface{}, name string, resName string, f *cmdutil.Factory) {
-	parent.AddCommand(NewCmdServiceMethod(f, spec, method, name, resName, nil))
+// detectFileFields returns the request-body file-upload field names.
+func detectFileFields(m meta.Method) []string {
+	files := m.Files()
+	if len(files) == 0 {
+		return nil
+	}
+	names := make([]string, len(files))
+	for i, f := range files {
+		names[i] = f.Name
+	}
+	return names
 }
 
 // NewCmdServiceMethod creates a command for a dynamically registered service method.
-func NewCmdServiceMethod(f *cmdutil.Factory, spec, method map[string]interface{}, name, resName string, runF func(*ServiceMethodOptions) error) *cobra.Command {
-	desc := registry.GetStrFromMap(method, "description")
-	httpMethod := registry.GetStrFromMap(method, "httpMethod")
-	specName := registry.GetStrFromMap(spec, "name")
-	schemaPath := fmt.Sprintf("%s.%s.%s", specName, resName, name)
+func NewCmdServiceMethod(f *cmdutil.Factory, svc meta.Service, m meta.Method, name, resName string, runF func(*ServiceMethodOptions) error) *cobra.Command {
+	return NewCmdServiceMethodWithContext(context.Background(), f, svc, m, name, resName, runF)
+}
 
+// NewCmdServiceMethodWithContext builds the command for one service method from
+// its (service, resource, method) coordinates, deriving the methodCommandSpec
+// via an apicatalog.MethodRef so direct callers and the catalog-driven
+// registration assemble the command identically.
+func NewCmdServiceMethodWithContext(ctx context.Context, f *cmdutil.Factory, svc meta.Service, m meta.Method, name, resName string, runF func(*ServiceMethodOptions) error) *cobra.Command {
+	m.Name = name
+	ref := apicatalog.MethodRef{Service: svc, ResourcePath: []string{resName}, Method: m}
+	// No root in scope here; persistent-flag collisions don't apply to a
+	// standalone command, and local/standard-flag collisions are still caught.
+	return buildMethodCommand(ctx, f, newMethodCommandSpec(ref), runF, nil)
+}
+
+// methodCommandSpec is the static description of one generated service method
+// command, read off an apicatalog.MethodRef — the single place command
+// construction gets the method's facts (schema path, HTTP base path, risk,
+// identities, params, file fields, request-body support), so the cobra command
+// is assembled from a typed spec rather than recomputing paths/flags inline.
+type methodCommandSpec struct {
+	method      meta.Method
+	schemaPath  string       // "service.resource.method", for the --help hint
+	servicePath string       // service HTTP base path
+	risk        string       // RiskRead | RiskWrite | RiskHighRiskWrite
+	restricts   bool         // method declares accessTokens (identity-restricted)
+	identities  []string     // permitted --as values; empty when unrestricted
+	params      []meta.Field // path/query params -> typed flags
+	fileFields  []string     // request-body file-upload field names
+	// acceptsBody is whether the HTTP method allows a request body at all (so
+	// --data is offered as a raw escape hatch). declaresBody is whether the
+	// metadata documents body fields (data or file). They differ for e.g. a POST
+	// with no documented requestBody: --data still works, but help must not imply
+	// the API declares a body.
+	acceptsBody  bool
+	declaresBody bool
+	paginates    bool   // method accepts a page_token param (so --page-all is meaningful)
+	serviceName  string // owning service name (e.g. "approval"), for the lazy affordance lookup
+}
+
+// methodPaginates reports whether a method takes a page_token param, the signal
+// that makes the --page-all/--page-limit/--page-delay flags meaningful.
+func methodPaginates(m meta.Method) bool {
+	for _, f := range m.Params() {
+		if f.Name == "page_token" {
+			return true
+		}
+	}
+	return false
+}
+
+func newMethodCommandSpec(ref apicatalog.MethodRef) methodCommandSpec {
+	m := ref.Method
+	return methodCommandSpec{
+		method:       m,
+		schemaPath:   ref.SchemaPath(),
+		servicePath:  ref.Service.ServicePath,
+		serviceName:  ref.Service.Name,
+		risk:         m.Risk,
+		restricts:    m.RestrictsIdentity(),
+		identities:   m.Identities(),
+		params:       m.Params(),
+		fileFields:   detectFileFields(m),
+		acceptsBody:  methodTakesBody(m.HTTPMethod),
+		declaresBody: len(m.Data()) > 0 || len(m.Files()) > 0,
+		paginates:    methodPaginates(m),
+	}
+}
+
+// methodTakesBody reports whether the HTTP method allows a request body, i.e.
+// whether --data applies (as a raw escape hatch even when no body is declared).
+func methodTakesBody(httpMethod string) bool {
+	switch httpMethod {
+	case "POST", "PUT", "PATCH", "DELETE":
+		return true
+	}
+	return false
+}
+
+// buildMethodCommand assembles the cobra command for a service method from its
+// static spec: the standard flags, the conditional --data/--file/--yes flags,
+// the generated typed param flags (via paramFlagBinder), and the risk/identity
+// policy annotations.
+func buildMethodCommand(ctx context.Context, f *cmdutil.Factory, spec methodCommandSpec, runF func(*ServiceMethodOptions) error, reserved *pflag.FlagSet) *cobra.Command {
+	m := spec.method
 	opts := &ServiceMethodOptions{
-		Factory:    f,
-		Spec:       spec,
-		Method:     method,
-		SchemaPath: schemaPath,
+		Factory:     f,
+		ServicePath: spec.servicePath,
+		Method:      m,
+		SchemaPath:  spec.schemaPath,
+		FileFields:  spec.fileFields,
 	}
 	var asStr string
 
 	cmd := &cobra.Command{
-		Use:   name,
-		Short: desc,
-		Long:  fmt.Sprintf("%s\n\nView parameter definitions before calling:\n  lark-cli schema %s", desc, schemaPath),
+		Use:   m.Name,
+		Short: m.Description,
+		// Long is assembled below, once the binder knows which params got no
+		// typed flag.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Cmd = cmd
 			opts.Ctx = cmd.Context()
@@ -153,41 +274,89 @@ func NewCmdServiceMethod(f *cmdutil.Factory, spec, method map[string]interface{}
 			return serviceMethodRun(opts)
 		},
 	}
+	cmdmeta.SetSource(cmd, cmdmeta.SourceService, true)
 
-	cmd.Flags().StringVar(&opts.Params, "params", "", "URL/query parameters JSON (supports - for stdin)")
-	switch httpMethod {
-	case "POST", "PUT", "PATCH", "DELETE":
-		cmd.Flags().StringVar(&opts.Data, "data", "", "request body JSON (supports - for stdin)")
+	cmd.Flags().StringVar(&opts.Params, "params", "", "Raw URL/query params JSON. Supports - and @file.")
+	if spec.acceptsBody {
+		dataUsage := "JSON request body. Supports - and @file."
+		if !spec.declaresBody {
+			// POST/etc. with no documented body fields: --data is a raw escape
+			// hatch, not a declared body — say so rather than imply structure.
+			dataUsage = "Raw JSON request body (no documented fields; see schema). Supports - and @file."
+		}
+		cmd.Flags().StringVar(&opts.Data, "data", "", dataUsage)
 	}
-	cmd.Flags().StringVar(&asStr, "as", "auto", "identity type: user | bot | auto (default)")
+	cmdutil.AddAPIIdentityFlag(ctx, cmd, f, &asStr)
 	cmd.Flags().StringVarP(&opts.Output, "output", "o", "", "output file path for binary responses")
 	cmd.Flags().BoolVar(&opts.PageAll, "page-all", false, "automatically paginate through all pages")
 	cmd.Flags().IntVar(&opts.PageLimit, "page-limit", 10, "max pages to fetch with --page-all (0 = unlimited)")
 	cmd.Flags().IntVar(&opts.PageDelay, "page-delay", 200, "delay in ms between pages")
-	cmd.Flags().StringVar(&opts.Format, "format", "json", "output format: json|ndjson|table|csv")
-	cmd.Flags().StringVarP(&opts.JqExpr, "jq", "q", "", "jq expression to filter JSON output")
-	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print request without executing")
-
-	// Conditionally register --file for methods with file-type fields.
-	fileFields := detectFileFields(method)
-	opts.FileFields = fileFields
-	if len(fileFields) > 0 {
-		switch httpMethod {
-		case "POST", "PUT", "PATCH", "DELETE":
-			cmd.Flags().StringVar(&opts.File, "file", "", "file to upload ([field=]path, supports - for stdin)")
+	// Keep the pagination flags registered (a harmless no-op if passed) but hide
+	// them from help on non-paginating commands, so help doesn't imply a
+	// get/write can paginate.
+	if !spec.paginates {
+		for _, name := range []string{"page-all", "page-limit", "page-delay"} {
+			_ = cmd.Flags().MarkHidden(name)
 		}
 	}
-
-	_ = cmd.RegisterFlagCompletionFunc("as", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{"user", "bot"}, cobra.ShellCompDirectiveNoFileComp
-	})
-	_ = cmd.RegisterFlagCompletionFunc("format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringVar(&opts.Format, "format", "json", "output format: json|ndjson|table|csv")
+	cmd.Flags().Bool("json", false, "shorthand for --format json")
+	cmd.Flags().StringVarP(&opts.JqExpr, "jq", "q", "", "jq expression to filter JSON output")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print request without executing")
+	if spec.risk == cmdutil.RiskHighRiskWrite {
+		cmd.Flags().Bool("yes", false, "confirm high-risk operation")
+	}
+	// --file only for body methods that actually declare file-type fields.
+	if len(spec.fileFields) > 0 && spec.acceptsBody {
+		cmd.Flags().StringVar(&opts.File, "file", "", "File upload [field=]path. Supports - and stdin.")
+	}
+	cmdutil.RegisterFlagCompletion(cmd, "format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "ndjson", "table", "csv"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
-	cmdutil.SetTips(cmd, registry.GetStrSliceFromMap(method, "tips"))
-	if tokens, ok := method["accessTokens"].([]interface{}); ok && len(tokens) > 0 {
-		cmdutil.SetSupportedIdentities(cmd, cmdutil.AccessTokensToIdentities(tokens))
+	// Registered last so the collision guard sees the standard flags above.
+	opts.binder = newParamFlagBinder(cmd, spec.params, reserved)
+	// Build-time Long; the agent guidance is added lazily by PrepareMethodHelp
+	// (setMethodHelpData records the coordinates it needs).
+	paramsOnly := opts.binder.paramsOnlyHelp()
+	cmd.Long = methodLong(m.Description, spec.schemaPath, paramsOnly)
+	setMethodHelpData(cmd, spec.serviceName, m.ID, spec.schemaPath, paramsOnly)
+
+	// Group flags for the grouped --help renderer (typed param flags are grouped
+	// as API Parameters by the binder). tagFlagGroup is a no-op for flags not
+	// registered above (e.g. --data/--file/--yes only exist for some methods).
+	// --data sits under Request Body only when the metadata documents body
+	// fields; otherwise it's a raw escape hatch, grouped with --params so help
+	// doesn't imply a declared body the API doesn't have.
+	if fl := cmd.Flags().Lookup("data"); fl != nil {
+		if spec.declaresBody {
+			annotate(fl, flagGroupAnnotation, []string{groupBody})
+		} else {
+			annotate(fl, flagGroupAnnotation, []string{groupRaw})
+		}
+	}
+	tagFlagGroup(cmd.Flags(), "file", groupBody)
+	if fl := cmd.Flags().Lookup("params"); fl != nil {
+		annotate(fl, flagGroupAnnotation, []string{groupRaw})
+		// Keep the precedence rule on the flag's own one line (not a multi-line
+		// note that breaks the one-entry-per-flag rhythm an agent parses). Only
+		// meaningful when typed flags exist to override.
+		if len(spec.params) > 0 {
+			fl.Usage = "Raw URL/query params JSON. Supports - and @file. If both set, typed flags override matching keys in --params."
+		}
+	}
+	for _, name := range []string{"as", "dry-run", "page-all", "page-limit", "page-delay", "yes"} {
+		tagFlagGroup(cmd.Flags(), name, groupExecution)
+	}
+	for _, name := range []string{"output", "format", "jq"} {
+		tagFlagGroup(cmd.Flags(), name, groupOutput)
+	}
+	applyGroupedUsage(cmd)
+
+	cmdutil.SetTips(cmd, m.Tips)
+	cmdutil.SetRisk(cmd, spec.risk)
+	if spec.restricts {
+		cmdutil.SetSupportedIdentities(cmd, spec.identities)
 	}
 
 	return cmd
@@ -202,14 +371,14 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	}
 
 	// Check if this API method supports the resolved identity.
-	if tokens, ok := opts.Method["accessTokens"].([]interface{}); ok && len(tokens) > 0 {
-		if err := f.CheckIdentity(opts.As, cmdutil.AccessTokensToIdentities(tokens)); err != nil {
+	if opts.Method.RestrictsIdentity() {
+		if err := f.CheckIdentity(opts.As, opts.Method.Identities()); err != nil {
 			return err
 		}
 	}
 
 	if opts.PageAll && opts.Output != "" {
-		return output.ErrValidation("--output and --page-all are mutually exclusive")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output and --page-all are mutually exclusive").WithParam("--output")
 	}
 	if err := output.ValidateJqFlags(opts.JqExpr, opts.Output, opts.Format); err != nil {
 		return err
@@ -219,12 +388,10 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	if err != nil {
 		return err
 	}
-	// Identity info is now included in the JSON envelope; skip stderr printing.
-	// cmdutil.PrintIdentity(f.IOStreams.ErrOut, opts.As, config, f.IdentityAutoDetected)
+	// Identity is not printed to stderr here: it is part of the JSON envelope.
 
-	scopes, _ := opts.Method["scopes"].([]interface{})
 	if !opts.As.IsBot() {
-		if err := checkServiceScopes(opts.Ctx, f.Credential, opts.As, config, opts.Method, scopes); err != nil {
+		if err := checkServiceScopes(opts.Ctx, f.Credential, opts.As, config, opts.Method); err != nil {
 			return err
 		}
 	}
@@ -236,9 +403,15 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 
 	if opts.DryRun {
 		if fileMeta != nil {
-			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
+			return cmdutil.PrintDryRunWithFile(request, config, serviceDryRunOutputOptions(f, opts), *fileMeta)
 		}
-		return serviceDryRun(f, request, config, opts.Format)
+		return serviceDryRun(f, request, config, opts)
+	}
+
+	if opts.Method.Risk == cmdutil.RiskHighRiskWrite {
+		if yes, _ := opts.Cmd.Flags().GetBool("yes"); !yes {
+			return cmdutil.RequireConfirmation(opts.SchemaPath)
+		}
 	}
 
 	ac, err := f.NewAPIClientWithConfig(config)
@@ -252,30 +425,36 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		fmt.Fprintf(f.IOStreams.ErrOut, "warning: unknown format %q, falling back to json\n", opts.Format)
 	}
 
-	checkErr := scopeAwareChecker(scopes, opts.As.IsBot())
+	// Scope-insufficient (99991679) and all other Lark API codes route through
+	// errclass.BuildAPIError via ac.CheckResponse, producing *errs.PermissionError
+	// with MissingScopes / Identity / ConsoleURL populated from the response.
+	checkErr := ac.CheckResponse
 
 	if opts.PageAll {
-		return servicePaginate(opts.Ctx, ac, request, format, opts.JqExpr, out, f.IOStreams.ErrOut,
-			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)
+		return servicePaginate(opts.Ctx, ac, request, format, opts.JqExpr, out, f.IOStreams.ErrOut, opts.Cmd.CommandPath(),
+			opts.SchemaPath, client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)
 	}
 
 	resp, err := ac.DoAPI(opts.Ctx, request)
 	if err != nil {
-		return output.ErrNetwork("API call failed: %s", err)
+		return err
 	}
 	return client.HandleResponse(resp, client.ResponseOptions{
-		OutputPath: opts.Output,
-		Format:     format,
-		JqExpr:     opts.JqExpr,
-		Out:        out,
-		ErrOut:     f.IOStreams.ErrOut,
-		FileIO:     f.ResolveFileIO(opts.Ctx),
-		CheckError: checkErr,
+		OutputPath:       opts.Output,
+		Format:           format,
+		JqExpr:           opts.JqExpr,
+		Out:              out,
+		ErrOut:           f.IOStreams.ErrOut,
+		FileIO:           f.ResolveFileIO(opts.Ctx),
+		CommandPath:      opts.Cmd.CommandPath(),
+		Identity:         opts.As,
+		CheckError:       checkErr,
+		TransformSuccess: serviceSuccessTransformer(opts.SchemaPath),
 	})
 }
 
 // checkServiceScopes pre-checks user scopes before making the API call.
-func checkServiceScopes(ctx context.Context, cred *credential.CredentialProvider, identity core.Identity, config *core.CliConfig, method map[string]interface{}, scopes []interface{}) error {
+func checkServiceScopes(ctx context.Context, cred *credential.CredentialProvider, identity core.Identity, config *core.CliConfig, method meta.Method) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -284,25 +463,15 @@ func checkServiceScopes(ctx context.Context, cred *credential.CredentialProvider
 		return nil //nolint:nilerr // skip scope check when token resolution fails or has no scopes
 	}
 
-	requiredScopes, hasRequired := method["requiredScopes"].([]interface{})
-
-	if hasRequired && len(requiredScopes) > 0 {
+	if len(method.RequiredScopes) > 0 {
 		// Strict: ALL requiredScopes must be present
-		required := make([]string, 0, len(requiredScopes))
-		for _, s := range requiredScopes {
-			if str, ok := s.(string); ok {
-				required = append(required, str)
-			}
-		}
-		if missing := auth.MissingScopes(result.Scopes, required); len(missing) > 0 {
-			return output.ErrWithHint(output.ExitAuth, "missing_scope",
-				fmt.Sprintf("missing required scope(s): %s", strings.Join(missing, ", ")),
-				fmt.Sprintf("run `lark-cli auth login --scope \"%s\"` in the background. It blocks and outputs a verification URL — retrieve the URL and open it in a browser to complete login.", strings.Join(missing, " ")))
+		if missing := auth.MissingScopes(result.Scopes, method.RequiredScopes); len(missing) > 0 {
+			return newPreflightMissingScopeError(string(config.Brand), config.AppID, string(identity), missing)
 		}
 		return nil
 	}
 
-	if len(scopes) == 0 {
+	if len(method.Scopes) == 0 {
 		return nil
 	}
 
@@ -311,86 +480,136 @@ func checkServiceScopes(ctx context.Context, cred *credential.CredentialProvider
 	for _, s := range strings.Fields(result.Scopes) {
 		grantedSet[s] = true
 	}
-	for _, s := range scopes {
-		if str, ok := s.(string); ok && grantedSet[str] {
+	for _, s := range method.Scopes {
+		if grantedSet[s] {
 			return nil
 		}
 	}
-	recommended := registry.SelectRecommendedScope(scopes, "user")
-	return output.ErrWithHint(output.ExitAPI, "permission",
-		fmt.Sprintf("insufficient permissions (required scope: %s)", recommended),
-		fmt.Sprintf(`run `+"`"+`lark-cli auth login --scope "%s"`+"`"+` in the background. It blocks and outputs a verification URL — retrieve the URL and open it in a browser to complete login.`, recommended))
+	recommended := registry.SelectRecommendedScopeFromStrings(method.Scopes, "user")
+	return newPreflightMissingScopeError(string(config.Brand), config.AppID, string(identity), []string{recommended})
+}
+
+// newPreflightMissingScopeError constructs a PermissionError for the local
+// pre-flight scope check that converges byte-for-byte with the dispatcher's
+// BuildAPIError path. Uses the canonical helpers in internal/errclass so
+// Hint and Message stay in lock-step with the server-response classifier.
+// ConsoleURL is deliberately omitted: the dispatcher only sets it for
+// SubtypeAppScopeNotApplied (bot-perspective dev-action recovery), and this
+// pre-flight path is user-perspective SubtypeMissingScope whose recovery is
+// `lark-cli auth login --scope ...`, not a console deep-link.
+func newPreflightMissingScopeError(brand, appID, identity string, missing []string) *errs.PermissionError {
+	consoleURL := errclass.ConsoleURL(brand, appID, missing)
+	return errs.NewPermissionError(errs.SubtypeMissingScope,
+		"%s", errclass.CanonicalPermissionMessage(errs.SubtypeMissingScope, appID, missing, "")).
+		WithHint("%s", errclass.PermissionHint(missing, identity, errs.SubtypeMissingScope, consoleURL)).
+		WithMissingScopes(missing...).
+		WithIdentity(identity)
+}
+
+// unusableParamValue reports whether a provided path/query parameter value
+// cannot form a usable request value: nil or an empty string. A key's presence
+// in params is the intent signal — a typed flag is overlaid only when
+// explicitly Changed, and a --params JSON key is deliberately written — so
+// false and 0 are real values and must not be conflated with "unset"
+// (reflect.IsZero would drop an explicit --with-deleted=false or --foo 0).
+// Only nil/"" stay treated as missing: that keeps the friendly pre-flight
+// error when a required param is fed an empty placeholder, and never emits a
+// declared param as an empty path segment or query value. Undeclared keys are
+// not judged by this rule — they pass through verbatim as the raw escape hatch.
+func unusableParamValue(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	s, ok := v.(string)
+	return ok && s == ""
+}
+
+// missingParamHint is the recovery hint for a missing required parameter. It
+// names both input paths — the typed flag when the binder registered one, and
+// the --params fallback — plus the schema pointer. A params-only field gets
+// only the --params form: a flag with its kebab name exists but belongs to
+// something else (e.g. the output --format), and the hint must not steer
+// there. Asking the binder, not cmd.Flags(), is what tells those apart.
+func missingParamHint(opts *ServiceMethodOptions, f meta.Field) string {
+	paramsForm := fmt.Sprintf("--params '{%q: \"<value>\"}'", f.Name)
+	if opts.binder.hasTypedFlag(f.Name) {
+		return fmt.Sprintf("set --%s <value> (or %s); see: lark-cli schema %s", f.FlagName(), paramsForm, opts.SchemaPath)
+	}
+	return fmt.Sprintf("set %s; see: lark-cli schema %s", paramsForm, opts.SchemaPath)
 }
 
 // buildServiceRequest parses flags, builds the URL with path/query params, and returns a RawApiRequest.
 // When dryRun is true and a file is provided, file reading is skipped and
 // FileUploadMeta is returned instead so the caller can render dry-run output.
 func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmdutil.FileUploadMeta, error) {
-	spec := opts.Spec
 	method := opts.Method
-	schemaPath := opts.SchemaPath
-	httpMethod := registry.GetStrFromMap(method, "httpMethod")
+	httpMethod := method.HTTPMethod
 
 	// stdin is an io.Reader consumed at most once. Only one of --params/--data
 	// may use "-" (stdin); the conflict check below prevents silent data loss.
 	stdin := opts.Factory.IOStreams.In
+	fileIO := opts.Factory.ResolveFileIO(opts.Ctx)
 
 	// Validate --file mutual exclusions.
 	if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, httpMethod); err != nil {
 		return client.RawApiRequest{}, nil, err
 	}
 	if opts.Params == "-" && opts.Data == "-" {
-		return client.RawApiRequest{}, nil, output.ErrValidation("--params and --data cannot both read from stdin (-)")
+		return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--params and --data cannot both read from stdin (-)").WithParam("--params")
 	}
-	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
+	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin, fileIO)
 	if err != nil {
 		return client.RawApiRequest{}, nil, err
 	}
+	opts.binder.overlay(opts.Cmd, params)
 
-	url := registry.GetStrFromMap(spec, "servicePath") + "/" + registry.GetStrFromMap(method, "path")
+	url := opts.ServicePath + "/" + method.Path
 
-	parameters, _ := method["parameters"].(map[string]interface{})
-	for name, param := range parameters {
-		p, _ := param.(map[string]interface{})
-		if registry.GetStrFromMap(p, "location") != "path" {
+	specs := method.Params()
+	for _, s := range specs {
+		if s.Location != "path" {
 			continue
 		}
-		val, ok := params[name]
-		if !ok || util.IsEmptyValue(val) {
-			return client.RawApiRequest{}, nil, output.ErrWithHint(output.ExitValidation, "validation",
-				fmt.Sprintf("missing required path parameter: %s", name),
-				fmt.Sprintf("lark-cli schema %s", schemaPath))
+		val, ok := params[s.Name]
+		if !ok || unusableParamValue(val) {
+			return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"missing required path parameter: %s", s.Name).
+				WithHint("%s", missingParamHint(opts, s)).
+				WithParam(s.Name)
 		}
 		valStr := fmt.Sprintf("%v", val)
-		if err := validate.ResourceName(valStr, name); err != nil {
-			return client.RawApiRequest{}, nil, output.ErrValidation("%s", err)
+		if err := validate.ResourceName(valStr, s.Name); err != nil {
+			return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam(s.Name).WithCause(err)
 		}
-		url = strings.Replace(url, "{"+name+"}", validate.EncodePathSegment(valStr), 1)
-		delete(params, name)
+		url = strings.Replace(url, "{"+s.Name+"}", validate.EncodePathSegment(valStr), 1)
+		delete(params, s.Name)
 	}
 
 	queryParams := map[string]interface{}{}
-	for name, param := range parameters {
-		p, _ := param.(map[string]interface{})
-		if registry.GetStrFromMap(p, "location") != "query" {
+	for _, s := range specs {
+		if s.Location != "query" {
 			continue
 		}
-		value, exists := params[name]
-		required, _ := p["required"].(bool)
-		isPaginationParam := opts.PageAll && (name == "page_token" || name == "page_size")
-		if required && !isPaginationParam && (!exists || util.IsEmptyValue(value)) {
-			return client.RawApiRequest{}, nil, output.ErrWithHint(output.ExitValidation, "validation",
-				fmt.Sprintf("missing required query parameter: %s", name),
-				fmt.Sprintf("lark-cli schema %s", schemaPath))
+		value, exists := params[s.Name]
+		isPaginationParam := opts.PageAll && (s.Name == "page_token" || s.Name == "page_size")
+		if s.Required && !isPaginationParam && (!exists || unusableParamValue(value)) {
+			return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"missing required query parameter: %s", s.Name).
+				WithHint("%s", missingParamHint(opts, s)).
+				WithParam(s.Name)
 		}
-		if exists && !util.IsEmptyValue(value) {
-			queryParams[name] = value
+		if exists && !unusableParamValue(value) {
+			queryParams[s.Name] = value
 		}
+		// This loop owns declared query params: consume the key so the
+		// passthrough below can't resurrect a value the gate dropped (an
+		// unusable "" would otherwise be sent as an empty query value).
+		delete(params, s.Name)
 	}
+	// Whatever remains is undeclared — the raw escape hatch for params the
+	// metadata doesn't (yet) describe; passed through verbatim, no filtering.
 	for name, value := range params {
-		if _, ok := queryParams[name]; !ok {
-			queryParams[name] = value
-		}
+		queryParams[name] = value
 	}
 
 	request := client.RawApiRequest{
@@ -411,12 +630,12 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		// Parse --data as form fields.
 		var dataFields any
 		if opts.Data != "" {
-			dataFields, err = cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
+			dataFields, err = cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin, fileIO)
 			if err != nil {
 				return client.RawApiRequest{}, nil, err
 			}
 			if _, ok := dataFields.(map[string]any); !ok {
-				return client.RawApiRequest{}, nil, output.ErrValidation("--data must be a JSON object when used with --file")
+				return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--data must be a JSON object when used with --file").WithParam("--data")
 			}
 		}
 
@@ -427,7 +646,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		}
 
 		fd, err := cmdutil.BuildFormdata(
-			opts.Factory.ResolveFileIO(opts.Ctx),
+			fileIO,
 			fieldName, filePath, isStdin, stdin, dataFields,
 		)
 		if err != nil {
@@ -436,7 +655,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		request.Data = fd
 		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileUpload())
 	} else {
-		data, err := cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
+		data, err := cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin, fileIO)
 		if err != nil {
 			return client.RawApiRequest{}, nil, err
 		}
@@ -449,71 +668,96 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 	return request, nil, nil
 }
 
-func serviceDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, format string) error {
-	return cmdutil.PrintDryRun(f.IOStreams.Out, request, config, format)
+func serviceDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, opts *ServiceMethodOptions) error {
+	return cmdutil.PrintDryRun(request, config, serviceDryRunOutputOptions(f, opts))
 }
 
-// scopeAwareChecker returns an error checker that enriches scope-related errors with login hints.
-func scopeAwareChecker(scopes []interface{}, isBotMode bool) func(interface{}) error {
-	return func(result interface{}) error {
-		resultMap, ok := result.(map[string]interface{})
-		if !ok || resultMap == nil {
-			return nil
-		}
-		code, _ := util.ToFloat64(resultMap["code"])
-		if code == 0 {
-			return nil
-		}
-		larkCode := int(code)
-		msg := registry.GetStrFromMap(resultMap, "msg")
-
-		if larkCode == output.LarkErrUserScopeInsufficient && len(scopes) > 0 {
-			identity := "user"
-			if isBotMode {
-				identity = "tenant"
-			}
-			recommended := registry.SelectRecommendedScope(scopes, identity)
-			return output.ErrWithHint(output.ExitAPI, "permission",
-				fmt.Sprintf("insufficient permissions: [%d] %s", larkCode, msg),
-				fmt.Sprintf(`run `+"`"+`lark-cli auth login --scope "%s"`+"`"+` in the background. It blocks and outputs a verification URL — retrieve the URL and open it in a browser to complete login.`, recommended))
-		}
-
-		return output.ErrAPI(larkCode, fmt.Sprintf("API error: [%d] %s", larkCode, msg), resultMap["error"])
+func serviceDryRunOutputOptions(f *cmdutil.Factory, opts *ServiceMethodOptions) cmdutil.DryRunOutputOptions {
+	return cmdutil.DryRunOutputOptions{
+		Format:      opts.Format,
+		JqExpr:      opts.JqExpr,
+		CommandPath: opts.Cmd.CommandPath(),
+		Identity:    opts.As,
+		Out:         f.IOStreams.Out,
+		ErrOut:      f.IOStreams.ErrOut,
 	}
 }
 
-func servicePaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, jqExpr string, out, errOut io.Writer, pagOpts client.PaginationOptions, checkErr func(interface{}) error) error {
+func servicePaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, jqExpr string, out, errOut io.Writer, commandPath, schemaPath string, pagOpts client.PaginationOptions, checkErr func(interface{}, core.Identity) error) error {
+	if pagOpts.Identity == "" {
+		pagOpts.Identity = request.As
+	}
+	transform := serviceSuccessTransformer(schemaPath)
 	// When jq is set, always aggregate all pages then filter.
 	if jqExpr != "" {
-		return client.PaginateWithJq(ctx, ac, request, jqExpr, out, pagOpts, checkErr)
+		result, err := ac.PaginateAll(ctx, request, pagOpts)
+		if err != nil {
+			return err
+		}
+		if apiErr := checkErr(result, pagOpts.Identity); apiErr != nil {
+			output.FormatValue(out, result, output.FormatJSON)
+			return apiErr
+		}
+		if transform != nil {
+			result = transform(result)
+		}
+		return output.WriteSuccessEnvelope(output.SuccessEnvelopeData(result), output.SuccessEnvelopeOptions{
+			CommandPath: commandPath,
+			Identity:    string(pagOpts.Identity),
+			JqExpr:      jqExpr,
+			Out:         out,
+			ErrOut:      errOut,
+		})
 	}
 
 	switch format {
 	case output.FormatNDJSON, output.FormatTable, output.FormatCSV:
-		pf := output.NewPaginatedFormatter(out, format)
-		result, hasItems, err := ac.StreamPages(ctx, request, func(items []interface{}) {
-			pf.FormatPage(items)
+		emitter := output.NewEmitter(output.EmitterConfig{
+			Out:            out,
+			ErrOut:         errOut,
+			CommandPath:    commandPath,
+			Identity:       string(pagOpts.Identity),
+			NoticeProvider: output.GetNotice,
+		})
+		result, hasItems, err := ac.StreamPages(ctx, request, func(items []interface{}) error {
+			// Streaming formats intentionally emit each page after that page has
+			// passed safety scanning. A later page may still fail, so callers
+			// must use the exit code to distinguish complete vs partial output.
+			return emitter.StreamPage(items, output.StreamOptions{Format: format.String()})
 		}, pagOpts)
 		if err != nil {
-			return output.ErrNetwork("API call failed: %s", err)
+			return err
 		}
-		if apiErr := checkErr(result); apiErr != nil {
+		if apiErr := checkErr(result, pagOpts.Identity); apiErr != nil {
 			return apiErr
 		}
 		if !hasItems {
 			fmt.Fprintf(errOut, "warning: this API does not return a list, format %q is not supported, falling back to json\n", format)
-			output.FormatValue(out, result, output.FormatJSON)
+			return output.WriteSuccessEnvelope(output.SuccessEnvelopeData(result), output.SuccessEnvelopeOptions{
+				CommandPath: commandPath,
+				Identity:    string(pagOpts.Identity),
+				Out:         out,
+				ErrOut:      errOut,
+			})
 		}
 		return nil
 	default:
 		result, err := ac.PaginateAll(ctx, request, pagOpts)
 		if err != nil {
-			return output.ErrNetwork("API call failed: %s", err)
+			return err
 		}
-		if apiErr := checkErr(result); apiErr != nil {
+		if apiErr := checkErr(result, pagOpts.Identity); apiErr != nil {
+			output.FormatValue(out, result, output.FormatJSON)
 			return apiErr
 		}
-		output.FormatValue(out, result, format)
-		return nil
+		if transform != nil {
+			result = transform(result)
+		}
+		return output.WriteSuccessEnvelope(output.SuccessEnvelopeData(result), output.SuccessEnvelopeOptions{
+			CommandPath: commandPath,
+			Identity:    string(pagOpts.Identity),
+			Out:         out,
+			ErrOut:      errOut,
+		})
 	}
 }

--- a/cmd/service/service_paginate_test.go
+++ b/cmd/service/service_paginate_test.go
@@ -1,0 +1,400 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
+)
+
+type serviceFailOnWriteWriter struct {
+	buf    bytes.Buffer
+	writes int
+	failAt int
+	err    error
+}
+
+func (w *serviceFailOnWriteWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failAt {
+		return 0, w.err
+	}
+	return w.buf.Write(p)
+}
+
+func newServicePaginateTestHarness(t *testing.T) (*client.APIClient, *bytes.Buffer, *bytes.Buffer, *httpmock.Registry) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_CONTENT_SAFETY_MODE", "off")
+	previousNotice := output.PendingNotice
+	output.PendingNotice = nil
+	t.Cleanup(func() { output.PendingNotice = previousNotice })
+
+	config := &core.CliConfig{
+		AppID:     "test-app",
+		AppSecret: "test-secret",
+		Brand:     core.BrandFeishu,
+	}
+	f, out, errOut, reg := cmdutil.TestFactory(t, config)
+	ac, err := f.NewAPIClientWithConfig(config)
+	if err != nil {
+		t.Fatalf("NewAPIClientWithConfig() error = %v", err)
+	}
+	ac.ErrOut = io.Discard
+	return ac, out, errOut, reg
+}
+
+func servicePaginateRequest() client.RawApiRequest {
+	return client.RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test/v1/items",
+		As:     core.AsBot,
+	}
+}
+
+func assertServicePaginateJSONBytes(t *testing.T, got []byte, want interface{}) {
+	t.Helper()
+	wantBytes, err := json.MarshalIndent(want, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal expected JSON: %v", err)
+	}
+	wantBytes = append(wantBytes, '\n')
+	if !bytes.Equal(got, wantBytes) {
+		t.Fatalf("stdout bytes mismatch\ngot:\n%s\nwant:\n%s", got, wantBytes)
+	}
+}
+
+func TestServicePaginate_DefaultAggregatesAllPages(t *testing.T) {
+	ac, out, errOut, reg := newServicePaginateTestHarness(t)
+	calls := 0
+	wantTokens := []string{"", "next-1", "next-2"}
+	for i, wantToken := range wantTokens {
+		page := i + 1
+		hasMore := page < len(wantTokens)
+		data := map[string]interface{}{
+			"items":    []interface{}{map[string]interface{}{"id": string(rune('0' + page))}},
+			"has_more": hasMore,
+		}
+		if hasMore {
+			data["page_token"] = wantTokens[page]
+		}
+		reg.Register(&httpmock.Stub{
+			URL: "/open-apis/test/v1/items",
+			OnMatch: func(req *http.Request) {
+				calls++
+				if got := req.URL.Query().Get("page_token"); got != wantToken {
+					t.Errorf("request %d page_token = %q, want %q", page, got, wantToken)
+				}
+			},
+			Body: map[string]interface{}{
+				"code": 0,
+				"msg":  "ok",
+				"data": data,
+			},
+		})
+	}
+
+	err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+		output.FormatJSON, "", out, errOut, "lark-cli test items list", "", client.PaginationOptions{
+			PageLimit: 10,
+			PageDelay: -1,
+		}, ac.CheckResponse)
+
+	if err != nil {
+		t.Fatalf("servicePaginate() error = %v, want nil", err)
+	}
+	if calls != 3 {
+		t.Fatalf("pagination requests = %d, want 3", calls)
+	}
+	assertServicePaginateJSONBytes(t, out.Bytes(), output.Envelope{
+		OK:       true,
+		Identity: "bot",
+		Data: map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{"id": "1"},
+				map[string]interface{}{"id": "2"},
+				map[string]interface{}{"id": "3"},
+			},
+			"has_more": false,
+		},
+	})
+	if got := errOut.String(); got != "" {
+		t.Fatalf("stderr bytes = %q, want empty", got)
+	}
+}
+
+func TestServicePaginate_StreamingFormatsEmitExactMultiPageBytes(t *testing.T) {
+	tests := []struct {
+		name   string
+		format output.Format
+		want   string
+	}{
+		{
+			name:   "ndjson",
+			format: output.FormatNDJSON,
+			want:   "{\"id\":\"1\",\"name\":\"Alice\"}\n{\"id\":\"2\",\"name\":\"Carol\",\"page_only\":\"ignored\"}\n",
+		},
+		{
+			name:   "table",
+			format: output.FormatTable,
+			want:   "id  name \n──  ─────\n1   Alice\n2   Carol\n",
+		},
+		{
+			name:   "csv",
+			format: output.FormatCSV,
+			want:   "id,name\n1,Alice\n2,Carol\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac, out, errOut, reg := newServicePaginateTestHarness(t)
+			reg.Register(&httpmock.Stub{
+				URL: "/open-apis/test/v1/items",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "ok",
+					"data": map[string]interface{}{
+						"items": []interface{}{
+							map[string]interface{}{"id": "1", "name": "Alice"},
+						},
+						"has_more":   true,
+						"page_token": "next-1",
+					},
+				},
+			})
+			reg.Register(&httpmock.Stub{
+				URL: "/open-apis/test/v1/items",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "ok",
+					"data": map[string]interface{}{
+						"items": []interface{}{
+							map[string]interface{}{"id": "2", "name": "Carol", "page_only": "ignored"},
+						},
+						"has_more": false,
+					},
+				},
+			})
+
+			err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+				tt.format, "", out, errOut, "lark-cli test items list", "", client.PaginationOptions{
+					PageLimit: 10,
+					PageDelay: -1,
+				}, ac.CheckResponse)
+
+			if err != nil {
+				t.Fatalf("servicePaginate() error = %v, want nil", err)
+			}
+			if got := out.String(); got != tt.want {
+				t.Fatalf("stdout byte mismatch\ngot (%d bytes):\n%q\nwant (%d bytes):\n%q", len(got), got, len(tt.want), tt.want)
+			}
+			if got := errOut.String(); got != "" {
+				t.Fatalf("stderr bytes = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestServicePaginate_StreamingWriteFailureStopsFurtherPages(t *testing.T) {
+	ac, _, errOut, reg := newServicePaginateTestHarness(t)
+	sentinel := errors.New("page write failed")
+	out := &serviceFailOnWriteWriter{failAt: 2, err: sentinel}
+	calls := 0
+	for page := 1; page <= 2; page++ {
+		hasMore := true
+		data := map[string]interface{}{
+			"items":    []interface{}{map[string]interface{}{"id": page}},
+			"has_more": hasMore,
+		}
+		if hasMore {
+			data["page_token"] = fmt.Sprintf("next-%d", page)
+		}
+		reg.Register(&httpmock.Stub{
+			URL: "/open-apis/test/v1/items",
+			OnMatch: func(*http.Request) {
+				calls++
+			},
+			Body: map[string]interface{}{
+				"code": 0,
+				"msg":  "ok",
+				"data": data,
+			},
+		})
+	}
+
+	err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+		output.FormatNDJSON, "", out, errOut, "lark-cli test items list",
+		"", client.PaginationOptions{PageLimit: 10, PageDelay: -1}, ac.CheckResponse)
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("servicePaginate() error = %v, want preserved writer cause", err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryInternal {
+		t.Fatalf("servicePaginate() problem = %#v, %v; want internal typed error", problem, ok)
+	}
+	if calls != 2 {
+		t.Fatalf("pagination requests = %d, want 2", calls)
+	}
+	if got, want := out.buf.String(), "{\"id\":1}\n"; got != want {
+		t.Fatalf("stdout bytes = %q, want %q", got, want)
+	}
+}
+
+func TestServicePaginate_StreamingFormatFallsBackToJSONWithoutList(t *testing.T) {
+	ac, out, errOut, reg := newServicePaginateTestHarness(t)
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/test/v1/items",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"name":    "Test User",
+				"user_id": "u123",
+			},
+		},
+	})
+
+	err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+		output.FormatNDJSON, "", out, errOut, "lark-cli test items get",
+		"", client.PaginationOptions{PageDelay: -1}, ac.CheckResponse)
+
+	if err != nil {
+		t.Fatalf("servicePaginate() error = %v, want nil", err)
+	}
+	assertServicePaginateJSONBytes(t, out.Bytes(), output.Envelope{
+		OK:       true,
+		Identity: "bot",
+		Data: map[string]interface{}{
+			"name":    "Test User",
+			"user_id": "u123",
+		},
+	})
+	wantWarning := "warning: this API does not return a list, format \"ndjson\" is not supported, falling back to json\n"
+	if got := errOut.String(); got != wantWarning {
+		t.Fatalf("stderr bytes = %q, want %q", got, wantWarning)
+	}
+}
+
+func TestServicePaginate_BusinessErrorsWriteRawAndRemainUnmarked(t *testing.T) {
+	businessResponse := map[string]interface{}{
+		"code": 123456,
+		"msg":  "fixture business error",
+		"data": map[string]interface{}{"detail": "business failed"},
+	}
+	tests := []struct {
+		name   string
+		format output.Format
+		jqExpr string
+	}{
+		{name: "jq", format: output.FormatJSON, jqExpr: ".data.items"},
+		{name: "default_json", format: output.FormatJSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac, out, errOut, reg := newServicePaginateTestHarness(t)
+			reg.Register(&httpmock.Stub{
+				URL:  "/open-apis/test/v1/items",
+				Body: businessResponse,
+			})
+
+			err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+				tt.format, tt.jqExpr, out, errOut, "lark-cli test items list",
+				"", client.PaginationOptions{PageDelay: -1}, ac.CheckResponse)
+
+			if err == nil {
+				t.Fatal("servicePaginate() error = nil, want business error")
+			}
+			if errs.IsRaw(err) {
+				t.Fatalf("errs.IsRaw(error) = true, want current servicePaginate pass-through behavior")
+			}
+			assertServicePaginateJSONBytes(t, out.Bytes(), businessResponse)
+			if bytes.Contains(out.Bytes(), []byte(`"ok": true`)) {
+				t.Fatalf("business-error stdout contains a success envelope:\n%s", out.Bytes())
+			}
+			if got := errOut.String(); got != "" {
+				t.Fatalf("stderr bytes = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestServicePaginate_TransportErrorsRemainUnmarked(t *testing.T) {
+	tests := []struct {
+		name   string
+		format output.Format
+		jqExpr string
+	}{
+		{name: "jq_paginate_all", format: output.FormatJSON, jqExpr: ".data.items"},
+		{name: "stream_pages", format: output.FormatNDJSON},
+		{name: "default_paginate_all", format: output.FormatJSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac, out, errOut, _ := newServicePaginateTestHarness(t)
+
+			err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+				tt.format, tt.jqExpr, out, errOut, "lark-cli test items list",
+				"", client.PaginationOptions{PageDelay: -1}, ac.CheckResponse)
+
+			if err == nil {
+				t.Fatal("servicePaginate() error = nil, want transport error")
+			}
+			if errs.IsRaw(err) {
+				t.Fatalf("errs.IsRaw(error) = true, want current servicePaginate pass-through behavior")
+			}
+			if got := out.String(); got != "" {
+				t.Fatalf("stdout bytes = %q, want empty", got)
+			}
+			if got := errOut.String(); got != "" {
+				t.Fatalf("stderr bytes = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestServicePaginate_StreamBusinessErrorRemainsUnmarked(t *testing.T) {
+	ac, out, errOut, reg := newServicePaginateTestHarness(t)
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/test/v1/items",
+		Body: map[string]interface{}{
+			"code": 123456,
+			"msg":  "fixture business error",
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+		output.FormatNDJSON, "", out, errOut, "lark-cli test items list",
+		"", client.PaginationOptions{PageDelay: -1}, ac.CheckResponse)
+
+	if err == nil {
+		t.Fatal("servicePaginate() error = nil, want business error")
+	}
+	if errs.IsRaw(err) {
+		t.Fatalf("errs.IsRaw(error) = true, want current servicePaginate pass-through behavior")
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("stdout bytes = %q, want empty", got)
+	}
+	if got := errOut.String(); got != "" {
+		t.Fatalf("stderr bytes = %q, want empty", got)
+	}
+}

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -4,14 +4,24 @@
 package service
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"mime"
+	"mime/multipart"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
+	extcs "github.com/larksuite/cli/extension/contentsafety"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/meta"
+	"github.com/larksuite/cli/internal/registry"
 	"github.com/spf13/cobra"
 )
 
@@ -21,14 +31,14 @@ var testConfig = &core.CliConfig{
 	AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
 }
 
-func driveSpec() map[string]interface{} {
-	return map[string]interface{}{
+func driveSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
 		"name":        "drive",
 		"servicePath": "/open-apis/drive/v1",
-	}
+	})
 }
 
-func driveMethod(httpMethod string, params map[string]interface{}) map[string]interface{} {
+func driveMethod(httpMethod string, params map[string]interface{}) meta.Method {
 	m := map[string]interface{}{
 		"path":       "files/{file_token}/copy",
 		"httpMethod": httpMethod,
@@ -42,7 +52,7 @@ func driveMethod(httpMethod string, params map[string]interface{}) map[string]in
 			},
 		}
 	}
-	return m
+	return meta.FromMap(m)
 }
 
 // ── registerService ──
@@ -50,23 +60,23 @@ func driveMethod(httpMethod string, params map[string]interface{}) map[string]in
 func TestRegisterService(t *testing.T) {
 	parent := &cobra.Command{Use: "root"}
 	f := &cmdutil.Factory{}
-	spec := map[string]interface{}{
+	base := meta.ServiceFromMap(map[string]interface{}{
 		"name":        "base",
 		"description": "Base API",
 		"servicePath": "/open-apis/base/v3",
-	}
-	resources := map[string]interface{}{
-		"tables": map[string]interface{}{
-			"methods": map[string]interface{}{
-				"list": map[string]interface{}{
-					"description": "List tables",
-					"httpMethod":  "GET",
+		"resources": map[string]interface{}{
+			"tables": map[string]interface{}{
+				"methods": map[string]interface{}{
+					"list": map[string]interface{}{
+						"description": "List tables",
+						"httpMethod":  "GET",
+					},
 				},
 			},
 		},
-	}
+	})
 
-	registerService(parent, spec, resources, f)
+	registerService(parent, base, f)
 
 	// service command exists
 	svc, _, err := parent.Find([]string{"base"})
@@ -91,18 +101,18 @@ func TestRegisterService_MergesExistingCommand(t *testing.T) {
 	parent.AddCommand(existing)
 
 	f := &cmdutil.Factory{}
-	spec := map[string]interface{}{
+	svc := meta.ServiceFromMap(map[string]interface{}{
 		"name": "base", "description": "Base API", "servicePath": "/open-apis/base/v3",
-	}
-	resources := map[string]interface{}{
-		"tables": map[string]interface{}{
-			"methods": map[string]interface{}{
-				"list": map[string]interface{}{"description": "List", "httpMethod": "GET"},
+		"resources": map[string]interface{}{
+			"tables": map[string]interface{}{
+				"methods": map[string]interface{}{
+					"list": map[string]interface{}{"description": "List", "httpMethod": "GET"},
+				},
 			},
 		},
-	}
+	})
 
-	registerService(parent, spec, resources, f)
+	registerService(parent, svc, f)
 
 	// Should reuse existing, not duplicate
 	count := 0
@@ -121,12 +131,107 @@ func TestRegisterService_MergesExistingCommand(t *testing.T) {
 	}
 }
 
+func TestRegisterService_MailSenderOverlayCommands(t *testing.T) {
+	parent := &cobra.Command{Use: "lark-cli"}
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+
+	RegisterServiceCommands(parent, f)
+
+	for _, path := range [][]string{
+		{"mail", "user_mailbox.allow_senders", "list"},
+		{"mail", "user_mailbox.allow_senders", "batch_create"},
+		{"mail", "user_mailbox.allow_senders", "batch_remove"},
+		{"mail", "user_mailbox.blocked_senders", "list"},
+		{"mail", "user_mailbox.blocked_senders", "batch_create"},
+		{"mail", "user_mailbox.blocked_senders", "batch_remove"},
+	} {
+		cmd, _, err := parent.Find(path)
+		if err != nil || cmd == nil || cmd.Name() != path[len(path)-1] {
+			t.Fatalf("expected command %v, got cmd=%v err=%v", path, cmd, err)
+		}
+	}
+
+	list, _, err := parent.Find([]string{"mail", "user_mailbox.allow_senders", "list"})
+	if err != nil {
+		t.Fatalf("find allow_senders list: %v", err)
+	}
+	for _, flag := range []string{"query", "page-size", "page-token"} {
+		if list.Flags().Lookup(flag) == nil {
+			t.Fatalf("list missing --%s flag", flag)
+		}
+	}
+	batchCreate, _, err := parent.Find([]string{"mail", "user_mailbox.blocked_senders", "batch_create"})
+	if err != nil {
+		t.Fatalf("find blocked_senders batch_create: %v", err)
+	}
+	if batchCreate.Flags().Lookup("data") == nil {
+		t.Fatal("batch_create missing --data flag")
+	}
+}
+
+func TestMailSenderOverlayScopes(t *testing.T) {
+	svc, ok := registry.ServiceTyped("mail")
+	if !ok {
+		t.Fatal("mail service missing")
+	}
+
+	for _, tt := range []struct {
+		resource string
+		method   string
+		scope    string
+		risk     string
+	}{
+		{"user_mailbox.allow_senders", "list", "mail:user_mailbox.message:readonly", core.RiskRead},
+		{"user_mailbox.blocked_senders", "list", "mail:user_mailbox.message:readonly", core.RiskRead},
+		{"user_mailbox.allow_senders", "batch_create", "mail:user_mailbox.message:modify", core.RiskWrite},
+		{"user_mailbox.allow_senders", "batch_remove", "mail:user_mailbox.message:modify", core.RiskWrite},
+		{"user_mailbox.blocked_senders", "batch_create", "mail:user_mailbox.message:modify", core.RiskWrite},
+		{"user_mailbox.blocked_senders", "batch_remove", "mail:user_mailbox.message:modify", core.RiskWrite},
+	} {
+		res, ok := svc.Resource(tt.resource)
+		if !ok {
+			t.Fatalf("%s resource missing", tt.resource)
+		}
+		method, ok := res.Method(tt.method)
+		if !ok {
+			t.Fatalf("%s.%s method missing", tt.resource, tt.method)
+		}
+		if method.Risk != tt.risk {
+			t.Fatalf("%s.%s risk = %q, want %q", tt.resource, tt.method, method.Risk, tt.risk)
+		}
+		if len(method.RequiredScopes) != 1 || method.RequiredScopes[0] != tt.scope {
+			t.Fatalf("%s.%s requiredScopes = %v, want [%s]", tt.resource, tt.method, method.RequiredScopes, tt.scope)
+		}
+		if len(method.AccessTokens) != 1 || method.AccessTokens[0] != meta.TokenUser {
+			t.Fatalf("%s.%s accessTokens = %v, want [user]", tt.resource, tt.method, method.AccessTokens)
+		}
+	}
+}
+
+func TestNewCmdServiceMethod_StrictModeHidesAsFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu, SupportedIdentities: 2,
+	})
+
+	cmd := NewCmdServiceMethod(f, driveSpec(), driveMethod("GET", nil), "copy", "files", nil)
+	flag := cmd.Flags().Lookup("as")
+	if flag == nil {
+		t.Fatal("expected --as flag to be registered")
+	}
+	if !flag.Hidden {
+		t.Fatal("expected --as flag to be hidden in strict mode")
+	}
+	if got := flag.DefValue; got != "bot" {
+		t.Fatalf("default value = %q, want %q", got, "bot")
+	}
+}
+
 // ── NewCmdServiceMethod flags ──
 
 func TestNewCmdServiceMethod_GETHasNoDataFlag(t *testing.T) {
 	f := &cmdutil.Factory{}
 	cmd := NewCmdServiceMethod(f, driveSpec(),
-		map[string]interface{}{"description": "desc", "httpMethod": "GET"}, "list", "files", nil)
+		meta.FromMap(map[string]interface{}{"description": "desc", "httpMethod": "GET"}), "list", "files", nil)
 
 	if cmd.Flags().Lookup("data") != nil {
 		t.Error("GET method should not have --data flag")
@@ -142,7 +247,7 @@ func TestNewCmdServiceMethod_GETHasNoDataFlag(t *testing.T) {
 func TestNewCmdServiceMethod_POSTHasDataFlag(t *testing.T) {
 	f := &cmdutil.Factory{}
 	cmd := NewCmdServiceMethod(f, driveSpec(),
-		map[string]interface{}{"description": "desc", "httpMethod": "POST"}, "create", "files", nil)
+		meta.FromMap(map[string]interface{}{"description": "desc", "httpMethod": "POST"}), "create", "files", nil)
 
 	if cmd.Flags().Lookup("data") == nil {
 		t.Error("POST method should have --data flag")
@@ -154,7 +259,7 @@ func TestNewCmdServiceMethod_RunFCallback(t *testing.T) {
 
 	var captured *ServiceMethodOptions
 	cmd := NewCmdServiceMethod(f, driveSpec(),
-		map[string]interface{}{"description": "desc", "httpMethod": "GET"}, "list", "files",
+		meta.FromMap(map[string]interface{}{"description": "desc", "httpMethod": "GET"}), "list", "files",
 		func(opts *ServiceMethodOptions) error {
 			captured = opts
 			return nil
@@ -197,11 +302,133 @@ func TestServiceMethod_DryRun_PathParam(t *testing.T) {
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !strings.Contains(stdout.String(), tt.wantInURL) {
-				t.Errorf("expected URL containing %q, got:\n%s", tt.wantInURL, stdout.String())
+			var got map[string]interface{}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			if got["ok"] != true || got["dry_run"] != true {
+				t.Fatalf("unexpected dry-run envelope: %#v", got)
+			}
+			data := got["data"].(map[string]interface{})
+			api := data["api"].([]interface{})
+			call := api[0].(map[string]interface{})
+			if call["url"] != tt.wantInURL {
+				t.Errorf("url = %q, want %q\nstdout:\n%s", call["url"], tt.wantInURL, stdout.String())
 			}
 		})
 	}
+}
+
+func TestServiceMethod_DryRunWithJq(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, driveSpec(), driveMethod("GET", nil), "get", "files", nil)
+	cmd.SetArgs([]string{
+		"--params", `{"file_token":"boxcn123abc"}`,
+		"--dry-run",
+		"--jq", ".data.api[0].url",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := strings.TrimSpace(stdout.String()), "/open-apis/drive/v1/files/boxcn123abc/copy"; got != want {
+		t.Fatalf("jq output = %q, want %q", got, want)
+	}
+}
+
+func TestMailSenderCommands_DryRunRequestShape(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantURL    string
+		wantParams map[string]interface{}
+		wantBody   map[string]interface{}
+	}{
+		{
+			name: "allow list",
+			args: []string{
+				"mail", "user_mailbox.allow_senders", "list",
+				"--as", "user",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--query", "example",
+				"--page-size", "20",
+				"--page-token", "next",
+				"--dry-run",
+			},
+			wantURL: "/open-apis/mail/v1/user_mailboxes/me/allow_senders",
+			wantParams: map[string]interface{}{
+				"query":      "example",
+				"page_size":  float64(20),
+				"page_token": "next",
+			},
+		},
+		{
+			name: "blocked batch create",
+			args: []string{
+				"mail", "user_mailbox.blocked_senders", "batch_create",
+				"--as", "user",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"addresses":["a@example.com","b.example"]}`,
+				"--dry-run",
+			},
+			wantURL: "/open-apis/mail/v1/user_mailboxes/me/blocked_senders/batch_create",
+			wantBody: map[string]interface{}{
+				"addresses": []interface{}{"a@example.com", "b.example"},
+			},
+		},
+		{
+			name: "allow batch remove",
+			args: []string{
+				"mail", "user_mailbox.allow_senders", "batch_remove",
+				"--as", "user",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"addresses":["a@example.com"]}`,
+				"--dry-run",
+			},
+			wantURL: "/open-apis/mail/v1/user_mailboxes/me/allow_senders/batch_remove",
+			wantBody: map[string]interface{}{
+				"addresses": []interface{}{"a@example.com"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+			root := &cobra.Command{Use: "lark-cli"}
+			RegisterServiceCommands(root, f)
+			root.SetArgs(tt.args)
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var got map[string]interface{}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			data := got["data"].(map[string]interface{})
+			api := data["api"].([]interface{})
+			call := api[0].(map[string]interface{})
+			if call["url"] != tt.wantURL {
+				t.Fatalf("url = %q, want %q\nstdout:\n%s", call["url"], tt.wantURL, stdout.String())
+			}
+			if tt.wantParams != nil {
+				if !mapsEqual(call["params"].(map[string]interface{}), tt.wantParams) {
+					t.Fatalf("params = %#v, want %#v", call["params"], tt.wantParams)
+				}
+			}
+			if tt.wantBody != nil {
+				if !mapsEqual(call["body"].(map[string]interface{}), tt.wantBody) {
+					t.Fatalf("body = %#v, want %#v", call["body"], tt.wantBody)
+				}
+			}
+		})
+	}
+}
+
+func mapsEqual(a, b map[string]interface{}) bool {
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	return bytes.Equal(ab, bb)
 }
 
 func TestServiceMethod_PathParamRejectsTraversal(t *testing.T) {
@@ -251,15 +478,15 @@ func TestServiceMethod_MissingPathParam(t *testing.T) {
 }
 
 func TestServiceMethod_MissingRequiredQueryParam(t *testing.T) {
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{
+	})
+	method := meta.FromMap(map[string]interface{}{
 		"path": "items", "httpMethod": "GET",
 		"parameters": map[string]interface{}{
 			"q": map[string]interface{}{"location": "query", "required": true},
 		},
-	}
+	})
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--params", `{}`, "--dry-run"})
@@ -274,15 +501,15 @@ func TestServiceMethod_MissingRequiredQueryParam(t *testing.T) {
 }
 
 func TestServiceMethod_PaginationParamSkippedWithPageAll(t *testing.T) {
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{
+	})
+	method := meta.FromMap(map[string]interface{}{
 		"path": "items", "httpMethod": "GET",
 		"parameters": map[string]interface{}{
 			"page_size": map[string]interface{}{"location": "query", "required": true},
 		},
-	}
+	})
 	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--params", `{}`, "--page-all", "--dry-run"})
@@ -291,17 +518,21 @@ func TestServiceMethod_PaginationParamSkippedWithPageAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error with --page-all skipping page_size, got: %v", err)
 	}
-	if !strings.Contains(stdout.String(), "Dry Run") {
-		t.Error("expected dry-run output")
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got["dry_run"] != true {
+		t.Fatalf("dry_run = %#v, want true", got["dry_run"])
 	}
 }
 
 func TestServiceMethod_InvalidParamsJSON(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET"}
+	})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET"})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--params", "{bad", "--dry-run"})
 
@@ -316,10 +547,10 @@ func TestServiceMethod_InvalidParamsJSON(t *testing.T) {
 
 func TestServiceMethod_InvalidDataJSON(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{"path": "items", "httpMethod": "POST", "parameters": map[string]interface{}{}}
+	})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "POST", "parameters": map[string]interface{}{}})
 	cmd := NewCmdServiceMethod(f, spec, method, "create", "items", nil)
 	cmd.SetArgs([]string{"--data", "{bad", "--dry-run"})
 
@@ -334,10 +565,10 @@ func TestServiceMethod_InvalidDataJSON(t *testing.T) {
 
 func TestServiceMethod_ParamsAndDataBothStdinConflict(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{"path": "items", "httpMethod": "POST", "parameters": map[string]interface{}{}}
+	})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "POST", "parameters": map[string]interface{}{}})
 	cmd := NewCmdServiceMethod(f, spec, method, "create", "items", nil)
 	cmd.SetArgs([]string{"--params", "-", "--data", "-", "--dry-run"})
 
@@ -352,10 +583,10 @@ func TestServiceMethod_ParamsAndDataBothStdinConflict(t *testing.T) {
 
 func TestServiceMethod_OutputAndPageAllConflict(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET"}
+	})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET"})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--page-all", "--output", "file.bin", "--as", "bot"})
 
@@ -381,49 +612,156 @@ func TestServiceMethod_BotMode_Success(t *testing.T) {
 		},
 	})
 
-	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}}
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--as", "bot"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(stdout.String(), "success") {
-		t.Errorf("expected 'success' in output, got:\n%s", stdout.String())
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout.String())
+	}
+	if got["ok"] != true || got["identity"] != "bot" {
+		t.Fatalf("unexpected envelope: %#v", got)
+	}
+	if _, hasCode := got["code"]; hasCode {
+		t.Fatalf("success envelope leaked outer code: %s", stdout.String())
+	}
+	data, ok := got["data"].(map[string]interface{})
+	if !ok || data["result"] != "success" {
+		t.Fatalf("data = %#v, want result=success", got["data"])
 	}
 }
 
-func TestServiceMethod_BotMode_APIError(t *testing.T) {
-	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
-		AppID: "test-app-err", AppSecret: "test-secret-err", Brand: core.BrandFeishu,
-	})
-
-	reg.Register(&httpmock.Stub{
-		URL:  "/open-apis/svc/v1/items",
-		Body: map[string]interface{}{"code": 40003, "msg": "invalid token"},
-	})
-
-	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}}
-	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
-	cmd.SetArgs([]string{"--as", "bot"})
-
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected API error")
+func TestMailSenderCommands_ProjectSuccessOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		stub       *httpmock.Stub
+		wantData   map[string]interface{}
+		forbidKeys []string
+	}{
+		{
+			name: "list",
+			args: []string{
+				"mail", "user_mailbox.allow_senders", "list",
+				"--as", "user",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--query", "sender",
+			},
+			stub: &httpmock.Stub{
+				Method: "GET",
+				URL:    "/open-apis/mail/v1/user_mailboxes/me/allow_senders",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "ok",
+					"data": map[string]interface{}{
+						"items": []interface{}{
+							map[string]interface{}{"address": "sender@example.com", "id": "should-not-leak", "created_time": "0"},
+						},
+						"next_page_token": "next",
+						"has_more":        true,
+					},
+				},
+			},
+			wantData: map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"address": "sender@example.com"},
+				},
+				"next_page_token": "next",
+			},
+			forbidKeys: []string{"id", "created_time", "has_more"},
+		},
+		{
+			name: "batch_create",
+			args: []string{
+				"mail", "user_mailbox.blocked_senders", "batch_create",
+				"--as", "user",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"addresses":["sender@example.com","sender@example.com"]}`,
+			},
+			stub: &httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/mail/v1/user_mailboxes/me/blocked_senders/batch_create",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "ok",
+					"data": map[string]interface{}{
+						"submitted_count":    1,
+						"deduplicated_count": 1,
+						"created_count":      1,
+						"filtered_count":     0,
+						"failed_items":       []interface{}{map[string]interface{}{"address": "bad"}},
+					},
+				},
+			},
+			wantData: map[string]interface{}{
+				"submitted_count":    float64(1),
+				"deduplicated_count": float64(1),
+			},
+			forbidKeys: []string{"created_count", "deleted_count", "filtered_count", "failed_items"},
+		},
+		{
+			name: "batch_remove",
+			args: []string{
+				"mail", "user_mailbox.allow_senders", "batch_remove",
+				"--as", "user",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", `{"addresses":["sender@example.com"]}`,
+			},
+			stub: &httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/mail/v1/user_mailboxes/me/allow_senders/batch_remove",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "ok",
+					"data": map[string]interface{}{
+						"submitted_count":    1,
+						"deduplicated_count": 0,
+						"deleted_count":      1,
+						"failed_items":       []interface{}{},
+					},
+				},
+			},
+			wantData: map[string]interface{}{
+				"submitted_count":    float64(1),
+				"deduplicated_count": float64(0),
+			},
+			forbidKeys: []string{"created_count", "deleted_count", "filtered_count", "failed_items"},
+		},
 	}
-	var exitErr *output.ExitError
-	if !isExitError(err, &exitErr) {
-		t.Fatalf("expected ExitError, got: %T %v", err, err)
-	}
-	if exitErr.Code != output.ExitAPI {
-		t.Errorf("expected ExitAPI code, got %d", exitErr.Code)
-	}
-	// stdout must be empty on API error — error details belong in stderr envelope only.
-	// This guards against re-introducing duplicate output (see commit 86215a10).
-	if stdout.Len() > 0 {
-		t.Errorf("expected no stdout on API error, got: %s", stdout.String())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, testConfig)
+			reg.Register(tt.stub)
+			root := &cobra.Command{Use: "lark-cli"}
+			RegisterServiceCommands(root, f)
+			root.SetArgs(tt.args)
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var got map[string]interface{}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			data, ok := got["data"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("data = %#v, want object", got["data"])
+			}
+			if !mapsEqual(data, tt.wantData) {
+				t.Fatalf("data = %#v, want %#v\nstdout:\n%s", data, tt.wantData, stdout.String())
+			}
+			for _, key := range tt.forbidKeys {
+				if strings.Contains(stdout.String(), `"`+key+`"`) {
+					t.Fatalf("stdout leaked %s:\n%s", key, stdout.String())
+				}
+			}
+		})
 	}
 }
 
@@ -443,16 +781,320 @@ func TestServiceMethod_BotMode_PageAll_JSON(t *testing.T) {
 		},
 	})
 
-	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}}
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--as", "bot", "--page-all"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(stdout.String(), `"id"`) {
-		t.Errorf("expected items in output, got:\n%s", stdout.String())
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout.String())
+	}
+	data, ok := got["data"].(map[string]interface{})
+	if got["ok"] != true || got["identity"] != "bot" || !ok {
+		t.Fatalf("unexpected envelope: %#v", got)
+	}
+	if _, hasCode := got["code"]; hasCode {
+		t.Fatalf("success envelope leaked outer code: %s", stdout.String())
+	}
+	items, ok := data["items"].([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("data.items = %#v, want one item", data["items"])
+	}
+}
+
+type serviceContentSafetyProvider struct {
+	called bool
+	path   string
+	data   interface{}
+	match  string
+}
+
+func (p *serviceContentSafetyProvider) Name() string { return "service-test" }
+
+func (p *serviceContentSafetyProvider) Scan(_ context.Context, req extcs.ScanRequest) (*extcs.Alert, error) {
+	p.called = true
+	p.path = req.Path
+	p.data = req.Data
+	if p.match != "" {
+		b, _ := json.Marshal(req.Data)
+		if !strings.Contains(string(b), p.match) {
+			return nil, nil
+		}
+	}
+	return &extcs.Alert{Provider: "service-test", MatchedRules: []string{"pagination"}}, nil
+}
+
+func TestServiceMethod_PageAll_DefaultJSONRunsContentSafety(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONTENT_SAFETY_MODE", "warn")
+	provider := &serviceContentSafetyProvider{}
+	extcs.Register(provider)
+	t.Cleanup(func() { extcs.Register(nil) })
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-service-safety", AppSecret: "test-secret-service-safety", Brand: core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":    []interface{}{map[string]interface{}{"id": "1"}},
+				"has_more": false,
+			},
+		},
+	})
+
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
+	root := &cobra.Command{Use: "lark-cli"}
+	root.AddCommand(NewCmdServiceMethod(f, spec, method, "list", "items", nil))
+	root.SetArgs([]string{"list", "--as", "bot", "--page-all"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !provider.called {
+		t.Fatal("expected content safety provider to scan paginated output")
+	}
+	if provider.path != "list" {
+		t.Fatalf("scan path = %q, want list", provider.path)
+	}
+	data, ok := provider.data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("scanned data type = %T, want map", provider.data)
+	}
+	if _, hasCode := data["code"]; hasCode {
+		t.Fatalf("scanned data should be business data only, got %#v", data)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout.String())
+	}
+	alert, ok := got["_content_safety_alert"].(map[string]interface{})
+	if !ok || alert["provider"] != "service-test" {
+		t.Fatalf("missing content safety alert in envelope: %#v", got)
+	}
+}
+
+func TestServiceMethod_PageAll_StreamFormatRunsContentSafety(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONTENT_SAFETY_MODE", "warn")
+	provider := &serviceContentSafetyProvider{}
+	extcs.Register(provider)
+	t.Cleanup(func() { extcs.Register(nil) })
+
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-service-stream-safety", AppSecret: "test-secret-service-stream-safety", Brand: core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":    []interface{}{map[string]interface{}{"id": "1"}},
+				"has_more": false,
+			},
+		},
+	})
+
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
+	root := &cobra.Command{Use: "lark-cli"}
+	root.AddCommand(NewCmdServiceMethod(f, spec, method, "list", "items", nil))
+	root.SetArgs([]string{"list", "--as", "bot", "--page-all", "--format", "ndjson"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !provider.called {
+		t.Fatal("expected content safety provider to scan streamed paginated output")
+	}
+	if provider.path != "list" {
+		t.Fatalf("scan path = %q, want list", provider.path)
+	}
+	items, ok := provider.data.([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("scanned data = %#v, want one streamed item", provider.data)
+	}
+	if !strings.Contains(stderr.String(), "warning: content safety alert from service-test") {
+		t.Fatalf("expected content safety warning on stderr, got: %s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"id":"1"`) {
+		t.Fatalf("expected streamed ndjson output, got: %s", stdout.String())
+	}
+}
+
+func TestServiceMethod_PageAll_StreamFormatBlockSkipsBlockedPage(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONTENT_SAFETY_MODE", "block")
+	provider := &serviceContentSafetyProvider{match: "blocked"}
+	extcs.Register(provider)
+	t.Cleanup(func() { extcs.Register(nil) })
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-service-stream-block", AppSecret: "test-secret-service-stream-block", Brand: core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "safe-page"}},
+				"has_more":   true,
+				"page_token": "next",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":    []interface{}{map[string]interface{}{"id": "blocked-page"}},
+				"has_more": false,
+			},
+		},
+	})
+
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
+	root := &cobra.Command{Use: "lark-cli"}
+	root.AddCommand(NewCmdServiceMethod(f, spec, method, "list", "items", nil))
+	root.SetArgs([]string{"list", "--as", "bot", "--page-all", "--format", "ndjson"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected content safety block error")
+	}
+	var safetyErr *errs.ContentSafetyError
+	if !errors.As(err, &safetyErr) {
+		t.Fatalf("expected ContentSafetyError, got %T: %v", err, err)
+	}
+	if safetyErr.Category != errs.CategoryPolicy || safetyErr.Subtype != errs.SubtypeContentSafety {
+		t.Fatalf("problem = %s/%s, want %s/%s", safetyErr.Category, safetyErr.Subtype, errs.CategoryPolicy, errs.SubtypeContentSafety)
+	}
+	if len(safetyErr.Rules) != 1 || safetyErr.Rules[0] != "pagination" {
+		t.Fatalf("rules = %v, want [pagination]", safetyErr.Rules)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "safe-page") {
+		t.Fatalf("expected earlier safe page to remain streamed, got: %s", out)
+	}
+	if strings.Contains(out, "blocked-page") {
+		t.Fatalf("blocked page was written before safety block: %s", out)
+	}
+}
+
+func TestServiceMethod_BusinessErrorReturnsTypedErrorWithoutSuccessEnvelope(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-service-err", AppSecret: "test-secret-service-err", Brand: core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 230027, "msg": "user not authorized",
+		},
+	})
+
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	cmd.SetArgs([]string{"--as", "bot"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-zero code")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+	var permErr *errs.PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected PermissionError, got %T: %v", err, err)
+	}
+	if strings.Contains(stdout.String(), `"ok": true`) || strings.Contains(stdout.String(), `"ok":true`) {
+		t.Fatalf("unexpected success envelope on error path: %s", stdout.String())
+	}
+}
+
+func TestServiceMethod_PageAll_DefaultBusinessErrorOutputsRawResponse(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-service-pageall-err", AppSecret: "test-secret-service-pageall-err", Brand: core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 230027, "msg": "user not authorized",
+		},
+	})
+
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--page-all"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-zero code")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+	if !strings.Contains(stdout.String(), "230027") || !strings.Contains(stdout.String(), "user not authorized") {
+		t.Fatalf("expected raw error response on stdout, got: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), `"ok": true`) || strings.Contains(stdout.String(), `"ok":true`) {
+		t.Fatalf("unexpected success envelope on error path: %s", stdout.String())
+	}
+}
+
+func TestServiceMethod_PageAll_StreamBusinessErrorDoesNotDumpJSON(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-service-pageall-stream-err", AppSecret: "test-secret-service-pageall-stream-err", Brand: core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "safe-page"}},
+				"has_more":   true,
+				"page_token": "next",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 230027,
+			"msg":  "user not authorized",
+		},
+	})
+
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--page-all", "--format", "ndjson"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-zero code")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+	out := stdout.String()
+	if !strings.Contains(out, "safe-page") {
+		t.Fatalf("expected earlier successful page to remain streamed, got: %s", out)
+	}
+	if strings.Contains(out, "230027") || strings.Contains(out, "user not authorized") {
+		t.Fatalf("streaming stdout should not contain raw error JSON, got: %s", out)
+	}
+	if strings.Contains(out, "\n  \"code\"") {
+		t.Fatalf("streaming stdout should not contain indented JSON error dump, got: %s", out)
 	}
 }
 
@@ -466,8 +1108,8 @@ func TestServiceMethod_UnknownFormat_Warning(t *testing.T) {
 		Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
 	})
 
-	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}}
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--as", "bot", "--format", "unknown"})
 
@@ -486,7 +1128,7 @@ func TestNewCmdServiceMethod_JqFlag(t *testing.T) {
 
 	var captured *ServiceMethodOptions
 	cmd := NewCmdServiceMethod(f, driveSpec(),
-		map[string]interface{}{"description": "desc", "httpMethod": "GET"}, "list", "files",
+		meta.FromMap(map[string]interface{}{"description": "desc", "httpMethod": "GET"}), "list", "files",
 		func(opts *ServiceMethodOptions) error {
 			captured = opts
 			return nil
@@ -508,7 +1150,7 @@ func TestNewCmdServiceMethod_JqShortForm(t *testing.T) {
 
 	var captured *ServiceMethodOptions
 	cmd := NewCmdServiceMethod(f, driveSpec(),
-		map[string]interface{}{"description": "desc", "httpMethod": "GET"}, "list", "files",
+		meta.FromMap(map[string]interface{}{"description": "desc", "httpMethod": "GET"}), "list", "files",
 		func(opts *ServiceMethodOptions) error {
 			captured = opts
 			return nil
@@ -524,10 +1166,10 @@ func TestNewCmdServiceMethod_JqShortForm(t *testing.T) {
 
 func TestServiceMethod_JqAndOutputConflict(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET"}
+	})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET"})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--jq", ".data", "--output", "file.bin", "--as", "bot"})
 
@@ -558,8 +1200,8 @@ func TestServiceMethod_JqFilter_AppliesExpression(t *testing.T) {
 		},
 	})
 
-	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}}
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--as", "bot", "--jq", ".data.items[].name"})
 
@@ -577,10 +1219,10 @@ func TestServiceMethod_JqFilter_AppliesExpression(t *testing.T) {
 
 func TestServiceMethod_JqAndFormatConflict(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET"}
+	})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET"})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--jq", ".data", "--format", "ndjson", "--as", "bot"})
 
@@ -595,10 +1237,10 @@ func TestServiceMethod_JqAndFormatConflict(t *testing.T) {
 
 func TestServiceMethod_JqInvalidExpression(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	spec := map[string]interface{}{
+	spec := meta.ServiceFromMap(map[string]interface{}{
 		"name": "svc", "servicePath": "/open-apis/svc/v1",
-	}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET"}
+	})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET"})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--jq", "invalid[", "--as", "bot"})
 
@@ -627,8 +1269,8 @@ func TestServiceMethod_PageAll_WithJq(t *testing.T) {
 		},
 	})
 
-	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
-	method := map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}}
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
 	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
 	cmd.SetArgs([]string{"--as", "bot", "--page-all", "--jq", ".data.items[].id"})
 
@@ -644,77 +1286,55 @@ func TestServiceMethod_PageAll_WithJq(t *testing.T) {
 	}
 }
 
-// ── scopeAwareChecker ──
+func TestServiceMethod_PageAll_WithJqBusinessErrorOutputsRawResponse(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-spjq-err", AppSecret: "test-secret-spjq-err", Brand: core.BrandFeishu,
+	})
 
-func TestScopeAwareChecker_Success(t *testing.T) {
-	checker := scopeAwareChecker(nil, false)
-	err := checker(map[string]interface{}{"code": 0.0, "msg": "ok"})
-	if err != nil {
-		t.Errorf("expected nil error for code=0, got: %v", err)
-	}
-}
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/svc/v1/items",
+		Body: map[string]interface{}{
+			"code": 230027, "msg": "user not authorized",
+		},
+	})
 
-func TestScopeAwareChecker_NonMapResult(t *testing.T) {
-	checker := scopeAwareChecker(nil, false)
-	err := checker("not a map")
-	if err != nil {
-		t.Errorf("expected nil for non-map result, got: %v", err)
-	}
-}
+	spec := meta.ServiceFromMap(map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"})
+	method := meta.FromMap(map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}})
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--page-all", "--jq", ".data.items[].id"})
 
-func TestScopeAwareChecker_APIError(t *testing.T) {
-	checker := scopeAwareChecker(nil, false)
-	err := checker(map[string]interface{}{"code": 40003.0, "msg": "bad request"})
+	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for non-zero code")
 	}
-	if !strings.Contains(err.Error(), "API error: [40003]") {
-		t.Errorf("unexpected error: %v", err)
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+	var permErr *errs.PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected PermissionError, got %T: %v", err, err)
+	}
+	if !strings.Contains(stdout.String(), "230027") || !strings.Contains(stdout.String(), "user not authorized") {
+		t.Fatalf("expected raw error response on stdout, got: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), `"ok": true`) || strings.Contains(stdout.String(), `"ok":true`) {
+		t.Fatalf("unexpected success envelope on error path: %s", stdout.String())
 	}
 }
 
-func TestScopeAwareChecker_ScopeError_UserMode(t *testing.T) {
-	scopes := []interface{}{"calendar:read"}
-	checker := scopeAwareChecker(scopes, false)
-	err := checker(map[string]interface{}{
-		"code": float64(output.LarkErrUserScopeInsufficient),
-		"msg":  "scope insufficient",
-	})
-	if err == nil {
-		t.Fatal("expected permission error")
+func requireProblem(t *testing.T, err error, category errs.Category, subtype errs.Subtype, code int) {
+	t.Helper()
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
 	}
-	var exitErr *output.ExitError
-	if !isExitError(err, &exitErr) {
-		t.Fatalf("expected ExitError, got %T", err)
-	}
-	if exitErr.Detail.Type != "permission" {
-		t.Errorf("expected type=permission, got %s", exitErr.Detail.Type)
-	}
-	if !strings.Contains(exitErr.Detail.Hint, "auth login") {
-		t.Errorf("expected auth login hint, got %s", exitErr.Detail.Hint)
-	}
-}
-
-func TestScopeAwareChecker_ScopeError_BotMode(t *testing.T) {
-	scopes := []interface{}{"calendar:read"}
-	checker := scopeAwareChecker(scopes, true)
-	err := checker(map[string]interface{}{
-		"code": float64(output.LarkErrUserScopeInsufficient),
-		"msg":  "scope insufficient",
-	})
-	if err == nil {
-		t.Fatal("expected permission error")
-	}
-	// Bot mode should still include the scope hint
-	if !strings.Contains(err.Error(), "insufficient permissions") {
-		t.Errorf("unexpected error: %v", err)
+	if p.Category != category || p.Subtype != subtype || p.Code != code {
+		t.Fatalf("problem = %s/%s/%d, want %s/%s/%d", p.Category, p.Subtype, p.Code, category, subtype, code)
 	}
 }
 
 // ── file upload ──
 
-func imImageMethod() map[string]interface{} {
-	return map[string]interface{}{
+func imImageMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
 		"path":       "images",
 		"httpMethod": "POST",
 		"requestBody": map[string]interface{}{
@@ -728,14 +1348,14 @@ func imImageMethod() map[string]interface{} {
 			},
 		},
 		"accessTokens": []interface{}{"user", "tenant"},
-	}
+	})
 }
 
-func imSpec() map[string]interface{} {
-	return map[string]interface{}{
+func imSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
 		"name":        "im",
 		"servicePath": "/open-apis/im/v1",
-	}
+	})
 }
 
 func TestServiceMethod_FileFlagRegistered(t *testing.T) {
@@ -767,7 +1387,7 @@ func TestServiceMethod_FileFlagNotRegisteredForGET(t *testing.T) {
 		},
 	}
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
-	cmd := NewCmdServiceMethod(f, imSpec(), getMethod, "get", "images", nil)
+	cmd := NewCmdServiceMethod(f, imSpec(), meta.FromMap(getMethod), "get", "images", nil)
 	flag := cmd.Flags().Lookup("file")
 	if flag != nil {
 		t.Fatal("expected --file flag NOT to be registered for GET method")
@@ -794,11 +1414,23 @@ func TestServiceMethod_FileUpload_DryRun(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "image") {
-		t.Errorf("expected dry-run output to mention file field, got: %s", out)
+	var env map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "Dry Run") {
-		t.Errorf("expected dry-run header, got: %s", out)
+	if env["dry_run"] != true {
+		t.Fatalf("dry_run = %#v, want true", env["dry_run"])
+	}
+	data := env["data"].(map[string]interface{})
+	api := data["api"].([]interface{})
+	call := api[0].(map[string]interface{})
+	body := call["body"].(map[string]interface{})
+	file := body["file"].(map[string]interface{})
+	if file["field"] != "image" || file["path"] != tmpFile {
+		t.Fatalf("unexpected file dry-run body: %#v", body)
+	}
+	if strings.Contains(out, "=== Dry Run ===") {
+		t.Fatalf("stdout should not contain dry-run banner: %s", out)
 	}
 }
 
@@ -835,7 +1467,7 @@ func TestDetectFileFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detectFileFields(tt.method)
+			got := detectFileFields(meta.FromMap(tt.method))
 			if len(got) != len(tt.want) {
 				t.Errorf("detectFileFields() = %v, want %v", got, tt.want)
 				return
@@ -849,12 +1481,78 @@ func TestDetectFileFields(t *testing.T) {
 	}
 }
 
-// ── helpers ──
-
-func isExitError(err error, target **output.ExitError) bool {
-	ee, ok := err.(*output.ExitError)
-	if ok && target != nil {
-		*target = ee
+// parseMultipartFilenames drives one service-method --file upload through the
+// mock transport and returns a map of field name -> part filename parsed from
+// the captured multipart body. Mirrors cmd/api's helper of the same name
+// (inlined here rather than shared, since the two live in different packages)
+// to give BuildFormdata's shared local-file fix a second real entry-point
+// covering it.
+func parseMultipartFilenames(t *testing.T, stub *httpmock.Stub) map[string]string {
+	t.Helper()
+	ct := stub.CapturedHeaders.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(ct)
+	if err != nil {
+		t.Fatalf("parse Content-Type %q: %v", ct, err)
 	}
-	return ok
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		t.Fatalf("Content-Type = %q, want multipart/*", mediaType)
+	}
+	filenames := map[string]string{}
+	mr := multipart.NewReader(bytes.NewReader(stub.CapturedBody), params["boundary"])
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			break
+		}
+		if fn := part.FileName(); fn != "" {
+			filenames[part.FormName()] = fn
+		}
+	}
+	return filenames
+}
+
+func TestServiceMethod_FileUpload_PreservesFilename(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "photo.jpg"), []byte("fake-image"), 0600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	stub := &httpmock.Stub{
+		URL:  "/open-apis/im/v1/images",
+		Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"image_key": "img_xxx"}},
+	}
+	reg.Register(stub)
+
+	cmd := NewCmdServiceMethod(f, imSpec(), imImageMethod(), "create", "images", nil)
+	cmd.SetArgs([]string{"--file", "photo.jpg", "--data", `{"image_type":"message"}`, "--as", "bot"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	filenames := parseMultipartFilenames(t, stub)
+	if got := filenames["image"]; got != "photo.jpg" {
+		t.Fatalf("part filename for field %q = %q, want %q", "image", got, "photo.jpg")
+	}
+}
+
+func TestServiceMethod_JsonFlag_Accepted(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+
+	var captured *ServiceMethodOptions
+	cmd := NewCmdServiceMethod(f, driveSpec(),
+		meta.FromMap(map[string]interface{}{"description": "desc", "httpMethod": "GET"}), "list", "files",
+		func(opts *ServiceMethodOptions) error {
+			captured = opts
+			return nil
+		})
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("--json should be accepted without error, got: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("expected runF to be called")
+	}
 }

--- a/internal/client/response.go
+++ b/internal/client/response.go
@@ -14,7 +14,9 @@ import (
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/util"
 )
@@ -23,14 +25,44 @@ import (
 
 // ResponseOptions configures how HandleResponse routes a raw API response.
 type ResponseOptions struct {
-	OutputPath string        // --output flag; "" = auto-detect
-	Format     output.Format // output format for JSON responses
-	JqExpr     string        // if set, apply jq filter instead of Format
-	Out        io.Writer     // stdout
-	ErrOut     io.Writer     // stderr
-	FileIO     fileio.FileIO // file transfer abstraction; required when saving files (--output or binary response)
-	// CheckError is called on parsed JSON results. Nil defaults to CheckLarkResponse.
-	CheckError func(interface{}) error
+	OutputPath  string        // --output flag; "" = auto-detect
+	Format      output.Format // output format for JSON responses
+	JqExpr      string        // if set, apply jq filter instead of Format
+	Out         io.Writer     // stdout
+	ErrOut      io.Writer     // stderr
+	FileIO      fileio.FileIO // file transfer abstraction; required when saving files (--output or binary response)
+	CommandPath string        // raw cobra CommandPath() for content safety scanning
+	// Identity is forwarded to CheckError (default or caller-supplied) so the
+	// classifier can populate identity-aware fields (e.g. PermissionError.Identity).
+	// Defaults to core.AsUser when empty.
+	Identity core.Identity
+	// CheckError is called on parsed JSON results. Nil defaults to (*APIClient).CheckResponse
+	// with the Identity field (or AsUser when unset).
+	CheckError func(result interface{}, identity core.Identity) error
+	// TransformSuccess, when set, rewrites a successful parsed JSON response
+	// before it is emitted. It runs after CheckError so business errors still
+	// see the raw API payload.
+	TransformSuccess func(result interface{}) interface{}
+}
+
+// httpStatusError classifies an HTTP error response by status when the body
+// carries no usable business error: 5xx → NetworkError (server tier), 404 →
+// APIError/not_found, any other 4xx → APIError/unknown. Used wherever a
+// status >= 400 must not be swallowed — a non-JSON body, an unparseable body,
+// or a JSON body whose business code is 0.
+func httpStatusError(status int, rawBody []byte) error {
+	body := util.TruncateStrWithEllipsis(strings.TrimSpace(string(rawBody)), 500)
+	if status >= 500 {
+		return errs.NewNetworkError(errs.SubtypeNetworkServer,
+			"HTTP %d: %s", status, body).
+			WithCode(status)
+	}
+	subtype := errs.SubtypeUnknown
+	if status == 404 {
+		subtype = errs.SubtypeNotFound
+	}
+	return errs.NewAPIError(subtype, "HTTP %d: %s", status, body).
+		WithCode(status)
 }
 
 // HandleResponse routes a raw *larkcore.ApiResp to the appropriate output:
@@ -39,40 +71,89 @@ type ResponseOptions struct {
 //  3. If Content-Type is non-JSON and no --output, auto-save binary to file.
 func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 	ct := resp.Header.Get("Content-Type")
+	identity := opts.Identity
+	if identity == "" {
+		identity = core.AsUser
+	}
 	check := opts.CheckError
 	if check == nil {
-		check = CheckLarkResponse
+		// Default check routes through BuildAPIError, producing typed
+		// *errs.PermissionError / AuthenticationError / etc. A zero-value
+		// *APIClient is safe here because BuildAPIError gracefully degrades
+		// identity-aware fields (ConsoleURL etc.) when AppID is empty.
+		check = func(r interface{}, id core.Identity) error {
+			return (&APIClient{}).CheckResponse(r, id)
+		}
 	}
 
-	// Non-JSON error responses (e.g. 404 text/plain from gateway): return error directly
-	// instead of falling through to the binary-save path.
+	// Non-JSON error responses (e.g. 404 text/plain from gateway): return error
+	// directly instead of falling through to the binary-save path.
 	if resp.StatusCode >= 400 && !IsJSONContentType(ct) && ct != "" {
-		body := util.TruncateStrWithEllipsis(strings.TrimSpace(string(resp.RawBody)), 500)
-		return output.Errorf(httpExitCode(resp.StatusCode), "http_error", "HTTP %d: %s", resp.StatusCode, body)
+		return httpStatusError(resp.StatusCode, resp.RawBody)
 	}
 
 	// JSON responses: always check for business errors before saving.
 	if IsJSONContentType(ct) || ct == "" {
 		result, err := ParseJSONResponse(resp)
 		if err != nil {
+			// An unparseable / empty body on an HTTP error (common with a
+			// missing Content-Type) must be classified by status, not reported
+			// as an internal decode failure, matching the non-JSON branch above.
+			if resp.StatusCode >= 400 {
+				return httpStatusError(resp.StatusCode, resp.RawBody)
+			}
 			return WrapJSONResponseParseError(err, resp.RawBody)
 		}
-		if apiErr := check(result); apiErr != nil {
+		if apiErr := check(result, identity); apiErr != nil {
 			return apiErr
 		}
+		// CheckResponse treats business code 0 as success, so a 4xx/5xx whose
+		// JSON body omits a non-zero code would otherwise be served as a
+		// successful result. Classify by HTTP status so it is never swallowed.
+		if resp.StatusCode >= 400 {
+			return httpStatusError(resp.StatusCode, resp.RawBody)
+		}
+		if opts.TransformSuccess != nil {
+			result = opts.TransformSuccess(result)
+		}
 		if opts.OutputPath != "" {
+			// File downloads keep the existing raw-response scan path because the
+			// saved payload is the API response body, not the success envelope.
+			scanResult := output.ScanForSafety(opts.CommandPath, result, opts.ErrOut)
+			if scanResult.Blocked {
+				return scanResult.BlockErr
+			}
+			if scanResult.Alert != nil {
+				output.WriteAlertWarning(opts.ErrOut, scanResult.Alert)
+			}
 			return saveAndPrint(opts.FileIO, resp, opts.OutputPath, opts.Out)
 		}
-		if opts.JqExpr != "" {
-			return output.JqFilter(opts.Out, result, opts.JqExpr)
+
+		if opts.JqExpr != "" || opts.Format == output.FormatJSON {
+			return output.WriteSuccessEnvelope(output.SuccessEnvelopeData(result), output.SuccessEnvelopeOptions{
+				CommandPath: opts.CommandPath,
+				Identity:    string(identity),
+				JqExpr:      opts.JqExpr,
+				Out:         opts.Out,
+				ErrOut:      opts.ErrOut,
+			})
 		}
-		output.FormatValue(opts.Out, result, opts.Format)
-		return nil
+
+		emitter := output.NewEmitter(output.EmitterConfig{
+			Out:            opts.Out,
+			ErrOut:         opts.ErrOut,
+			CommandPath:    opts.CommandPath,
+			Identity:       string(identity),
+			NoticeProvider: output.GetNotice,
+		})
+		return emitter.Success(result, output.EmitOptions{Format: opts.Format.String()})
 	}
 
 	// Non-JSON (binary) responses.
 	if opts.JqExpr != "" {
-		return output.ErrValidation("--jq requires a JSON response (got Content-Type: %s)", ct)
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--jq requires a JSON response (got Content-Type: %s)", ct).
+			WithParam("--jq")
 	}
 	if opts.OutputPath != "" {
 		return saveAndPrint(opts.FileIO, resp, opts.OutputPath, opts.Out)
@@ -81,7 +162,7 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 	// No --output: auto-save with derived filename.
 	meta, err := SaveResponse(opts.FileIO, resp, ResolveFilename(resp))
 	if err != nil {
-		return output.Errorf(output.ExitInternal, "file_error", "%s", err)
+		return classifySaveErr(err)
 	}
 	fmt.Fprintf(opts.ErrOut, "binary response detected (Content-Type: %s), saved to file\n", ct)
 	output.PrintJson(opts.Out, meta)
@@ -91,10 +172,21 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 func saveAndPrint(fio fileio.FileIO, resp *larkcore.ApiResp, path string, w io.Writer) error {
 	meta, err := SaveResponse(fio, resp, path)
 	if err != nil {
-		return output.Errorf(output.ExitInternal, "file_error", "%s", err)
+		return classifySaveErr(err)
 	}
 	output.PrintJson(w, meta)
 	return nil
+}
+
+// classifySaveErr routes a SaveResponse error to the right typed shape.
+// Path-validation failures are caller-induced (an unsafe --output path),
+// so they surface as ValidationError on --output. Mkdir / write failures
+// are local I/O issues classified as InternalError with SubtypeFileIO.
+func classifySaveErr(err error) error {
+	if errors.Is(err, fileio.ErrPathValidation) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "%v", err).WithParam("--output")
+	}
+	return errs.NewInternalError(errs.SubtypeFileIO, "save response: %v", err).WithCause(err)
 }
 
 // ── JSON helpers ──
@@ -130,13 +222,13 @@ func SaveResponse(fio fileio.FileIO, resp *larkcore.ApiResp, outputPath string) 
 		var we *fileio.WriteError
 		switch {
 		case errors.Is(err, fileio.ErrPathValidation):
-			return nil, fmt.Errorf("unsafe output path: %s", err)
+			return nil, fmt.Errorf("unsafe output path: %w", err)
 		case errors.As(err, &me):
-			return nil, fmt.Errorf("create directory: %s", err)
+			return nil, fmt.Errorf("create directory: %w", err)
 		case errors.As(err, &we):
-			return nil, fmt.Errorf("cannot write file: %s", err)
+			return nil, fmt.Errorf("cannot write file: %w", err)
 		default:
-			return nil, fmt.Errorf("cannot write file: %s", err)
+			return nil, fmt.Errorf("cannot write file: %w", err)
 		}
 	}
 
@@ -194,13 +286,4 @@ func mimeToExt(ct string) string {
 	default:
 		return ".bin"
 	}
-}
-
-// httpExitCode maps HTTP status ranges to CLI exit codes:
-// 5xx → ExitNetwork (server error), 4xx → ExitAPI (client error).
-func httpExitCode(status int) int {
-	if status >= 500 {
-		return output.ExitNetwork
-	}
-	return output.ExitAPI
 }

--- a/internal/registry/builtin_mail_sender_overlay.go
+++ b/internal/registry/builtin_mail_sender_overlay.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package registry
+
+import (
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/meta"
+)
+
+const (
+	mailUserMailboxMessageReadonly = "mail:user_mailbox.message:readonly"
+	mailUserMailboxMessageModify   = "mail:user_mailbox.message:modify"
+)
+
+func applyBuiltInServiceOverlays() {
+	mergeServiceOverlay(mailUserSenderOverlay())
+}
+
+func mergeServiceOverlay(overlay meta.Service) {
+	if overlay.Name == "" {
+		return
+	}
+	base, ok := mergedServices[overlay.Name]
+	if !ok {
+		mergedServices[overlay.Name] = overlay
+		return
+	}
+	if base.Version == "" {
+		base.Version = overlay.Version
+	}
+	if base.Title == "" {
+		base.Title = overlay.Title
+	}
+	if base.Description == "" {
+		base.Description = overlay.Description
+	}
+	if base.ServicePath == "" {
+		base.ServicePath = overlay.ServicePath
+	}
+	if base.Resources == nil {
+		base.Resources = map[string]meta.Resource{}
+	}
+	for name, resource := range overlay.Resources {
+		base.Resources[name] = mergeResourceOverlay(base.Resources[name], resource)
+	}
+	mergedServices[overlay.Name] = base
+}
+
+func mergeResourceOverlay(base, overlay meta.Resource) meta.Resource {
+	if base.Methods == nil {
+		base.Methods = map[string]meta.Method{}
+	}
+	for name, method := range overlay.Methods {
+		if _, exists := base.Methods[name]; !exists {
+			base.Methods[name] = method
+		}
+	}
+	if base.Resources == nil && len(overlay.Resources) > 0 {
+		base.Resources = map[string]meta.Resource{}
+	}
+	for name, resource := range overlay.Resources {
+		base.Resources[name] = mergeResourceOverlay(base.Resources[name], resource)
+	}
+	return base
+}
+
+func mailUserSenderOverlay() meta.Service {
+	return meta.Service{
+		Name:        "mail",
+		Version:     "v1",
+		Title:       "Mail",
+		Description: "Mail API",
+		ServicePath: "/open-apis/mail/v1",
+		Resources: map[string]meta.Resource{
+			"user_mailbox.allow_senders":   mailSenderResource("allow_senders"),
+			"user_mailbox.blocked_senders": mailSenderResource("blocked_senders"),
+		},
+	}
+}
+
+func mailSenderResource(segment string) meta.Resource {
+	methods := map[string]meta.Method{
+		"list":         mailSenderListMethod(segment),
+		"batch_create": mailSenderBatchMethod(segment, "batch_create"),
+		"batch_remove": mailSenderBatchMethod(segment, "batch_remove"),
+	}
+	return meta.Resource{Methods: methods}
+}
+
+func mailSenderListMethod(segment string) meta.Method {
+	scope := mailUserMailboxMessageReadonly
+	return meta.Method{
+		Path:           "user_mailboxes/{user_mailbox_id}/" + segment,
+		HTTPMethod:     "GET",
+		Description:    "List user mailbox " + segment + ".",
+		Risk:           core.RiskRead,
+		Scopes:         []string{scope},
+		RequiredScopes: []string{scope},
+		AccessTokens:   []meta.Token{meta.TokenUser},
+		Parameters: map[string]meta.Field{
+			"user_mailbox_id": {
+				Type:        "string",
+				Location:    "path",
+				Required:    true,
+				Description: "User mailbox ID. Use me for the current user.",
+			},
+			"query": {
+				Type:        "string",
+				Location:    "query",
+				Description: "Search keyword for sender address.",
+			},
+			"page_size": {
+				Type:        "integer",
+				Location:    "query",
+				Description: "Page size.",
+			},
+			"page_token": {
+				Type:        "string",
+				Location:    "query",
+				Description: "Page token.",
+			},
+		},
+		ResponseBody: map[string]meta.Field{
+			"items": {
+				Type: "array",
+				Properties: map[string]meta.Field{
+					"address": {Type: "string", Description: "Sender address."},
+				},
+			},
+			"next_page_token": {Type: "string"},
+		},
+	}
+}
+
+func mailSenderBatchMethod(segment, action string) meta.Method {
+	scope := mailUserMailboxMessageModify
+	return meta.Method{
+		Path:           "user_mailboxes/{user_mailbox_id}/" + segment + "/" + action,
+		HTTPMethod:     "POST",
+		Description:    action + " user mailbox " + segment + ".",
+		Risk:           core.RiskWrite,
+		Scopes:         []string{scope},
+		RequiredScopes: []string{scope},
+		AccessTokens:   []meta.Token{meta.TokenUser},
+		Parameters: map[string]meta.Field{
+			"user_mailbox_id": {
+				Type:        "string",
+				Location:    "path",
+				Required:    true,
+				Description: "User mailbox ID. Use me for the current user.",
+			},
+		},
+		RequestBody: map[string]meta.Field{
+			"addresses": {
+				Type:        "array",
+				Required:    true,
+				Description: "Sender addresses.",
+			},
+		},
+		ResponseBody: map[string]meta.Field{
+			"submitted_count":    {Type: "integer"},
+			"deduplicated_count": {Type: "integer"},
+		},
+	}
+}

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/meta"
+	"github.com/larksuite/cli/internal/update"
 )
 
 //go:embed scope_priorities.json scope_overrides.json
@@ -23,9 +25,41 @@ var registryFS embed.FS
 var embeddedMetaJSON []byte
 
 var (
-	mergedServices    = make(map[string]map[string]interface{}) // project name → parsed spec
-	mergedProjectList []string                                  // sorted project names
-	embeddedVersion   string                                    // version from embedded meta_data.json
+	embeddedServices       []meta.Service          // parsed once, sorted by name (no overlay)
+	embeddedServicesByName map[string]meta.Service // same, keyed by name
+	embeddedVersion        string                  // version from embedded meta_data.json
+	embeddedParseOnce      sync.Once
+)
+
+// parseEmbedded decodes the embedded meta_data.json into the typed model exactly
+// once. It is the single parse of the embedded bytes: both the overlay-free
+// envelope path (EmbeddedServicesTyped) and the merged command/scope path
+// (loadEmbeddedIntoMerged) build from this result, so the JSON is never parsed
+// twice and no map round-trip is needed downstream.
+func parseEmbedded() {
+	embeddedParseOnce.Do(func() {
+		reg, _ := meta.Parse(embeddedMetaJSON)
+		embeddedVersion = reg.Version
+		embeddedServices = reg.Services
+		sort.Slice(embeddedServices, func(i, j int) bool { return embeddedServices[i].Name < embeddedServices[j].Name })
+		embeddedServicesByName = make(map[string]meta.Service, len(embeddedServices))
+		for _, svc := range embeddedServices {
+			embeddedServicesByName[svc.Name] = svc
+		}
+	})
+}
+
+// EmbeddedServicesTyped returns the embedded services (no remote overlay) as the
+// typed meta model, sorted by name. This is the overlay-free parse boundary the
+// schema envelope builds from — deterministic across machines.
+func EmbeddedServicesTyped() []meta.Service {
+	parseEmbedded()
+	return embeddedServices
+}
+
+var (
+	mergedServices    = make(map[string]meta.Service) // project name → typed service (embedded + overlay)
+	mergedProjectList []string                        // sorted project names
 	initOnce          sync.Once
 )
 
@@ -33,6 +67,12 @@ var (
 // It is safe to call multiple times (sync.Once).
 func Init() {
 	InitWithBrand(core.BrandFeishu)
+}
+
+// ConfiguredBrand reports the brand the registry was initialized with
+// (empty before initialization). Diagnostics and startup-order tests use it.
+func ConfiguredBrand() core.LarkBrand {
+	return configuredBrand
 }
 
 // InitWithBrand initializes the registry by loading embedded data and optionally
@@ -48,39 +88,39 @@ func InitWithBrand(brand core.LarkBrand) {
 		// 2. Remote overlay
 		if remoteEnabled() && cacheWritable() {
 			// Check if brand changed since last cache
-			meta, metaErr := loadCacheMeta()
-			brandChanged := metaErr == nil && meta.Brand != "" && meta.Brand != string(brand)
+			cm, metaErr := loadCacheMeta()
+			brandChanged := metaErr == nil && cm.Brand != "" && cm.Brand != string(brand)
 
 			if !brandChanged {
-				if cached, err := loadCachedMerged(); err == nil {
+				// After a CLI upgrade the embedded data can be fresher than an old
+				// cache; an equal/older cache must not shadow it.
+				if cached, err := loadCachedMerged(); err == nil && update.IsNewer(cached.Version, embeddedVersion) {
 					overlayMergedServices(cached)
 				}
 			}
 			if len(mergedServices) == 0 || brandChanged {
 				// No data at all or brand changed — must sync fetch
 				doSyncFetch()
-			} else if shouldRefresh(meta) || metaErr != nil {
+			} else if shouldRefresh(cm) || metaErr != nil {
 				// Have embedded/cached data; refresh in background if TTL expired or first run
 				triggerBackgroundRefresh()
 			}
 		}
-		// 3. Build sorted project list
+		// 3. Built-in overlays for narrowly scoped APIs that must be callable
+		// before the generated registry baseline catches up.
+		applyBuiltInServiceOverlays()
+		// 4. Build sorted project list
 		rebuildProjectList()
 	})
 }
 
-// loadEmbeddedIntoMerged parses the embedded meta_data.json and populates
-// mergedServices. No-op if meta_data.json is not compiled in.
+// loadEmbeddedIntoMerged seeds mergedServices from the embedded typed services
+// (the same parse EmbeddedServicesTyped uses). No-op if no services compiled in.
 func loadEmbeddedIntoMerged() {
-	if len(embeddedMetaJSON) == 0 {
-		return
+	parseEmbedded()
+	for name, svc := range embeddedServicesByName {
+		mergedServices[name] = svc
 	}
-	var reg MergedRegistry
-	if err := json.Unmarshal(embeddedMetaJSON, &reg); err != nil {
-		return
-	}
-	embeddedVersion = reg.Version
-	overlayMergedServices(&reg)
 }
 
 // rebuildProjectList rebuilds the sorted list of project names from mergedServices.
@@ -92,83 +132,32 @@ func rebuildProjectList() {
 	sort.Strings(mergedProjectList)
 }
 
-var cachedAllScopes map[string][]string
+var (
+	servicesTyped     []meta.Service
+	servicesTypedOnce sync.Once
+)
 
-// CollectAllScopesFromMeta collects all unique scopes from from_meta/*.json
-// for the given identity ("user" or "tenant"). Results are deduplicated and sorted.
-func CollectAllScopesFromMeta(identity string) []string {
-	if cachedAllScopes == nil {
-		cachedAllScopes = make(map[string][]string)
-	}
-	if cached, ok := cachedAllScopes[identity]; ok {
-		return cached
-	}
-
-	scopeSet := make(map[string]bool)
-	for _, project := range ListFromMetaProjects() {
-		spec := LoadFromMeta(project)
-		if spec == nil {
-			continue
+// ServicesTyped returns the merged registry (embedded + remote overlay) as typed
+// meta.Services, sorted by name. The merged store is already typed, so this just
+// projects it into a sorted slice — no map round-trip. This is the typed entry
+// the command tree and scope computation build from.
+func ServicesTyped() []meta.Service {
+	servicesTypedOnce.Do(func() {
+		Init()
+		servicesTyped = make([]meta.Service, 0, len(mergedProjectList))
+		for _, name := range mergedProjectList {
+			servicesTyped = append(servicesTyped, mergedServices[name])
 		}
-		resources, ok := spec["resources"].(map[string]interface{})
-		if !ok {
-			continue
-		}
-		for _, resSpec := range resources {
-			resMap, ok := resSpec.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			methods, ok := resMap["methods"].(map[string]interface{})
-			if !ok {
-				continue
-			}
-			for _, methodSpec := range methods {
-				methodMap, ok := methodSpec.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				// Check if method supports the requested identity
-				if tokens, ok := methodMap["accessTokens"].([]interface{}); ok {
-					supported := false
-					for _, t := range tokens {
-						if ts, ok := t.(string); ok && ts == IdentityToAccessToken(identity) {
-							supported = true
-							break
-						}
-					}
-					if !supported {
-						continue
-					}
-				}
-				// Collect scopes
-				scopes, ok := methodMap["scopes"].([]interface{})
-				if !ok {
-					continue
-				}
-				for _, s := range scopes {
-					if str, ok := s.(string); ok {
-						scopeSet[str] = true
-					}
-				}
-			}
-		}
-	}
-
-	result := make([]string, 0, len(scopeSet))
-	for s := range scopeSet {
-		result = append(result, s)
-	}
-	sort.Strings(result)
-	cachedAllScopes[identity] = result
-	return result
+	})
+	return servicesTyped
 }
 
-// LoadFromMeta loads a service schema by project name.
-// It returns data from the merged registry (embedded + cached remote overlay).
-func LoadFromMeta(project string) map[string]interface{} {
+// ServiceTyped returns one merged service (embedded + overlay) by name, or false
+// if unknown.
+func ServiceTyped(name string) (meta.Service, bool) {
 	Init()
-	return mergedServices[project]
+	svc, ok := mergedServices[name]
+	return svc, ok
 }
 
 // ListFromMetaProjects lists available service project names (sorted).


### PR DESCRIPTION
## Summary
- add mail sender service command wrappers for allow/block sender management
- add builtin registry overlay for mail sender APIs
- extend response handling and command tests

## Review resolution
- workflow-related changes are not included in this PR; the head branch compare only contains the mail sender command implementation files

Meego: https://meego.larkoffice.com/larksuite/story/detail/6930175032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in mail sender commands for listing, adding, and removing allowed or blocked senders.
  * Service commands now provide improved parameter handling, scope checks, identity restrictions, pagination, dry-run output, and file-upload validation.
  * Added clearer structured success and error responses across API commands.

* **Bug Fixes**
  * Improved HTTP error classification and prevented invalid responses from being treated as successful results.
  * Mail sender responses now return focused, consistent output for lists and batch operations.
  * Streaming output stops safely when writing fails and falls back appropriately for unsupported response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->