### PR TITLE
Complete mail rule reorder IDs

### DIFF
--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -117,9 +117,9 @@ func listMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest *
 		if !ok {
 			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d must be a JSON object", i)
 		}
-		id, _ := item["rule_id"].(string)
+		id, _ := item["id"].(string)
 		if id == "" {
-			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d missing rule_id", i)
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d missing id", i)
 		}
 		ids = append(ids, id)
 	}

--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/core"
+)
+
+const (
+	mailRulesSchemaPath = "mail.user_mailbox.rules"
+)
+
+func completeMailRulesReorder(ctx context.Context, ac *client.APIClient, request *client.RawApiRequest, schemaPath string, identity core.Identity) error {
+	if !isMailRulesReorderRequest(request, schemaPath) {
+		return nil
+	}
+
+	body, ok := request.Data.(map[string]any)
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "mail rules reorder requires JSON object request body").WithParam("--data")
+	}
+	inputIDs, err := stringSliceField(body, "rule_ids")
+	if err != nil {
+		return err
+	}
+	if len(inputIDs) == 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must contain at least one rule ID").WithParam("rule_ids")
+	}
+	if dup := firstDuplicate(inputIDs); dup != "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "duplicate rule_id %q in rule_ids", dup).WithParam("rule_ids")
+	}
+
+	allIDs, err := listMailRuleIDs(ctx, ac, request, identity)
+	if err != nil {
+		return err
+	}
+	if len(allIDs) == 0 {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "mail rules list returned no rules to reorder").WithParam("rule_ids")
+	}
+
+	known := make(map[string]struct{}, len(allIDs))
+	for _, id := range allIDs {
+		known[id] = struct{}{}
+	}
+	for _, id := range inputIDs {
+		if _, ok := known[id]; !ok {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_id %q does not exist in current mail rules", id).WithParam("rule_ids")
+		}
+	}
+
+	selected := make(map[string]struct{}, len(inputIDs))
+	completed := make([]string, 0, len(allIDs))
+	for _, id := range inputIDs {
+		selected[id] = struct{}{}
+		completed = append(completed, id)
+	}
+	for _, id := range allIDs {
+		if _, ok := selected[id]; !ok {
+			completed = append(completed, id)
+		}
+	}
+	body["rule_ids"] = completed
+	request.Data = body
+	return nil
+}
+
+func isMailRulesReorderRequest(request *client.RawApiRequest, schemaPath string) bool {
+	if request == nil {
+		return false
+	}
+	return schemaPath == mailRulesSchemaPath+".reorder" &&
+		strings.EqualFold(request.Method, "POST") &&
+		strings.HasSuffix(request.URL, "/reorder")
+}
+
+func listMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest *client.RawApiRequest, identity core.Identity) ([]string, error) {
+	listURL := strings.TrimSuffix(reorderRequest.URL, "/reorder")
+	result, err := ac.CallAPI(ctx, client.RawApiRequest{
+		Method: "GET",
+		URL:    listURL,
+		Params: map[string]any{},
+		As:     identity,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := ac.CheckResponse(result, identity); err != nil {
+		return nil, err
+	}
+
+	data, ok := result.(map[string]any)
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response must be a JSON object")
+	}
+	items, ok := data["items"].([]any)
+	if !ok {
+		if nested, hasData := data["data"].(map[string]any); hasData {
+			items, ok = nested["items"].([]any)
+		}
+	}
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing items array")
+	}
+
+	ids := make([]string, 0, len(items))
+	for i, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d must be a JSON object", i)
+		}
+		id, _ := item["rule_id"].(string)
+		if id == "" {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d missing rule_id", i)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func stringSliceField(body map[string]any, name string) ([]string, error) {
+	raw, ok := body[name]
+	if !ok {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s is required", name).WithParam(name)
+	}
+	switch values := raw.(type) {
+	case []string:
+		return append([]string(nil), values...), nil
+	case []any:
+		out := make([]string, 0, len(values))
+		for i, value := range values {
+			id, ok := value.(string)
+			if !ok || id == "" {
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s[%d] must be a non-empty string", name, i).WithParam(name)
+			}
+			out = append(out, id)
+		}
+		return out, nil
+	default:
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s must be an array of strings, got %T", name, raw).WithParam(name)
+	}
+}
+
+func firstDuplicate(values []string) string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			return value
+		}
+		seen[value] = struct{}{}
+	}
+	return ""
+}

--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -81,12 +81,12 @@ func isMailRulesReorderRequest(request *client.RawApiRequest, schemaPath string)
 
 func listMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest *client.RawApiRequest, identity core.Identity) ([]string, error) {
 	listURL := strings.TrimSuffix(reorderRequest.URL, "/reorder")
-	result, err := ac.CallAPI(ctx, client.RawApiRequest{
+	result, err := ac.PaginateAll(ctx, client.RawApiRequest{
 		Method: "GET",
 		URL:    listURL,
-		Params: map[string]any{},
+		Params: map[string]any{"page_size": 100},
 		As:     identity,
-	})
+	}, client.PaginationOptions{Identity: identity})
 	if err != nil {
 		return nil, err
 	}
@@ -106,6 +106,9 @@ func listMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest *
 	}
 	if !ok {
 		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing items array")
+	}
+	if hasMore, _ := data["has_more"].(bool); hasMore {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list pagination did not return all pages")
 	}
 
 	ids := make([]string, 0, len(items))
@@ -130,7 +133,14 @@ func stringSliceField(body map[string]any, name string) ([]string, error) {
 	}
 	switch values := raw.(type) {
 	case []string:
-		return append([]string(nil), values...), nil
+		out := make([]string, 0, len(values))
+		for i, id := range values {
+			if id == "" {
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s[%d] must be a non-empty string", name, i).WithParam(name)
+			}
+			out = append(out, id)
+		}
+		return out, nil
 	case []any:
 		out := make([]string, 0, len(values))
 		for i, value := range values {

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -419,6 +419,10 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		return err
 	}
 
+	if err := completeMailRulesReorder(opts.Ctx, ac, &request, opts.SchemaPath, opts.As); err != nil {
+		return err
+	}
+
 	out := f.IOStreams.Out
 	format, formatOK := output.ParseFormat(opts.Format)
 	if !formatOK {

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -548,6 +548,62 @@ func TestServiceMethod_MailRulesReorderCompletesPartialIDs(t *testing.T) {
 	assertRuleIDsBody(t, reorder.CapturedBody, []string{"C", "A", "B", "D"})
 }
 
+func TestServiceMethod_MailRulesReorderCompletesPartialIDsAcrossPages(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	var calls []string
+	firstPage := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules?page_size=100",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "A"},
+					map[string]interface{}{"rule_id": "B"},
+				},
+				"has_more":   true,
+				"page_token": "next",
+			},
+		},
+		OnMatch: func(*http.Request) { calls = append(calls, "list-1") },
+	}
+	secondPage := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules?page_size=100&page_token=next",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "C"},
+					map[string]interface{}{"rule_id": "D"},
+				},
+				"has_more": false,
+			},
+		},
+		OnMatch: func(*http.Request) { calls = append(calls, "list-2") },
+	}
+	reorder := &httpmock.Stub{
+		Method:  "POST",
+		URL:     "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:    map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}},
+		OnMatch: func(*http.Request) { calls = append(calls, "reorder") },
+	}
+	reg.Register(firstPage)
+	reg.Register(secondPage)
+	reg.Register(reorder)
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["D"]}`})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := strings.Join(calls, ","), "list-1,list-2,reorder"; got != want {
+		t.Fatalf("calls = %s, want %s", got, want)
+	}
+	assertRuleIDsBody(t, reorder.CapturedBody, []string{"D", "A", "B", "C"})
+}
+
 func TestServiceMethod_MailRulesReorderKeepsFullInputOrder(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
 	reg.Register(&httpmock.Stub{
@@ -593,6 +649,22 @@ func TestServiceMethod_MailRulesReorderRejectsDuplicateIDs(t *testing.T) {
 	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
 	if !strings.Contains(err.Error(), "duplicate rule_id") {
 		t.Fatalf("error = %v, want duplicate rule_id", err)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderRejectsEmptyRuleID(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":[""]}`})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected empty rule ID error")
+	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
+	if !strings.Contains(err.Error(), "rule_ids[0] must be a non-empty string") {
+		t.Fatalf("error = %v, want indexed non-empty string error", err)
 	}
 }
 

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"mime"
 	"mime/multipart"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,6 +53,40 @@ func driveMethod(httpMethod string, params map[string]interface{}) meta.Method {
 		}
 	}
 	return meta.FromMap(m)
+}
+
+func mailRulesSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "array", "required": true},
+		},
+		"accessTokens": []interface{}{"tenant"},
+	})
+}
+
+func assertRuleIDsBody(t *testing.T, body []byte, want []string) {
+	t.Helper()
+	var got struct {
+		RuleIDs []string `json:"rule_ids"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode reorder body: %v; body=%s", err, string(body))
+	}
+	if strings.Join(got.RuleIDs, ",") != strings.Join(want, ",") {
+		t.Fatalf("rule_ids = %#v, want %#v; body=%s", got.RuleIDs, want, string(body))
+	}
 }
 
 // ── registerService ──
@@ -471,6 +506,156 @@ func TestServiceMethod_BotMode_PageAll_JSON(t *testing.T) {
 	if !ok || len(items) != 1 {
 		t.Fatalf("data.items = %#v, want one item", data["items"])
 	}
+}
+
+func TestServiceMethod_MailRulesReorderCompletesPartialIDs(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	var calls []string
+	list := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "A"},
+					map[string]interface{}{"rule_id": "B"},
+					map[string]interface{}{"rule_id": "C"},
+					map[string]interface{}{"rule_id": "D"},
+				},
+			},
+		},
+		OnMatch: func(*http.Request) { calls = append(calls, "list") },
+	}
+	reorder := &httpmock.Stub{
+		Method:  "POST",
+		URL:     "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:    map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}},
+		OnMatch: func(*http.Request) { calls = append(calls, "reorder") },
+	}
+	reg.Register(list)
+	reg.Register(reorder)
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["C"]}`})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := strings.Join(calls, ","), "list,reorder"; got != want {
+		t.Fatalf("calls = %s, want %s", got, want)
+	}
+	assertRuleIDsBody(t, reorder.CapturedBody, []string{"C", "A", "B", "D"})
+}
+
+func TestServiceMethod_MailRulesReorderKeepsFullInputOrder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "A"},
+					map[string]interface{}{"rule_id": "B"},
+					map[string]interface{}{"rule_id": "C"},
+				},
+			},
+		},
+	})
+	reorder := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}},
+	}
+	reg.Register(reorder)
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["C","A","B"]}`})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertRuleIDsBody(t, reorder.CapturedBody, []string{"C", "A", "B"})
+}
+
+func TestServiceMethod_MailRulesReorderRejectsDuplicateIDs(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["C","C"]}`})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected duplicate rule ID error")
+	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
+	if !strings.Contains(err.Error(), "duplicate rule_id") {
+		t.Fatalf("error = %v, want duplicate rule_id", err)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderRejectsUnknownID(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "A"},
+					map[string]interface{}{"rule_id": "B"},
+				},
+			},
+		},
+	})
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["X"]}`})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected unknown rule ID error")
+	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("error = %v, want does not exist", err)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderListFailureSkipsReorder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body:   map[string]interface{}{"code": 230027, "msg": "user not authorized"},
+	})
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["A"]}`})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected list API error")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+}
+
+func TestServiceMethod_MailRulesReorderEmptyListSkipsReorder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{"items": []interface{}{}}},
+	})
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["A"]}`})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected empty list error")
+	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeFailedPrecondition, 0)
 }
 
 type serviceContentSafetyProvider struct {

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -518,10 +518,10 @@ func TestServiceMethod_MailRulesReorderCompletesPartialIDs(t *testing.T) {
 			"code": 0,
 			"data": map[string]interface{}{
 				"items": []interface{}{
-					map[string]interface{}{"rule_id": "A"},
-					map[string]interface{}{"rule_id": "B"},
-					map[string]interface{}{"rule_id": "C"},
-					map[string]interface{}{"rule_id": "D"},
+					map[string]interface{}{"id": "A"},
+					map[string]interface{}{"id": "B"},
+					map[string]interface{}{"id": "C"},
+					map[string]interface{}{"id": "D"},
 				},
 			},
 		},
@@ -558,8 +558,8 @@ func TestServiceMethod_MailRulesReorderCompletesPartialIDsAcrossPages(t *testing
 			"code": 0,
 			"data": map[string]interface{}{
 				"items": []interface{}{
-					map[string]interface{}{"rule_id": "A"},
-					map[string]interface{}{"rule_id": "B"},
+					map[string]interface{}{"id": "A"},
+					map[string]interface{}{"id": "B"},
 				},
 				"has_more":   true,
 				"page_token": "next",
@@ -574,8 +574,8 @@ func TestServiceMethod_MailRulesReorderCompletesPartialIDsAcrossPages(t *testing
 			"code": 0,
 			"data": map[string]interface{}{
 				"items": []interface{}{
-					map[string]interface{}{"rule_id": "C"},
-					map[string]interface{}{"rule_id": "D"},
+					map[string]interface{}{"id": "C"},
+					map[string]interface{}{"id": "D"},
 				},
 				"has_more": false,
 			},
@@ -613,9 +613,9 @@ func TestServiceMethod_MailRulesReorderKeepsFullInputOrder(t *testing.T) {
 			"code": 0,
 			"data": map[string]interface{}{
 				"items": []interface{}{
-					map[string]interface{}{"rule_id": "A"},
-					map[string]interface{}{"rule_id": "B"},
-					map[string]interface{}{"rule_id": "C"},
+					map[string]interface{}{"id": "A"},
+					map[string]interface{}{"id": "B"},
+					map[string]interface{}{"id": "C"},
 				},
 			},
 		},
@@ -668,6 +668,22 @@ func TestServiceMethod_MailRulesReorderRejectsEmptyRuleID(t *testing.T) {
 	}
 }
 
+func TestServiceMethod_MailRulesReorderRejectsEmptyRuleIDs(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":[]}`})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected empty rule_ids error")
+	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
+	if !strings.Contains(err.Error(), "rule_ids must contain at least one rule ID") {
+		t.Fatalf("error = %v, want empty rule_ids error", err)
+	}
+}
+
 func TestServiceMethod_MailRulesReorderRejectsUnknownID(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
 	reg.Register(&httpmock.Stub{
@@ -677,8 +693,8 @@ func TestServiceMethod_MailRulesReorderRejectsUnknownID(t *testing.T) {
 			"code": 0,
 			"data": map[string]interface{}{
 				"items": []interface{}{
-					map[string]interface{}{"rule_id": "A"},
-					map[string]interface{}{"rule_id": "B"},
+					map[string]interface{}{"id": "A"},
+					map[string]interface{}{"id": "B"},
 				},
 			},
 		},


### PR DESCRIPTION
Fetch the current mail rule order before submitting reorder requests.

- Complete partial reorder input with the remaining rule IDs in their current order.
- Reject duplicate or unknown rule IDs before sending the write request.
- Avoid calling reorder when listing rules fails or returns no rules.
- Add focused tests for completion, validation, and call ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mail rule reordering with validation for empty, duplicate, invalid, and unknown rule IDs.
  * Supports partial reorder requests while keeping unspecified existing rules afterward.
  * Preserves the requested order when all rule IDs are supplied.

* **Bug Fixes**
  * Prevents invalid reorder requests from being submitted.
  * Handles unavailable or empty mail rule lists without attempting a reorder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->