### PR TITLE
docs(slides): correct +xml-get flag requirements

### DIFF
--- a/skills/lark-slides/references/lark-slides-xml-presentations-get.md
+++ b/skills/lark-slides/references/lark-slides-xml-presentations-get.md
@@ -22,9 +22,9 @@ lark-cli slides +xml-get --as user \
 |------|------|------|------|
 | `--presentation` | string | 是 | 演示文稿的唯一标识符 |
 | `--revision-id` | integer | 否 | 版本号，`-1` 表示最新版本 |
-| `--output` | string | 是 | 本地文件，必须使用相对路径 |
+| `--output` | string | 否 | XML 保存路径，必须使用相对路径；省略时 XML 在 stdout 的 JSON envelope 中返回 |
 | `--remove-attr-id` | flag | 否 | 移除 XML id 属性后读取 |
-| `--json` | flag | 是 | 必须按照 json 格式输出 |
+| `--json` | flag | 否 | `--format json` 的简写，json 为默认输出格式 |
 
 
 ### 基础示例


### PR DESCRIPTION
Neither --output nor --json is required: omitting --output returns the XML in the JSON envelope on stdout, and json is the default --format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--output` and `--json` options are optional when retrieving presentation data.
  * Documented default JSON output and stdout JSON-envelope behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->