### PR TITLE
fix: drop stale target version from root upgrade prompt

### DIFF
--- a/cmd/root_upgrade.go
+++ b/cmd/root_upgrade.go
@@ -65,7 +65,17 @@ func offerRootUpgrade(f *cmdutil.Factory, cmd *cobra.Command) {
 	if info == nil {
 		return
 	}
-	fmt.Fprintf(ios.ErrOut, "lark-cli %s available (current %s). Upgrade now? [y/N]: ", info.Latest, info.Current)
+	// Deliberately no target version here: info.Latest comes from the on-disk
+	// cache, which has no expiry (the 24h TTL only throttles refreshes, and a
+	// failed refresh leaves the old value in place), so it can name a version
+	// that is no longer the one npm would install. The version actually
+	// installed is resolved live by the update subcommand, which prints
+	// "Updating lark-cli <cur> -> <latest> via <pm> ..." before installing —
+	// that is where the user sees the real target. Keep going through the
+	// update subcommand rather than calling RunNpmInstall directly, otherwise
+	// that line disappears and the user approves a global install without ever
+	// being told what gets installed.
+	fmt.Fprintf(ios.ErrOut, "A newer lark-cli is available (current %s). Upgrade now? [y/N]: ", info.Current)
 	if !readYes(ios.In) {
 		return
 	}

--- a/cmd/root_upgrade_test.go
+++ b/cmd/root_upgrade_test.go
@@ -128,6 +128,17 @@ func TestOfferRootUpgrade(t *testing.T) {
 			if gotPrompt != tc.wantPrompt {
 				t.Errorf("prompt: got %v want %v (stderr=%q)", gotPrompt, tc.wantPrompt, errBuf.String())
 			}
+			// The prompt must not name a target version: info.Latest comes from
+			// the on-disk cache and can be stale, while the version actually
+			// installed is resolved live by the update subcommand.
+			if tc.wantPrompt {
+				if strings.Contains(errBuf.String(), tc.latest) {
+					t.Errorf("prompt must not name the cached target version %q (stderr=%q)", tc.latest, errBuf.String())
+				}
+				if !strings.Contains(errBuf.String(), build.Version) {
+					t.Errorf("prompt must name the current version %q (stderr=%q)", build.Version, errBuf.String())
+				}
+			}
 			if called != tc.wantRun {
 				t.Errorf("runRootUpgrade called: got %v want %v", called, tc.wantRun)
 			}


### PR DESCRIPTION
## Summary

The interactive upgrade prompt for bare `lark-cli` named a target version that
could differ from the version actually installed. The prompt's version came from
the on-disk cache read by `update.CheckCached`, which has no expiry — the 24h
`cacheTTL` only throttles `RefreshCache`, and a failed refresh leaves the old
value in place, so on an offline or registry-unreachable machine the cached
`latest_version` can persist indefinitely. The version actually installed is
resolved live: pressing `y` runs the `update` subcommand, which re-queries the
npm registry and pins that version. Any release published between the cache write
and the keypress made the prompt wrong.

The prompt now names only the current version, so everything it states is locally
verifiable. The `update` subcommand still prints
`Updating lark-cli <cur> -> <latest> via <pm> ...` before installing, so the user
still sees the real target version before anything is written.

## Changes

- `cmd/root_upgrade.go`: drop `info.Latest` from the prompt; the text is now
  `A newer lark-cli is available (current <version>). Upgrade now? [y/N]: `.
  Added a comment recording why no target version is named, and that the upgrade
  must keep going through the `update` subcommand — calling `RunNpmInstall`
  directly would remove the only place the real target version is shown.
- `cmd/root_upgrade_test.go`: strengthen `TestOfferRootUpgrade`. The existing
  `Contains(stderr, "available")` assertion holds for both the old and the new
  text, so it could not detect this change or a regression. On prompting cases the
  test now asserts stderr does not contain the cached target version and does
  contain the current version.

Not touched: the JSON `_notice` channel (`update.Message()`), `cacheTTL`,
`CheckCached` / `RefreshCache`, and everything under `cmd/update/`.

## Test Plan

- `go test ./cmd/ -run TestOfferRootUpgrade -v` — 12/12 subtests pass. Verified
  red-green: with the new assertions but the old text, the 5 prompting subtests
  fail with `prompt must not name the cached target version "2.0.0"`.
- `go test ./cmd/ -run 'TestReadYes|TestIsBareRootInvocation|TestInstallRootUpgradePrompt|TestRunRootUpgradeDispatchesToUpdate'` — pass.
- `go build ./...`, `go vet`, unit and integration tests — pass.
- `golangci-lint run --new-from-rev=origin/main` — 0 issues.
- Manual, under a real TTY (a separate pty per stream, built with a clean release
  version so `isRelease()` does not suppress the prompt): stderr is exactly
  `A newer lark-cli is available (current 1.0.79). Upgrade now? [y/N]: ` — 68
  bytes, no trailing newline, no target version. All four gates behave as before:
  silent when any stream is not a TTY, silent under
  `LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1`, silent under `CI=true`, no prompt when a
  flag token is present, and Enter is treated as No.

## Related Issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the root upgrade prompt to display the currently installed version without showing a potentially outdated target version.
  * Preserved the existing confirmation and upgrade flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->