### PR TITLE
fix(slides): add agent-friendly aliases for screenshot flags

### DIFF
--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -287,6 +287,10 @@ func slidesScreenshotSelectors(runtime *common.RuntimeContext) ([]string, []int,
 	slideIDs := normalizeSlideIDs(slideIDValues)
 	if len(slideIDs) > 0 && len(slideNumbers) > 0 {
 		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slide-id and --slide-number cannot be used together").
+			WithParams(
+				errs.InvalidParam{Name: "--slide-id", Reason: "mutually exclusive with --slide-number"},
+				errs.InvalidParam{Name: "--slide-number", Reason: "mutually exclusive with --slide-id"},
+			).
 			WithHint("choose either slide IDs or slide numbers for one screenshot request")
 	}
 	return slideIDs, slideNumbers, nil

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -30,8 +30,7 @@ const (
 
 var (
 	unsafeScreenshotFileCharRegex = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
-	slideNumberAliasRegex         = regexp.MustCompile(`^[1-9][0-9]*$`)
-	slideIDAliasRegex             = regexp.MustCompile(`^p[A-Za-z]{2,}$`)
+	slideNumberAliasRegex         = regexp.MustCompile(`^[0-9]+$`)
 )
 
 // SlidesScreenshot fetches server-rendered slide screenshots and writes them to
@@ -48,12 +47,8 @@ var SlidesScreenshot = common.Shortcut{
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
 		listModePresentationRefFlag(),
-		{Name: "slide-id", Type: "string_slice", Desc: "slide page identifier (repeat or comma-separated for multiple slides; max 10 pages per request)"},
-		{Name: "slide-number", Type: "int_array", Desc: "slide page number (repeat for multiple slides; max 10 pages per request)"},
-		{Name: "presentation-id", Desc: "hidden alias for --presentation", Hidden: true},
-		{Name: "slide-ids", Type: "string_slice", Desc: "hidden alias for --slide-id", Hidden: true},
-		{Name: "slides", Type: "string_slice", Desc: "hidden alias for --slide-id", Hidden: true},
-		{Name: "slide-numbers", Type: "int_array", Desc: "hidden alias for --slide-number", Hidden: true},
+		{Name: "slide-id", Aliases: []string{"slide-ids", "slides"}, Type: "string_slice", Desc: "slide page identifier (repeat or comma-separated for multiple slides; max 10 pages per request)"},
+		{Name: "slide-number", Aliases: []string{"slide-numbers"}, Type: "int_array", Desc: "slide page number (repeat for multiple slides; max 10 pages per request)"},
 		{Name: "slide", Desc: "hidden alias routed to --slide-number for digits, otherwise --slide-id", Hidden: true},
 		{Name: "content", Desc: "slide XML content to render directly instead of fetching existing slides", Input: []string{common.File, common.Stdin}},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
@@ -61,21 +56,21 @@ var SlidesScreenshot = common.Shortcut{
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		renderMode := runtime.Changed("content")
-		slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
-		if err != nil {
-			return err
-		}
 		if renderMode {
 			if strings.TrimSpace(runtime.Str("content")) == "" {
 				return slidesScreenshotFlagErrorf("--content cannot be empty")
 			}
-			if len(slideIDs) > 0 || len(slideNumbers) > 0 {
+			if slidesScreenshotHasSelectorInput(runtime) {
 				return slidesScreenshotFlagErrorf("--content cannot be used with --slide-id or --slide-number")
 			}
-			if runtime.Changed("presentation") || runtime.Changed("presentation-id") {
+			if runtime.Changed("presentation") {
 				return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
 			}
 		} else {
+			slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
+			if err != nil {
+				return err
+			}
 			ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
 			if err != nil {
 				return err
@@ -205,14 +200,10 @@ func dryRunRenderScreenshot(runtime *common.RuntimeContext) *common.DryRunAPI {
 	if strings.TrimSpace(content) == "" {
 		return common.NewDryRunAPI().Set("error", "--content cannot be empty")
 	}
-	slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
-	if err != nil {
-		return common.NewDryRunAPI().Set("error", err.Error())
-	}
-	if len(slideIDs) > 0 || len(slideNumbers) > 0 {
+	if slidesScreenshotHasSelectorInput(runtime) {
 		return common.NewDryRunAPI().Set("error", "--content cannot be used with --slide-id or --slide-number")
 	}
-	if runtime.Changed("presentation") || runtime.Changed("presentation-id") {
+	if runtime.Changed("presentation") {
 		return common.NewDryRunAPI().Set("error", "--presentation cannot be used with --content")
 	}
 	dry := common.NewDryRunAPI().Desc("Render slide XML content to a screenshot file")
@@ -228,14 +219,10 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 	if strings.TrimSpace(content) == "" {
 		return slidesScreenshotFlagErrorf("--content cannot be empty")
 	}
-	slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
-	if err != nil {
-		return err
-	}
-	if len(slideIDs) > 0 || len(slideNumbers) > 0 {
+	if slidesScreenshotHasSelectorInput(runtime) {
 		return slidesScreenshotFlagErrorf("--content cannot be used with --slide-id or --slide-number")
 	}
-	if runtime.Changed("presentation") || runtime.Changed("presentation-id") {
+	if runtime.Changed("presentation") {
 		return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
 	}
 	outputDir := runtime.Str("output-dir")
@@ -262,53 +249,51 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 }
 
 func slidesScreenshotPresentation(runtime *common.RuntimeContext) string {
-	if runtime.Changed("presentation") {
-		return runtime.Str("presentation")
-	}
-	return runtime.Str("presentation-id")
+	return runtime.Str("presentation")
 }
 
 func slidesScreenshotSelectors(runtime *common.RuntimeContext) ([]string, []int, error) {
 	aliasSlide := strings.TrimSpace(runtime.Str("slide"))
 	aliasSlideIsNumber := runtime.Changed("slide") && slideNumberAliasRegex.MatchString(aliasSlide)
-	aliasSlideIsID := runtime.Changed("slide") && slideIDAliasRegex.MatchString(aliasSlide)
-	if runtime.Changed("slide") && !aliasSlideIsNumber && !aliasSlideIsID {
+	aliasSlideIsID := runtime.Changed("slide") && aliasSlide != "" && !aliasSlideIsNumber
+	if runtime.Changed("slide") && aliasSlide == "" {
 		return nil, nil, errs.NewValidationError(
 			errs.SubtypeInvalidArgument,
-			"--slide must be a positive page number or a slide ID matching p[A-Za-z]{2,}",
+			"--slide cannot be empty",
 		).WithParam("--slide").WithHint("use --slide-number or --slide-id to specify the selector type explicitly")
 	}
 
-	var slideIDValues []string
-	if runtime.Changed("slide-id") {
-		slideIDValues = runtime.StrSlice("slide-id")
-	} else {
-		slideIDValues = append(slideIDValues, runtime.StrSlice("slide-ids")...)
-		slideIDValues = append(slideIDValues, runtime.StrSlice("slides")...)
-		if aliasSlideIsID {
-			slideIDValues = append(slideIDValues, aliasSlide)
-		}
+	slideIDValues := append([]string(nil), runtime.StrSlice("slide-id")...)
+	if aliasSlideIsID {
+		slideIDValues = append(slideIDValues, aliasSlide)
 	}
 
-	var slideNumberValues []int
-	if runtime.Changed("slide-number") {
-		slideNumberValues = runtime.IntArray("slide-number")
-	} else {
-		slideNumberValues = append(slideNumberValues, runtime.IntArray("slide-numbers")...)
-		if aliasSlideIsNumber {
-			n, err := strconv.Atoi(aliasSlide)
-			if err != nil {
-				return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slide must be a valid page number or slide ID").WithParam("--slide")
-			}
-			slideNumberValues = append(slideNumberValues, n)
+	slideNumberValues := append([]int(nil), runtime.IntArray("slide-number")...)
+	if aliasSlideIsNumber {
+		n, err := strconv.Atoi(aliasSlide)
+		if err != nil {
+			return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slide page number is outside the supported integer range").WithParam("--slide")
 		}
+		if n < 1 {
+			return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slide must be a positive page number").WithParam("--slide")
+		}
+		slideNumberValues = append(slideNumberValues, n)
 	}
 
 	slideNumbers, err := normalizeSlideNumbers(slideNumberValues)
 	if err != nil {
 		return nil, nil, err
 	}
-	return normalizeSlideIDs(slideIDValues), slideNumbers, nil
+	slideIDs := normalizeSlideIDs(slideIDValues)
+	if len(slideIDs) > 0 && len(slideNumbers) > 0 {
+		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slide-id and --slide-number cannot be used together").
+			WithHint("choose either slide IDs or slide numbers for one screenshot request")
+	}
+	return slideIDs, slideNumbers, nil
+}
+
+func slidesScreenshotHasSelectorInput(runtime *common.RuntimeContext) bool {
+	return runtime.Changed("slide-id") || runtime.Changed("slide-number") || runtime.Changed("slide")
 }
 
 func normalizeSlideIDs(values []string) []string {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -61,7 +61,7 @@ var SlidesScreenshot = common.Shortcut{
 				return slidesScreenshotFlagErrorf("--content cannot be empty")
 			}
 			if slidesScreenshotHasSelectorInput(runtime) {
-				return slidesScreenshotFlagErrorf("--content cannot be used with --slide-id or --slide-number")
+				return slidesScreenshotContentSelectorConflictError(runtime)
 			}
 			if runtime.Changed("presentation") {
 				return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
@@ -201,7 +201,7 @@ func dryRunRenderScreenshot(runtime *common.RuntimeContext) *common.DryRunAPI {
 		return common.NewDryRunAPI().Set("error", "--content cannot be empty")
 	}
 	if slidesScreenshotHasSelectorInput(runtime) {
-		return common.NewDryRunAPI().Set("error", "--content cannot be used with --slide-id or --slide-number")
+		return common.NewDryRunAPI().Set("error", "--content cannot be used with slide selectors")
 	}
 	if runtime.Changed("presentation") {
 		return common.NewDryRunAPI().Set("error", "--presentation cannot be used with --content")
@@ -220,7 +220,7 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 		return slidesScreenshotFlagErrorf("--content cannot be empty")
 	}
 	if slidesScreenshotHasSelectorInput(runtime) {
-		return slidesScreenshotFlagErrorf("--content cannot be used with --slide-id or --slide-number")
+		return slidesScreenshotContentSelectorConflictError(runtime)
 	}
 	if runtime.Changed("presentation") {
 		return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
@@ -286,21 +286,52 @@ func slidesScreenshotSelectors(runtime *common.RuntimeContext) ([]string, []int,
 	}
 	slideIDs := normalizeSlideIDs(slideIDValues)
 	if len(slideIDs) > 0 && len(slideNumbers) > 0 {
-		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slide-id and --slide-number cannot be used together").
-			WithParams(
-				errs.InvalidParam{Name: "--slide-id", Reason: "mutually exclusive with --slide-number"},
-				errs.InvalidParam{Name: "--slide-number", Reason: "mutually exclusive with --slide-id"},
-			).
+		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "slide ID selectors and slide number selectors cannot be used together").
+			WithParams(slidesScreenshotSelectorConflictParams(runtime, aliasSlideIsID, aliasSlideIsNumber)...).
 			WithHint("choose either slide IDs or slide numbers for one screenshot request")
 	}
 	return slideIDs, slideNumbers, nil
 }
 
 func slidesScreenshotHasSelectorInput(runtime *common.RuntimeContext) bool {
-	if runtime.Changed("slide-number") || runtime.Changed("slide") {
-		return true
+	return len(slidesScreenshotSelectorInputParams(runtime, "")) > 0
+}
+
+func slidesScreenshotSelectorConflictParams(runtime *common.RuntimeContext, aliasSlideIsID, aliasSlideIsNumber bool) []errs.InvalidParam {
+	params := make([]errs.InvalidParam, 0, 3)
+	if len(normalizeSlideIDs(runtime.StrSlice("slide-id"))) > 0 {
+		params = append(params, errs.InvalidParam{Name: "--slide-id", Reason: "selects by slide ID; cannot be combined with slide-number selectors"})
 	}
-	return len(normalizeSlideIDs(runtime.StrSlice("slide-id"))) > 0
+	if aliasSlideIsID {
+		params = append(params, errs.InvalidParam{Name: "--slide", Reason: "selects by slide ID; cannot be combined with slide-number selectors"})
+	}
+	if runtime.Changed("slide-number") {
+		params = append(params, errs.InvalidParam{Name: "--slide-number", Reason: "selects by slide number; cannot be combined with slide-ID selectors"})
+	}
+	if aliasSlideIsNumber {
+		params = append(params, errs.InvalidParam{Name: "--slide", Reason: "selects by slide number; cannot be combined with slide-ID selectors"})
+	}
+	return params
+}
+
+func slidesScreenshotSelectorInputParams(runtime *common.RuntimeContext, reason string) []errs.InvalidParam {
+	params := make([]errs.InvalidParam, 0, 3)
+	if len(normalizeSlideIDs(runtime.StrSlice("slide-id"))) > 0 {
+		params = append(params, errs.InvalidParam{Name: "--slide-id", Reason: reason})
+	}
+	if runtime.Changed("slide-number") {
+		params = append(params, errs.InvalidParam{Name: "--slide-number", Reason: reason})
+	}
+	if runtime.Changed("slide") {
+		params = append(params, errs.InvalidParam{Name: "--slide", Reason: reason})
+	}
+	return params
+}
+
+func slidesScreenshotContentSelectorConflictError(runtime *common.RuntimeContext) error {
+	params := []errs.InvalidParam{{Name: "--content", Reason: "cannot be combined with slide selectors"}}
+	params = append(params, slidesScreenshotSelectorInputParams(runtime, "cannot be combined with --content")...)
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, "--content cannot be used with slide selectors").WithParams(params...)
 }
 
 func normalizeSlideIDs(values []string) []string {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -27,7 +28,11 @@ const (
 	maxSlidesPerScreenshot     = 10
 )
 
-var unsafeScreenshotFileCharRegex = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+var (
+	unsafeScreenshotFileCharRegex = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+	slideNumberAliasRegex         = regexp.MustCompile(`^[1-9][0-9]*$`)
+	slideIDAliasRegex             = regexp.MustCompile(`^p[A-Za-z]{2,}$`)
+)
 
 // SlidesScreenshot fetches server-rendered slide screenshots and writes them to
 // local files. The raw API returns Base64 image payloads; this shortcut keeps
@@ -45,24 +50,33 @@ var SlidesScreenshot = common.Shortcut{
 		listModePresentationRefFlag(),
 		{Name: "slide-id", Type: "string_slice", Desc: "slide page identifier (repeat or comma-separated for multiple slides; max 10 pages per request)"},
 		{Name: "slide-number", Type: "int_array", Desc: "slide page number (repeat for multiple slides; max 10 pages per request)"},
+		{Name: "presentation-id", Desc: "hidden alias for --presentation", Hidden: true},
+		{Name: "slide-ids", Type: "string_slice", Desc: "hidden alias for --slide-id", Hidden: true},
+		{Name: "slides", Type: "string_slice", Desc: "hidden alias for --slide-id", Hidden: true},
+		{Name: "slide-numbers", Type: "int_array", Desc: "hidden alias for --slide-number", Hidden: true},
+		{Name: "slide", Desc: "hidden alias routed to --slide-number for digits, otherwise --slide-id", Hidden: true},
 		{Name: "content", Desc: "slide XML content to render directly instead of fetching existing slides", Input: []string{common.File, common.Stdin}},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
 		{Name: "output-name", Desc: "file name stem for --content render output"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		renderMode := runtime.Changed("content")
+		slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
+		if err != nil {
+			return err
+		}
 		if renderMode {
 			if strings.TrimSpace(runtime.Str("content")) == "" {
 				return slidesScreenshotFlagErrorf("--content cannot be empty")
 			}
-			if len(normalizeSlideIDs(runtime.StrSlice("slide-id"))) > 0 || len(runtime.IntArray("slide-number")) > 0 {
+			if len(slideIDs) > 0 || len(slideNumbers) > 0 {
 				return slidesScreenshotFlagErrorf("--content cannot be used with --slide-id or --slide-number")
 			}
-			if runtime.Changed("presentation") {
+			if runtime.Changed("presentation") || runtime.Changed("presentation-id") {
 				return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
 			}
 		} else {
-			ref, err := parsePresentationRef(runtime.Str("presentation"))
+			ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
 			if err != nil {
 				return err
 			}
@@ -70,11 +84,6 @@ var SlidesScreenshot = common.Shortcut{
 				if err := runtime.EnsureScopes([]string{"wiki:node:read"}); err != nil {
 					return err
 				}
-			}
-			slideIDs := normalizeSlideIDs(runtime.StrSlice("slide-id"))
-			slideNumbers, err := normalizeSlideNumbers(runtime.IntArray("slide-number"))
-			if err != nil {
-				return err
 			}
 			if len(slideIDs) == 0 && len(slideNumbers) == 0 {
 				return slidesScreenshotFlagErrorf("--slide-id or --slide-number is required")
@@ -92,12 +101,11 @@ var SlidesScreenshot = common.Shortcut{
 		if runtime.Changed("content") {
 			return dryRunRenderScreenshot(runtime)
 		}
-		ref, err := parsePresentationRef(runtime.Str("presentation"))
+		ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
 		if err != nil {
 			return common.NewDryRunAPI().Set("error", err.Error())
 		}
-		slideIDs := normalizeSlideIDs(runtime.StrSlice("slide-id"))
-		slideNumbers, err := normalizeSlideNumbers(runtime.IntArray("slide-number"))
+		slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
 		if err != nil {
 			return common.NewDryRunAPI().Set("error", err.Error())
 		}
@@ -137,7 +145,7 @@ var SlidesScreenshot = common.Shortcut{
 		if runtime.Changed("content") {
 			return executeRenderScreenshot(runtime)
 		}
-		ref, err := parsePresentationRef(runtime.Str("presentation"))
+		ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
 		if err != nil {
 			return err
 		}
@@ -146,8 +154,7 @@ var SlidesScreenshot = common.Shortcut{
 			return err
 		}
 
-		slideIDs := normalizeSlideIDs(runtime.StrSlice("slide-id"))
-		slideNumbers, err := normalizeSlideNumbers(runtime.IntArray("slide-number"))
+		slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
 		if err != nil {
 			return err
 		}
@@ -198,10 +205,14 @@ func dryRunRenderScreenshot(runtime *common.RuntimeContext) *common.DryRunAPI {
 	if strings.TrimSpace(content) == "" {
 		return common.NewDryRunAPI().Set("error", "--content cannot be empty")
 	}
-	if len(normalizeSlideIDs(runtime.StrSlice("slide-id"))) > 0 || len(runtime.IntArray("slide-number")) > 0 {
+	slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
+	if err != nil {
+		return common.NewDryRunAPI().Set("error", err.Error())
+	}
+	if len(slideIDs) > 0 || len(slideNumbers) > 0 {
 		return common.NewDryRunAPI().Set("error", "--content cannot be used with --slide-id or --slide-number")
 	}
-	if runtime.Changed("presentation") {
+	if runtime.Changed("presentation") || runtime.Changed("presentation-id") {
 		return common.NewDryRunAPI().Set("error", "--presentation cannot be used with --content")
 	}
 	dry := common.NewDryRunAPI().Desc("Render slide XML content to a screenshot file")
@@ -217,10 +228,14 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 	if strings.TrimSpace(content) == "" {
 		return slidesScreenshotFlagErrorf("--content cannot be empty")
 	}
-	if len(normalizeSlideIDs(runtime.StrSlice("slide-id"))) > 0 || len(runtime.IntArray("slide-number")) > 0 {
+	slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
+	if err != nil {
+		return err
+	}
+	if len(slideIDs) > 0 || len(slideNumbers) > 0 {
 		return slidesScreenshotFlagErrorf("--content cannot be used with --slide-id or --slide-number")
 	}
-	if runtime.Changed("presentation") {
+	if runtime.Changed("presentation") || runtime.Changed("presentation-id") {
 		return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
 	}
 	outputDir := runtime.Str("output-dir")
@@ -244,6 +259,56 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 		"screenshots": saved,
 	}, nil)
 	return nil
+}
+
+func slidesScreenshotPresentation(runtime *common.RuntimeContext) string {
+	if runtime.Changed("presentation") {
+		return runtime.Str("presentation")
+	}
+	return runtime.Str("presentation-id")
+}
+
+func slidesScreenshotSelectors(runtime *common.RuntimeContext) ([]string, []int, error) {
+	aliasSlide := strings.TrimSpace(runtime.Str("slide"))
+	aliasSlideIsNumber := runtime.Changed("slide") && slideNumberAliasRegex.MatchString(aliasSlide)
+	aliasSlideIsID := runtime.Changed("slide") && slideIDAliasRegex.MatchString(aliasSlide)
+	if runtime.Changed("slide") && !aliasSlideIsNumber && !aliasSlideIsID {
+		return nil, nil, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--slide must be a positive page number or a slide ID matching p[A-Za-z]{2,}",
+		).WithParam("--slide").WithHint("use --slide-number or --slide-id to specify the selector type explicitly")
+	}
+
+	var slideIDValues []string
+	if runtime.Changed("slide-id") {
+		slideIDValues = runtime.StrSlice("slide-id")
+	} else {
+		slideIDValues = append(slideIDValues, runtime.StrSlice("slide-ids")...)
+		slideIDValues = append(slideIDValues, runtime.StrSlice("slides")...)
+		if aliasSlideIsID {
+			slideIDValues = append(slideIDValues, aliasSlide)
+		}
+	}
+
+	var slideNumberValues []int
+	if runtime.Changed("slide-number") {
+		slideNumberValues = runtime.IntArray("slide-number")
+	} else {
+		slideNumberValues = append(slideNumberValues, runtime.IntArray("slide-numbers")...)
+		if aliasSlideIsNumber {
+			n, err := strconv.Atoi(aliasSlide)
+			if err != nil {
+				return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slide must be a valid page number or slide ID").WithParam("--slide")
+			}
+			slideNumberValues = append(slideNumberValues, n)
+		}
+	}
+
+	slideNumbers, err := normalizeSlideNumbers(slideNumberValues)
+	if err != nil {
+		return nil, nil, err
+	}
+	return normalizeSlideIDs(slideIDValues), slideNumbers, nil
 }
 
 func normalizeSlideIDs(values []string) []string {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -67,11 +67,11 @@ var SlidesScreenshot = common.Shortcut{
 				return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
 			}
 		} else {
-			slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
+			ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
 			if err != nil {
 				return err
 			}
-			ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
+			slideIDs, slideNumbers, err := slidesScreenshotSelectors(runtime)
 			if err != nil {
 				return err
 			}
@@ -293,7 +293,10 @@ func slidesScreenshotSelectors(runtime *common.RuntimeContext) ([]string, []int,
 }
 
 func slidesScreenshotHasSelectorInput(runtime *common.RuntimeContext) bool {
-	return runtime.Changed("slide-id") || runtime.Changed("slide-number") || runtime.Changed("slide")
+	if runtime.Changed("slide-number") || runtime.Changed("slide") {
+		return true
+	}
+	return len(normalizeSlideIDs(runtime.StrSlice("slide-id"))) > 0
 }
 
 func normalizeSlideIDs(values []string) []string {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -154,8 +154,12 @@ func TestSlidesScreenshotSlideAliasRejectsAmbiguousValues(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected validation error")
 			}
-			if _, ok := errs.ProblemOf(err); !ok {
+			problem, ok := errs.ProblemOf(err)
+			if !ok {
 				t.Fatalf("error = %v, want typed validation error", err)
+			}
+			if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem = %s/%s, want %s/%s", problem.Category, problem.Subtype, errs.CategoryValidation, errs.SubtypeInvalidArgument)
 			}
 			var validationErr *errs.ValidationError
 			if !errors.As(err, &validationErr) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -53,6 +53,7 @@ func TestSlidesScreenshotCompatibilityAliases(t *testing.T) {
 		{name: "slides", args: []string{"--presentation", "pres_abc", "--slides", "s1,s2"}, wantIDs: []string{"s1", "s2"}},
 		{name: "slide-numbers", args: []string{"--presentation", "pres_abc", "--slide-numbers", "1,2"}, wantNumbers: []int{1, 2}},
 		{name: "slide-routes-id", args: []string{"--presentation", "pres_abc", "--slide", "pII"}, wantIDs: []string{"pII"}},
+		{name: "slide-routes-nonnumeric-id", args: []string{"--presentation", "pres_abc", "--slide", "sld_123"}, wantIDs: []string{"sld_123"}},
 		{name: "slide-routes-number", args: []string{"--presentation", "pres_abc", "--slide", "7"}, wantNumbers: []int{7}},
 	}
 
@@ -83,65 +84,101 @@ func TestSlidesScreenshotCompatibilityAliases(t *testing.T) {
 	}
 }
 
-func TestSlidesScreenshotCompatibilityAliasesAreHidden(t *testing.T) {
-	wantTypes := map[string]string{
-		"presentation-id": "",
-		"slide-ids":       "string_slice",
-		"slides":          "string_slice",
-		"slide-numbers":   "int_array",
-		"slide":           "",
+func TestSlidesScreenshotCompatibilityAliasesUseCanonicalFlags(t *testing.T) {
+	wantAliases := map[string][]string{
+		"presentation": {"presentation-id", "presentation-token", "token", "presentation_id", "xml-presentation-id", "url"},
+		"slide-id":     {"slide-ids", "slides"},
+		"slide-number": {"slide-numbers"},
 	}
 	for _, flag := range SlidesScreenshot.Flags {
-		wantType, ok := wantTypes[flag.Name]
+		want, ok := wantAliases[flag.Name]
 		if !ok {
+			if flag.Name == "presentation-id" || flag.Name == "slide-ids" || flag.Name == "slides" || flag.Name == "slide-numbers" {
+				t.Errorf("--%s registered independently, want a canonical flag alias", flag.Name)
+			}
 			continue
 		}
-		if !flag.Hidden {
-			t.Errorf("--%s Hidden = false, want true", flag.Name)
+		if !reflect.DeepEqual(flag.Aliases, want) {
+			t.Errorf("--%s aliases = %#v, want %#v", flag.Name, flag.Aliases, want)
 		}
-		if flag.Type != wantType {
-			t.Errorf("--%s Type = %q, want %q", flag.Name, flag.Type, wantType)
-		}
-		delete(wantTypes, flag.Name)
+		delete(wantAliases, flag.Name)
 	}
-	if len(wantTypes) != 0 {
-		t.Fatalf("missing compatibility flags: %#v", wantTypes)
+	if len(wantAliases) != 0 {
+		t.Fatalf("missing canonical alias declarations: %#v", wantAliases)
+	}
+	for _, flag := range SlidesScreenshot.Flags {
+		if flag.Name == "slide" && !flag.Hidden {
+			t.Fatal("--slide Hidden = false, want true")
+		}
 	}
 }
 
-func TestSlidesScreenshotCanonicalFlagsOverrideAliases(t *testing.T) {
+func TestSlidesScreenshotSameTypeSelectorsMergeAndDeduplicate(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantIDs     []string
+		wantNumbers []int
+	}{
+		{
+			name:    "ids",
+			args:    []string{"--slide-id", "canonical_id", "--slide-ids", "alias_id", "--slides", "canonical_id,alias_id_2", "--slide", "pII"},
+			wantIDs: []string{"canonical_id", "alias_id", "alias_id_2", "pII"},
+		},
+		{
+			name:        "numbers",
+			args:        []string{"--slide-number", "8", "--slide-numbers", "9,8", "--slide", "10"},
+			wantNumbers: []int{8, 9, 10},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			args := append([]string{"+screenshot", "--presentation", "pres_abc"}, tt.args...)
+			args = append(args, "--dry-run", "--as", "user")
+			if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := decodeSlidesScreenshotDryRunRequest(t, stdout)
+			if !reflect.DeepEqual(got.Body.SlideIDs, tt.wantIDs) {
+				t.Fatalf("slide_ids = %#v, want %#v", got.Body.SlideIDs, tt.wantIDs)
+			}
+			if !reflect.DeepEqual(got.Body.SlideNumbers, tt.wantNumbers) {
+				t.Fatalf("slide_numbers = %#v, want %#v", got.Body.SlideNumbers, tt.wantNumbers)
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotRejectsMixedSelectorTypes(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
-		"--presentation", "pres_canonical",
-		"--presentation-id", "pres_alias",
-		"--slide-id", "canonical_id",
-		"--slide-ids", "alias_id",
-		"--slides", "alias_id_2",
-		"--slide-number", "8",
-		"--slide-numbers", "9",
-		"--slide", "10",
+		"--presentation", "pres_abc",
+		"--slide-id", "pII",
+		"--slide-number", "2",
 		"--dry-run",
 		"--as", "user",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected validation error")
 	}
-
-	got := decodeSlidesScreenshotDryRunRequest(t, stdout)
-	if got.URL != "/open-apis/slides_ai/v1/xml_presentations/pres_canonical/slide_images" {
-		t.Fatalf("url = %q, want canonical presentation", got.URL)
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("error = %v, want typed validation error", err)
 	}
-	if !reflect.DeepEqual(got.Body.SlideIDs, []string{"canonical_id"}) {
-		t.Fatalf("slide_ids = %#v, want canonical selector only", got.Body.SlideIDs)
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %s/%s, want %s/%s", problem.Category, problem.Subtype, errs.CategoryValidation, errs.SubtypeInvalidArgument)
 	}
-	if !reflect.DeepEqual(got.Body.SlideNumbers, []int{8}) {
-		t.Fatalf("slide_numbers = %#v, want canonical selector only", got.Body.SlideNumbers)
+	if !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("error = %v, want mixed selector guidance", err)
 	}
 }
 
-func TestSlidesScreenshotSlideAliasRejectsAmbiguousValues(t *testing.T) {
-	for _, value := range []string{"0", "-1", "pA", "p12", "slide_1"} {
+func TestSlidesScreenshotSlideAliasRejectsInvalidNumbers(t *testing.T) {
+	for _, value := range []string{"0", "999999999999999999999999999999"} {
 		t.Run(value, func(t *testing.T) {
 			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
@@ -697,7 +734,7 @@ func TestSlidesScreenshotRenderRejectsSlideNumberSelector(t *testing.T) {
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
 		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
-		"--slide-number", "1",
+		"--slide-number", "0",
 		"--as", "user",
 	})
 	if err == nil {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -4,8 +4,10 @@
 package slides
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -31,6 +33,167 @@ func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("declared scopes = %#v, want %#v", got, want)
 	}
+}
+
+func TestSlidesScreenshotCompatibilityAliases(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantURL     string
+		wantIDs     []string
+		wantNumbers []int
+	}{
+		{
+			name:    "presentation-id",
+			args:    []string{"--presentation-id", "pres_alias", "--slide-id", "slide_1"},
+			wantURL: "/open-apis/slides_ai/v1/xml_presentations/pres_alias/slide_images",
+			wantIDs: []string{"slide_1"},
+		},
+		{name: "slide-id-aliases-merge", args: []string{"--presentation", "pres_abc", "--slide-ids", "s1", "--slides", "s2"}, wantIDs: []string{"s1", "s2"}},
+		{name: "slides", args: []string{"--presentation", "pres_abc", "--slides", "s1,s2"}, wantIDs: []string{"s1", "s2"}},
+		{name: "slide-numbers", args: []string{"--presentation", "pres_abc", "--slide-numbers", "1,2"}, wantNumbers: []int{1, 2}},
+		{name: "slide-routes-id", args: []string{"--presentation", "pres_abc", "--slide", "pII"}, wantIDs: []string{"pII"}},
+		{name: "slide-routes-number", args: []string{"--presentation", "pres_abc", "--slide", "7"}, wantNumbers: []int{7}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			args := append([]string{"+screenshot"}, tt.args...)
+			args = append(args, "--dry-run", "--as", "user")
+			if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := decodeSlidesScreenshotDryRunRequest(t, stdout)
+			wantURL := tt.wantURL
+			if wantURL == "" {
+				wantURL = "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images"
+			}
+			if got.URL != wantURL {
+				t.Fatalf("url = %q, want %q", got.URL, wantURL)
+			}
+			if !reflect.DeepEqual(got.Body.SlideIDs, tt.wantIDs) {
+				t.Fatalf("slide_ids = %#v, want %#v", got.Body.SlideIDs, tt.wantIDs)
+			}
+			if !reflect.DeepEqual(got.Body.SlideNumbers, tt.wantNumbers) {
+				t.Fatalf("slide_numbers = %#v, want %#v", got.Body.SlideNumbers, tt.wantNumbers)
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotCompatibilityAliasesAreHidden(t *testing.T) {
+	wantTypes := map[string]string{
+		"presentation-id": "",
+		"slide-ids":       "string_slice",
+		"slides":          "string_slice",
+		"slide-numbers":   "int_array",
+		"slide":           "",
+	}
+	for _, flag := range SlidesScreenshot.Flags {
+		wantType, ok := wantTypes[flag.Name]
+		if !ok {
+			continue
+		}
+		if !flag.Hidden {
+			t.Errorf("--%s Hidden = false, want true", flag.Name)
+		}
+		if flag.Type != wantType {
+			t.Errorf("--%s Type = %q, want %q", flag.Name, flag.Type, wantType)
+		}
+		delete(wantTypes, flag.Name)
+	}
+	if len(wantTypes) != 0 {
+		t.Fatalf("missing compatibility flags: %#v", wantTypes)
+	}
+}
+
+func TestSlidesScreenshotCanonicalFlagsOverrideAliases(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_canonical",
+		"--presentation-id", "pres_alias",
+		"--slide-id", "canonical_id",
+		"--slide-ids", "alias_id",
+		"--slides", "alias_id_2",
+		"--slide-number", "8",
+		"--slide-numbers", "9",
+		"--slide", "10",
+		"--dry-run",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := decodeSlidesScreenshotDryRunRequest(t, stdout)
+	if got.URL != "/open-apis/slides_ai/v1/xml_presentations/pres_canonical/slide_images" {
+		t.Fatalf("url = %q, want canonical presentation", got.URL)
+	}
+	if !reflect.DeepEqual(got.Body.SlideIDs, []string{"canonical_id"}) {
+		t.Fatalf("slide_ids = %#v, want canonical selector only", got.Body.SlideIDs)
+	}
+	if !reflect.DeepEqual(got.Body.SlideNumbers, []int{8}) {
+		t.Fatalf("slide_numbers = %#v, want canonical selector only", got.Body.SlideNumbers)
+	}
+}
+
+func TestSlidesScreenshotSlideAliasRejectsAmbiguousValues(t *testing.T) {
+	for _, value := range []string{"0", "-1", "pA", "p12", "slide_1"} {
+		t.Run(value, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+				"+screenshot",
+				"--presentation", "pres_abc",
+				"--slide", value,
+				"--dry-run",
+				"--as", "user",
+			})
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if _, ok := errs.ProblemOf(err); !ok {
+				t.Fatalf("error = %v, want typed validation error", err)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error type = %T, want *errs.ValidationError", err)
+			}
+			if validationErr.Param != "--slide" {
+				t.Fatalf("param = %q, want --slide", validationErr.Param)
+			}
+		})
+	}
+}
+
+func decodeSlidesScreenshotDryRunRequest(t *testing.T, stdout *bytes.Buffer) struct {
+	URL  string `json:"url"`
+	Body struct {
+		SlideIDs     []string `json:"slide_ids"`
+		SlideNumbers []int    `json:"slide_numbers"`
+	} `json:"body"`
+} {
+	t.Helper()
+	var envelope struct {
+		Data struct {
+			API []struct {
+				URL  string `json:"url"`
+				Body struct {
+					SlideIDs     []string `json:"slide_ids"`
+					SlideNumbers []int    `json:"slide_numbers"`
+				} `json:"body"`
+			} `json:"api"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode dry-run output: %v\nraw=%s", err, stdout.String())
+	}
+	if len(envelope.Data.API) != 1 {
+		t.Fatalf("api calls = %d, want 1\nraw=%s", len(envelope.Data.API), stdout.String())
+	}
+	return envelope.Data.API[0]
 }
 
 func TestSlidesScreenshotWritesFilesAndSuppressesBase64(t *testing.T) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -175,6 +175,17 @@ func TestSlidesScreenshotRejectsMixedSelectorTypes(t *testing.T) {
 	if !strings.Contains(err.Error(), "cannot be used together") {
 		t.Fatalf("error = %v, want mixed selector guidance", err)
 	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *errs.ValidationError", err)
+	}
+	wantParams := []errs.InvalidParam{
+		{Name: "--slide-id", Reason: "mutually exclusive with --slide-number"},
+		{Name: "--slide-number", Reason: "mutually exclusive with --slide-id"},
+	}
+	if !reflect.DeepEqual(validationErr.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", validationErr.Params, wantParams)
+	}
 }
 
 func TestSlidesScreenshotValidatesPresentationBeforeSelectors(t *testing.T) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -177,6 +177,31 @@ func TestSlidesScreenshotRejectsMixedSelectorTypes(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotValidatesPresentationBeforeSelectors(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "tmp/wiki/invalid",
+		"--slide-id", "pII",
+		"--slide-number", "2",
+		"--dry-run",
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *errs.ValidationError", err)
+	}
+	if validationErr.Param != "--presentation" {
+		t.Fatalf("param = %q, want --presentation", validationErr.Param)
+	}
+	if !strings.Contains(err.Error(), "unsupported --presentation input") {
+		t.Fatalf("error = %v, want presentation validation before selector conflict", err)
+	}
+}
+
 func TestSlidesScreenshotSlideAliasRejectsInvalidNumbers(t *testing.T) {
 	for _, value := range []string{"0", "999999999999999999999999999999"} {
 		t.Run(value, func(t *testing.T) {
@@ -742,6 +767,24 @@ func TestSlidesScreenshotRenderRejectsSlideNumberSelector(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--content cannot be used with --slide-id or --slide-number") {
 		t.Fatalf("error = %v, want content/slide selector conflict", err)
+	}
+}
+
+func TestSlidesScreenshotRenderIgnoresEmptySlideID(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--slide-id", "",
+		"--dry-run",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "/open-apis/slides_ai/v1/slide_image/render") {
+		t.Fatalf("dry-run missing render endpoint: %s", stdout.String())
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -180,11 +180,55 @@ func TestSlidesScreenshotRejectsMixedSelectorTypes(t *testing.T) {
 		t.Fatalf("error type = %T, want *errs.ValidationError", err)
 	}
 	wantParams := []errs.InvalidParam{
-		{Name: "--slide-id", Reason: "mutually exclusive with --slide-number"},
-		{Name: "--slide-number", Reason: "mutually exclusive with --slide-id"},
+		{Name: "--slide-id", Reason: "selects by slide ID; cannot be combined with slide-number selectors"},
+		{Name: "--slide-number", Reason: "selects by slide number; cannot be combined with slide-ID selectors"},
 	}
 	if !reflect.DeepEqual(validationErr.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", validationErr.Params, wantParams)
+	}
+}
+
+func TestSlidesScreenshotAttributesMixedSelectorAliasesToCallerInput(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantParams []errs.InvalidParam
+	}{
+		{
+			name: "numeric slide alias",
+			args: []string{"--slides", "pII", "--slide", "2"},
+			wantParams: []errs.InvalidParam{
+				{Name: "--slides", Reason: "selects by slide ID; cannot be combined with slide-number selectors"},
+				{Name: "--slide", Reason: "selects by slide number; cannot be combined with slide-ID selectors"},
+			},
+		},
+		{
+			name: "ID slide alias",
+			args: []string{"--slide", "pII", "--slide-numbers", "2"},
+			wantParams: []errs.InvalidParam{
+				{Name: "--slide", Reason: "selects by slide ID; cannot be combined with slide-number selectors"},
+				{Name: "--slide-numbers", Reason: "selects by slide number; cannot be combined with slide-ID selectors"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			args := append([]string{"+screenshot", "--presentation", "pres_abc"}, tt.args...)
+			args = append(args, "--dry-run", "--as", "user")
+			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error type = %T, want *errs.ValidationError", err)
+			}
+			if !reflect.DeepEqual(validationErr.Params, tt.wantParams) {
+				t.Fatalf("params = %#v, want %#v", validationErr.Params, tt.wantParams)
+			}
+		})
 	}
 }
 
@@ -755,7 +799,7 @@ func TestSlidesScreenshotRenderRejectsSlideSelectors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "--content cannot be used with --slide-id or --slide-number") {
+	if !strings.Contains(err.Error(), "--content cannot be used with slide selectors") {
 		t.Fatalf("error = %v, want content/slide selector conflict", err)
 	}
 }
@@ -776,8 +820,33 @@ func TestSlidesScreenshotRenderRejectsSlideNumberSelector(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "--content cannot be used with --slide-id or --slide-number") {
+	if !strings.Contains(err.Error(), "--content cannot be used with slide selectors") {
 		t.Fatalf("error = %v, want content/slide selector conflict", err)
+	}
+}
+
+func TestSlidesScreenshotRenderAttributesSlideAliasConflictToCallerInput(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--slide", "pII",
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *errs.ValidationError", err)
+	}
+	wantParams := []errs.InvalidParam{
+		{Name: "--content", Reason: "cannot be combined with slide selectors"},
+		{Name: "--slide", Reason: "cannot be combined with --content"},
+	}
+	if !reflect.DeepEqual(validationErr.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", validationErr.Params, wantParams)
 	}
 }
 

--- a/skills/lark-slides/references/lark-slides-screenshot.md
+++ b/skills/lark-slides/references/lark-slides-screenshot.md
@@ -26,8 +26,8 @@ lark-cli slides +screenshot --as user \
 | 参数 | 必需 | 说明 |
 |------|------|------|
 | `--presentation` | list 模式必需 | `xml_presentation_id`、`/slides/` URL，或解析后为 slides 的 `/wiki/` URL。传 `--content` 时不能使用 |
-| `--slide-id` | list 模式至少提供 `--slide-id` / `--slide-number` 之一 | 页面 short ID；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-id slide_1,slide_2`）；一次最多 10 页（`--slide-id` + `--slide-number` 合计小于等于 10） |
-| `--slide-number` | list 模式至少提供 `--slide-id` / `--slide-number` 之一 | 页面页号；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-number 1,2,3`）；一次最多 10 页（`--slide-id` + `--slide-number` 合计小于等于 10） |
+| `--slide-id` | list 模式与 `--slide-number` 二选一 | 页面 short ID；不能与 `--slide-number` 同时使用；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-id slide_1,slide_2`）；一次最多 10 个 ID |
+| `--slide-number` | list 模式与 `--slide-id` 二选一 | 页面页号；不能与 `--slide-id` 同时使用；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-number 1,2,3`）；一次最多 10 个页码 |
 | `--content` | render 模式必需 | 要直接渲染的 `<slide>` XML 片段；支持直接传值、`@file`、`-` stdin。传入后不能同时传 `--slide-id` / `--slide-number` |
 | `--output-dir` | 否 | 输出目录，默认 `.lark-slides/screenshots`；必须是当前目录内的相对路径 |
 | `--output-name` | 否 | render 模式的输出文件名 stem；未指定时优先用返回的 `slide_id`，否则用 `rendered-slide`。若目标文件已存在，会自动追加递增后缀避免覆盖 |
@@ -92,6 +92,6 @@ lark-cli slides +screenshot --as user \
 2. 已存在 PPT 页面截图时，不传 `--content`，用 `--presentation` + `--slide-id` 或 `--slide-number`。
 3. 本地 XML 预览时，传 `--content @file` 或 `--content -`，内容应为单个 `<slide>` XML 片段；此时不要传 `--presentation` / `--slide-id` / `--slide-number`。
 4. `slide_id` 是页面 short ID，页码请用 `--slide-number`。
-5. list 模式一次最多传 10 页（`--slide-id` + `--slide-number` 合计小于等于 10）；更多页面请分批截图。
+5. list 模式下 `--slide-id` 与 `--slide-number` 必须二选一；同一类型 selector 一次最多传 10 个，更多页面请分批截图。
 6. list 模式默认文件名包含 presentation ID、页码和/或 slide ID；文件已存在时自动追加 `_2`、`_3` 等后缀，避免覆盖旧截图。
 7. 截图来自服务端渲染结果，适合创建/替换后验证页面是否为空白、破图或布局明显异常。

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -47,3 +47,32 @@ func TestSlidesScreenshotSlideIDCSVDryRunE2E(t *testing.T) {
 	require.Equal(t, "slide_1", slideIDs[0].String(), result.Stdout)
 	require.Equal(t, "slide_2", slideIDs[1].String(), result.Stdout)
 }
+
+func TestSlidesScreenshotAliasesDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation-id", "presScreenshotAlias",
+			"--slides", "slide_1,slide_2",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t,
+		"/open-apis/slides_ai/v1/xml_presentations/presScreenshotAlias/slide_images",
+		gjson.Get(result.Stdout, "data.api.0.url").String(),
+		result.Stdout,
+	)
+	slideIDs := gjson.Get(result.Stdout, "data.api.0.body.slide_ids").Array()
+	require.Len(t, slideIDs, 2, result.Stdout)
+	require.Equal(t, "slide_1", slideIDs[0].String(), result.Stdout)
+	require.Equal(t, "slide_2", slideIDs[1].String(), result.Stdout)
+}

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -76,3 +76,26 @@ func TestSlidesScreenshotAliasesDryRunE2E(t *testing.T) {
 	require.Equal(t, "slide_1", slideIDs[0].String(), result.Stdout)
 	require.Equal(t, "slide_2", slideIDs[1].String(), result.Stdout)
 }
+
+func TestSlidesScreenshotMixedSelectorsDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation", "presScreenshotMixed",
+			"--slide-id", "pII",
+			"--slide-number", "2",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "cannot be used together")
+}

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -104,6 +104,66 @@ func TestSlidesScreenshotMixedSelectorsDryRunE2E(t *testing.T) {
 	require.Empty(t, result.Stdout)
 }
 
+func TestSlidesScreenshotMixedSelectorAliasAttributionDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+	tests := []struct {
+		name       string
+		args       []string
+		wantParams []string
+	}{
+		{
+			name:       "numeric slide alias",
+			args:       []string{"--slides", "pII", "--slide", "2"},
+			wantParams: []string{"--slides", "--slide"},
+		},
+		{
+			name:       "ID slide alias",
+			args:       []string{"--slide", "pII", "--slide-numbers", "2"},
+			wantParams: []string{"--slide", "--slide-numbers"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			args := append([]string{"slides", "+screenshot", "--presentation", "presScreenshotMixedAlias"}, tt.args...)
+			args = append(args, "--dry-run")
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: args, DefaultAs: "bot"})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 2)
+			require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+			require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+			require.Equal(t, int64(2), gjson.Get(result.Stderr, "error.params.#").Int(), result.Stderr)
+			require.Equal(t, tt.wantParams[0], gjson.Get(result.Stderr, "error.params.0.name").String(), result.Stderr)
+			require.Equal(t, tt.wantParams[1], gjson.Get(result.Stderr, "error.params.1.name").String(), result.Stderr)
+			require.Empty(t, result.Stdout)
+		})
+	}
+}
+
+func TestSlidesScreenshotContentSlideAliasAttributionDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+			"--slide", "pII",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Equal(t, "--content", gjson.Get(result.Stderr, "error.params.0.name").String(), result.Stderr)
+	require.Equal(t, "--slide", gjson.Get(result.Stderr, "error.params.1.name").String(), result.Stderr)
+	require.Empty(t, result.Stdout)
+}
+
 func TestSlidesScreenshotValidationPriorityDryRunE2E(t *testing.T) {
 	setSlidesDryRunEnv(t)
 

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -99,3 +99,45 @@ func TestSlidesScreenshotMixedSelectorsDryRunE2E(t *testing.T) {
 	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
 	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "cannot be used together")
 }
+
+func TestSlidesScreenshotValidationPriorityDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation", "tmp/wiki/invalid",
+			"--slide-id", "pII",
+			"--slide-number", "2",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Equal(t, "--presentation", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "unsupported --presentation input")
+}
+
+func TestSlidesScreenshotEmptySlideIDDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+			"--slide-id", "",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	require.Equal(t, "/open-apis/slides_ai/v1/slide_image/render", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
+}

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -98,6 +98,10 @@ func TestSlidesScreenshotMixedSelectorsDryRunE2E(t *testing.T) {
 	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
 	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
 	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "cannot be used together")
+	require.Equal(t, int64(2), gjson.Get(result.Stderr, "error.params.#").Int(), result.Stderr)
+	require.Equal(t, "--slide-id", gjson.Get(result.Stderr, "error.params.0.name").String(), result.Stderr)
+	require.Equal(t, "--slide-number", gjson.Get(result.Stderr, "error.params.1.name").String(), result.Stderr)
+	require.Empty(t, result.Stdout)
 }
 
 func TestSlidesScreenshotValidationPriorityDryRunE2E(t *testing.T) {
@@ -118,8 +122,11 @@ func TestSlidesScreenshotValidationPriorityDryRunE2E(t *testing.T) {
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 2)
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
 	require.Equal(t, "--presentation", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
 	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "unsupported --presentation input")
+	require.Empty(t, result.Stdout)
 }
 
 func TestSlidesScreenshotEmptySlideIDDryRunE2E(t *testing.T) {

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package slides
+
+import (
+	"context"
+	"encoding/json"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	title := "slides-screenshot-alias-e2e-" + suffix
+	slideXML := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + title + `</p></content></shape></data></slide>`
+	slidesJSON, err := json.Marshal([]string{slideXML})
+	require.NoError(t, err)
+
+	createResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+create",
+			"--title", title,
+			"--slides", string(slidesJSON),
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	createResult.AssertExitCode(t, 0)
+	createResult.AssertStdoutStatus(t, true)
+
+	presentationID := gjson.Get(createResult.Stdout, "data.xml_presentation_id").String()
+	require.NotEmpty(t, presentationID, "stdout:\n%s", createResult.Stdout)
+	slideID := gjson.Get(createResult.Stdout, "data.slide_ids.0").String()
+	require.NotEmpty(t, slideID, "stdout:\n%s", createResult.Stdout)
+
+	parentT.Cleanup(func() {
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+
+		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+			Args: []string{
+				"drive", "+delete",
+				"--file-token", presentationID,
+				"--type", "slides",
+				"--yes",
+			},
+			DefaultAs: "bot",
+		})
+		clie2e.ReportCleanupFailure(parentT, "delete presentation "+presentationID, deleteResult, deleteErr)
+	})
+
+	workDir := t.TempDir()
+	screenshotResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation-id", presentationID,
+			"--slides", slideID,
+			"--output-dir", "shots",
+		},
+		DefaultAs: "bot",
+		WorkDir:   workDir,
+	})
+	require.NoError(t, err)
+	screenshotResult.AssertExitCode(t, 0)
+	screenshotResult.AssertStdoutStatus(t, true)
+
+	require.Equal(t, presentationID, gjson.Get(screenshotResult.Stdout, "data.xml_presentation_id").String(), "stdout:\n%s", screenshotResult.Stdout)
+	require.Equal(t, "shots", gjson.Get(screenshotResult.Stdout, "data.output_dir").String(), "stdout:\n%s", screenshotResult.Stdout)
+	screenshots := gjson.Get(screenshotResult.Stdout, "data.screenshots").Array()
+	require.Len(t, screenshots, 1, "stdout:\n%s", screenshotResult.Stdout)
+	require.Equal(t, slideID, screenshots[0].Get("slide_id").String(), "stdout:\n%s", screenshotResult.Stdout)
+	require.Equal(t, int64(1), screenshots[0].Get("slide_number").Int(), "stdout:\n%s", screenshotResult.Stdout)
+
+	imagePath := screenshots[0].Get("path").String()
+	require.True(t, filepath.IsAbs(imagePath), "path must be absolute: %s", imagePath)
+	requireScreenshotPathUnderDir(t, imagePath, filepath.Join(workDir, "shots"))
+
+	imageFile, err := os.Open(imagePath)
+	require.NoError(t, err)
+	defer imageFile.Close()
+	config, format, err := image.DecodeConfig(imageFile)
+	require.NoError(t, err)
+	require.Positive(t, config.Width)
+	require.Positive(t, config.Height)
+	require.Contains(t, []string{"jpeg", "png"}, format)
+	require.Equal(t, format, screenshots[0].Get("format").String(), "stdout:\n%s", screenshotResult.Stdout)
+
+	info, err := imageFile.Stat()
+	require.NoError(t, err)
+	require.Equal(t, info.Size(), screenshots[0].Get("size").Int(), "stdout:\n%s", screenshotResult.Stdout)
+	require.False(t, screenshots[0].Get("data").Exists(), "stdout must not expose screenshot payload: %s", screenshotResult.Stdout)
+	require.NotContains(t, screenshotResult.Stdout, "data:image/", "stdout must not expose screenshot payload")
+}
+
+func requireScreenshotPathUnderDir(t *testing.T, path, dir string) {
+	t.Helper()
+	canonicalPath, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	canonicalDir, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	rel, err := filepath.Rel(canonicalDir, canonicalPath)
+	require.NoError(t, err)
+	require.False(t, rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)), "path %s escapes %s", path, dir)
+}

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -9,12 +9,12 @@ import (
 	"image"
 	_ "image/jpeg"
 	_ "image/png"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/larksuite/cli/internal/vfs"
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -47,9 +47,6 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 
 	presentationID := gjson.Get(createResult.Stdout, "data.xml_presentation_id").String()
 	require.NotEmpty(t, presentationID, "stdout:\n%s", createResult.Stdout)
-	slideID := gjson.Get(createResult.Stdout, "data.slide_ids.0").String()
-	require.NotEmpty(t, slideID, "stdout:\n%s", createResult.Stdout)
-
 	parentT.Cleanup(func() {
 		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
 		defer cleanupCancel()
@@ -65,6 +62,8 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 		})
 		clie2e.ReportCleanupFailure(parentT, "delete presentation "+presentationID, deleteResult, deleteErr)
 	})
+	slideID := gjson.Get(createResult.Stdout, "data.slide_ids.0").String()
+	require.NotEmpty(t, slideID, "stdout:\n%s", createResult.Stdout)
 
 	workDir := t.TempDir()
 	screenshotResult, err := clie2e.RunCmd(ctx, clie2e.Request{
@@ -92,7 +91,7 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 	require.True(t, filepath.IsAbs(imagePath), "path must be absolute: %s", imagePath)
 	requireScreenshotPathUnderDir(t, imagePath, filepath.Join(workDir, "shots"))
 
-	imageFile, err := os.Open(imagePath)
+	imageFile, err := vfs.Open(imagePath)
 	require.NoError(t, err)
 	defer imageFile.Close()
 	config, format, err := image.DecodeConfig(imageFile)


### PR DESCRIPTION
## Summary

Improve `slides +screenshot` compatibility for common AI-generated presentation and slide selector flags while preserving the canonical interface.

## Changes

- Add hidden `--presentation-id` alias for `--presentation`
- Add hidden `--slide` alias:
  - positive integer routes to slide number
  - SXSD short slide ID matching `p[A-Za-z]{2,}` routes to slide ID
- Add hidden comma-separated aliases:
  - `--slide-ids`
  - `--slide-numbers`
  - `--slides`
- Keep canonical flags authoritative when canonical and alias forms are both present
- Reject invalid or ambiguous `--slide` values with typed validation metadata
- Add unit, dry-run E2E, and self-contained bot live E2E coverage

## Test Plan

- [x] `GOTOOLCHAIN=go1.23.12 make build`
- [x] `GOTOOLCHAIN=go1.23.12 make unit-test`
- [x] `GOTOOLCHAIN=go1.23.12 go vet ./...`
- [x] `gofmt -l .` produces no output
- [x] `GOTOOLCHAIN=go1.23.12 go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `golangci-lint` reports 0 issues
- [x] Screenshot alias dry-run E2E passes locally
- [x] Bot screenshot alias live E2E passes in PR CI

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added convenient aliases for selecting presentations and slides in screenshot commands.
  - Supports positive slide numbers, slide IDs, and comma-separated selections.
  - Added presentation selection through `--presentation-id`.

- **Bug Fixes**
  - Improved validation and guidance for invalid, duplicate, empty, or ambiguous selectors.
  - Ensured consistent selector behavior across validation, dry runs, and execution.
  - Preserved canonical option precedence when aliases are combined.
  - Empty slide IDs now correctly fall back to content-based rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->