### PR TITLE
ci: allow concurrent live e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,11 +374,6 @@ jobs:
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.unit-test.result == 'success' && needs.lint.result == 'success' && needs.script-test.result == 'success' && needs.deterministic-gate.result == 'success' && needs.e2e-dry-run.result == 'success' && (needs.e2e-dry-run.outputs.mode == 'full' || needs.e2e-dry-run.outputs.mode == 'subset') && needs.e2e-dry-run.outputs.live_packages != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Live E2E uses one repository-wide execution slot.
-    concurrency:
-      group: lark-cli-e2e-live
-      cancel-in-progress: false
-      queue: max
     permissions:
       actions: read
       contents: read

--- a/scripts/ci-workflow.test.sh
+++ b/scripts/ci-workflow.test.sh
@@ -237,12 +237,12 @@ if ! grep -Fq "deterministic-gate" <<<"$results_section"; then
 fi
 
 if ! grep -Fq "if: \${{ $live_job_condition }}" <<<"$section"; then
-  echo "e2e-live should preserve active cleanup while requiring a successful non-skip dry run and excluding fork pull requests"
+  echo "e2e-live should require a successful non-skip dry run and exclude fork pull requests"
   exit 1
 fi
 
 if ! grep -Fq "needs: [unit-test, lint, script-test, deterministic-gate, e2e-dry-run]" <<<"$section"; then
-  echo "e2e-live should wait outside the exclusive queue until e2e-dry-run finishes"
+  echo "e2e-live should wait for e2e-dry-run to finish"
   exit 1
 fi
 
@@ -252,22 +252,12 @@ if ! grep -Fq "timeout-minutes: 20" <<<"$dry_run_section"; then
 fi
 
 if ! grep -Fq "timeout-minutes: 30" <<<"$section"; then
-  echo "e2e-live should release the repository-wide slot after 30 minutes" >&2
+  echo "e2e-live should remain bounded at 30 minutes" >&2
   exit 1
 fi
 
-if ! grep -Fq "group: lark-cli-e2e-live" <<<"$section"; then
-  echo "e2e-live should use one repository-wide execution slot" >&2
-  exit 1
-fi
-
-if ! grep -Fq "cancel-in-progress: false" <<<"$section"; then
-  echo "e2e-live should queue waiting runs instead of cancelling an active live test" >&2
-  exit 1
-fi
-
-if ! grep -Fq "queue: max" <<<"$section"; then
-  echo "e2e-live should preserve queued runs instead of replacing an existing pending run" >&2
+if grep -Eq '^    concurrency:$' <<<"$section"; then
+  echo "e2e-live should allow unrelated pull requests to run concurrently" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- remove the repository-wide single-slot concurrency group from `e2e-live`
- keep workflow-level same-PR run deduplication, prerequisite gates, and the stale-run startup check
- add a workflow contract assertion that prevents job-level live E2E serialization from being reintroduced

Each live job already fetches one tenant access token and reuses it across CLI subprocesses, so concurrent PRs no longer multiply token exchange requests per command. Domain-directed package selection also limits each run to affected E2E packages.

## Tradeoff

Different pull requests can now exercise the shared test tenant at the same time. This may expose service-level throttling or resource contention, so live E2E stability should be monitored after merge.

## Test plan

- `make script-test`
- `make quality-gate QUALITY_GATE_CHANGED_FROM=origin/main`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified E2E testing pipeline configuration to improve CI/CD efficiency.
  * Updated test validations to align with workflow modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->