### PR TITLE
test(e2e): wait for base role update visibility

### DIFF
--- a/tests/cli_e2e/base/base_role_workflow_test.go
+++ b/tests/cli_e2e/base/base_role_workflow_test.go
@@ -111,11 +111,15 @@ func TestBase_RoleWorkflow(t *testing.T) {
 		result.AssertExitCode(t, 0)
 		result.AssertStdoutStatus(t, true)
 
-		err = clie2e.WaitForCondition(ctx, clie2e.WaitOptions{
-			Timeout:  30 * time.Second,
+		pollTimeout := 30 * time.Second
+		pollCtx, pollCancel := context.WithTimeout(ctx, pollTimeout)
+		defer pollCancel()
+
+		err = clie2e.WaitForCondition(pollCtx, clie2e.WaitOptions{
+			Timeout:  pollTimeout,
 			Interval: 3 * time.Second,
 		}, func() (bool, error) {
-			getResult, getErr := clie2e.RunCmd(ctx, clie2e.Request{
+			getResult, getErr := clie2e.RunCmd(pollCtx, clie2e.Request{
 				Args:      []string{"base", "+role-get", "--base-token", baseToken, "--role-id", roleID},
 				DefaultAs: "bot",
 			})

--- a/tests/cli_e2e/base/base_role_workflow_test.go
+++ b/tests/cli_e2e/base/base_role_workflow_test.go
@@ -111,18 +111,25 @@ func TestBase_RoleWorkflow(t *testing.T) {
 		result.AssertExitCode(t, 0)
 		result.AssertStdoutStatus(t, true)
 
-		getResult, err := clie2e.RunCmd(ctx, clie2e.Request{
-			Args:      []string{"base", "+role-get", "--base-token", baseToken, "--role-id", roleID},
-			DefaultAs: "bot",
-		})
-		require.NoError(t, err)
-		getResult.AssertExitCode(t, 0)
-		getResult.AssertStdoutStatus(t, true)
+		err = clie2e.WaitForCondition(ctx, clie2e.WaitOptions{
+			Timeout:  30 * time.Second,
+			Interval: 3 * time.Second,
+		}, func() (bool, error) {
+			getResult, getErr := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      []string{"base", "+role-get", "--base-token", baseToken, "--role-id", roleID},
+				DefaultAs: "bot",
+			})
+			if getErr != nil {
+				return false, getErr
+			}
+			if getResult.ExitCode != 0 {
+				return false, getResult.RunErr
+			}
 
-		rolePayload := gjson.Get(getResult.Stdout, "data.data").String()
-		require.NotEmpty(t, rolePayload, "stdout:\n%s", getResult.Stdout)
-		require.True(t, gjson.Valid(rolePayload), "stdout:\n%s", getResult.Stdout)
-		assert.Equal(t, updatedRoleName, gjson.Get(rolePayload, "role_name").String())
+			rolePayload := gjson.Get(getResult.Stdout, "data.data").String()
+			return gjson.Valid(rolePayload) && gjson.Get(rolePayload, "role_name").String() == updatedRoleName, nil
+		})
+		require.NoError(t, err, "role name should converge to %q", updatedRoleName)
 	})
 
 }


### PR DESCRIPTION
## Summary

- poll `base +role-get` after a successful role update until the updated name is visible
- bound eventual-consistency handling to 30 seconds with a 3-second polling interval
- keep API-level retry behavior in `RunCmd` unchanged

## Why

The role update can be acknowledged before a subsequent read observes the new name. This exact stale-read assertion appeared in 6 independent failed e2e-live jobs over the last 7 days across unrelated PRs. Example: https://github.com/larksuite/cli/actions/runs/30353306511/job/90257011797

## Testing

- `go test ./tests/cli_e2e/base -run '^TestBase_RoleWorkflow$' -count=1`\n- `make quality-gate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role updates to reliably show up in subsequent role lookups, reducing failures caused by eventual consistency.
* **Tests**
  * Updated end-to-end role workflow coverage to poll until updated role data is available before asserting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->