### PR TITLE
Fix mail rule reorder with partial IDs

### DIFF
--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -128,18 +128,39 @@ func listAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderReques
 		Params: copyRequestParamsWithoutPageToken(reorderRequest.Params),
 		As:     reorderRequest.As,
 	}
-	result, err := ac.PaginateAll(ctx, listRequest, client.PaginationOptions{
-		PageLimit: 0,
-		PageDelay: -1,
-		Identity:  reorderRequest.As,
-	})
-	if err != nil {
-		return nil, err
+	var allIDs []string
+	pageToken := ""
+	for {
+		pageRequest := listRequest
+		pageRequest.Params = copyRequestParamsWithoutPageToken(listRequest.Params)
+		if pageToken != "" {
+			pageRequest.Params["page_token"] = pageToken
+		}
+
+		result, err := ac.CallAPI(ctx, pageRequest)
+		if err != nil {
+			return nil, err
+		}
+		if apiErr := checkErr(result, reorderRequest.As); apiErr != nil {
+			return nil, apiErr
+		}
+
+		ids, err := extractMailRuleIDs(result)
+		if err != nil {
+			return nil, err
+		}
+		allIDs = append(allIDs, ids...)
+
+		nextToken, hasMore, err := nextMailRulesPageToken(result)
+		if err != nil {
+			return nil, err
+		}
+		if !hasMore {
+			break
+		}
+		pageToken = nextToken
 	}
-	if apiErr := checkErr(result, reorderRequest.As); apiErr != nil {
-		return nil, apiErr
-	}
-	return extractMailRuleIDs(result)
+	return allIDs, nil
 }
 
 func mailRulesListURL(reorderURL string) string {
@@ -162,12 +183,16 @@ func extractMailRuleIDs(result any) ([]string, error) {
 	if !ok {
 		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing data")
 	}
-	rules, ok := data["items"].([]any)
+	rawRules, ok := data["items"]
 	if !ok {
-		rules, ok = data["rules"].([]any)
+		rawRules, ok = data["rules"]
 	}
+	if !ok || rawRules == nil {
+		return []string{}, nil
+	}
+	rules, ok := rawRules.([]any)
 	if !ok {
-		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing items")
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response items is not an array")
 	}
 
 	ids := make([]string, 0, len(rules))
@@ -186,6 +211,24 @@ func extractMailRuleIDs(result any) ([]string, error) {
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+func nextMailRulesPageToken(result any) (string, bool, error) {
+	data, ok := nestedMap(result, "data")
+	if !ok {
+		return "", false, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing data")
+	}
+	hasMore, _ := data["has_more"].(bool)
+	if !hasMore {
+		return "", false, nil
+	}
+	if token, ok := data["page_token"].(string); ok && token != "" {
+		return token, true, nil
+	}
+	if token, ok := data["next_page_token"].(string); ok && token != "" {
+		return token, true, nil
+	}
+	return "", false, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing next page token")
 }
 
 func nestedMap(result any, key string) (map[string]any, bool) {

--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/core"
+)
+
+const mailRulesReorderSchemaPath = "mail.user_mailbox.rules.reorder"
+
+func maybeCompleteMailRulesReorderIDs(ctx context.Context, ac *client.APIClient, opts *ServiceMethodOptions, request *client.RawApiRequest, checkErr func(interface{}, core.Identity) error) error {
+	if opts.SchemaPath != mailRulesReorderSchemaPath {
+		return nil
+	}
+
+	body, ok := toStringAnyMap(request.Data)
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "mail rules reorder requires a JSON object body").WithParam("--data")
+	}
+
+	requestedIDs, err := mailRuleIDsFromBody(body)
+	if err != nil {
+		return err
+	}
+	if err := validateRequestedMailRuleIDs(requestedIDs); err != nil {
+		return err
+	}
+
+	existingIDs, err := listAllMailRuleIDs(ctx, ac, *request, checkErr)
+	if err != nil {
+		return err
+	}
+
+	completedIDs, err := completeMailRuleIDs(requestedIDs, existingIDs)
+	if err != nil {
+		return err
+	}
+	body["rule_ids"] = completedIDs
+	request.Data = body
+	return nil
+}
+
+func toStringAnyMap(v any) (map[string]any, bool) {
+	if m, ok := v.(map[string]any); ok {
+		return m, true
+	}
+	return nil, false
+}
+
+func mailRuleIDsFromBody(body map[string]any) ([]string, error) {
+	raw, ok := body["rule_ids"]
+	if !ok {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids is required").WithParam("rule_ids")
+	}
+	switch ids := raw.(type) {
+	case []string:
+		return append([]string(nil), ids...), nil
+	case []any:
+		out := make([]string, 0, len(ids))
+		for i, id := range ids {
+			s, ok := id.(string)
+			if !ok {
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids[%d] must be a string", i).WithParam("rule_ids")
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must be an array of strings").WithParam("rule_ids")
+	}
+}
+
+func validateRequestedMailRuleIDs(requestedIDs []string) error {
+	if len(requestedIDs) == 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "at least one rule_id is required for reorder").WithParam("rule_ids")
+	}
+	seen := map[string]struct{}{}
+	for _, id := range requestedIDs {
+		if id == "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids cannot contain an empty string").WithParam("rule_ids")
+		}
+		if _, ok := seen[id]; ok {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "duplicate rule_id: %s", id).WithParam("rule_ids")
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
+}
+
+func completeMailRuleIDs(requestedIDs, existingIDs []string) ([]string, error) {
+	existingSet := make(map[string]struct{}, len(existingIDs))
+	for _, id := range existingIDs {
+		if id == "" {
+			continue
+		}
+		existingSet[id] = struct{}{}
+	}
+	for _, id := range requestedIDs {
+		if _, ok := existingSet[id]; !ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "unknown rule_id: %s", id).WithParam("rule_ids")
+		}
+	}
+
+	requestedSet := make(map[string]struct{}, len(requestedIDs))
+	completed := make([]string, 0, len(existingIDs))
+	for _, id := range requestedIDs {
+		requestedSet[id] = struct{}{}
+		completed = append(completed, id)
+	}
+	for _, id := range existingIDs {
+		if _, ok := requestedSet[id]; !ok {
+			completed = append(completed, id)
+		}
+	}
+	return completed, nil
+}
+
+func listAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest client.RawApiRequest, checkErr func(interface{}, core.Identity) error) ([]string, error) {
+	listRequest := client.RawApiRequest{
+		Method: "GET",
+		URL:    mailRulesListURL(reorderRequest.URL),
+		Params: copyRequestParamsWithoutPageToken(reorderRequest.Params),
+		As:     reorderRequest.As,
+	}
+	result, err := ac.PaginateAll(ctx, listRequest, client.PaginationOptions{
+		PageLimit: 0,
+		PageDelay: -1,
+		Identity:  reorderRequest.As,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := checkErr(result, reorderRequest.As); apiErr != nil {
+		return nil, apiErr
+	}
+	return extractMailRuleIDs(result)
+}
+
+func mailRulesListURL(reorderURL string) string {
+	return strings.TrimSuffix(reorderURL, "/reorder")
+}
+
+func copyRequestParamsWithoutPageToken(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if k == "page_token" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func extractMailRuleIDs(result any) ([]string, error) {
+	data, ok := nestedMap(result, "data")
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing data")
+	}
+	rules, ok := data["items"].([]any)
+	if !ok {
+		rules, ok = data["rules"].([]any)
+	}
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing items")
+	}
+
+	ids := make([]string, 0, len(rules))
+	for i, item := range rules {
+		rule, ok := item.(map[string]any)
+		if !ok {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d is not an object", i)
+		}
+		id, ok := rule["rule_id"].(string)
+		if !ok || id == "" {
+			id, ok = rule["id"].(string)
+		}
+		if !ok || id == "" {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d missing rule_id", i)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func nestedMap(result any, key string) (map[string]any, bool) {
+	m, ok := toStringAnyMap(result)
+	if !ok {
+		return nil, false
+	}
+	return toStringAnyMap(m[key])
+}

--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -130,6 +130,7 @@ func listAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderReques
 	}
 	var allIDs []string
 	pageToken := ""
+	seenPageTokens := map[string]struct{}{}
 	for {
 		pageRequest := listRequest
 		pageRequest.Params = copyRequestParamsWithoutPageToken(listRequest.Params)
@@ -158,6 +159,10 @@ func listAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderReques
 		if !hasMore {
 			break
 		}
+		if _, seen := seenPageTokens[nextToken]; seen {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response repeated page token %q", nextToken)
+		}
+		seenPageTokens[nextToken] = struct{}{}
 		pageToken = nextToken
 	}
 	return allIDs, nil

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -150,17 +150,8 @@ func TestMailRulesReorder_FullIDsRemainInRequestedOrder(t *testing.T) {
 	}
 }
 
-func TestMailRulesReorder_DryRunCompletesPartialIDs(t *testing.T) {
-	_, stdout, reg, cmd := newMailRulesReorderCommand(t)
-	registerMailRulesListPage(reg, "me", map[string]interface{}{
-		"items": []interface{}{
-			map[string]interface{}{"rule_id": "r1"},
-			map[string]interface{}{"rule_id": "r2"},
-			map[string]interface{}{"rule_id": "r3"},
-		},
-		"has_more": false,
-	}, nil)
-
+func TestMailRulesReorder_DryRunDoesNotFetchRules(t *testing.T) {
+	_, stdout, _, cmd := newMailRulesReorderCommand(t)
 	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r2"]}`, "--dry-run"})
 	if err := cmd.execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -183,8 +174,8 @@ func TestMailRulesReorder_DryRunCompletesPartialIDs(t *testing.T) {
 	if !ok {
 		t.Fatalf("dry-run body = %#v, want object", call["body"])
 	}
-	if gotIDs := interfaceSliceToStrings(t, body["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
-		t.Fatalf("dry-run rule_ids = %#v, want [r2 r1 r3]", gotIDs)
+	if gotIDs := interfaceSliceToStrings(t, body["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2"}) {
+		t.Fatalf("dry-run rule_ids = %#v, want [r2]", gotIDs)
 	}
 }
 
@@ -205,8 +196,12 @@ func TestMailRulesReorder_ValidationErrorsDoNotCallAPIs(t *testing.T) {
 		name    string
 		data    string
 		wantMsg string
+		param   string
 	}{
+		{name: "non object body", data: `["r1"]`, wantMsg: "requires a JSON object body", param: "--data"},
 		{name: "empty", data: `{"rule_ids":[]}`, wantMsg: "at least one"},
+		{name: "not array", data: `{"rule_ids":"r1"}`, wantMsg: "rule_ids must be an array"},
+		{name: "item not string", data: `{"rule_ids":["r1",1]}`, wantMsg: "rule_ids[1] must be a string"},
 		{name: "duplicate", data: `{"rule_ids":["r1","r1"]}`, wantMsg: "duplicate rule_id: r1"},
 		{name: "empty string", data: `{"rule_ids":[""]}`, wantMsg: "empty string"},
 	}
@@ -215,7 +210,11 @@ func TestMailRulesReorder_ValidationErrorsDoNotCallAPIs(t *testing.T) {
 			_, _, _, cmd := newMailRulesReorderCommand(t)
 			cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", tt.data})
 			err := cmd.execute()
-			assertServiceValidationError(t, err, tt.wantMsg)
+			wantParam := tt.param
+			if wantParam == "" {
+				wantParam = "rule_ids"
+			}
+			assertServiceValidationErrorWithParam(t, err, tt.wantMsg, wantParam)
 		})
 	}
 }
@@ -229,6 +228,17 @@ func TestMailRulesReorder_UnknownIDDoesNotCallReorder(t *testing.T) {
 
 	err := cmd.execute()
 	assertServiceValidationError(t, err, "unknown rule_id: missing")
+}
+
+func TestMailRulesReorder_EmptyRuleListReturnsValidationError(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"has_more": false,
+	}, nil)
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+
+	err := cmd.execute()
+	assertServiceValidationError(t, err, "unknown rule_id: r1")
 }
 
 func TestMailRulesReorder_ListFailureDoesNotCallReorder(t *testing.T) {
@@ -245,6 +255,46 @@ func TestMailRulesReorder_ListFailureDoesNotCallReorder(t *testing.T) {
 
 	err := cmd.execute()
 	assertServiceAPIError(t, err, 999, "list failed")
+}
+
+func TestMailRulesReorder_ListLaterPageFailureDoesNotCallReorder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items":      []interface{}{map[string]interface{}{"rule_id": "r1"}},
+		"has_more":   true,
+		"page_token": "next-1",
+	}, nil)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules?page_token=next-1",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "second page failed",
+		},
+	})
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+
+	err := cmd.execute()
+	assertServiceAPIError(t, err, 999, "second page failed")
+}
+
+func TestMailRulesReorder_ListMissingNextPageTokenDoesNotCallReorder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items":    []interface{}{map[string]interface{}{"rule_id": "r1"}},
+		"has_more": true,
+	}, nil)
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+
+	err := cmd.execute()
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("expected internal error, got %T: %v", err, err)
+	}
+	requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, 0)
+	if !strings.Contains(err.Error(), "missing next page token") {
+		t.Fatalf("internal error = %q, want missing next page token", err.Error())
+	}
 }
 
 func TestMailRulesReorder_ReorderFailureIsSurfaced(t *testing.T) {
@@ -324,13 +374,18 @@ func TestMailRulesReorder_ListUsesRulesBaseWhenReorderHasSubpath(t *testing.T) {
 
 func assertServiceValidationError(t *testing.T, err error, wantSubstr string) {
 	t.Helper()
+	assertServiceValidationErrorWithParam(t, err, wantSubstr, "rule_ids")
+}
+
+func assertServiceValidationErrorWithParam(t *testing.T, err error, wantSubstr, wantParam string) {
+	t.Helper()
 	var validationErr *errs.ValidationError
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected validation error, got %T: %v", err, err)
 	}
 	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
-	if validationErr.Param != "rule_ids" {
-		t.Fatalf("validation error param = %q, want rule_ids", validationErr.Param)
+	if validationErr.Param != wantParam {
+		t.Fatalf("validation error param = %q, want %q", validationErr.Param, wantParam)
 	}
 	if !strings.Contains(err.Error(), wantSubstr) {
 		t.Fatalf("validation error = %q, want substring %q", err.Error(), wantSubstr)

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -171,9 +171,9 @@ func TestMailRulesReorder_DryRunCompletesPartialIDs(t *testing.T) {
 	if err := decoder.Decode(&dryRun); err != nil {
 		t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
 	}
-	calls, ok := dryRun["api"].([]any)
+	calls, ok := dryRunAPICalls(dryRun)
 	if !ok || len(calls) != 1 {
-		t.Fatalf("dry-run api = %#v, want one call", dryRun["api"])
+		t.Fatalf("dry-run api = %#v, want one call", dryRun)
 	}
 	call, ok := calls[0].(map[string]any)
 	if !ok {
@@ -186,6 +186,18 @@ func TestMailRulesReorder_DryRunCompletesPartialIDs(t *testing.T) {
 	if gotIDs := interfaceSliceToStrings(t, body["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
 		t.Fatalf("dry-run rule_ids = %#v, want [r2 r1 r3]", gotIDs)
 	}
+}
+
+func dryRunAPICalls(dryRun map[string]any) ([]any, bool) {
+	if calls, ok := dryRun["api"].([]any); ok {
+		return calls, true
+	}
+	data, ok := dryRun["data"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	calls, ok := data["api"].([]any)
+	return calls, ok
 }
 
 func TestMailRulesReorder_ValidationErrorsDoNotCallAPIs(t *testing.T) {

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func mailSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules",
+		"httpMethod": "PATCH",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "list", "required": true},
+		},
+	})
+}
+
+func mailRulesReorderSubpathMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "PATCH",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "list", "required": true},
+		},
+	})
+}
+
+func newMailRulesReorderCommand(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *httpmock.Registry, *cobraCommandShim) {
+	t.Helper()
+	f, stdout, _, reg := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	return f, stdout, reg, &cobraCommandShim{setArgs: cmd.SetArgs, execute: cmd.Execute}
+}
+
+type cobraCommandShim struct {
+	setArgs func([]string)
+	execute func() error
+}
+
+func registerMailRulesListPage(reg *httpmock.Registry, mailboxID string, body map[string]interface{}, onMatch func(*http.Request)) {
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "/open-apis/mail/v1/user_mailboxes/" + mailboxID + "/rules",
+		OnMatch: onMatch,
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": body,
+		},
+	})
+}
+
+func registerMailRulesReorder(reg *httpmock.Registry, mailboxID string, onMatch func(*http.Request, map[string]interface{}), body map[string]interface{}) {
+	reg.Register(&httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/mail/v1/user_mailboxes/" + mailboxID + "/rules",
+		OnMatch: func(req *http.Request) {
+			var got map[string]interface{}
+			if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+				panic(err)
+			}
+			onMatch(req, got)
+		},
+		Body: body,
+	})
+}
+
+func TestMailRulesReorder_CompletesPartialIDsBeforeReorder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	var listMailbox, reorderMailbox string
+	registerMailRulesListPage(reg, "shared@example.com", map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"rule_id": "r1"},
+			map[string]interface{}{"rule_id": "r2"},
+			map[string]interface{}{"rule_id": "r3"},
+		},
+		"has_more": false,
+	}, func(req *http.Request) {
+		listMailbox = req.URL.Path
+	})
+	registerMailRulesReorder(reg, "shared@example.com", func(req *http.Request, got map[string]interface{}) {
+		reorderMailbox = req.URL.Path
+		if gotIDs := interfaceSliceToStrings(got["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
+			t.Fatalf("rule_ids = %#v, want [r2 r1 r3]", got["rule_ids"])
+		}
+	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
+
+	cmd.setArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"shared@example.com"}`,
+		"--data", `{"rule_ids":["r2"]}`,
+	})
+	if err := cmd.execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if listMailbox != reorderMailbox {
+		t.Fatalf("list path = %q, reorder path = %q; want same mailbox context", listMailbox, reorderMailbox)
+	}
+}
+
+func TestMailRulesReorder_FullIDsRemainInRequestedOrder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"rule_id": "r1"},
+			map[string]interface{}{"rule_id": "r2"},
+			map[string]interface{}{"rule_id": "r3"},
+		},
+		"has_more": false,
+	}, nil)
+	registerMailRulesReorder(reg, "me", func(req *http.Request, got map[string]interface{}) {
+		if gotIDs := interfaceSliceToStrings(got["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r3", "r1", "r2"}) {
+			t.Fatalf("rule_ids = %#v, want [r3 r1 r2]", got["rule_ids"])
+		}
+	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}})
+
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r3","r1","r2"]}`})
+	if err := cmd.execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestMailRulesReorder_ValidationErrorsDoNotCallAPIs(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantMsg string
+	}{
+		{name: "empty", data: `{"rule_ids":[]}`, wantMsg: "at least one"},
+		{name: "duplicate", data: `{"rule_ids":["r1","r1"]}`, wantMsg: "duplicate rule_id: r1"},
+		{name: "empty string", data: `{"rule_ids":[""]}`, wantMsg: "empty string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, cmd := newMailRulesReorderCommand(t)
+			cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", tt.data})
+			err := cmd.execute()
+			assertServiceValidationError(t, err, tt.wantMsg)
+		})
+	}
+}
+
+func TestMailRulesReorder_UnknownIDDoesNotCallReorder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items": []interface{}{map[string]interface{}{"rule_id": "known"}},
+	}, nil)
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["missing"]}`})
+
+	err := cmd.execute()
+	assertServiceValidationError(t, err, "unknown rule_id: missing")
+}
+
+func TestMailRulesReorder_ListFailureDoesNotCallReorder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "list failed",
+		},
+	})
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+
+	err := cmd.execute()
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) || !strings.Contains(err.Error(), "list failed") {
+		t.Fatalf("expected list API error, got %T: %v", err, err)
+	}
+}
+
+func TestMailRulesReorder_ReorderFailureIsSurfaced(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items": []interface{}{map[string]interface{}{"rule_id": "r1"}},
+	}, nil)
+	registerMailRulesReorder(reg, "me", func(req *http.Request, got map[string]interface{}) {}, map[string]interface{}{
+		"code": 998,
+		"msg":  "reorder failed",
+	})
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+
+	err := cmd.execute()
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) || !strings.Contains(err.Error(), "reorder failed") {
+		t.Fatalf("expected reorder API error, got %T: %v", err, err)
+	}
+}
+
+func TestMailRulesReorder_ListPaginationFetchesAllRules(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	var tokens []string
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items":      []interface{}{map[string]interface{}{"rule_id": "r1"}},
+		"has_more":   true,
+		"page_token": "next-1",
+	}, func(req *http.Request) {
+		tokens = append(tokens, req.URL.Query().Get("page_token"))
+	})
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items":    []interface{}{map[string]interface{}{"rule_id": "r2"}},
+		"has_more": false,
+	}, func(req *http.Request) {
+		tokens = append(tokens, req.URL.Query().Get("page_token"))
+	})
+	registerMailRulesReorder(reg, "me", func(req *http.Request, got map[string]interface{}) {
+		if gotIDs := interfaceSliceToStrings(got["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1"}) {
+			t.Fatalf("rule_ids = %#v, want [r2 r1]", got["rule_ids"])
+		}
+	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}})
+
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r2"]}`})
+	if err := cmd.execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !reflect.DeepEqual(tokens, []string{"", "next-1"}) {
+		t.Fatalf("page tokens = %v, want [ next-1]", tokens)
+	}
+}
+
+func TestMailRulesReorder_ListUsesRulesBaseWhenReorderHasSubpath(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderSubpathMethod(), "reorder", "user_mailbox.rules", nil)
+	var listed, reordered bool
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items": []interface{}{map[string]interface{}{"rule_id": "r1"}},
+	}, func(req *http.Request) {
+		listed = true
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		OnMatch: func(req *http.Request) {
+			reordered = true
+		},
+		Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	})
+
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !listed || !reordered {
+		t.Fatalf("listed=%v reordered=%v, want both true", listed, reordered)
+	}
+}
+
+func assertServiceValidationError(t *testing.T, err error, wantSubstr string) {
+	t.Helper()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), wantSubstr) {
+		t.Fatalf("validation error = %q, want substring %q", err.Error(), wantSubstr)
+	}
+}
+
+func interfaceSliceToStrings(v interface{}) []string {
+	items, _ := v.([]interface{})
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.(string))
+	}
+	return out
+}

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -171,9 +171,17 @@ func TestMailRulesReorder_DryRunCompletesPartialIDs(t *testing.T) {
 	if err := decoder.Decode(&dryRun); err != nil {
 		t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
 	}
-	body, ok := dryRun["body"].(map[string]any)
+	calls, ok := dryRun["api"].([]any)
+	if !ok || len(calls) != 1 {
+		t.Fatalf("dry-run api = %#v, want one call", dryRun["api"])
+	}
+	call, ok := calls[0].(map[string]any)
 	if !ok {
-		t.Fatalf("dry-run body = %#v, want object", dryRun["body"])
+		t.Fatalf("dry-run api[0] = %#v, want object", calls[0])
+	}
+	body, ok := call["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run body = %#v, want object", call["body"])
 	}
 	if gotIDs := interfaceSliceToStrings(t, body["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
 		t.Fatalf("dry-run rule_ids = %#v, want [r2 r1 r3]", gotIDs)

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -297,6 +297,77 @@ func TestMailRulesReorder_ListMissingNextPageTokenDoesNotCallReorder(t *testing.
 	}
 }
 
+func TestMailRulesReorder_ListRepeatedPageTokenDoesNotCallReorder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items":      []interface{}{map[string]interface{}{"rule_id": "r1"}},
+		"has_more":   true,
+		"page_token": "next-1",
+	}, nil)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items":      []interface{}{map[string]interface{}{"rule_id": "r2"}},
+		"has_more":   true,
+		"page_token": "next-1",
+	}, nil)
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+
+	err := cmd.execute()
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("expected internal error, got %T: %v", err, err)
+	}
+	requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, 0)
+	if !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("internal error = %q, want repeated page token", err.Error())
+	}
+}
+
+func TestMailRulesReorder_ListPageTokenCycleDoesNotCallReorder(t *testing.T) {
+	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items":      []interface{}{map[string]interface{}{"rule_id": "r1"}},
+		"has_more":   true,
+		"page_token": "next-1",
+	}, nil)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules?page_token=next-1",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"rule_id": "r2"}},
+				"has_more":   true,
+				"page_token": "next-2",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules?page_token=next-2",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"rule_id": "r3"}},
+				"has_more":   true,
+				"page_token": "next-1",
+			},
+		},
+	})
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
+
+	err := cmd.execute()
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("expected internal error, got %T: %v", err, err)
+	}
+	requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, 0)
+	if !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("internal error = %q, want repeated page token", err.Error())
+	}
+}
+
 func TestMailRulesReorder_ReorderFailureIsSurfaced(t *testing.T) {
 	_, _, reg, cmd := newMailRulesReorderCommand(t)
 	registerMailRulesListPage(reg, "me", map[string]interface{}{

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -108,7 +107,7 @@ func TestMailRulesReorder_CompletesPartialIDsBeforeReorder(t *testing.T) {
 	})
 	registerMailRulesReorder(reg, "shared@example.com", func(req *http.Request, got map[string]interface{}) {
 		reorderMailbox = req.URL.Path
-		gotRuleIDs = interfaceSliceToStrings(got["rule_ids"])
+		gotRuleIDs = interfaceSliceToStrings(t, got["rule_ids"])
 	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
 
 	cmd.setArgs([]string{
@@ -139,7 +138,7 @@ func TestMailRulesReorder_FullIDsRemainInRequestedOrder(t *testing.T) {
 		"has_more": false,
 	}, nil)
 	registerMailRulesReorder(reg, "me", func(req *http.Request, got map[string]interface{}) {
-		gotRuleIDs = interfaceSliceToStrings(got["rule_ids"])
+		gotRuleIDs = interfaceSliceToStrings(t, got["rule_ids"])
 	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}})
 
 	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r3","r1","r2"]}`})
@@ -176,7 +175,7 @@ func TestMailRulesReorder_DryRunCompletesPartialIDs(t *testing.T) {
 	if !ok {
 		t.Fatalf("dry-run body = %#v, want object", dryRun["body"])
 	}
-	if gotIDs := interfaceSliceToStrings(body["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
+	if gotIDs := interfaceSliceToStrings(t, body["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
 		t.Fatalf("dry-run rule_ids = %#v, want [r2 r1 r3]", gotIDs)
 	}
 }
@@ -261,7 +260,7 @@ func TestMailRulesReorder_ListPaginationFetchesAllRules(t *testing.T) {
 		tokens = append(tokens, req.URL.Query().Get("page_token"))
 	})
 	registerMailRulesReorder(reg, "me", func(req *http.Request, got map[string]interface{}) {
-		gotRuleIDs = interfaceSliceToStrings(got["rule_ids"])
+		gotRuleIDs = interfaceSliceToStrings(t, got["rule_ids"])
 	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}})
 
 	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r2"]}`})
@@ -330,11 +329,19 @@ func assertServiceAPIError(t *testing.T, err error, wantCode int, wantSubstr str
 	}
 }
 
-func interfaceSliceToStrings(v interface{}) []string {
-	items, _ := v.([]interface{})
+func interfaceSliceToStrings(t *testing.T, v interface{}) []string {
+	t.Helper()
+	items, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("rule_ids = %#v, want []interface{}", v)
+	}
 	out := make([]string, 0, len(items))
-	for _, item := range items {
-		out = append(out, fmt.Sprint(item))
+	for i, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			t.Fatalf("rule_ids[%d] = %#v, want string", i, item)
+		}
+		out = append(out, s)
 	}
 	return out
 }

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -94,6 +95,7 @@ func registerMailRulesReorder(reg *httpmock.Registry, mailboxID string, onMatch 
 func TestMailRulesReorder_CompletesPartialIDsBeforeReorder(t *testing.T) {
 	_, _, reg, cmd := newMailRulesReorderCommand(t)
 	var listMailbox, reorderMailbox string
+	var gotRuleIDs []string
 	registerMailRulesListPage(reg, "shared@example.com", map[string]interface{}{
 		"items": []interface{}{
 			map[string]interface{}{"rule_id": "r1"},
@@ -106,9 +108,7 @@ func TestMailRulesReorder_CompletesPartialIDsBeforeReorder(t *testing.T) {
 	})
 	registerMailRulesReorder(reg, "shared@example.com", func(req *http.Request, got map[string]interface{}) {
 		reorderMailbox = req.URL.Path
-		if gotIDs := interfaceSliceToStrings(got["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
-			t.Fatalf("rule_ids = %#v, want [r2 r1 r3]", got["rule_ids"])
-		}
+		gotRuleIDs = interfaceSliceToStrings(got["rule_ids"])
 	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
 
 	cmd.setArgs([]string{
@@ -119,6 +119,9 @@ func TestMailRulesReorder_CompletesPartialIDsBeforeReorder(t *testing.T) {
 	if err := cmd.execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
+	if !reflect.DeepEqual(gotRuleIDs, []string{"r2", "r1", "r3"}) {
+		t.Fatalf("rule_ids = %#v, want [r2 r1 r3]", gotRuleIDs)
+	}
 	if listMailbox != reorderMailbox {
 		t.Fatalf("list path = %q, reorder path = %q; want same mailbox context", listMailbox, reorderMailbox)
 	}
@@ -126,6 +129,7 @@ func TestMailRulesReorder_CompletesPartialIDsBeforeReorder(t *testing.T) {
 
 func TestMailRulesReorder_FullIDsRemainInRequestedOrder(t *testing.T) {
 	_, _, reg, cmd := newMailRulesReorderCommand(t)
+	var gotRuleIDs []string
 	registerMailRulesListPage(reg, "me", map[string]interface{}{
 		"items": []interface{}{
 			map[string]interface{}{"rule_id": "r1"},
@@ -135,14 +139,45 @@ func TestMailRulesReorder_FullIDsRemainInRequestedOrder(t *testing.T) {
 		"has_more": false,
 	}, nil)
 	registerMailRulesReorder(reg, "me", func(req *http.Request, got map[string]interface{}) {
-		if gotIDs := interfaceSliceToStrings(got["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r3", "r1", "r2"}) {
-			t.Fatalf("rule_ids = %#v, want [r3 r1 r2]", got["rule_ids"])
-		}
+		gotRuleIDs = interfaceSliceToStrings(got["rule_ids"])
 	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}})
 
 	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r3","r1","r2"]}`})
 	if err := cmd.execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+	if !reflect.DeepEqual(gotRuleIDs, []string{"r3", "r1", "r2"}) {
+		t.Fatalf("rule_ids = %#v, want [r3 r1 r2]", gotRuleIDs)
+	}
+}
+
+func TestMailRulesReorder_DryRunCompletesPartialIDs(t *testing.T) {
+	_, stdout, reg, cmd := newMailRulesReorderCommand(t)
+	registerMailRulesListPage(reg, "me", map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"rule_id": "r1"},
+			map[string]interface{}{"rule_id": "r2"},
+			map[string]interface{}{"rule_id": "r3"},
+		},
+		"has_more": false,
+	}, nil)
+
+	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r2"]}`, "--dry-run"})
+	if err := cmd.execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var dryRun map[string]any
+	decoder := json.NewDecoder(strings.NewReader(strings.TrimPrefix(stdout.String(), "=== Dry Run ===\n")))
+	if err := decoder.Decode(&dryRun); err != nil {
+		t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
+	}
+	body, ok := dryRun["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("dry-run body = %#v, want object", dryRun["body"])
+	}
+	if gotIDs := interfaceSliceToStrings(body["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1", "r3"}) {
+		t.Fatalf("dry-run rule_ids = %#v, want [r2 r1 r3]", gotIDs)
 	}
 }
 
@@ -190,10 +225,7 @@ func TestMailRulesReorder_ListFailureDoesNotCallReorder(t *testing.T) {
 	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
 
 	err := cmd.execute()
-	var apiErr *errs.APIError
-	if !errors.As(err, &apiErr) || !strings.Contains(err.Error(), "list failed") {
-		t.Fatalf("expected list API error, got %T: %v", err, err)
-	}
+	assertServiceAPIError(t, err, 999, "list failed")
 }
 
 func TestMailRulesReorder_ReorderFailureIsSurfaced(t *testing.T) {
@@ -208,15 +240,13 @@ func TestMailRulesReorder_ReorderFailureIsSurfaced(t *testing.T) {
 	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r1"]}`})
 
 	err := cmd.execute()
-	var apiErr *errs.APIError
-	if !errors.As(err, &apiErr) || !strings.Contains(err.Error(), "reorder failed") {
-		t.Fatalf("expected reorder API error, got %T: %v", err, err)
-	}
+	assertServiceAPIError(t, err, 998, "reorder failed")
 }
 
 func TestMailRulesReorder_ListPaginationFetchesAllRules(t *testing.T) {
 	_, _, reg, cmd := newMailRulesReorderCommand(t)
 	var tokens []string
+	var gotRuleIDs []string
 	registerMailRulesListPage(reg, "me", map[string]interface{}{
 		"items":      []interface{}{map[string]interface{}{"rule_id": "r1"}},
 		"has_more":   true,
@@ -231,14 +261,15 @@ func TestMailRulesReorder_ListPaginationFetchesAllRules(t *testing.T) {
 		tokens = append(tokens, req.URL.Query().Get("page_token"))
 	})
 	registerMailRulesReorder(reg, "me", func(req *http.Request, got map[string]interface{}) {
-		if gotIDs := interfaceSliceToStrings(got["rule_ids"]); !reflect.DeepEqual(gotIDs, []string{"r2", "r1"}) {
-			t.Fatalf("rule_ids = %#v, want [r2 r1]", got["rule_ids"])
-		}
+		gotRuleIDs = interfaceSliceToStrings(got["rule_ids"])
 	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}})
 
 	cmd.setArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["r2"]}`})
 	if err := cmd.execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+	if !reflect.DeepEqual(gotRuleIDs, []string{"r2", "r1"}) {
+		t.Fatalf("rule_ids = %#v, want [r2 r1]", gotRuleIDs)
 	}
 	if !reflect.DeepEqual(tokens, []string{"", "next-1"}) {
 		t.Fatalf("page tokens = %v, want [ next-1]", tokens)
@@ -278,8 +309,24 @@ func assertServiceValidationError(t *testing.T, err error, wantSubstr string) {
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected validation error, got %T: %v", err, err)
 	}
+	requireProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, 0)
+	if validationErr.Param != "rule_ids" {
+		t.Fatalf("validation error param = %q, want rule_ids", validationErr.Param)
+	}
 	if !strings.Contains(err.Error(), wantSubstr) {
 		t.Fatalf("validation error = %q, want substring %q", err.Error(), wantSubstr)
+	}
+}
+
+func assertServiceAPIError(t *testing.T, err error, wantCode int, wantSubstr string) {
+	t.Helper()
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected API error, got %T: %v", err, err)
+	}
+	requireProblem(t, err, errs.CategoryAPI, errs.SubtypeUnknown, wantCode)
+	if !strings.Contains(err.Error(), wantSubstr) {
+		t.Fatalf("api error = %q, want substring %q", err.Error(), wantSubstr)
 	}
 }
 
@@ -287,7 +334,7 @@ func interfaceSliceToStrings(v interface{}) []string {
 	items, _ := v.([]interface{})
 	out := make([]string, 0, len(items))
 	for _, item := range items {
-		out = append(out, item.(string))
+		out = append(out, fmt.Sprint(item))
 	}
 	return out
 }

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -430,6 +430,10 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	// with MissingScopes / Identity / ConsoleURL populated from the response.
 	checkErr := ac.CheckResponse
 
+	if err := maybeCompleteMailRulesReorderIDs(opts.Ctx, ac, opts, &request, checkErr); err != nil {
+		return err
+	}
+
 	if opts.PageAll {
 		return servicePaginate(opts.Ctx, ac, request, format, opts.JqExpr, out, f.IOStreams.ErrOut, opts.Cmd.CommandPath(),
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -401,19 +401,6 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		return err
 	}
 
-	var ac *client.APIClient
-	mailRulesReorderCompleted := false
-	if opts.SchemaPath == mailRulesReorderSchemaPath {
-		ac, err = f.NewAPIClientWithConfig(config)
-		if err != nil {
-			return err
-		}
-		if err := maybeCompleteMailRulesReorderIDs(opts.Ctx, ac, opts, &request, ac.CheckResponse); err != nil {
-			return err
-		}
-		mailRulesReorderCompleted = true
-	}
-
 	if opts.DryRun {
 		if fileMeta != nil {
 			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
@@ -427,11 +414,9 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		}
 	}
 
-	if ac == nil {
-		ac, err = f.NewAPIClientWithConfig(config)
-		if err != nil {
-			return err
-		}
+	ac, err := f.NewAPIClientWithConfig(config)
+	if err != nil {
+		return err
 	}
 
 	out := f.IOStreams.Out
@@ -445,10 +430,8 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	// with MissingScopes / Identity / ConsoleURL populated from the response.
 	checkErr := ac.CheckResponse
 
-	if !mailRulesReorderCompleted {
-		if err := maybeCompleteMailRulesReorderIDs(opts.Ctx, ac, opts, &request, checkErr); err != nil {
-			return err
-		}
+	if err := maybeCompleteMailRulesReorderIDs(opts.Ctx, ac, opts, &request, checkErr); err != nil {
+		return err
 	}
 
 	if opts.PageAll {

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -401,6 +401,19 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		return err
 	}
 
+	var ac *client.APIClient
+	mailRulesReorderCompleted := false
+	if opts.SchemaPath == mailRulesReorderSchemaPath {
+		ac, err = f.NewAPIClientWithConfig(config)
+		if err != nil {
+			return err
+		}
+		if err := maybeCompleteMailRulesReorderIDs(opts.Ctx, ac, opts, &request, ac.CheckResponse); err != nil {
+			return err
+		}
+		mailRulesReorderCompleted = true
+	}
+
 	if opts.DryRun {
 		if fileMeta != nil {
 			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
@@ -414,9 +427,11 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		}
 	}
 
-	ac, err := f.NewAPIClientWithConfig(config)
-	if err != nil {
-		return err
+	if ac == nil {
+		ac, err = f.NewAPIClientWithConfig(config)
+		if err != nil {
+			return err
+		}
 	}
 
 	out := f.IOStreams.Out
@@ -430,8 +445,10 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	// with MissingScopes / Identity / ConsoleURL populated from the response.
 	checkErr := ac.CheckResponse
 
-	if err := maybeCompleteMailRulesReorderIDs(opts.Ctx, ac, opts, &request, checkErr); err != nil {
-		return err
+	if !mailRulesReorderCompleted {
+		if err := maybeCompleteMailRulesReorderIDs(opts.Ctx, ac, opts, &request, checkErr); err != nil {
+			return err
+		}
 	}
 
 	if opts.PageAll {

--- a/internal/qualitygate/rules/dryrun.go
+++ b/internal/qualitygate/rules/dryrun.go
@@ -416,6 +416,9 @@ func fakeContextualURLValueForPlaceholder(name string, ctx placeholderContext) (
 	if !hasPlaceholderToken(nameTokens, "url", "link") && !hasPlaceholderToken(flagTokens, "url", "link") {
 		return "", false
 	}
+	if hasPlaceholderToken(nameTokens, "wiki") {
+		return "https://example.feishu.cn/wiki/wiki_test123", true
+	}
 	usage := strings.ToLower(ctx.FlagUsage)
 	if strings.Contains(usage, "lark") || strings.Contains(usage, "feishu") || strings.Contains(usage, "document url") {
 		return "https://example.feishu.cn/docx/doc_test123", true

--- a/internal/qualitygate/rules/dryrun_test.go
+++ b/internal/qualitygate/rules/dryrun_test.go
@@ -397,6 +397,38 @@ func TestRunDryRunsMaterializesLarkDocumentURLPlaceholders(t *testing.T) {
 	}
 }
 
+func TestRunDryRunsMaterializesWikiURLPlaceholders(t *testing.T) {
+	cliBin, argsPath := fakeDryRunCLI(t, `{"api":[{"method":"GET","url":"/open-apis/wiki/v2/spaces/get_node","params":{"token":"wiki_test123"}}]}`)
+	m := manifest.Manifest{Commands: []manifest.Command{{
+		Path:     "wiki +node-get",
+		Runnable: true,
+		Flags: []manifest.Flag{
+			{Name: "node-token", TakesValue: true, Usage: "node token, obj token, or Lark URL"},
+			{Name: "as", TakesValue: true},
+			{Name: "format", TakesValue: true},
+			{Name: "dry-run"},
+		},
+	}}}
+	ex := skillscan.Example{
+		Raw:            "lark-cli wiki +node-get --node-token '<wiki_url>' --as user --format json",
+		SourceFile:     "skills/lark-wiki/references/lark-wiki-delete-space.md",
+		Line:           123,
+		HasPlaceholder: true,
+	}
+
+	diags, facts := RunDryRuns(context.Background(), cliBin, m, []skillscan.Example{ex})
+	if len(diags) != 0 {
+		t.Fatalf("RunDryRuns() diagnostics = %#v", diags)
+	}
+	if len(facts) != 1 || !facts[0].Executable || facts[0].SkipReason != "" {
+		t.Fatalf("wiki URL placeholder example should be executable after materialization: %#v", facts)
+	}
+	wantArgs := []string{"wiki", "+node-get", "--node-token", "https://example.feishu.cn/wiki/wiki_test123", "--as", "user", "--format", "json", "--dry-run"}
+	if gotArgs := readArgs(t, argsPath); !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("fake CLI args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
 func TestRunDryRunsMaterializesResourceIDPlaceholderFlagValues(t *testing.T) {
 	cliBin, argsPath := fakeDryRunCLI(t, `{"api":[{"method":"GET","url":"/open-apis/wiki/v2/spaces/space_test123/nodes"}]}`)
 	m := manifest.Manifest{Commands: []manifest.Command{{

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -2,6 +2,18 @@
 
 管理自动处理收到邮件的规则。规则写操作需使用真实 `rule_id`，不要猜测 ID。规则写操作执行前需按 SKILL.md 的写操作确认规则获得用户确认。
 
+## 重排序
+
+`user_mailbox.rules reorder` 可以只传需要优先排序的一部分规则 ID。CLI 会先用同一个 `user_mailbox_id` / `--as` 身份上下文调用 `user_mailbox.rules list` 读取当前全部规则，再按“用户输入顺序优先 + 未输入规则保持当前相对顺序”补齐完整 `rule_ids` 后调用 reorder。
+
+```bash
+lark-cli mail user_mailbox.rules reorder --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"rule_ids":["<rule_id_to_move_first>","<rule_id_to_move_second>"]}'
+```
+
+空 `rule_ids`、重复 ID、未知 ID 会在 CLI 侧报 validation error，且不会调用 reorder。list 失败时也不会调用 reorder；reorder 失败时透传 API error。
+
 ## 主题包含文本 → 标记为已读
 
 ```bash

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -25,9 +25,9 @@ metadata:
 ## 快速决策
 
 - 用户要**整理 / 盘点 / 归类 / 重构知识库、个人文档库、文档库目录或 Wiki 节点结构**，或要生成整理方案、目标目录树、移动计划时，不要只使用 Wiki 节点 API。必须先阅读 [`../lark-drive/references/lark-drive-workflow-knowledge-organize.md`](../lark-drive/references/lark-drive-workflow-knowledge-organize.md)，该 workflow 负责 Drive / Wiki / 个人文档库的统一入口解析、资源盘点、分类计划、写前确认和结果验证。
-- 用户给的是知识库 URL（`.../wiki/<token>`），且后续要查成员/加成员/删成员：先调用 `lark-cli wiki +node-get --node-token <wiki_url> --as user --format json` 获取 `space_id`，后续成员接口统一使用 `space_id`。
+- 用户给的是知识库 URL（`.../wiki/<token>`），且后续要查成员/加成员/删成员：先调用 `lark-cli wiki +node-get --node-token '<wiki_url>' --as user --format json` 获取 `space_id`，后续成员接口统一使用 `space_id`。
 - 用户要**删除**知识空间（`wiki +delete-space`）但只给了名称或 URL：**不能**把名称 / URL 原样传给 `--space-id`，必须先解析出真实 `space_id`。解析方式：
-  - URL（`.../wiki/<token>`）：`lark-cli wiki +node-get --node-token <wiki_url> --as user --format json`，读 `data.node.space_id`。
+  - URL（`.../wiki/<token>`）：`lark-cli wiki +node-get --node-token '<wiki_url>' --as user --format json`，读 `data.space_id`。
   - 只知名称：`lark-cli wiki spaces list --format json`，边翻页边收集 items 并按 `name` 精确匹配；**一旦任一页累计到至少 1 条精确匹配就停止翻页**。只有当翻完所有页（`has_more=false`）仍无精确匹配时，才对已收集的全量 items 做宽松匹配（`name` trim 空格、大小写不敏感、子串包含）。
   - **关键安全约束**：无论精确还是模糊，**无论命中 1 条还是多条，发起删除前都必须把候选（`name` + `space_id` + `description` + `space_type`）列给用户，由用户明确选定一个 `space_id` 再执行**。不要因为"只命中一条"就自动执行删除。
   - 命中 0 条：停下来问用户是名称拼错了还是调用方无权限；**不要**自行改名字重试。

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -25,14 +25,14 @@ metadata:
 ## 快速决策
 
 - 用户要**整理 / 盘点 / 归类 / 重构知识库、个人文档库、文档库目录或 Wiki 节点结构**，或要生成整理方案、目标目录树、移动计划时，不要只使用 Wiki 节点 API。必须先阅读 [`../lark-drive/references/lark-drive-workflow-knowledge-organize.md`](../lark-drive/references/lark-drive-workflow-knowledge-organize.md)，该 workflow 负责 Drive / Wiki / 个人文档库的统一入口解析、资源盘点、分类计划、写前确认和结果验证。
-- 用户给的是知识库 URL（`.../wiki/<token>`），且后续要查成员/加成员/删成员：先调用 `lark-cli wiki spaces get_node --params '{"token":"<wiki_token>"}'` 获取 `space_id`，后续成员接口统一使用 `space_id`。
+- 用户给的是知识库 URL（`.../wiki/<token>`），且后续要查成员/加成员/删成员：先调用 `lark-cli wiki +node-get --node-token <wiki_url> --as user --format json` 获取 `space_id`，后续成员接口统一使用 `space_id`。
 - 用户要**删除**知识空间（`wiki +delete-space`）但只给了名称或 URL：**不能**把名称 / URL 原样传给 `--space-id`，必须先解析出真实 `space_id`。解析方式：
-  - URL（`.../wiki/<token>`）：`lark-cli wiki spaces get_node --params '{"token":"<wiki_token>"}' --format json`，读 `data.node.space_id`。
+  - URL（`.../wiki/<token>`）：`lark-cli wiki +node-get --node-token <wiki_url> --as user --format json`，读 `data.node.space_id`。
   - 只知名称：`lark-cli wiki spaces list --format json`，边翻页边收集 items 并按 `name` 精确匹配；**一旦任一页累计到至少 1 条精确匹配就停止翻页**。只有当翻完所有页（`has_more=false`）仍无精确匹配时，才对已收集的全量 items 做宽松匹配（`name` trim 空格、大小写不敏感、子串包含）。
   - **关键安全约束**：无论精确还是模糊，**无论命中 1 条还是多条，发起删除前都必须把候选（`name` + `space_id` + `description` + `space_type`）列给用户，由用户明确选定一个 `space_id` 再执行**。不要因为"只命中一条"就自动执行删除。
   - 命中 0 条：停下来问用户是名称拼错了还是调用方无权限；**不要**自行改名字重试。
   - 用户明确选定后再执行 `lark-cli wiki +delete-space --space-id <ID> --yes`（高风险写操作，必须显式 `--yes`）。
-  - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki spaces get_node` 解析出 `data.node.space_id` 再传。
+  - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki +node-get` 解析出 `data.node.space_id` 再传。
 - 用户要在知识库中创建新节点，优先使用 `lark-cli wiki +node-create`。
 - 用户要列出 Wiki 节点：先用 `wiki +space-list --as user` 拿数字 `space_id`，再用 `wiki +node-list --space-id <space_id>`。不要把 wiki URL、node token、doc token、名称直接当 `--space-id`。钻子节点时 `--parent-node-token` 必须是 wiki node token；如果用户给的是 docx/sheet/base URL，先用 `wiki +node-get --node-token <url>` 解析出 `node_token`。
 - `wiki +node-list` 命中 `invalid_parameters`、`not_found`、`permission_denied` 时，不要重复调用同一参数；按 hint 修 `space_id` / `parent_node_token` / 权限。只有 `rate_limit` 才做退避重试。

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -32,7 +32,7 @@ metadata:
   - **关键安全约束**：无论精确还是模糊，**无论命中 1 条还是多条，发起删除前都必须把候选（`name` + `space_id` + `description` + `space_type`）列给用户，由用户明确选定一个 `space_id` 再执行**。不要因为"只命中一条"就自动执行删除。
   - 命中 0 条：停下来问用户是名称拼错了还是调用方无权限；**不要**自行改名字重试。
   - 用户明确选定后再执行 `lark-cli wiki +delete-space --space-id <ID> --yes`（高风险写操作，必须显式 `--yes`）。
-  - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki +node-get` 解析出 `data.node.space_id` 再传。
+  - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki +node-get` 解析出 `data.space_id` 再传。
 - 用户要在知识库中创建新节点，优先使用 `lark-cli wiki +node-create`。
 - 用户要列出 Wiki 节点：先用 `wiki +space-list --as user` 拿数字 `space_id`，再用 `wiki +node-list --space-id <space_id>`。不要把 wiki URL、node token、doc token、名称直接当 `--space-id`。钻子节点时 `--parent-node-token` 必须是 wiki node token；如果用户给的是 docx/sheet/base URL，先用 `wiki +node-get --node-token <url>` 解析出 `node_token`。
 - `wiki +node-list` 命中 `invalid_parameters`、`not_found`、`permission_denied` 时，不要重复调用同一参数；按 hint 修 `space_id` / `parent_node_token` / 权限。只有 `rate_limit` 才做退避重试。

--- a/skills/lark-wiki/references/lark-wiki-delete-space.md
+++ b/skills/lark-wiki/references/lark-wiki-delete-space.md
@@ -118,8 +118,9 @@ dry-run 会展示两步调用链：
 ### 2. 只有知识库 URL（`.../wiki/<token>`）
 
 ```bash
-lark-cli wiki spaces get_node \
-  --params '{"token":"<wiki_token>"}' \
+lark-cli wiki +node-get \
+  --node-token '<wiki_url>' \
+  --as user \
   --format json
 ```
 

--- a/skills/lark-wiki/references/lark-wiki-delete-space.md
+++ b/skills/lark-wiki/references/lark-wiki-delete-space.md
@@ -124,7 +124,7 @@ lark-cli wiki +node-get \
   --format json
 ```
 
-读取 `data.node.space_id`。
+读取 `data.space_id`。
 
 ### 3. 只有知识库名称
 


### PR DESCRIPTION
This completes mail receive-rule reorder requests before they are sent to the service.

- Fetches the current rule list before reorder operations.
- Validates requested rule IDs against the current mailbox rules.
- Sends the full ordered rule ID list expected by the reorder API.
- Adds tests for partial reorder input and documents the behavior.

Tested with `go test ./cmd/service`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail rules can now be reordered by specifying only the rules that should move to the front; remaining rules are automatically appended in their existing order.
  * Complete rule lists are retrieved across paginated results before changes are applied.

* **Bug Fixes**
  * Added validation for empty, duplicate, or unknown rule IDs.
  * Improved handling of list and reorder API failures, including dry-run behavior.

* **Documentation**
  * Documented partial mail-rule reordering and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->