### PR TITLE
fix(contact): stop bot match segments carrying tags or empty entries

### DIFF
--- a/affordance/contact.md
+++ b/affordance/contact.md
@@ -26,6 +26,9 @@ lark-cli contact +search-user --user-ids "ou_3a8b****6a7b,me" --as user
 ## +search-bot
 Search bots (apps) by keyword. Pass `--query` or `--queries`; use `--chat-ids` to search within specific chats.
 
+### Skills
+- lark-contact/references/lark-contact-search-bot.md
+
 ### Avoid when
 - Looking for a person rather than a bot → use [[+search-user]]
 - Running as a bot — this shortcut is user-only

--- a/shortcuts/contact/contact_search_bot.go
+++ b/shortcuts/contact/contact_search_bot.go
@@ -100,16 +100,13 @@ var ContactSearchBot = common.Shortcut{
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		if raw := strings.TrimSpace(runtime.Str("queries")); raw != "" {
-			filter, err := buildBotFanoutFilter(runtime)
+			filter, err := buildBotSearchFilter(runtime)
 			if err != nil {
 				return common.NewDryRunAPI().Set("error", err.Error())
 			}
 			api := common.NewDryRunAPI()
 			for _, q := range parseAndDedupQueries(raw) {
-				body := &botSearchAPIRequest{Query: q}
-				if filter != nil {
-					body.Filter = filter
-				}
+				body := &botSearchAPIRequest{Query: q, Filter: filter}
 				api.POST(botSearchURL).
 					Params(map[string]interface{}{"page_size": runtime.Int("page-size")}).
 					Body(body)
@@ -256,8 +253,9 @@ func parseBotSearchChatIDs(runtime *common.RuntimeContext) ([]string, error) {
 	return chatIDs, nil
 }
 
-func buildBotSearchBody(runtime *common.RuntimeContext) (*botSearchAPIRequest, error) {
-	req := &botSearchAPIRequest{Query: strings.TrimSpace(runtime.Str("query"))}
+// buildBotSearchFilter reads the scope flags shared by single and fanout search.
+// A nil filter means "no scope": an empty filter object is not the same request.
+func buildBotSearchFilter(runtime *common.RuntimeContext) (*botSearchAPIFilter, error) {
 	filter := &botSearchAPIFilter{}
 	hasFilter := false
 
@@ -274,10 +272,21 @@ func buildBotSearchBody(runtime *common.RuntimeContext) (*botSearchAPIRequest, e
 		hasFilter = true
 	}
 
-	if hasFilter {
-		req.Filter = filter
+	if !hasFilter {
+		return nil, nil
 	}
-	return req, nil
+	return filter, nil
+}
+
+func buildBotSearchBody(runtime *common.RuntimeContext) (*botSearchAPIRequest, error) {
+	filter, err := buildBotSearchFilter(runtime)
+	if err != nil {
+		return nil, err
+	}
+	return &botSearchAPIRequest{
+		Query:  strings.TrimSpace(runtime.Str("query")),
+		Filter: filter,
+	}, nil
 }
 
 // botSearchStdoutCarriesEnvelope reports whether the chosen format puts the
@@ -373,17 +382,27 @@ func projectBots(data *botSearchAPIData) []searchBot {
 	return bots
 }
 
+func stripHighlightTags(value string) string {
+	value = strings.ReplaceAll(value, "<h>", "")
+	return strings.ReplaceAll(value, "</h>", "")
+}
+
 func parseBotDisplayInfo(raw string) (name, description string, matchSegments []string) {
 	matchSegments = make([]string, 0)
 	for _, match := range displayInfoHighlightRE.FindAllStringSubmatch(raw, -1) {
-		matchSegments = append(matchSegments, html.UnescapeString(match[1]))
+		// The capture can still carry a tag: the non-greedy pattern pairs a
+		// stray `<h>` with the next `</h>`. Strip it so a segment reads like the
+		// name and description it came from, and drop a highlight with no text.
+		segment := html.UnescapeString(stripHighlightTags(match[1]))
+		if strings.TrimSpace(segment) == "" {
+			continue
+		}
+		matchSegments = append(matchSegments, segment)
 	}
 
 	lines := strings.Split(raw, "\n")
 	stripTags := func(value string) string {
-		value = strings.ReplaceAll(value, "<h>", "")
-		value = strings.ReplaceAll(value, "</h>", "")
-		return strings.TrimSpace(html.UnescapeString(value))
+		return strings.TrimSpace(html.UnescapeString(stripHighlightTags(value)))
 	}
 
 	// nameLine records which line the name came from, so the description is read

--- a/shortcuts/contact/contact_search_bot_fanout.go
+++ b/shortcuts/contact/contact_search_bot_fanout.go
@@ -187,7 +187,7 @@ func buildBotFanoutResponse(queries []string, results []botFanoutResult) (*botFa
 func executeBotSearchFanout(ctx context.Context, runtime *common.RuntimeContext) error {
 	queries := parseAndDedupQueries(runtime.Str("queries"))
 
-	filter, err := buildBotFanoutFilter(runtime)
+	filter, err := buildBotSearchFilter(runtime)
 	if err != nil {
 		return err
 	}
@@ -271,30 +271,6 @@ schedule:
 		}
 	}
 	return nil
-}
-
-// buildBotFanoutFilter applies the same search scope and filter to every query.
-func buildBotFanoutFilter(runtime *common.RuntimeContext) (*botSearchAPIFilter, error) {
-	filter := &botSearchAPIFilter{}
-	hasFilter := false
-
-	chatIDs, err := parseBotSearchChatIDs(runtime)
-	if err != nil {
-		return nil, err
-	}
-	if len(chatIDs) > 0 {
-		filter.ChatIDs = chatIDs
-		hasFilter = true
-	}
-	if runtime.Cmd.Flags().Changed("has-chatted") && runtime.Bool("has-chatted") {
-		filter.HasChatter = true
-		hasFilter = true
-	}
-
-	if !hasFilter {
-		return nil, nil
-	}
-	return filter, nil
 }
 
 func prettyBotFanoutRows(bots []fanoutBot) []map[string]interface{} {

--- a/shortcuts/contact/contact_search_bot_fanout_test.go
+++ b/shortcuts/contact/contact_search_bot_fanout_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -518,7 +519,58 @@ func TestBotFanoutNDJSONKeepsStdoutClean(t *testing.T) {
 	}
 }
 
-func TestBotFanoutCancelledContextFailsEveryQuery(t *testing.T) {
+// TestBotFanoutCancelledSchedulingFailsQueuedQueries drives the real command so
+// the scheduler inside executeBotSearchFanout — not just runOneBotQuery — sees
+// the cancellation. Queueing more keywords than fanoutConcurrency while every
+// worker is parked keeps all semaphore slots held, so the queued keywords can
+// only leave the loop through its ctx.Done() branch.
+func TestBotFanoutCancelledSchedulingFailsQueuedQueries(t *testing.T) {
+	factory, stdout, _, registry := cmdutil.TestFactory(t, botSearchDefaultConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	var once sync.Once
+	stub := botSearchStub(botSearchURL+"?page_size=20", "")
+	stub.Reusable = true
+	stub.OnMatch = func(*http.Request) {
+		once.Do(func() { close(started) })
+		<-ctx.Done() // hold the slot so later keywords must queue on the semaphore
+	}
+	registry.Register(stub)
+
+	go func() {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second): // never leave the workers parked
+		}
+		cancel()
+	}()
+
+	queries := make([]string, 0, fanoutConcurrency+3)
+	for i := 0; i < fanoutConcurrency+3; i++ {
+		queries = append(queries, fmt.Sprintf("q%d", i))
+	}
+
+	err := mountAndRunContext(t, ctx, ContactSearchBot, []string{
+		"+search-bot", "--queries", strings.Join(queries, ","), "--format", "json", "--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("a cancelled batch must surface as a command error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation cause must be preserved: %v", err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryNetwork || problem.Subtype != errs.SubtypeNetworkTransport {
+		t.Fatalf("problem: got %+v, want network/%s", problem, errs.SubtypeNetworkTransport)
+	}
+}
+
+// TestBotFanoutCancelledContextShortCircuitsBeforeRequest pins the other half:
+// a queued worker must fail on the pre-check instead of issuing its request.
+func TestBotFanoutCancelledContextShortCircuitsBeforeRequest(t *testing.T) {
 	results := make([]botFanoutResult, 0, 2)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/shortcuts/contact/contact_search_bot_test.go
+++ b/shortcuts/contact/contact_search_bot_test.go
@@ -336,6 +336,18 @@ func TestParseBotDisplayInfo(t *testing.T) {
 		// swallow the real description on the line after it.
 		{name: "blank first line keeps description", raw: "\n真名\n简介", wantName: "真名", wantDescription: "简介", wantSegments: []string{}},
 		{name: "blank first line without description", raw: "\n真名", wantName: "真名", wantSegments: []string{}},
+		// A highlight with no text carries nothing; an empty match segment is junk
+		// in the envelope. Which line the name comes from is left unchanged.
+		{name: "empty highlight yields no segment", raw: "<h></h>\n简介", wantName: "简介", wantSegments: []string{}},
+		// The non-greedy pattern pairs a stray `<h>` with the next `</h>`, so the
+		// capture can carry a tag the name and description already dropped.
+		{name: "nested highlight", raw: "<h>甲<h>乙</h></h>\n简介", wantName: "甲乙", wantDescription: "简介", wantSegments: []string{"甲乙"}},
+		{name: "dangling open tag", raw: "<h><h>甲</h>\n简介", wantName: "甲", wantDescription: "简介", wantSegments: []string{"甲"}},
+		{name: "unclosed highlight", raw: "<h>甲乙\n简介", wantName: "甲乙", wantDescription: "简介", wantSegments: []string{}},
+		// A literal `<h>` in a name arrives escaped, so it must survive: tags are
+		// stripped before unescaping. Swapping that order eats the name's own text.
+		{name: "escaped angle brackets are name text", raw: "名称&lt;h&gt;工具\n简介", wantName: "名称<h>工具", wantDescription: "简介", wantSegments: []string{}},
+		{name: "escaped angle brackets inside a highlight", raw: "<h>名称&lt;h&gt;</h>工具\n简介", wantName: "名称<h>工具", wantDescription: "简介", wantSegments: []string{"名称<h>"}},
 	}
 
 	for _, tt := range tests {

--- a/shortcuts/contact/contact_search_user_test.go
+++ b/shortcuts/contact/contact_search_user_test.go
@@ -551,6 +551,13 @@ func TestDecodeSearchUserAPIData_MarshalFailureTyped(t *testing.T) {
 // with the given args. Mirrors the pattern used in other shortcut packages.
 func mountAndRun(t *testing.T, s common.Shortcut, args []string, f *cmdutil.Factory, stdout *bytes.Buffer) error {
 	t.Helper()
+	return mountAndRunContext(t, context.Background(), s, args, f, stdout)
+}
+
+// mountAndRunContext is mountAndRun with a caller-supplied context, so a test
+// can cancel the run the shortcut actually sees (runShortcut reads cmd.Context).
+func mountAndRunContext(t *testing.T, ctx context.Context, s common.Shortcut, args []string, f *cmdutil.Factory, stdout *bytes.Buffer) error {
+	t.Helper()
 	parent := &cobra.Command{Use: "contact"}
 	s.Mount(parent, f)
 	parent.SetArgs(args)
@@ -559,7 +566,7 @@ func mountAndRun(t *testing.T, s common.Shortcut, args []string, f *cmdutil.Fact
 	if stdout != nil {
 		stdout.Reset()
 	}
-	return parent.Execute()
+	return parent.ExecuteContext(ctx)
 }
 
 // searchUserStub returns a representative user search response with a notice.

--- a/skills/lark-contact/SKILL.md
+++ b/skills/lark-contact/SKILL.md
@@ -60,7 +60,7 @@ lark-cli contact +search-bot --queries '会议助手,日报助手,审批助手' 
 
 ## 注意事项
 
-- **41050 / Permission denied** 受当前身份的可见范围限制(两条命令都可能遇到)。换 bot 身份或让管理员调整可见范围,细节见 [`lark-shared`](../lark-shared/SKILL.md)。
+- **41050 / Permission denied** 受当前身份的可见范围限制(三条命令都可能遇到)。细节见 [`lark-shared`](../lark-shared/SKILL.md)。
 - **跨租户用户**(`is_cross_tenant=true`)多数业务字段为空字符串,这是飞书可见性规则,下游做空值兜底。
 - **ID 类型**:`+get-user` 可通过 `--user-id-type` 使用 `open_id`、`union_id` 或 `user_id`;`+search-user` 使用用户 open_id;`+search-bot` 不支持按 ID 查询,它按关键词搜索并返回机器人 open_id。
 


### PR DESCRIPTION
## Summary

Follow-up to #2083. These changes were made after that PR's head was snapshotted for the squash merge, so they never reached `main`.

## Changes

- Bot search match segments no longer carry `<h>` tags or empty entries — the non-greedy highlight pattern can pair a stray `<h>` with the next `</h>`, leaving a tag inside the capture.
- One `buildBotSearchFilter` shared by `--query` and `--queries`, replacing two copies of the same logic.
- Test for the fanout scheduler's cancellation branch.
- Docs: `+search-bot` affordance points at its skill reference; the 41050 recovery path no longer suggests switching to a bot identity for a user-only command.

## Test Plan

- [x] `go test ./shortcuts/contact/...`, `go vet`, `gofmt`, `skill-format-check` all pass
- [x] `--dry-run` confirms the shared filter builder is behavior-preserving: no scope flags omits `filter` entirely, and `--has-chatted` yields the same filter for both flags

## Related Issues

- Follow-up to #2083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced contact bot search so request scoping behaves consistently.
  - Improved parsing of highlighted match segments for cleaner names and descriptions.

- **Bug Fixes**
  - Strengthened fanout cancellation so queued work and already-canceled runs stop correctly and preserve cancellation causes.
  - Ensured unscoped searches omit filter data entirely rather than sending empty filters.

- **Documentation**
  - Updated Skills guidance for “Permission denied” to reflect the correct number of affected commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->