### PR TITLE
Fix mail rule reorder request IDs

### DIFF
--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -435,6 +436,12 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)
 	}
 
+	if opts.SchemaPath == "mail.user_mailbox.rules.reorder" {
+		if err := completeMailRulesReorderRequest(opts.Ctx, ac, opts, &request); err != nil {
+			return err
+		}
+	}
+
 	resp, err := ac.DoAPI(opts.Ctx, request)
 	if err != nil {
 		return err
@@ -669,6 +676,206 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 
 func serviceDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, format string) error {
 	return cmdutil.PrintDryRun(f.IOStreams.Out, request, config, format)
+}
+
+func completeMailRulesReorderRequest(ctx context.Context, ac *client.APIClient, opts *ServiceMethodOptions, request *client.RawApiRequest) error {
+	if request == nil {
+		return errs.NewInternalError(errs.SubtypeUnknown, "mail rules reorder request is not initialized")
+	}
+	userMailboxID, ok := mailRulesReorderMailboxID(opts, request)
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "missing required path parameter: user_mailbox_id").
+			WithHint("%s", missingParamHint(opts, meta.Field{Name: "user_mailbox_id"})).
+			WithParam("user_mailbox_id")
+	}
+
+	body, ok := request.Data.(map[string]interface{})
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--data must be a JSON object for mail rules reorder").WithParam("--data")
+	}
+	inputIDs, err := stringSliceField(body, "rule_ids")
+	if err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must be an array of non-empty strings").WithParam("rule_ids").WithCause(err)
+	}
+	if duplicates := duplicateStrings(inputIDs); len(duplicates) > 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "duplicate rule_ids: %s", strings.Join(duplicates, ", ")).WithParam("rule_ids")
+	}
+
+	currentIDs, err := fetchAllMailRuleIDs(ctx, ac, *request, userMailboxID)
+	if err != nil {
+		return err
+	}
+	completedIDs, err := completeMailRuleIDs(inputIDs, currentIDs)
+	if err != nil {
+		return err
+	}
+	body["rule_ids"] = completedIDs
+	request.Data = body
+	return nil
+}
+
+func mailRulesReorderMailboxID(opts *ServiceMethodOptions, request *client.RawApiRequest) (string, bool) {
+	for _, p := range opts.Method.Params() {
+		if p.Name != "user_mailbox_id" || p.Location != "path" {
+			continue
+		}
+		marker := "{" + p.Name + "}"
+		prefix, suffix, ok := strings.Cut(opts.Method.Path, marker)
+		if !ok {
+			break
+		}
+		urlPrefix := strings.TrimRight(opts.ServicePath, "/") + "/" + prefix
+		if !strings.HasPrefix(request.URL, urlPrefix) || !strings.HasSuffix(request.URL, suffix) {
+			break
+		}
+		val := strings.TrimSuffix(strings.TrimPrefix(request.URL, urlPrefix), suffix)
+		if val == "" {
+			break
+		}
+		if decoded, err := url.PathUnescape(val); err == nil {
+			return decoded, true
+		}
+		return val, true
+	}
+	if v, ok := request.Params["user_mailbox_id"].(string); ok && v != "" {
+		return v, true
+	}
+	return "", false
+}
+
+func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, base client.RawApiRequest, userMailboxID string) ([]string, error) {
+	listPath := fmt.Sprintf("/open-apis/mail/v1/user_mailboxes/%s/rules", validate.EncodePathSegment(userMailboxID))
+	result, err := ac.PaginateAll(ctx, client.RawApiRequest{
+		Method: "GET",
+		URL:    listPath,
+		Params: map[string]interface{}{"page_size": 100},
+		As:     base.As,
+	}, client.PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: base.As})
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := ac.CheckResponse(result, base.As); apiErr != nil {
+		return nil, apiErr
+	}
+	return extractMailRuleIDs(result), nil
+}
+
+func extractMailRuleIDs(result interface{}) []string {
+	data, ok := dataMap(result)
+	if !ok {
+		return nil
+	}
+	for _, key := range []string{"items", "rules", "rule_list"} {
+		items, ok := data[key].([]interface{})
+		if !ok {
+			continue
+		}
+		ids := make([]string, 0, len(items))
+		for _, item := range items {
+			obj, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if id := firstString(obj, "rule_id", "id"); id != "" {
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	}
+	return nil
+}
+
+func dataMap(result interface{}) (map[string]interface{}, bool) {
+	top, ok := result.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	data, ok := top["data"].(map[string]interface{})
+	return data, ok
+}
+
+func firstString(values map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := values[key].(string); ok {
+			if trimmed := strings.TrimSpace(v); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+func stringSliceField(values map[string]interface{}, key string) ([]string, error) {
+	raw, ok := values[key]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s is %T", key, raw)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok || strings.TrimSpace(s) == "" {
+			return nil, fmt.Errorf("%s contains %T", key, item)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func duplicateStrings(items []string) []string {
+	seen := map[string]bool{}
+	dups := map[string]bool{}
+	for _, item := range items {
+		if seen[item] {
+			dups[item] = true
+			continue
+		}
+		seen[item] = true
+	}
+	out := make([]string, 0, len(dups))
+	for item := range dups {
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func completeMailRuleIDs(inputIDs, currentIDs []string) ([]string, error) {
+	current := make(map[string]bool, len(currentIDs))
+	for _, id := range currentIDs {
+		current[id] = true
+	}
+	if len(currentIDs) == 0 {
+		if len(inputIDs) == 0 {
+			return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition, "no mail rules to reorder").WithParam("rule_ids")
+		}
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "unknown rule_ids: %s", strings.Join(inputIDs, ", ")).WithParam("rule_ids")
+	}
+	var unknown []string
+	for _, id := range inputIDs {
+		if !current[id] {
+			unknown = append(unknown, id)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "unknown rule_ids: %s", strings.Join(unknown, ", ")).WithParam("rule_ids")
+	}
+
+	selected := make(map[string]bool, len(inputIDs))
+	out := make([]string, 0, len(currentIDs))
+	for _, id := range inputIDs {
+		selected[id] = true
+		out = append(out, id)
+	}
+	for _, id := range currentIDs {
+		if !selected[id] {
+			out = append(out, id)
+		}
+	}
+	return out, nil
 }
 
 func servicePaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, jqExpr string, out, errOut io.Writer, commandPath string, pagOpts client.PaginationOptions, checkErr func(interface{}, core.Identity) error) error {

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"mime"
 	"mime/multipart"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,6 +53,30 @@ func driveMethod(httpMethod string, params map[string]interface{}) meta.Method {
 		}
 	}
 	return meta.FromMap(m)
+}
+
+func mailSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "array", "required": true},
+		},
+	})
+}
+
+func newMailRulesReorderCommand(f *cmdutil.Factory) *cobra.Command {
+	return NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
 }
 
 // ── registerService ──
@@ -198,6 +223,282 @@ func TestNewCmdServiceMethod_RunFCallback(t *testing.T) {
 	}
 	if captured.SchemaPath != "drive.files.list" {
 		t.Errorf("expected SchemaPath=drive.files.list, got %s", captured.SchemaPath)
+	}
+}
+
+func TestMailRulesReorderCompletesPartialRuleIDs(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "rule_1"},
+					map[string]interface{}{"rule_id": "rule_2"},
+					map[string]interface{}{"rule_id": "rule_3"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reorderCalled := false
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		BodyFilter: func(body []byte) bool {
+			var data map[string]interface{}
+			if err := json.Unmarshal(body, &data); err != nil {
+				return false
+			}
+			ids, ok := data["rule_ids"].([]interface{})
+			if !ok || len(ids) != 3 {
+				return false
+			}
+			return ids[0] == "rule_3" && ids[1] == "rule_1" && ids[2] == "rule_2"
+		},
+		OnMatch: func(req *http.Request) { reorderCalled = true },
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{"ok": true},
+		},
+	})
+
+	cmd := newMailRulesReorderCommand(f)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_3"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reorderCalled {
+		t.Fatal("expected reorder API to be called")
+	}
+	if !strings.Contains(stdout.String(), `"ok": true`) {
+		t.Fatalf("unexpected stdout: %s", stdout.String())
+	}
+}
+
+func TestMailRulesReorderKeepsCompleteRuleIDsOrder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "rule_1"},
+					map[string]interface{}{"rule_id": "rule_2"},
+					map[string]interface{}{"rule_id": "rule_3"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		BodyFilter: func(body []byte) bool {
+			var data map[string]interface{}
+			if err := json.Unmarshal(body, &data); err != nil {
+				return false
+			}
+			ids := data["rule_ids"].([]interface{})
+			return ids[0] == "rule_2" && ids[1] == "rule_1" && ids[2] == "rule_3"
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{"ok": true},
+		},
+	})
+
+	cmd := newMailRulesReorderCommand(f)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_2","rule_1","rule_3"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMailRulesReorderReadsAllRulePages(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	var pageTokens []string
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		BodyFilter: func(_ []byte) bool {
+			return len(pageTokens) == 0
+		},
+		OnMatch: func(req *http.Request) {
+			pageTokens = append(pageTokens, req.URL.Query().Get("page_token"))
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "rule_1"},
+				},
+				"has_more":   true,
+				"page_token": "next_1",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		BodyFilter: func(_ []byte) bool {
+			return len(pageTokens) == 1
+		},
+		OnMatch: func(req *http.Request) {
+			pageTokens = append(pageTokens, req.URL.Query().Get("page_token"))
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "rule_2"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		BodyFilter: func(body []byte) bool {
+			var data map[string]interface{}
+			if err := json.Unmarshal(body, &data); err != nil {
+				return false
+			}
+			ids := data["rule_ids"].([]interface{})
+			return len(ids) == 2 && ids[0] == "rule_2" && ids[1] == "rule_1"
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{"ok": true},
+		},
+	})
+
+	cmd := newMailRulesReorderCommand(f)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_2"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pageTokens) < 2 || pageTokens[0] != "" || pageTokens[1] != "next_1" {
+		t.Fatalf("page tokens = %v, want ['', 'next_1']", pageTokens)
+	}
+}
+
+func TestMailRulesReorderRejectsInvalidInputBeforeReorder(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      string
+		listItems []interface{}
+		want      string
+	}{
+		{
+			name:      "duplicate IDs",
+			data:      `{"rule_ids":["rule_1","rule_1"]}`,
+			listItems: []interface{}{map[string]interface{}{"rule_id": "rule_1"}},
+			want:      "duplicate rule_ids: rule_1",
+		},
+		{
+			name:      "unknown ID",
+			data:      `{"rule_ids":["missing"]}`,
+			listItems: []interface{}{map[string]interface{}{"rule_id": "rule_1"}},
+			want:      "unknown rule_ids: missing",
+		},
+		{
+			name:      "empty list with empty input",
+			data:      `{"rule_ids":[]}`,
+			listItems: nil,
+			want:      "no mail rules to reorder",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+			if tt.name != "duplicate IDs" {
+				reg.Register(&httpmock.Stub{
+					Method: "GET",
+					URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+					Body: map[string]interface{}{
+						"code": 0,
+						"msg":  "ok",
+						"data": map[string]interface{}{
+							"items":    tt.listItems,
+							"has_more": false,
+						},
+					},
+				})
+			}
+
+			cmd := newMailRulesReorderCommand(f)
+			cmd.SetArgs([]string{
+				"--as", "bot",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", tt.data,
+			})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			prob, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed error, got %T: %v", err, err)
+			}
+			if prob.Category != errs.CategoryValidation {
+				t.Fatalf("category = %q, want %q", prob.Category, errs.CategoryValidation)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "list failed",
+		},
+	})
+
+	cmd := newMailRulesReorderCommand(f)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_1"]}`,
+	})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected list error")
 	}
 }
 


### PR DESCRIPTION
Fixes mail rule reordering so the CLI sends the full ordered rule ID list expected by the mail API.

- Fetches the current rules before applying a reorder.
- Expands the provided subset into the complete final order.
- Rejects duplicate or unknown rule IDs before submitting the request.
- Adds service tests for successful reorder, duplicate IDs, and unknown IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mailbox rules can now be reordered using a partial list of rule IDs; any omitted rules are automatically retained and placed afterward.
  - Rule ordering continues to work across large mailboxes with many rules.

- **Bug Fixes**
  - Improved validation prevents duplicate, unknown, or empty rule IDs from being submitted.
  - Reordering is no longer attempted when existing rule information cannot be retrieved successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->