### PR TITLE
feat(base): classify Base resource permission denials as typed errors

### DIFF
--- a/shortcuts/base/base_errors.go
+++ b/shortcuts/base/base_errors.go
@@ -160,12 +160,42 @@ func baseAPIErrorFromResult(resultMap map[string]interface{}, cc errclass.Classi
 	if logID := extractBaseErrorLogID(resultMap); logID != "" {
 		resultMap["log_id"] = logID
 	}
+	if err := baseResourcePermissionError(resultMap, cc, hint); err != nil {
+		return err
+	}
 	err := errclass.BuildAPIError(resultMap, cc)
 	if err == nil {
 		return nil
 	}
 	if p, ok := errs.ProblemOf(err); ok && hint != "" {
 		p.Hint = hint
+	}
+	return err
+}
+
+func baseResourcePermissionError(resultMap map[string]interface{}, cc errclass.ClassifyContext, upstreamHint string) error {
+	code, ok := util.ToFloat64(resultMap["code"])
+	if !ok || int(code) != 91403 {
+		return nil
+	}
+	msg, _ := resultMap["msg"].(string)
+	if strings.TrimSpace(msg) == "" {
+		msg = "you don't have permission"
+	}
+	identity := strings.TrimSpace(cc.Identity)
+	if identity == "" {
+		identity = "current identity"
+	}
+	hint := fmt.Sprintf("resource access denied for %s; ask the Base owner to grant access, or retry once with --as user only if a user identity is already logged in. Do not run auth login or switch identities repeatedly for this resource-level permission error", identity)
+	if upstreamHint != "" {
+		hint = upstreamHint + "; " + hint
+	}
+	err := errs.NewPermissionError(errs.SubtypePermissionDenied, "%s", msg).
+		WithCode(91403).
+		WithHint("%s", hint)
+	err.Identity = identity
+	if logID, _ := resultMap["log_id"].(string); strings.TrimSpace(logID) != "" {
+		err.WithLogID(strings.TrimSpace(logID))
 	}
 	return err
 }

--- a/shortcuts/base/base_errors_test.go
+++ b/shortcuts/base/base_errors_test.go
@@ -118,6 +118,38 @@ func TestHandleBaseAPIResultClassifiesKnownPermissionCode(t *testing.T) {
 	}
 }
 
+func TestHandleBaseAPIResultClassifiesBaseResourcePermission(t *testing.T) {
+	result := map[string]interface{}{
+		"code": 91403,
+		"msg":  "you don't have permission",
+		"data": map[string]interface{}{},
+	}
+
+	_, err := handleBaseAPIResultAny(result, nil, "list dashboards")
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T %v", err, err)
+	}
+	if p.Code != 91403 {
+		t.Fatalf("code=%d", p.Code)
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied {
+		t.Fatalf("category/subtype=%s/%s", p.Category, p.Subtype)
+	}
+	perm, ok := err.(*errs.PermissionError)
+	if !ok {
+		t.Fatalf("err=%T, want *errs.PermissionError", err)
+	}
+	if perm.Identity != "current identity" {
+		t.Fatalf("identity=%q", perm.Identity)
+	}
+	for _, want := range []string{"resource access denied", "Base owner", "Do not run auth login"} {
+		if !strings.Contains(p.Hint, want) {
+			t.Fatalf("hint=%q missing %q", p.Hint, want)
+		}
+	}
+}
+
 func TestAttachBaseResponseLogIDFromHeader(t *testing.T) {
 	result := map[string]interface{}{
 		"code": 91402,


### PR DESCRIPTION
## Summary

Base API responses with code `91403` (resource-level permission denial) were previously flowing through the generic API error path, producing a non-specific error that AI agents could not reliably act on. This change maps `91403` to a typed `PermissionError` so agents receive a structured, actionable signal instead of a bare API failure.

## Changes

- Add `baseResourcePermissionError` in `shortcuts/base/base_errors.go`, which detects the Base `91403` response code and returns a typed `errs.PermissionError` with `SubtypePermissionDenied`.
- Populate the typed error with the resolved identity, the error code (`91403`), the server log ID when present, and a preserved upstream hint.
- Emit an actionable hint that directs the caller to ask the Base owner for access (or retry once with `--as user` when a user identity is already logged in) rather than repeatedly running `auth login` or switching identities for a resource-level denial.
- Wire the new classifier into `baseAPIErrorFromResult` so it runs before the generic `errclass.BuildAPIError` fallback.
- Add `TestHandleBaseAPIResultClassifiesBaseResourcePermission` covering the `91403` path: asserts category/subtype/code, the `*errs.PermissionError` type, the default identity, and the hint content.

## Test Plan

- `git diff --check` — passed (no whitespace errors or conflict markers).
- New unit test `TestHandleBaseAPIResultClassifiesBaseResourcePermission` asserts the typed metadata (`Category`, `Subtype`, `Code`), the concrete `*errs.PermissionError` type, the default `Identity`, and the presence of the actionable hint fragments.

## Related Issues

Auto research task: 01KWYNV56GBPYYSFEHMHM8ZWMP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Base resource permission errors.
  * Displays clearer authorization-denied messages with helpful hints.
  * Preserves relevant error details, including identity and request reference information, to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->