### PR TITLE
feat(slides): inline slides reference docs into help output

### DIFF
--- a/affordance/slides.md
+++ b/affordance/slides.md
@@ -1,0 +1,85 @@
+# slides
+> skill: lark-slides
+
+## Skills
+- lark-slides/references/xml/xml-schema-quick-ref.md
+
+## +create
+
+### Skills
+- lark-slides/references/cli/lark-slides-create.md
+
+## +add-slide
+
+### Skills
+- lark-slides/references/cli/lark-slides-add-slide.md
+
+## +delete-slide
+
+### Skills
+- lark-slides/references/cli/lark-slides-delete-slide.md
+
+## +xml-get
+
+### Skills
+- lark-slides/references/cli/lark-slides-xml-presentations-get.md
+
+## +screenshot
+
+### Skills
+- lark-slides/references/cli/lark-slides-screenshot.md
+
+## +media-upload
+
+### Skills
+- lark-slides/references/cli/lark-slides-media-upload.md
+
+## +replace-slide
+
+### Skills
+- lark-slides/references/cli/lark-slides-replace-slide.md
+- lark-slides/references/workflow/slides-editing.md
+- lark-slides/references/xml/xml-schema-quick-ref.md
+
+## +update-slide
+
+### Skills
+- lark-slides/references/cli/lark-slides-update-slide.md
+- lark-slides/references/workflow/slides-editing.md
+- lark-slides/references/xml/xml-schema-quick-ref.md
+
+## +update
+Hidden alias of [[+update-slide]]; kept so the shorter spelling resolves.
+
+### Skills
+- lark-slides/references/cli/lark-slides-update-slide.md
+- lark-slides/references/workflow/slides-editing.md
+- lark-slides/references/xml/xml-schema-quick-ref.md
+
+## +replace-pages
+
+### Skills
+- lark-slides/references/cli/lark-slides-update-slide.md
+- lark-slides/references/workflow/slides-editing.md
+- lark-slides/references/xml/xml-schema-quick-ref.md
+
+## +history-list
+
+### Skills
+- lark-slides/references/cli/lark-slides-history.md
+
+## +history-revert
+
+### Prerequisites
+- `history_version_id` from [[+history-list]]
+
+### Skills
+- lark-slides/references/cli/lark-slides-history.md
+
+## +history-revert-status
+
+### Prerequisites
+- `task_id` from [[+history-revert]]
+
+### Skills
+- lark-slides/references/cli/lark-slides-history.md

--- a/internal/affordance/slides_source_test.go
+++ b/internal/affordance/slides_source_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package affordance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/meta"
+)
+
+// slidesShortcutReferences is the audit table of every Slides shortcut and the
+// skill reference paths its `### Skills` block must route to. Migrated from the
+// former hardcoded slidesShortcutReferencePaths map in cmd/service, with the
+// paths corrected to the current cli/, xml/, and workflow/ subdirectories.
+var slidesDomainReferences = []string{
+	"lark-slides/references/xml/xml-schema-quick-ref.md",
+}
+
+var slidesShortcutReferences = map[string][]string{
+	"+create":                {"lark-slides/references/cli/lark-slides-create.md"},
+	"+add-slide":             {"lark-slides/references/cli/lark-slides-add-slide.md"},
+	"+delete-slide":          {"lark-slides/references/cli/lark-slides-delete-slide.md"},
+	"+xml-get":               {"lark-slides/references/cli/lark-slides-xml-presentations-get.md"},
+	"+screenshot":            {"lark-slides/references/cli/lark-slides-screenshot.md"},
+	"+media-upload":          {"lark-slides/references/cli/lark-slides-media-upload.md"},
+	"+history-list":          {"lark-slides/references/cli/lark-slides-history.md"},
+	"+history-revert":        {"lark-slides/references/cli/lark-slides-history.md"},
+	"+history-revert-status": {"lark-slides/references/cli/lark-slides-history.md"},
+	"+replace-slide": {
+		"lark-slides/references/cli/lark-slides-replace-slide.md",
+		"lark-slides/references/workflow/slides-editing.md",
+		"lark-slides/references/xml/xml-schema-quick-ref.md",
+	},
+	"+update-slide": {
+		"lark-slides/references/cli/lark-slides-update-slide.md",
+		"lark-slides/references/workflow/slides-editing.md",
+		"lark-slides/references/xml/xml-schema-quick-ref.md",
+	},
+	// +update is the hidden alias of +update-slide; keep its routes in sync.
+	"+update": {
+		"lark-slides/references/cli/lark-slides-update-slide.md",
+		"lark-slides/references/workflow/slides-editing.md",
+		"lark-slides/references/xml/xml-schema-quick-ref.md",
+	},
+	// +replace-pages is deprecated in favor of +update-slide, so it routes to
+	// the replacement's docs.
+	"+replace-pages": {
+		"lark-slides/references/cli/lark-slides-update-slide.md",
+		"lark-slides/references/workflow/slides-editing.md",
+		"lark-slides/references/xml/xml-schema-quick-ref.md",
+	},
+}
+
+func TestSlidesAffordanceReferenceRoutes(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	if got, ok := DomainSkill("slides"); !ok || got != "lark-slides" {
+		t.Fatalf("DomainSkill(slides) = (%q, %v), want (lark-slides, true)", got, ok)
+	}
+	if got, ok := DomainSkills("slides"); !ok {
+		t.Fatal("DomainSkills(slides) ok=false")
+	} else {
+		for _, ref := range append([]string{"lark-slides"}, slidesDomainReferences...) {
+			if !containsExact(got, ref) {
+				t.Fatalf("DomainSkills(slides) = %v, want %q", got, ref)
+			}
+		}
+	}
+
+	affordanceSource, err := os.ReadFile("../../affordance/slides.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedDomain := parseDomainMD(affordanceSource, commandFormResolver("slides"))
+	if got, want := len(parsedDomain.methods), len(slidesShortcutReferences); got != want {
+		t.Fatalf("parsed Slides affordance entries = %d, audited refs = %d", got, want)
+	}
+	for command := range parsedDomain.methods {
+		if _, ok := slidesShortcutReferences[command]; !ok {
+			t.Errorf("Slides affordance entry %s bypasses the skill-source audit table", command)
+		}
+	}
+
+	for command, refs := range slidesShortcutReferences {
+		t.Run(command, func(t *testing.T) {
+			raw, ok := For("slides", command)
+			if !ok {
+				t.Fatalf("For(slides, %s) ok=false", command)
+			}
+			a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+			if !ok {
+				t.Fatalf("slides %s affordance did not parse", command)
+			}
+			// The domain skill is prepended by mergeSkills; each mapped
+			// reference path must follow it.
+			if !containsExact(a.Skills, "lark-slides") {
+				t.Fatalf("slides %s skills = %v, missing domain skill", command, a.Skills)
+			}
+			for _, ref := range refs {
+				if !containsExact(a.Skills, ref) {
+					t.Fatalf("slides %s skills = %v, want %q", command, a.Skills, ref)
+				}
+			}
+		})
+	}
+}
+
+// TestSlidesAffordanceReferencePathsResolveToRealDocs pins the exact invariant
+// this migration fixed: every reference path must resolve to a live document,
+// not a moved-away compatibility stub. The former hardcoded map pointed at the
+// flat references/*.md paths that are now redirect stubs (references/cli/,
+// references/xml/, references/workflow/ hold the real docs), so a stub target
+// would silently route agents to a "本文档已迁移" placeholder.
+func TestSlidesAffordanceReferencePathsResolveToRealDocs(t *testing.T) {
+	skillsRoot := filepath.Join("..", "..", "skills")
+	seen := map[string]bool{}
+	for _, ref := range append([]string{"lark-slides"}, slidesDomainReferences...) {
+		seen[ref] = true
+		data, err := os.ReadFile(filepath.Join(skillsRoot, SkillStatPath(ref)))
+		if err != nil {
+			t.Errorf("domain help references missing file %q: %v", ref, err)
+			continue
+		}
+		if strings.HasSuffix(ref, ".md") &&
+			(strings.Contains(string(data), "兼容入口") || strings.Contains(string(data), "本文档已迁移")) {
+			t.Errorf("domain help references compatibility stub %q; point at the migrated doc instead", ref)
+		}
+	}
+	for command, refs := range slidesShortcutReferences {
+		for _, ref := range refs {
+			if seen[ref] {
+				continue
+			}
+			seen[ref] = true
+			data, err := os.ReadFile(filepath.Join(skillsRoot, SkillStatPath(ref)))
+			if err != nil {
+				t.Errorf("shortcut %q references missing file %q: %v", command, ref, err)
+				continue
+			}
+			if strings.Contains(string(data), "兼容入口") || strings.Contains(string(data), "本文档已迁移") {
+				t.Errorf("shortcut %q references compatibility stub %q; point at the migrated doc instead", command, ref)
+			}
+		}
+	}
+}

--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -38,7 +38,7 @@ metadata:
 - `<td>` 直接子元素只有 `<fill>`（背景）、`<content>`（文字）和边框配置（一般不用），不能嵌套 `<shape>`、`<img>`、`<icon>`。
 - `<shape type="rect">` 只是形状不是容器，`<icon>`、`<img>`、`<shape type="text">` 和其他 `<shape>` 必须与它平级靠坐标叠放。
 - 填充渐变颜色必须用 `<fill><fillColor color="linear-gradient(135deg, rgba(R,G,B,A) 0%, rgba(R,G,B,A) 100%)"/></fill>`。
-- 编辑页面前必须阅读 [`workflow/slides_editing.md`](references/workflow/slides_editing.md)。
+- 编辑页面前必须阅读 [`workflow/slides-editing.md`](references/workflow/slides-editing.md)。
 - 绘制图表前必须阅读 [`xml/slides_chart_demo.xml`](references/xml/slides_chart_demo.xml)。
 - 当用户要求无损复述历史上下文时，必须无损复述以上权威经验、必读的技能文档（需要重新阅读）和易错元素语法（尤其是 `<table>` 和 `<chart>`）。
 
@@ -112,7 +112,7 @@ metadata:
 
 **CRITICAL — 创建前自检或失败排障时，MUST 按 [workflow/error-handling.md](references/workflow/error-handling.md) 检查 XML 转义、结构、shell 截断、图片 token、3350001 和布局风险。**
 
-**编辑已有幻灯片页面**：单个标题、文本块、图片或局部元素优先用 [`+replace-slide`](references/cli/lark-slides-replace-slide.md)（块级替换/插入，不动页序）；一页里改动很多（例如批量换字体）、要改背景、或要删掉若干元素时用 [`+update-slide`](references/lark-slides-update-slide.md) 整页覆盖（`slide_id` 和页序不变，但没写进 `--content` 的元素会被删除）；**多页大改就对每一页各跑一次 `+update-slide`**。选择 action 和完整读-改-写流程见 [`workflow/slides_editing.md`](references/workflow/slides_editing.md)。
+**编辑已有幻灯片页面**：单个标题、文本块、图片或局部元素优先用 [`+replace-slide`](references/cli/lark-slides-replace-slide.md)（块级替换/插入，不动页序）；一页里改动很多（例如批量换字体）、要改背景、或要删掉若干元素时用 [`+update-slide`](references/cli/lark-slides-update-slide.md) 整页覆盖（`slide_id` 和页序不变，但没写进 `--content` 的元素会被删除）；**多页大改就对每一页各跑一次 `+update-slide`**。选择 action 和完整读-改-写流程见 [`workflow/slides-editing.md`](references/workflow/slides-editing.md)。
 
 **用户要求使用模板**：按 [workflow/template-editing.md](references/workflow/template-editing.md) 处理。
 
@@ -151,7 +151,7 @@ lark-cli auth login --domain slides
 - 创建：[`cli/lark-slides-create.md`](references/cli/lark-slides-create.md)、[`cli/lark-slides-add-slide.md`](references/cli/lark-slides-add-slide.md)（逐页添加 / 给已有 PPT 追加页面）
 - 删除页面：[`cli/lark-slides-delete-slide.md`](references/cli/lark-slides-delete-slide.md)
 - 阅读：[`cli/lark-slides-xml-presentations-get.md`](references/cli/lark-slides-xml-presentations-get.md)
-- 编辑：[`workflow/slides_editing.md`](references/workflow/slides_editing.md)、[`cli/lark-slides-replace-slide.md`](references/cli/lark-slides-replace-slide.md)、[`lark-slides-update-slide.md`](references/lark-slides-update-slide.md)
+- 编辑：[`workflow/slides-editing.md`](references/workflow/slides-editing.md)、[`cli/lark-slides-replace-slide.md`](references/cli/lark-slides-replace-slide.md)、[`lark-slides-update-slide.md`](references/cli/lark-slides-update-slide.md)
 - 历史版本：[`cli/lark-slides-history.md`](references/cli/lark-slides-history.md)
 - 截图：[`cli/lark-slides-screenshot.md`](references/cli/lark-slides-screenshot.md)
 - 图片：[`cli/lark-slides-media-upload.md`](references/cli/lark-slides-media-upload.md)
@@ -290,7 +290,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 | [`+screenshot`](references/cli/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；用 `--slide-number` 指定页码（从 1 开始，多页重复传入）或用 `--slide-id` 指定页面；单张用 `--output .lark-slides/screenshots/<deck-or-task-id>/page-01`，批量用 `--output-dir .lark-slides/screenshots/<deck-or-task-id>`（一次最多 10 页）；后续必须读取返回的 `output` / `screenshots[].path` |
 | [`+media-upload`](references/cli/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |
 | [`+replace-slide`](references/cli/lark-slides-replace-slide.md) | 对已有幻灯片页面进行块级替换/插入（`block_replace` / `block_insert`），自动注入 id 和 `<content/>`，不改变页序 |
-| [`+update-slide`](references/lark-slides-update-slide.md) | 把一整页 XML 交给已有页面，页面变成 `--content` 描述的样子；能一次改样式/插入/删除/备注/背景，`slide_id` 和页序不变。**没写进 `--content` 的元素会被删除** |
+| [`+update-slide`](references/cli/lark-slides-update-slide.md) | 把一整页 XML 交给已有页面，页面变成 `--content` 描述的样子；能一次改样式/插入/删除/备注/背景，`slide_id` 和页序不变。**没写进 `--content` 的元素会被删除** |
 
 没有 Shortcut 覆盖时使用原生 API。高频资源：`slides +xml-get` 读取全文；`xml_presentation.slide.create/delete/get/replace` 管理单页。
 

--- a/skills/lark-slides/references/cli/lark-slides-replace-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-replace-slide.md
@@ -256,4 +256,4 @@ lark-cli slides +replace-slide --as user \
 - [xml_presentation.slide get](lark-slides-xml-presentation-slide-get.md) — 读原页拿 `block_id` / `revision_id`
 - [xml_presentation.slide replace](lark-slides-xml-presentation-slide-replace.md) — 底层 replace API 参考
 - [+media-upload](lark-slides-media-upload.md) — 上传图片拿 `file_token`
-- [slides_editing.md](../workflow/slides_editing.md) — 读-改-写闭环 + 决策树
+- [slides-editing.md](../workflow/slides-editing.md) — 读-改-写闭环 + 决策树

--- a/skills/lark-slides/references/cli/lark-slides-update-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-update-slide.md
@@ -88,7 +88,7 @@ lark-cli slides +update-slide --as user \
 
 ## 什么时候不要用它
 
-- **只改一个元素** → 用 [`+replace-slide`](cli/lark-slides-replace-slide.md)，一条 `block_replace` part 更省，也不用带上整页
+- **只改一个元素** → 用 [`+replace-slide`](lark-slides-replace-slide.md)，一条 `block_replace` part 更省，也不用带上整页
 - **要改多个页面** → 对每一页各跑一次本命令
 - **要新建页面** → `slides +create` 或 `xml_presentation.slide create`
 
@@ -109,7 +109,7 @@ lark-cli slides +xml-get --as user \
   --presentation "$PRES" --output readback.xml
 ```
 
-按当前已加载 `lark-slides/SKILL.md` 指向的 [validation-xml.md](workflow/validation-xml.md) 完成验证：核对总页数、目标页和关键元素（包括需要保留的 ID、文本、背景与备注），并对回读 XML 运行同一版式 lint；发现差异时先停止后续写入并重新基于最新版处理。
+按当前已加载 `lark-slides/SKILL.md` 指向的 [validation-xml.md](../workflow/validation-xml.md) 完成验证：核对总页数、目标页和关键元素（包括需要保留的 ID、文本、背景与备注），并对回读 XML 运行同一版式 lint；发现差异时先停止后续写入并重新基于最新版处理。
 
 ## 成功输出
 
@@ -141,6 +141,6 @@ lark-cli slides +xml-get --as user \
 | 现象 | 原因 | 解决 |
 |------|------|------|
 | 3350001，原因包含 `not found` | `--presentation` 不匹配，或 `--slide-id` 对应的页面已被删除 | 检查 `--presentation` 和 `--slide-id`，再用 `slides +xml-get` 回读当前页面 ID |
-| 3350001，其他 invalid param | `--content` 的 XML 结构有问题（如 `<shape>` 缺 `<content/>`、包含服务端不支持的元素） | 按 [error-handling.md](workflow/error-handling.md) 检查 `--content` 的 XML 结构 |
+| 3350001，其他 invalid param | `--content` 的 XML 结构有问题（如 `<shape>` 缺 `<content/>`、包含服务端不支持的元素） | 按 [error-handling.md](../workflow/error-handling.md) 检查 `--content` 的 XML 结构 |
 | 3350002 not found | `--revision-id` 传了不存在的版本号 | 用 `-1` 或真实存在的 `revision_id` |
 | 1061004 / 403 | 当前身份对这份 PPT 没有编辑权限 | 检查是否拥有 `slides:presentation:update` 或 `slides:presentation:write_only` scope；wiki 链接另需 `wiki:node:read`；`--as bot` 还要求该 bot 对目标 PPT 有编辑权限 |

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
@@ -107,4 +107,4 @@ lark-cli slides xml_presentation.slide get --as user --params '{
 - [slides +replace-slide](lark-slides-replace-slide.md) — 块级替换 shortcut（推荐）
 - [xml_presentation.slide replace](lark-slides-xml-presentation-slide-replace.md) — 底层 replace API 参考
 - [slides +xml-get](lark-slides-xml-presentations-get.md) — 读整个 PPT 并保存到本地文件
-- [slides_editing.md](../workflow/slides_editing.md) — 读-改-写闭环
+- [slides-editing.md](../workflow/slides-editing.md) — 读-改-写闭环

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-replace.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-replace.md
@@ -185,4 +185,4 @@ lark-cli slides xml_presentation.slide replace --as user --params '{
 - [slides +replace-slide](lark-slides-replace-slide.md) — 块级替换 shortcut（推荐，自动注入 id）
 - [xml_presentation.slide get](lark-slides-xml-presentation-slide-get.md) — 读原页拿 block short ID
 - [slides +media-upload](lark-slides-media-upload.md) — 上传图片拿 file_token
-- [slides_editing.md](../workflow/slides_editing.md) — 读-改-写闭环 + 决策树
+- [slides-editing.md](../workflow/slides-editing.md) — 读-改-写闭环 + 决策树

--- a/skills/lark-slides/references/lark-slides-edit-workflows.md
+++ b/skills/lark-slides/references/lark-slides-edit-workflows.md
@@ -1,5 +1,5 @@
 # 编辑已有 PPT：读-改-写闭环（兼容入口）
 
-本文档已迁移至 [`workflow/slides_editing.md`](workflow/slides_editing.md)。
+本文档已迁移至 [`workflow/slides-editing.md`](workflow/slides-editing.md)。
 
 此文件仅保留旧路径兼容性；后续引用请使用新路径。

--- a/skills/lark-slides/references/workflow/slides-editing.md
+++ b/skills/lark-slides/references/workflow/slides-editing.md
@@ -1,6 +1,6 @@
 # 编辑已有 PPT：读-改-写闭环
 
-局部编辑走 **shortcut [`+replace-slide`](../cli/lark-slides-replace-slide.md)**（块级替换 / 插入），配合 `xml_presentation.slide.get` 读原页拿 `block_id`。整页重建走 **[`+update-slide`](../lark-slides-update-slide.md)**，多页就每页各跑一次 —— 它原地覆盖并保留 `slide_id` 和页序；只有写进 `--content` 且带原 id 的元素才会保留元素 id，遗漏的元素会被删除。
+局部编辑走 **shortcut [`+replace-slide`](../cli/lark-slides-replace-slide.md)**（块级替换 / 插入），配合 `xml_presentation.slide.get` 读原页拿 `block_id`。整页重建走 **[`+update-slide`](../cli/lark-slides-update-slide.md)**，多页就每页各跑一次 —— 它原地覆盖并保留 `slide_id` 和页序；只有写进 `--content` 且带原 id 的元素才会保留元素 id，遗漏的元素会被删除。
 
 > 生成 XML 前**必读** [xml-schema-quick-ref.md](../xml/xml-schema-quick-ref.md)。
 
@@ -136,7 +136,7 @@ cat parts.json | lark-cli slides +replace-slide --as user --presentation "$PID" 
 ## 相关文档
 
 - [lark-slides-replace-slide.md](../cli/lark-slides-replace-slide.md) — +replace-slide shortcut 参数详情
-- [lark-slides-update-slide.md](../lark-slides-update-slide.md) — +update-slide shortcut 参数详情（整页覆盖）
+- [lark-slides-update-slide.md](../cli/lark-slides-update-slide.md) — +update-slide shortcut 参数详情（整页覆盖）
 - [lark-slides-xml-presentation-slide-get.md](../cli/lark-slides-xml-presentation-slide-get.md) — slide.get 参考（拿 `block_id` / `revision_id`）
 - [lark-slides-xml-presentation-slide-replace.md](../cli/lark-slides-xml-presentation-slide-replace.md) — 底层 replace API 参考（一般直接用 shortcut 即可）
 - [lark-slides-media-upload.md](../cli/lark-slides-media-upload.md) — 上传图片拿 file_token


### PR DESCRIPTION
## Summary

Move `lark-cli slides` help output from Go hardcoded blocks to declarative markdown in `affordance/slides.md`, using the new domain-level `## Skills` section and per-command `### Skills` blocks. This lets AI agents see actionable pointers to reference docs instead of searching blind.

## Changes

- **Domain help** (`slides --help`): the canonical `> skill: lark-slides` (SKILL.md) is shown first automatically; the `## Skills` domain section adds a pointer to `xml-schema-quick-ref.md` as a display-only extra entry.
- **Shortcut help** (`+create`, `+add-slide`, `+delete-slide`, `+xml-get`, `+screenshot`, `+media-upload`, `+replace-slide`, `+update-slide`, `+history-list`, `+history-revert`, `+history-revert-status`): each command's `### Skills` block routes to its matching reference doc, with paths corrected to the refactored subdirectory structure (`cli/`, `xml/`, `workflow/`).
- **Deprecated `+replace-pages` and hidden alias `+update`**: both route to the `+update-slide` replacement docs.
- **Dead code cleanup**: removed `appendSlidesDomainRoutingHints`, `slidesDocumentRoutes`, `slidesSkillReadPath`, and the `slidesSkillName`/`slidesXMLQuickReferencePath` constants from `cmd/service/affordance.go` (replaced by `writeDomainSkills`). Removed the stale `TestPrepareDomainHelp_SlidesIncludesDocumentRoutes` test.

## Test Plan

- [x] `./lark-cli slides --help` shows `Domain skills` with both SKILL.md and xml-quick-ref
- [x] All 12 shortcut `--help` outputs show correct `Related skills` entries with resolved paths
- [x] All reference paths in `affordance/slides.md` resolve to existing files (no stale flat paths)

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added slide-management capabilities for creating, adding, deleting, inspecting, updating, replacing, and screenshotting slides.
  - Added media upload, page replacement, and slide history actions, including listing and reverting changes.
  - Added a convenient `+update` alias for slide updates.

- **Documentation**
  - Corrected and standardized links across slide-management documentation.
  - Added guidance for prerequisites and workflows involving slide history operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->