### PR TITLE
fix(base): validate workflow message action shapes

### DIFF
--- a/shortcuts/base/workflow_create.go
+++ b/shortcuts/base/workflow_create.go
@@ -38,10 +38,11 @@ var BaseWorkflowCreate = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		if _, err := parseJSONObject(pc, raw, "json"); err != nil {
+		body, err := parseJSONObject(pc, raw, "json")
+		if err != nil {
 			return err
 		}
-		return nil
+		return validateWorkflowMessageActions(body)
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		pc := newParseCtx(runtime)

--- a/shortcuts/base/workflow_message_validation.go
+++ b/shortcuts/base/workflow_message_validation.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"fmt"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func validateWorkflowMessageActions(body map[string]interface{}) error {
+	rawSteps, ok := body["steps"]
+	if !ok || rawSteps == nil {
+		return nil
+	}
+
+	steps, ok := rawSteps.([]interface{})
+	if !ok {
+		// The API owns validation for the workflow definition as a whole.
+		// This preflight only validates recognized message action shapes.
+		return nil
+	}
+
+	for index, rawStep := range steps {
+		step, ok := rawStep.(map[string]interface{})
+		if !ok || step["type"] != "LarkMessageAction" {
+			continue
+		}
+
+		dataPath := fmt.Sprintf("--json.steps[%d].data", index)
+		data, ok := step["data"].(map[string]interface{})
+		if !ok || data == nil {
+			return workflowMessageActionShapeError(
+				dataPath,
+				"a JSON object",
+				fmt.Sprintf("Set %s to a JSON object.", dataPath),
+			)
+		}
+
+		receiverPath := dataPath + ".receiver"
+		if receiver, ok := data["receiver"].([]interface{}); !ok || len(receiver) == 0 {
+			return workflowMessageActionShapeError(
+				receiverPath,
+				"a non-empty JSON array",
+				fmt.Sprintf("Set %s to a non-empty JSON array.", receiverPath),
+			)
+		}
+
+		contentPath := dataPath + ".content"
+		if content, ok := data["content"].([]interface{}); !ok || len(content) == 0 {
+			return workflowMessageActionShapeError(
+				contentPath,
+				"a non-empty JSON array",
+				fmt.Sprintf("Set %s to a non-empty JSON array.", contentPath),
+			)
+		}
+
+		if sendToEveryone, exists := data["send_to_everyone"]; exists {
+			if _, ok := sendToEveryone.(bool); !ok {
+				path := dataPath + ".send_to_everyone"
+				return workflowMessageActionShapeError(
+					path,
+					"a JSON boolean when provided",
+					fmt.Sprintf("Omit %s when unused, or set it to true or false.", path),
+				)
+			}
+		}
+
+		if buttonList, exists := data["btn_list"]; exists {
+			if _, ok := buttonList.([]interface{}); !ok {
+				path := dataPath + ".btn_list"
+				return workflowMessageActionShapeError(
+					path,
+					"a JSON array when provided",
+					fmt.Sprintf("Omit %s when unused, or provide a JSON array; an empty array is valid.", path),
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func workflowMessageActionShapeError(path, expected, hint string) error {
+	return errs.NewValidationError(
+		errs.SubtypeInvalidArgument,
+		"%s for LarkMessageAction must be %s",
+		path,
+		expected,
+	).WithParam("--json").WithHint(hint)
+}

--- a/shortcuts/base/workflow_message_validation_test.go
+++ b/shortcuts/base/workflow_message_validation_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func TestBaseWorkflowMessageActionValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantPath     string
+		wantHint     string
+		unwantedHint string
+	}{
+		{
+			name:     "data must be object",
+			body:     `{"steps":[{"type":"LarkMessageAction","data":[]}]}`,
+			wantPath: "--json.steps[0].data",
+			wantHint: "JSON object",
+		},
+		{
+			name:         "receiver is required",
+			body:         `{"steps":[{"type":"LarkMessageAction","data":{"content":[{}]}}]}`,
+			wantPath:     "--json.steps[0].data.receiver",
+			wantHint:     "non-empty JSON array",
+			unwantedHint: "btn_list",
+		},
+		{
+			name:     "content must not be empty",
+			body:     `{"steps":[{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[]}}]}`,
+			wantPath: "--json.steps[0].data.content",
+			wantHint: "non-empty JSON array",
+		},
+		{
+			name:     "send to everyone must be boolean when present",
+			body:     `{"steps":[{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[{}],"send_to_everyone":"yes"}}]}`,
+			wantPath: "--json.steps[0].data.send_to_everyone",
+			wantHint: "true or false",
+		},
+		{
+			name:     "button list validates later message action",
+			body:     `{"steps":[{"type":"HTTPClientAction","data":null},{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[{}],"btn_list":{}}}]}`,
+			wantPath: "--json.steps[1].data.btn_list",
+			wantHint: "empty array is valid",
+		},
+	}
+
+	for _, tt := range tests {
+		for _, command := range workflowValidationCommands(tt.body) {
+			t.Run(tt.name+"/"+command.name, func(t *testing.T) {
+				err := command.shortcut.Validate(context.Background(), newBaseTestRuntime(command.flags, nil, nil))
+				problem, ok := errs.ProblemOf(err)
+				if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+					t.Fatalf("expected validation/invalid_argument problem, got %T %v", err, err)
+				}
+
+				var validationErr *errs.ValidationError
+				if !errors.As(err, &validationErr) {
+					t.Fatalf("expected ValidationError, got %T %v", err, err)
+				}
+				if validationErr.Param != "--json" {
+					t.Fatalf("param=%q, want --json", validationErr.Param)
+				}
+				if cause := errors.Unwrap(err); cause != nil {
+					t.Fatalf("semantic validation error cause=%v, want nil", cause)
+				}
+				if !strings.Contains(validationErr.Message, tt.wantPath) {
+					t.Fatalf("message=%q, want path %q", validationErr.Message, tt.wantPath)
+				}
+				if !strings.Contains(validationErr.Hint, tt.wantHint) {
+					t.Fatalf("hint=%q, want %q", validationErr.Hint, tt.wantHint)
+				}
+				if tt.unwantedHint != "" && strings.Contains(validationErr.Hint, tt.unwantedHint) {
+					t.Fatalf("hint=%q must not include unrelated %q guidance", validationErr.Hint, tt.unwantedHint)
+				}
+			})
+		}
+	}
+}
+
+func TestBaseWorkflowMessageActionValidationAcceptsGeneralShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "optional fields omitted",
+			body: `{"steps":[{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[{}]}}]}`,
+		},
+		{
+			name: "optional fields present with valid types",
+			body: `{"steps":[{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[{}],"send_to_everyone":false,"btn_list":[]}}]}`,
+		},
+		{
+			name: "unrelated action remains server validated",
+			body: `{"steps":[{"type":"HTTPClientAction","data":null},{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[{}]}}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		for _, command := range workflowValidationCommands(tt.body) {
+			t.Run(tt.name+"/"+command.name, func(t *testing.T) {
+				if err := command.shortcut.Validate(context.Background(), newBaseTestRuntime(command.flags, nil, nil)); err != nil {
+					t.Fatalf("validation rejected a supported shape: %v", err)
+				}
+			})
+		}
+	}
+}
+
+type workflowValidationCommand struct {
+	name     string
+	shortcut common.Shortcut
+	flags    map[string]string
+}
+
+func workflowValidationCommands(body string) []workflowValidationCommand {
+	return []workflowValidationCommand{
+		{
+			name:     "create",
+			shortcut: BaseWorkflowCreate,
+			flags:    map[string]string{"base-token": "app_x", "json": body},
+		},
+		{
+			name:     "update",
+			shortcut: BaseWorkflowUpdate,
+			flags:    map[string]string{"base-token": "app_x", "workflow-id": "wkf_x", "json": body},
+		},
+	}
+}

--- a/shortcuts/base/workflow_update.go
+++ b/shortcuts/base/workflow_update.go
@@ -39,10 +39,11 @@ var BaseWorkflowUpdate = common.Shortcut{
 			return baseFlagErrorf("--workflow-id must not be blank")
 		}
 		pc := newParseCtx(runtime)
-		if _, err := parseJSONObject(pc, runtime.Str("json"), "json"); err != nil {
+		body, err := parseJSONObject(pc, runtime.Str("json"), "json")
+		if err != nil {
 			return err
 		}
-		return nil
+		return validateWorkflowMessageActions(body)
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		pc := newParseCtx(runtime)

--- a/skills/lark-base/references/lark-base-workflow-schema.md
+++ b/skills/lark-base/references/lark-base-workflow-schema.md
@@ -442,11 +442,11 @@
 
 | 字段 | 必填 | 说明 |
 |------|------|------|
-| `receiver` | 是 | ValueInfo[] |
-| `send_to_everyone` | 是 | 是否发送给所有人 |
+| `receiver` | 是 | 非空 ValueInfo[] |
+| `send_to_everyone` | 否 | boolean；是否发送给所有人，可省略 |
 | `title` | 否 | TextRefItem[] 消息标题 |
-| `content` | 是 | TextRefItem[] 消息内容 |
-| `btn_list` | 是 | 按钮列表，不需要时为空数组 |
+| `content` | 是 | 非空 TextRefItem[] 消息内容 |
+| `btn_list` | 否 | ButtonConfig[]；不需要时可省略，空数组也有效 |
 
 `ButtonConfig`：
 

--- a/tests/cli_e2e/base/coverage.md
+++ b/tests/cli_e2e/base/coverage.md
@@ -2,18 +2,19 @@
 
 ## Metrics
 - Denominator: 78 leaf commands
-- Covered: 22
-- Coverage: 28.2%
+- Covered: 24
+- Coverage: 30.8%
 
 ## Summary
 - TestBase_BasicWorkflow: proves `+base-create`, `+base-get`, `+table-create`, `+table-get`, and `+table-list`; key `t.Run(...)` proof points are `get base as bot`, `get table as bot`, and `list tables and find created table as bot`.
 - TestBaseBlockDryRun: proves the five `+base-block-*` shortcuts request shapes without touching live data.
 - TestBaseFieldCreateDryRunArrayCompat: proves `+field-create` dry-run request shape for the internal JSON-array compatibility path.
 - TestBaseRecordBatchUpdatePerRecordDryRun: proves `+record-batch-update` preserves the per-record `update_records` request shape.
+- TestBaseWorkflowMessageActionDryRun: proves `+workflow-create` and `+workflow-update` preserve valid `LarkMessageAction` optional fields and reject invalid optional-field types before dispatch.
 - TestBaseRecordBatchUpdatePerRecordWorkflow: creates two records, updates different field types in one request, asserts the minimal response contract, reads both records back, verifies a missing record ID is not prevalidated, and cleans up the temporary Base.
 - TestBase_RoleWorkflow: proves `+advperm-enable`, `+role-create`, `+role-list`, `+role-get`, and `+role-update`; key `t.Run(...)` proof points are `list as bot`, `get as bot`, and `update as bot`.
 - Cleanup note: `+table-delete` and `+role-delete` only run in cleanup and are intentionally left uncovered.
-- Blocked area: dashboard, field, most record operations, form, view, and workflow operations still lack deterministic create/read/update workflows in this suite.
+- Blocked area: dashboard, field, most record operations, form, view, and live workflow CRUD still lack deterministic create/read/update workflows in this suite.
 
 ## Command Table
 
@@ -94,9 +95,9 @@
 | ✕ | base +view-set-sort | shortcut |  | none | view workflows not covered |
 | ✕ | base +view-set-timebar | shortcut |  | none | view workflows not covered |
 | ✕ | base +view-set-visible-fields | shortcut |  | none | view workflows not covered |
-| ✕ | base +workflow-create | shortcut |  | none | workflow CRUD not covered |
+| ✓ | base +workflow-create | shortcut | workflow_dryrun_test.go::TestBaseWorkflowMessageActionDryRun/create preserves typed optional fields | `--json` with required `receiver`/`content` and typed optional `send_to_everyone`/`btn_list`; dry-run only | request shape and local validation only |
 | ✕ | base +workflow-disable | shortcut |  | none | workflow CRUD not covered |
 | ✕ | base +workflow-enable | shortcut |  | none | workflow CRUD not covered |
 | ✕ | base +workflow-get | shortcut |  | none | workflow CRUD not covered |
 | ✕ | base +workflow-list | shortcut |  | none | workflow CRUD not covered |
-| ✕ | base +workflow-update | shortcut |  | none | workflow CRUD not covered |
+| ✓ | base +workflow-update | shortcut | workflow_dryrun_test.go::TestBaseWorkflowMessageActionDryRun/update keeps optional fields omitted | `--workflow-id`; `--json` with omitted optional message fields; dry-run only | request shape and local validation only |

--- a/tests/cli_e2e/base/workflow_dryrun_test.go
+++ b/tests/cli_e2e/base/workflow_dryrun_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestBaseWorkflowMessageActionDryRun(t *testing.T) {
+	t.Run("create preserves typed optional fields", func(t *testing.T) {
+		result := runBaseDryRun(t, 0,
+			"base", "+workflow-create",
+			"--base-token", "app_x",
+			"--json", `{"title":"Reminder","client_token":"create_1","steps":[{"type":"LarkMessageAction","data":{"receiver":[{"value_type":"user","value":{"id":"ou_x"}}],"content":[{"value_type":"text","value":"Review the request"}],"send_to_everyone":false,"btn_list":[]}}]}`,
+		)
+
+		out := result.Stdout
+		require.Equal(t, "POST", gjson.Get(out, "data.api.0.method").String(), out)
+		require.Equal(t, "/open-apis/base/v3/bases/app_x/workflows", gjson.Get(out, "data.api.0.url").String(), out)
+		require.Equal(t, "ou_x", gjson.Get(out, "data.api.0.body.steps.0.data.receiver.0.value.id").String(), out)
+		require.Equal(t, "Review the request", gjson.Get(out, "data.api.0.body.steps.0.data.content.0.value").String(), out)
+		require.True(t, gjson.Get(out, "data.api.0.body.steps.0.data.send_to_everyone").Exists(), out)
+		require.False(t, gjson.Get(out, "data.api.0.body.steps.0.data.send_to_everyone").Bool(), out)
+		require.True(t, gjson.Get(out, "data.api.0.body.steps.0.data.btn_list").Exists(), out)
+		require.Equal(t, int64(0), gjson.Get(out, "data.api.0.body.steps.0.data.btn_list.#").Int(), out)
+	})
+
+	t.Run("update keeps optional fields omitted", func(t *testing.T) {
+		result := runBaseDryRun(t, 0,
+			"base", "+workflow-update",
+			"--base-token", "app_x",
+			"--workflow-id", "wkf_x",
+			"--json", `{"title":"Reminder","steps":[{"type":"LarkMessageAction","data":{"receiver":[{"value_type":"user","value":{"id":"ou_x"}}],"content":[{"value_type":"text","value":"Review the request"}]}}]}`,
+		)
+
+		out := result.Stdout
+		require.Equal(t, "PUT", gjson.Get(out, "data.api.0.method").String(), out)
+		require.Equal(t, "/open-apis/base/v3/bases/app_x/workflows/wkf_x", gjson.Get(out, "data.api.0.url").String(), out)
+		require.False(t, gjson.Get(out, "data.api.0.body.steps.0.data.send_to_everyone").Exists(), out)
+		require.False(t, gjson.Get(out, "data.api.0.body.steps.0.data.btn_list").Exists(), out)
+	})
+}
+
+func TestBaseWorkflowMessageActionDryRunRejectsInvalidOptionalTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantPath string
+		wantHint string
+	}{
+		{
+			name: "create send_to_everyone",
+			args: []string{
+				"base", "+workflow-create",
+				"--base-token", "app_x",
+				"--json", `{"title":"Reminder","client_token":"create_1","steps":[{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[{}],"send_to_everyone":"yes"}}]}`,
+			},
+			wantPath: "--json.steps[0].data.send_to_everyone",
+			wantHint: "true or false",
+		},
+		{
+			name: "update btn_list",
+			args: []string{
+				"base", "+workflow-update",
+				"--base-token", "app_x",
+				"--workflow-id", "wkf_x",
+				"--json", `{"title":"Reminder","steps":[{"type":"LarkMessageAction","data":{"receiver":[{}],"content":[{}],"btn_list":{}}}]}`,
+			},
+			wantPath: "--json.steps[0].data.btn_list",
+			wantHint: "empty array is valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runBaseDryRun(t, 2, tt.args...)
+			require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+			require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+			require.Equal(t, "--json", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+			require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), tt.wantPath)
+			require.Contains(t, gjson.Get(result.Stderr, "error.hint").String(), tt.wantHint)
+			require.Empty(t, result.Stdout)
+		})
+	}
+}

--- a/tests/cli_e2e/base/workflow_skill_contract_test.go
+++ b/tests/cli_e2e/base/workflow_skill_contract_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowSchemaMessageActionContractIsDelivered(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"skills", "read", "lark-base", "references/lark-base-workflow-schema.md"},
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	for name, pattern := range map[string]string{
+		"receiver required and non-empty":   `(?m)^\|\s*` + "`receiver`" + `\s*\|\s*是\s*\|\s*非空 ValueInfo\[\]`,
+		"content required and non-empty":    `(?m)^\|\s*` + "`content`" + `\s*\|\s*是\s*\|\s*非空 TextRefItem\[\]`,
+		"send_to_everyone optional boolean": `(?m)^\|\s*` + "`send_to_everyone`" + `\s*\|\s*否\s*\|\s*boolean`,
+		"btn_list optional array":           `(?m)^\|\s*` + "`btn_list`" + `\s*\|\s*否\s*\|\s*ButtonConfig\[\]`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Regexp(t, regexp.MustCompile(pattern), result.Stdout)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add shared preflight validation for the known `LarkMessageAction` request shape used by workflow create and update. This is a focused replacement for #2078: it keeps reusable schema validation while excluding case-specific unsupported-trigger guidance and duplicated field advice in command help.

## Changes

- Validate `LarkMessageAction.data` as an object with non-empty `receiver` and `content` arrays for both create and update.
- Keep `send_to_everyone` and `btn_list` optional, but validate their boolean/array types when supplied.
- Return field-specific typed validation errors that identify `--json` and the failing indexed path.
- Make the workflow schema the single source of truth for these field contracts.
- Add table-driven unit coverage, real-binary dry-run coverage, and an embedded-skill delivery check.

## Test Plan

- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `go mod tidy` (no changes)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=upstream/main`
- [x] `make build`
- [x] Targeted create/update dry-run E2E with the branch-built binary
- [x] `skills read` E2E confirms the updated embedded workflow schema is delivered

Live workflow E2E was not run; this change is fully covered at the local preflight and dry-run boundaries and does not call the service.

## Related Issues

- Supersedes the reusable workflow-validation portion of #2078 without modifying that PR.

```ai-signature
改动范围: Base workflow create/update 预检、LarkMessageAction schema、单测、dry-run E2E 与嵌入 skill 交付测试
思考过程: 新 PR 基于最新 upstream/main，仅保留可复用的消息动作契约；排除原 PR 的单 case unsupported-trigger 文案和 help 重复事实
改动原因: 修复无效消息动作直到服务端才报错的问题，并用通用结构约束替换面向单个评测样例的过拟合改动
Break Change: 行为 breaking | 无效 LarkMessageAction 在本地预检阶段失败
```

Co-authored-by: BASE Infra Harness <ai@base-infra-harness.noreply.local>
AI-SHA256: 5367e32fc010a944e95b4109e107077d0b05e0216c2de20004a29c5a22b56bd3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for workflow message actions in workflow create and update commands.
  - Validates required receiver and content arrays, plus optional field types.
  - Supports omitting optional `send_to_everyone` and `btn_list` fields.

- **Bug Fixes**
  - Invalid, well-formed workflow JSON is now rejected with actionable validation errors.

- **Documentation**
  - Updated workflow schema documentation to reflect optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->