### PR TITLE
chore: release v1.0.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.80] - 2026-07-29
+
+### Features
+
+- **drive**: add +member-list shortcut (#1795)
+- **drive**: add +permission-get-setting shortcut (#1738)
+- propagate invocation metadata (#2097)
+
+### Documentation
+
+- **slides**: 补齐 shortcut 参数说明，修正 +xml-get --output 必填标注 (#2088)
+- **slides**: +create 的参数下沉到 create.md，主 skill 只留路由 (#2096)
+
+### Tests
+
+- **e2e**: wait for base role update visibility (#2087)
+
+### Misc
+
+- Feat/detect line text overlap (#2069)
+
 ## [v1.0.79] - 2026-07-28
 
 ### Features
@@ -1701,6 +1722,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.80]: https://github.com/larksuite/cli/releases/tag/v1.0.80
 [v1.0.79]: https://github.com/larksuite/cli/releases/tag/v1.0.79
 [v1.0.78]: https://github.com/larksuite/cli/releases/tag/v1.0.78
 [v1.0.77]: https://github.com/larksuite/cli/releases/tag/v1.0.77

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.79",
+  "version": "1.0.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larksuite/cli",
-      "version": "1.0.79",
+      "version": "1.0.80",
       "cpu": [
         "x64",
         "arm64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.79",
+  "version": "1.0.80",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.79` |
| Release version | `1.0.80` |
| Tag | `v1.0.80` |
| Branch | `release/v1.0.80` |
| Date | `2026-07-29` |

## Changes

- test(e2e): wait for base role update visibility (#2087)
- docs(slides): 补齐 shortcut 参数说明，修正 +xml-get --output 必填标注 (#2088)
- Feat/detect line text overlap (#2069)
- feat(drive): add +member-list shortcut (#1795)
- feat(drive): add +permission-get-setting shortcut (#1738)
- feat: propagate invocation metadata (#2097)
- docs(slides): +create 的参数下沉到 create.md，主 skill 只留路由 (#2096)

## Files Changed

- `package.json`
- `package-lock.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional and package metadata versions match
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.0.80, covering features, documentation, tests, and miscellaneous updates.
* **Release**
  * Updated the package version to 1.0.80.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->