### PR TITLE
docs: remove broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,6 @@ lark-cli config risk-control default
 
 Please fully understand all usage risks. By using this tool, you are deemed to voluntarily assume all related responsibilities.
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=larksuite/cli&type=Date)](https://star-history.com/#larksuite/cli&Date)
-
 ## Contributing
 
 Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/larksuite/cli/issues) or [Pull Request](https://github.com/larksuite/cli/pulls).

--- a/README.zh.md
+++ b/README.zh.md
@@ -311,10 +311,6 @@ lark-cli config risk-control default
 
 请您充分知悉全部使用风险，使用本工具即视为您自愿承担相关所有责任。
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=larksuite/cli&type=Date)](https://star-history.com/#larksuite/cli&Date)
-
 ## 贡献
 
 欢迎社区贡献！如果你发现 bug 或有功能建议，请提交 [Issue](https://github.com/larksuite/cli/issues) 或 [Pull Request](https://github.com/larksuite/cli/pulls)。


### PR DESCRIPTION
## Summary
Remove the unavailable Star History chart from the project documentation so the README pages no longer depend on the broken external service.

## Changes
- Remove the Star History section from `README.md`
- Remove the matching section from `README.zh.md`

## Test Plan
- [ ] Unit tests pass (not run; documentation-only change)
- [x] Verified both README files no longer contain Star History references

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the “Star History” section and chart from the English and Chinese README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->