### PR TITLE
feat: add runtime delegate protocol

### DIFF
--- a/internal/runtimedelegate/delegate.go
+++ b/internal/runtimedelegate/delegate.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package runtimedelegate implements the provider-neutral, environment-driven
+// runtime delegation handshake used before normal command bootstrap.
+package runtimedelegate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+const (
+	ProtocolVersion     = 1
+	DescriptorEnv       = "LARK_CLI_RUNTIME_DELEGATE"
+	ProtocolEnv         = "LARK_CLI_RUNTIME_PROTOCOL"
+	BoundEnv            = "LARK_CLI_RUNTIME_BOUND"
+	NativeExecutableEnv = "LARK_CLI_RUNTIME_NATIVE_EXECUTABLE"
+	NativeVersionEnv    = "LARK_CLI_RUNTIME_NATIVE_VERSION"
+	CapabilityCommand   = "__runtime-delegate-capabilities"
+)
+
+type descriptor struct {
+	ProtocolVersion int      `json:"protocolVersion"`
+	BindingID       string   `json:"bindingId"`
+	Delegate        string   `json:"delegate"`
+	DelegateArgs    []string `json:"delegateArgs,omitempty"`
+	Context         any      `json:"context,omitempty"`
+}
+
+type capability struct {
+	Name                    string `json:"name"`
+	Version                 string `json:"version"`
+	RuntimeDelegateProtocol int    `json:"runtimeDelegateProtocol"`
+}
+
+// IsCapabilityRequest recognizes the side-effect-free setup handshake.
+func IsCapabilityRequest(args []string) bool {
+	return len(args) == 1 && args[0] == CapabilityCommand
+}
+
+// Capabilities returns a stable machine-readable capability document.
+func Capabilities(version string) string {
+	data, _ := json.Marshal(capability{Name: "lark-cli", Version: version, RuntimeDelegateProtocol: ProtocolVersion})
+	return string(data)
+}
+
+// Dispatch delegates an opted-in invocation. handled is false only when the
+// descriptor environment variable is absent. All malformed or unsafe binding
+// state fails closed instead of falling through to normal command dispatch.
+func Dispatch(argv []string, version string) (code int, handled bool, err error) {
+	descriptorPath := strings.TrimSpace(os.Getenv(DescriptorEnv))
+	if descriptorPath == "" {
+		return 0, false, nil
+	}
+	if len(argv) == 0 {
+		return 1, true, errors.New("missing argv[0]")
+	}
+	d, err := loadDescriptor(descriptorPath)
+	if err != nil {
+		return 1, true, err
+	}
+	protocol := fmt.Sprint(ProtocolVersion)
+	if os.Getenv(ProtocolEnv) != protocol {
+		return 1, true, fmt.Errorf("environment protocol must be %s", protocol)
+	}
+	if os.Getenv(BoundEnv) == d.BindingID {
+		return 0, false, nil
+	}
+	if os.Getenv(BoundEnv) != "" {
+		return 1, true, errors.New("binding marker does not match descriptor")
+	}
+
+	args := append(append([]string{}, d.DelegateArgs...), argv[1:]...)
+	cwd, err := vfs.Getwd()
+	if err != nil {
+		return 1, true, fmt.Errorf("resolve working directory: %w", err)
+	}
+	native, err := os.Executable()
+	if err != nil {
+		return 1, true, fmt.Errorf("resolve native executable: %w", err)
+	}
+	native, err = filepath.EvalSymlinks(native)
+	if err != nil {
+		return 1, true, fmt.Errorf("canonicalize native executable: %w", err)
+	}
+	env := overriddenEnv(os.Environ(), map[string]string{NativeExecutableEnv: native, NativeVersionEnv: version})
+	code, err = executeDelegate(d.Delegate, args, env, cwd)
+	if err != nil {
+		return 1, true, fmt.Errorf("execute delegate: %w", err)
+	}
+	return code, true, nil
+}
+
+func overriddenEnv(base []string, values map[string]string) []string {
+	result := make([]string, 0, len(base)+len(values))
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, replaced := values[key]; !replaced {
+			result = append(result, entry)
+		}
+	}
+	for key, value := range values {
+		result = append(result, key+"="+value)
+	}
+	return result
+}
+
+func loadDescriptor(file string) (descriptor, error) {
+	var result descriptor
+	if !filepath.IsAbs(file) || filepath.Clean(file) != file {
+		return result, errors.New("descriptor path must be clean and absolute")
+	}
+	if err := validatePrivateDirectory(filepath.Dir(file)); err != nil {
+		return result, err
+	}
+	if err := validatePrivateRegularFile(file, "descriptor"); err != nil {
+		return result, err
+	}
+	raw, err := vfs.ReadFile(file)
+	if err != nil {
+		return result, fmt.Errorf("read descriptor: %w", err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&result); err != nil {
+		return result, fmt.Errorf("decode descriptor: %w", err)
+	}
+	if result.ProtocolVersion != ProtocolVersion {
+		return result, fmt.Errorf("descriptor protocol must be %d", ProtocolVersion)
+	}
+	if strings.TrimSpace(result.BindingID) == "" {
+		return result, errors.New("descriptor bindingId is required")
+	}
+	if !filepath.IsAbs(result.Delegate) || filepath.Clean(result.Delegate) != result.Delegate {
+		return result, errors.New("delegate path must be clean and absolute")
+	}
+	if err := validateExecutable(result.Delegate); err != nil {
+		return result, err
+	}
+	for _, arg := range result.DelegateArgs {
+		if strings.IndexByte(arg, 0) >= 0 {
+			return result, errors.New("delegate argument contains NUL")
+		}
+	}
+	return result, nil
+}
+
+func validatePrivateRegularFile(file, label string) error {
+	info, err := vfs.Lstat(file)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", label, err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s must be a regular non-symlink file", label)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%s must not be accessible by group or others", label)
+	}
+	if !ownedByCurrentUser(file, info) {
+		return fmt.Errorf("%s must be owned by the current user", label)
+	}
+	return nil
+}
+
+func validatePrivateDirectory(directory string) error {
+	info, err := vfs.Lstat(directory)
+	if err != nil {
+		return fmt.Errorf("stat descriptor directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 || !ownedByCurrentUser(directory, info) {
+		return errors.New("descriptor directory must be private, owned, and non-symlink")
+	}
+	return nil
+}
+
+func validateExecutable(file string) error {
+	info, err := vfs.Lstat(file)
+	if err != nil {
+		return fmt.Errorf("stat delegate: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("delegate must be a regular non-symlink file")
+	}
+	if !ownedByCurrentUser(file, info) {
+		return errors.New("delegate must be owned by the current user")
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return errors.New("delegate must not be writable by group or others")
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		return errors.New("delegate is not executable")
+	}
+	return nil
+}

--- a/internal/runtimedelegate/delegate_test.go
+++ b/internal/runtimedelegate/delegate_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package runtimedelegate
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCapabilities(t *testing.T) {
+	var got map[string]any
+	if err := json.Unmarshal([]byte(Capabilities("1.2.3")), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["name"] != "lark-cli" || got["version"] != "1.2.3" || got["runtimeDelegateProtocol"] != float64(1) {
+		t.Fatalf("unexpected capabilities: %#v", got)
+	}
+}
+
+func TestDispatchAbsentBindingFallsThrough(t *testing.T) {
+	t.Setenv(DescriptorEnv, "")
+	if code, handled, err := Dispatch([]string{"lark-cli", "version"}, "test"); code != 0 || handled || err != nil {
+		t.Fatalf("Dispatch = (%d, %v, %v)", code, handled, err)
+	}
+}
+
+func TestDispatchFailsClosedForInvalidDescriptor(t *testing.T) {
+	t.Setenv(DescriptorEnv, "relative.json")
+	if code, handled, err := Dispatch([]string{"lark-cli"}, "test"); code != 1 || !handled || err == nil {
+		t.Fatalf("Dispatch = (%d, %v, %v)", code, handled, err)
+	}
+}
+
+func TestDispatchPreservesArgsCwdAndExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture")
+	}
+	if os.Getenv("GO_WANT_RUNTIME_DELEGATE_HELPER") == "1" {
+		code, handled, err := Dispatch([]string{"lark-cli", "one", "two words"}, "test-version")
+		if err != nil || !handled {
+			t.Fatalf("Dispatch = (%d, %v, %v)", code, handled, err)
+		}
+		os.Exit(code)
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	delegate := filepath.Join(dir, "delegate")
+	output := filepath.Join(dir, "out")
+	script := "#!/bin/sh\nread line\nprintf '%s\\n' \"$PWD\" \"$@\" \"$line\" \"$LARK_CLI_RUNTIME_NATIVE_VERSION\" > \"$OUT\"\nprintf stdout-marker\nprintf stderr-marker >&2\nexit 23\n"
+	if err := os.WriteFile(delegate, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	descriptorFile := filepath.Join(dir, "descriptor.json")
+	raw, _ := json.Marshal(descriptor{ProtocolVersion: 1, BindingID: "binding-1", Delegate: delegate, DelegateArgs: []string{"prefix"}})
+	if err := os.WriteFile(descriptorFile, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	working := filepath.Join(dir, "working")
+	if err := os.Mkdir(working, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	working, err := filepath.EvalSymlinks(working)
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(os.Args[0], "-test.run=TestDispatchPreservesArgsCwdAndExit")
+	command.Dir = working
+	command.Env = append(os.Environ(), DescriptorEnv+"="+descriptorFile, ProtocolEnv+"=1", BoundEnv+"=", "OUT="+output, "GO_WANT_RUNTIME_DELEGATE_HELPER=1")
+	command.Stdin = strings.NewReader("stdin-marker\n")
+	var stdout, stderr strings.Builder
+	command.Stdout, command.Stderr = &stdout, &stderr
+	err = command.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 23 {
+		t.Fatalf("run = %v", err)
+	}
+	if stdout.String() != "stdout-marker" || stderr.String() != "stderr-marker" {
+		t.Fatalf("stdio = %q / %q", stdout.String(), stderr.String())
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != working+"\nprefix\none\ntwo words\nstdin-marker\ntest-version\n" {
+		t.Fatalf("output = %q", got)
+	}
+}
+
+func TestMatchingBoundMarkerFallsThroughAndMismatchFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	delegate := filepath.Join(dir, "delegate")
+	if err := os.WriteFile(delegate, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	descriptorFile := filepath.Join(dir, "descriptor.json")
+	raw, _ := json.Marshal(descriptor{ProtocolVersion: 1, BindingID: "binding-1", Delegate: delegate})
+	if err := os.WriteFile(descriptorFile, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(DescriptorEnv, descriptorFile)
+	t.Setenv(ProtocolEnv, "1")
+	t.Setenv(BoundEnv, "binding-1")
+	if code, handled, err := Dispatch([]string{"lark-cli"}, "test"); code != 0 || handled || err != nil {
+		t.Fatalf("matching = (%d,%v,%v)", code, handled, err)
+	}
+	t.Setenv(BoundEnv, "another")
+	if code, handled, err := Dispatch([]string{"lark-cli"}, "test"); code != 1 || !handled || err == nil {
+		t.Fatalf("mismatch = (%d,%v,%v)", code, handled, err)
+	}
+}
+
+func TestDispatchRejectsGroupWritableDelegate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX mode semantics")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	delegate := filepath.Join(dir, "delegate")
+	if err := os.WriteFile(delegate, []byte("#!/bin/sh\nexit 0\n"), 0o720); err != nil {
+		t.Fatal(err)
+	}
+	descriptorFile := filepath.Join(dir, "descriptor.json")
+	raw, _ := json.Marshal(descriptor{ProtocolVersion: 1, BindingID: "binding-1", Delegate: delegate})
+	if err := os.WriteFile(descriptorFile, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(DescriptorEnv, descriptorFile)
+	t.Setenv(ProtocolEnv, "1")
+	if code, handled, err := Dispatch([]string{"lark-cli"}, "test"); code != 1 || !handled || err == nil {
+		t.Fatalf("Dispatch = (%d,%v,%v)", code, handled, err)
+	}
+}

--- a/internal/runtimedelegate/execute_unix.go
+++ b/internal/runtimedelegate/execute_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package runtimedelegate
+
+import "syscall"
+
+func executeDelegate(file string, args, env []string, _ string) (int, error) {
+	return 0, syscall.Exec(file, append([]string{file}, args...), env)
+}

--- a/internal/runtimedelegate/execute_windows.go
+++ b/internal/runtimedelegate/execute_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package runtimedelegate
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// Windows has no execve equivalent. Running one attached child with inherited
+// standard handles and returning its exact exit code is the closest portable
+// process behavior available to the CLI entry point.
+func executeDelegate(file string, args, env []string, cwd string) (int, error) {
+	child := exec.Command(file, args...)
+	child.Stdin, child.Stdout, child.Stderr = os.Stdin, os.Stdout, os.Stderr
+	child.Env, child.Dir = env, cwd
+	if err := child.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, err
+	}
+	return 0, nil
+}

--- a/internal/runtimedelegate/execute_windows_test.go
+++ b/internal/runtimedelegate/execute_windows_test.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package runtimedelegate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsExecuteDelegateReturnsChildExitAndPreservesCwd(t *testing.T) {
+	if os.Getenv("GO_WANT_WINDOWS_EXECUTE_HELPER") == "1" {
+		if err := os.WriteFile(os.Getenv("WINDOWS_EXECUTE_MARKER"), []byte(mustGetwd(t)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		os.Exit(17)
+	}
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+	env := append(os.Environ(), "GO_WANT_WINDOWS_EXECUTE_HELPER=1", "WINDOWS_EXECUTE_MARKER="+marker)
+	code, err := executeDelegate(os.Args[0], []string{"-test.run=TestWindowsExecuteDelegateReturnsChildExitAndPreservesCwd"}, env, dir)
+	if err != nil || code != 17 {
+		t.Fatalf("executeDelegate = (%d,%v)", code, err)
+	}
+	bytes, err := os.ReadFile(marker)
+	if err != nil || string(bytes) != dir {
+		t.Fatalf("marker = %q, %v", bytes, err)
+	}
+}
+
+func mustGetwd(t *testing.T) string {
+	t.Helper()
+	value, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}

--- a/internal/runtimedelegate/owner_unix.go
+++ b/internal/runtimedelegate/owner_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package runtimedelegate
+
+import (
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+func ownedByCurrentUser(_ string, info fs.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == uint32(os.Getuid())
+}

--- a/internal/runtimedelegate/owner_windows.go
+++ b/internal/runtimedelegate/owner_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package runtimedelegate
+
+import (
+	"io/fs"
+
+	"golang.org/x/sys/windows"
+)
+
+func ownedByCurrentUser(file string, _ fs.FileInfo) bool {
+	descriptor, err := windows.GetNamedSecurityInfo(file, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return false
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil || owner == nil {
+		return false
+	}
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	return err == nil && user != nil && user.User.Sid != nil && owner.Equals(user.User.Sid)
+}

--- a/main.go
+++ b/main.go
@@ -5,13 +5,26 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/larksuite/cli/cmd"
+	"github.com/larksuite/cli/internal/build"
+	"github.com/larksuite/cli/internal/runtimedelegate"
 
 	_ "github.com/larksuite/cli/extension/credential/env" // activate env credential provider
 )
 
 func main() {
+	if runtimedelegate.IsCapabilityRequest(os.Args[1:]) {
+		fmt.Fprintln(os.Stdout, runtimedelegate.Capabilities(build.Version))
+		return
+	}
+	if code, handled, err := runtimedelegate.Dispatch(os.Args, build.Version); handled {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error: runtime delegate:", err)
+		}
+		os.Exit(code)
+	}
 	os.Exit(cmd.Execute())
 }

--- a/runtime_delegate_e2e_test.go
+++ b/runtime_delegate_e2e_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestMainProcessRuntimeDelegateE2E(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(root, "lark-cli")
+	build := exec.Command("go", "build", "-o", binary, ".")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, output)
+	}
+	binary, err := filepath.EvalSymlinks(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("bootstrap stdio cwd argv and ordinary exit", func(t *testing.T) {
+		working := filepath.Join(root, "working")
+		if err := os.Mkdir(working, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		working, err = filepath.EvalSymlinks(working)
+		if err != nil {
+			t.Fatal(err)
+		}
+		delegate := filepath.Join(root, "delegate")
+		script := `#!/bin/sh
+read line
+printf 'out:%s:%s:%s:%s\n' "$PWD" "$1" "$line" "$LARK_CLI_RUNTIME_NATIVE_VERSION"
+printf 'err-marker\n' >&2
+test "$LARK_CLI_RUNTIME_NATIVE_EXECUTABLE" = "$EXPECTED_NATIVE" || exit 91
+exit 29
+`
+		if err := os.WriteFile(delegate, []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		descriptor := filepath.Join(root, "descriptor.json")
+		writeDescriptor(t, descriptor, delegate)
+		command := exec.Command(binary, "definitely-not-a-cobra-command", "two words")
+		command.Dir = working
+		command.Env = append(os.Environ(), "LARK_CLI_RUNTIME_DELEGATE="+descriptor, "LARK_CLI_RUNTIME_PROTOCOL=1", "EXPECTED_NATIVE="+binary)
+		command.Stdin = bytes.NewBufferString("stdin-marker\n")
+		var stdout, stderr bytes.Buffer
+		command.Stdout, command.Stderr = &stdout, &stderr
+		err := command.Run()
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 29 {
+			t.Fatalf("exit = %v", err)
+		}
+		if stdout.String() != "out:"+working+":definitely-not-a-cobra-command:stdin-marker:DEV\n" {
+			t.Fatalf("stdout = %q", stdout.String())
+		}
+		if stderr.String() != "err-marker\n" {
+			t.Fatalf("stderr = %q", stderr.String())
+		}
+	})
+
+	t.Run("signal terminates the replaced process", func(t *testing.T) {
+		delegate := filepath.Join(root, "signal-delegate")
+		marker := filepath.Join(root, "started")
+		if err := os.WriteFile(delegate, []byte("#!/bin/sh\nprintf started > \"$STARTED\"\nexec sleep 30\n"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		descriptor := filepath.Join(root, "signal-descriptor.json")
+		writeDescriptor(t, descriptor, delegate)
+		command := exec.Command(binary, "ignored")
+		command.Env = append(os.Environ(), "LARK_CLI_RUNTIME_DELEGATE="+descriptor, "LARK_CLI_RUNTIME_PROTOCOL=1", "STARTED="+marker)
+		if err := command.Start(); err != nil {
+			t.Fatal(err)
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := os.Stat(marker); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				_ = command.Process.Kill()
+				t.Fatal("delegate startup marker timed out")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if err := command.Process.Signal(syscall.SIGTERM); err != nil {
+			t.Fatal(err)
+		}
+		err := command.Wait()
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("wait = %v", err)
+		}
+		status, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok || status.Signal() != syscall.SIGTERM {
+			t.Fatalf("status = %#v", exitErr.Sys())
+		}
+	})
+}
+
+func writeDescriptor(t *testing.T, file, delegate string) {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"protocolVersion": 1, "bindingId": "e2e-binding", "delegate": delegate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
Add a provider-neutral, environment-driven runtime delegation handshake before normal command bootstrap. This lets a host bind a global `lark-cli` invocation to a runtime-owned policy wrapper without relying on PATH shims.

## Changes
- add a machine-readable protocol-v1 capability probe and strict private descriptor validation
- delegate with Unix process replacement while preserving argv, cwd, stdio, signals, and exit behavior; provide the closest attached-child behavior on Windows
- pass the canonical native executable/version to the delegate and fail closed for malformed, mismatched, or unsafe bindings

## Test Plan
- [x] `go test ./internal/runtimedelegate ./cmd .`
- [x] `go vet ./internal/runtimedelegate`
- [x] Windows amd64 package cross-build
- [x] main-process E2E covers pre-bootstrap dispatch, argv/cwd/stdio, exit code, and SIGTERM

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime delegation support through a configurable external delegate.
  - Added capability discovery for compatible runtime features and version information.
  - Preserves command arguments, working directory, environment, input/output streams, and exit status during delegation.
  - Supports secure descriptor and delegate validation across Unix and Windows platforms.

- **Tests**
  - Added comprehensive coverage for capability reporting, delegation behavior, security checks, platform-specific execution, and end-to-end process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->