### PR TITLE
feat: propagate invocation metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
+/go.mod @liangshuo-1
+/go.sum @liangshuo-1
 /internal/ @liangshuo-1
+/shortcuts/common/ @liangshuo-1
 
 # Last match wins: existing domains below are exempt, only new skills/ entries need review.
 /skills/ @liangshuo-1

--- a/internal/cmdutil/secheader.go
+++ b/internal/cmdutil/secheader.go
@@ -26,6 +26,7 @@ const (
 	HeaderShortcut    = "X-Cli-Shortcut"
 	HeaderExecutionId = "X-Cli-Execution-Id"
 	HeaderAgentTrace  = "X-Agent-Trace"
+	HeaderAgentName   = "X-Agent-Name"
 
 	SourceValue = "lark-cli"
 
@@ -54,6 +55,9 @@ func BaseSecurityHeaders() http.Header {
 	h.Set(HeaderUserAgent, UserAgentValue())
 	if v := envvars.AgentTrace(); v != "" {
 		h.Set(HeaderAgentTrace, v)
+	}
+	if v := envvars.AgentName(); v != "" {
+		h.Set(HeaderAgentName, v)
 	}
 	return h
 }

--- a/internal/cmdutil/secheader_test.go
+++ b/internal/cmdutil/secheader_test.go
@@ -263,8 +263,33 @@ func TestBaseSecurityHeaders_AllRequiredHeaders(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// HeaderAgentTrace injection (via BaseSecurityHeaders)
+// Agent headers injected via BaseSecurityHeaders
 // ---------------------------------------------------------------------------
+
+func TestBaseSecurityHeaders_NoAgentNameHeaderWhenEnvUnset(t *testing.T) {
+	t.Setenv(envvars.CliAgentName, "")
+	h := BaseSecurityHeaders()
+	if v := h.Get(HeaderAgentName); v != "" {
+		t.Fatalf("BaseSecurityHeaders() included %s = %q, want absent when env unset", HeaderAgentName, v)
+	}
+}
+
+func TestBaseSecurityHeaders_IncludesAgentNameHeaderWhenEnvSet(t *testing.T) {
+	const agentName = "sample-agent"
+	t.Setenv(envvars.CliAgentName, agentName)
+	h := BaseSecurityHeaders()
+	if v := h.Get(HeaderAgentName); v != agentName {
+		t.Fatalf("BaseSecurityHeaders()[%s] = %q, want %q", HeaderAgentName, v, agentName)
+	}
+}
+
+func TestBaseSecurityHeaders_NoAgentNameHeaderWhenEnvInvalid(t *testing.T) {
+	t.Setenv(envvars.CliAgentName, "agent\r\nX-Evil: attack")
+	h := BaseSecurityHeaders()
+	if v := h.Get(HeaderAgentName); v != "" {
+		t.Fatalf("BaseSecurityHeaders() included %s = %q, want absent for invalid input", HeaderAgentName, v)
+	}
+}
 
 func TestBaseSecurityHeaders_NoAgentTraceHeaderWhenEnvUnset(t *testing.T) {
 	t.Setenv(envvars.CliAgentTrace, "")

--- a/internal/envvars/read_test.go
+++ b/internal/envvars/read_test.go
@@ -16,16 +16,18 @@ func TestAgentName_EmptyWhenEnvUnset(t *testing.T) {
 }
 
 func TestAgentName_ReturnsCleanValue(t *testing.T) {
-	t.Setenv(CliAgentName, "claude-code")
-	if got := AgentName(); got != "claude-code" {
-		t.Fatalf("AgentName() = %q, want %q", got, "claude-code")
+	const agentName = "sample-agent"
+	t.Setenv(CliAgentName, agentName)
+	if got := AgentName(); got != agentName {
+		t.Fatalf("AgentName() = %q, want %q", got, agentName)
 	}
 }
 
 func TestAgentName_TrimsWhitespace(t *testing.T) {
-	t.Setenv(CliAgentName, "  cursor  ")
-	if got := AgentName(); got != "cursor" {
-		t.Fatalf("AgentName() = %q, want %q (whitespace trimmed)", got, "cursor")
+	const agentName = "sample-agent"
+	t.Setenv(CliAgentName, "  "+agentName+"  ")
+	if got := AgentName(); got != agentName {
+		t.Fatalf("AgentName() = %q, want %q (whitespace trimmed)", got, agentName)
 	}
 }
 


### PR DESCRIPTION
## Summary
Extend shared request metadata propagation for agent-driven CLI invocations while preserving existing behavior when the metadata is unavailable or invalid.

## Changes
- Reuse the existing validated invocation metadata reader in the shared request metadata assembly path.
- Add regression coverage for configured, absent, and invalid metadata using vendor-neutral fixtures.
- Require `@liangshuo-1` review for `go.mod`, `go.sum`, and shared shortcut infrastructure under `shortcuts/common/`.

## Test Plan
- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .` produces no output
- [x] `go mod tidy` produces no changes
- [x] `golangci-lint v2.1.6 run --new-from-rev=origin/main`

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Security responses now include the configured agent name via an `X-Agent-Name` header when available.
- **Bug Fixes**
  - Prevents `X-Agent-Name` from being sent when the agent name is missing or contains invalid line-break characters, preserving existing security header behavior.
- **Chores**
  - Expanded ownership rules to cover additional key files and directories for better change management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->