### PR TITLE
chore: release v1.0.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.83] - 2026-08-04
+
+### Features
+
+- **slides**: add +update-slide for whole-page updates (#2143)
+- **apps**: friendly error for db commands on an app with no database (#2162)
+- **slides**: support embedded SVG content (#2154)
+
+### Bug Fixes
+
+- **slides**: add agent-friendly aliases for screenshot flags (#2156)
+- **slides**: migrate SML namespace from HTTP to HTTPS (#2169)
+- **slides**: improve missing screenshot selector guidance (#2177)
+- **slides**: name the wrong --parts field instead of "non-empty replacement" (#2174)
+
+### Documentation
+
+- **base**: clarify unsupported capability boundaries (#2133)
+- **slides**: correct +xml-get flag requirements (#2171)
+
+### Misc
+
+- notarize macOS release candidates (#2073)
+- allow concurrent live e2e jobs (#2182)
+
 ## [v1.0.82] - 2026-08-03
 
 ### Features
@@ -1773,6 +1798,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.83]: https://github.com/larksuite/cli/releases/tag/v1.0.83
 [v1.0.82]: https://github.com/larksuite/cli/releases/tag/v1.0.82
 [v1.0.81]: https://github.com/larksuite/cli/releases/tag/v1.0.81
 [v1.0.80]: https://github.com/larksuite/cli/releases/tag/v1.0.80

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larksuite/cli",
-      "version": "1.0.82",
+      "version": "1.0.83",
       "cpu": [
         "x64",
         "arm64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.82` |
| Release version | `1.0.83` |
| Tag | `v1.0.83` |
| Branch | `release/v1.0.83` |
| Date | `2026-08-04` |

## Changes

- feat(slides): add +update-slide for whole-page updates (#2143)
- docs(base): clarify unsupported capability boundaries (#2133)
- feat(apps): friendly error for db commands on an app with no database (#2162)
- fix(slides): add agent-friendly aliases for screenshot flags (#2156)
- ci: notarize macOS release candidates (#2073)
- docs(slides): correct +xml-get flag requirements (#2171)
- fix(slides): migrate SML namespace from HTTP to HTTPS (#2169)
- fix(slides): improve missing screenshot selector guidance (#2177)
- feat(slides): support embedded SVG content (#2154)
- fix(slides): name the wrong --parts field instead of "non-empty replacement" (#2174)
- ci: allow concurrent live e2e jobs (#2182)

## Files Changed

- `package.json`
- `package-lock.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional and package metadata versions match
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package to version 1.0.83.

* **Documentation**
  * Added the v1.0.83 changelog entry dated August 4, 2026.
  * Included a corresponding link to the v1.0.83 release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->