### PR TITLE
fix(slides): migrate SML namespace from HTTP to HTTPS

### DIFF
--- a/shortcuts/slides/slides_add_slide_test.go
+++ b/shortcuts/slides/slides_add_slide_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/larksuite/cli/internal/httpmock"
 )
 
-const testSlideXML = `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>hi</p></content></shape></data></slide>`
+const testSlideXML = `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>hi</p></content></shape></data></slide>`
 
 func TestAddSlideDeclaredScopes(t *testing.T) {
 	// Pre-flight must stay at the two slides scopes: an XML-only page needs
@@ -161,7 +161,7 @@ func TestAddSlideUploadsImagePlaceholder(t *testing.T) {
 	reg.Register(slideStub)
 
 	// The same image referenced twice must still upload once.
-	slideXML := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>` +
+	slideXML := `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>` +
 		`<img src="@./chart.png" topLeftX="10" topLeftY="10" width="100" height="100"/>` +
 		`<img src="@./chart.png" topLeftX="200" topLeftY="10" width="100" height="100"/>` +
 		`</data></slide>`
@@ -202,7 +202,7 @@ func TestAddSlideRejectsNonSlideRoot(t *testing.T) {
 	err := runSlidesShortcut(t, f, stdout, SlidesAddSlide, []string{
 		"+add-slide",
 		"--presentation", "pres_abc",
-		"--slide", `<presentation xmlns="http://www.larkoffice.com/sml/2.0"><slide/></presentation>`,
+		"--slide", `<presentation xmlns="https://www.larkoffice.com/sml/2.0"><slide/></presentation>`,
 		"--as", "user",
 	})
 	if err == nil {
@@ -360,7 +360,7 @@ func TestAddSlideDryRunPlansUploadsBeforePost(t *testing.T) {
 	withSlidesTestWorkingDir(t, dir)
 
 	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	slideXML := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>` +
+	slideXML := `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>` +
 		`<img src="@./chart.png" topLeftX="10" topLeftY="10" width="100" height="100"/>` +
 		`</data></slide>`
 
@@ -526,7 +526,7 @@ func TestAddSlideReportsUploadedImagesWhenPageFails(t *testing.T) {
 		Body:   map[string]interface{}{"code": 3350001, "msg": "invalid slide xml"},
 	})
 
-	slideXML := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>` +
+	slideXML := `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>` +
 		`<img src="@./chart.png" topLeftX="10" topLeftY="10" width="100" height="100"/>` +
 		`</data></slide>`
 
@@ -576,7 +576,7 @@ func TestAddSlideReportsProgressWhenUploadFails(t *testing.T) {
 	// The slide endpoint is deliberately unstubbed: reaching it would fail as
 	// "no stub for POST .../slide", which is the no-page-created assertion.
 
-	slideXML := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>` +
+	slideXML := `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>` +
 		`<img src="@./chart.png" topLeftX="10" topLeftY="10" width="100" height="100"/>` +
 		`</data></slide>`
 

--- a/shortcuts/slides/slides_create.go
+++ b/shortcuts/slides/slides_create.go
@@ -241,7 +241,7 @@ func buildPresentationXML(title string) string {
 		escapedTitle = "Untitled"
 	}
 	return fmt.Sprintf(
-		`<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="%d" height="%d"><title>%s</title></presentation>`,
+		`<presentation xmlns="https://www.larkoffice.com/sml/2.0" width="%d" height="%d"><title>%s</title></presentation>`,
 		defaultPresentationWidth, defaultPresentationHeight, escapedTitle,
 	)
 }

--- a/shortcuts/slides/slides_create_test.go
+++ b/shortcuts/slides/slides_create_test.go
@@ -63,6 +63,14 @@ func TestSlidesCreateBasic(t *testing.T) {
 	}
 }
 
+func TestBuildPresentationXMLUsesCanonicalHTTPSNamespace(t *testing.T) {
+	got := buildPresentationXML("Demo")
+	want := `<presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540"><title>Demo</title></presentation>`
+	if got != want {
+		t.Fatalf("buildPresentationXML() = %q, want %q", got, want)
+	}
+}
+
 // TestSlidesCreateBotAutoGrant verifies that bot mode grants the current user full_access on the new presentation.
 func TestSlidesCreateBotAutoGrant(t *testing.T) {
 	t.Parallel()
@@ -324,7 +332,7 @@ func TestSlidesCreateWithSlides(t *testing.T) {
 		},
 	})
 
-	slidesJSON := `["<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>","<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>"]`
+	slidesJSON := `["<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>","<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>"]`
 	err := runSlidesCreateShortcut(t, f, stdout, []string{
 		"+create",
 		"--title", "With Slides",
@@ -380,7 +388,7 @@ func TestSlidesCreatePreservesSchemaIssues(t *testing.T) {
 
 	err := runSlidesCreateShortcut(t, f, stdout, []string{
 		"+create",
-		"--slides", `["<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data/></slide>"]`,
+		"--slides", `["<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data/></slide>"]`,
 		"--as", "user",
 	})
 	if err != nil {
@@ -441,7 +449,7 @@ func TestSlidesCreateWithSlidesPartialFailure(t *testing.T) {
 		},
 	})
 
-	slidesJSON := `["<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>","<bad-xml>"]`
+	slidesJSON := `["<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>","<bad-xml>"]`
 	err := runSlidesCreateShortcut(t, f, stdout, []string{
 		"+create",
 		"--title", "Partial",
@@ -624,7 +632,7 @@ func TestSlidesCreateWithSlidesDryRun(t *testing.T) {
 	t.Parallel()
 
 	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	slidesJSON := `["<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>","<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>"]`
+	slidesJSON := `["<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>","<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>"]`
 	err := runSlidesCreateShortcut(t, f, stdout, []string{
 		"+create",
 		"--title", "DryRun Slides",
@@ -856,8 +864,8 @@ func TestSlidesCreateWithImagePlaceholders(t *testing.T) {
 	reg.Register(slideStub2)
 
 	slidesJSON := `[
-	  "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data><img src=\"@a.png\" topLeftX=\"10\"/><img src=\"@b.png\" topLeftX=\"20\"/></data></slide>",
-	  "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data><img src=\"@a.png\" topLeftX=\"30\"/></data></slide>"
+	  "<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data><img src=\"@a.png\" topLeftX=\"10\"/><img src=\"@b.png\" topLeftX=\"20\"/></data></slide>",
+	  "<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data><img src=\"@a.png\" topLeftX=\"30\"/></data></slide>"
 	]`
 	err := runSlidesCreateShortcut(t, f, stdout, []string{
 		"+create",

--- a/shortcuts/slides/slides_replace_pages_test.go
+++ b/shortcuts/slides/slides_replace_pages_test.go
@@ -64,7 +64,7 @@ func TestReplacePagesCreatesBeforeThenDeletesOld(t *testing.T) {
 	}
 	reg.Register(deleteStub)
 
-	pages := `[{"slide_id":"old2","content":"<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>"}]`
+	pages := `[{"slide_id":"old2","content":"<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>"}]`
 	err := runSlidesShortcut(t, f, stdout, SlidesReplacePages, []string{
 		"+replace-pages",
 		"--presentation", "pres_abc",
@@ -159,8 +159,8 @@ func TestReplacePagesContinueOnErrorReturnsPartialFailure(t *testing.T) {
 	})
 
 	pages := `[
-		{"slide_id":"old1","content":"<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>"},
-		{"slide_id":"old2","content":"<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>"}
+		{"slide_id":"old1","content":"<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>"},
+		{"slide_id":"old2","content":"<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>"}
 	]`
 	err := runSlidesShortcut(t, f, stdout, SlidesReplacePages, []string{
 		"+replace-pages",
@@ -222,7 +222,7 @@ func TestReplacePagesContinueOnErrorDeleteFailureIncludesNewSlideID(t *testing.T
 		},
 	})
 
-	pages := `[{"slide_id":"old1","content":"<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>"}]`
+	pages := `[{"slide_id":"old1","content":"<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>"}]`
 	err := runSlidesShortcut(t, f, stdout, SlidesReplacePages, []string{
 		"+replace-pages",
 		"--presentation", "pres_abc",
@@ -257,7 +257,7 @@ func TestReplacePagesDryRunPlansOnly(t *testing.T) {
 
 	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 
-	pages := `[{"slide_id":"old2","content":"<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data></data></slide>"}]`
+	pages := `[{"slide_id":"old2","content":"<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data></data></slide>"}]`
 	err := runSlidesShortcut(t, f, stdout, SlidesReplacePages, []string{
 		"+replace-pages",
 		"--presentation", "pres_abc",

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -720,7 +720,7 @@ func TestSlidesScreenshotRenderContentWritesFile(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
 
-	content := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`
+	content := `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`
 	if err := os.WriteFile(filepath.Join(dir, "slide.xml"), []byte(content), 0o644); err != nil {
 		t.Fatalf("write input xml: %v", err)
 	}
@@ -792,7 +792,7 @@ func TestSlidesScreenshotRenderRejectsSlideSelectors(t *testing.T) {
 
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
-		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 		"--slide-id", "slide_1",
 		"--as", "user",
 	})
@@ -813,7 +813,7 @@ func TestSlidesScreenshotRenderRejectsSlideNumberSelector(t *testing.T) {
 	// --slide-id side of that same `||` condition).
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
-		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 		"--slide-number", "0",
 		"--as", "user",
 	})
@@ -830,7 +830,7 @@ func TestSlidesScreenshotRenderAttributesSlideAliasConflictToCallerInput(t *test
 
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
-		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 		"--slide", "pII",
 		"--as", "user",
 	})
@@ -855,7 +855,7 @@ func TestSlidesScreenshotRenderIgnoresEmptySlideID(t *testing.T) {
 
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
-		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 		"--slide-id", "",
 		"--dry-run",
 		"--as", "user",
@@ -873,7 +873,7 @@ func TestSlidesScreenshotRenderRejectsListOnlyFlags(t *testing.T) {
 
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
-		"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 		"--presentation", "pres_abc",
 		"--as", "user",
 	})
@@ -911,7 +911,7 @@ func TestSlidesScreenshotDryRunSelectsListOrRenderAPI(t *testing.T) {
 		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 			"+screenshot",
-			"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+			"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 			"--dry-run",
 			"--as", "user",
 		})

--- a/skills/lark-slides/references/lark-slides-add-slide.md
+++ b/skills/lark-slides/references/lark-slides-add-slide.md
@@ -12,7 +12,7 @@
 # 追加到末尾（XML 直接作为参数）
 lark-cli slides +add-slide --as user \
   --presentation "$PID" \
-  --slide '<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>'
+  --slide '<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>'
 
 # XML 从文件读（推荐：避免 shell 转义和长参数截断）
 lark-cli slides +add-slide --as user \
@@ -58,7 +58,7 @@ XML 里写 `<img src="@./chart.png" .../>`，CLI 会：先把每个不重复的�
 ```bash
 lark-cli slides +add-slide --as user \
   --presentation "$PID" \
-  --slide '<slide xmlns="http://www.larkoffice.com/sml/2.0"><data><img src="@./chart.png" topLeftX="100" topLeftY="100" width="320" height="180"/></data></slide>'
+  --slide '<slide xmlns="https://www.larkoffice.com/sml/2.0"><data><img src="@./chart.png" topLeftX="100" topLeftY="100" width="320" height="180"/></data></slide>'
 ```
 
 - 文件不存在、不是普通文件、超过 20 MB，都在**调用任何接口之前**报错，不会留下半成品。

--- a/skills/lark-slides/references/lark-slides-create.md
+++ b/skills/lark-slides/references/lark-slides-create.md
@@ -28,8 +28,8 @@ lark-cli slides +create --title "项目汇报"
 
 # 创建 PPT + 添加 slide 页面
 lark-cli slides +create --title "项目汇报" --slides '[
-  "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data><shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>封面</p></content></shape></data></slide>",
-  "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data><shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>第二页</p></content></shape></data></slide>"
+  "<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data><shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>封面</p></content></shape></data></slide>",
+  "<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data><shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>第二页</p></content></shape></data></slide>"
 ]'
 
 # 以应用身份创建（自动授权当前用户）
@@ -89,8 +89,8 @@ lark-cli slides +create --as user --title "项目汇报" \
 
 ```json
 [
-  "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\">...第1页XML...</slide>",
-  "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\">...第2页XML...</slide>"
+  "<slide xmlns=\"https://www.larkoffice.com/sml/2.0\">...第1页XML...</slide>",
+  "<slide xmlns=\"https://www.larkoffice.com/sml/2.0\">...第2页XML...</slide>"
 ]
 ```
 
@@ -102,7 +102,7 @@ JSON string 数组，每个元素是一页 slide 的完整 XML。CLI 内部负�
 
 ```bash
 lark-cli slides +create --as user --title "图测试" --slides '[
-  "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data><img src=\"@./assets/chart.png\" topLeftX=\"100\" topLeftY=\"100\" width=\"320\" height=\"180\"/></data></slide>"
+  "<slide xmlns=\"https://www.larkoffice.com/sml/2.0\"><data><img src=\"@./assets/chart.png\" topLeftX=\"100\" topLeftY=\"100\" width=\"320\" height=\"180\"/></data></slide>"
 ]'
 ```
 

--- a/skills/lark-slides/references/lark-slides-xml-presentations-get.md
+++ b/skills/lark-slides/references/lark-slides-xml-presentations-get.md
@@ -96,7 +96,7 @@ lark-cli slides xml_presentations get --as user --params '<json_params>'
     "xml_presentation": {
       "presentation_id": "slides_example_presentation_id",
       "revision_id": 1,
-      "content": "<presentation xmlns=\"http://www.larkoffice.com/sml/2.0\" height=\"540\" width=\"960\">...</presentation>"
+      "content": "<presentation xmlns=\"https://www.larkoffice.com/sml/2.0\" height=\"540\" width=\"960\">...</presentation>"
     }
   }
 }

--- a/skills/lark-slides/references/slides_chart_demo.xml
+++ b/skills/lark-slides/references/slides_chart_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<presentation xmlns="/sml/2.0" width="960" height="540">
+<presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
   <title>原生图表 Chart Demo</title>
   <theme>
     <textStyles>

--- a/skills/lark-slides/references/slides_xml_schema_definition.xml
+++ b/skills/lark-slides/references/slides_xml_schema_definition.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema
         xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:sml="http://www.larkoffice.com/sml/2.0"
-        targetNamespace="http://www.larkoffice.com/sml/2.0"
+        xmlns:sml="https://www.larkoffice.com/sml/2.0"
+        targetNamespace="https://www.larkoffice.com/sml/2.0"
         elementFormDefault="qualified"
         attributeFormDefault="unqualified">
     <xs:annotation>
@@ -11,7 +11,7 @@
 
             版本信息：
             - Schema 版本: 2.0.0
-            - 命名空间: http://www.larkoffice.com/sml/2.0
+            - 命名空间: https://www.larkoffice.com/sml/2.0
             - 发布日期: 2025-11-03
         </xs:documentation>
     </xs:annotation>

--- a/skills/lark-slides/references/validation-checklist.md
+++ b/skills/lark-slides/references/validation-checklist.md
@@ -57,7 +57,7 @@ python3 "<lark-slides-skill-dir>/scripts/xml_text_overlap_lint.py" --input <pres
 | code | 含义 | 处理方式 |
 |------|------|----------|
 | `xml_not_well_formed` | XML 语法错误或文本未转义 | 修复标签闭合、属性引号、`&` / `<` / `>` 转义 |
-| `sml_prefixed_tag` | SML 元素使用了命名空间前缀，如 `<ns0:slide>` 或 `<sml:shape>` | 使用 `<slide xmlns="http://www.larkoffice.com/sml/2.0">` 的默认命名空间，或使用无前缀标签 |
+| `sml_prefixed_tag` | SML 元素使用了命名空间前缀，如 `<ns0:slide>` 或 `<sml:shape>` | 使用 `<slide xmlns="https://www.larkoffice.com/sml/2.0">` 的默认命名空间，或使用无前缀标签 |
 | `sxsd_unsupported_tag` | 使用了 SXSD 不支持的标签 | 按 lint `hint` 替换为受支持标签；常见如 `textbox -> <shape type="text">`、`image -> <img>` |
 | `sxsd_unsupported_attr` | 支持的标签上使用了不支持的属性 | 按 lint `hint` 改为支持的属性；常见如 `x -> topLeftX`、`fontColor -> color` |
 | `iconpark_unsupported_icon_type` | `<icon>` 使用了 `iconpark-index.json` 中不存在的 `iconType` | 按 lint `hint` 改为名单内的 `iconType`，或先用 `scripts/iconpark_tool.py` 搜索 |

--- a/skills/lark-slides/references/xml-schema-quick-ref.md
+++ b/skills/lark-slides/references/xml-schema-quick-ref.md
@@ -4,7 +4,7 @@
 
 ## 最重要的规则
 
-1. 协议标准写法应使用 `<presentation xmlns="http://www.larkoffice.com/sml/2.0">`；当前服务端实现可能兼容不带 `xmlns` 的输入，但不作为协议保证
+1. 协议标准写法应使用 `<presentation xmlns="https://www.larkoffice.com/sml/2.0">`；当前服务端实现可能兼容不带 `xmlns` 的输入，但不作为协议保证
 2. `<presentation>` 直接子元素只有 `<title>`、`<theme>`、`<slide>`
 3. `<slide>` 直接子元素只有 `<style>`、`<data>`、`<note>`
 4. 页面中的文本通常通过 `<content>` 表达，而不是把 `<title>`、`<body>` 直接挂在 `<slide>` 下
@@ -13,7 +13,7 @@
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+<presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
   <slide>
     <data>
       <shape type="text" topLeftX="80" topLeftY="80" width="800" height="120">
@@ -418,7 +418,7 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+<presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
   <title>季度报告</title>
   <theme>
     <textStyles>
@@ -466,7 +466,7 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 
 ## 最佳实践
 
-1. 始终带上命名空间 `xmlns="http://www.larkoffice.com/sml/2.0"`
+1. 始终带上命名空间 `xmlns="https://www.larkoffice.com/sml/2.0"`
 2. 用 `shape type="text"` + `content` 表达页面文本
 3. 用 `topLeftX` / `topLeftY`、`startX` / `startY` 等 schema 中定义的属性名
 4. 优先使用 `rgb` / `rgba` 颜色格式；渐变必须使用 `rgba()` 且带百分比停靠点
@@ -481,5 +481,5 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 ## Schema 版本信息
 
 - **版本**: 2.0.0
-- **命名空间**: http://www.larkoffice.com/sml/2.0
+- **命名空间**: https://www.larkoffice.com/sml/2.0
 - **发布日期**: 2025-11-03

--- a/skills/lark-slides/scripts/sxsd_validator.py
+++ b/skills/lark-slides/scripts/sxsd_validator.py
@@ -16,11 +16,11 @@ from typing import Any
 
 
 XS_NS = "{http://www.w3.org/2001/XMLSchema}"
-SML_NAMESPACE = "http://www.larkoffice.com/sml/2.0"
+SML_NAMESPACE = "https://www.larkoffice.com/sml/2.0"
+SML_LEGACY_HTTP_NAMESPACE = "http://www.larkoffice.com/sml/2.0"
 SML_READBACK_NAMESPACE = "/sml/2.0"
-SML_HTTPS_READBACK_NAMESPACE = "https://www.larkoffice.com/sml/2.0"
 ACCEPTED_SML_NAMESPACES = frozenset(
-    (SML_NAMESPACE, SML_READBACK_NAMESPACE, SML_HTTPS_READBACK_NAMESPACE)
+    (SML_NAMESPACE, SML_LEGACY_HTTP_NAMESPACE, SML_READBACK_NAMESPACE)
 )
 
 

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -23,7 +23,7 @@ import sxsd_validator
 XS_NS = "{http://www.w3.org/2001/XMLSchema}"
 XML_NS = "{http://www.w3.org/XML/1998/namespace}"
 SVG_NS = "{http://www.w3.org/2000/svg}"
-SML_NAMESPACE = "http://www.larkoffice.com/sml/2.0"
+SML_NAMESPACE = "https://www.larkoffice.com/sml/2.0"
 SXSD_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "references" / "slides_xml_schema_definition.xml"
 ICONPARK_INDEX_PATH = Path(__file__).resolve().parents[1] / "references" / "iconpark-index.json"
 SXSD_TAG_ALIASES = {
@@ -683,7 +683,8 @@ def validate_sml_tag_prefixes(xml: str) -> list[dict[str, Any]]:
         if not prefix:
             return
 
-        if namespace_map.get(prefix) != SML_NAMESPACE:
+        actual_namespace = namespace_map.get(prefix)
+        if actual_namespace not in sxsd_validator.ACCEPTED_SML_NAMESPACES:
             return
         path = "/".join(element_stack)
         issues.append(
@@ -691,7 +692,7 @@ def validate_sml_tag_prefixes(xml: str) -> list[dict[str, Any]]:
                 "level": "error",
                 "code": "sml_prefixed_tag",
                 "tag": element_name,
-                "namespace": SML_NAMESPACE,
+                "namespace": actual_namespace,
                 "path": path,
                 "line": parser.CurrentLineNumber,
                 "column": parser.CurrentColumnNumber,

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -2690,8 +2690,9 @@ def run_cli(argv: list[str] | None = None) -> None:
     if not options.get("input"):
         print_usage()
         fail("--input is required")
-    input_path = Path(options["input"]).resolve()
-    result = lint_xml(read_file(input_path), str(input_path))
+    requested_path = options["input"]
+    resolved_path = Path(requested_path).resolve()
+    result = lint_xml(read_file(resolved_path), requested_path)
     print(json.dumps(result, ensure_ascii=False, indent=2))
     if result["summary"]["error_count"] > 0:
         raise SystemExit(1)

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -58,8 +58,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             resolved_path = temp_path / "resolved.xml"
             requested_path = temp_path / "requested.xml"
             resolved_path.write_text(
-                '<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">'
-                '<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>'
+                '<presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">'
+                '<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>'
                 '<shape type="text" topLeftX="10" topLeftY="10" width="100" height="30">'
                 '<content><p><span>Test</span></p></content>'
                 '</shape></data></slide>'
@@ -85,7 +85,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             input_path = Path(temp_dir) / "invalid-slide.xml"
             input_path.write_text(
                 """
-                <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <slide xmlns="https://www.larkoffice.com/sml/2.0">
                   <data><shape type="text" topLeftX="10" topLeftY="20" width="300"/></data>
                 </slide>
                 """,
@@ -113,8 +113,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_xml_text_overlap_lint_accepts_inline_fixture_xml_samples(self) -> None:
         samples = {
             "image-led-cover": """
-                <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-                  <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+                  <slide xmlns="https://www.larkoffice.com/sml/2.0">
                     <style><fill><fillColor color="rgb(15,23,42)"/></fill></style>
                     <data>
                       <img src="tok" topLeftX="560" topLeftY="0" width="400" height="540"/>
@@ -129,8 +129,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
                 </presentation>
             """,
             "content-grid": """
-                <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-                  <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+                  <slide xmlns="https://www.larkoffice.com/sml/2.0">
                     <data>
                       <shape type="text" topLeftX="60" topLeftY="44" width="620" height="46">
                         <content textType="title"><p><span fontSize="30">Execution Snapshot</span></p></content>
@@ -164,7 +164,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_unescaped_ampersand_in_text(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                   <content textType="body"><p>Q&A</p></content>
@@ -184,7 +184,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_unescaped_ampersand_in_attribute(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                   <content textType="body"><p><a href="https://example.com/?a=1&b=2">link</a></p></content>
@@ -201,7 +201,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_mismatched_xml_tag(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                   <content textType="body"><p>Broken XML</content>
@@ -221,9 +221,9 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_rejects_prefixed_sml_tags(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <ns0:slide xmlns:ns0="http://www.larkoffice.com/sml/2.0">
+            <ns0:slide xmlns:ns0="https://www.larkoffice.com/sml/2.0">
               <ns0:data>
-                <sml:shape xmlns:sml="http://www.larkoffice.com/sml/2.0" type="text" topLeftX="80" topLeftY="80" width="300" height="60">
+                <sml:shape xmlns:sml="https://www.larkoffice.com/sml/2.0" type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                   <sml:content textType="body"><sml:p>Prefixed SML</sml:p></sml:content>
                 </sml:shape>
               </ns0:data>
@@ -235,6 +235,29 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual([issue["code"] for issue in issues], ["sml_prefixed_tag"] * 5)
         self.assertEqual(issues[0]["tag"], "ns0:slide")
         self.assertIn("default namespace", issues[0]["hint"])
+        self.assertEqual({issue["namespace"] for issue in issues}, {SML_NAMESPACE})
+
+    def test_lint_xml_reports_bound_namespace_for_prefixed_sml_tags(self) -> None:
+        for namespace in (
+            "http://www.larkoffice.com/sml/2.0",
+            "/sml/2.0",
+            SML_NAMESPACE,
+        ):
+            with self.subTest(namespace=namespace):
+                result = xml_text_overlap_lint.lint_xml(
+                    f"""
+                    <sml:slide xmlns:sml="{namespace}">
+                      <sml:data>
+                        <sml:shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
+                          <sml:content textType="body"><sml:p>Prefixed SML</sml:p></sml:content>
+                        </sml:shape>
+                      </sml:data>
+                    </sml:slide>
+                    """
+                )
+                issues = result["issues"]
+                self.assertEqual([issue["code"] for issue in issues], ["sml_prefixed_tag"] * 5)
+                self.assertEqual({issue["namespace"] for issue in issues}, {namespace})
 
     def test_lint_xml_accepts_server_readback_slide_without_namespace(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
@@ -286,6 +309,24 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(result["summary"]["slide_count"], 1)
         self.assertEqual(result["summary"]["error_count"], 0)
 
+    def test_lint_xml_accepts_legacy_http_namespace(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540" id="legacy-http-id">
+              <slide id="server-slide-id">
+                <data>
+                  <shape id="server-shape-id" type="text" topLeftX="80" topLeftY="80" width="300" height="60">
+                    <content textType="body"><p>Legacy HTTP namespace</p></content>
+                  </shape>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+
+        self.assertEqual(result["summary"]["slide_count"], 1)
+        self.assertEqual(result["summary"]["error_count"], 0)
+
     def test_lint_xml_rejects_server_readback_presentation_wrong_namespace(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
@@ -300,7 +341,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
 
     def test_lint_xml_rejects_xml_declaration(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
-            '<?xml version="1.0"?><slide xmlns="http://www.larkoffice.com/sml/2.0"><data/></slide>'
+            '<?xml version="1.0"?><slide xmlns="https://www.larkoffice.com/sml/2.0"><data/></slide>'
         )
 
         self.assertEqual(result["summary"]["error_count"], 1)
@@ -309,7 +350,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_missing_required_sxsd_attribute(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data><shape type="text" topLeftX="80" topLeftY="80" width="300"/></data>
             </slide>
             """
@@ -324,7 +365,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_rejects_child_order_that_violates_xsd_sequence(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide/>
               <title>Late title</title>
             </presentation>
@@ -337,7 +378,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_accepts_escaped_entities_without_suspicious_entity_warning(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                   <content textType="body"><p>Q&amp;A</p></content>
@@ -352,7 +393,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_accepts_chinese_full_width_punctuation(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeftX="80" topLeftY="80" width="620" height="90">
                   <content textType="body"><p>承诺：按期交付；持续复盘｜风险透明</p></content>
@@ -366,7 +407,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_single_slide_reports_out_of_canvas_and_blank_slide_errors(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeftX="1000" topLeftY="500" width="120" height="80">
                   <content textType="body"><p>Body text outside the canvas</p></content>
@@ -386,15 +427,15 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_preserves_presentation_canvas_and_slide_order(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="1280" height="720">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="1280" height="720">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape id="first" type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                     <content textType="body"><p>First slide</p></content>
                   </shape>
                 </data>
               </slide>
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <img id="second" src="tok" topLeftX="100" topLeftY="120" width="240" height="160"/>
                   <shape id="second-shape" type="text" topLeftX="80" topLeftY="80" width="300" height="60">
@@ -415,7 +456,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_handles_self_closing_slide_before_normal_slide(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide/>
               <slide>
                 <data>
@@ -438,7 +479,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_keeps_trailing_self_closing_slide(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide>
                 <data>
                   <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
@@ -460,7 +501,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_slide_markup_inside_xml_comments(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide>
                 <data>
                   <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
@@ -479,7 +520,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_invalid_slide_markup_inside_xml_comments(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide><data/></slide>
               <!-- Old draft: <slide bogus="x"/> -->
             </presentation>
@@ -495,7 +536,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_skips_only_invalid_slide_and_continues_geometry_checks(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide>
                 <data>
                   <shape id="invalid" type="text" topLeftX="1000" topLeftY="80" width="300">
@@ -532,7 +573,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_scopes_invalid_slide_root_attribute_to_that_slide(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide bogusAttr="oops">
                 <data><shape type="rect" topLeftX="80" topLeftY="80" width="100" height="100"/></data>
               </slide>
@@ -562,7 +603,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             with self.subTest(tag=tag_name):
                 result = xml_text_overlap_lint.lint_xml(
                     f"""
-                    <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                    <slide xmlns="https://www.larkoffice.com/sml/2.0">
                       <data>{element_xml}</data>
                     </slide>
                     """
@@ -590,7 +631,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             with self.subTest(attr=attr_name):
                 result = xml_text_overlap_lint.lint_xml(
                     f"""
-                    <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                    <slide xmlns="https://www.larkoffice.com/sml/2.0">
                       <data>{element_xml}</data>
                     </slide>
                     """
@@ -612,7 +653,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_keeps_unrelated_unsupported_and_missing_attrs(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" bogus="x" topLeftX="80" topLeftY="80" width="300"/>
               </data>
@@ -628,7 +669,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_keeps_missing_attrs_when_suggestion_is_ambiguous(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeft="80" width="300" height="60"/>
               </data>
@@ -648,7 +689,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_suppresses_only_missing_attr_that_resolves_ambiguous_suggestion(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="text" topLeftXX="80" topLeftY="80" width="300" height="60"/>
               </data>
@@ -667,7 +708,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_server_filled_id_attrs(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide id="server-slide-id" xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide id="server-slide-id" xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="server-shape-id" type="rect" topLeftX="80" topLeftY="80" width="300" height="160">
                   <fill id="server-fill-id" unexpected="value">
@@ -688,7 +729,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_chart_roundtrip_attrs(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <chart updated="true" topLeftX="80" topLeftY="80" width="300" height="160">
                   <chartPlotArea><chartPlot type="line"/></chartPlotArea>
@@ -707,7 +748,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_chart_parsed_values_roundtrip_tags(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <chart topLeftX="80" topLeftY="80" width="300" height="160">
                   <chartPlotArea><chartPlot type="line"/></chartPlotArea>
@@ -730,7 +771,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_chart_parsed_values_roundtrip_tag(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <chart topLeftX="80" topLeftY="80" width="300" height="160">
                   <chartPlotArea><chartPlot type="line"/></chartPlotArea>
@@ -754,7 +795,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_rejects_chart_parsed_values_outside_chart_field(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="rect" topLeftX="80" topLeftY="80" width="300" height="160">
                   <chartParsedValues>unexpected</chartParsedValues>
@@ -777,7 +818,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_limits_chart_roundtrip_attrs_to_matching_tags(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <chart isStaticData="true" topLeftX="80" topLeftY="80" width="300" height="160">
                   <chartPlotArea><chartPlot type="line"/></chartPlotArea>
@@ -802,7 +843,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_gradient_shorthand_attrs_on_fill_color(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape type="rect" topLeftX="80" topLeftY="80" width="300" height="160">
                   <fill>
@@ -832,7 +873,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_accepts_chart_field_simple_content_attrs(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <chart topLeftX="80" topLeftY="80" width="520" height="320">
                   <chartPlotArea>
@@ -864,7 +905,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         try:
             result = xml_text_overlap_lint.lint_xml(
                 """
-                <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <slide xmlns="https://www.larkoffice.com/sml/2.0">
                   <data>
                     <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                       <content><p>No icons here</p></content>
@@ -882,7 +923,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_accepts_iconpark_icon_type_from_index(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <icon iconType="iconpark/Base/setting.svg" topLeftX="80" topLeftY="80" width="48" height="48">
                   <fill><fillColor color="rgba(37, 99, 235, 1)"/></fill>
@@ -907,7 +948,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             with self.subTest(icon=icon_xml):
                 result = xml_text_overlap_lint.lint_xml(
                     f"""
-                    <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                    <slide xmlns="https://www.larkoffice.com/sml/2.0">
                       <data>{icon_xml}</data>
                     </slide>
                     """
@@ -921,7 +962,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_icon_transparent_fill_color(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <icon iconType="iconpark/Base/setting.svg" topLeftX="80" topLeftY="80" width="48" height="48">
                   <fill><fillColor color="rgba(37, 99, 235, 0)"/></fill>
@@ -939,7 +980,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_iconpark_icon_type_outside_index(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <icon iconType="iconpark/Base/settng.svg" topLeftX="80" topLeftY="80" width="48" height="48">
                   <fill><fillColor color="rgba(37, 99, 235, 1)"/></fill>
@@ -960,8 +1001,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_detects_overlapping_text_boxes(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                     <content textType="title"><p>Title</p></content>
@@ -981,7 +1022,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_detects_current_itinerary_cjk_caption_occlusion(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide id="pQO" xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide id="pQO" xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape width="190" height="80" topLeftX="580" topLeftY="170" presetHandlers="0" type="rect" id="blI">
                   <fill><fillColor color="rgba(255, 255, 255, 0.9)"/></fill>
@@ -1039,7 +1080,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_detects_horizontal_text_overflow_across_declared_box_gap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="source" type="text" topLeftX="80" topLeftY="100" width="160" height="40">
                   <content fontSize="18" wrap="false"><p>这是一个足够长的中文文本用于检测跨越间隙的横向溢出</p></content>
@@ -1062,7 +1103,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_horizontal_text_with_default_wrap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="source" type="text" topLeftX="80" topLeftY="100" width="160" height="40">
                   <content fontSize="18"><p>这是一个足够长的中文文本用于检测默认自动换行</p></content>
@@ -1083,8 +1124,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_text_out_of_canvas_and_warns_for_text_height(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape type="text" topLeftX="80" topLeftY="80" width="180" height="20">
                     <content textType="body" fontSize="18"><p>This paragraph is intentionally much longer than the box can safely contain.</p></content>
@@ -1106,7 +1147,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_warns_when_text_may_overflow_its_own_shape(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="overflowing" type="text" topLeftX="80" topLeftY="80" width="360" height="80">
                   <content fontSize="20" lineSpacing="multiple:1.5" autoFit="no-auto-fit">
@@ -1150,7 +1191,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_uses_fixed_line_spacing_for_text_height_warning(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="fixed-overflow" type="text" topLeftX="80" topLeftY="80" width="360" height="50">
                   <content fontSize="20" lineSpacing="fixed:20" autoFit="no-auto-fit">
@@ -1172,7 +1213,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_subpixel_text_height_overflow_tolerance(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="minor-overflow" type="text" topLeftX="80" topLeftY="80" width="360" height="39.8">
                   <content fontSize="20" lineSpacing="fixed:20" autoFit="no-auto-fit">
@@ -1193,7 +1234,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_single_line_width_estimation_jitter(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="metric" type="text" topLeftX="80" topLeftY="80" width="152" height="54">
                   <content fontSize="36" lineSpacing="multiple:1.2" autoFit="no-auto-fit"><p>4.16万亿</p></content>
@@ -1212,7 +1253,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_short_metric_text_with_separators_as_single_line(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="metric" type="text" topLeftX="80" topLeftY="80" width="150" height="50">
                   <content textType="title" fontSize="36" autoFit="no-auto-fit"><p>4.16万亿</p></content>
@@ -1234,7 +1275,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_plain_short_metric_when_it_wraps(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="plain-age" type="text" topLeftX="80" topLeftY="80" width="50" height="80">
                   <content textType="title" fontSize="36" bold="true" autoFit="no-auto-fit"><p>82岁</p></content>
@@ -1254,7 +1295,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_centered_short_label_near_fit_as_single_line(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="centered-label" type="text" topLeftX="80" topLeftY="80" width="200" height="30">
                   <content fontSize="14" bold="true" textAlign="center" autoFit="no-auto-fit">
@@ -1275,7 +1316,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_headline_near_fit_as_single_line(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="headline" type="text" topLeftX="80" topLeftY="80" width="700" height="50">
                   <content textType="headline" fontSize="26" bold="true" lineSpacing="multiple:1.3" autoFit="no-auto-fit">
@@ -1296,7 +1337,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_dense_body_line_spacing_estimation_slack(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="dense-body" type="text" topLeftX="80" topLeftY="80" width="360" height="140">
                   <content fontSize="13" bold="true" lineSpacing="multiple:1.7" autoFit="no-auto-fit">
@@ -1322,7 +1363,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_dense_body_when_adjusted_height_still_overflows(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="dense-body" type="text" topLeftX="80" topLeftY="80" width="360" height="100">
                   <content fontSize="13" bold="true" lineSpacing="multiple:1.7" autoFit="no-auto-fit">
@@ -1349,7 +1390,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_letter_spaced_caption_near_fit(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="caption" type="text" topLeftX="80" topLeftY="80" width="120" height="20">
                   <content textType="caption" fontSize="11" letterSpacing="1" autoFit="no-auto-fit">
@@ -1371,7 +1412,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_micro_caption_when_wrapping_overflows(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="micro-caption" type="text" topLeftX="80" topLeftY="60" width="200" height="16">
                   <content textType="caption" fontSize="3" lineSpacing="multiple:1.3" letterSpacing="160" autoFit="no-auto-fit">
@@ -1393,7 +1434,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_text_may_overflow_shape_upgrades_to_error_above_threshold(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="just-warning" type="text" topLeftX="80" topLeftY="80" width="360" height="50">
                   <content fontSize="20" lineSpacing="fixed:20" autoFit="no-auto-fit">
@@ -1420,7 +1461,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_text_may_overflow_shape_downgrades_background_decoration_to_info(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="bg-deco" type="text" topLeftX="0" topLeftY="0" width="600" height="80" alpha="0.3">
                   <content fontSize="120" lineSpacing="fixed:120" autoFit="no-auto-fit"><p>2026</p></content>
@@ -1446,7 +1487,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_shape_alpha_ghost_text_out_of_canvas_but_allows_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="ghost-number" type="text" topLeftX="-60" topLeftY="30" width="360" height="180" alpha="0.2">
                   <content fontSize="160" lineSpacing="fixed:160" wrap="false"><p>01</p></content>
@@ -1466,7 +1507,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_content_color_alpha_ghost_text_out_of_canvas_but_allows_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="ghost-year" type="text" topLeftX="760" topLeftY="20" width="260" height="160">
                   <content fontSize="140" color="rgba(0,0,0,0.2)" lineSpacing="fixed:140" wrap="false"><p>2026</p></content>
@@ -1486,7 +1527,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_faint_medium_ghost_text_out_of_canvas_but_allows_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="medium-ghost" type="text" topLeftX="820" topLeftY="300" width="270" height="72" alpha="0.32">
                   <content fontSize="40" lineSpacing="fixed:40" wrap="false"><p>OFF EDGE</p></content>
@@ -1506,7 +1547,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_ghost_text_image_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="ghost-label" type="text" topLeftX="100" topLeftY="40" width="560" height="160" alpha="0.2">
                   <content fontSize="120" lineSpacing="fixed:120" wrap="false"><p>2026</p></content>
@@ -1526,7 +1567,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_slide_allows_ghost_text_whiteboard_overlap(self) -> None:
         result = xml_text_overlap_lint.lint_slide(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <whiteboard id="board" topLeftX="180" topLeftY="70" width="420" height="300"/>
                 <shape id="ghost-label" type="text" topLeftX="100" topLeftY="40" width="560" height="160" alpha="0.2">
@@ -1546,7 +1587,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_faint_ghost_text_out_of_canvas_without_area_threshold(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="small-ghost" type="text" topLeftX="940" topLeftY="300" width="40" height="40" alpha="0.32">
                   <content fontSize="36" lineSpacing="fixed:36" wrap="false"><p>土</p></content>
@@ -1561,7 +1602,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_keeps_out_of_canvas_error_for_medium_text_without_faint_alpha(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="medium-not-ghost" type="text" topLeftX="820" topLeftY="300" width="270" height="72" alpha="0.36">
                   <content fontSize="54" lineSpacing="fixed:54" wrap="false"><p>OFF EDGE</p></content>
@@ -1577,7 +1618,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_keeps_out_of_canvas_error_for_half_alpha_large_text(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="half-alpha" type="text" topLeftX="760" topLeftY="20" width="260" height="160">
                   <content fontSize="140" color="rgba(0,0,0,0.5)" lineSpacing="fixed:140" wrap="false"><p>2026</p></content>
@@ -1593,7 +1634,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_text_may_overflow_shape_keeps_error_when_alpha_not_low(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="opaque-big" type="text" topLeftX="0" topLeftY="0" width="600" height="80" alpha="0.9">
                   <content fontSize="120" lineSpacing="fixed:120" autoFit="no-auto-fit"><p>2026</p></content>
@@ -1615,7 +1656,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_text_may_overflow_shape_keeps_error_when_no_foreground_text(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="lonely-big" type="text" topLeftX="0" topLeftY="0" width="600" height="80" alpha="0.3">
                   <content fontSize="120" lineSpacing="fixed:120" autoFit="no-auto-fit"><p>2026</p></content>
@@ -1634,7 +1675,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_text_may_overflow_shape_keeps_error_when_foreground_alpha_zero(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="bg-deco" type="text" topLeftX="0" topLeftY="0" width="600" height="80" alpha="0.3">
                   <content fontSize="120" lineSpacing="fixed:120" autoFit="no-auto-fit"><p>2026</p></content>
@@ -1656,7 +1697,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_text_may_overflow_shape_keeps_error_when_foreground_is_below_in_order(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="foreground" type="text" topLeftX="40" topLeftY="20" width="400" height="60">
                   <content fontSize="20" lineSpacing="fixed:24"><p>Annual Report</p></content>
@@ -1678,7 +1719,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_uses_paragraph_spacing_overrides_for_text_height_warning(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="paragraph-overflow" type="text" topLeftX="80" topLeftY="80" width="360" height="30">
                   <content fontSize="20" lineSpacing="multiple:1.5" autoFit="no-auto-fit">
@@ -1705,7 +1746,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_uses_letter_spacing_for_text_overflow_warning(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="baseline" type="text" topLeftX="0" topLeftY="0" width="120" height="30">
                   <content fontSize="20" lineSpacing="multiple:1.5" autoFit="no-auto-fit"><p>一二三四五六</p></content>
@@ -1740,8 +1781,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_template_style_images_outside_canvas(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <img src="tok" topLeftX="-120" topLeftY="20" width="360" height="360"/>
                   <shape type="text" topLeftX="40" topLeftY="80" width="180" height="80">
@@ -1761,7 +1802,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_extract_elements_preserves_supported_element_geometry_order_and_text_metadata(self) -> None:
         elements = xml_text_overlap_lint.extract_elements(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <img id="photo" src="tok" topLeftX="10" topLeftY="20" width="100" height="80"/>
                 <shape id="headline" type="text" topLeftX="40" topLeftY="60" width="320" height="90">
@@ -1793,8 +1834,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_small_out_of_bounds_images(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <img src="tok" topLeftX="-20" topLeftY="20" width="120" height="120"/>
                 </data>
@@ -1807,8 +1848,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_out_of_canvas_images(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <img src="right" topLeftX="780" topLeftY="0" width="500" height="540"/>
                   <img src="bottom" topLeftX="0" topLeftY="430" width="900" height="280"/>
@@ -1822,8 +1863,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_full_bleed_images_outside_canvas(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <img src="tok" topLeftX="-80" topLeftY="-20" width="1080" height="600"/>
                 </data>
@@ -1836,8 +1877,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_text_and_chart_but_not_image_out_of_canvas(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape id="outside-shape" type="text" topLeftX="-10" topLeftY="40" width="50" height="50"/>
                   <img id="outside-img" src="token" topLeftX="120" topLeftY="-20" width="50" height="50"/>
@@ -1866,7 +1907,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_line_out_of_canvas(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="body" type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                   <content fontSize="18"><p>Visible content</p></content>
@@ -1883,7 +1924,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_horizontal_line_crossing_headline_glyphs(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="title" type="text" topLeftX="80" topLeftY="200" width="500" height="90">
                   <content fontSize="60"><p>测试文字 ABC</p></content>
@@ -1904,7 +1945,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_vertical_line_crossing_multiline_text(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="col" type="text" topLeftX="700" topLeftY="180" width="240" height="180">
                   <content fontSize="20"><p>第一行文字内容</p><p>第二行文字内容</p><p>第三行文字内容</p></content>
@@ -1924,7 +1965,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_diagonal_line_crossing_text_block(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="para" type="text" topLeftX="80" topLeftY="400" width="420" height="140">
                   <content fontSize="18"><p>这是一段测试文字用于验证线条穿过</p></content>
@@ -1946,7 +1987,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         # through empty space in the opposite corner -- a naive bbox test would false-positive here.
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="corner-text" type="text" topLeftX="80" topLeftY="80" width="120" height="40">
                   <content fontSize="18"><p>corner</p></content>
@@ -1966,7 +2007,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_line_touching_text_frame_but_not_glyphs(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="lbl" type="text" topLeftX="80" topLeftY="80" width="300" height="200">
                   <content fontSize="18" verticalAlign="top"><p>短标签</p></content>
@@ -1983,7 +2024,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_ignores_invisible_line_crossing_text(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="title" type="text" topLeftX="80" topLeftY="200" width="500" height="90">
                   <content fontSize="60"><p>测试文字 ABC</p></content>
@@ -2002,7 +2043,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         # frame's left edge renders before the first glyph, so it must not be flagged.
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape width="240" height="60" topLeftX="120" topLeftY="100" type="text" id="bmm">
                   <content fontSize="20" fontFamily="Arial" color="rgba(31, 35, 41, 1)" lineSpacing="fixed:24">
@@ -2023,7 +2064,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         # <line> only, so a <polyline> over text is not flagged.
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape width="240" height="60" topLeftX="120" topLeftY="100" type="text" id="bmr">
                   <content fontSize="20" fontFamily="Arial" color="rgba(31, 35, 41, 1)" lineSpacing="fixed:24">
@@ -2045,7 +2086,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         # under the visual glyph box (underline look) and must not be flagged.
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape width="240" height="80" topLeftX="120" topLeftY="100" type="text" id="bmB">
                   <content fontSize="20" fontFamily="Arial" color="rgba(31, 35, 41, 1)" lineSpacing="fixed:24">
@@ -2064,8 +2105,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_uses_rotated_text_and_chart_bounds_for_canvas_validation(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape id="rotated-text" type="text" topLeftX="0" topLeftY="0" width="100" height="100" rotation="45"/>
                   <chart id="rotated-chart" topLeftX="860" topLeftY="200" width="100" height="100" rotation="45">
@@ -2091,8 +2132,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_uses_declared_bounds_for_rect_and_ignores_images(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape id="rotated-rect" type="rect" topLeftX="900" topLeftY="0" width="100" height="100" rotation="45"/>
                   <img id="rotated-image" src="token" topLeftX="860" topLeftY="200" width="100" height="100" rotation="45"/>
@@ -2154,8 +2195,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_rejects_non_finite_rotation_values_from_xsd(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape id="infinite" type="text" topLeftX="-10" topLeftY="0" width="20" height="20" rotation="inf"/>
                   <shape id="negative-infinite" type="text" topLeftX="0" topLeftY="-10" width="20" height="20" rotation="-inf"/>
@@ -2179,8 +2220,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_table_bottom_overflow_from_declared_bounds(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="score-table" topLeftX="54" topLeftY="238" width="414" height="385">
                     <tr><td><content><p>Score</p></content></td></tr>
@@ -2200,8 +2241,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_table_right_overflow_from_declared_bounds(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="wide-table" topLeftX="850" topLeftY="80" width="180" height="120">
                     <tr><td><content><p>Score</p></content></td></tr>
@@ -2219,8 +2260,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_allows_table_with_declared_bounds_inside_canvas(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="inside-table" topLeftX="40" topLeftY="120" width="880" height="360">
                     <tr><td><content><p>Score</p></content></td></tr>
@@ -2236,8 +2277,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_resolved_table_bounds_when_declared_sizes_are_missing(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="implicit-size-table" topLeftX="850" topLeftY="480">
                     <colgroup><col/><col/></colgroup>
@@ -2258,8 +2299,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_uses_resolved_table_bounds_for_canvas_validation(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="resolved-overflow-table" topLeftX="800" topLeftY="80" width="100" height="40">
                     <colgroup><col width="100"/><col width="100"/></colgroup>
@@ -2282,8 +2323,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_uses_the_same_anonymous_table_id_for_all_table_diagnostics(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <shape id="title" type="text" topLeftX="40" topLeftY="40" width="200" height="40"/>
                   <img id="logo" src="token" topLeftX="40" topLeftY="100" width="40" height="40"/>
@@ -2305,8 +2346,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_info_when_table_target_size_resolves_larger_than_declared(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="size-mismatch" topLeftX="40" topLeftY="120" width="200" height="80">
                     <colgroup><col span="2" width="100"/><col width="50"/></colgroup>
@@ -2332,8 +2373,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_does_not_report_info_when_table_target_size_is_resolved_exactly(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="size-match" topLeftX="40" topLeftY="120" width="300" height="100">
                     <colgroup><col width="100"/><col/></colgroup>
@@ -2352,8 +2393,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_keeps_resolved_table_sizes_positive_when_target_is_too_small(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="https://www.larkoffice.com/sml/2.0">
                 <data>
                   <table id="narrow-table" topLeftX="40" topLeftY="120" width="1">
                     <colgroup><col/><col/></colgroup>
@@ -2420,8 +2461,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
                     input_path = Path(temp_dir) / f"{name}.xml"
                     input_path.write_text(
                         f"""
-                        <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-                          <slide xmlns="http://www.larkoffice.com/sml/2.0"><data>{table_xml}</data></slide>
+                        <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+                          <slide xmlns="https://www.larkoffice.com/sml/2.0"><data>{table_xml}</data></slide>
                         </presentation>
                         """,
                         encoding="utf-8",
@@ -2460,8 +2501,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             with self.subTest(name=name):
                 result = xml_text_overlap_lint.lint_xml(
                     f"""
-                    <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
-                      <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                    <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+                      <slide xmlns="https://www.larkoffice.com/sml/2.0">
                         <data>{shapes}</data>
                       </slide>
                     </presentation>
@@ -2474,7 +2515,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
     def test_lint_xml_reports_vertical_text_image_overlap_as_warning(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0"><data>
+            <slide xmlns="https://www.larkoffice.com/sml/2.0"><data>
               <shape id="text" type="text" vert="vert" topLeftX="100" topLeftY="100" width="100" height="100">
                 <content><p>Vertical</p></content>
               </shape>
@@ -2492,7 +2533,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_blocks_blank_slide(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
               <slide id="content-slide">
                 <data>
                   <shape id="title" type="text" topLeftX="60" topLeftY="60" width="400" height="50">
@@ -2527,7 +2568,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_blocks_blank_slide_with_only_transparent_image(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <img id="ghost" src="token" topLeftX="60" topLeftY="60" width="200" height="200" alpha="0"/>
               </data>
@@ -2542,7 +2583,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_warns_when_large_container_is_mostly_empty(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="trend-card" type="rect" topLeftX="500" topLeftY="135" width="410" height="370"/>
                 <shape id="trend-title" type="text" topLeftX="515" topLeftY="147" width="380" height="28">
@@ -2586,7 +2627,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_warns_for_sparse_short_cards(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card-1" type="rect" topLeftX="60" topLeftY="180" width="400" height="105"/>
                 <shape id="text-1" type="text" topLeftX="80" topLeftY="220" width="360" height="30">
@@ -2632,7 +2673,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_warns_when_whole_slide_has_too_little_effective_content(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="background" type="rect" topLeftX="0" topLeftY="0" width="960" height="540"/>
                 <shape id="text-1" type="text" topLeftX="60" topLeftY="80" width="200" height="30">
@@ -2664,7 +2705,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_ignores_isolated_short_layout_bar(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="summary-bar" type="rect" topLeftX="52" topLeftY="82" width="856" height="105"/>
                 <shape id="summary" type="text" topLeftX="72" topLeftY="115" width="816" height="30">
@@ -2680,7 +2721,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_counts_rect_own_content_as_visible_content(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="load-card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
                   <content fontSize="18">
@@ -2699,7 +2740,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_reports_nonzero_coverage_for_rect_own_content_reproduction(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="load-card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
                   <content fontSize="18">
@@ -2721,7 +2762,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_still_warns_for_sparse_rect_own_content(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="sparse-card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
                   <content fontSize="12"><p>A</p></content>
@@ -2740,7 +2781,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_unions_rect_own_content_with_child_content(self) -> None:
         self_only = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
                   <content fontSize="12"><p>A</p></content>
@@ -2751,7 +2792,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
         )
         with_overlapping_child = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
                   <content fontSize="12"><p>A</p></content>
@@ -2775,7 +2816,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_extract_density_elements_reads_nested_font_size_from_rect_content(self) -> None:
         elements = xml_text_overlap_lint.extract_density_elements(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184">
                   <content fontSize="12"><p><span fontSize="36">32.0 t</span></p></content>
@@ -2790,7 +2831,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_extract_density_elements_does_not_attach_following_text_to_self_closing_rect(self) -> None:
         elements = xml_text_overlap_lint.extract_density_elements(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184"/>
                 <shape id="title" type="text" topLeftX="80" topLeftY="160" width="180" height="30">
@@ -2807,7 +2848,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_allows_container_with_large_visual_child(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="chart-card" type="rect" topLeftX="500" topLeftY="135" width="410" height="300"/>
                 <chart id="chart" topLeftX="525" topLeftY="170" width="350" height="220">
@@ -2827,7 +2868,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_does_not_let_transparent_visual_child_suppress_sparse_warning(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="title" type="text" topLeftX="40" topLeftY="40" width="300" height="40">
                   <content fontSize="20"><p>Section title</p></content>
@@ -2853,7 +2894,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_warns_for_small_empty_visual_placeholder_cards(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="letter-placeholder" type="rect" topLeftX="520" topLeftY="180" width="200" height="200"/>
                 <shape id="letter" type="text" topLeftX="540" topLeftY="250" width="160" height="70">
@@ -2875,7 +2916,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_applies_global_threshold_to_normal_text_card(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="70" topLeftY="184" width="260" height="288"/>
                 <shape id="title" type="text" topLeftX="90" topLeftY="215" width="220" height="30">
@@ -2896,7 +2937,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_allows_image_overlay_rect(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <img id="hero" topLeftX="560" topLeftY="0" width="400" height="540"/>
                 <shape id="tint" type="rect" topLeftX="560" topLeftY="0" width="400" height="540"/>
@@ -2910,7 +2951,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_does_not_let_transparent_image_overlay_suppress_sparse_warning(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="title" type="text" topLeftX="40" topLeftY="40" width="300" height="40">
                   <content fontSize="20"><p>Section title</p></content>
@@ -2930,7 +2971,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_allows_edge_spanning_layout_panel_and_nested_decoration(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="panel" type="rect" topLeftX="600" topLeftY="0" width="360" height="540"/>
                 <shape id="decoration" type="rect" topLeftX="660" topLeftY="150" width="240" height="240"/>
@@ -2944,7 +2985,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_counts_icons_as_visible_content(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="80" topLeftY="140" width="320" height="240"/>
                 <icon id="visual" iconType="iconpark/Safe/shield.svg" topLeftX="100" topLeftY="160" width="180" height="180">
@@ -2960,7 +3001,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_does_not_count_transparent_icon_as_visible_content(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="title" type="text" topLeftX="40" topLeftY="40" width="300" height="40">
                   <content fontSize="20"><p>Section title</p></content>
@@ -2983,7 +3024,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_warns_when_coverage_is_below_global_threshold(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="80" topLeftY="140" width="200" height="200"/>
                 <icon id="visual" iconType="iconpark/Safe/shield.svg" topLeftX="100" topLeftY="160" width="70" height="70">
@@ -3002,7 +3043,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_allows_quarter_coverage_under_lower_threshold(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="80" topLeftY="140" width="200" height="200"/>
                 <icon id="visual" iconType="iconpark/Safe/shield.svg" topLeftX="100" topLeftY="160" width="100" height="100">
@@ -3018,7 +3059,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_allows_large_metric_card_above_lower_threshold(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="metric-card" type="rect" topLeftX="80" topLeftY="140" width="360" height="300"/>
                 <shape id="metric" type="text" topLeftX="104" topLeftY="190" width="340" height="90">
@@ -3034,7 +3075,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_does_not_report_blank_slide_for_line_only_content(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <line id="l1" startX="100" startY="100" endX="800" endY="100"><border/></line>
                 <line id="l2" startX="100" startY="200" endX="800" endY="200"><border/></line>
@@ -3052,7 +3093,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_reports_bbox_overlap_measurement_from_decision_time_visual_bbox(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="left" type="text" topLeftX="80" topLeftY="80" width="300" height="60">
                   <content fontSize="14"><p>overlap text <span fontSize="96">big</span></p></content>
@@ -3089,7 +3130,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_reports_schema_version_2_for_sparse_issues(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="card" type="rect" topLeftX="60" topLeftY="140" width="220" height="184"/>
               </data>
@@ -3105,7 +3146,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_does_not_report_blank_slide_for_textless_decorative_shapes(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="deco1" type="ellipse" topLeftX="60" topLeftY="60" width="300" height="300">
                   <fill><fillColor color="rgba(37, 99, 235, 1)"/></fill>
@@ -3129,7 +3170,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
         # trivially "pass" that density check.
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="background" type="rect" topLeftX="0" topLeftY="0" width="960" height="540"/>
                 <shape id="text-1" type="text" topLeftX="60" topLeftY="80" width="200" height="30">
@@ -3155,7 +3196,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_accepts_whitespace_around_attribute_equals_sign(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="visible" type="text" topLeftX = "80" topLeftY = "80" width = "300" height = "60">
                   <content><p>hello</p></content>
@@ -3172,7 +3213,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
     def test_lint_xml_reports_blank_slide_for_full_canvas_background_only(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
-            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
               <data>
                 <shape id="background" type="rect" topLeftX="0" topLeftY="0" width="960" height="540">
                   <fill><fillColor color="rgba(240, 235, 220, 1)"/></fill>
@@ -3201,7 +3242,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
         )
 
 
-SML_NAMESPACE = "http://www.larkoffice.com/sml/2.0"
+SML_NAMESPACE = "https://www.larkoffice.com/sml/2.0"
 
 
 class SxsdSyntaxTestCase(unittest.TestCase):

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -51,6 +51,34 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             f"xml-text-overlap-lint error: unexpected argument: {input_path}, need --input\n",
         )
 
+    def test_cli_preserves_requested_symlink_path_in_result(self) -> None:
+        script_path = Path(xml_text_overlap_lint.__file__).resolve()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            resolved_path = temp_path / "resolved.xml"
+            requested_path = temp_path / "requested.xml"
+            resolved_path.write_text(
+                '<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">'
+                '<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>'
+                '<shape type="text" topLeftX="10" topLeftY="10" width="100" height="30">'
+                '<content><p><span>Test</span></p></content>'
+                '</shape></data></slide>'
+                '</presentation>',
+                encoding="utf-8",
+            )
+            requested_path.symlink_to(resolved_path)
+
+            completed = subprocess.run(
+                [sys.executable, str(script_path), "--input", str(requested_path)],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        result = json.loads(completed.stdout)
+        self.assertEqual(result["file"], str(requested_path))
+
     def test_cli_reports_structured_slide_sxsd_error_outside_skill_directory(self) -> None:
         script_path = Path(xml_text_overlap_lint.__file__).resolve()
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/cli_e2e/slides/slides_create_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_create_workflow_test.go
@@ -25,7 +25,7 @@ func TestSlides_CreateWorkflowAsUser(t *testing.T) {
 	title := "slides-e2e-" + suffix
 	slideTitle := "Overview " + suffix
 	slideBody := "Body " + suffix
-	slideXML := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + slideTitle + `</p></content></shape><shape type="text" topLeftX="80" topLeftY="200" width="800" height="180"><content textType="body"><p>` + slideBody + `</p></content></shape></data></slide>`
+	slideXML := `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + slideTitle + `</p></content></shape><shape type="text" topLeftX="80" topLeftY="200" width="800" height="180"><content textType="body"><p>` + slideBody + `</p></content></shape></data></slide>`
 
 	var presentationID string
 

--- a/tests/cli_e2e/slides/slides_history_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_history_workflow_test.go
@@ -200,7 +200,7 @@ func slidesHistoryWorkflowSlideXML(title, marker, markerShapeID string) string {
 	if markerShapeID != "" {
 		markerIDAttr = ` id="` + markerShapeID + `"`
 	}
-	return `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>` +
+	return `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>` +
 		`<shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + slidesHistoryWorkflowXMLEscape(title) + `</p></content></shape>` +
 		`<shape` + markerIDAttr + ` type="text" topLeftX="80" topLeftY="220" width="800" height="180"><content textType="body"><p>` + slidesHistoryWorkflowXMLEscape(marker) + `</p></content></shape>` +
 		`</data></slide>`

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -151,7 +151,7 @@ func TestSlidesScreenshotContentSlideAliasAttributionDryRunE2E(t *testing.T) {
 	result, err := clie2e.RunCmd(ctx, clie2e.Request{
 		Args: []string{
 			"slides", "+screenshot",
-			"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+			"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 			"--slide", "pII",
 			"--dry-run",
 		},
@@ -198,7 +198,7 @@ func TestSlidesScreenshotEmptySlideIDDryRunE2E(t *testing.T) {
 	result, err := clie2e.RunCmd(ctx, clie2e.Request{
 		Args: []string{
 			"slides", "+screenshot",
-			"--content", `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+			"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
 			"--slide-id", "",
 			"--dry-run",
 		},

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -29,7 +29,7 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 
 	suffix := clie2e.GenerateSuffix()
 	title := "slides-screenshot-alias-e2e-" + suffix
-	slideXML := `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + title + `</p></content></shape></data></slide>`
+	slideXML := `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + title + `</p></content></shape></data></slide>`
 	slidesJSON, err := json.Marshal([]string{slideXML})
 	require.NoError(t, err)
 

--- a/tests/cli_e2e/slides/slides_slide_add_delete_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_slide_add_delete_dryrun_test.go
@@ -24,7 +24,7 @@ func TestSlidesAddSlideDryRunE2E(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
-	const slideXML = `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data></data></slide>`
+	const slideXML = `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`
 
 	tests := []struct {
 		name      string

--- a/tests/cli_e2e/slides/slides_slide_add_delete_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_slide_add_delete_workflow_test.go
@@ -17,7 +17,7 @@ import (
 // slideXMLWithBody renders a one-shape page carrying a caller-supplied marker,
 // so a readback can tell the pages apart by content instead of by index.
 func slideXMLWithBody(body string) string {
-	return `<slide xmlns="http://www.larkoffice.com/sml/2.0"><data>` +
+	return `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>` +
 		`<shape type="text" topLeftX="80" topLeftY="80" width="800" height="120">` +
 		`<content textType="title"><p>` + body + `</p></content></shape></data></slide>`
 }


### PR DESCRIPTION
## Summary

Migrate the SML 2.0 namespace from `http://www.larkoffice.com/sml/2.0` to `https://www.larkoffice.com/sml/2.0` across the entire codebase: protocol schema, production code, Skill docs, and all tests.

## Changes

- **Protocol source**: XSD `targetNamespace` and `xmlns:sml` → HTTPS
- **Production code**: `buildPresentationXML` in `slides_create.go` now emits HTTPS
- **Validator**: `SML_NAMESPACE` is now HTTPS; old HTTP URI kept as `SML_LEGACY_HTTP_NAMESPACE`; `ACCEPTED_SML_NAMESPACES` retains three-format compat (HTTPS, HTTP, `/sml/2.0`)
- **Lint**: `SML_NAMESPACE` → HTTPS; `validate_sml_tag_prefixes` now checks against all accepted namespaces (was previously HTTP-only, missing HTTPS-prefixed tags)
- **Demo template**: `slides_chart_demo.xml` changed from `/sml/2.0` to HTTPS
- **Docs**: 6 Skill reference markdown files updated to HTTPS
- **Tests**: 8 Go test files + Python lint tests → HTTPS; new `test_lint_xml_accepts_legacy_http_namespace` regression test

## Design

- **HTTPS is the canonical namespace** for all generation and documentation
- **HTTP and `/sml/2.0` remain accepted** by the lint validator for backward compatibility with existing content

## Verification

- [x] `python3 -m unittest xml_text_overlap_lint_test` — 185 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Slide XML generation and examples now use the secure HTTPS namespace as the canonical format.
  * Validation continues to recognize legacy HTTP and supported readback namespaces for compatibility.
  * Improved lint diagnostics and preservation of supplied file paths during validation.

* **Documentation**
  * Updated slide XML guides, schema references, examples, and validation guidance to use HTTPS.

* **Tests**
  * Expanded coverage for namespace handling, legacy compatibility, diagnostics, and file-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->