### PR TITLE
feat: add im message patch meta api

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -172,6 +172,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
   - `delete` — 撤回消息。Identity: supports `user` and `bot`; for `bot` calls, the bot must be in the chat to revoke group messages; to revoke another user's group message, the bot must be the owner, an admin, or the creator; for user P2P recalls, the target user must be within the bot's availability.
   - `forward` — 转发消息。Identity: supports `user` and `bot`.
   - `merge_forward` — 合并转发消息。Identity: `bot` only (`tenant_access_token`).
+  - `patch` — 更新已发送的消息卡片。Update an interactive message card sent by the app. Identity: supports `user` and `bot`; the message must have been sent within the last 14 days, and `content` must be a JSON-serialized string no larger than 30 KB.
   - `read_users` — 查询消息已读信息。Identity: `bot` only (`tenant_access_token`); the bot must be in the chat, and can only query read status for messages it sent within the last 7 days.
   - `urgent_app` — 发送应用内加急。Identity: `bot` only (`tenant_access_token`); the bot must be the message sender and must be in the conversation that contains the message.
   - `urgent_phone` — 发送电话加急。Identity: `bot` only (`tenant_access_token`); the bot must be the message sender and must be in the conversation that contains the message.
@@ -228,6 +229,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `messages.delete` | `im:message:recall` |
 | `messages.forward` | `im:message` |
 | `messages.merge_forward` | `im:message` |
+| `messages.patch` | `im:message:update` |
 | `messages.read_users` | `im:message:readonly` |
 | `messages.urgent_app` | `im:message.urgent` |
 | `messages.urgent_phone` | `im:message.urgent:phone` |


### PR DESCRIPTION
  ## Summary

  The IM skill did not document the existing Meta API for updating interactive
  message cards. This PR adds `im messages patch` to the domain guide so agents
  can discover its constraints and required scope.

  ## Changes

  - Document `messages.patch`, including supported identities, the 14-day update
    window, and the 30 KB serialized card-content limit
  - Map `messages.patch` to the required `im:message:update` scope

  ## Test Plan

  - [x] `node scripts/skill-format-check/index.js`
  - [x] `git diff --check upstream/main...HEAD`
  - [x] Verified the agent discovery flow through:
    - `./lark-cli im --help`
    - `./lark-cli im messages --help`
    - `./lark-cli im messages patch --help`
    - `./lark-cli schema im.messages.patch --format json`
  - [x] Manually updated an interactive card as a bot with
    `./lark-cli im messages patch`

  ## Related Issues

  - None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating interactive message cards through the `messages.patch` API.
  * Documented identity, recency, and payload-size constraints for message updates.
  * Added the required message-update permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->