### PR TITLE
chore: release v1.0.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.81] - 2026-07-31
+
+### Features
+
+- support visible_rule for form questions (#1891)
+- **contact**: add bot search shortcut (#2083)
+- add SXSD schema validation to Slides lint (#2103)
+- **drive**: add comment-operation shortcuts (#1898)
+- **drive**: extend permission shortcuts for Miaoda (#2070)
+- **apps**: add cache debug commands (+cache-get/-delete/-clear) (#1896)
+- support source file preview artifacts (#2085)
+
+### Bug Fixes
+
+- **contact**: stop bot match segments carrying tags or empty entries (#2115)
+- **base**: resolve Base URL block types accurately (#2099)
+- **drive**: use title for default download filename (#2089)
+- drop stale target version from root upgrade prompt (#2100)
+
+### Documentation
+
+- **calendar**: warn against container-default timezone in time conversion (#2104)
+- **calendar**: confirm scope before editing recurring events (#2119)
+- **base**: clarify form and file operation routing (#2110)
+
+### Misc
+
+- add protected public domain allowlists (#2111)
+
 ## [v1.0.80] - 2026-07-29
 
 ### Features
@@ -1722,6 +1751,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.81]: https://github.com/larksuite/cli/releases/tag/v1.0.81
 [v1.0.80]: https://github.com/larksuite/cli/releases/tag/v1.0.80
 [v1.0.79]: https://github.com/larksuite/cli/releases/tag/v1.0.79
 [v1.0.78]: https://github.com/larksuite/cli/releases/tag/v1.0.78

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.80",
+  "version": "1.0.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larksuite/cli",
-      "version": "1.0.80",
+      "version": "1.0.81",
       "cpu": [
         "x64",
         "arm64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.80",
+  "version": "1.0.81",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.80` |
| Release version | `1.0.81` |
| Tag | `v1.0.81` |
| Branch | `release/v1.0.81` |
| Date | `2026-07-31` |

## Changes

- feat: support visible_rule for form questions (#1891)
- docs(calendar): warn against container-default timezone in time conversion (#2104)
- feat(contact): add bot search shortcut (#2083)
- fix(contact): stop bot match segments carrying tags or empty entries (#2115)
- feat: add SXSD schema validation to Slides lint (#2103)
- fix(base): resolve Base URL block types accurately (#2099)
- feat(drive): add comment-operation shortcuts (#1898)
- docs(calendar): confirm scope before editing recurring events (#2119)
- ci: add protected public domain allowlists (#2111)
- fix(drive): use title for default download filename (#2089)
- feat(drive): extend permission shortcuts for Miaoda (#2070)
- fix: drop stale target version from root upgrade prompt (#2100)
- feat(apps): add cache debug commands (+cache-get/-delete/-clear) (#1896)
- docs(base): clarify form and file operation routing (#2110)
- feat: support source file preview artifacts (#2085)

## Files Changed

- `package.json`
- `package-lock.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional and package metadata versions match
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.0.81 with corresponding changelog updates documenting the latest features, improvements, and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->