### PR TITLE
fix(slides): accept presentation aliases on slide add and delete

### DIFF
--- a/shortcuts/slides/shortcuts_alias_test.go
+++ b/shortcuts/slides/shortcuts_alias_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestShortcutsDeclarePresentationFlagAliases(t *testing.T) {
 	wantRequired := map[string]bool{
+		"+add-slide":             true,
+		"+delete-slide":          true,
 		"+media-upload":          true,
 		"+replace-slide":         true,
 		"+replace-pages":         true,

--- a/shortcuts/slides/slides_add_slide.go
+++ b/shortcuts/slides/slides_add_slide.go
@@ -47,7 +47,7 @@ var SlidesAddSlide = common.Shortcut{
 	ConditionalScopes: []string{"wiki:node:read", "docs:document.media:upload"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "presentation", Desc: "xml_presentation_id, slides URL, or wiki URL that resolves to slides", Required: true},
+		requiredPresentationRefFlag(),
 		// The "(supports @file, - reads stdin ...)" suffix is appended from Input
 		// below, so spelling it out here too produced a doubled parenthetical.
 		{Name: "slide", Desc: "one complete <slide> XML document", Required: true, Input: []string{common.File, common.Stdin}},

--- a/shortcuts/slides/slides_delete_slide.go
+++ b/shortcuts/slides/slides_delete_slide.go
@@ -33,7 +33,7 @@ var SlidesDeleteSlide = common.Shortcut{
 	ConditionalScopes: []string{"wiki:node:read"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "presentation", Desc: "xml_presentation_id, slides URL, or wiki URL that resolves to slides", Required: true},
+		requiredPresentationRefFlag(),
 		{Name: "slide-id", Desc: "slide page identifier (slide_id) to delete", Required: true},
 		{Name: "revision-id", Type: "int", Default: "-1", Desc: "presentation revision (-1 = latest; pass a specific number for optimistic locking)"},
 	},


### PR DESCRIPTION
## Summary

`slides +add-slide` and `slides +delete-slide` declare `--presentation` as an inline flag literal instead of using the domain's shared locator flag, so they are the only two slides commands that reject `--url`, `--token`, `--presentation-id`, `--presentation-token`, `--presentation_id` and `--xml-presentation-id`. Every sibling command accepts all six. This PR routes both commands through the shared flag and registers them in the contract test that pins it.

The inconsistency is invisible from `--help` (aliases are not listed there) and shows up only at call time, which makes it the kind of defect an agent caller hits and cannot diagnose: the same locator argument works on one verb of the same domain and fails on the next.

`main` currently fails `unit-test` and `coverage` on the contract test that catches this, which blocks every open pull request. Both commands were written before the shared flag existed, and the contract test that pins it landed before they merged, so each change was green on its own base and only the combination fails.

## Changes

- Replace the inline `--presentation` literal with the shared `requiredPresentationRefFlag()` in `shortcuts/slides/slides_add_slide.go` and `shortcuts/slides/slides_delete_slide.go`, so both commands carry the same alias set and description as the rest of the domain
- Register `+add-slide` and `+delete-slide` in `wantRequired` in `shortcuts/slides/shortcuts_alias_test.go`, which is what makes the contract test hold both commands to the shared alias set from now on

No behavior changes beyond the aliases: the canonical `--presentation` flag, its description, its required-ness, and every other flag on both commands are untouched.

## Test Plan

- [x] `make unit-test` passed
- [x] build, vet and the slides package suite pass
- [x] red-green verified on the contract test: it reports `unexpected presentation flag on +add-slide` / `+delete-slide` before the change and passes after
- [x] manual verification of the actual defect, not just the test: `slides +add-slide --url <slides-url> --slide '<slide/>' --dry-run` returns `unknown flag "--url"` on `main` and renders the dry-run envelope after the change
- [x] confirmed the sibling domain is unaffected: `shortcuts/sheets` declares its locator flag through the shared helper everywhere and its equivalent contract test passes

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `+add-slide` and `+delete-slide` shortcuts now correctly require a presentation to be specified.
  * Improved consistency in presentation selection across slide management commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->