### PR TITLE
test: fix bot contact user discovery parameters

### DIFF
--- a/tests/cli_e2e/contact/contact_lookup_workflow_test.go
+++ b/tests/cli_e2e/contact/contact_lookup_workflow_test.go
@@ -60,7 +60,7 @@ func TestContact_LookupWorkflowAsBot(t *testing.T) {
 
 	t.Run("discover user via api as bot", func(t *testing.T) {
 		result, err := clie2e.RunCmd(ctx, clie2e.Request{
-			Args:      []string{"api", "get", "/open-apis/contact/v3/users"},
+			Args:      []string{"api", "get", "/open-apis/contact/v3/users", "--params", `{"department_id":"0","page_size":10}`},
 			DefaultAs: "bot",
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

- pass `department_id=0` and `page_size=10` through the raw API command's structured `--params` input
- avoid embedding query parameters in the API path, which is normalized with its query fragment stripped
- restore deterministic bot contact discovery for the live E2E workflow

## Verification

- `go test ./cmd/api -count=1`
- `go test ./tests/cli_e2e/contact -run '^TestContact_LookupWorkflowAsBot$' -count=1 -v` with the CI TEST_BOT1 tenant credentials\n- live result: both `discover_user_via_api_as_bot` and `get_user_by_open_id_as_bot` passed\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the contact lookup end-to-end test to include department filtering and page-size parameters when retrieving users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->