### PR TITLE
fix(slides): restore presentation aliases

### DIFF
--- a/shortcuts/slides/shortcuts_alias_test.go
+++ b/shortcuts/slides/shortcuts_alias_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestShortcutsDeclarePresentationFlagAliases(t *testing.T) {
 	wantRequired := map[string]bool{
+		"+add-slide":             true,
+		"+delete-slide":          true,
 		"+media-upload":          true,
 		"+replace-slide":         true,
 		"+replace-pages":         true,

--- a/shortcuts/slides/slides_add_slide.go
+++ b/shortcuts/slides/slides_add_slide.go
@@ -47,7 +47,7 @@ var SlidesAddSlide = common.Shortcut{
 	ConditionalScopes: []string{"wiki:node:read", "docs:document.media:upload"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "presentation", Desc: "xml_presentation_id, slides URL, or wiki URL that resolves to slides", Required: true},
+		requiredPresentationRefFlag(),
 		// The "(supports @file, - reads stdin ...)" suffix is appended from Input
 		// below, so spelling it out here too produced a doubled parenthetical.
 		{Name: "slide", Desc: "one complete <slide> XML document", Required: true, Input: []string{common.File, common.Stdin}},

--- a/shortcuts/slides/slides_delete_slide.go
+++ b/shortcuts/slides/slides_delete_slide.go
@@ -33,7 +33,7 @@ var SlidesDeleteSlide = common.Shortcut{
 	ConditionalScopes: []string{"wiki:node:read"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "presentation", Desc: "xml_presentation_id, slides URL, or wiki URL that resolves to slides", Required: true},
+		requiredPresentationRefFlag(),
 		{Name: "slide-id", Desc: "slide page identifier (slide_id) to delete", Required: true},
 		{Name: "revision-id", Type: "int", Default: "-1", Desc: "presentation revision (-1 = latest; pass a specific number for optimistic locking)"},
 	},

--- a/tests/cli_e2e/slides/slides_slide_add_delete_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_slide_add_delete_dryrun_test.go
@@ -49,10 +49,10 @@ func TestSlidesAddSlideDryRunE2E(t *testing.T) {
 			},
 		},
 		{
-			name: "insert before a page with locking",
+			name: "insert before a page with locking via presentation alias",
 			args: []string{
 				"slides", "+add-slide",
-				"--presentation", "presAddDryRun",
+				"--presentation-id", "presAddDryRun",
 				"--slide", slideXML,
 				"--before-slide-id", "slide_target",
 				"--revision-id", "12",
@@ -98,7 +98,7 @@ func TestSlidesDeleteSlideDryRunE2E(t *testing.T) {
 	result, err := clie2e.RunCmd(ctx, clie2e.Request{
 		Args: []string{
 			"slides", "+delete-slide",
-			"--presentation", "presDeleteDryRun",
+			"--presentation-token", "presDeleteDryRun",
 			"--slide-id", "slide_gone",
 			"--dry-run",
 		},


### PR DESCRIPTION
## Summary

Restore the shared Slides presentation aliases for `+add-slide` and `+delete-slide`. PR #2120 was based before the alias framework from #2146 and declared standalone `--presentation` flags, leaving the new shortcuts outside the domain contract.

## Changes

- Reuse `requiredPresentationRefFlag()` in both new shortcuts.
- Extend the Slides alias contract and dry-run E2E coverage for the new commands.

## Test Plan

- [x] `make unit-test` in a clean worktree
- [x] `go vet ./...`
- [x] `gofmt -l .` produces no output
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] golangci-lint, lint module tests, and source-contract lint pass
- [x] Built-binary dry-run E2E verifies `--presentation-id` and `--presentation-token`

## Related Issues

- Follow-up to #2120 and #2146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized presentation references for adding and deleting slides.
  * Added support for the `--presentation-id` and `--presentation-token` aliases in slide commands.
  * Updated validation coverage to ensure both shortcuts accept the shared presentation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->