### PR TITLE
feat(slides): 支持嵌入 SVG 内容协议

### DIFF
--- a/skills/lark-slides/references/slides_xml_schema_definition.xml
+++ b/skills/lark-slides/references/slides_xml_schema_definition.xml
@@ -1076,6 +1076,7 @@
                         <xs:element ref="sml:img"/>
                         <xs:element ref="sml:table"/>
                         <xs:element ref="sml:icon"/>
+                        <xs:element ref="sml:embed"/>
                         <xs:element ref="sml:chart"/>
                         <xs:element ref="sml:undefined"/>
                     </xs:choice>
@@ -1611,6 +1612,49 @@
 
             <xs:attribute name="id" type="xs:string" use="optional"/>
             <xs:attribute name="iconType" type="xs:string" use="optional" default="iconpark/Base/setting.svg"/>
+            <xs:attribute name="topLeftX" type="sml:XType" use="required"/>
+            <xs:attribute name="topLeftY" type="sml:YType" use="required"/>
+            <xs:attribute name="width" type="sml:PositiveSize" use="required"/>
+            <xs:attribute name="height" type="sml:PositiveSize" use="required"/>
+            <xs:attribute name="rotation" type="sml:RotationType" use="optional" default="0"/>
+            <xs:attribute name="flipX" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="flipY" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="alpha" type="sml:AlphaType" use="optional" default="1"/>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- 嵌入内容元素 -->
+    <xs:element name="embed">
+        <xs:annotation>
+            <xs:documentation>
+                嵌入内容容器, 外层承载 Slides 摆放和效果属性, 内层承载外部标准内容。
+                当前内层内容为标准 SVG, 必须使用 http://www.w3.org/2000/svg 命名空间。
+                后续可扩展承载 HTML 等其他外部内容。
+
+                必需属性:
+                - topLeftX/topLeftY: 左上角坐标
+                - width/height: 显示尺寸
+
+                可选属性:
+                - id: 唯一标识符
+                - rotation: 旋转角度[0, 360)
+                - flipX/flipY: 水平/垂直翻转
+                - alpha: 不透明度[0,1]
+
+                子元素:
+                - svg: 标准 SVG 根元素, 仅描述嵌入内容, 不承载 Slides 布局属性
+                - reflection: 倒影样式, 无reflection标签代表无倒影, 空reflection标签代表使用默认样式
+                - shadow: 阴影样式, 无shadow标签代表无阴影, 空shadow标签代表使用默认样式
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any namespace="http://www.w3.org/2000/svg" processContents="lax" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="reflection" type="sml:ReflectionType" minOccurs="0"/>
+                <xs:element name="shadow" type="sml:ShadowType" minOccurs="0"/>
+            </xs:sequence>
+
+            <xs:attribute name="id" type="xs:string" use="optional"/>
             <xs:attribute name="topLeftX" type="sml:XType" use="required"/>
             <xs:attribute name="topLeftY" type="sml:YType" use="required"/>
             <xs:attribute name="width" type="sml:PositiveSize" use="required"/>

--- a/skills/lark-slides/references/xml-schema-quick-ref.md
+++ b/skills/lark-slides/references/xml-schema-quick-ref.md
@@ -81,7 +81,7 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 **子元素：**
 
 - `<style>?` - 页面样式，目前可放 `<fill>`
-- `<data>?` - 页面元素容器，可放 `shape`、`line`、`polyline`、`img`、`table`、`icon`、`chart`、`undefined`
+- `<data>?` - 页面元素容器，可放 `shape`、`line`、`polyline`、`img`、`table`、`icon`、`embed`、`chart`、`undefined`
 - `<note>?` - 演讲者备注，内部可放 `<content>`
 
 这意味着 `<title>`、`<headline>`、`<body>`、`<caption>` 不能直接放在 `<slide>` 下。
@@ -354,6 +354,20 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 隐藏 `<chart>` 的图例只能通过不写或删除 `<chartLegend>` 实现，`<chartLegend>` 不支持 `position="none"`。
 
 详细用法见 [slides_xml_schema_definition.xml](slides_xml_schema_definition.xml)。
+
+### embed
+
+嵌入内容容器：外层 `<embed>` 承载 Slides 的摆放和效果属性（`topLeftX`/`topLeftY`/`width`/`height` 必填，`rotation`/`flipX`/`flipY`/`alpha` 可选），内层承载外部标准内容。当前内层内容为标准 SVG，`<svg>` 必须使用 `http://www.w3.org/2000/svg` 命名空间，且仅描述嵌入内容本身，不承载 Slides 布局属性。
+
+```xml
+<embed topLeftX="80" topLeftY="120" width="200" height="120">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120">
+    <circle cx="100" cy="60" r="40" fill="rgba(37, 99, 235, 1)"/>
+  </svg>
+</embed>
+```
+
+`<embed>` 直接子元素为一个 `<svg>`（必需），以及可选的 `<reflection>`（倒影）与 `<shadow>`（阴影）。
 
 ## 颜色与样式
 


### PR DESCRIPTION
## 背景

同步服务端 [larkslide/ai_xsd MR 62](https://code.byted.org/larkslide/ai_xsd/merge_requests/62) 的嵌入 SVG 内容协议到 CLI 内置的 Slides SML 2.0 schema。根据服务端协作结论，schema 定义可以先行更新合入。

## 改动

- 在 `slides_xml_schema_definition.xml` 的 `<data>` 元素列表中注册 `<embed>`。
- 定义 `<embed>` 的布局与效果属性：
  - 必填：`topLeftX`、`topLeftY`、`width`、`height`
  - 可选：`id`、`rotation`、`flipX`、`flipY`、`alpha`
- 定义 `<embed>` 的子元素：一个 SVG 命名空间内容，以及可选的 `reflection`、`shadow`。
- 更新 `xml-schema-quick-ref.md`，补充 `<embed>` 说明和示例。
- 更新 Slides XML lint：放行 `<embed>` 内的 SVG 子树，并将 `<embed>` 纳入页面元素提取、空白页判断和版式密度检查。

## 验证

- Slides XML lint 单元测试通过。
- 覆盖 `<embed>` 内 SVG 标签与属性放行。
- 覆盖仅含 `<embed>` 的页面不被误判为空白页。
- 覆盖 `<embed>` 的元素提取、顺序及几何信息。

## 关联改动

- 服务端协议：[larkslide/ai_xsd MR 62](https://code.byted.org/larkslide/ai_xsd/merge_requests/62)
