### PR TITLE
feat(slides): support embedded SVG content

### DIFF
--- a/skills/lark-slides/references/slides_xml_schema_definition.xml
+++ b/skills/lark-slides/references/slides_xml_schema_definition.xml
@@ -1052,7 +1052,7 @@
                 单页幻灯片结构
                 子元素:
                 - style: 页面样式(背景色等), style的fill默认颜色为白色rgba(255, 255, 255, 1)
-                - data: 页面元素容器(shape/line/polyline/img/table/icon/chart/undefined)
+                - data: 页面元素容器(shape/line/polyline/img/table/icon/embed/chart/undefined)
                 - note: 演讲者备注
             </xs:documentation>
         </xs:annotation>
@@ -1076,6 +1076,7 @@
                         <xs:element ref="sml:img"/>
                         <xs:element ref="sml:table"/>
                         <xs:element ref="sml:icon"/>
+                        <xs:element ref="sml:embed"/>
                         <xs:element ref="sml:chart"/>
                         <xs:element ref="sml:undefined"/>
                     </xs:choice>
@@ -1611,6 +1612,49 @@
 
             <xs:attribute name="id" type="xs:string" use="optional"/>
             <xs:attribute name="iconType" type="xs:string" use="optional" default="iconpark/Base/setting.svg"/>
+            <xs:attribute name="topLeftX" type="sml:XType" use="required"/>
+            <xs:attribute name="topLeftY" type="sml:YType" use="required"/>
+            <xs:attribute name="width" type="sml:PositiveSize" use="required"/>
+            <xs:attribute name="height" type="sml:PositiveSize" use="required"/>
+            <xs:attribute name="rotation" type="sml:RotationType" use="optional" default="0"/>
+            <xs:attribute name="flipX" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="flipY" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="alpha" type="sml:AlphaType" use="optional" default="1"/>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- 嵌入内容元素 -->
+    <xs:element name="embed">
+        <xs:annotation>
+            <xs:documentation>
+                嵌入内容容器, 外层承载 Slides 摆放和效果属性, 内层承载外部标准内容。
+                当前内层内容为标准 SVG, 必须使用 http://www.w3.org/2000/svg 命名空间。
+                后续可扩展承载 HTML 等其他外部内容。
+
+                必需属性:
+                - topLeftX/topLeftY: 左上角坐标
+                - width/height: 显示尺寸
+
+                可选属性:
+                - id: 唯一标识符
+                - rotation: 旋转角度[0, 360)
+                - flipX/flipY: 水平/垂直翻转
+                - alpha: 不透明度[0,1]
+
+                子元素:
+                - svg: 标准 SVG 根元素, 仅描述嵌入内容, 不承载 Slides 布局属性
+                - reflection: 倒影样式, 无reflection标签代表无倒影, 空reflection标签代表使用默认样式
+                - shadow: 阴影样式, 无shadow标签代表无阴影, 空shadow标签代表使用默认样式
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any namespace="http://www.w3.org/2000/svg" processContents="lax" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="reflection" type="sml:ReflectionType" minOccurs="0"/>
+                <xs:element name="shadow" type="sml:ShadowType" minOccurs="0"/>
+            </xs:sequence>
+
+            <xs:attribute name="id" type="xs:string" use="optional"/>
             <xs:attribute name="topLeftX" type="sml:XType" use="required"/>
             <xs:attribute name="topLeftY" type="sml:YType" use="required"/>
             <xs:attribute name="width" type="sml:PositiveSize" use="required"/>

--- a/skills/lark-slides/references/xml-schema-quick-ref.md
+++ b/skills/lark-slides/references/xml-schema-quick-ref.md
@@ -81,7 +81,7 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 **子元素：**
 
 - `<style>?` - 页面样式，目前可放 `<fill>`
-- `<data>?` - 页面元素容器，可放 `shape`、`line`、`polyline`、`img`、`table`、`icon`、`chart`、`undefined`
+- `<data>?` - 页面元素容器，可放 `shape`、`line`、`polyline`、`img`、`table`、`icon`、`embed`、`chart`、`undefined`
 - `<note>?` - 演讲者备注，内部可放 `<content>`
 
 这意味着 `<title>`、`<headline>`、`<body>`、`<caption>` 不能直接放在 `<slide>` 下。
@@ -354,6 +354,20 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 隐藏 `<chart>` 的图例只能通过不写或删除 `<chartLegend>` 实现，`<chartLegend>` 不支持 `position="none"`。
 
 详细用法见 [slides_xml_schema_definition.xml](slides_xml_schema_definition.xml)。
+
+### embed
+
+嵌入内容容器：外层 `<embed>` 承载 Slides 的摆放和效果属性（`topLeftX`/`topLeftY`/`width`/`height` 必填，`rotation`/`flipX`/`flipY`/`alpha` 可选），内层承载外部标准内容。当前内层内容为标准 SVG，`<svg>` 必须使用 `http://www.w3.org/2000/svg` 命名空间，且仅描述嵌入内容本身，不承载 Slides 布局属性。
+
+```xml
+<embed topLeftX="80" topLeftY="120" width="200" height="120">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120">
+    <circle cx="100" cy="60" r="40" fill="rgba(37, 99, 235, 1)"/>
+  </svg>
+</embed>
+```
+
+`<embed>` 直接子元素为一个 `<svg>`（必需），以及可选的 `<reflection>`（倒影）与 `<shadow>`（阴影）。
 
 ## 颜色与样式
 

--- a/skills/lark-slides/scripts/sxsd_validator.py
+++ b/skills/lark-slides/scripts/sxsd_validator.py
@@ -80,6 +80,15 @@ class ChildRule:
 
 
 @dataclass(frozen=True)
+class WildcardRule:
+    namespace: str
+    process_contents: str
+    min_occurs: int
+    max_occurs: int | None
+    order: int | None
+
+
+@dataclass(frozen=True)
 class ChoiceRequirement:
     names: tuple[str, ...]
     min_occurs: int
@@ -307,12 +316,13 @@ def multiplied_max(left: int | None, right: int | None) -> int | None:
 
 def child_rules_for_complex_type(
     complex_type: ET.Element,
-) -> tuple[list[ChildRule], list[ChoiceRequirement]]:
+) -> tuple[list[ChildRule], list[WildcardRule], list[ChoiceRequirement]]:
     particle = particle_for_complex_type(complex_type)
     if particle is None:
-        return [], []
+        return [], [], []
 
     rules: list[ChildRule] = []
+    wildcard_rules: list[WildcardRule] = []
     requirements: list[ChoiceRequirement] = []
     next_order = 0
 
@@ -331,6 +341,25 @@ def child_rules_for_complex_type(
         rules.append(
             ChildRule(
                 element=element_rule,
+                min_occurs=0 if optional_by_choice else minimum,
+                max_occurs=multiplied_max(maximum, max_multiplier),
+                order=order,
+            )
+        )
+
+    def add_wildcard(
+        wildcard: ET.Element,
+        *,
+        order: int | None,
+        optional_by_choice: bool,
+        max_multiplier: int | None,
+    ) -> None:
+        minimum = occurs_value(wildcard.attrib.get("minOccurs"), 1) or 0
+        maximum = occurs_value(wildcard.attrib.get("maxOccurs"), 1)
+        wildcard_rules.append(
+            WildcardRule(
+                namespace=wildcard.attrib.get("namespace", "##any"),
+                process_contents=wildcard.attrib.get("processContents", "strict"),
                 min_occurs=0 if optional_by_choice else minimum,
                 max_occurs=multiplied_max(maximum, max_multiplier),
                 order=order,
@@ -369,6 +398,13 @@ def child_rules_for_complex_type(
                         optional_by_choice=True,
                         max_multiplier=effective_max,
                     )
+                elif child_kind == "any":
+                    add_wildcard(
+                        child,
+                        order=choice_order,
+                        optional_by_choice=True,
+                        max_multiplier=effective_max,
+                    )
                 elif child_kind in {"sequence", "all", "choice"}:
                     walk_group(
                         child,
@@ -395,6 +431,17 @@ def child_rules_for_complex_type(
                     optional_by_choice=optional_by_choice or group_min == 0,
                     max_multiplier=effective_max,
                 )
+            elif child_kind == "any":
+                child_order = fixed_order
+                if child_order is None and ordered and group_ordered:
+                    child_order = next_order
+                    next_order += 1
+                add_wildcard(
+                    child,
+                    order=child_order,
+                    optional_by_choice=optional_by_choice or group_min == 0,
+                    max_multiplier=effective_max,
+                )
             elif child_kind in {"sequence", "all", "choice"}:
                 walk_group(
                     child,
@@ -405,7 +452,7 @@ def child_rules_for_complex_type(
                 )
 
     walk_group(particle, ordered=local_name(particle.tag) == "sequence")
-    return rules, requirements
+    return rules, wildcard_rules, requirements
 
 
 def issue(
@@ -688,6 +735,31 @@ def element_namespace(tag: str) -> str | None:
     return tag[1:].split("}", 1)[0]
 
 
+def wildcard_matches_namespace(namespace_rule: str, namespace: str | None) -> bool:
+    tokens = namespace_rule.split()
+    if "##any" in tokens:
+        return True
+    if "##local" in tokens and namespace is None:
+        return True
+    if "##targetNamespace" in tokens and namespace == SML_NAMESPACE:
+        return True
+    if "##other" in tokens and namespace not in {None, SML_NAMESPACE}:
+        return True
+    return namespace in tokens
+
+
+def wildcard_namespace_description(namespace_rule: str) -> str:
+    if namespace_rule == "##any":
+        return "any namespace"
+    if namespace_rule == "##local":
+        return "the local namespace"
+    if namespace_rule == "##targetNamespace":
+        return f"the target namespace {SML_NAMESPACE}"
+    if namespace_rule == "##other":
+        return "a namespace other than the SXSD target namespace"
+    return f"namespace {namespace_rule}"
+
+
 def validate_element_children(
     element: ET.Element,
     path: str,
@@ -696,8 +768,10 @@ def validate_element_children(
 ) -> tuple[list[dict[str, Any]], dict[int, ElementRule]]:
     tag = local_name(element.tag)
     complex_type = complex_type_for_element(element_rule, model)
-    child_rules, choice_requirements = (
-        child_rules_for_complex_type(complex_type) if complex_type is not None else ([], [])
+    child_rules, wildcard_rules, choice_requirements = (
+        child_rules_for_complex_type(complex_type)
+        if complex_type is not None
+        else ([], [], [])
     )
     rules_by_name: dict[str, list[ChildRule]] = {}
     for child_rule in child_rules:
@@ -706,24 +780,76 @@ def validate_element_children(
     issues: list[dict[str, Any]] = []
     matched: dict[int, ElementRule] = {}
     counts: dict[str, int] = {}
+    wildcard_counts: dict[int, int] = {}
     latest_order = -1
     for child in element:
         child_name = local_name(child.tag)
         child_path = f"{path}/{child_name}"
         candidates = rules_by_name.get(child_name, [])
-        if not candidates:
+        wildcard_match = next(
+            (
+                (index, wildcard_rule)
+                for index, wildcard_rule in enumerate(wildcard_rules)
+                if wildcard_matches_namespace(
+                    wildcard_rule.namespace,
+                    element_namespace(child.tag),
+                )
+            ),
+            None,
+        )
+        if not candidates and wildcard_match is None:
+            expected_children = sorted(rules_by_name)
+            expected_children.extend(
+                wildcard_namespace_description(rule.namespace) for rule in wildcard_rules
+            )
             issues.append(
                 issue(
                     "sxsd_unexpected_child",
                     child_path,
                     child_name,
                     attr=None,
-                    expected="one of: " + ", ".join(sorted(rules_by_name)) if rules_by_name else "no child elements",
+                    expected="one of: " + ", ".join(expected_children)
+                    if expected_children
+                    else "no child elements",
                     actual=child_name,
                     message=f"unexpected SXSD child <{child_name}> under <{tag}> at {child_path}",
                     hint=f"Move or remove <{child_name}> so <{tag}> follows the SXSD child structure.",
                 )
             )
+            continue
+
+        if not candidates and wildcard_match is not None:
+            wildcard_index, wildcard_rule = wildcard_match
+            if wildcard_rule.order is not None:
+                if wildcard_rule.order < latest_order:
+                    issues.append(
+                        issue(
+                            "sxsd_invalid_child_order",
+                            child_path,
+                            child_name,
+                            attr=None,
+                            expected="children in xs:sequence order",
+                            actual=child_name,
+                            message=f"SXSD child <{child_name}> is out of order under <{tag}> at {child_path}",
+                            hint=f"Reorder <{child_name}> according to the SXSD sequence for <{tag}>.",
+                        )
+                    )
+                latest_order = max(latest_order, wildcard_rule.order)
+            wildcard_counts[wildcard_index] = wildcard_counts.get(wildcard_index, 0) + 1
+            actual_count = wildcard_counts[wildcard_index]
+            if wildcard_rule.max_occurs is not None and actual_count > wildcard_rule.max_occurs:
+                issues.append(
+                    issue(
+                        "sxsd_too_many_children",
+                        child_path,
+                        child_name,
+                        attr=None,
+                        expected=f"at most {wildcard_rule.max_occurs} child from {wildcard_namespace_description(wildcard_rule.namespace)}",
+                        actual=actual_count,
+                        message=f"too many wildcard SXSD children under <{tag}> at {path}",
+                        hint=f"Keep at most {wildcard_rule.max_occurs} child from {wildcard_namespace_description(wildcard_rule.namespace)} under <{tag}>.",
+                    )
+                )
             continue
 
         child_rule = candidates[0]
@@ -774,6 +900,24 @@ def validate_element_children(
                 actual=actual_count,
                 message=f"missing required SXSD child <{child_name}> under <{tag}> at {path}",
                 hint=f"Add at least {child_rule.min_occurs} <{child_name}> child under <{tag}>.",
+            )
+        )
+
+    for wildcard_index, wildcard_rule in enumerate(wildcard_rules):
+        actual_count = wildcard_counts.get(wildcard_index, 0)
+        if wildcard_rule.min_occurs <= actual_count:
+            continue
+        namespace_description = wildcard_namespace_description(wildcard_rule.namespace)
+        issues.append(
+            issue(
+                "sxsd_missing_required_child",
+                path,
+                tag,
+                attr=None,
+                expected=f"at least {wildcard_rule.min_occurs} child from {namespace_description}",
+                actual=actual_count,
+                message=f"missing required wildcard SXSD child under <{tag}> at {path}",
+                hint=f"Add at least {wildcard_rule.min_occurs} child from {namespace_description} under <{tag}>.",
             )
         )
 

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -348,7 +348,7 @@ def build_sxsd_tag_hint(tag_name: str, supported_tags: set[str]) -> str:
     if alias:
         return f"Use {alias} instead of <{tag_name}>."
     if tag_name == "svg":
-        return 'Inside <whiteboard>, write SVG as <svg xmlns="http://www.w3.org/2000/svg">...</svg>.'
+        return 'Inside <embed> or <whiteboard>, write SVG as <svg xmlns="http://www.w3.org/2000/svg">...</svg>.'
     close_matches = get_close_matches(tag_name, sorted(supported_tags), n=3, cutoff=0.72)
     if close_matches:
         return "Unsupported SXSD tag. Did you mean " + ", ".join(f"<{match}>" for match in close_matches) + "?"
@@ -375,7 +375,7 @@ def build_sxsd_attr_hint(tag_name: str, attr_name: str, allowed_attrs: set[str])
 
 
 def should_skip_sxsd_subtree(element: ET.Element, ancestors: list[str]) -> bool:
-    return "whiteboard" in ancestors and xml_namespace(element.tag) == SVG_NS
+    return ("whiteboard" in ancestors or "embed" in ancestors) and xml_namespace(element.tag) == SVG_NS
 
 
 def should_skip_sxsd_attribute(tag_name: str, attr_name: str) -> bool:
@@ -532,6 +532,53 @@ def _validate_sxsd_schema_constraints(xml: str, root: ET.Element) -> list[dict[s
             SXSD_SCHEMA_PATH,
         )
     )
+    issues.extend(validate_embed_svg_roots(root))
+    return issues
+
+
+def validate_embed_svg_roots(root: ET.Element) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    document_namespace = sxsd_validator.element_namespace(root.tag)
+    is_bare_slide_fragment = (
+        xml_local_name(root.tag) == "slide" and document_namespace is None
+    )
+    if (
+        document_namespace not in sxsd_validator.ACCEPTED_SML_NAMESPACES
+        and not is_bare_slide_fragment
+    ):
+        return issues
+
+    def visit(element: ET.Element, ancestors: list[str], parent_path: str) -> None:
+        if should_skip_sxsd_subtree(element, ancestors):
+            return
+
+        tag_name = xml_local_name(element.tag)
+        path = f"{parent_path}/{tag_name}" if parent_path else tag_name
+        if (
+            tag_name == "embed"
+            and sxsd_validator.element_namespace(element.tag) == document_namespace
+        ):
+            for child in element:
+                if xml_namespace(child.tag) != SVG_NS or xml_local_name(child.tag) == "svg":
+                    continue
+                child_name = xml_local_name(child.tag)
+                child_path = f"{path}/{child_name}"
+                issues.append(
+                    {
+                        "level": "error",
+                        "code": "sxsd_unexpected_child",
+                        "path": child_path,
+                        "tag": child_name,
+                        "expected": '<svg xmlns="http://www.w3.org/2000/svg">',
+                        "actual": child_name,
+                        "message": f"embedded SVG content must use an <svg> root at {child_path}",
+                        "hint": 'Wrap the SVG content in <svg xmlns="http://www.w3.org/2000/svg">...</svg>.',
+                    }
+                )
+        for child in element:
+            visit(child, [*ancestors, tag_name], path)
+
+    visit(root, [], "")
     return issues
 
 
@@ -577,8 +624,11 @@ def validate_iconpark_icon_types(root: ET.Element) -> list[dict[str, Any]]:
             }
         )
 
-    def visit(element: ET.Element, path: str) -> None:
+    def visit(element: ET.Element, ancestors: list[str], path: str) -> None:
         nonlocal supported_icon_types
+        if should_skip_sxsd_subtree(element, ancestors):
+            return
+
         tag_name = xml_local_name(element.tag)
         current_path = f"{path}/{tag_name}" if path else tag_name
         if tag_name == "icon":
@@ -618,9 +668,9 @@ def validate_iconpark_icon_types(root: ET.Element) -> list[dict[str, Any]]:
                     }
                 )
         for child in element:
-            visit(child, current_path)
+            visit(child, [*ancestors, tag_name], current_path)
 
-    visit(root, "")
+    visit(root, [], "")
     return issues
 
 
@@ -773,7 +823,7 @@ def parse_presentation(root: ET.Element) -> dict[str, Any]:
 def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
     elements: list[dict[str, Any]] = []
 
-    for match in re.finditer(r"<(shape|img|table|chart|whiteboard)\b([^>]*)>", slide_xml):
+    for match in re.finditer(r"<(shape|img|table|chart|whiteboard|embed)\b([^>]*)>", slide_xml):
         kind, attrs = match.group(1), match.group(2)
         is_self_closing = attrs.rstrip().endswith("/")
         content = ""
@@ -2074,7 +2124,7 @@ def slide_content_visual_bbox(
         # a straight horizontal/vertical line has zero width or height in one axis; clipped_bbox
         # treats zero-area rects as invisible, so pad to its rendered stroke thickness instead.
         return clipped_bbox(line_stroke_bbox(element), slide_bbox)
-    if element["kind"] in {"img", "chart", "table", "whiteboard", "icon", "polyline"}:
+    if element["kind"] in {"img", "chart", "table", "whiteboard", "embed", "icon", "polyline"}:
         return clipped_bbox(element, slide_bbox)
     return None
 
@@ -2112,7 +2162,7 @@ def is_slide_content_present(
 
 
 def is_large_visual_child(element: dict[str, Any], container: dict[str, Any]) -> bool:
-    if element["kind"] not in {"img", "chart", "table", "whiteboard"}:
+    if element["kind"] not in {"img", "chart", "table", "whiteboard", "embed"}:
         return False
     if not is_visually_rendered(element):
         return False

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -525,6 +525,118 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             [issue["code"] for issue in result["slides"][1]["errors"]],
         )
 
+    def test_lint_xml_allows_svg_subtree_inside_embed(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <embed topLeftX="80" topLeftY="120" width="240" height="140">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 140">
+                    <rect x="10" y="10" width="220" height="120" rx="12" fill="#EFF6FF"/>
+                    <circle cx="70" cy="70" r="34" fill="#2563EB"/>
+                    <text x="130" y="76" font-size="18" fill="#1E3A8A">SVG OK</text>
+                    <foreignObject x="0" y="0" width="1" height="1">
+                      <embed xmlns="http://www.w3.org/1999/xhtml">
+                        <rect xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>
+                      </embed>
+                    </foreignObject>
+                  </svg>
+                </embed>
+              </data>
+            </slide>
+            """
+        )
+        codes = [issue["code"] for issue in result["slides"][0]["issues"]]
+        self.assertNotIn("sxsd_unsupported_tag", codes)
+        self.assertNotIn("sxsd_unsupported_attr", codes)
+        self.assertEqual(result["summary"]["error_count"], 0)
+
+    def test_lint_xml_enforces_embed_svg_contract(self) -> None:
+        cases = [
+            ("missing SVG", "", "sxsd_missing_required_child"),
+            ("wrong namespace", '<svg viewBox="0 0 20 20"/>', "sxsd_unsupported_tag"),
+            (
+                "multiple SVG roots",
+                '<svg xmlns="http://www.w3.org/2000/svg"/><svg xmlns="http://www.w3.org/2000/svg"/>',
+                "sxsd_too_many_children",
+            ),
+            (
+                "non-SVG root element",
+                '<rect xmlns="http://www.w3.org/2000/svg" width="20" height="20"/>',
+                "sxsd_unexpected_child",
+            ),
+            (
+                "SVG after reflection",
+                '<reflection/><svg xmlns="http://www.w3.org/2000/svg"/>',
+                "sxsd_invalid_child_order",
+            ),
+        ]
+        for name, children, expected_code in cases:
+            with self.subTest(name=name):
+                result = xml_text_overlap_lint.lint_xml(
+                    f"""
+                    <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                      <data>
+                        <embed topLeftX="80" topLeftY="120" width="240" height="140">
+                          {children}
+                        </embed>
+                      </data>
+                    </slide>
+                    """
+                )
+                codes = [issue["code"] for issue in result["slides"][0]["issues"]]
+                self.assertIn(expected_code, codes)
+
+    def test_lint_xml_enforces_embed_svg_root_for_readback_namespaces(self) -> None:
+        document_templates = [
+            ("bare slide", "<slide>{content}</slide>"),
+            (
+                "short namespace",
+                '<presentation xmlns="/sml/2.0" width="960" height="540">'
+                "<slide>{content}</slide>"
+                "</presentation>",
+            ),
+            (
+                "HTTPS namespace",
+                '<presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">'
+                "<slide>{content}</slide>"
+                "</presentation>",
+            ),
+        ]
+        embed_template = """
+            <data>
+              <embed topLeftX="80" topLeftY="120" width="240" height="140">
+                {svg_root}
+              </embed>
+            </data>
+        """
+        roots = [
+            ("valid SVG root", '<svg xmlns="http://www.w3.org/2000/svg"/>', False),
+            (
+                "non-SVG root element",
+                '<rect xmlns="http://www.w3.org/2000/svg" width="20" height="20"/>',
+                True,
+            ),
+        ]
+
+        for document_name, document_template in document_templates:
+            for root_name, svg_root, should_error in roots:
+                with self.subTest(document=document_name, root=root_name):
+                    content = embed_template.format(svg_root=svg_root)
+                    result = xml_text_overlap_lint.lint_xml(
+                        document_template.format(content=content)
+                    )
+                    codes = [
+                        issue["code"]
+                        for slide in result["slides"]
+                        for issue in slide["issues"]
+                    ]
+                    if should_error:
+                        self.assertIn("sxsd_unexpected_child", codes)
+                    else:
+                        self.assertNotIn("sxsd_unexpected_child", codes)
+                        self.assertEqual(result["summary"]["error_count"], 0)
+
     def test_lint_xml_reports_sxsd_unsupported_tag_with_alias_hint(self) -> None:
         cases = [
             ("textbox", '<textbox topLeftX="80" topLeftY="80" width="300" height="60">Text</textbox>', '<shape type="text">'),
@@ -928,6 +1040,29 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(issue["iconType"], "iconpark/Base/settng.svg")
         self.assertIn("iconpark-index.json", issue["hint"])
         self.assertIn("iconpark/Base/setting.svg", issue["hint"])
+
+    def test_lint_xml_skips_iconpark_validation_inside_embedded_svg(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <embed topLeftX="80" topLeftY="120" width="240" height="140">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 140">
+                    <rect x="10" y="10" width="220" height="120" fill="#EFF6FF"/>
+                    <icon iconType="not-an-iconpark-name"/>
+                    <foreignObject x="0" y="0" width="60" height="60">
+                      <icon xmlns="http://www.w3.org/1999/xhtml" iconType="not-an-iconpark-name"/>
+                    </foreignObject>
+                  </svg>
+                </embed>
+              </data>
+            </slide>
+            """
+        )
+        codes = [issue["code"] for issue in result["document"]["errors"]]
+        self.assertNotIn("iconpark_unsupported_icon_type", codes)
+        self.assertNotIn("icon_missing_fill_color", codes)
+        self.assertEqual(result["summary"]["error_count"], 0)
 
     def test_lint_xml_detects_overlapping_text_boxes(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
@@ -1745,6 +1880,9 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
                 <table id="table" topLeftX="400" topLeftY="60" width="220" height="120"></table>
                 <chart id="chart" topLeftX="640" topLeftY="60" width="220" height="120"/>
                 <whiteboard id="wb" topLeftX="80" topLeftY="220" width="760" height="240"/>
+                <embed id="emb" topLeftX="600" topLeftY="320" width="240" height="140">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 140"><rect x="0" y="0" width="240" height="140"/></svg>
+                </embed>
                 <shape id="missing-height" type="text" topLeftX="80" topLeftY="480" width="320">
                   <content><p>Skipped</p></content>
                 </shape>
@@ -1752,9 +1890,9 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             </slide>
             """
         )
-        self.assertEqual([element["id"] for element in elements], ["photo", "headline", "table", "chart", "wb"])
-        self.assertEqual([element["kind"] for element in elements], ["img", "shape", "table", "chart", "whiteboard"])
-        self.assertEqual([element["order"] for element in elements], [0, 1, 2, 3, 4])
+        self.assertEqual([element["id"] for element in elements], ["photo", "headline", "table", "chart", "wb", "emb"])
+        self.assertEqual([element["kind"] for element in elements], ["img", "shape", "table", "chart", "whiteboard", "embed"])
+        self.assertEqual([element["order"] for element in elements], [0, 1, 2, 3, 4, 5])
         self.assertEqual(elements[1]["type"], "text")
         self.assertEqual(elements[1]["textType"], "headline")
         self.assertEqual(elements[1]["textAlign"], "center")
@@ -3002,6 +3140,25 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
         )
 
         self.assertEqual(result["slides"][0]["issues"], [])
+
+    def test_lint_xml_does_not_report_blank_slide_for_embed_only_content(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <embed id="emb" topLeftX="280" topLeftY="130" width="400" height="280">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 280">
+                    <circle cx="200" cy="140" r="100" fill="#2563EB"/>
+                  </svg>
+                </embed>
+              </data>
+            </slide>
+            """
+        )
+
+        self.assertEqual(result["summary"]["error_count"], 0)
+        codes = [issue["code"] for issue in result["slides"][0]["issues"]]
+        self.assertNotIn("blank_slide", codes)
 
     def test_lint_xml_does_not_report_blank_slide_for_line_only_content(self) -> None:
         result = xml_text_overlap_lint.lint_xml(


### PR DESCRIPTION
## Summary

Add embedded SVG content to the bundled Slides SML 2.0 schema, so a presentation can carry vector graphics inline via a new `<embed>` element alongside native shapes and text.

## Changes

- Register `<embed>` in the Slides XML schema and document its layout, visual effects, SVG namespace, and child ordering contract.
- Teach the schema validator to honor `xs:any` namespace, occurrence, and sequence constraints, while requiring embedded SVG content to use an `<svg>` root.
- Allow SVG subtrees inside `<embed>` and include embedded content in element extraction, blank-slide detection, and layout-density checks.
- Keep embedded SVG payloads out of IconPark validation, so an `<icon>` that only shares a local name with the SML element is no longer misreported.
- Add regression coverage for valid SVG, missing/wrong/multiple roots, invalid ordering, geometry extraction, embed-only slides, and `<icon>` inside an SVG payload.

## Test Plan

- [x] `python3 skills/lark-slides/scripts/xml_text_overlap_lint_test.py` (188 tests)
- [x] `make unit-test`
- [x] `make script-test`
- [x] `go vet ./...`
- [x] `gofmt -l .` produces no output
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `golangci-lint v2.1.6 run --new-from-rev=origin/main` reports 0 issues
- [x] The embedded SVG example validates against `slides_xml_schema_definition.xml` with `xmllint`
- [ ] Manual `lark-cli` API verification — not applicable; this change updates the bundled schema and local lint only.

## Related Issues

- Supersedes closed PR #2090.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for embedding SVG graphics in slides.
  - Embedded graphics support positioning, sizing, rotation, flipping, transparency, reflection, and shadow effects.

- **Documentation**
  - Added schema reference documentation and examples for SVG embedding.

- **Bug Fixes**
  - Improved validation and slide analysis for embedded SVG content.
  - Embedded graphics are recognized as visual content, including on SVG-only slides.
  - Added clearer validation for invalid SVG roots, namespaces, child elements, and ordering.
  - Improved handling of supported extensible slide elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
