### PR TITLE
feat(calendar): allow bot auth for search-event

### DIFF
--- a/shortcuts/calendar/calendar_search_event.go
+++ b/shortcuts/calendar/calendar_search_event.go
@@ -174,7 +174,7 @@ var CalendarSearchEvent = common.Shortcut{
 	Description: "Search calendar events by keyword, time range, and attendees",
 	Risk:        "read",
 	Scopes:      []string{"calendar:calendar.event:read"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "calendar-id", Desc: "calendar ID (default: primary)"},


### PR DESCRIPTION
## Summary
Enable bot identity for the calendar `+search-event` shortcut so app/bot credentials can search calendar events, not just user auth.

## Changes
- Add `"bot"` to the `AuthTypes` of the `CalendarSearchEvent` shortcut alongside the existing `"user"` type.

## Test Plan
- [x] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli calendar +search-event` flow works as expected with bot auth

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar event search now supports bot authentication in addition to user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->