### PR TITLE
feat(slides): support explicit screenshot output paths

### DIFF
--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -52,18 +52,12 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "slide", Desc: "hidden alias routed to --slide-number for digits, otherwise --slide-id", Hidden: true},
 		{Name: "content", Desc: "slide XML content to render directly instead of fetching existing slides", Input: []string{common.File, common.Stdin}},
 		{Name: "output", Desc: "preferred relative output path for a single screenshot (extension optional; .png, .jpg, or .jpeg)"},
-		{Name: "overwrite", Type: "bool", Desc: "overwrite an existing file selected by --output"},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
 		{Name: "output-name", Desc: "legacy file name stem for --content render output; prefer --output for new calls"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		renderMode := runtime.Changed("content")
 		selectorCount := 1
-		if runtime.Changed("overwrite") && !runtime.Changed("output") {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overwrite requires --output").
-				WithParam("--overwrite").
-				WithHint("use --overwrite only with --output <file>")
-		}
 		if renderMode {
 			if strings.TrimSpace(runtime.Str("content")) == "" {
 				return slidesScreenshotFlagErrorf("--content cannot be empty")
@@ -211,7 +205,7 @@ var SlidesScreenshot = common.Shortcut{
 			return enrichSlidesScreenshotSelectorError(err, slideNumbers)
 		}
 
-		saved, err := saveSlideScreenshots(runtime, data, outputTarget.safeOutputDir, presentationID, outputTarget.requested, outputTarget.overwrite)
+		saved, err := saveSlideScreenshots(runtime, data, outputTarget.safeOutputDir, presentationID, outputTarget.requested)
 		if err != nil {
 			return err
 		}
@@ -266,7 +260,7 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	saved, err := saveRenderedSlideScreenshot(runtime, data, outputTarget.safeOutputDir, runtime.Str("output-name"), outputTarget.requested, outputTarget.overwrite)
+	saved, err := saveRenderedSlideScreenshot(runtime, data, outputTarget.safeOutputDir, runtime.Str("output-name"), outputTarget.requested)
 	if err != nil {
 		return err
 	}
@@ -279,7 +273,7 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 }
 
 func setSlidesScreenshotDryRunOutput(dry *common.DryRunAPI, runtime *common.RuntimeContext) *common.DryRunAPI {
-	if outputPath := strings.TrimSpace(runtime.Str("output")); outputPath != "" {
+	if outputPath := runtime.Str("output"); outputPath != "" {
 		return dry.Set("output", outputPath)
 	}
 	return dry.Set("output_dir", runtime.Str("output-dir"))
@@ -290,14 +284,12 @@ type slidesScreenshotOutputTarget struct {
 	requestedResolved string
 	outputDir         string
 	safeOutputDir     string
-	overwrite         bool
 }
 
 func resolveSlidesScreenshotOutputTarget(runtime *common.RuntimeContext) (slidesScreenshotOutputTarget, error) {
 	target := slidesScreenshotOutputTarget{
-		requested: strings.TrimSpace(runtime.Str("output")),
+		requested: runtime.Str("output"),
 		outputDir: runtime.Str("output-dir"),
-		overwrite: runtime.Bool("overwrite"),
 	}
 	if target.requested != "" {
 		resolved, err := runtime.ResolveSavePath(target.requested)
@@ -483,9 +475,13 @@ func validateScreenshotOutputDir(runtime *common.RuntimeContext, outputDir strin
 }
 
 func validateScreenshotOutputPath(runtime *common.RuntimeContext, outputPath string) error {
-	outputPath = strings.TrimSpace(outputPath)
 	if outputPath == "" {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output cannot be empty").WithParam("--output")
+	}
+	if strings.TrimSpace(outputPath) != outputPath {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output cannot have leading or trailing whitespace").
+			WithParam("--output").
+			WithHint("remove surrounding whitespace and retry")
 	}
 	if os.IsPathSeparator(outputPath[len(outputPath)-1]) {
 		return screenshotOutputDirectoryError(outputPath)
@@ -517,7 +513,7 @@ func ensureScreenshotOutputDir(runtime *common.RuntimeContext, outputDir string)
 	return validateScreenshotOutputDir(runtime, outputDir)
 }
 
-func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, presentationID string, outputPath string, overwrite bool) ([]map[string]interface{}, error) {
+func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, presentationID string, outputPath string) ([]map[string]interface{}, error) {
 	items := common.GetSlice(data, "slide_images")
 	if len(items) == 0 {
 		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned no slide_images")
@@ -531,7 +527,7 @@ func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interf
 		if !ok {
 			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide_images[%d]", i)
 		}
-		item, err := saveSlideScreenshotImage(runtime, m, outputDir, slideScreenshotListFileBase(presentationID, m, i), "", outputPath, overwrite)
+		item, err := saveSlideScreenshotImage(runtime, m, outputDir, slideScreenshotListFileBase(presentationID, m, i), "", outputPath)
 		if err != nil {
 			if isSlidesScreenshotPassthroughError(err) {
 				return nil, err
@@ -543,12 +539,12 @@ func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interf
 	return saved, nil
 }
 
-func saveRenderedSlideScreenshot(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, outputName string, outputPath string, overwrite bool) ([]map[string]interface{}, error) {
+func saveRenderedSlideScreenshot(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, outputName string, outputPath string) ([]map[string]interface{}, error) {
 	item := common.GetMap(data, "slide_image")
 	if item == nil {
 		return nil, slidesScreenshotAPIDataError(data, "slides render screenshot returned no slide_image")
 	}
-	saved, err := saveSlideScreenshotImage(runtime, item, outputDir, outputName, "rendered-slide", outputPath, overwrite)
+	saved, err := saveSlideScreenshotImage(runtime, item, outputDir, outputName, "rendered-slide", outputPath)
 	if err != nil {
 		if isSlidesScreenshotPassthroughError(err) {
 			return nil, err
@@ -558,7 +554,7 @@ func saveRenderedSlideScreenshot(runtime *common.RuntimeContext, data map[string
 	return []map[string]interface{}{saved}, nil
 }
 
-func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]interface{}, outputDir string, outputName string, fallbackName string, outputPath string, overwrite bool) (map[string]interface{}, error) {
+func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]interface{}, outputDir string, outputName string, fallbackName string, outputPath string) (map[string]interface{}, error) {
 	slideID := strings.TrimSpace(common.GetString(item, "slide_id"))
 	ext, label, err := slideScreenshotFormat(item)
 	if err != nil {
@@ -574,7 +570,7 @@ func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]in
 	}
 	var path string
 	if outputPath != "" {
-		path, err = writeScreenshotOutputPath(runtime, slideScreenshotOutputPathForFormat(outputPath, ext), imageBytes, overwrite)
+		path, err = writeUniqueScreenshotPath(runtime, slideScreenshotOutputPathForFormat(outputPath, ext), imageBytes)
 	} else {
 		fileBase := strings.TrimSpace(outputName)
 		if fileBase == "" {
@@ -769,29 +765,6 @@ func safeScreenshotFileBase(base string) string {
 func writeUniqueScreenshotFile(runtime *common.RuntimeContext, outputDir string, fileBase string, ext string, imageBytes []byte) (string, error) {
 	base := safeScreenshotFileBase(fileBase)
 	return writeUniqueScreenshotPath(runtime, filepath.Join(outputDir, base+"."+ext), imageBytes)
-}
-
-func writeScreenshotOutputPath(runtime *common.RuntimeContext, outputPath string, imageBytes []byte, overwrite bool) (string, error) {
-	if info, err := runtime.FileIO().Stat(outputPath); err == nil {
-		if info.IsDir() {
-			return "", screenshotOutputDirectoryError(outputPath)
-		}
-		if !overwrite {
-			return "", errs.NewValidationError(errs.SubtypeFailedPrecondition, "output file already exists: %s", outputPath).
-				WithParam("--output").
-				WithHint("add --overwrite to replace the existing file")
-		}
-	} else if !isScreenshotFileNotExist(err) {
-		return "", errs.NewInternalError(errs.SubtypeFileIO, "inspect screenshot output %s: %v", outputPath, err).WithCause(err)
-	}
-	if _, err := runtime.FileIO().Save(outputPath, fileio.SaveOptions{}, bytes.NewReader(imageBytes)); err != nil {
-		return "", common.WrapSaveErrorTyped(err)
-	}
-	resolvedPath, err := runtime.ResolveSavePath(outputPath)
-	if err != nil {
-		return "", errs.NewInternalError(errs.SubtypeFileIO, "resolve saved screenshot path %s: %v", outputPath, err).WithCause(err)
-	}
-	return resolvedPath, nil
 }
 
 func writeUniqueScreenshotPath(runtime *common.RuntimeContext, outputPath string, imageBytes []byte) (string, error) {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -51,11 +51,19 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "slide-number", Aliases: []string{"slide-numbers"}, Type: "int_array", Desc: "slide page number (repeat for multiple slides; max 10 pages per request)"},
 		{Name: "slide", Desc: "hidden alias routed to --slide-number for digits, otherwise --slide-id", Hidden: true},
 		{Name: "content", Desc: "slide XML content to render directly instead of fetching existing slides", Input: []string{common.File, common.Stdin}},
+		{Name: "output", Desc: "preferred relative output path for a single screenshot (extension optional; .png, .jpg, or .jpeg)"},
+		{Name: "overwrite", Type: "bool", Desc: "overwrite an existing file selected by --output"},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
-		{Name: "output-name", Desc: "file name stem for --content render output"},
+		{Name: "output-name", Desc: "legacy file name stem for --content render output; prefer --output for new calls"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		renderMode := runtime.Changed("content")
+		selectorCount := 1
+		if runtime.Changed("overwrite") && !runtime.Changed("output") {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overwrite requires --output").
+				WithParam("--overwrite").
+				WithHint("use --overwrite only with --output <file>")
+		}
 		if renderMode {
 			if strings.TrimSpace(runtime.Str("content")) == "" {
 				return slidesScreenshotFlagErrorf("--content cannot be empty")
@@ -83,12 +91,33 @@ var SlidesScreenshot = common.Shortcut{
 			if len(slideIDs) == 0 && len(slideNumbers) == 0 {
 				return slidesScreenshotMissingSelectorError()
 			}
-			if err := validateSlidesScreenshotSelectorLimit(len(slideIDs) + len(slideNumbers)); err != nil {
+			selectorCount = len(slideIDs) + len(slideNumbers)
+			if err := validateSlidesScreenshotSelectorLimit(selectorCount); err != nil {
 				return err
 			}
 		}
-		if _, err := validateScreenshotOutputDir(runtime, runtime.Str("output-dir")); err != nil {
-			return err
+		if runtime.Changed("output") {
+			if runtime.Changed("output-dir") {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output cannot be combined with --output-dir").WithParam("--output")
+			}
+			if runtime.Changed("output-name") {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output cannot be combined with --output-name").WithParam("--output")
+			}
+			if selectorCount != 1 {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output requires exactly one slide; use --output-dir for multiple screenshots").WithParam("--output")
+			}
+			if err := validateScreenshotOutputPath(runtime, runtime.Str("output")); err != nil {
+				return err
+			}
+		} else {
+			if !renderMode && runtime.Changed("output-name") {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output-name is only supported with --content").
+					WithParam("--output-name").
+					WithHint("use --output <file> for one existing slide, or --output-dir for multiple slides")
+			}
+			if _, err := validateScreenshotOutputDir(runtime, runtime.Str("output-dir")); err != nil {
+				return err
+			}
 		}
 		return nil
 	},
@@ -117,7 +146,11 @@ var SlidesScreenshot = common.Shortcut{
 				Desc("[1] Resolve wiki node to slides presentation").
 				Params(map[string]interface{}{"token": ref.Token})
 		} else {
-			dry.Desc(fmt.Sprintf("Fetch %d slide screenshot(s) and save files under %s", len(slideIDs)+len(slideNumbers), runtime.Str("output-dir")))
+			if outputPath := strings.TrimSpace(runtime.Str("output")); outputPath != "" {
+				dry.Desc(fmt.Sprintf("Fetch one slide screenshot and save it as %s", outputPath))
+			} else {
+				dry.Desc(fmt.Sprintf("Fetch %d slide screenshot(s) and save files under %s", len(slideIDs)+len(slideNumbers), runtime.Str("output-dir")))
+			}
 		}
 		body := map[string]interface{}{}
 		if len(slideIDs) > 0 {
@@ -131,7 +164,7 @@ var SlidesScreenshot = common.Shortcut{
 			validate.EncodePathSegment(presentationID),
 		)).
 			Body(body)
-		return dry.Set("output_dir", runtime.Str("output-dir")).Set("base64_output", "suppressed; decoded to local files during execution")
+		return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded to local files during execution")
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if runtime.Changed("content") {
@@ -156,8 +189,7 @@ var SlidesScreenshot = common.Shortcut{
 		if err := validateSlidesScreenshotSelectorLimit(len(slideIDs) + len(slideNumbers)); err != nil {
 			return err
 		}
-		outputDir := runtime.Str("output-dir")
-		safeOutputDir, err := ensureScreenshotOutputDir(runtime, outputDir)
+		outputTarget, err := resolveSlidesScreenshotOutputTarget(runtime)
 		if err != nil {
 			return err
 		}
@@ -179,15 +211,16 @@ var SlidesScreenshot = common.Shortcut{
 			return enrichSlidesScreenshotSelectorError(err, slideNumbers)
 		}
 
-		saved, err := saveSlideScreenshots(runtime, data, safeOutputDir, presentationID)
+		saved, err := saveSlideScreenshots(runtime, data, outputTarget.safeOutputDir, presentationID, outputTarget.requested, outputTarget.overwrite)
 		if err != nil {
 			return err
 		}
-		runtime.Out(map[string]interface{}{
+		result := map[string]interface{}{
 			"xml_presentation_id": presentationID,
-			"output_dir":          outputDir,
 			"screenshots":         saved,
-		}, nil)
+		}
+		setSlidesScreenshotResultOutput(result, outputTarget, saved)
+		runtime.Out(result, nil)
 		return nil
 	},
 }
@@ -208,7 +241,7 @@ func dryRunRenderScreenshot(runtime *common.RuntimeContext) *common.DryRunAPI {
 		Body(map[string]interface{}{
 			"content": fmt.Sprintf("<xml omitted; length=%d>", len(content)),
 		})
-	return dry.Set("output_dir", runtime.Str("output-dir")).Set("base64_output", "suppressed; decoded to local file during execution")
+	return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded to local file during execution")
 }
 
 func executeRenderScreenshot(runtime *common.RuntimeContext) error {
@@ -222,8 +255,7 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 	if runtime.Changed("presentation") {
 		return slidesScreenshotFlagErrorf("--presentation cannot be used with --content")
 	}
-	outputDir := runtime.Str("output-dir")
-	safeOutputDir, err := ensureScreenshotOutputDir(runtime, outputDir)
+	outputTarget, err := resolveSlidesScreenshotOutputTarget(runtime)
 	if err != nil {
 		return err
 	}
@@ -234,15 +266,68 @@ func executeRenderScreenshot(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	saved, err := saveRenderedSlideScreenshot(runtime, data, safeOutputDir, runtime.Str("output-name"))
+	saved, err := saveRenderedSlideScreenshot(runtime, data, outputTarget.safeOutputDir, runtime.Str("output-name"), outputTarget.requested, outputTarget.overwrite)
 	if err != nil {
 		return err
 	}
-	runtime.Out(map[string]interface{}{
-		"output_dir":  outputDir,
+	result := map[string]interface{}{
 		"screenshots": saved,
-	}, nil)
+	}
+	setSlidesScreenshotResultOutput(result, outputTarget, saved)
+	runtime.Out(result, nil)
 	return nil
+}
+
+func setSlidesScreenshotDryRunOutput(dry *common.DryRunAPI, runtime *common.RuntimeContext) *common.DryRunAPI {
+	if outputPath := strings.TrimSpace(runtime.Str("output")); outputPath != "" {
+		return dry.Set("output", outputPath)
+	}
+	return dry.Set("output_dir", runtime.Str("output-dir"))
+}
+
+type slidesScreenshotOutputTarget struct {
+	requested         string
+	requestedResolved string
+	outputDir         string
+	safeOutputDir     string
+	overwrite         bool
+}
+
+func resolveSlidesScreenshotOutputTarget(runtime *common.RuntimeContext) (slidesScreenshotOutputTarget, error) {
+	target := slidesScreenshotOutputTarget{
+		requested: strings.TrimSpace(runtime.Str("output")),
+		outputDir: runtime.Str("output-dir"),
+		overwrite: runtime.Bool("overwrite"),
+	}
+	if target.requested != "" {
+		resolved, err := runtime.ResolveSavePath(target.requested)
+		if err != nil {
+			return target, errs.NewValidationError(errs.SubtypeInvalidArgument, "--output invalid: %v", err).
+				WithParam("--output").
+				WithCause(err)
+		}
+		target.requestedResolved = resolved
+		return target, nil
+	}
+	safeOutputDir, err := ensureScreenshotOutputDir(runtime, target.outputDir)
+	if err != nil {
+		return target, err
+	}
+	target.safeOutputDir = safeOutputDir
+	return target, nil
+}
+
+func setSlidesScreenshotResultOutput(result map[string]interface{}, target slidesScreenshotOutputTarget, saved []map[string]interface{}) {
+	if target.requested != "" && len(saved) == 1 {
+		actualPath, _ := saved[0]["path"].(string)
+		result["output"] = actualPath
+		if filepath.Clean(target.requestedResolved) != filepath.Clean(actualPath) {
+			result["requested_output"] = target.requested
+			result["output_adjusted"] = true
+		}
+		return
+	}
+	result["output_dir"] = target.outputDir
 }
 
 func slidesScreenshotPresentation(runtime *common.RuntimeContext) string {
@@ -397,14 +482,48 @@ func validateScreenshotOutputDir(runtime *common.RuntimeContext, outputDir strin
 	return outputDir, nil
 }
 
+func validateScreenshotOutputPath(runtime *common.RuntimeContext, outputPath string) error {
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output cannot be empty").WithParam("--output")
+	}
+	if os.IsPathSeparator(outputPath[len(outputPath)-1]) {
+		return screenshotOutputDirectoryError(outputPath)
+	}
+	ext := strings.ToLower(filepath.Ext(outputPath))
+	if ext != "" && ext != ".png" && ext != ".jpg" && ext != ".jpeg" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output must have no extension or end with .png, .jpg, or .jpeg").WithParam("--output")
+	}
+	if _, err := runtime.ResolveSavePath(outputPath); err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output invalid: %v", err).WithParam("--output").WithCause(err)
+	}
+	if info, err := runtime.FileIO().Stat(outputPath); err == nil {
+		if info.IsDir() {
+			return screenshotOutputDirectoryError(outputPath)
+		}
+	} else if !isScreenshotFileNotExist(err) {
+		return errs.NewInternalError(errs.SubtypeFileIO, "inspect --output path %s: %v", outputPath, err).WithCause(err)
+	}
+	return nil
+}
+
+func screenshotOutputDirectoryError(outputPath string) error {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output expects a file path, got directory %q", outputPath).
+		WithParam("--output").
+		WithHint("use --output-dir <directory> for directory output")
+}
+
 func ensureScreenshotOutputDir(runtime *common.RuntimeContext, outputDir string) (string, error) {
 	return validateScreenshotOutputDir(runtime, outputDir)
 }
 
-func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, presentationID string) ([]map[string]interface{}, error) {
+func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, presentationID string, outputPath string, overwrite bool) ([]map[string]interface{}, error) {
 	items := common.GetSlice(data, "slide_images")
 	if len(items) == 0 {
 		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned no slide_images")
+	}
+	if outputPath != "" && len(items) != 1 {
+		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned %d slide_images for single --output", len(items))
 	}
 	saved := make([]map[string]interface{}, 0, len(items))
 	for i, item := range items {
@@ -412,7 +531,7 @@ func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interf
 		if !ok {
 			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide_images[%d]", i)
 		}
-		item, err := saveSlideScreenshotImage(runtime, m, outputDir, slideScreenshotListFileBase(presentationID, m, i), "")
+		item, err := saveSlideScreenshotImage(runtime, m, outputDir, slideScreenshotListFileBase(presentationID, m, i), "", outputPath, overwrite)
 		if err != nil {
 			if isSlidesScreenshotPassthroughError(err) {
 				return nil, err
@@ -424,12 +543,12 @@ func saveSlideScreenshots(runtime *common.RuntimeContext, data map[string]interf
 	return saved, nil
 }
 
-func saveRenderedSlideScreenshot(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, outputName string) ([]map[string]interface{}, error) {
+func saveRenderedSlideScreenshot(runtime *common.RuntimeContext, data map[string]interface{}, outputDir string, outputName string, outputPath string, overwrite bool) ([]map[string]interface{}, error) {
 	item := common.GetMap(data, "slide_image")
 	if item == nil {
 		return nil, slidesScreenshotAPIDataError(data, "slides render screenshot returned no slide_image")
 	}
-	saved, err := saveSlideScreenshotImage(runtime, item, outputDir, outputName, "rendered-slide")
+	saved, err := saveSlideScreenshotImage(runtime, item, outputDir, outputName, "rendered-slide", outputPath, overwrite)
 	if err != nil {
 		if isSlidesScreenshotPassthroughError(err) {
 			return nil, err
@@ -439,7 +558,7 @@ func saveRenderedSlideScreenshot(runtime *common.RuntimeContext, data map[string
 	return []map[string]interface{}{saved}, nil
 }
 
-func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]interface{}, outputDir string, outputName string, fallbackName string) (map[string]interface{}, error) {
+func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]interface{}, outputDir string, outputName string, fallbackName string, outputPath string, overwrite bool) (map[string]interface{}, error) {
 	slideID := strings.TrimSpace(common.GetString(item, "slide_id"))
 	ext, label, err := slideScreenshotFormat(item)
 	if err != nil {
@@ -453,14 +572,19 @@ func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]in
 	if err != nil {
 		return nil, slidesScreenshotImageDataCauseError(slideID, err, "decode screenshot: %s", err)
 	}
-	fileBase := strings.TrimSpace(outputName)
-	if fileBase == "" {
-		fileBase = slideID
+	var path string
+	if outputPath != "" {
+		path, err = writeScreenshotOutputPath(runtime, slideScreenshotOutputPathForFormat(outputPath, ext), imageBytes, overwrite)
+	} else {
+		fileBase := strings.TrimSpace(outputName)
+		if fileBase == "" {
+			fileBase = slideID
+		}
+		if fileBase == "" {
+			fileBase = fallbackName
+		}
+		path, err = writeUniqueScreenshotFile(runtime, outputDir, fileBase, ext, imageBytes)
 	}
-	if fileBase == "" {
-		fileBase = fallbackName
-	}
-	path, err := writeUniqueScreenshotFile(runtime, outputDir, fileBase, ext, imageBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -471,6 +595,25 @@ func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]in
 		"path":         path,
 		"size":         len(imageBytes),
 	}, nil
+}
+
+func slideScreenshotOutputExtMatches(outputExt string, responseExt string) bool {
+	outputExt = strings.ToLower(outputExt)
+	if responseExt == "jpg" {
+		return outputExt == ".jpg" || outputExt == ".jpeg"
+	}
+	return outputExt == "."+responseExt
+}
+
+func slideScreenshotOutputPathForFormat(outputPath string, responseExt string) string {
+	outputExt := filepath.Ext(outputPath)
+	if outputExt == "" {
+		return outputPath + "." + responseExt
+	}
+	if slideScreenshotOutputExtMatches(outputExt, responseExt) {
+		return outputPath
+	}
+	return strings.TrimSuffix(outputPath, outputExt) + "." + responseExt
 }
 
 func slideScreenshotListFileBase(presentationID string, item map[string]interface{}, index int) string {
@@ -625,28 +768,55 @@ func safeScreenshotFileBase(base string) string {
 
 func writeUniqueScreenshotFile(runtime *common.RuntimeContext, outputDir string, fileBase string, ext string, imageBytes []byte) (string, error) {
 	base := safeScreenshotFileBase(fileBase)
-	for i := 0; i < 1000; i++ {
-		candidateBase := base
-		if i > 0 {
-			candidateBase = fmt.Sprintf("%s_%d", base, i+1)
+	return writeUniqueScreenshotPath(runtime, filepath.Join(outputDir, base+"."+ext), imageBytes)
+}
+
+func writeScreenshotOutputPath(runtime *common.RuntimeContext, outputPath string, imageBytes []byte, overwrite bool) (string, error) {
+	if info, err := runtime.FileIO().Stat(outputPath); err == nil {
+		if info.IsDir() {
+			return "", screenshotOutputDirectoryError(outputPath)
 		}
-		path := filepath.Join(outputDir, candidateBase+"."+ext)
-		if _, err := runtime.FileIO().Stat(path); err == nil {
+		if !overwrite {
+			return "", errs.NewValidationError(errs.SubtypeFailedPrecondition, "output file already exists: %s", outputPath).
+				WithParam("--output").
+				WithHint("add --overwrite to replace the existing file")
+		}
+	} else if !isScreenshotFileNotExist(err) {
+		return "", errs.NewInternalError(errs.SubtypeFileIO, "inspect screenshot output %s: %v", outputPath, err).WithCause(err)
+	}
+	if _, err := runtime.FileIO().Save(outputPath, fileio.SaveOptions{}, bytes.NewReader(imageBytes)); err != nil {
+		return "", common.WrapSaveErrorTyped(err)
+	}
+	resolvedPath, err := runtime.ResolveSavePath(outputPath)
+	if err != nil {
+		return "", errs.NewInternalError(errs.SubtypeFileIO, "resolve saved screenshot path %s: %v", outputPath, err).WithCause(err)
+	}
+	return resolvedPath, nil
+}
+
+func writeUniqueScreenshotPath(runtime *common.RuntimeContext, outputPath string, imageBytes []byte) (string, error) {
+	ext := filepath.Ext(outputPath)
+	base := strings.TrimSuffix(outputPath, ext)
+	for i := 0; i < 1000; i++ {
+		candidate := outputPath
+		if i > 0 {
+			candidate = fmt.Sprintf("%s_%d%s", base, i+1, ext)
+		}
+		if _, err := runtime.FileIO().Stat(candidate); err == nil {
 			continue
 		} else if !isScreenshotFileNotExist(err) {
-			return "", errs.NewInternalError(errs.SubtypeFileIO, "write screenshot %s: %v", path, err).WithCause(err)
+			return "", errs.NewInternalError(errs.SubtypeFileIO, "write screenshot %s: %v", candidate, err).WithCause(err)
 		}
-		if _, err := runtime.FileIO().Save(path, fileio.SaveOptions{}, bytes.NewReader(imageBytes)); err != nil {
+		if _, err := runtime.FileIO().Save(candidate, fileio.SaveOptions{}, bytes.NewReader(imageBytes)); err != nil {
 			return "", common.WrapSaveErrorTyped(err)
 		}
-		resolvedPath, err := runtime.ResolveSavePath(path)
+		resolvedPath, err := runtime.ResolveSavePath(candidate)
 		if err != nil {
-			return "", errs.NewInternalError(errs.SubtypeFileIO, "resolve saved screenshot path %s: %v", path, err).WithCause(err)
+			return "", errs.NewInternalError(errs.SubtypeFileIO, "resolve saved screenshot path %s: %v", candidate, err).WithCause(err)
 		}
 		return resolvedPath, nil
 	}
-	path := filepath.Join(outputDir, base+"."+ext)
-	return "", errs.NewInternalError(errs.SubtypeFileIO, "write screenshot %s: too many duplicate file names", path)
+	return "", errs.NewInternalError(errs.SubtypeFileIO, "write screenshot %s: too many duplicate file names", outputPath)
 }
 
 func isScreenshotFileNotExist(err error) bool {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -53,7 +53,7 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "content", Desc: "slide XML content to render directly instead of fetching existing slides", Input: []string{common.File, common.Stdin}},
 		{Name: "output", Desc: "preferred relative output path for a single screenshot (extension optional; .png, .jpg, or .jpeg)"},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
-		{Name: "output-name", Desc: "legacy file name stem for --content render output; prefer --output for new calls"},
+		{Name: "output-name", Desc: "file name stem for --content render output"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		renderMode := runtime.Changed("content")

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -469,6 +469,497 @@ func TestSlidesScreenshotListBySlideNumber(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotOutputWritesRequestedSingleListPath(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+
+	imageBytes := []byte("jpeg-bytes")
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_images": []map[string]interface{}{
+					{
+						"slide_number": 2,
+						"format":       2,
+						"data":         base64.StdEncoding.EncodeToString(imageBytes),
+					},
+				},
+			},
+		},
+	})
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "2",
+		"--output", "shots/cover.jpeg",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join(dir, "shots", "cover.jpeg")
+	gotBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read requested output: %v", err)
+	}
+	if string(gotBytes) != string(imageBytes) {
+		t.Fatalf("written bytes = %q, want %q", gotBytes, imageBytes)
+	}
+
+	data := decodeShortcutData(t, stdout)
+	items, ok := data["screenshots"].([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("screenshots = %#v, want one item", data["screenshots"])
+	}
+	item, _ := items[0].(map[string]interface{})
+	gotPath := item["path"].(string)
+	if !filepath.IsAbs(gotPath) || !strings.HasSuffix(gotPath, filepath.Join("shots", "cover.jpeg")) {
+		t.Fatalf("path = %q, want absolute path ending in shots/cover.jpeg", gotPath)
+	}
+	if got := data["output"]; got != gotPath {
+		t.Fatalf("output = %v, want actual path %q", got, gotPath)
+	}
+	if _, ok := data["requested_output"]; ok {
+		t.Fatalf("requested_output must be omitted when the requested path is unchanged: %#v", data)
+	}
+	if _, ok := data["output_adjusted"]; ok {
+		t.Fatalf("output_adjusted must be omitted when the requested path is unchanged: %#v", data)
+	}
+	if _, ok := data["output_dir"]; ok {
+		t.Fatalf("output_dir must be omitted when --output is used: %#v", data)
+	}
+}
+
+func TestSlidesScreenshotOutputRejectsMultipleSelectors(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1,2",
+		"--output", "shots/cover.jpg",
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %#v, want validation/invalid_argument", problem)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--output" {
+		t.Fatalf("error = %#v, want --output validation error", err)
+	}
+	if !strings.Contains(err.Error(), "exactly one slide") {
+		t.Fatalf("error = %v, want single-slide guidance", err)
+	}
+}
+
+func TestSlidesScreenshotOutputRejectsConflictingNamingFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "output-dir",
+			args: []string{"--presentation", "pres_abc", "--slide-number", "1", "--output", "cover.jpg", "--output-dir", "shots"},
+		},
+		{
+			name: "output-name",
+			args: []string{"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`, "--output", "cover.png", "--output-name", "preview"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			args := append([]string{"+screenshot"}, tt.args...)
+			args = append(args, "--as", "user")
+			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) || validationErr.Param != "--output" {
+				t.Fatalf("error = %#v, want --output validation error", err)
+			}
+			if !strings.Contains(err.Error(), "cannot be combined") {
+				t.Fatalf("error = %v, want naming flag conflict", err)
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotOutputRejectsInvalidPath(t *testing.T) {
+	tests := []struct {
+		name            string
+		output          string
+		createDirectory bool
+		wantDirHint     bool
+	}{
+		{name: "unsupported extension", output: "shots/cover.gif"},
+		{name: "path escapes working directory", output: "../cover.jpg"},
+		{name: "directory suffix", output: "shots/", wantDirHint: true},
+		{name: "existing directory", output: "shots", createDirectory: true, wantDirHint: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			withSlidesTestWorkingDir(t, dir)
+			if tt.createDirectory {
+				if err := os.MkdirAll(filepath.Join(dir, tt.output), 0o755); err != nil {
+					t.Fatalf("create output directory: %v", err)
+				}
+			}
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+				"+screenshot",
+				"--presentation", "pres_abc",
+				"--slide-number", "1",
+				"--output", tt.output,
+				"--as", "user",
+			})
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem = %#v, want validation/invalid_argument", problem)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) || validationErr.Param != "--output" {
+				t.Fatalf("error = %#v, want --output validation error", err)
+			}
+			if tt.wantDirHint && !strings.Contains(validationErr.Hint, "--output-dir") {
+				t.Fatalf("hint = %q, want --output-dir guidance", validationErr.Hint)
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotOutputAdjustsExtensionToResponseFormat(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_images": []map[string]interface{}{
+					{
+						"slide_number": 1,
+						"format":       2,
+						"data":         base64.StdEncoding.EncodeToString([]byte("jpeg-bytes")),
+					},
+				},
+			},
+		},
+	})
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1",
+		"--output", "shots/cover.png",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	actualPath := filepath.Join(dir, "shots", "cover.jpg")
+	if got, readErr := os.ReadFile(actualPath); readErr != nil || string(got) != "jpeg-bytes" {
+		t.Fatalf("adjusted output = %q, err=%v", got, readErr)
+	}
+	actualPath = canonicalSlidesScreenshotTestPath(t, actualPath)
+	if _, statErr := os.Stat(filepath.Join(dir, "shots", "cover.png")); !os.IsNotExist(statErr) {
+		t.Fatalf("requested .png path unexpectedly exists, stat error = %v", statErr)
+	}
+	data := decodeShortcutData(t, stdout)
+	if got := data["requested_output"]; got != "shots/cover.png" {
+		t.Fatalf("requested_output = %v, want shots/cover.png", got)
+	}
+	if got := data["output"]; got != actualPath {
+		t.Fatalf("output = %v, want %q", got, actualPath)
+	}
+	if got := data["output_adjusted"]; got != true {
+		t.Fatalf("output_adjusted = %v, want true", got)
+	}
+}
+
+func TestSlidesScreenshotOutputAppendsResponseExtensionWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_images": []map[string]interface{}{{
+					"slide_number": 1,
+					"format":       1,
+					"data":         base64.StdEncoding.EncodeToString([]byte("png-bytes")),
+				}},
+			},
+		},
+	})
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1",
+		"--output", "shots/cover",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	actualPath := filepath.Join(dir, "shots", "cover.png")
+	if got, readErr := os.ReadFile(actualPath); readErr != nil || string(got) != "png-bytes" {
+		t.Fatalf("output = %q, err=%v", got, readErr)
+	}
+	actualPath = canonicalSlidesScreenshotTestPath(t, actualPath)
+	data := decodeShortcutData(t, stdout)
+	if data["requested_output"] != "shots/cover" || data["output"] != actualPath || data["output_adjusted"] != true {
+		t.Fatalf("adjusted output metadata = %#v", data)
+	}
+}
+
+func TestSlidesScreenshotOutputRejectsExistingPathWithoutOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "shots"), 0o755); err != nil {
+		t.Fatalf("create output dir: %v", err)
+	}
+	existingPath := filepath.Join(dir, "shots", "cover.jpg")
+	if err := os.WriteFile(existingPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_images": []map[string]interface{}{
+					{
+						"slide_number": 1,
+						"format":       2,
+						"data":         base64.StdEncoding.EncodeToString([]byte("new-jpeg")),
+					},
+				},
+			},
+		},
+	})
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1",
+		"--output", "shots/cover.jpg",
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected existing output error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("problem = %#v, want validation/failed_precondition", problem)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--output" {
+		t.Fatalf("error = %#v, want --output validation error", err)
+	}
+	if !strings.Contains(validationErr.Hint, "--overwrite") {
+		t.Fatalf("hint = %q, want --overwrite guidance", validationErr.Hint)
+	}
+	if got, err := os.ReadFile(existingPath); err != nil || string(got) != "existing" {
+		t.Fatalf("existing output = %q, err=%v", got, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "shots", "cover_2.jpg")); !os.IsNotExist(statErr) {
+		t.Fatalf("unexpected deduplicated output, stat error = %v", statErr)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no success envelope", stdout.String())
+	}
+}
+
+func TestSlidesScreenshotOutputOverwriteReplacesExistingPath(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "shots"), 0o755); err != nil {
+		t.Fatalf("create output dir: %v", err)
+	}
+	existingPath := filepath.Join(dir, "shots", "cover.jpg")
+	if err := os.WriteFile(existingPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_images": []map[string]interface{}{{
+					"slide_number": 1,
+					"format":       2,
+					"data":         base64.StdEncoding.EncodeToString([]byte("new-jpeg")),
+				}},
+			},
+		},
+	})
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1",
+		"--output", "shots/cover.jpg",
+		"--overwrite",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, err := os.ReadFile(existingPath); err != nil || string(got) != "new-jpeg" {
+		t.Fatalf("overwritten output = %q, err=%v", got, err)
+	}
+	data := decodeShortcutData(t, stdout)
+	wantPath := canonicalSlidesScreenshotTestPath(t, existingPath)
+	if data["output"] != wantPath {
+		t.Fatalf("output = %v, want %q", data["output"], wantPath)
+	}
+	if _, ok := data["output_adjusted"]; ok {
+		t.Fatalf("output_adjusted must be omitted for an exact overwrite: %#v", data)
+	}
+	if _, ok := data["requested_output"]; ok {
+		t.Fatalf("requested_output must be omitted for an exact overwrite: %#v", data)
+	}
+}
+
+func TestSlidesScreenshotOverwriteRequiresOutput(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1",
+		"--overwrite",
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %#v, want validation/invalid_argument", problem)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--overwrite" {
+		t.Fatalf("error = %#v, want --overwrite validation error", err)
+	}
+}
+
+func TestSetSlidesScreenshotResultOutputUsesPreResolvedRequestedPath(t *testing.T) {
+	result := map[string]interface{}{}
+	target := slidesScreenshotOutputTarget{
+		requested:         "shots/cover.png",
+		requestedResolved: filepath.Join(string(filepath.Separator), "work", "shots", "cover.png"),
+	}
+	actualPath := filepath.Join(string(filepath.Separator), "work", "shots", "cover.jpg")
+	setSlidesScreenshotResultOutput(result, target, []map[string]interface{}{{"path": actualPath}})
+
+	if result["output"] != actualPath || result["requested_output"] != target.requested || result["output_adjusted"] != true {
+		t.Fatalf("result = %#v, want adjustment metadata from pre-resolved requested path", result)
+	}
+}
+
+func canonicalSlidesScreenshotTestPath(t *testing.T, path string) string {
+	t.Helper()
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("canonicalize %s: %v", path, err)
+	}
+	return canonical
+}
+
+func TestSlidesScreenshotOutputNameRejectsListMode(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1",
+		"--output-name", "cover",
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %#v, want validation/invalid_argument", problem)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--output-name" {
+		t.Fatalf("error = %#v, want --output-name validation error", err)
+	}
+	if !strings.Contains(err.Error(), "--output") {
+		t.Fatalf("error = %v, want migration guidance", err)
+	}
+}
+
+func TestSlidesScreenshotOutputRejectsMultipleResponseImagesBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_images": []map[string]interface{}{
+					{"slide_number": 1, "format": 2, "data": base64.StdEncoding.EncodeToString([]byte("one"))},
+					{"slide_number": 2, "format": 2, "data": base64.StdEncoding.EncodeToString([]byte("two"))},
+				},
+			},
+		},
+	})
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "1",
+		"--output", "shots/cover.jpg",
+		"--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected invalid response error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("problem = %#v, want api/invalid_response", problem)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "shots", "cover.jpg")); !os.IsNotExist(statErr) {
+		t.Fatalf("output file exists after multi-image response, stat error = %v", statErr)
+	}
+}
+
 func TestSlidesScreenshotListBySlideIDCSV(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	dir := t.TempDir()
@@ -835,6 +1326,40 @@ func TestSlidesScreenshotRenderContentWritesFile(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotOutputWritesRequestedRenderPath(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+
+	imageBytes := []byte("rendered-png")
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/slides_ai/v1/slide_image/render",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"slide_image": map[string]interface{}{
+					"format": 1,
+					"data":   base64.StdEncoding.EncodeToString(imageBytes),
+				},
+			},
+		},
+	})
+
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+		"--output", "shots/preview.png",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(dir, "shots", "preview.png")); err != nil || string(got) != string(imageBytes) {
+		t.Fatalf("render output = %q, err=%v", got, err)
+	}
+}
+
 func TestSlidesScreenshotRenderRejectsSlideSelectors(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 
@@ -974,6 +1499,27 @@ func TestSlidesScreenshotDryRunSelectsListOrRenderAPI(t *testing.T) {
 			t.Fatalf("dry-run missing base64 suppression note: %s", out)
 		}
 	})
+}
+
+func TestSlidesScreenshotDryRunReportsRequestedOutput(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot",
+		"--presentation", "pres_abc",
+		"--slide-number", "2",
+		"--output", "shots/cover.jpg",
+		"--dry-run",
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"output": "shots/cover.jpg"`) {
+		t.Fatalf("dry-run output = %s, want requested output path", stdout.String())
+	}
+	if strings.Contains(stdout.String(), `"output_dir"`) {
+		t.Fatalf("dry-run output = %s, output_dir must be omitted with --output", stdout.String())
+	}
 }
 
 func TestSlidesScreenshotRejectsBadOutputDir(t *testing.T) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -589,6 +589,10 @@ func TestSlidesScreenshotOutputRejectsConflictingNamingFlags(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected validation error")
 			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem = %#v, want validation/invalid_argument", problem)
+			}
 			var validationErr *errs.ValidationError
 			if !errors.As(err, &validationErr) || validationErr.Param != "--output" {
 				t.Fatalf("error = %#v, want --output validation error", err)

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -221,6 +221,10 @@ func TestSlidesScreenshotAttributesMixedSelectorAliasesToCallerInput(t *testing.
 			if err == nil {
 				t.Fatal("expected validation error")
 			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("problem = %#v, want validation/invalid_argument", problem)
+			}
 			var validationErr *errs.ValidationError
 			if !errors.As(err, &validationErr) {
 				t.Fatalf("error type = %T, want *errs.ValidationError", err)
@@ -607,6 +611,8 @@ func TestSlidesScreenshotOutputRejectsInvalidPath(t *testing.T) {
 		{name: "path escapes working directory", output: "../cover.jpg"},
 		{name: "directory suffix", output: "shots/", wantDirHint: true},
 		{name: "existing directory", output: "shots", createDirectory: true, wantDirHint: true},
+		{name: "leading whitespace", output: " shots/cover.png"},
+		{name: "trailing whitespace", output: "shots/cover.png "},
 	}
 
 	for _, tt := range tests {
@@ -737,7 +743,7 @@ func TestSlidesScreenshotOutputAppendsResponseExtensionWhenMissing(t *testing.T)
 	}
 }
 
-func TestSlidesScreenshotOutputRejectsExistingPathWithoutOverwrite(t *testing.T) {
+func TestSlidesScreenshotOutputAvoidsExistingPath(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
 	if err := os.MkdirAll(filepath.Join(dir, "shots"), 0o755); err != nil {
@@ -773,38 +779,30 @@ func TestSlidesScreenshotOutputRejectsExistingPathWithoutOverwrite(t *testing.T)
 		"--output", "shots/cover.jpg",
 		"--as", "user",
 	})
-	if err == nil {
-		t.Fatal("expected existing output error")
-	}
-	problem, ok := errs.ProblemOf(err)
-	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeFailedPrecondition {
-		t.Fatalf("problem = %#v, want validation/failed_precondition", problem)
-	}
-	var validationErr *errs.ValidationError
-	if !errors.As(err, &validationErr) || validationErr.Param != "--output" {
-		t.Fatalf("error = %#v, want --output validation error", err)
-	}
-	if !strings.Contains(validationErr.Hint, "--overwrite") {
-		t.Fatalf("hint = %q, want --overwrite guidance", validationErr.Hint)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if got, err := os.ReadFile(existingPath); err != nil || string(got) != "existing" {
 		t.Fatalf("existing output = %q, err=%v", got, err)
 	}
-	if _, statErr := os.Stat(filepath.Join(dir, "shots", "cover_2.jpg")); !os.IsNotExist(statErr) {
-		t.Fatalf("unexpected deduplicated output, stat error = %v", statErr)
+	actualPath := filepath.Join(dir, "shots", "cover_2.jpg")
+	if got, readErr := os.ReadFile(actualPath); readErr != nil || string(got) != "new-jpeg" {
+		t.Fatalf("deduplicated output = %q, err=%v", got, readErr)
 	}
-	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %q, want no success envelope", stdout.String())
+	actualPath = canonicalSlidesScreenshotTestPath(t, actualPath)
+	data := decodeShortcutData(t, stdout)
+	if data["requested_output"] != "shots/cover.jpg" || data["output"] != actualPath || data["output_adjusted"] != true {
+		t.Fatalf("adjusted output metadata = %#v", data)
 	}
 }
 
-func TestSlidesScreenshotOutputOverwriteReplacesExistingPath(t *testing.T) {
+func TestSlidesScreenshotOutputAdjustsFormatBeforeAvoidingExistingPath(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
 	if err := os.MkdirAll(filepath.Join(dir, "shots"), 0o755); err != nil {
 		t.Fatalf("create output dir: %v", err)
 	}
-	existingPath := filepath.Join(dir, "shots", "cover.jpg")
+	existingPath := filepath.Join(dir, "shots", "cover.png")
 	if err := os.WriteFile(existingPath, []byte("existing"), 0o644); err != nil {
 		t.Fatalf("write existing output: %v", err)
 	}
@@ -818,8 +816,8 @@ func TestSlidesScreenshotOutputOverwriteReplacesExistingPath(t *testing.T) {
 			"data": map[string]interface{}{
 				"slide_images": []map[string]interface{}{{
 					"slide_number": 1,
-					"format":       2,
-					"data":         base64.StdEncoding.EncodeToString([]byte("new-jpeg")),
+					"format":       1,
+					"data":         base64.StdEncoding.EncodeToString([]byte("new-png")),
 				}},
 			},
 		},
@@ -830,47 +828,22 @@ func TestSlidesScreenshotOutputOverwriteReplacesExistingPath(t *testing.T) {
 		"--presentation", "pres_abc",
 		"--slide-number", "1",
 		"--output", "shots/cover.jpg",
-		"--overwrite",
 		"--as", "user",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got, err := os.ReadFile(existingPath); err != nil || string(got) != "new-jpeg" {
-		t.Fatalf("overwritten output = %q, err=%v", got, err)
+	if got, err := os.ReadFile(existingPath); err != nil || string(got) != "existing" {
+		t.Fatalf("existing output = %q, err=%v", got, err)
 	}
+	actualPath := filepath.Join(dir, "shots", "cover_2.png")
+	if got, readErr := os.ReadFile(actualPath); readErr != nil || string(got) != "new-png" {
+		t.Fatalf("deduplicated output = %q, err=%v", got, readErr)
+	}
+	actualPath = canonicalSlidesScreenshotTestPath(t, actualPath)
 	data := decodeShortcutData(t, stdout)
-	wantPath := canonicalSlidesScreenshotTestPath(t, existingPath)
-	if data["output"] != wantPath {
-		t.Fatalf("output = %v, want %q", data["output"], wantPath)
-	}
-	if _, ok := data["output_adjusted"]; ok {
-		t.Fatalf("output_adjusted must be omitted for an exact overwrite: %#v", data)
-	}
-	if _, ok := data["requested_output"]; ok {
-		t.Fatalf("requested_output must be omitted for an exact overwrite: %#v", data)
-	}
-}
-
-func TestSlidesScreenshotOverwriteRequiresOutput(t *testing.T) {
-	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
-		"+screenshot",
-		"--presentation", "pres_abc",
-		"--slide-number", "1",
-		"--overwrite",
-		"--as", "user",
-	})
-	if err == nil {
-		t.Fatal("expected validation error")
-	}
-	problem, ok := errs.ProblemOf(err)
-	if !ok || problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
-		t.Fatalf("problem = %#v, want validation/invalid_argument", problem)
-	}
-	var validationErr *errs.ValidationError
-	if !errors.As(err, &validationErr) || validationErr.Param != "--overwrite" {
-		t.Fatalf("error = %#v, want --overwrite validation error", err)
+	if data["requested_output"] != "shots/cover.jpg" || data["output"] != actualPath || data["output_adjusted"] != true {
+		t.Fatalf("adjusted output metadata = %#v", data)
 	}
 }
 
@@ -1349,14 +1322,23 @@ func TestSlidesScreenshotOutputWritesRequestedRenderPath(t *testing.T) {
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 		"+screenshot",
 		"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
-		"--output", "shots/preview.png",
+		"--output", "shots/preview.jpg",
 		"--as", "user",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got, err := os.ReadFile(filepath.Join(dir, "shots", "preview.png")); err != nil || string(got) != string(imageBytes) {
+	actualPath := filepath.Join(dir, "shots", "preview.png")
+	if got, err := os.ReadFile(actualPath); err != nil || string(got) != string(imageBytes) {
 		t.Fatalf("render output = %q, err=%v", got, err)
+	}
+	actualPath = canonicalSlidesScreenshotTestPath(t, actualPath)
+	data := decodeShortcutData(t, stdout)
+	if data["requested_output"] != "shots/preview.jpg" || data["output"] != actualPath || data["output_adjusted"] != true {
+		t.Fatalf("adjusted render output metadata = %#v", data)
+	}
+	if _, ok := data["output_dir"]; ok {
+		t.Fatalf("output_dir must be omitted with --output: %#v", data)
 	}
 }
 
@@ -1485,6 +1467,7 @@ func TestSlidesScreenshotDryRunSelectsListOrRenderAPI(t *testing.T) {
 		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
 			"+screenshot",
 			"--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>`,
+			"--output", "shots/preview.png",
 			"--dry-run",
 			"--as", "user",
 		})
@@ -1497,6 +1480,12 @@ func TestSlidesScreenshotDryRunSelectsListOrRenderAPI(t *testing.T) {
 		}
 		if !strings.Contains(out, "base64_output") {
 			t.Fatalf("dry-run missing base64 suppression note: %s", out)
+		}
+		if !strings.Contains(out, `"output": "shots/preview.png"`) {
+			t.Fatalf("dry-run missing requested output: %s", out)
+		}
+		if strings.Contains(out, `"output_dir"`) {
+			t.Fatalf("dry-run output_dir must be omitted with --output: %s", out)
 		}
 	})
 }

--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -87,7 +87,7 @@ metadata:
 | 删除页面 | 按 `slide_id` 单页删除，删前先回读确认 | `slides +delete-slide`、`lark-slides-delete-slide.md` |
 | 读取或分析已有 PPT | 解析 slides/wiki token，用 shortcut 回读全文 XML 或读取单页 XML，保存 `xml_presentation_id`、`slide_id`、`revision_id` | `slides +xml-get`、`xml_presentation.slide.get`、`lark-slides-xml-presentations-get.md` |
 | 查看或回滚历史版本 | 先用 `+history-list` 找 `history_version_id`，再 `+history-revert`，必要时 `+history-revert-status` 轮询 | [`lark-slides-history.md`](references/lark-slides-history.md) |
-| 获取幻灯片页面截图 | 按页码用 `--slide-number`，按 ID 用 `--slide-id`；单张用 `--output`，批量或全量用 `--output-dir`，每批最多 10 页串行执行；后续读取返回的实际路径 | `slides +screenshot`、`lark-slides-screenshot.md` |
+| 获取幻灯片页面截图 | 按页码用 `--slide-number`，按 ID 用 `--slide-id`；单张用 `--output`，批量或全量用 `--output-dir`，每批最多 10 页串行执行；截图目录复用同一任务的 deck/task 标识，后续读取返回的实际路径 | `slides +screenshot`、`lark-slides-screenshot.md` |
 | 上传或使用图片 | 先上传为 `file_token`，禁止直接写 http(s) 外链 | `slides +media-upload`、`lark-slides-media-upload.md`，或 `+create --slides` 的 XML 里写 `<img src="@./path">` 占位符 |
 | 绘制图表 | 原生图表（柱状、条形、折线、面积、饼（环）、雷达、组合图）用 `<chart>`，其他（漏斗图、金字塔图、象限图、矩阵图等）用 `<shape>` + `<line>` 模拟 | `xml-schema-quick-ref.md`、`slides_chart_demo.xml` |
 | 绘制表格 | 优先用 `rect` 和 `text` 模拟，其他用 `<table>` | `xml-schema-quick-ref.md` |
@@ -287,7 +287,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 | [`+add-slide`](references/lark-slides-add-slide.md) | 向已有演示文稿追加或插入**一页**（`--before-slide-id` 控制位置），XML 支持 `@file` / stdin，`<img src="@./path">` 占位符自动上传 |
 | [`+delete-slide`](references/lark-slides-delete-slide.md) | 按 `slide_id` 删除**一页** |
 | [`+xml-get`](references/lark-slides-xml-presentations-get.md) | 读取全文 XML，用 `--presentation` 指定演示文稿的 `xml_presentation_id`，用 `--output` 把 XML 存到本地文件（必须是 CWD 内的相对路径，如 `.lark-slides/plan/<deck>/readback.xml`） |
-| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；用 `--slide-number` 指定页码（从 1 开始，多页重复传入）或用 `--slide-id` 指定页面；单张用 `--output path/name.png`，批量用 `--output-dir`（路径必须在 CWD 内，一次最多 10 页）；后续必须读取返回的 `output` / `screenshots[].path` |
+| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；用 `--slide-number` 指定页码（从 1 开始，多页重复传入）或用 `--slide-id` 指定页面；单张用 `--output .lark-slides/screenshots/<deck-or-task-id>/page-01`，批量用 `--output-dir .lark-slides/screenshots/<deck-or-task-id>`（一次最多 10 页）；后续必须读取返回的 `output` / `screenshots[].path` |
 | [`+media-upload`](references/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |
 | [`+replace-slide`](references/lark-slides-replace-slide.md) | 对已有幻灯片页面进行块级替换/插入（`block_replace` / `block_insert`），自动注入 id 和 `<content/>`，不改变页序 |
 | [`+replace-pages`](references/lark-slides-replace-pages.md) | 在原演示文稿内重建一页或多页：先创建新页到旧页前，再删除旧页；适合已有 Slides 的整页大改，不新建链接 |

--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -287,7 +287,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 | [`+add-slide`](references/lark-slides-add-slide.md) | 向已有演示文稿追加或插入**一页**（`--before-slide-id` 控制位置），XML 支持 `@file` / stdin，`<img src="@./path">` 占位符自动上传 |
 | [`+delete-slide`](references/lark-slides-delete-slide.md) | 按 `slide_id` 删除**一页** |
 | [`+xml-get`](references/lark-slides-xml-presentations-get.md) | 读取全文 XML，用 `--presentation` 指定演示文稿的 `xml_presentation_id`，用 `--output` 把 XML 存到本地文件（必须是 CWD 内的相对路径，如 `.lark-slides/plan/<deck>/readback.xml`） |
-| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；单张用 `--output path/name.png`，批量用 `--output-dir`（路径必须在 CWD 内，一次最多 10 页）；单张同名文件默认报错，明确传 `--overwrite` 才覆盖；格式修正可能改变最终路径，后续必须读取返回的 `output` / `screenshots[].path` |
+| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；单张用 `--output path/name.png`，批量用 `--output-dir`（路径必须在 CWD 内，一次最多 10 页）；CLI 先按真实格式修正扩展名，再用 `_2`、`_3` 避免同名覆盖；后续必须读取返回的 `output` / `screenshots[].path` |
 | [`+media-upload`](references/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |
 | [`+replace-slide`](references/lark-slides-replace-slide.md) | 对已有幻灯片页面进行块级替换/插入（`block_replace` / `block_insert`），自动注入 id 和 `<content/>`，不改变页序 |
 | [`+replace-pages`](references/lark-slides-replace-pages.md) | 在原演示文稿内重建一页或多页：先创建新页到旧页前，再删除旧页；适合已有 Slides 的整页大改，不新建链接 |

--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -287,7 +287,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 | [`+add-slide`](references/lark-slides-add-slide.md) | 向已有演示文稿追加或插入**一页**（`--before-slide-id` 控制位置），XML 支持 `@file` / stdin，`<img src="@./path">` 占位符自动上传 |
 | [`+delete-slide`](references/lark-slides-delete-slide.md) | 按 `slide_id` 删除**一页** |
 | [`+xml-get`](references/lark-slides-xml-presentations-get.md) | 读取全文 XML，用 `--presentation` 指定演示文稿的 `xml_presentation_id`，用 `--output` 把 XML 存到本地文件（必须是 CWD 内的相对路径，如 `.lark-slides/plan/<deck>/readback.xml`） |
-| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；单张用 `--output path/name.png`，批量用 `--output-dir`（路径必须在 CWD 内，一次最多 10 页）；CLI 先按真实格式修正扩展名，再用 `_2`、`_3` 避免同名覆盖；后续必须读取返回的 `output` / `screenshots[].path` |
+| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；用 `--slide-number` 指定页码（从 1 开始，多页重复传入）或用 `--slide-id` 指定页面；单张用 `--output path/name.png`，批量用 `--output-dir`（路径必须在 CWD 内，一次最多 10 页）；后续必须读取返回的 `output` / `screenshots[].path` |
 | [`+media-upload`](references/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |
 | [`+replace-slide`](references/lark-slides-replace-slide.md) | 对已有幻灯片页面进行块级替换/插入（`block_replace` / `block_insert`），自动注入 id 和 `<content/>`，不改变页序 |
 | [`+replace-pages`](references/lark-slides-replace-pages.md) | 在原演示文稿内重建一页或多页：先创建新页到旧页前，再删除旧页；适合已有 Slides 的整页大改，不新建链接 |

--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -87,7 +87,7 @@ metadata:
 | 删除页面 | 按 `slide_id` 单页删除，删前先回读确认 | `slides +delete-slide`、`lark-slides-delete-slide.md` |
 | 读取或分析已有 PPT | 解析 slides/wiki token，用 shortcut 回读全文 XML 或读取单页 XML，保存 `xml_presentation_id`、`slide_id`、`revision_id` | `slides +xml-get`、`xml_presentation.slide.get`、`lark-slides-xml-presentations-get.md` |
 | 查看或回滚历史版本 | 先用 `+history-list` 找 `history_version_id`，再 `+history-revert`，必要时 `+history-revert-status` 轮询 | [`lark-slides-history.md`](references/lark-slides-history.md) |
-| 获取幻灯片页面截图 | 指定页面直接截图；全量截图枚举全部页面 ID 或页码，再按每批最多 10 页串行执行 | `slides +screenshot`、`lark-slides-screenshot.md` |
+| 获取幻灯片页面截图 | 按页码用 `--slide-number`，按 ID 用 `--slide-id`；单张用 `--output`，批量或全量用 `--output-dir`，每批最多 10 页串行执行；后续读取返回的实际路径 | `slides +screenshot`、`lark-slides-screenshot.md` |
 | 上传或使用图片 | 先上传为 `file_token`，禁止直接写 http(s) 外链 | `slides +media-upload`、`lark-slides-media-upload.md`，或 `+create --slides` 的 XML 里写 `<img src="@./path">` 占位符 |
 | 绘制图表 | 原生图表（柱状、条形、折线、面积、饼（环）、雷达、组合图）用 `<chart>`，其他（漏斗图、金字塔图、象限图、矩阵图等）用 `<shape>` + `<line>` 模拟 | `xml-schema-quick-ref.md`、`slides_chart_demo.xml` |
 | 绘制表格 | 优先用 `rect` 和 `text` 模拟，其他用 `<table>` | `xml-schema-quick-ref.md` |
@@ -287,7 +287,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 | [`+add-slide`](references/lark-slides-add-slide.md) | 向已有演示文稿追加或插入**一页**（`--before-slide-id` 控制位置），XML 支持 `@file` / stdin，`<img src="@./path">` 占位符自动上传 |
 | [`+delete-slide`](references/lark-slides-delete-slide.md) | 按 `slide_id` 删除**一页** |
 | [`+xml-get`](references/lark-slides-xml-presentations-get.md) | 读取全文 XML，用 `--presentation` 指定演示文稿的 `xml_presentation_id`，用 `--output` 把 XML 存到本地文件（必须是 CWD 内的相对路径，如 `.lark-slides/plan/<deck>/readback.xml`） |
-| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片，用 `--slide-number` 指定页号（从 1 开始，多页重复传入，一次最多 10 页），用 `--output-dir` 指定保存目录（必须是 CWD 内的相对路径，默认 `.lark-slides/screenshots`），失败时降级到 XML 回读等非截图检查 |
+| [`+screenshot`](references/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；单张用 `--output path/name.png`，批量用 `--output-dir`（路径必须在 CWD 内，一次最多 10 页）；单张同名文件默认报错，明确传 `--overwrite` 才覆盖；格式修正可能改变最终路径，后续必须读取返回的 `output` / `screenshots[].path` |
 | [`+media-upload`](references/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |
 | [`+replace-slide`](references/lark-slides-replace-slide.md) | 对已有幻灯片页面进行块级替换/插入（`block_replace` / `block_insert`），自动注入 id 和 `<content/>`，不改变页序 |
 | [`+replace-pages`](references/lark-slides-replace-pages.md) | 在原演示文稿内重建一页或多页：先创建新页到旧页前，再删除旧页；适合已有 Slides 的整页大改，不新建链接 |

--- a/skills/lark-slides/references/lark-slides-screenshot.md
+++ b/skills/lark-slides/references/lark-slides-screenshot.md
@@ -45,7 +45,7 @@ lark-cli slides +screenshot --as user \
 lark-cli slides +screenshot --as user \
   --presentation slides_example_presentation_id \
   --slide-number 1 \
-  --output .lark-slides/screenshots/demo/cover.jpg
+  --output .lark-slides/screenshots/example-deck-task/page-01
 ```
 
 按 `slide_id` 选择单页时同样使用 `--output`：
@@ -54,7 +54,7 @@ lark-cli slides +screenshot --as user \
 lark-cli slides +screenshot --as user \
   --presentation slides_example_presentation_id \
   --slide-id slide_example_id \
-  --output .lark-slides/screenshots/demo/cover.jpg
+  --output .lark-slides/screenshots/example-deck-task/page-01
 ```
 
 ### 多页截图
@@ -66,7 +66,7 @@ lark-cli slides +screenshot --as user \
   --presentation slides_example_presentation_id \
   --slide-number 1 \
   --slide-number 2 \
-  --output-dir .lark-slides/screenshots/demo
+  --output-dir .lark-slides/screenshots/example-deck-task
 ```
 
 ### 渲染 XML 预览
@@ -74,7 +74,7 @@ lark-cli slides +screenshot --as user \
 ```bash
 lark-cli slides +screenshot --as user \
   --content @.lark-slides/out/demo/slide.xml \
-  --output .lark-slides/screenshots/demo/preview.png
+  --output .lark-slides/screenshots/example-deck-task/preview
 ```
 
 ## 返回值
@@ -87,13 +87,13 @@ lark-cli slides +screenshot --as user \
   "identity": "user",
   "data": {
     "xml_presentation_id": "slides_example_presentation_id",
-    "output": "/abs/path/.lark-slides/screenshots/demo/cover.jpg",
+    "output": "/abs/path/.lark-slides/screenshots/example-deck-task/page-01.jpg",
     "screenshots": [
       {
         "slide_id": "slide_example_id",
         "slide_number": 1,
         "format": "jpeg",
-        "path": "/abs/path/.lark-slides/screenshots/demo/cover.jpg",
+        "path": "/abs/path/.lark-slides/screenshots/example-deck-task/page-01.jpg",
         "size": 12345
       }
     ]
@@ -108,7 +108,7 @@ lark-cli slides +screenshot --as user \
 3. 本地 XML 预览时，传 `--content @file` 或 `--content -`，内容应为单个 `<slide>` XML 片段；此时不要传 `--presentation` / `--slide-id` / `--slide-number`。
 4. `slide_id` 是页面 short ID，页码请用 `--slide-number`。
 5. list 模式下 `--slide-id` 与 `--slide-number` 必须二选一；同一类型 selector 一次最多传 10 个，更多页面请分批截图。
-6. 单张且需要调用方统一路径和命名时使用 `--output`；多张时使用 `--output-dir`，由 CLI 按页面信息生成文件名。不要为批量截图循环传同一个 `--output`。
+6. 单张使用 `--output`，多张使用 `--output-dir`，由 CLI 按页面信息生成文件名。新建或大幅改写 Deck 时，截图目录复用 planning 阶段的 `<deck-or-task-id>`；已有 Deck 没有 task ID 时，使用 presentation ID 作为目录名。
 7. CLI 不转换图片格式，也不要求模型预判服务端格式。未写扩展名时自动追加真实扩展名；请求扩展名与真实格式不一致时保留目录和名称、修正扩展名，例如请求 `slide3.png` 而服务端返回 JPEG 时实际保存为 `slide3.jpg`。
 8. 发生扩展名修正或同名避让时会返回原始 `requested_output`、实际绝对路径 `output` 和 `output_adjusted: true`；后续必须使用 `output` / `screenshots[].path`，不要继续猜测请求路径。
 9. list 模式默认文件名包含 presentation ID、页码和/或 slide ID。

--- a/skills/lark-slides/references/lark-slides-screenshot.md
+++ b/skills/lark-slides/references/lark-slides-screenshot.md
@@ -34,7 +34,6 @@ lark-cli slides +screenshot --as user \
 | `--slide-number` | list 模式与 `--slide-id` 二选一 | 页面页号；不能与 `--slide-id` 同时使用；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-number 1,2,3`）；一次最多 10 个页码 |
 | `--content` | render 模式必需 | 要直接渲染的 `<slide>` XML 片段；支持直接传值、`@file`、`-` stdin。传入后不能同时传 `--slide-id` / `--slide-number` |
 | `--output` | 否 | 单张截图的期望相对输出路径，可不写扩展名，显式扩展名只支持 `.png`、`.jpg`、`.jpeg`。只能选择一页，不能与 `--output-dir` / `--output-name` 同时使用；最终路径以返回的 `output` 为准 |
-| `--overwrite` | 否 | 仅与 `--output` 一起使用；目标文件已存在时明确覆盖。未传该参数时返回错误，不会静默改名 |
 | `--output-dir` | 否 | 输出目录，默认 `.lark-slides/screenshots`；必须是当前目录内的相对路径 |
 | `--output-name` | 否 | 仅为旧版 `--content` render 调用保留的文件名 stem；新调用统一使用 `--output`。普通页面截图传入该参数会返回 `validation/invalid_argument`（`param: --output-name`）并提示改用 `--output` |
 
@@ -111,6 +110,6 @@ lark-cli slides +screenshot --as user \
 5. list 模式下 `--slide-id` 与 `--slide-number` 必须二选一；同一类型 selector 一次最多传 10 个，更多页面请分批截图。
 6. 单张且需要调用方统一路径和命名时使用 `--output`；多张时使用 `--output-dir`，由 CLI 按页面信息生成文件名。不要为批量截图循环传同一个 `--output`。
 7. CLI 不转换图片格式，也不要求模型预判服务端格式。未写扩展名时自动追加真实扩展名；请求扩展名与真实格式不一致时保留目录和名称、修正扩展名，例如请求 `slide3.png` 而服务端返回 JPEG 时实际保存为 `slide3.jpg`。
-8. 使用 `--output` 时，目标文件已存在会返回 `validation/failed_precondition`，需要明确传 `--overwrite` 才会替换；CLI 不会静默改成 `_2`。批量 `--output-dir` 和旧版自动命名仍会追加 `_2`、`_3` 避免覆盖。服务端图片格式导致扩展名修正时会返回 `requested_output` 和 `output_adjusted: true`；后续必须使用 `output` / `screenshots[].path` 中的实际绝对路径。
+8. 发生扩展名修正或同名避让时会返回原始 `requested_output`、实际绝对路径 `output` 和 `output_adjusted: true`；后续必须使用 `output` / `screenshots[].path`，不要继续猜测请求路径。
 9. list 模式默认文件名包含 presentation ID、页码和/或 slide ID。
 10. 截图来自服务端渲染结果，适合创建/替换后验证页面是否为空白、破图或布局明显异常。

--- a/skills/lark-slides/references/lark-slides-screenshot.md
+++ b/skills/lark-slides/references/lark-slides-screenshot.md
@@ -35,7 +35,7 @@ lark-cli slides +screenshot --as user \
 | `--content` | render 模式必需 | 要直接渲染的 `<slide>` XML 片段；支持直接传值、`@file`、`-` stdin。传入后不能同时传 `--slide-id` / `--slide-number` |
 | `--output` | 否 | 单张截图的期望相对输出路径，可不写扩展名，显式扩展名只支持 `.png`、`.jpg`、`.jpeg`。只能选择一页，不能与 `--output-dir` / `--output-name` 同时使用；最终路径以返回的 `output` 为准 |
 | `--output-dir` | 否 | 输出目录，默认 `.lark-slides/screenshots`；必须是当前目录内的相对路径 |
-| `--output-name` | 否 | 仅为旧版 `--content` render 调用保留的文件名 stem；新调用统一使用 `--output`。普通页面截图传入该参数会返回 `validation/invalid_argument`（`param: --output-name`）并提示改用 `--output` |
+| `--output-name` | 否 | 仅用于 `--content` render 模式设置输出文件名 stem。普通页面截图传入该参数会返回 `validation/invalid_argument`（`param: --output-name`）并提示改用 `--output` |
 
 ## 示例
 

--- a/skills/lark-slides/references/lark-slides-screenshot.md
+++ b/skills/lark-slides/references/lark-slides-screenshot.md
@@ -33,17 +33,29 @@ lark-cli slides +screenshot --as user \
 | `--slide-id` | list 模式与 `--slide-number` 二选一 | 页面 short ID；不能与 `--slide-number` 同时使用；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-id slide_1,slide_2`）；一次最多 10 个 ID |
 | `--slide-number` | list 模式与 `--slide-id` 二选一 | 页面页号；不能与 `--slide-id` 同时使用；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-number 1,2,3`）；一次最多 10 个页码 |
 | `--content` | render 模式必需 | 要直接渲染的 `<slide>` XML 片段；支持直接传值、`@file`、`-` stdin。传入后不能同时传 `--slide-id` / `--slide-number` |
+| `--output` | 否 | 单张截图的期望相对输出路径，可不写扩展名，显式扩展名只支持 `.png`、`.jpg`、`.jpeg`。只能选择一页，不能与 `--output-dir` / `--output-name` 同时使用；最终路径以返回的 `output` 为准 |
+| `--overwrite` | 否 | 仅与 `--output` 一起使用；目标文件已存在时明确覆盖。未传该参数时返回错误，不会静默改名 |
 | `--output-dir` | 否 | 输出目录，默认 `.lark-slides/screenshots`；必须是当前目录内的相对路径 |
-| `--output-name` | 否 | render 模式的输出文件名 stem；未指定时优先用返回的 `slide_id`，否则用 `rendered-slide`。若目标文件已存在，会自动追加递增后缀避免覆盖 |
+| `--output-name` | 否 | 仅为旧版 `--content` render 调用保留的文件名 stem；新调用统一使用 `--output`。普通页面截图传入该参数会返回 `validation/invalid_argument`（`param: --output-name`）并提示改用 `--output` |
 
 ## 示例
 
-### 单页截图
+### 单页截图并固定路径
 
 ```bash
 lark-cli slides +screenshot --as user \
   --presentation slides_example_presentation_id \
-  --slide-number 1
+  --slide-number 1 \
+  --output .lark-slides/screenshots/demo/cover.jpg
+```
+
+按 `slide_id` 选择单页时同样使用 `--output`：
+
+```bash
+lark-cli slides +screenshot --as user \
+  --presentation slides_example_presentation_id \
+  --slide-id slide_example_id \
+  --output .lark-slides/screenshots/demo/cover.jpg
 ```
 
 ### 多页截图
@@ -63,7 +75,7 @@ lark-cli slides +screenshot --as user \
 ```bash
 lark-cli slides +screenshot --as user \
   --content @.lark-slides/out/demo/slide.xml \
-  --output-name preview
+  --output .lark-slides/screenshots/demo/preview.png
 ```
 
 ## 返回值
@@ -76,13 +88,13 @@ lark-cli slides +screenshot --as user \
   "identity": "user",
   "data": {
     "xml_presentation_id": "slides_example_presentation_id",
-    "output_dir": ".lark-slides/screenshots",
+    "output": "/abs/path/.lark-slides/screenshots/demo/cover.jpg",
     "screenshots": [
       {
         "slide_id": "slide_example_id",
         "slide_number": 1,
-        "format": "png",
-        "path": "/abs/path/.lark-slides/screenshots/slides_example_presentation_id_p001_slide_example_id.png",
+        "format": "jpeg",
+        "path": "/abs/path/.lark-slides/screenshots/demo/cover.jpg",
         "size": 12345
       }
     ]
@@ -97,5 +109,8 @@ lark-cli slides +screenshot --as user \
 3. 本地 XML 预览时，传 `--content @file` 或 `--content -`，内容应为单个 `<slide>` XML 片段；此时不要传 `--presentation` / `--slide-id` / `--slide-number`。
 4. `slide_id` 是页面 short ID，页码请用 `--slide-number`。
 5. list 模式下 `--slide-id` 与 `--slide-number` 必须二选一；同一类型 selector 一次最多传 10 个，更多页面请分批截图。
-6. list 模式默认文件名包含 presentation ID、页码和/或 slide ID；文件已存在时自动追加 `_2`、`_3` 等后缀，避免覆盖旧截图。
-7. 截图来自服务端渲染结果，适合创建/替换后验证页面是否为空白、破图或布局明显异常。
+6. 单张且需要调用方统一路径和命名时使用 `--output`；多张时使用 `--output-dir`，由 CLI 按页面信息生成文件名。不要为批量截图循环传同一个 `--output`。
+7. CLI 不转换图片格式，也不要求模型预判服务端格式。未写扩展名时自动追加真实扩展名；请求扩展名与真实格式不一致时保留目录和名称、修正扩展名，例如请求 `slide3.png` 而服务端返回 JPEG 时实际保存为 `slide3.jpg`。
+8. 使用 `--output` 时，目标文件已存在会返回 `validation/failed_precondition`，需要明确传 `--overwrite` 才会替换；CLI 不会静默改成 `_2`。批量 `--output-dir` 和旧版自动命名仍会追加 `_2`、`_3` 避免覆盖。服务端图片格式导致扩展名修正时会返回 `requested_output` 和 `output_adjusted: true`；后续必须使用 `output` / `screenshots[].path` 中的实际绝对路径。
+9. list 模式默认文件名包含 presentation ID、页码和/或 slide ID。
+10. 截图来自服务端渲染结果，适合创建/替换后验证页面是否为空白、破图或布局明显异常。

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -96,6 +96,37 @@ func TestSlidesScreenshotRejectsEmptySlideIDWithSlideNumberDryRunE2E(t *testing.
 	require.Empty(t, result.Stdout)
 }
 
+func TestSlidesScreenshotOutputDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation", "presScreenshotOutput",
+			"--slide-number", "3",
+			"--output", "./slide3.png",
+			"--overwrite",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, "./slide3.png", gjson.Get(result.Stdout, "data.output").String(), result.Stdout)
+	require.False(t, gjson.Get(result.Stdout, "data.output_dir").Exists(), result.Stdout)
+	require.Equal(t, "POST", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
+	require.Equal(t,
+		"/open-apis/slides_ai/v1/xml_presentations/presScreenshotOutput/slide_images",
+		gjson.Get(result.Stdout, "data.api.0.url").String(),
+		result.Stdout,
+	)
+	require.Equal(t, int64(3), gjson.Get(result.Stdout, "data.api.0.body.slide_numbers.0").Int(), result.Stdout)
+}
+
 func TestSlidesScreenshotAliasesDryRunE2E(t *testing.T) {
 	setSlidesDryRunEnv(t)
 

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -108,7 +108,6 @@ func TestSlidesScreenshotOutputDryRunE2E(t *testing.T) {
 			"--presentation", "presScreenshotOutput",
 			"--slide-number", "3",
 			"--output", "./slide3.png",
-			"--overwrite",
 			"--dry-run",
 		},
 		DefaultAs: "bot",

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -106,6 +106,47 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 	require.Equal(t, info.Size(), screenshots[0].Get("size").Int(), "stdout:\n%s", screenshotResult.Stdout)
 	require.False(t, screenshots[0].Get("data").Exists(), "stdout must not expose screenshot payload: %s", screenshotResult.Stdout)
 	require.NotContains(t, screenshotResult.Stdout, "data:image/", "stdout must not expose screenshot payload")
+
+	requestedExt := ".png"
+	if format == "png" {
+		requestedExt = ".jpg"
+	}
+	requestedOutput := filepath.Join("fixed", "cover"+requestedExt)
+	fixedOutputResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation", presentationID,
+			"--slide-id", slideID,
+			"--output", requestedOutput,
+		},
+		DefaultAs: "bot",
+		WorkDir:   workDir,
+	})
+	require.NoError(t, err)
+	fixedOutputResult.AssertExitCode(t, 0)
+	fixedOutputResult.AssertStdoutStatus(t, true)
+
+	actualFormat := gjson.Get(fixedOutputResult.Stdout, "data.screenshots.0.format").String()
+	wantExt := ".png"
+	if actualFormat == "jpeg" {
+		wantExt = ".jpg"
+	}
+	wantOutput := filepath.Join(workDir, "fixed", "cover"+wantExt)
+	wantOutput, err = filepath.EvalSymlinks(wantOutput)
+	require.NoError(t, err)
+	require.Equal(t, wantOutput, gjson.Get(fixedOutputResult.Stdout, "data.output").String(), fixedOutputResult.Stdout)
+	require.False(t, gjson.Get(fixedOutputResult.Stdout, "data.output_dir").Exists(), fixedOutputResult.Stdout)
+	require.Equal(t, wantOutput, gjson.Get(fixedOutputResult.Stdout, "data.screenshots.0.path").String(), fixedOutputResult.Stdout)
+	if requestedExt != wantExt {
+		require.Equal(t, requestedOutput, gjson.Get(fixedOutputResult.Stdout, "data.requested_output").String(), fixedOutputResult.Stdout)
+		require.True(t, gjson.Get(fixedOutputResult.Stdout, "data.output_adjusted").Bool(), fixedOutputResult.Stdout)
+	}
+	fixedImageFile, err := vfs.Open(wantOutput)
+	require.NoError(t, err)
+	defer fixedImageFile.Close()
+	_, decodedFormat, err := image.DecodeConfig(fixedImageFile)
+	require.NoError(t, err)
+	require.Equal(t, actualFormat, decodedFormat, fixedOutputResult.Stdout)
 }
 
 func requireScreenshotPathUnderDir(t *testing.T, path, dir string) {

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -132,7 +132,7 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 		wantExt = ".jpg"
 	}
 	wantOutput := filepath.Join(workDir, "fixed", "cover"+wantExt)
-	wantOutput, err = filepath.EvalSymlinks(wantOutput)
+	wantOutput, err = vfs.EvalSymlinks(wantOutput)
 	require.NoError(t, err)
 	require.Equal(t, wantOutput, gjson.Get(fixedOutputResult.Stdout, "data.output").String(), fixedOutputResult.Stdout)
 	require.False(t, gjson.Get(fixedOutputResult.Stdout, "data.output_dir").Exists(), fixedOutputResult.Stdout)


### PR DESCRIPTION
## Summary

Add AI-friendly `--output` support to `slides +screenshot`, aligning single-image screenshots with other file-producing shortcuts while preserving the server-returned image format and avoiding normal name collisions.

## Changes

- Add `--output <file>` for exactly one screenshot in both existing-slide and XML render modes.
- Reconcile `.png`, `.jpg`, and `.jpeg` extensions with the actual server response format before choosing the final path.
- When the final path exists, save as `_2`, `_3`, and so on.
- Return the original `requested_output`, actual absolute `output`, and `output_adjusted: true` whenever extension reconciliation or conflict avoidance changes the path.
- Reject directory-like paths, leading/trailing whitespace, unsafe paths, and unsupported extensions before the API request.
- Keep batch `--output-dir` output on the same conflict-avoidance naming rule.
- Resolve the requested output path before the network request and reuse it when producing result metadata.
- Update the Slides Skill, technical plan, unit tests, dry-run E2E, and live workflow coverage; no `--overwrite` flag is introduced.

## Test Plan

- [x] `GOTOOLCHAIN=go1.23.0 make build`
- [x] `GOTOOLCHAIN=go1.23.0 make unit-test`
- [x] `GOTOOLCHAIN=go1.23.0 make vet`
- [x] `GOTOOLCHAIN=go1.23.0 make fmt-check`
- [x] `GOTOOLCHAIN=go1.23.0 go mod tidy` produces no changes
- [x] Incremental golangci-lint reports 0 issues
- [x] Slides dry-run E2E tests pass
- [x] Local CLI help and embedded Skill content expose the new contract

## Related Issues

- Follow-up to #2156



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save a single slide screenshot to a specific file with `--output`.
  * Continue saving multiple screenshots to a directory with `--output-dir`.
  * Automatically adjust extensions to match the selected image format.
  * Report actual output paths in command results and dry-run previews.

* **Bug Fixes**
  * Added safeguards for invalid paths, conflicting options, overwrites, and incompatible selectors.
  * Improved naming and collision handling.

* **Documentation**
  * Updated screenshot guidance and examples for file and directory output modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->