### PR TITLE
fix(slides): name the wrong --parts field instead of non-empty replacement

### DIFF
--- a/shortcuts/slides/slides_replace_slide.go
+++ b/shortcuts/slides/slides_replace_slide.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -49,7 +50,7 @@ var SlidesReplaceSlide = common.Shortcut{
 	Flags: []common.Flag{
 		requiredPresentationRefFlag(),
 		{Name: "slide-id", Desc: "slide page identifier (slide_id)", Required: true},
-		{Name: "parts", Desc: "JSON array of replace parts (each: {action: block_replace|block_insert, ...}); max 200", Required: true, Input: []string{common.File, common.Stdin}},
+		{Name: "parts", Desc: "JSON array of replace parts; each needs action plus block_id + replacement (block_replace) or insertion [+ insert_before_block_id] (block_insert); any other key is rejected; max 200", Required: true, Input: []string{common.File, common.Stdin}},
 		{Name: "revision-id", Type: "int", Default: "-1", Desc: "presentation revision (-1 = latest; pass a specific number for optimistic locking)"},
 		{Name: "tid", Desc: "transaction id for concurrent-edit locking (usually empty)"},
 	},
@@ -193,10 +194,11 @@ type replacePart struct {
 
 // parseReplaceParts decodes the --parts JSON into typed structs.
 //
-// Accepts JSON with extra keys (pattern / is_multiple) so that a user who
-// copy-pasted a doc example doesn't get a decoder error; those keys are
-// ignored because str_replace isn't exposed. validateReplaceParts enforces
-// that nothing from the str_replace family actually gets used.
+// Fields outside the action's own set are rejected (see
+// checkReplacePartFields) rather than dropped: silently ignoring them is what
+// made XML in a hallucinated field (e.g. "content") surface as the misleading
+// "requires non-empty replacement". Parts carrying an action this shortcut
+// doesn't expose keep their own errors from validateReplaceParts.
 func parseReplaceParts(raw string) ([]replacePart, error) {
 	s := strings.TrimSpace(raw)
 	if s == "" {
@@ -215,6 +217,14 @@ func parseReplaceParts(raw string) ([]replacePart, error) {
 				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d].action must be a string", i).WithParam("--parts")
 			}
 			p.Action = s
+		} else if err := checkMisspelledAction(i, m); err != nil {
+			// "Action" selects no schema, so the per-action check below would skip
+			// the part entirely and validateReplaceParts would only say action is
+			// required. Name the misspelling instead.
+			return nil, err
+		}
+		if err := checkReplacePartFields(i, m, p.Action); err != nil {
+			return nil, err
 		}
 		if v, ok := m["replacement"]; ok {
 			s, ok := v.(string)
@@ -247,6 +257,148 @@ func parseReplaceParts(raw string) ([]replacePart, error) {
 		out = append(out, p)
 	}
 	return out, nil
+}
+
+// replacePartSchema describes one exposed action: the fields it accepts, the
+// field carrying its XML fragment, and a correct one-liner to echo back.
+type replacePartSchema struct {
+	fields  []string
+	payload string
+	hint    string
+}
+
+// replacePartSchemas is the field contract of the two exposed actions. Holding
+// it in one place lets the error name the exact set the caller may use, instead
+// of a generic "unknown field".
+var replacePartSchemas = map[string]replacePartSchema{
+	"block_replace": {
+		fields:  []string{"action", "block_id", "replacement"},
+		payload: "replacement",
+		hint:    `correct shape: {"action":"block_replace","block_id":"bUn","replacement":"<shape type=\"text\"><content><p>text</p></content></shape>"}`,
+	},
+	"block_insert": {
+		fields:  []string{"action", "insertion", "insert_before_block_id"},
+		payload: "insertion",
+		hint:    `correct shape: {"action":"block_insert","insertion":"<shape type=\"rect\" width=\"100\" height=\"100\"/>"}`,
+	},
+}
+
+// xmlPayloadAliases are the wrong field names callers reach for when they mean
+// the XML payload. internal/suggest can't route these: edit distance misses
+// most of them outright (content → replacement), and its prefix ranking would
+// send block / block_xml to block_id — the wrong field. Hence the explicit
+// list. "content" dominates in practice because <shape> nests a <content>
+// child, which makes it the intuitive-but-wrong top-level key.
+//
+// Entries are limited to names actually observed carrying a fragment. A
+// shape attribute like "fill" is deliberately absent: whoever writes it means
+// "recolor this block", not "here is my XML", so pointing them at replacement
+// would be guessing. The unknown-field error already names the valid set.
+var xmlPayloadAliases = []string{"block", "block_xml", "content", "data", "element", "new_xml", "xml"}
+
+// normalizeFieldKey folds case and the _/- separators so "Content", "newXml",
+// "new-xml" and "new_xml" collapse onto one key. Callers pick the casing of
+// whatever language they happen to be thinking in (the CLI's own flags are
+// kebab-case), and the suggestion should survive that; the whitelist itself
+// stays exact, because the API only accepts snake_case.
+func normalizeFieldKey(k string) string {
+	k = strings.ReplaceAll(k, "_", "")
+	k = strings.ReplaceAll(k, "-", "")
+	return strings.ToLower(k)
+}
+
+// matchNormalized returns the candidate that matches k once both are
+// normalized, so "blockId" resolves to "block_id".
+func matchNormalized(k string, candidates []string) (string, bool) {
+	nk := normalizeFieldKey(k)
+	for _, c := range candidates {
+		if normalizeFieldKey(c) == nk {
+			return c, true
+		}
+	}
+	return "", false
+}
+
+// checkMisspelledAction runs when a part has no exact "action" key: if some key
+// normalizes to it, that spelling is the real problem, and saying so beats the
+// bare "action is required" the caller would otherwise get.
+func checkMisspelledAction(i int, m map[string]interface{}) error {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		if normalizeFieldKey(k) != "action" {
+			continue
+		}
+		err := errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--parts[%d] unknown field %q; did you mean %q?", i, k, "action",
+		).WithParam("--parts")
+		// The misspelled key still holds the action name, so the example can be
+		// the one the caller was actually reaching for.
+		if name, ok := m[k].(string); ok {
+			if schema, known := replacePartSchemas[name]; known {
+				return err.WithHint("%s", schema.hint)
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+// checkReplacePartFields rejects fields that don't belong to the part's action,
+// naming the field the caller most likely meant. Actions this shortcut doesn't
+// expose ("", str_replace, unknown) are skipped so their own errors from
+// validateReplaceParts still win.
+func checkReplacePartFields(i int, m map[string]interface{}, action string) error {
+	schema, ok := replacePartSchemas[action]
+	if !ok {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Sorted so a part carrying several bad fields always reports the same one.
+	slices.Sort(keys)
+	for _, k := range keys {
+		if slices.Contains(schema.fields, k) {
+			continue
+		}
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"%s", unknownPartFieldMessage(i, k, action, schema),
+		).WithParam("--parts").WithHint("%s", schema.hint)
+	}
+	return nil
+}
+
+// unknownPartFieldMessage builds the error text for one rejected field,
+// naming the field the caller most likely meant.
+func unknownPartFieldMessage(i int, key, action string, schema replacePartSchema) string {
+	valid := fmt.Sprintf("Valid fields for %s: %s", action, strings.Join(schema.fields, ", "))
+	// Right field, wrong casing or separator (e.g. "blockId", "block-id").
+	if field, ok := matchNormalized(key, schema.fields); ok {
+		return fmt.Sprintf("--parts[%d] unknown field %q; did you mean %q? %s", i, key, field, valid)
+	}
+	if _, ok := matchNormalized(key, xmlPayloadAliases); ok {
+		return fmt.Sprintf("--parts[%d] unknown field %q; did you mean %q? %s", i, key, schema.payload, valid)
+	}
+	// Other actions are checked in sorted-name order so the one named in the
+	// error stays deterministic even if a future field matches several.
+	others := make([]string, 0, len(replacePartSchemas))
+	for name := range replacePartSchemas {
+		if name != action {
+			others = append(others, name)
+		}
+	}
+	slices.Sort(others)
+	for _, other := range others {
+		if _, ok := matchNormalized(key, replacePartSchemas[other].fields); ok {
+			return fmt.Sprintf("--parts[%d] unknown field %q; it belongs to %s. %s", i, key, other, valid)
+		}
+	}
+	return fmt.Sprintf("--parts[%d] unknown field %q. %s", i, key, valid)
 }
 
 const larkCodeSlidesInvalidParam = 3350001

--- a/shortcuts/slides/slides_replace_slide_test.go
+++ b/shortcuts/slides/slides_replace_slide_test.go
@@ -284,6 +284,9 @@ func TestReplaceSlideMissingRequiredField(t *testing.T) {
 		{"block_replace missing replacement", `[{"action":"block_replace","block_id":"bUn"}]`, "replacement"},
 		{"block_insert missing insertion", `[{"action":"block_insert"}]`, "insertion"},
 		{"empty action", `[{"block_id":"bUn"}]`, "action is required"},
+		// An actually-empty payload keeps the non-empty wording; only a wrong
+		// field name gets rerouted to the unknown-field error.
+		{"block_replace empty replacement", `[{"action":"block_replace","block_id":"bUn","replacement":""}]`, "requires non-empty replacement"},
 	}
 
 	for _, tt := range tests {
@@ -302,6 +305,17 @@ func TestReplaceSlideMissingRequiredField(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem = %#v, ok = %v, want CategoryValidation/SubtypeInvalidArgument", problem, ok)
+			}
+			var ve *errs.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("err = %v, want *errs.ValidationError", err)
+			}
+			if ve.Param != "--parts" {
+				t.Fatalf("Param = %q, want %q", ve.Param, "--parts")
 			}
 		})
 	}
@@ -745,5 +759,234 @@ func TestReplaceSlideValidationParam(t *testing.T) {
 				t.Fatalf("Param = %q, want %q", ve.Param, tt.wantParam)
 			}
 		})
+	}
+}
+
+// TestReplaceSlideUnknownPartField covers the field-name hallucinations seen in
+// the wild: XML written into "content" (and friends) instead of the action's own
+// payload field. Each case must name the wrong field and point at the right one,
+// so the caller fixes the key instead of rewriting the value.
+func TestReplaceSlideUnknownPartField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		parts    string
+		want     []string
+		notWant  string
+		wantHint string
+	}{
+		{
+			name:     "content alias",
+			parts:    `[{"action":"block_replace","block_id":"bUn","content":"<shape type=\"text\"/>"}]`,
+			want:     []string{`unknown field "content"`, `did you mean "replacement"?`, "Valid fields for block_replace: action, block_id, replacement"},
+			wantHint: `"action":"block_replace"`,
+		},
+		{
+			name:  "xml alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","xml":"<shape/>"}]`,
+			want:  []string{`unknown field "xml"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "new_xml alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","new_xml":"<shape/>"}]`,
+			want:  []string{`unknown field "new_xml"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "block_xml alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","block_xml":"<shape/>"}]`,
+			want:  []string{`unknown field "block_xml"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "block alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","block":{"content":"x"}}]`,
+			want:  []string{`unknown field "block"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "element alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","element":"<shape/>"}]`,
+			want:  []string{`unknown field "element"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "data alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","data":{"x":1}}]`,
+			want:  []string{`unknown field "data"`, `did you mean "replacement"?`},
+		},
+		{
+			// A shape attribute is not a payload alias: "recolor this block" is a
+			// different intent from "here is my XML", so no field is guessed.
+			name:    "shape attribute is not treated as a payload alias",
+			parts:   `[{"action":"block_replace","block_id":"bUn","fill":"#fff"}]`,
+			want:    []string{`unknown field "fill"`, "Valid fields for block_replace: action, block_id, replacement"},
+			notWant: "did you mean",
+		},
+		{
+			name:     "alias under block_insert points at insertion",
+			parts:    `[{"action":"block_insert","content":"<shape/>"}]`,
+			want:     []string{`unknown field "content"`, `did you mean "insertion"?`, "Valid fields for block_insert: action, insertion, insert_before_block_id"},
+			wantHint: `"action":"block_insert"`,
+		},
+		{
+			name:  "field of the other action",
+			parts: `[{"action":"block_replace","block_id":"bUn","insertion":"<shape/>"}]`,
+			want:  []string{`unknown field "insertion"`, "it belongs to block_insert"},
+		},
+		{
+			name:  "block_id under block_insert",
+			parts: `[{"action":"block_insert","insertion":"<shape/>","block_id":"bUn"}]`,
+			want:  []string{`unknown field "block_id"`, "it belongs to block_replace"},
+		},
+		{
+			// Casing and separator variants: models write the casing of whatever
+			// language they're thinking in, so these must still resolve.
+			name:  "capitalized alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","Content":"<shape/>"}]`,
+			want:  []string{`unknown field "Content"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "camelCase alias",
+			parts: `[{"action":"block_replace","block_id":"bUn","newXml":"<shape/>"}]`,
+			want:  []string{`unknown field "newXml"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "right field wrong casing",
+			parts: `[{"action":"block_replace","block_id":"bUn","Replacement":"<shape/>"}]`,
+			want:  []string{`unknown field "Replacement"`, `did you mean "replacement"?`},
+		},
+		{
+			name:  "right field camelCased",
+			parts: `[{"action":"block_replace","blockId":"bUn","replacement":"<shape/>"}]`,
+			want:  []string{`unknown field "blockId"`, `did you mean "block_id"?`},
+		},
+		{
+			// The CLI's own flags are kebab-case (--slide-id), so callers copy
+			// that separator into part fields too.
+			name:  "right field kebab-cased",
+			parts: `[{"action":"block_replace","block-id":"bUn","replacement":"<shape/>"}]`,
+			want:  []string{`unknown field "block-id"`, `did you mean "block_id"?`},
+		},
+		{
+			// "action" picks the schema, so a misspelling there would otherwise
+			// skip the field check and surface only as "action is required".
+			name:  "action itself misspelled",
+			parts: `[{"Action":"block_replace","block_id":"bUn","replacement":"<shape/>"}]`,
+			want:  []string{`unknown field "Action"`, `did you mean "action"?`},
+		},
+		{
+			name:  "action misspelled with a separator",
+			parts: `[{"action-":"block_replace","block_id":"bUn","replacement":"<shape/>"}]`,
+			want:  []string{`unknown field "action-"`, `did you mean "action"?`},
+		},
+		{
+			name:  "camelCased field of the other action",
+			parts: `[{"action":"block_replace","block_id":"bUn","insertBeforeBlockId":"bab","replacement":"<shape/>"}]`,
+			want:  []string{`unknown field "insertBeforeBlockId"`, "it belongs to block_insert"},
+		},
+		{
+			// Not in the alias table: still rejected, but without a misleading
+			// "did you mean" pointing at an unrelated field.
+			name:    "unlisted typo falls back to the field list",
+			parts:   `[{"action":"block_replace","block_id":"bUn","replacment":"<shape/>"}]`,
+			want:    []string{`unknown field "replacment"`, "Valid fields for block_replace: action, block_id, replacement"},
+			notWant: "did you mean",
+		},
+		{
+			// Two bad fields: the reported one is sorted-first, so the message
+			// doesn't flip between runs on Go's randomized map iteration.
+			// TestReplaceSlideUnknownFieldIsDeterministic re-parses to prove it.
+			name:  "several bad fields report deterministically",
+			parts: `[{"action":"block_replace","block_id":"bUn","zzz":"1","content":"<shape/>"}]`,
+			want:  []string{`unknown field "content"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			err := runSlidesShortcut(t, f, stdout, SlidesReplaceSlide, []string{
+				"+replace-slide",
+				"--presentation", "pres_abc",
+				"--slide-id", "s",
+				"--parts", tt.parts,
+				"--as", "user",
+			})
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("err = %v, want substring %q", err, want)
+				}
+			}
+			if tt.notWant != "" && strings.Contains(err.Error(), tt.notWant) {
+				t.Fatalf("err = %v, should not contain %q", err, tt.notWant)
+			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem = %#v, ok = %v, want CategoryValidation/SubtypeInvalidArgument", problem, ok)
+			}
+			var ve *errs.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("err = %v, want *errs.ValidationError", err)
+			}
+			if ve.Param != "--parts" {
+				t.Fatalf("Param = %q, want %q", ve.Param, "--parts")
+			}
+			if ve.Hint == "" {
+				t.Fatalf("hint is empty; the correct-shape example should be attached")
+			}
+			if tt.wantHint != "" && !strings.Contains(ve.Hint, tt.wantHint) {
+				t.Fatalf("hint = %q, want substring %q", ve.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+// TestReplaceSlideAllKnownPartFieldsAccepted guards the field whitelist against
+// typos: every legitimate field of both actions must survive a mixed batch.
+func TestReplaceSlideAllKnownPartFieldsAccepted(t *testing.T) {
+	t.Parallel()
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	parts := `[` +
+		`{"action":"block_replace","block_id":"bUn","replacement":"<shape type=\"rect\"/>"},` +
+		`{"action":"block_insert","insertion":"<shape type=\"rect\"/>","insert_before_block_id":"bUn"}` +
+		`]`
+	err := runSlidesShortcut(t, f, stdout, SlidesReplaceSlide, []string{
+		"+replace-slide",
+		"--presentation", "pres_abc",
+		"--slide-id", "slide_xyz",
+		"--parts", parts,
+		"--dry-run",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out := stdout.String(); !strings.Contains(out, "insert_before_block_id") {
+		t.Fatalf("dry-run body should keep insert_before_block_id: %s", out)
+	}
+}
+
+// TestReplaceSlideUnknownFieldIsDeterministic re-parses one payload carrying
+// several rejected fields. A single parse would pass by luck even without the
+// key sort, since Go's randomized map iteration can still land on the same
+// field; repeating it makes the sort the only way every message matches.
+func TestReplaceSlideUnknownFieldIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// "content", "data" and "zzz" are all rejected; sorted order reports "content".
+	parts := `[{"action":"block_replace","block_id":"bUn","zzz":"1","data":{"x":1},"content":"<shape/>"}]`
+	const want = `--parts[0] unknown field "content"; did you mean "replacement"? Valid fields for block_replace: action, block_id, replacement`
+
+	for i := 0; i < 50; i++ {
+		_, err := parseReplaceParts(parts)
+		if err == nil {
+			t.Fatalf("parse %d: expected an error", i)
+		}
+		if err.Error() != want {
+			t.Fatalf("parse %d: err = %q, want %q", i, err.Error(), want)
+		}
 	}
 }

--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -304,7 +304,7 @@ lark-cli slides <resource> <method> [flags] # 调用 API
 1. **先规划再写 XML**：新建演示文稿或大幅改写页面时，必须先写入 `.lark-slides/plan/<deck-or-task-id>/slide_plan.json`；模板、风格和大纲只能作为规划输入，不能绕过规划层
 2. **创建流程**：新建演示文稿用 `slides +create`，一步创建还是两步创建按 [`lark-slides-create.md`](references/lark-slides-create.md) 判断
 3. **`<slide>` 直接子元素只有 `<style>`、`<data>`、`<note>`**：文本和图形必须放在 `<data>` 内
-4. **文本通过 `<content>` 表达**：必须用 `<content><p>...</p></content>`，不能把文字直接写在 shape 内
+4. **文本通过 `<content>` 表达**：必须用 `<content><p>...</p></content>`，不能把文字直接写在 shape 内；注意 `<content>` 只是 XML 元素，不是 `--parts` 的字段名——part 里装 XML 的字段，`block_replace` 是 `replacement`，`block_insert` 是 `insertion`
 5. **保存关键 ID**：后续操作需要 `xml_presentation_id`、`slide_id`、`revision_id`
 6. **删除谨慎**：删除不可逆，删前先回读确认 `slide_id`
 7. **编辑已有页面优先原链接更新**：修改单个 shape/img 用 `+replace-slide`（`block_replace` / `block_insert`），不要整页重建；一页改动很多或要改背景用 `+update-slide` 整页覆盖（保 `slide_id` 和页序），多页整页重建就对每页各跑一次 `+update-slide`，不要用 `slides +create` 新建整份 PPT；追加/插入单页用 `+add-slide`、删除单页用 `+delete-slide`，只有这些 shortcut 未覆盖的参数才手动调 `slide.create` / `slide.delete`

--- a/skills/lark-slides/references/lark-slides-edit-workflows.md
+++ b/skills/lark-slides/references/lark-slides-edit-workflows.md
@@ -33,6 +33,8 @@ lark-cli slides +replace-slide --as user \
 
 `slide_id` / 页序不会变。`block_replace` 的 `replacement` 根元素 `id` 会自动注入为 `block_id`，用户手写 XML 时不需要自己加。
 
+> **part 的字段名是 `block_id` + `replacement`（XML 字符串）**：写成 `content` / `xml` / `block` 会被 CLI 拒绝（报 `unknown field "content"; did you mean "replacement"?`）。收到这个报错时改字段名，不要改字段值。
+
 ## `revision_id` 参数
 
 `--revision-id` 默认 `-1`，表示基于当前最新版执行。传具体版本号时，服务端以该版本为 base 应用变更：

--- a/skills/lark-slides/references/lark-slides-replace-slide.md
+++ b/skills/lark-slides/references/lark-slides-replace-slide.md
@@ -2,6 +2,8 @@
 
 对指定 slide 做块级替换或插入。编辑已有 PPT 的主路径——`slide_id` 不变、页序不动、只影响被指定的块。
 
+> **`--parts` 字段名是硬约束**：装 XML 片段的字段，`block_replace` 只认 `replacement`，`block_insert` 只认 `insertion`（都是字符串）。`content` / `xml` / `new_xml` / `block_xml` / `block` / `element` / `data` 这些写法，以及任何其他字段名，**一律被 CLI 直接拒绝**——常见的错法会直接告诉你该用哪个字段（`unknown field "content"; did you mean "replacement"?`），其余只列出该 action 的合法字段集。`<content>` 是 `<shape>` 的**子元素**，不是 part 的字段名——这是最常见的搞混点。
+
 相比直接调 `xml_presentation.slide.replace`，这个 shortcut 的四个额外价值：
 
 1. `--presentation` 接受 `xml_presentation_id` / `/slides/` URL / `/wiki/` URL（wiki 自动解析）；
@@ -71,6 +73,23 @@ lark-cli slides +replace-slide --as user \
 | `action` | 是 | `"block_insert"` |
 | `insertion` | 是 | 要插入的 XML 片段 |
 | `insert_before_block_id` | 否 | 插到这个块之前；省略（不提供此字段）则追加到页末 |
+
+### 错误字段名（CLI 直接拒绝）
+
+part 里出现上表以外的字段一律报错，不会被静默忽略。报错总会点名写错的那个字段，并按情况给出下一步：能对上正确字段时直接建议它（`did you mean "replacement"?`），字段属于另一个 action 时说明归属（`it belongs to block_insert`），都对不上时列出该 action 的合法字段集。无论哪种，**要改的是字段名，不是字段值**。
+
+```jsonc
+// ❌ 全部被拒
+[{"action":"block_replace","block_id":"bUn","content":"<p>...</p>"}]        // unknown field "content"; did you mean "replacement"?
+[{"action":"block_replace","block_id":"bUn","xml":"<shape.../>"}]           // 同上（new_xml / block_xml / element / data 一样）
+[{"action":"block_replace","block_id":"bUn","block":{"content":"..."}}]     // 不能把内容嵌一层 block
+[{"action":"block_replace","block_id":"bUn","insertion":"<shape/>"}]        // insertion 属于 block_insert
+[{"action":"block_replace","block_id":"bUn","replacement":{"type":"..."}}]  // replacement 必须是字符串，报 .replacement must be a string
+
+// ✅ 正确
+[{"action":"block_replace","block_id":"bUn","replacement":"<shape type=\"text\"><content><p>新内容</p></content></shape>"}]
+[{"action":"block_insert","insertion":"<shape type=\"rect\" width=\"100\" height=\"100\"/>"}]
+```
 
 ## 合法根元素速查
 
@@ -224,7 +243,9 @@ lark-cli slides +replace-slide --as user \
 | 3350002 not found | `--revision-id` 传了不存在的版本号（超过当前 revision） | 用 `-1` 或用 `slide.get` 拿到的有效 `revision_id` |
 | `--parts[i] action "str_replace" is not supported` | CLI 不暴露 `str_replace` | 把替换需求改写成 `block_replace` / `block_insert` |
 | `--parts contains N items, exceeds maximum of 200` | 一次提交 parts 太多 | 拆多次调用 |
-| `--parts[i] (block_replace) requires non-empty block_id` / `replacement` | 字段缺失 | 按 parts 元素结构补齐 |
+| `--parts[i] unknown field "content"; did you mean "replacement"?` | XML 塞进了不存在的字段名（`content` / `xml` / `block` / `data` 等） | 只改字段名：`block_replace` 用 `replacement`，`block_insert` 用 `insertion`；报错自带一行正确写法的 hint |
+| `--parts[i] unknown field "insertion"; it belongs to block_insert` | 字段和 `action` 不配对 | 按 action 取字段：`block_replace` = `block_id` + `replacement`；`block_insert` = `insertion` (+ `insert_before_block_id`) |
+| `--parts[i] (block_replace) requires non-empty block_id` / `replacement` | 字段名对，但值缺失或是空串 | 按 parts 元素结构补齐值 |
 | `<img>` 不显示 / 显示破图 | `src` 写了外链 URL | 换成通过 [`+media-upload`](lark-slides-media-upload.md) 拿到的 `file_token` |
 | 3350001 | `replacement` 不是合法单根 XML 片段，或 `block_id` 不存在 | CLI 已自动注入 `id` 和 `<content/>`；如果仍报错，重新 `slide.get` 拿最新 XML 确认 `block_id` 存在；检查 XML 结构是否合法；坐标是否超出 960×540 |
 | 403 | 权限不足 | 需要 `slides:presentation:update` 或 `slides:presentation:write_only`；wiki URL 还需要 `wiki:node:read` |

--- a/tests/cli_e2e/slides/coverage.md
+++ b/tests/cli_e2e/slides/coverage.md
@@ -1,9 +1,9 @@
 # Slides CLI E2E Coverage
 
 ## Metrics
-- Denominator: 5 leaf commands
-- Covered: 4
-- Coverage: 80.0%
+- Denominator: 6 leaf commands
+- Covered: 5
+- Coverage: 83.3%
 
 ## Summary
 - TestSlides_CreateWorkflowAsUser: proves the user slides workflow through `create presentation with slide as user` and `get created presentation xml as user`; creates a fresh presentation, asserts returned IDs, then reads back the XML content to prove the title and slide body persisted.
@@ -11,6 +11,7 @@
 - TestSlides_SlideAddDeleteWorkflowAsUser: live add/delete round trip on a throwaway presentation created and torn down per run. Asserts against a readback rather than the write's own response, so it proves what the request shape cannot: the returned `slide_id` addresses a real page, `--before-slide-id` positions the page between its neighbours instead of merely being forwarded, and the deleted page is gone while both neighbours survive.
 - TestSlidesUpdateSlideDryRunE2E / TestSlidesUpdateAliasDryRunE2E / TestSlidesUpdateSlideRefuses*DryRunE2E: dry-run coverage for `+update-slide` through the built binary — one request carrying one `block_replace` part whose `block_id` is the PAGE id (the whole design; an element id there would replace one element and leave the rest of the page), the `slide` service alias / `+update` command alias / `--xml` spelling, and the two refusals that must not produce a request (a bare element root, and a root id naming a different page).
 - TestSlides_HistoryWorkflow: opt-in live round-trip coverage for `+update-slide`; creates a presentation, updates its page in place, asserts the returned `slide_id`, the persisted marker, and that an element written back with its original id keeps that id, then reverts through slide history and self-cleans. It runs only when `LARK_SLIDES_HISTORY_E2E=1` and therefore does not yet exercise the default live lane.
+- TestSlidesReplaceSlideUnknownFieldDryRunE2E / TestSlidesReplaceSlideEmptyReplacementDryRunE2E / TestSlidesReplaceSlideDryRunE2E: dry-run coverage for `+replace-slide` through the built binary. The package tests receive the Go error directly and never run the dispatcher, so only these pin the user-visible contract: exit code 2, an empty stdout, and a stderr envelope carrying `validation` / `invalid_argument`, `param: "--parts"` and the actionable `hint` — which is what an agent parses to repair its own command. The three cases split the two failures that must stay distinguishable (a wrong field name names the field and suggests the right one; an actually-empty payload keeps the `requires non-empty` wording) and prove the field whitelist still admits a legitimate mixed `block_replace` + `block_insert` batch with the block id injected.
 - **Known gap**: the default live lane cannot exercise `+update-slide` until it carries a backend that accepts the page's own id as `block_id`; until then, dry-run is the default-CI proof and the opt-in history workflow is the real-API proof when explicitly enabled. Once rollout completes, add a dedicated live workflow covering restyle / no-op / insert / delete / background and asserting the control page and deck order did not move.
 - Blocked area: `slides +media-upload` is still uncovered because it needs a deterministic local image fixture plus XML follow-up proof that is separate from the base create/read workflow.
 
@@ -22,4 +23,5 @@
 | ✓ | slides +add-slide | shortcut | slides_slide_add_delete_dryrun_test.go::TestSlidesAddSlideDryRunE2E; slides_slide_add_delete_workflow_test.go::TestSlides_SlideAddDeleteWorkflowAsUser | `--slide "<slide ...>"`; `--before-slide-id`; `--revision-id` | live append and insert both verified by reading the deck back |
 | ✓ | slides +delete-slide | shortcut | slides_slide_add_delete_dryrun_test.go::TestSlidesDeleteSlideDryRunE2E, TestSlidesDeleteSlideWikiDryRunE2E; slides_slide_add_delete_workflow_test.go::TestSlides_SlideAddDeleteWorkflowAsUser | `--slide-id`; `--revision-id`; wiki URL | live delete runs on a throwaway deck; readback proves the neighbours survive |
 | ◐ | slides +update-slide | shortcut | slides_update_slide_dryrun_test.go::TestSlidesUpdateSlideDryRunE2E (+ alias / refusal cases); slides_history_workflow_test.go::TestSlides_HistoryWorkflow (opt-in live) | `--presentation`; `--slide-id`; `--content "<slide ...>"`; `--revision-id` | default CI is dry-run only; opt-in history workflow proves a live in-place update and persisted content |
+| ◐ | slides +replace-slide | shortcut | slides_replace_slide_dryrun_test.go::TestSlidesReplaceSlideUnknownFieldDryRunE2E, TestSlidesReplaceSlideEmptyReplacementDryRunE2E, TestSlidesReplaceSlideDryRunE2E | `--presentation`; `--slide-id`; `--parts '[{action,block_id,replacement}]'` / `'[{action,insertion,insert_before_block_id}]'` | dry-run only; covers the rejected-field envelope, the empty-payload split and an accepted mixed batch. No live lane yet: a real round trip needs a throwaway deck plus a readback proving only the named block moved |
 | ✕ | slides +media-upload | shortcut |  | none | needs a stable local image fixture plus follow-up slide XML proof |

--- a/tests/cli_e2e/slides/slides_replace_slide_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_replace_slide_dryrun_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package slides
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestSlidesReplaceSlideUnknownFieldDryRunE2E pins the user-visible half of the
+// contract, which package-level tests cannot reach: they receive the Go error
+// directly and never run the dispatcher. Through the built binary the caller
+// sees an exit code, a clean stdout and a stderr envelope — and it is the
+// envelope, not the Go error, that an agent parses to fix its own command.
+func TestSlidesReplaceSlideUnknownFieldDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	// "content" is the field callers reach for instead of "replacement",
+	// because <shape> nests a <content> child.
+	parts := `[{"action":"block_replace","block_id":"bUn","content":"` + `<shape type=\"text\"/>` + `"}]`
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+replace-slide",
+			"--presentation", "presReplaceSlideDryRun",
+			"--slide-id", "pYw",
+			"--parts", parts,
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+
+	require.Empty(t, result.Stdout,
+		"a rejected command must not print a success envelope: %s", result.Stdout)
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Equal(t, "--parts", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+
+	message := gjson.Get(result.Stderr, "error.message").String()
+	require.Contains(t, message, `unknown field "content"`,
+		"the error must name the field the caller actually wrote: %s", result.Stderr)
+	require.Contains(t, message, `did you mean "replacement"?`,
+		"naming the field is only half the fix; the caller needs the right name: %s", result.Stderr)
+	require.NotContains(t, message, "non-empty",
+		"the old wording read as an empty value and sent callers rewriting the value: %s", result.Stderr)
+
+	require.Contains(t, gjson.Get(result.Stderr, "error.hint").String(), `"replacement"`,
+		"the hint carries a copyable correct shape: %s", result.Stderr)
+}
+
+// TestSlidesReplaceSlideEmptyReplacementDryRunE2E guards the other side of the
+// split: an actually-empty payload must keep the non-empty wording, so the two
+// failures stay distinguishable to whoever reads the envelope.
+func TestSlidesReplaceSlideEmptyReplacementDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+replace-slide",
+			"--presentation", "presReplaceSlideDryRun",
+			"--slide-id", "pYw",
+			"--parts", `[{"action":"block_replace","block_id":"bUn","replacement":""}]`,
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+
+	require.Empty(t, result.Stdout,
+		"a rejected command must not print a success envelope: %s", result.Stdout)
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Equal(t, "--parts", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(),
+		"requires non-empty replacement", result.Stderr)
+}
+
+// TestSlidesReplaceSlideDryRunE2E keeps the accepted path honest: the field
+// whitelist must not reject a legitimate mixed batch, and the request body must
+// carry both parts with the id injected into the block_replace fragment.
+func TestSlidesReplaceSlideDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	parts := `[{"action":"block_replace","block_id":"bUn","replacement":"` +
+		`<shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\">` +
+		`<content textType=\"title\"><p>hi</p></content></shape>"},` +
+		`{"action":"block_insert","insertion":"<shape type=\"rect\" width=\"100\" height=\"100\"/>",` +
+		`"insert_before_block_id":"bUn"}]`
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+replace-slide",
+			"--presentation", "presReplaceSlideDryRun",
+			"--slide-id", "pYw",
+			"--parts", parts,
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, "POST", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
+	require.Equal(t,
+		"/open-apis/slides_ai/v1/xml_presentations/presReplaceSlideDryRun/slide/replace",
+		gjson.Get(result.Stdout, "data.api.0.url").String(),
+		result.Stdout,
+	)
+	require.Equal(t, "pYw", gjson.Get(result.Stdout, "data.api.0.params.slide_id").String(), result.Stdout)
+
+	body := gjson.Get(result.Stdout, "data.api.0.body.parts").Array()
+	require.Len(t, body, 2, "both parts of the mixed batch must survive validation: %s", result.Stdout)
+	require.Equal(t, "block_replace", body[0].Get("action").String(), result.Stdout)
+	require.Equal(t, "bUn", body[0].Get("block_id").String(), result.Stdout)
+	require.Contains(t, body[0].Get("replacement").String(), `id="bUn"`,
+		"the shortcut injects the block id into the fragment root: %s", result.Stdout)
+	require.Equal(t, "block_insert", body[1].Get("action").String(), result.Stdout)
+	require.Equal(t, `<shape type="rect" width="100" height="100"><content/></shape>`,
+		body[1].Get("insertion").String(),
+		"the insertion payload must reach the request, with <content/> filled in: %s", result.Stdout)
+	require.Equal(t, "bUn", body[1].Get("insert_before_block_id").String(),
+		"insert_before_block_id is a valid block_insert field and must not be rejected: %s", result.Stdout)
+}


### PR DESCRIPTION
## Summary

When a `--parts` entry carries the XML fragment under a field name the shortcut does not accept — `content` being the common one, since `<shape>` nests a `<content>` child — the key was silently dropped and the part then failed the required-field check with `requires non-empty replacement`. That message reads as "the value is empty", so callers rewrite the value instead of the key and never converge.

## Changes

- Reject fields outside the action's own set and name the field the caller most likely meant: a payload alias (`content`, `xml`, `block`, …) points at `replacement` / `insertion`, a field belonging to the other action says so, and anything else falls back to listing the valid set. Every such error carries a correct one-line `hint`.
- Fold case and `_` / `-` separators when matching the suggestion, so `Content`, `newXml` and `block-id` resolve too. The whitelist itself stays an exact match, since the API accepts only snake_case.
- An actually-empty payload keeps the existing `requires non-empty …` wording, and parts carrying an action this shortcut does not expose keep their existing errors.
- Spell the field names out in the `--parts` flag description instead of eliding them behind `...`.
- Carry the same constraint into the skill docs: SKILL.md, the `+replace-slide` reference (warning, counter-examples, error table) and the read-modify-write workflow.

Note: this tightens parsing — extra keys inside a part used to be ignored, and are now rejected.

## Test Plan

- [x] `go test ./shortcuts/slides/` — 20 new cases covering each payload alias, casing / separator variants, cross-action fields, unlisted typos, deterministic reporting when several fields are wrong, and the empty-payload regression
- [x] `go vet ./shortcuts/slides/`
- [x] `gofmt -l .` produces no output
- [x] golangci-lint `--new-from-rev=origin/main` reports 0 issues
- [x] Source-contract lint guards (`go run -C lint .`) pass
- [x] `node scripts/skill-format-check/index.js` and `scripts/check-skill-wire-vocab.sh` pass
- [x] Built-binary dry-run verifies each rejected field name, the casing / separator variants, and that a correct mixed `block_replace` + `block_insert` batch still passes

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added stricter validation for slide replacement and insertion fields.
  * Invalid, misspelled, or action-incompatible fields now provide consistent diagnostics, suggestions, and action-specific guidance.
  * Empty replacement values are rejected with clearer feedback.
  * Validation handles casing and separator variations consistently.

* **Documentation**
  * Clarified required fields and XML value formats, with examples for common mistakes.

* **Tests**
  * Expanded dry-run coverage for valid and invalid slide editing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->