### PR TITLE
fix(slides): bind lint issues to source XML nodes

### DIFF
--- a/skills/lark-slides/references/validation-checklist.md
+++ b/skills/lark-slides/references/validation-checklist.md
@@ -47,7 +47,7 @@ python3 "<lark-slides-skill-dir>/scripts/xml_text_overlap_lint.py" --input <pres
 - `element_ids`：相关 XML 元素 ID；
 - `rule`：规则 ID、名称、阈值和比较关系；
 - `measurement`：越界量、交叠面积、覆盖率等实测值；
-- `related_objects`：相关对象的类型与坐标框；
+- `related_objects`：相关对象的类型、坐标框，以及指向当前输入 XML 节点的 XPath-like `xml_path`；
 - `target`、`message`、`hint`：页码、语义说明和处理建议。
 
 当 `sparse_container_content.measurement.content_coverage_ratio < rule.threshold` 时，需要结合同页截图判断留白是否有意设计；不要仅凭 warning 自动扩充内容。

--- a/skills/lark-slides/references/validation-checklist.md
+++ b/skills/lark-slides/references/validation-checklist.md
@@ -66,7 +66,7 @@ python3 "<lark-slides-skill-dir>/scripts/xml_text_overlap_lint.py" --input <pres
 | `bbox_overlap` | 文本元素的估算绘制区域明显重叠 | 拉开文本坐标、缩小文本框/字号，或改成明确的分栏/分组结构 |
 | `*_out_of_canvas` | 元素边界超出页面画布 | 根据 `measurement.overflow` 移回画布或缩小尺寸 |
 | `blank_slide` | 页面没有画布内可见内容 | 补充主体内容；仅有空背景或空形状不能准出 |
-| `sparse_container_content` | 大卡片内容覆盖率低于阈值 | 按元素 ID 定位卡片，结合截图判断是否补充或放大内容 |
+| `sparse_container_content` | 大卡片内容覆盖率低于阈值 | 按 `related_objects[].xml_path` 定位卡片；`element_id` 存在且唯一时也可按 ID 定位，再结合截图判断是否补充或放大内容 |
 | `sparse_slide_content` | 全页有效内容覆盖率偏低 | 复核截图，确认是否为有意留白 |
 
 ## Screenshot QA

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -807,6 +807,75 @@ def attach_source_xml_paths(
         offsets[kind] = max(offsets.get(kind, 0), offset + 1)
 
 
+def extract_nested_id_elements(slide_xml: str, slide_number: int) -> list[dict[str, Any]]:
+    root = ET.fromstring(slide_xml)
+    elements: list[dict[str, Any]] = []
+
+    note_index = 0
+    for child in root:
+        if xml_local_name(child.tag) != "note":
+            continue
+        note_index += 1
+        source_id = extract_attribute(
+            ET.tostring(child, encoding="unicode").split(">", 1)[0], "id"
+        )
+        if not source_id:
+            continue
+        xml_path = f"slide[{slide_number}]/note[{note_index}]"
+        elements.append(
+            {
+                "id": source_id,
+                "_source_id": source_id,
+                "kind": "note",
+                "type": "note",
+                "xml_path": xml_path,
+                "_ref": xml_path,
+                "_slide_number": slide_number,
+            }
+        )
+
+    data = next((child for child in root if xml_local_name(child.tag) == "data"), None)
+    if data is None:
+        return elements
+
+    table_index = 0
+    for table in data:
+        if xml_local_name(table.tag) != "table":
+            continue
+        table_index += 1
+        row_index = 0
+        for row in table:
+            if xml_local_name(row.tag) != "tr":
+                continue
+            row_index += 1
+            cell_index = 0
+            for cell in row:
+                if xml_local_name(cell.tag) != "td":
+                    continue
+                cell_index += 1
+                source_id = extract_attribute(
+                    ET.tostring(cell, encoding="unicode").split(">", 1)[0], "id"
+                )
+                if not source_id:
+                    continue
+                xml_path = (
+                    f"slide[{slide_number}]/data/table[{table_index}]"
+                    f"/tr[{row_index}]/td[{cell_index}]"
+                )
+                elements.append(
+                    {
+                        "id": source_id,
+                        "_source_id": source_id,
+                        "kind": "td",
+                        "type": "td",
+                        "xml_path": xml_path,
+                        "_ref": xml_path,
+                        "_slide_number": slide_number,
+                    }
+                )
+    return elements
+
+
 def element_ref(element: dict[str, Any]) -> str:
     ref = element.get("_ref") or element.get("xml_path")
     if isinstance(ref, str) and ref:
@@ -2518,8 +2587,10 @@ def related_object(element: dict[str, Any]) -> dict[str, Any]:
     related = {
         "kind": element["kind"],
         "type": element["type"],
-        "bbox": {key: element[key] for key in ("x", "y", "width", "height")},
     }
+    bbox_keys = ("x", "y", "width", "height")
+    if all(key in element for key in bbox_keys):
+        related["bbox"] = {key: element[key] for key in bbox_keys}
     if source_element_id(element) is not None:
         related["element_id"] = source_element_id(element)
     if element.get("xml_path"):
@@ -2743,7 +2814,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
     presentation = parse_presentation(root)
     slide_roots = presentation["slide_roots"]
     slides: list[dict[str, Any]] = []
-    presentation_density_elements: list[dict[str, Any]] = []
+    presentation_id_elements: list[dict[str, Any]] = []
     for index, slide_xml in enumerate(presentation["slides"]):
         slide_number = index + 1
         slide_root = slide_roots[index]
@@ -2778,13 +2849,21 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             presentation["height"],
         )
         density_elements = extract_density_elements(slide_xml, slide_number)
-        presentation_density_elements.extend(density_elements)
+        id_elements = [
+            *density_elements,
+            *extract_nested_id_elements(slide_xml, slide_number),
+        ]
+        presentation_id_elements.extend(id_elements)
         extra_elements = [
             element for element in density_elements if element["kind"] in {"icon", "polyline", "line"}
         ]
         elements_by_ref = {
             element_ref(element): element for element in density_elements
         }
+        visible_element_count = len(elements_by_ref)
+        elements_by_ref.update(
+            {element_ref(element): element for element in id_elements}
+        )
         # geometry["elements"] are the exact objects should_flag_overlap/detect_elements_out_of_canvas
         # selected inside lint_slide; prefer them so measurement/related_objects stay consistent
         # with whatever actually triggered the issue, instead of density_elements' separate re-parse.
@@ -2799,7 +2878,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
         raw_issues = [
             *geometry["issues"],
             *extra_overflow_issues,
-            *detect_duplicate_element_ids(density_elements),
+            *detect_duplicate_element_ids(id_elements),
             *detect_blank_slide(
                 density_elements,
                 slide_number,
@@ -2833,7 +2912,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             {
                 "slide_number": slide_number,
                 "status": slide_status(errors, warnings),
-                "element_count": len(elements_by_ref),
+                "element_count": visible_element_count,
                 "errors": errors,
                 "warnings": warnings,
                 "infos": infos,
@@ -2842,12 +2921,12 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
         )
 
     presentation_elements_by_ref = {
-        element_ref(element): element for element in presentation_density_elements
+        element_ref(element): element for element in presentation_id_elements
     }
     top_level_issues.extend(
         normalize_issue(issue, None, presentation_elements_by_ref)
         for issue in detect_duplicate_element_ids(
-            presentation_density_elements, cross_slide_only=True
+            presentation_id_elements, cross_slide_only=True
         )
     )
 

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -2596,10 +2596,14 @@ def normalize_issue(
     if normalized["code"] == "sparse_container_content":
         ratio = normalized["measurement"]["content_coverage_ratio"]
         threshold = normalized["rule"]["threshold"]
-        container_id = normalized["target"].get("container_id", "unknown")
+        container_locator = (
+            normalized["target"].get("container_id")
+            or normalized["target"].get("container_xml_path")
+            or "unknown"
+        )
         normalized.setdefault(
             "message",
-            f"large card {container_id} content coverage {ratio:.1%} is below {threshold:.1%}",
+            f"large card {container_locator} content coverage {ratio:.1%} is below {threshold:.1%}",
         )
         normalized.setdefault(
             "hint",

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -72,6 +72,7 @@ LINE_MIN_VISIBLE_ALPHA = 0.08
 # Sub-pixel canvas overflow is floating-point rounding noise (e.g. rotated-bbox math), not a
 # visible defect; keep this well under 1px so real overflow is still always caught.
 CANVAS_OVERFLOW_TOLERANCE = 0.5
+XML_PATH_HINT_PREFIX = "Locate via related_objects[].xml_path."
 _SXSD_TAG_ATTRIBUTES_CACHE: dict[str, set[str]] | None = None
 _ICONPARK_ICON_TYPES_CACHE: set[str] | None = None
 
@@ -2374,7 +2375,7 @@ def detect_duplicate_element_ids(
             "hint": (
                 "Do not invent replacement IDs. For newly authored elements, remove the id attribute. "
                 "When updating read-back XML, keep the server ID on the original element only and remove it "
-                "from copied or new elements. Use xml_path to edit the correct nodes."
+                "from copied or new elements."
             ),
         }
         for source_id, duplicates in elements_by_source_id.items()
@@ -2631,6 +2632,10 @@ def normalize_issue(
     normalized.setdefault(
         "hint", "Inspect the reported elements and adjust them to satisfy the rule comparison."
     )
+    if any(related.get("xml_path") for related in normalized["related_objects"]):
+        hint = normalized["hint"]
+        if not hint.startswith(XML_PATH_HINT_PREFIX):
+            normalized["hint"] = f"{XML_PATH_HINT_PREFIX} {hint}"
     return normalized
 
 

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -807,72 +807,39 @@ def attach_source_xml_paths(
         offsets[kind] = max(offsets.get(kind, 0), offset + 1)
 
 
-def extract_nested_id_elements(slide_xml: str, slide_number: int) -> list[dict[str, Any]]:
+def extract_source_id_elements(slide_xml: str, slide_number: int) -> list[dict[str, Any]]:
     root = ET.fromstring(slide_xml)
     elements: list[dict[str, Any]] = []
+    root_path = f"slide[{slide_number}]"
 
-    note_index = 0
-    for child in root:
-        if xml_local_name(child.tag) != "note":
-            continue
-        note_index += 1
-        source_id = extract_attribute(
-            ET.tostring(child, encoding="unicode").split(">", 1)[0], "id"
-        )
-        if not source_id:
-            continue
-        xml_path = f"slide[{slide_number}]/note[{note_index}]"
-        elements.append(
-            {
-                "id": source_id,
-                "_source_id": source_id,
-                "kind": "note",
-                "type": "note",
-                "xml_path": xml_path,
-                "_ref": xml_path,
-                "_slide_number": slide_number,
-            }
-        )
-
-    data = next((child for child in root if xml_local_name(child.tag) == "data"), None)
-    if data is None:
-        return elements
-
-    table_index = 0
-    for table in data:
-        if xml_local_name(table.tag) != "table":
-            continue
-        table_index += 1
-        row_index = 0
-        for row in table:
-            if xml_local_name(row.tag) != "tr":
-                continue
-            row_index += 1
-            cell_index = 0
-            for cell in row:
-                if xml_local_name(cell.tag) != "td":
-                    continue
-                cell_index += 1
-                source_id = extract_attribute(
-                    ET.tostring(cell, encoding="unicode").split(">", 1)[0], "id"
-                )
-                if not source_id:
-                    continue
-                xml_path = (
-                    f"slide[{slide_number}]/data/table[{table_index}]"
-                    f"/tr[{row_index}]/td[{cell_index}]"
-                )
+    def walk(parent: ET.Element, parent_path: str) -> None:
+        child_counts: dict[str, int] = {}
+        for child in parent:
+            kind = xml_local_name(child.tag)
+            child_counts[kind] = child_counts.get(kind, 0) + 1
+            xml_path = (
+                f"{parent_path}/data"
+                if parent is root and kind == "data"
+                else f"{parent_path}/{kind}[{child_counts[kind]}]"
+            )
+            source_id = extract_attribute(
+                ET.tostring(child, encoding="unicode").split(">", 1)[0], "id"
+            )
+            if source_id:
                 elements.append(
                     {
                         "id": source_id,
                         "_source_id": source_id,
-                        "kind": "td",
-                        "type": "td",
+                        "kind": kind,
+                        "type": child.attrib.get("type") or kind,
                         "xml_path": xml_path,
                         "_ref": xml_path,
                         "_slide_number": slide_number,
                     }
                 )
+            walk(child, xml_path)
+
+    walk(root, root_path)
     return elements
 
 
@@ -2821,6 +2788,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
     slide_roots = presentation["slide_roots"]
     slides: list[dict[str, Any]] = []
     presentation_id_elements: list[dict[str, Any]] = []
+    presentation_elements_by_ref: dict[str, dict[str, Any]] = {}
     for index, slide_xml in enumerate(presentation["slides"]):
         slide_number = index + 1
         slide_root = slide_roots[index]
@@ -2855,10 +2823,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             presentation["height"],
         )
         density_elements = extract_density_elements(slide_xml, slide_number)
-        id_elements = [
-            *density_elements,
-            *extract_nested_id_elements(slide_xml, slide_number),
-        ]
+        id_elements = extract_source_id_elements(slide_xml, slide_number)
         presentation_id_elements.extend(id_elements)
         extra_elements = [
             element for element in density_elements if element["kind"] in {"icon", "polyline", "line"}
@@ -2867,14 +2832,19 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             element_ref(element): element for element in density_elements
         }
         visible_element_count = len(elements_by_ref)
-        elements_by_ref.update(
-            {element_ref(element): element for element in id_elements}
-        )
+        for element in id_elements:
+            elements_by_ref.setdefault(element_ref(element), element)
         # geometry["elements"] are the exact objects should_flag_overlap/detect_elements_out_of_canvas
         # selected inside lint_slide; prefer them so measurement/related_objects stay consistent
         # with whatever actually triggered the issue, instead of density_elements' separate re-parse.
         elements_by_ref.update(
             {element_ref(element): element for element in geometry["elements"]}
+        )
+        presentation_elements_by_ref.update(
+            {
+                element_ref(element): elements_by_ref[element_ref(element)]
+                for element in id_elements
+            }
         )
         extra_overflow_issues = detect_elements_out_of_canvas(
             extra_elements,
@@ -2926,9 +2896,6 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             }
         )
 
-    presentation_elements_by_ref = {
-        element_ref(element): element for element in presentation_id_elements
-    }
     top_level_issues.extend(
         normalize_issue(issue, None, presentation_elements_by_ref)
         for issue in detect_duplicate_element_ids(

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -2650,11 +2650,17 @@ def normalize_issue(
     elements_by_ref: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
     normalized = dict(issue)
-    element_refs = normalized.get("elements", [])
+    element_refs = list(dict.fromkeys(normalized.get("elements", [])))
     resolved_elements = [
         elements_by_ref[element_ref]
         for element_ref in element_refs
         if element_ref in elements_by_ref
+    ]
+    element_locators = [
+        source_element_id(elements_by_ref[element_ref]) or element_ref
+        if element_ref in elements_by_ref
+        else element_ref
+        for element_ref in element_refs
     ]
     element_ids = [
         source_id
@@ -2662,7 +2668,7 @@ def normalize_issue(
         if (source_id := source_element_id(element)) is not None
     ]
     normalized["schema_version"] = "2.0"
-    normalized["elements"] = element_ids
+    normalized["elements"] = element_locators
     normalized["element_ids"] = element_ids
     normalized["target"] = {
         **({"slide_number": slide_number} if slide_number is not None else {}),

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -2130,6 +2130,8 @@ def extract_density_elements(slide_xml: str, slide_number: int = 1) -> list[dict
         line_element["order"] = len(elements)
         elements.append(line_element)
     attach_source_xml_paths(elements, source_paths)
+    for element in elements:
+        element["_slide_number"] = slide_number
     return elements
 
 
@@ -2351,7 +2353,9 @@ def detect_blank_slide(
     ]
 
 
-def detect_duplicate_element_ids(elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def detect_duplicate_element_ids(
+    elements: list[dict[str, Any]], *, cross_slide_only: bool = False
+) -> list[dict[str, Any]]:
     elements_by_source_id: dict[str, list[dict[str, Any]]] = {}
     for element in elements:
         source_id = source_element_id(element)
@@ -2375,6 +2379,10 @@ def detect_duplicate_element_ids(elements: list[dict[str, Any]]) -> list[dict[st
         }
         for source_id, duplicates in elements_by_source_id.items()
         if len(duplicates) > 1
+        and (
+            not cross_slide_only
+            or len({element.get("_slide_number") for element in duplicates}) > 1
+        )
     ]
 
 
@@ -2730,6 +2738,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
     presentation = parse_presentation(root)
     slide_roots = presentation["slide_roots"]
     slides: list[dict[str, Any]] = []
+    presentation_density_elements: list[dict[str, Any]] = []
     for index, slide_xml in enumerate(presentation["slides"]):
         slide_number = index + 1
         slide_root = slide_roots[index]
@@ -2764,6 +2773,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             presentation["height"],
         )
         density_elements = extract_density_elements(slide_xml, slide_number)
+        presentation_density_elements.extend(density_elements)
         extra_elements = [
             element for element in density_elements if element["kind"] in {"icon", "polyline", "line"}
         ]
@@ -2825,6 +2835,16 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
                 "issues": issues,
             }
         )
+
+    presentation_elements_by_ref = {
+        element_ref(element): element for element in presentation_density_elements
+    }
+    top_level_issues.extend(
+        normalize_issue(issue, None, presentation_elements_by_ref)
+        for issue in detect_duplicate_element_ids(
+            presentation_density_elements, cross_slide_only=True
+        )
+    )
 
     return build_result(
         source_path,

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -771,6 +771,35 @@ def parse_presentation(root: ET.Element) -> dict[str, Any]:
     }
 
 
+def build_source_xml_paths(slide_xml: str, slide_number: int) -> dict[str, list[str]]:
+    root = ET.fromstring(slide_xml)
+    data = next((child for child in root if xml_local_name(child.tag) == "data"), None)
+    paths: dict[str, list[str]] = {}
+    if data is None:
+        return paths
+    counts: dict[str, int] = {}
+    for child in data:
+        kind = xml_local_name(child.tag)
+        counts[kind] = counts.get(kind, 0) + 1
+        paths.setdefault(kind, []).append(
+            f"slide[{slide_number}]/data/{kind}[{counts[kind]}]"
+        )
+    return paths
+
+
+def attach_source_xml_paths(
+    elements: list[dict[str, Any]], source_paths: dict[str, list[str]]
+) -> None:
+    offsets: dict[str, int] = {}
+    for element in elements:
+        kind = element["kind"]
+        offset = offsets.get(kind, 0)
+        kind_paths = source_paths.get(kind, [])
+        if offset < len(kind_paths):
+            element["xml_path"] = kind_paths[offset]
+        offsets[kind] = offset + 1
+
+
 def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
     elements: list[dict[str, Any]] = []
 
@@ -2374,12 +2403,15 @@ def issue_measurement(
 
 
 def related_object(element: dict[str, Any]) -> dict[str, Any]:
-    return {
+    related = {
         "element_id": element["id"],
         "kind": element["kind"],
         "type": element["type"],
         "bbox": {key: element[key] for key in ("x", "y", "width", "height")},
     }
+    if element.get("xml_path"):
+        related["xml_path"] = element["xml_path"]
+    return related
 
 
 def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
@@ -2605,13 +2637,16 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             )
             continue
 
+        source_paths = build_source_xml_paths(slide_xml, slide_number)
         geometry = lint_slide(
             slide_xml,
             slide_number,
             presentation["width"],
             presentation["height"],
         )
+        attach_source_xml_paths(geometry["elements"], source_paths)
         density_elements = extract_density_elements(slide_xml)
+        attach_source_xml_paths(density_elements, source_paths)
         extra_elements = [
             element for element in density_elements if element["kind"] in {"icon", "polyline", "line"}
         ]

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import copy
-import html
 import json
 import math
 import re
@@ -113,8 +112,7 @@ def extract_attribute(tag_source: str, name: str) -> str | None:
     )
     if not match:
         return None
-    raw = match.group(1) if match.group(1) is not None else match.group(2)
-    return html.unescape(raw)
+    return match.group(1) if match.group(1) is not None else match.group(2)
 
 
 def extract_numeric_attribute(tag_source: str, name: str) -> int | float | None:

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -2369,7 +2369,11 @@ def detect_duplicate_element_ids(elements: list[dict[str, Any]]) -> list[dict[st
                 "duplicate_count": len(duplicates),
             },
             "message": f'element id "{source_id}" is used by {len(duplicates)} elements',
-            "hint": "Give every element a unique non-empty id before editing by element_id.",
+            "hint": (
+                "Do not invent replacement IDs. For newly authored elements, remove the id attribute. "
+                "When updating read-back XML, keep the server ID on the original element only and remove it "
+                "from copied or new elements. Use xml_path to edit the correct nodes."
+            ),
         }
         for source_id, duplicates in elements_by_source_id.items()
         if len(duplicates) > 1

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import copy
+import html
 import json
 import math
 import re
@@ -112,7 +113,8 @@ def extract_attribute(tag_source: str, name: str) -> str | None:
     )
     if not match:
         return None
-    return match.group(1) if match.group(1) is not None else match.group(2)
+    raw = match.group(1) if match.group(1) is not None else match.group(2)
+    return html.unescape(raw)
 
 
 def extract_numeric_attribute(tag_source: str, name: str) -> int | float | None:
@@ -802,7 +804,29 @@ def attach_source_xml_paths(
         kind_paths = source_paths.get(kind, [])
         if offset < len(kind_paths):
             element["xml_path"] = kind_paths[offset]
+            element["_ref"] = kind_paths[offset]
         offsets[kind] = max(offsets.get(kind, 0), offset + 1)
+
+
+def element_ref(element: dict[str, Any]) -> str:
+    ref = element.get("_ref") or element.get("xml_path")
+    if isinstance(ref, str) and ref:
+        return ref
+    # Low-level detector tests and external callers may pass already-extracted objects.
+    # The lint_xml pipeline always attaches the source path before issue detection.
+    fallback = element.get("id")
+    if isinstance(fallback, str) and fallback:
+        return fallback
+    raise AssertionError("lint element must have a source xml path or fallback id")
+
+
+def source_element_id(element: dict[str, Any]) -> str | None:
+    value = element.get("_source_id")
+    return value if isinstance(value, str) and value else None
+
+
+def element_label(element: dict[str, Any]) -> str:
+    return source_element_id(element) or element_ref(element)
 
 
 def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
@@ -820,7 +844,8 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
             if close_index != -1:
                 content = slide_xml[match.end() : close_index]
 
-        element_id = extract_attribute(attrs, "id") or f"{kind}-{len(elements) + 1}"
+        source_id = extract_attribute(attrs, "id") or None
+        element_id = source_id or f"{kind}-{len(elements) + 1}"
         x = extract_numeric_attribute(attrs, "topLeftX")
         y = extract_numeric_attribute(attrs, "topLeftY")
         width = extract_numeric_attribute(attrs, "width")
@@ -838,6 +863,7 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
         if all(value is not None for value in [x, y, width, height]):
             element = {
                 "id": element_id,
+                "_source_id": source_id,
                 "kind": kind,
                 "type": extract_attribute(attrs, "type") or kind,
                 "x": x,
@@ -948,8 +974,11 @@ def detect_image_text_occlusions(elements: list[dict[str, Any]]) -> list[dict[st
                     issues.append({
                         "level": "info",
                         "code": "image_may_cover_vertical_text",
-                        "elements": [image_element["id"], text_element["id"]],
-                        "message": f'image {image_element["id"]} may cover vertical text shape {text_element["id"]}',
+                        "elements": [element_ref(image_element), element_ref(text_element)],
+                        "message": (
+                            f"image {element_label(image_element)} may cover vertical text shape "
+                            f"{element_label(text_element)}"
+                        ),
                         "hint": "Inspect the rendered slide because vertical text layout is not statically modeled.",
                     })
                 continue
@@ -958,8 +987,11 @@ def detect_image_text_occlusions(elements: list[dict[str, Any]]) -> list[dict[st
                 issues.append({
                     "level": "error",
                     "code": "image_covers_text",
-                    "elements": [image_element["id"], text_element["id"]],
-                    "message": f'image {image_element["id"]} covers text shape {text_element["id"]}',
+                    "elements": [element_ref(image_element), element_ref(text_element)],
+                    "message": (
+                        f"image {element_label(image_element)} covers text shape "
+                        f"{element_label(text_element)}"
+                    ),
                     "hint": "Move the image before the text shape in XML order, or adjust the image and text shape coordinates or dimensions.",
                 })
     return issues
@@ -1225,7 +1257,7 @@ def detect_text_may_overflow_shapes(elements: list[dict[str, Any]]) -> list[dict
         else:
             level = "error" if overflow > 10 else "warning"
         message = (
-            f'text shape {element["id"]} may overflow its own content box '
+            f"text shape {element_label(element)} may overflow its own content box "
             f'(estimated {estimated_height:g}px, available {available_height:g}px); '
             'consider setting content wrap="true" autoFit="normal-auto-fit"'
         )
@@ -1235,7 +1267,7 @@ def detect_text_may_overflow_shapes(elements: list[dict[str, Any]]) -> list[dict
             {
                 "level": level,
                 "code": "text_may_overflow_shape",
-                "elements": [element["id"]],
+                "elements": [element_ref(element)],
                 "line_count": line_count,
                 "line_height": max(line_heights),
                 "estimated_height": estimated_height,
@@ -1476,12 +1508,15 @@ def should_flag_overlap(left: dict[str, Any], right: dict[str, Any]) -> bool:
 def build_whiteboard_external_overlap_issue(
     whiteboard: dict[str, Any], overlap_details: list[dict[str, Any]]
 ) -> dict[str, Any]:
-    element_ids = [detail["element"] for detail in overlap_details]
+    element_refs = [detail["element"] for detail in overlap_details]
     return {
         "level": "warning",
         "code": "whiteboard_external_overlap",
-        "elements": [whiteboard["id"], *element_ids],
-        "message": f'whiteboard {whiteboard["id"]} overlaps {len(element_ids)} sibling elements across its boundary',
+        "elements": [element_ref(whiteboard), *element_refs],
+        "message": (
+            f"whiteboard {element_label(whiteboard)} overlaps {len(element_refs)} "
+            "sibling elements across its boundary"
+        ),
         "hint": (
             "Treat this as a static whiteboard container-bbox risk, not final visual proof. "
             "After moving or accepting the overlap, use screenshot QA or equivalent rendered visual inspection as "
@@ -1522,7 +1557,7 @@ def should_report_whiteboard_overlap(
         return None
 
     return {
-        "element": other["id"],
+        "element": element_ref(other),
         "kind": other["kind"],
         "type": other.get("type"),
         "overlap_width": overlap_width,
@@ -1532,16 +1567,16 @@ def should_report_whiteboard_overlap(
 
 
 def prune_contained_text_overlap_details(
-    overlap_details: list[dict[str, Any]], elements_by_id: dict[str, dict[str, Any]]
+    overlap_details: list[dict[str, Any]], elements_by_ref: dict[str, dict[str, Any]]
 ) -> list[dict[str, Any]]:
     pruned: list[dict[str, Any]] = []
     for detail in overlap_details:
-        element = elements_by_id[detail["element"]]
+        element = elements_by_ref[detail["element"]]
         if is_text_element(element):
             has_reported_container = any(
                 detail["element"] != other_detail["element"]
-                and not is_text_element(elements_by_id[other_detail["element"]])
-                and contains(elements_by_id[other_detail["element"]], element)
+                and not is_text_element(elements_by_ref[other_detail["element"]])
+                and contains(elements_by_ref[other_detail["element"]], element)
                 for other_detail in overlap_details
             )
             if has_reported_container:
@@ -1554,7 +1589,7 @@ def detect_whiteboard_external_overlaps(
     elements: list[dict[str, Any]], slide_width: int | float, slide_height: int | float
 ) -> list[dict[str, Any]]:
     issues: list[dict[str, Any]] = []
-    elements_by_id = {element["id"]: element for element in elements}
+    elements_by_ref = {element_ref(element): element for element in elements}
     for whiteboard in [element for element in elements if is_whiteboard_element(element)]:
         overlap_details = [
             detail
@@ -1569,7 +1604,7 @@ def detect_whiteboard_external_overlaps(
             )
             is not None
         ]
-        overlap_details = prune_contained_text_overlap_details(overlap_details, elements_by_id)
+        overlap_details = prune_contained_text_overlap_details(overlap_details, elements_by_ref)
         if overlap_details:
             issues.append(build_whiteboard_external_overlap_issue(whiteboard, overlap_details))
     return issues
@@ -1628,12 +1663,12 @@ def detect_elements_out_of_canvas(
             {
                 "level": "error",
                 "code": f'{element["kind"]}_out_of_canvas',
-                "elements": [element["id"]],
+                "elements": [element_ref(element)],
                 "canvas": {"width": slide_width, "height": slide_height},
                 "bbox": bbox,
                 "overflow": overflow,
                 "message": (
-                    f'{element["kind"]} {element["id"]} exceeds the {slide_width:g}x{slide_height:g} canvas '
+                    f'{element["kind"]} {element_label(element)} exceeds the {slide_width:g}x{slide_height:g} canvas '
                     f'({", ".join(overflow_details)})'
                 ),
                 "hint": (
@@ -1701,13 +1736,13 @@ def detect_table_layout_size_mismatches(elements: list[dict[str, Any]]) -> list[
                 {
                     "level": "info",
                     "code": "table_resolved_size_mismatch",
-                    "elements": [table["id"]],
+                    "elements": [element_ref(table)],
                     "dimension": dimension,
                     "declared_size": target_size,
                     "resolved_size": actual_size,
                     "resolved_sizes": layout["final_sizes"],
                     "message": (
-                        f'table {table["id"]} declares {dimension}={format_size(target_size)}px, but its '
+                        f'table {element_label(table)} declares {dimension}={format_size(target_size)}px, but its '
                         f"{child_description} resolve to {format_size(actual_size)}px"
                     ),
                     "hint": (
@@ -1783,11 +1818,12 @@ def line_crosses_text(line: dict[str, Any], text_element: dict[str, Any]) -> boo
 
 
 def detect_line_text_crossings(
-    slide_xml: str, elements: list[dict[str, Any]]
+    slide_xml: str, elements: list[dict[str, Any]], slide_number: int
 ) -> list[dict[str, Any]]:
     lines = extract_line_elements(slide_xml)
     if not lines:
         return []
+    attach_source_xml_paths(lines, build_source_xml_paths(slide_xml, slide_number))
     text_elements = [element for element in elements if is_text_element(element)]
     issues: list[dict[str, Any]] = []
     for line in lines:
@@ -1798,8 +1834,10 @@ def detect_line_text_crossings(
                 {
                     "level": "error",
                     "code": "bbox_overlap",
-                    "elements": [line["id"], text_element["id"]],
-                    "message": f'line {line["id"]} crosses text {text_element["id"]}',
+                    "elements": [element_ref(line), element_ref(text_element)],
+                    "message": (
+                        f"line {element_label(line)} crosses text {element_label(text_element)}"
+                    ),
                     "hint": "Move the line off the text glyphs so it no longer cuts through the letterforms.",
                 }
             )
@@ -1810,13 +1848,14 @@ def lint_slide(
     slide_xml: str, slide_number: int, slide_width: int | float = 960, slide_height: int | float = 540
 ) -> dict[str, Any]:
     elements = extract_elements(slide_xml)
+    attach_source_xml_paths(elements, build_source_xml_paths(slide_xml, slide_number))
     issues: list[dict[str, Any]] = [
         *detect_whiteboard_external_overlaps(elements, slide_width, slide_height),
         *detect_elements_out_of_canvas(elements, slide_width, slide_height),
         *detect_table_layout_size_mismatches(elements),
         *detect_text_may_overflow_shapes(elements),
         *detect_image_text_occlusions(elements),
-        *detect_line_text_crossings(slide_xml, elements),
+        *detect_line_text_crossings(slide_xml, elements, slide_number),
     ]
 
     for index, left in enumerate(elements):
@@ -1828,8 +1867,8 @@ def lint_slide(
                 {
                     "level": "error",
                     "code": "bbox_overlap",
-                    "elements": [left["id"], right["id"]],
-                    "message": f'{left["id"]} overlaps {right["id"]}',
+                    "elements": [element_ref(left), element_ref(right)],
+                    "message": f"{element_label(left)} overlaps {element_label(right)}",
                     "hint": "Move or resize the elements so their visual bounds no longer intersect.",
                     **(
                         {"measurement": horizontal_text_overflow_measurement(left, right)}
@@ -1973,14 +2012,22 @@ def is_nested_in_layout_panel(
     )
 
 
-def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
+def extract_density_elements(slide_xml: str, slide_number: int = 1) -> list[dict[str, Any]]:
     elements = extract_elements(slide_xml)
-    elements_by_id = {element["id"]: element for element in elements}
+    source_paths = build_source_xml_paths(slide_xml, slide_number)
+    attach_source_xml_paths(elements, source_paths)
+    shape_elements_by_index = {
+        element["_source_kind_index"]: element
+        for element in elements
+        if element["kind"] == "shape"
+    }
     root = ET.fromstring(slide_xml)
+    shape_index = 0
     for node in root.iter():
         if xml_local_name(node.tag) != "shape":
             continue
-        element = elements_by_id.get(node.attrib.get("id", ""))
+        shape_index += 1
+        element = shape_elements_by_index.get(shape_index)
         if element is None:
             continue
         content_node = next(
@@ -2029,6 +2076,7 @@ def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
         re.finditer(r"<icon\b([^>]*)>", slide_xml), start=1
     ):
         attrs = match.group(1)
+        source_id = extract_attribute(attrs, "id") or None
         x = extract_numeric_attribute(attrs, "topLeftX")
         y = extract_numeric_attribute(attrs, "topLeftY")
         width = extract_numeric_attribute(attrs, "width")
@@ -2038,7 +2086,8 @@ def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
         icon_alpha = extract_numeric_attribute(attrs, "alpha")
         elements.append(
             {
-                "id": extract_attribute(attrs, "id") or f"icon-{len(elements) + 1}",
+                "id": source_id or f"icon-{len(elements) + 1}",
+                "_source_id": source_id,
                 "kind": "icon",
                 "type": "icon",
                 "x": x,
@@ -2062,9 +2111,11 @@ def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
         if any(value is None for value in (x, y, width, height)):
             continue
         polyline_alpha = extract_numeric_attribute(attrs, "alpha")
+        source_id = extract_attribute(attrs, "id") or None
         elements.append(
             {
-                "id": extract_attribute(attrs, "id") or f"polyline-{len(elements) + 1}",
+                "id": source_id or f"polyline-{len(elements) + 1}",
+                "_source_id": source_id,
                 "kind": "polyline",
                 "type": "polyline",
                 "x": x,
@@ -2080,6 +2131,7 @@ def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
     for line_element in extract_line_elements(slide_xml):
         line_element["order"] = len(elements)
         elements.append(line_element)
+    attach_source_xml_paths(elements, source_paths)
     return elements
 
 
@@ -2199,7 +2251,12 @@ def detect_sparse_container_content(
                 "code": "sparse_container_content",
                 "target": {
                     "slide_number": slide_number,
-                    "container_id": container["id"],
+                    **(
+                        {"container_id": source_element_id(container)}
+                        if source_element_id(container) is not None
+                        else {}
+                    ),
+                    "container_xml_path": element_ref(container),
                     "container_type": container["type"],
                     "bbox": {key: container[key] for key in ("x", "y", "width", "height")},
                 },
@@ -2214,7 +2271,10 @@ def detect_sparse_container_content(
                     "content_coverage_ratio": round(coverage_ratio, 3),
                     "content_element_count": len(children) + (1 if own_text_bbox else 0),
                 },
-                "elements": [container["id"], *[child["id"] for child in children]],
+                "elements": [
+                    element_ref(container),
+                    *[element_ref(child) for child in children],
+                ],
             }
         )
     return issues
@@ -2255,7 +2315,7 @@ def detect_sparse_slide_content(
                 "content_coverage_ratio": round(coverage_ratio, 3),
                 "content_element_count": len(content),
             },
-            "elements": [element["id"] for element, _ in content],
+            "elements": [element_ref(element) for element, _ in content],
         }
     ]
 
@@ -2286,12 +2346,34 @@ def detect_blank_slide(
                 "visible_element_count": 0,
                 "declared_element_count": len(elements),
             },
-            "elements": [element["id"] for element in elements],
+            "elements": [element_ref(element) for element in elements],
             "message": "slide has no visible content beyond empty layout shapes",
             "hint": "Add visible text, an image, a chart, a table, a whiteboard, or an icon before creating the slide.",
         }
     ]
 
+
+def detect_duplicate_element_ids(elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    elements_by_source_id: dict[str, list[dict[str, Any]]] = {}
+    for element in elements:
+        source_id = source_element_id(element)
+        if source_id is not None:
+            elements_by_source_id.setdefault(source_id, []).append(element)
+    return [
+        {
+            "level": "error",
+            "code": "duplicate_element_id",
+            "elements": [element_ref(element) for element in duplicates],
+            "measurement": {
+                "element_id": source_id,
+                "duplicate_count": len(duplicates),
+            },
+            "message": f'element id "{source_id}" is used by {len(duplicates)} elements',
+            "hint": "Give every element a unique non-empty id before editing by element_id.",
+        }
+        for source_id, duplicates in elements_by_source_id.items()
+        if len(duplicates) > 1
+    ]
 
 
 RULE_METADATA: dict[str, dict[str, Any]] = {
@@ -2351,6 +2433,10 @@ RULE_METADATA: dict[str, dict[str, Any]] = {
         "name": "slide_has_visible_content",
         "comparison": "visible_element_count > 0",
     },
+    "duplicate_element_id": {
+        "name": "element_ids_are_unique",
+        "comparison": "duplicate_count == 0",
+    },
 }
 
 
@@ -2373,13 +2459,13 @@ def issue_rule(issue: dict[str, Any]) -> dict[str, Any]:
 
 
 def issue_measurement(
-    issue: dict[str, Any], elements_by_id: dict[str, dict[str, Any]]
+    issue: dict[str, Any], elements_by_ref: dict[str, dict[str, Any]]
 ) -> dict[str, Any]:
     if issue.get("measurement") is not None:
         return issue["measurement"]
     if issue["code"] == "bbox_overlap" and len(issue.get("elements", [])) == 2:
-        left = elements_by_id.get(issue["elements"][0])
-        right = elements_by_id.get(issue["elements"][1])
+        left = elements_by_ref.get(issue["elements"][0])
+        right = elements_by_ref.get(issue["elements"][1])
         if left and right:
             left_box = (estimate_text_visual_bbox(left) if is_text_element(left) else None) or left
             right_box = (estimate_text_visual_bbox(right) if is_text_element(right) else None) or right
@@ -2419,11 +2505,12 @@ def issue_measurement(
 
 def related_object(element: dict[str, Any]) -> dict[str, Any]:
     related = {
-        "element_id": element["id"],
         "kind": element["kind"],
         "type": element["type"],
         "bbox": {key: element[key] for key in ("x", "y", "width", "height")},
     }
+    if source_element_id(element) is not None:
+        related["element_id"] = source_element_id(element)
     if element.get("xml_path"):
         related["xml_path"] = element["xml_path"]
     return related
@@ -2435,6 +2522,7 @@ def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
         re.finditer(r"<line\b([^>]*?)(/?)>", slide_xml), start=1
     ):
         attrs = match.group(1)
+        source_id = extract_attribute(attrs, "id") or None
         start_x = extract_numeric_attribute(attrs, "startX")
         start_y = extract_numeric_attribute(attrs, "startY")
         end_x = extract_numeric_attribute(attrs, "endX")
@@ -2453,7 +2541,8 @@ def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
                 border_alpha = color_alpha
         elements.append(
             {
-                "id": extract_attribute(attrs, "id") or f"line-{len(elements) + 1}",
+                "id": source_id or f"line-{len(elements) + 1}",
+                "_source_id": source_id,
                 "kind": "line",
                 "type": "line",
                 "x": min(start_x, end_x),
@@ -2476,23 +2565,30 @@ def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
 def normalize_issue(
     issue: dict[str, Any],
     slide_number: int | None,
-    elements_by_id: dict[str, dict[str, Any]],
+    elements_by_ref: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
     normalized = dict(issue)
-    element_ids = list(dict.fromkeys(normalized.get("elements", [])))
+    element_refs = normalized.get("elements", [])
+    resolved_elements = [
+        elements_by_ref[element_ref]
+        for element_ref in element_refs
+        if element_ref in elements_by_ref
+    ]
+    element_ids = [
+        source_id
+        for element in resolved_elements
+        if (source_id := source_element_id(element)) is not None
+    ]
     normalized["schema_version"] = "2.0"
+    normalized["elements"] = element_ids
     normalized["element_ids"] = element_ids
     normalized["target"] = {
         **({"slide_number": slide_number} if slide_number is not None else {}),
         **normalized.get("target", {}),
     }
     normalized["rule"] = issue_rule(normalized)
-    normalized["measurement"] = issue_measurement(normalized, elements_by_id)
-    normalized["related_objects"] = [
-        related_object(elements_by_id[element_id])
-        for element_id in element_ids
-        if element_id in elements_by_id
-    ]
+    normalized["measurement"] = issue_measurement(issue, elements_by_ref)
+    normalized["related_objects"] = [related_object(element) for element in resolved_elements]
     if normalized["code"] == "sparse_container_content":
         ratio = normalized["measurement"]["content_coverage_ratio"]
         threshold = normalized["rule"]["threshold"]
@@ -2655,26 +2751,25 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             )
             continue
 
-        source_paths = build_source_xml_paths(slide_xml, slide_number)
         geometry = lint_slide(
             slide_xml,
             slide_number,
             presentation["width"],
             presentation["height"],
         )
-        attach_source_xml_paths(geometry["elements"], source_paths)
-        density_elements = extract_density_elements(slide_xml)
-        attach_source_xml_paths(density_elements, source_paths)
+        density_elements = extract_density_elements(slide_xml, slide_number)
         extra_elements = [
             element for element in density_elements if element["kind"] in {"icon", "polyline", "line"}
         ]
-        elements_by_id = {
-            element["id"]: element for element in [*density_elements, *extra_elements]
+        elements_by_ref = {
+            element_ref(element): element for element in density_elements
         }
         # geometry["elements"] are the exact objects should_flag_overlap/detect_elements_out_of_canvas
-        # decided with inside lint_slide; prefer them so measurement/related_objects stay consistent
+        # selected inside lint_slide; prefer them so measurement/related_objects stay consistent
         # with whatever actually triggered the issue, instead of density_elements' separate re-parse.
-        elements_by_id.update({element["id"]: element for element in geometry["elements"]})
+        elements_by_ref.update(
+            {element_ref(element): element for element in geometry["elements"]}
+        )
         extra_overflow_issues = detect_elements_out_of_canvas(
             extra_elements,
             presentation["width"],
@@ -2683,6 +2778,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
         raw_issues = [
             *geometry["issues"],
             *extra_overflow_issues,
+            *detect_duplicate_element_ids(density_elements),
             *detect_blank_slide(
                 density_elements,
                 slide_number,
@@ -2705,7 +2801,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
         issues = [
             *slide_sxsd_issues,
             *[
-                normalize_issue(issue, slide_number, elements_by_id)
+                normalize_issue(issue, slide_number, elements_by_ref)
                 for issue in raw_issues
             ],
         ]
@@ -2716,7 +2812,7 @@ def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
             {
                 "slide_number": slide_number,
                 "status": slide_status(errors, warnings),
-                "element_count": len(elements_by_id),
+                "element_count": len(elements_by_ref),
                 "errors": errors,
                 "warnings": warnings,
                 "infos": infos,

--- a/skills/lark-slides/scripts/xml_text_overlap_lint.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint.py
@@ -793,18 +793,26 @@ def attach_source_xml_paths(
     offsets: dict[str, int] = {}
     for element in elements:
         kind = element["kind"]
-        offset = offsets.get(kind, 0)
+        source_kind_index = element.get("_source_kind_index")
+        offset = (
+            source_kind_index - 1
+            if isinstance(source_kind_index, int) and source_kind_index > 0
+            else offsets.get(kind, 0)
+        )
         kind_paths = source_paths.get(kind, [])
         if offset < len(kind_paths):
             element["xml_path"] = kind_paths[offset]
-        offsets[kind] = offset + 1
+        offsets[kind] = max(offsets.get(kind, 0), offset + 1)
 
 
 def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
     elements: list[dict[str, Any]] = []
+    source_kind_counts: dict[str, int] = {}
 
     for match in re.finditer(r"<(shape|img|table|chart|whiteboard)\b([^>]*)>", slide_xml):
         kind, attrs = match.group(1), match.group(2)
+        source_kind_counts[kind] = source_kind_counts.get(kind, 0) + 1
+        source_kind_index = source_kind_counts[kind]
         is_self_closing = attrs.rstrip().endswith("/")
         content = ""
         if kind in {"shape", "table"} and not is_self_closing:
@@ -839,6 +847,7 @@ def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "rotation": rotation,
                 "alpha": alpha if alpha is not None else 1,
                 "order": len(elements),
+                "_source_kind_index": source_kind_index,
             }
             if kind == "table":
                 element.update(
@@ -2016,7 +2025,9 @@ def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
                 continue
         if declared_font_sizes:
             element["fontSize"] = max(declared_font_sizes)
-    for match in re.finditer(r"<icon\b([^>]*)>", slide_xml):
+    for source_kind_index, match in enumerate(
+        re.finditer(r"<icon\b([^>]*)>", slide_xml), start=1
+    ):
         attrs = match.group(1)
         x = extract_numeric_attribute(attrs, "topLeftX")
         y = extract_numeric_attribute(attrs, "topLeftY")
@@ -2037,9 +2048,12 @@ def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "rotation": extract_numeric_attribute(attrs, "rotation") or 0,
                 "alpha": icon_alpha if icon_alpha is not None else 1,
                 "order": len(elements),
+                "_source_kind_index": source_kind_index,
             }
         )
-    for match in re.finditer(r"<polyline\b([^>]*)>", slide_xml):
+    for source_kind_index, match in enumerate(
+        re.finditer(r"<polyline\b([^>]*)>", slide_xml), start=1
+    ):
         attrs = match.group(1)
         x = extract_numeric_attribute(attrs, "topLeftX")
         y = extract_numeric_attribute(attrs, "topLeftY")
@@ -2060,6 +2074,7 @@ def extract_density_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "rotation": extract_numeric_attribute(attrs, "rotation") or 0,
                 "alpha": polyline_alpha if polyline_alpha is not None else 1,
                 "order": len(elements),
+                "_source_kind_index": source_kind_index,
             }
         )
     for line_element in extract_line_elements(slide_xml):
@@ -2416,7 +2431,9 @@ def related_object(element: dict[str, Any]) -> dict[str, Any]:
 
 def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
     elements: list[dict[str, Any]] = []
-    for match in re.finditer(r"<line\b([^>]*?)(/?)>", slide_xml):
+    for source_kind_index, match in enumerate(
+        re.finditer(r"<line\b([^>]*?)(/?)>", slide_xml), start=1
+    ):
         attrs = match.group(1)
         start_x = extract_numeric_attribute(attrs, "startX")
         start_y = extract_numeric_attribute(attrs, "startY")
@@ -2450,6 +2467,7 @@ def extract_line_elements(slide_xml: str) -> list[dict[str, Any]]:
                 "rotation": 0,
                 "alpha": base_alpha * border_alpha,
                 "order": len(elements),
+                "_source_kind_index": source_kind_index,
             }
         )
     return elements

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2443,6 +2443,44 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             ["slide[1]/data/shape[1]", "slide[1]/data/table[1]/tr[1]/td[1]"],
         )
 
+    def test_lint_xml_blocks_duplicate_id_shared_by_shape_and_undefined(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="dup" type="rect" topLeftX="40" topLeftY="40" width="80" height="80"/>
+                <undefined id="dup" type="video"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "duplicate_element_id"
+        )
+        self.assertFalse(result["summary"]["release_ready"])
+        self.assertEqual(issue["element_ids"], ["dup", "dup"])
+        self.assertEqual(
+            issue["related_objects"],
+            [
+                {
+                    "element_id": "dup",
+                    "kind": "shape",
+                    "type": "rect",
+                    "bbox": {"x": 40, "y": 40, "width": 80, "height": 80},
+                    "xml_path": "slide[1]/data/shape[1]",
+                },
+                {
+                    "element_id": "dup",
+                    "kind": "undefined",
+                    "type": "video",
+                    "xml_path": "slide[1]/data/undefined[1]",
+                },
+            ],
+        )
+
     def test_lint_xml_does_not_report_unique_table_cell_and_note_ids(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
@@ -2489,8 +2527,60 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertFalse(result["summary"]["release_ready"])
         self.assertEqual(issue["element_ids"], ["dup", "dup"])
         self.assertEqual(
-            [obj["xml_path"] for obj in issue["related_objects"]],
-            ["slide[1]/data/shape[1]", "slide[2]/data/shape[1]"],
+            issue["related_objects"],
+            [
+                {
+                    "element_id": "dup",
+                    "kind": "shape",
+                    "type": "rect",
+                    "bbox": {"x": 40, "y": 40, "width": 80, "height": 80},
+                    "xml_path": "slide[1]/data/shape[1]",
+                },
+                {
+                    "element_id": "dup",
+                    "kind": "shape",
+                    "type": "rect",
+                    "bbox": {"x": 140, "y": 40, "width": 80, "height": 80},
+                    "xml_path": "slide[2]/data/shape[1]",
+                },
+            ],
+        )
+
+    def test_lint_xml_does_not_treat_slide_ids_as_element_ids(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide id="dup"><data/></slide>
+              <slide id="dup"><data/></slide>
+            </presentation>
+            """
+        )
+
+        self.assertNotIn(
+            "duplicate_element_id",
+            [issue["code"] for issue in result["document"]["errors"]],
+        )
+
+    def test_lint_xml_does_not_treat_presentation_id_as_element_id(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" id="dup" width="960" height="540">
+              <slide>
+                <data><undefined id="dup" type="video"/></data>
+              </slide>
+            </presentation>
+            """
+        )
+
+        self.assertNotIn(
+            "duplicate_element_id",
+            [
+                issue["code"]
+                for issue in [
+                    *result["document"]["errors"],
+                    *result["slides"][0]["errors"],
+                ]
+            ],
         )
 
     def test_lint_xml_blocks_duplicate_note_ids_across_slides(self) -> None:

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2376,6 +2376,93 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             ["slide[1]/data/shape[1]", "slide[1]/data/shape[2]"],
         )
 
+    def test_lint_xml_blocks_duplicate_table_cell_ids(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <table id="table-1" topLeftX="80" topLeftY="80" width="800" height="120">
+                  <colgroup><col width="400"/><col width="400"/></colgroup>
+                  <tr height="120">
+                    <td id="bjs"><content fontSize="24"><p>Original cell</p></content></td>
+                    <td id="bjs"><content fontSize="24"><p>Copied cell</p></content></td>
+                  </tr>
+                </table>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "duplicate_element_id"
+        )
+        self.assertFalse(result["summary"]["release_ready"])
+        self.assertEqual(issue["element_ids"], ["bjs", "bjs"])
+        self.assertEqual(
+            issue["related_objects"],
+            [
+                {
+                    "element_id": "bjs",
+                    "kind": "td",
+                    "type": "td",
+                    "xml_path": "slide[1]/data/table[1]/tr[1]/td[1]",
+                },
+                {
+                    "element_id": "bjs",
+                    "kind": "td",
+                    "type": "td",
+                    "xml_path": "slide[1]/data/table[1]/tr[1]/td[2]",
+                },
+            ],
+        )
+
+    def test_lint_xml_blocks_duplicate_id_shared_by_shape_and_table_cell(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="baa" type="rect" topLeftX="40" topLeftY="40" width="80" height="80"/>
+                <table id="table-1" topLeftX="160" topLeftY="40" width="200" height="80">
+                  <tr height="80"><td id="baa"><content fontSize="12"><p>Cell</p></content></td></tr>
+                </table>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "duplicate_element_id"
+        )
+        self.assertEqual(issue["element_ids"], ["baa", "baa"])
+        self.assertEqual(
+            [obj["xml_path"] for obj in issue["related_objects"]],
+            ["slide[1]/data/shape[1]", "slide[1]/data/table[1]/tr[1]/td[1]"],
+        )
+
+    def test_lint_xml_does_not_report_unique_table_cell_and_note_ids(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <table id="table-1" topLeftX="80" topLeftY="80" width="800" height="120">
+                  <colgroup><col width="400"/><col width="400"/></colgroup>
+                  <tr height="120"><td id="baa"/><td id="bab"/></tr>
+                </table>
+              </data>
+              <note id="bac"><content fontSize="12"><p>Note</p></content></note>
+            </slide>
+            """
+        )
+
+        self.assertNotIn(
+            "duplicate_element_id",
+            [issue["code"] for issue in result["slides"][0]["issues"]],
+        )
+
     def test_lint_xml_blocks_duplicate_ids_across_slides(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
@@ -2404,6 +2491,45 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(
             [obj["xml_path"] for obj in issue["related_objects"]],
             ["slide[1]/data/shape[1]", "slide[2]/data/shape[1]"],
+        )
+
+    def test_lint_xml_blocks_duplicate_note_ids_across_slides(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide>
+                <note id="baa"><content fontSize="12"><p>First note</p></content></note>
+              </slide>
+              <slide>
+                <note id="baa"><content fontSize="12"><p>Copied note</p></content></note>
+              </slide>
+            </presentation>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["document"]["errors"]
+            if issue["code"] == "duplicate_element_id"
+        )
+        self.assertFalse(result["summary"]["release_ready"])
+        self.assertEqual(issue["element_ids"], ["baa", "baa"])
+        self.assertEqual(
+            issue["related_objects"],
+            [
+                {
+                    "element_id": "baa",
+                    "kind": "note",
+                    "type": "note",
+                    "xml_path": "slide[1]/note[1]",
+                },
+                {
+                    "element_id": "baa",
+                    "kind": "note",
+                    "type": "note",
+                    "xml_path": "slide[2]/note[1]",
+                },
+            ],
         )
 
     def test_lint_xml_cross_kind_duplicate_id_does_not_change_related_object_kind(self) -> None:

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2963,6 +2963,35 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
         self.assertEqual(result["slides"][0]["status"], "needs_screenshot_review")
         self.assertEqual(result["slides"][0]["warnings"], result["slides"][0]["issues"])
 
+    def test_lint_xml_uses_xml_path_in_anonymous_sparse_container_message(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape type="rect" topLeftX="500" topLeftY="135" width="410" height="370"/>
+                <shape id="trend-title" type="text" topLeftX="515" topLeftY="147" width="380" height="28">
+                  <content fontSize="15"><p>Core trends</p></content>
+                </shape>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "sparse_container_content"
+        )
+        self.assertNotIn("container_id", issue["target"])
+        self.assertEqual(
+            issue["target"]["container_xml_path"],
+            "slide[1]/data/shape[1]",
+        )
+        self.assertEqual(
+            issue["message"],
+            "large card slide[1]/data/shape[1] content coverage 1.0% is below 15.0%",
+        )
+
     def test_lint_xml_warns_for_sparse_short_cards(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2323,6 +2323,194 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             "slide[1]/data/table[2]",
         )
 
+    def test_lint_xml_duplicate_id_keeps_issue_bound_to_original_shape(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="dup" type="rect" topLeftX="-20" topLeftY="40" width="50" height="50"/>
+                <shape id="dup" type="rect" topLeftX="100" topLeftY="40" width="50" height="50"/>
+              </data>
+            </slide>
+            """
+        )
+
+        canvas_issue = next(
+            issue for issue in result["slides"][0]["issues"]
+            if issue["code"] == "shape_out_of_canvas"
+        )
+        self.assertEqual(canvas_issue["element_ids"], ["dup"])
+        self.assertEqual(
+            canvas_issue["related_objects"],
+            [
+                {
+                    "element_id": "dup",
+                    "kind": "shape",
+                    "type": "rect",
+                    "bbox": {"x": -20, "y": 40, "width": 50, "height": 50},
+                    "xml_path": "slide[1]/data/shape[1]",
+                }
+            ],
+        )
+        duplicate_issue = next(
+            issue for issue in result["slides"][0]["issues"]
+            if issue["code"] == "duplicate_element_id"
+        )
+        self.assertEqual(duplicate_issue["element_ids"], ["dup", "dup"])
+        self.assertEqual(
+            [obj["xml_path"] for obj in duplicate_issue["related_objects"]],
+            ["slide[1]/data/shape[1]", "slide[1]/data/shape[2]"],
+        )
+
+    def test_lint_xml_cross_kind_duplicate_id_does_not_change_related_object_kind(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="dup" type="rect" topLeftX="-20" topLeftY="40" width="50" height="50"/>
+                <img id="dup" src="token" topLeftX="100" topLeftY="40" width="50" height="50"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue for issue in result["slides"][0]["issues"]
+            if issue["code"] == "shape_out_of_canvas"
+        )
+        self.assertEqual(issue["related_objects"][0]["kind"], "shape")
+        self.assertEqual(
+            issue["related_objects"][0]["xml_path"],
+            "slide[1]/data/shape[1]",
+        )
+        duplicate_issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "duplicate_element_id"
+        )
+        self.assertEqual(
+            [obj["xml_path"] for obj in duplicate_issue["related_objects"]],
+            ["slide[1]/data/shape[1]", "slide[1]/data/img[1]"],
+        )
+
+    def test_lint_xml_reports_duplicate_ids_for_every_linted_element_kind(self) -> None:
+        duplicate_pairs = {
+            "shape": (
+                '<shape id="dup" type="rect" topLeftX="10" topLeftY="10" width="40" height="40"/>',
+                '<shape id="dup" type="rect" topLeftX="60" topLeftY="10" width="40" height="40"/>',
+            ),
+            "chart": (
+                '<chart id="dup" topLeftX="10" topLeftY="10" width="40" height="40"><chartPlotArea><chartPlot type="line"/></chartPlotArea><chartData><dim1><chartField name="category" valueType="string">A</chartField></dim1><dim2><chartField name="value" valueType="number">1</chartField></dim2></chartData></chart>',
+                '<chart id="dup" topLeftX="60" topLeftY="10" width="40" height="40"><chartPlotArea><chartPlot type="line"/></chartPlotArea><chartData><dim1><chartField name="category" valueType="string">A</chartField></dim1><dim2><chartField name="value" valueType="number">1</chartField></dim2></chartData></chart>',
+            ),
+            "table": (
+                '<table id="dup" topLeftX="10" topLeftY="10" width="40" height="40"><colgroup><col width="40"/></colgroup><tr height="40"><td/></tr></table>',
+                '<table id="dup" topLeftX="60" topLeftY="10" width="40" height="40"><colgroup><col width="40"/></colgroup><tr height="40"><td/></tr></table>',
+            ),
+            "img": (
+                '<img id="dup" src="token" topLeftX="10" topLeftY="10" width="40" height="40"/>',
+                '<img id="dup" src="token" topLeftX="60" topLeftY="10" width="40" height="40"/>',
+            ),
+            "line": (
+                '<line id="dup" startX="10" startY="10" endX="40" endY="40"><border color="rgb(0, 0, 0)"/></line>',
+                '<line id="dup" startX="60" startY="10" endX="90" endY="40"><border color="rgb(0, 0, 0)"/></line>',
+            ),
+            "icon": (
+                '<icon id="dup" iconType="iconpark/Base/setting.svg" topLeftX="10" topLeftY="10" width="40" height="40"><fill><fillColor color="rgb(0, 0, 0)"/></fill></icon>',
+                '<icon id="dup" iconType="iconpark/Base/setting.svg" topLeftX="60" topLeftY="10" width="40" height="40"><fill><fillColor color="rgb(0, 0, 0)"/></fill></icon>',
+            ),
+            "polyline": (
+                '<polyline id="dup" topLeftX="10" topLeftY="10" width="40" height="40"><border color="rgb(0, 0, 0)"/></polyline>',
+                '<polyline id="dup" topLeftX="60" topLeftY="10" width="40" height="40"><border color="rgb(0, 0, 0)"/></polyline>',
+            ),
+        }
+        for kind, pair in duplicate_pairs.items():
+            with self.subTest(kind=kind):
+                result = xml_text_overlap_lint.lint_xml(
+                    f'<slide xmlns="https://www.larkoffice.com/sml/2.0"><data>{pair[0]}{pair[1]}</data></slide>'
+                )
+                issue = next(
+                    issue
+                    for issue in result["slides"][0]["issues"]
+                    if issue["code"] == "duplicate_element_id"
+                )
+                self.assertEqual(issue["element_ids"], ["dup", "dup"])
+                self.assertEqual(
+                    [obj["xml_path"] for obj in issue["related_objects"]],
+                    [
+                        f"slide[1]/data/{kind}[1]",
+                        f"slide[1]/data/{kind}[2]",
+                    ],
+                )
+
+    def test_lint_xml_missing_id_does_not_collide_with_explicit_synthetic_like_id(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape type="rect" topLeftX="-20" topLeftY="40" width="50" height="50"/>
+                <shape id="shape-1" type="rect" topLeftX="100" topLeftY="40" width="50" height="50"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue for issue in result["slides"][0]["issues"]
+            if issue["code"] == "shape_out_of_canvas"
+        )
+        self.assertEqual(issue["element_ids"], [])
+        self.assertNotIn("element_id", issue["related_objects"][0])
+        self.assertEqual(
+            issue["related_objects"][0]["xml_path"],
+            "slide[1]/data/shape[1]",
+        )
+        self.assertNotIn(
+            "duplicate_element_id",
+            [candidate["code"] for candidate in result["slides"][0]["issues"]],
+        )
+
+    def test_lint_xml_empty_id_is_not_exposed_as_an_element_id(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="" type="rect" topLeftX="-20" topLeftY="40" width="50" height="50"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "shape_out_of_canvas"
+        )
+        self.assertEqual(issue["element_ids"], [])
+        self.assertNotIn("element_id", issue["related_objects"][0])
+        self.assertEqual(
+            issue["related_objects"][0]["xml_path"],
+            "slide[1]/data/shape[1]",
+        )
+
+    def test_lint_xml_element_id_uses_decoded_xml_attribute_value(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="amp&amp;id" type="rect" topLeftX="-20" topLeftY="40" width="50" height="50"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue for issue in result["slides"][0]["issues"]
+            if issue["code"] == "shape_out_of_canvas"
+        )
+        self.assertEqual(issue["element_ids"], ["amp&id"])
+        self.assertEqual(issue["related_objects"][0]["element_id"], "amp&id")
+
     def test_lint_xml_uses_resolved_table_bounds_for_canvas_validation(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
@@ -2347,7 +2535,7 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(mismatch_issue["dimension"], "width")
         self.assertEqual(mismatch_issue["resolved_size"], canvas_issue["bbox"]["width"])
 
-    def test_lint_xml_uses_the_same_anonymous_table_id_for_all_table_diagnostics(self) -> None:
+    def test_lint_xml_uses_the_same_anonymous_table_path_for_all_table_diagnostics(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """
             <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
@@ -2367,8 +2555,18 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         issues = result["slides"][0]["issues"]
         canvas_issue = next(issue for issue in issues if issue["code"] == "table_out_of_canvas")
         mismatch_issue = next(issue for issue in issues if issue["code"] == "table_resolved_size_mismatch")
-        self.assertEqual(canvas_issue["elements"], ["table-3"])
-        self.assertEqual(mismatch_issue["elements"], ["table-3"])
+        self.assertEqual(canvas_issue["elements"], [])
+        self.assertEqual(mismatch_issue["elements"], [])
+        self.assertEqual(
+            canvas_issue["related_objects"][0]["xml_path"],
+            "slide[1]/data/table[1]",
+        )
+        self.assertEqual(
+            mismatch_issue["related_objects"][0]["xml_path"],
+            "slide[1]/data/table[1]",
+        )
+        self.assertNotIn("element_id", canvas_issue["related_objects"][0])
+        self.assertNotIn("element_id", mismatch_issue["related_objects"][0])
 
     def test_lint_xml_reports_info_when_table_target_size_resolves_larger_than_declared(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
@@ -2590,14 +2788,14 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             if issue["code"] == "image_covers_text"
         )
         self.assertEqual(
-            {
-                obj["element_id"]: obj["xml_path"]
-                for obj in issue["related_objects"]
-            },
-            {
-                "img-4": "slide[2]/data/img[1]",
-                "shape-3": "slide[2]/data/shape[3]",
-            },
+            [(obj["kind"], obj["xml_path"]) for obj in issue["related_objects"]],
+            [
+                ("img", "slide[2]/data/img[1]"),
+                ("shape", "slide[2]/data/shape[3]"),
+            ],
+        )
+        self.assertTrue(
+            all("element_id" not in obj for obj in issue["related_objects"])
         )
 
     def test_lint_xml_related_objects_include_line_xml_path(self) -> None:
@@ -2737,6 +2935,7 @@ class XmlTextOverlapLintDensityTest(unittest.TestCase):
         self.assertEqual(issue["target"], {
             "slide_number": 1,
             "container_id": "trend-card",
+            "container_xml_path": "slide[1]/data/shape[1]",
             "container_type": "rect",
             "bbox": {"x": 500, "y": 135, "width": 410, "height": 370},
         })

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2368,6 +2368,36 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             ["slide[1]/data/shape[1]", "slide[1]/data/shape[2]"],
         )
 
+    def test_lint_xml_blocks_duplicate_ids_across_slides(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="https://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide>
+                <data>
+                  <shape id="dup" type="rect" topLeftX="40" topLeftY="40" width="80" height="80"/>
+                </data>
+              </slide>
+              <slide>
+                <data>
+                  <shape id="dup" type="rect" topLeftX="140" topLeftY="40" width="80" height="80"/>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["document"]["errors"]
+            if issue["code"] == "duplicate_element_id"
+        )
+        self.assertFalse(result["summary"]["release_ready"])
+        self.assertEqual(issue["element_ids"], ["dup", "dup"])
+        self.assertEqual(
+            [obj["xml_path"] for obj in issue["related_objects"]],
+            ["slide[1]/data/shape[1]", "slide[2]/data/shape[1]"],
+        )
+
     def test_lint_xml_cross_kind_duplicate_id_does_not_change_related_object_kind(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2499,24 +2499,6 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             "slide[1]/data/shape[1]",
         )
 
-    def test_lint_xml_element_id_uses_decoded_xml_attribute_value(self) -> None:
-        result = xml_text_overlap_lint.lint_xml(
-            """
-            <slide xmlns="https://www.larkoffice.com/sml/2.0">
-              <data>
-                <shape id="amp&amp;id" type="rect" topLeftX="-20" topLeftY="40" width="50" height="50"/>
-              </data>
-            </slide>
-            """
-        )
-
-        issue = next(
-            issue for issue in result["slides"][0]["issues"]
-            if issue["code"] == "shape_out_of_canvas"
-        )
-        self.assertEqual(issue["element_ids"], ["amp&id"])
-        self.assertEqual(issue["related_objects"][0]["element_id"], "amp&id")
-
     def test_lint_xml_uses_resolved_table_bounds_for_canvas_validation(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -217,6 +217,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertIsInstance(issue["line"], int)
         self.assertIsInstance(issue["column"], int)
         self.assertIn("Broken XML", issue["context"])
+        self.assertEqual(issue["related_objects"], [])
+        self.assertNotIn("Locate via related_objects[].xml_path.", issue["hint"])
 
     def test_lint_xml_rejects_prefixed_sml_tags(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
@@ -2352,15 +2354,21 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
                 }
             ],
         )
+        self.assertTrue(
+            canvas_issue["hint"].startswith(
+                "Locate via related_objects[].xml_path. "
+            )
+        )
         duplicate_issue = next(
             issue for issue in result["slides"][0]["issues"]
             if issue["code"] == "duplicate_element_id"
         )
         self.assertEqual(
             duplicate_issue["hint"],
+            "Locate via related_objects[].xml_path. "
             "Do not invent replacement IDs. For newly authored elements, remove the id attribute. "
             "When updating read-back XML, keep the server ID on the original element only and remove it "
-            "from copied or new elements. Use xml_path to edit the correct nodes.",
+            "from copied or new elements.",
         )
         self.assertEqual(duplicate_issue["element_ids"], ["dup", "dup"])
         self.assertEqual(
@@ -2428,6 +2436,38 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             [obj["xml_path"] for obj in duplicate_issue["related_objects"]],
             ["slide[1]/data/shape[1]", "slide[1]/data/img[1]"],
         )
+
+    def test_normalize_issue_does_not_repeat_xml_path_hint_prefix(self) -> None:
+        xml_path = "slide[1]/data/shape[1]"
+        element = {
+            "id": "box",
+            "_source_id": "box",
+            "_ref": xml_path,
+            "xml_path": xml_path,
+            "kind": "shape",
+            "type": "rect",
+            "x": 0,
+            "y": 0,
+            "width": 40,
+            "height": 40,
+        }
+        prefix = "Locate via related_objects[].xml_path."
+
+        issue = xml_text_overlap_lint.normalize_issue(
+            {
+                "level": "error",
+                "code": "shape_out_of_canvas",
+                "elements": [xml_path],
+                "canvas": {"width": 960, "height": 540},
+                "bbox": {"x": -10, "y": 0, "width": 40, "height": 40},
+                "overflow": {"left": 10, "top": 0, "right": 0, "bottom": 0},
+                "hint": f"{prefix} Move the shape inside the canvas.",
+            },
+            1,
+            {xml_path: element},
+        )
+
+        self.assertEqual(issue["hint"].count(prefix), 1)
 
     def test_lint_xml_reports_duplicate_ids_for_every_linted_element_kind(self) -> None:
         duplicate_pairs = {
@@ -2500,6 +2540,9 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(
             issue["related_objects"][0]["xml_path"],
             "slide[1]/data/shape[1]",
+        )
+        self.assertTrue(
+            issue["hint"].startswith("Locate via related_objects[].xml_path. ")
         )
         self.assertNotIn(
             "duplicate_element_id",

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2356,6 +2356,12 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
             issue for issue in result["slides"][0]["issues"]
             if issue["code"] == "duplicate_element_id"
         )
+        self.assertEqual(
+            duplicate_issue["hint"],
+            "Do not invent replacement IDs. For newly authored elements, remove the id attribute. "
+            "When updating read-back XML, keep the server ID on the original element only and remove it "
+            "from copied or new elements. Use xml_path to edit the correct nodes.",
+        )
         self.assertEqual(duplicate_issue["element_ids"], ["dup", "dup"])
         self.assertEqual(
             [obj["xml_path"] for obj in duplicate_issue["related_objects"]],

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2528,8 +2528,115 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(result["summary"]["error_count"], 0)
         self.assertEqual(result["summary"]["info_count"], 1)
 
+    def test_lint_xml_related_objects_include_source_xml_paths(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide>
+                <data>
+                  <shape type="text" topLeftX="80" topLeftY="80" width="400" height="60">
+                    <content fontSize="24"><p>Control slide</p></content>
+                  </shape>
+                </data>
+              </slide>
+              <slide>
+                <data>
+                  <shape type="text" topLeftX="70" topLeftY="55" width="820" height="70">
+                    <content fontSize="32"><p>shape-3 mapping experiment</p></content>
+                  </shape>
+                  <shape type="text" topLeftX="80" topLeftY="165" width="400" height="70">
+                    <content fontSize="18"><p>First, preserve source order.</p></content>
+                  </shape>
+                  <shape type="text" topLeftX="80" topLeftY="315" width="400" height="64">
+                    <content fontSize="26"><p>TARGET_SHAPE_THREE</p></content>
+                  </shape>
+                  <img src="token" topLeftX="80" topLeftY="305" width="400" height="110"/>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][1]["issues"]
+            if issue["code"] == "image_covers_text"
+        )
+        self.assertEqual(
+            {
+                obj["element_id"]: obj["xml_path"]
+                for obj in issue["related_objects"]
+            },
+            {
+                "img-4": "slide[2]/data/img[1]",
+                "shape-3": "slide[2]/data/shape[3]",
+            },
+        )
+
+    def test_lint_xml_related_objects_include_line_xml_path(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="label" type="text" topLeftX="100" topLeftY="100" width="200" height="80">
+                  <content fontSize="24"><p>Crossed text</p></content>
+                </shape>
+                <line id="connector" startX="80" startY="130" endX="330" endY="130">
+                  <border color="rgb(15, 23, 42)" width="2"/>
+                </line>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "bbox_overlap" and issue["elements"][0] == "connector"
+        )
+        self.assertEqual(
+            {
+                obj["element_id"]: obj["xml_path"]
+                for obj in issue["related_objects"]
+            },
+            {
+                "connector": "slide[1]/data/line[1]",
+                "label": "slide[1]/data/shape[1]",
+            },
+        )
+
 
 class XmlTextOverlapLintDensityTest(unittest.TestCase):
+    def test_lint_xml_sparse_container_related_objects_include_icon_xml_path(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape id="card" type="rect" topLeftX="60" topLeftY="120" width="400" height="300"/>
+                <icon id="visual" iconType="iconpark/Base/setting.svg" topLeftX="80" topLeftY="140" width="32" height="32">
+                  <fill><fillColor color="rgb(37, 99, 235)"/></fill>
+                </icon>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "sparse_container_content"
+        )
+        self.assertEqual(
+            {
+                obj["element_id"]: obj["xml_path"]
+                for obj in issue["related_objects"]
+            },
+            {
+                "card": "slide[1]/data/shape[1]",
+                "visual": "slide[1]/data/icon[1]",
+            },
+        )
+
     def test_lint_xml_blocks_blank_slide(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2296,6 +2296,33 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         self.assertEqual(issue["bbox"], {"x": 850, "y": 480, "width": 220, "height": 74})
         self.assertEqual(issue["overflow"], {"left": 0, "top": 0, "right": 110, "bottom": 14})
 
+    def test_lint_xml_xml_path_preserves_source_index_after_filtered_table(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="http://www.larkoffice.com/sml/2.0">
+              <data>
+                <table id="t1" topLeftX="20" topLeftY="20">
+                  <tr><td/></tr>
+                </table>
+                <table id="t2" topLeftX="20" topLeftY="100" width="9999" height="100">
+                  <tr><td/></tr>
+                </table>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "table_out_of_canvas"
+        )
+        self.assertEqual(issue["element_ids"], ["t2"])
+        self.assertEqual(
+            issue["related_objects"][0]["xml_path"],
+            "slide[1]/data/table[2]",
+        )
+
     def test_lint_xml_uses_resolved_table_bounds_for_canvas_validation(self) -> None:
         result = xml_text_overlap_lint.lint_xml(
             """

--- a/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
+++ b/skills/lark-slides/scripts/xml_text_overlap_lint_test.py
@@ -2595,6 +2595,65 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
 
         self.assertEqual(issue["hint"].count(prefix), 1)
 
+    def test_lint_xml_elements_keep_locator_for_anonymous_related_object(self) -> None:
+        result = xml_text_overlap_lint.lint_xml(
+            """
+            <slide xmlns="https://www.larkoffice.com/sml/2.0">
+              <data>
+                <shape type="text" topLeftX="100" topLeftY="100" width="300" height="100">
+                  <content fontSize="24"><p>Important text</p></content>
+                </shape>
+                <img id="srv-42" src="token" topLeftX="100" topLeftY="100" width="300" height="100"/>
+              </data>
+            </slide>
+            """
+        )
+
+        issue = next(
+            issue
+            for issue in result["slides"][0]["issues"]
+            if issue["code"] == "image_covers_text"
+        )
+        self.assertEqual(
+            issue["elements"],
+            ["srv-42", "slide[1]/data/shape[1]"],
+        )
+        self.assertEqual(issue["element_ids"], ["srv-42"])
+        self.assertEqual(len(issue["related_objects"]), 2)
+
+    def test_normalize_issue_deduplicates_repeated_element_refs(self) -> None:
+        xml_path = "slide[1]/data/shape[1]"
+        element = {
+            "id": "srv-42",
+            "_source_id": "srv-42",
+            "_ref": xml_path,
+            "xml_path": xml_path,
+            "kind": "shape",
+            "type": "rect",
+            "x": 0,
+            "y": 0,
+            "width": 40,
+            "height": 40,
+        }
+
+        issue = xml_text_overlap_lint.normalize_issue(
+            {
+                "level": "warning",
+                "code": "blank_slide",
+                "measurement": {
+                    "visible_element_count": 0,
+                    "declared_element_count": 1,
+                },
+                "elements": [xml_path, xml_path],
+            },
+            1,
+            {xml_path: element},
+        )
+
+        self.assertEqual(issue["elements"], ["srv-42"])
+        self.assertEqual(issue["element_ids"], ["srv-42"])
+        self.assertEqual(len(issue["related_objects"]), 1)
+
     def test_lint_xml_reports_duplicate_ids_for_every_linted_element_kind(self) -> None:
         duplicate_pairs = {
             "shape": (
@@ -2742,8 +2801,8 @@ class XmlTextOverlapLintGeometryTest(unittest.TestCase):
         issues = result["slides"][0]["issues"]
         canvas_issue = next(issue for issue in issues if issue["code"] == "table_out_of_canvas")
         mismatch_issue = next(issue for issue in issues if issue["code"] == "table_resolved_size_mismatch")
-        self.assertEqual(canvas_issue["elements"], [])
-        self.assertEqual(mismatch_issue["elements"], [])
+        self.assertEqual(canvas_issue["elements"], ["slide[1]/data/table[1]"])
+        self.assertEqual(mismatch_issue["elements"], ["slide[1]/data/table[1]"])
         self.assertEqual(
             canvas_issue["related_objects"][0]["xml_path"],
             "slide[1]/data/table[1]",


### PR DESCRIPTION
## Summary

- Preserve source XML indices when lint extraction filters elements.
- Bind lint issues to elements by `xml_path` instead of user-provided IDs.
- Report blocking `duplicate_element_id` errors for duplicate IDs.
- Decode XML entities in returned element IDs.
- Stop exposing synthetic IDs for elements with missing or empty IDs.

## Validation

- `196/196` Slides lint Python tests passed.
- `GOTOOLCHAIN=go1.23.0 make unit-test` passed.
- Validated all 87 regression slides:
  - 203 related objects checked
  - 0 missing or invalid XML paths
  - 0 ID or kind mismatches
  - 0 pages with lint-code drift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated slide layout validation with stable references to relevant slide elements.
  * Diagnostics now include source XML paths for related images, lines, tables, and containers.
  * Improved handling of encoded, missing, and duplicate element identifiers, including duplicates across slides.
  * Improved consistency across overlap, overflow, density, line, icon, and layout checks.

* **Documentation**
  * Updated validation guidance to explain XML paths and path-based troubleshooting for sparse container content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->