### PR TITLE
fix(base): surface url resolve block list errors

### DIFF
--- a/shortcuts/base/base_resolve.go
+++ b/shortcuts/base/base_resolve.go
@@ -195,7 +195,9 @@ func executeBaseURLResolve(runtime *common.RuntimeContext) error {
 	switch classifyBaseURL(parsed) {
 	case "base_url":
 		out := resolveBaseURL(parsed)
-		enrichBaseResolveHint(runtime, out, resolveBaseURLSelection(parsed))
+		if err := enrichBaseResolveHint(runtime, out, resolveBaseURLSelection(parsed)); err != nil {
+			return err
+		}
 		runtime.OutFormat(out, nil, nil)
 		return nil
 	case "wiki_url":
@@ -205,7 +207,9 @@ func executeBaseURLResolve(runtime *common.RuntimeContext) error {
 		}
 		selection := resolveBaseURLSelection(parsed)
 		applyBaseURLSelection(out, selection)
-		enrichBaseResolveHint(runtime, out, selection)
+		if err := enrichBaseResolveHint(runtime, out, selection); err != nil {
+			return err
+		}
 		runtime.OutFormat(out, nil, nil)
 		return nil
 	case "record_share_url":
@@ -422,15 +426,19 @@ func executeBaseTitleResolve(runtime *common.RuntimeContext) error {
 	}
 }
 
-func enrichBaseResolveHint(runtime *common.RuntimeContext, out map[string]interface{}, selection baseURLSelection) {
+func enrichBaseResolveHint(runtime *common.RuntimeContext, out map[string]interface{}, selection baseURLSelection) error {
 	baseToken := strings.TrimSpace(common.GetString(out, "base_token"))
 	selectedBlockID := strings.TrimSpace(common.GetString(out, "block_id"))
 	if baseToken == "" || selectedBlockID == "" {
 		out["hint"] = resolveHint("", nil)
-		return
+		return nil
 	}
 
-	if block, found, err := resolveSelectedBaseBlock(runtime, baseToken, selectedBlockID); err == nil && found {
+	block, found, err := resolveSelectedBaseBlock(runtime, baseToken, selectedBlockID)
+	if err != nil {
+		return err
+	}
+	if found {
 		out["block_type"] = block.Type
 		if block.Name != "" {
 			out["block_name"] = block.Name
@@ -467,10 +475,11 @@ func enrichBaseResolveHint(runtime *common.RuntimeContext, out map[string]interf
 		default:
 			out["hint"] = resolveUnknownBlockHint()
 		}
-		return
+		return nil
 	}
 
 	out["hint"] = resolveUnknownBlockHint()
+	return nil
 }
 
 type resolvedBaseBlock struct {

--- a/shortcuts/base/base_resolve_test.go
+++ b/shortcuts/base/base_resolve_test.go
@@ -102,42 +102,11 @@ func TestBaseURLResolveBaseURL(t *testing.T) {
 
 	t.Run("block list error is returned", func(t *testing.T) {
 		factory, stdout, reg := newExecuteFactory(t)
-		reg.Register(&httpmock.Stub{
-			Method: "POST",
-			URL:    "/open-apis/base/v3/bases/bas123/blocks/list",
-			Body: map[string]interface{}{
-				"code": 99991672,
-				"msg":  "access denied",
-				"error": map[string]interface{}{
-					"permission_violations": []interface{}{
-						map[string]interface{}{"subject": "base:block:read"},
-					},
-				},
-			},
-		})
+		reg.Register(baseBlockListScopeErrorStub("bas123"))
 		err := runShortcutWithAuthTypes(t, BaseURLResolve, authTypes(), []string{
 			"+url-resolve", "--url", "https://example.larkoffice.com/base/bas123?table=tbl123&view=vew_stale", "--as", "bot",
 		}, factory, stdout)
-		if err == nil {
-			t.Fatal("expected block-list error to be returned")
-		}
-		p, ok := errs.ProblemOf(err)
-		if !ok {
-			t.Fatalf("expected typed problem, got %T %v", err, err)
-		}
-		if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypeAppScopeNotApplied || p.Code != 99991672 {
-			t.Fatalf("unexpected problem: %#v", p)
-		}
-		var permissionErr *errs.PermissionError
-		if !errors.As(err, &permissionErr) {
-			t.Fatalf("expected PermissionError, got %T %v", err, err)
-		}
-		if len(permissionErr.MissingScopes) != 1 || permissionErr.MissingScopes[0] != "base:block:read" {
-			t.Fatalf("missing scopes=%v", permissionErr.MissingScopes)
-		}
-		if stdout.Len() != 0 {
-			t.Fatalf("stdout should stay empty when block-list fails: %s", stdout.String())
-		}
+		assertBaseBlockReadPermissionError(t, err, stdout)
 	})
 
 	t.Run("field endpoint does not confirm untyped block", func(t *testing.T) {
@@ -313,6 +282,22 @@ func baseBlockListResolveStub(baseToken string, blocks ...map[string]interface{}
 	}
 }
 
+func baseBlockListScopeErrorStub(baseToken string) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/base/v3/bases/" + baseToken + "/blocks/list",
+		Body: map[string]interface{}{
+			"code": 99991672,
+			"msg":  "access denied",
+			"error": map[string]interface{}{
+				"permission_violations": []interface{}{
+					map[string]interface{}{"subject": "base:block:read"},
+				},
+			},
+		},
+	}
+}
+
 func TestBaseURLResolveWikiURL(t *testing.T) {
 	t.Run("bitable", func(t *testing.T) {
 		factory, stdout, reg := newExecuteFactory(t)
@@ -351,6 +336,19 @@ func TestBaseURLResolveWikiURL(t *testing.T) {
 		if data["input_type"] != "wiki_url" || data["base_token"] != "bas123" || data["block_id"] != "tbl123" || data["block_type"] != "table" || data["table_id"] != "tbl123" || data["view_id"] != "vew123" || data["record_id"] != "rec123" {
 			t.Fatalf("unexpected Wiki Base table coordinates: %#v", data)
 		}
+	})
+
+	t.Run("bitable table coordinates return block list error", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(wikiBaseNodeStub("wik123", "bas123", "Demo Base"))
+		reg.Register(baseBlockListScopeErrorStub("bas123"))
+
+		err := runShortcutWithAuthTypes(t, BaseURLResolve, authTypes(), []string{
+			"+url-resolve",
+			"--url", "https://example.larkoffice.com/wiki/wik123?table=tbl123&view=vew_stale",
+			"--as", "bot",
+		}, factory, stdout)
+		assertBaseBlockReadPermissionError(t, err, stdout)
 	})
 
 	t.Run("bitable with dashboard selection", func(t *testing.T) {
@@ -417,6 +415,33 @@ func wikiBaseNodeStub(wikiToken, baseToken, title string) *httpmock.Stub {
 				},
 			},
 		},
+	}
+}
+
+func assertBaseBlockReadPermissionError(t *testing.T, err error, stdout interface {
+	Len() int
+	String() string
+}) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected block-list error to be returned")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypeAppScopeNotApplied || p.Code != 99991672 {
+		t.Fatalf("unexpected problem: %#v", p)
+	}
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("expected PermissionError, got %T %v", err, err)
+	}
+	if len(permissionErr.MissingScopes) != 1 || permissionErr.MissingScopes[0] != "base:block:read" {
+		t.Fatalf("missing scopes=%v", permissionErr.MissingScopes)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout should stay empty when block-list fails: %s", stdout.String())
 	}
 }
 

--- a/shortcuts/base/base_resolve_test.go
+++ b/shortcuts/base/base_resolve_test.go
@@ -4,6 +4,7 @@
 package base
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -67,7 +68,10 @@ func TestBaseURLResolveBaseURL(t *testing.T) {
 	})
 
 	t.Run("unconfirmed selected block stays neutral", func(t *testing.T) {
-		factory, stdout, _ := newExecuteFactory(t)
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(baseBlockListResolveStub("bas123",
+			map[string]interface{}{"id": "tbl_other", "type": "table", "name": "Other"},
+		))
 		err := runShortcutWithAuthTypes(t, BaseURLResolve, authTypes(), []string{
 			"+url-resolve", "--url", "https://example.larkoffice.com/base/bas123?table=tbl123&view=vew_stale&record=rec_stale", "--as", "user",
 		}, factory, stdout)
@@ -93,6 +97,46 @@ func TestBaseURLResolveBaseURL(t *testing.T) {
 		}
 		if _, ok := hint["fields"]; ok {
 			t.Fatalf("fields should be omitted when enrichment fails: %#v", hint)
+		}
+	})
+
+	t.Run("block list error is returned", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/base/v3/bases/bas123/blocks/list",
+			Body: map[string]interface{}{
+				"code": 99991672,
+				"msg":  "access denied",
+				"error": map[string]interface{}{
+					"permission_violations": []interface{}{
+						map[string]interface{}{"subject": "base:block:read"},
+					},
+				},
+			},
+		})
+		err := runShortcutWithAuthTypes(t, BaseURLResolve, authTypes(), []string{
+			"+url-resolve", "--url", "https://example.larkoffice.com/base/bas123?table=tbl123&view=vew_stale", "--as", "bot",
+		}, factory, stdout)
+		if err == nil {
+			t.Fatal("expected block-list error to be returned")
+		}
+		p, ok := errs.ProblemOf(err)
+		if !ok {
+			t.Fatalf("expected typed problem, got %T %v", err, err)
+		}
+		if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypeAppScopeNotApplied || p.Code != 99991672 {
+			t.Fatalf("unexpected problem: %#v", p)
+		}
+		var permissionErr *errs.PermissionError
+		if !errors.As(err, &permissionErr) {
+			t.Fatalf("expected PermissionError, got %T %v", err, err)
+		}
+		if len(permissionErr.MissingScopes) != 1 || permissionErr.MissingScopes[0] != "base:block:read" {
+			t.Fatalf("missing scopes=%v", permissionErr.MissingScopes)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("stdout should stay empty when block-list fails: %s", stdout.String())
 		}
 	})
 


### PR DESCRIPTION
## Summary
`base +url-resolve` now returns the underlying `blocks/list` API error when selected Base block enrichment fails, instead of emitting `ok=true` with only a neutral unknown-block hint. This makes missing `base:block:read` scope and other block-list failures visible to users and CI.

## Changes
- Propagate `resolveSelectedBaseBlock` errors through `executeBaseURLResolve` for Base and Wiki Base URLs.
- Keep successful-but-nonmatching block-list responses as neutral unknown block output.
- Add regression coverage for block-list authorization errors and successful nonmatching block-list responses.

## Test Plan
- [x] Unit tests pass: `go test ./shortcuts/base`
- [x] Dry-run E2E pass: `go test ./tests/cli_e2e/base -run 'TestBaseURLResolveSelectedBlockDryRun|TestBaseURLResolveWikiSelectedBlockDryRun'`\n- [x] Manual local verification confirms `base +url-resolve --as bot` surfaces `base:block:read` missing scope for a bot without that scope, while `--as user` still resolves the same table URL successfully.\n\n## Related Issues\n- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Base and Wiki URL resolution now correctly reports failures when selected-block authorization or resolution fails.
  * Authorization errors include missing-scope details and no longer produce misleading output.
* **Tests**
  * Added coverage for block-list authorization failures and neutral block selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->