### PR TITLE
fix: isolate git credential helper chain for scoped repos

### DIFF
--- a/shortcuts/apps/git_credential_test.go
+++ b/shortcuts/apps/git_credential_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -637,7 +638,7 @@ func TestGitCredentialListPayloadDoesNotExposeExpiry(t *testing.T) {
 func TestAppsGitCredentialRemoveReportsGitConfigWarning(t *testing.T) {
 	factory, stdout, reg := newAppsExecuteFactory(t)
 	factory.Keychain = newAppsTestKeychain()
-	installAppsFakeGit(t, 7) // unsetting useHttpPath exits non-zero -> ConfigWarning
+	installAppsFakeGitUnsetUseHTTPPathFailure(t, 7)
 	expiresAt := time.Now().Add(24 * time.Hour).Unix()
 	for _, appID := range []string{"app_one", "app_two"} {
 		reg.Register(&httpmock.Stub{
@@ -1203,29 +1204,57 @@ func (i testAppsIssuer) Issue(ctx context.Context, appID string, profile gitcred
 
 func installAppsFakeGit(t *testing.T, failUseHTTPPathExit int) {
 	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find real git: %v", err)
+	}
 	dir := t.TempDir()
 	gitPath := filepath.Join(dir, "git")
-	script := `#!/bin/sh
-case "$*" in
-  *"--get"*) exit 1 ;;
-esac
-exit 0
-`
+	script := fmt.Sprintf("#!/bin/sh\nexec %q \"$@\"\n", realGit)
 	if failUseHTTPPathExit != 0 {
-		script = `#!/bin/sh
+		script = fmt.Sprintf(`#!/bin/sh
 case "$*" in
-  *"--get"*) exit 1 ;;
+  *"useHttpPath true"*) exit %d ;;
 esac
-case "$*" in
-  *useHttpPath*) exit 7 ;;
-esac
-exit 0
-`
+exec %q "$@"
+`, failUseHTTPPathExit, realGit)
 	}
 	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
+	globalConfig := filepath.Join(t.TempDir(), "global.config")
+	if err := os.WriteFile(globalConfig, nil, 0600); err != nil {
+		t.Fatalf("write isolated global git config: %v", err)
+	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+func installAppsFakeGitUnsetUseHTTPPathFailure(t *testing.T, exitCode int) {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find real git: %v", err)
+	}
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	script := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+  *"--unset-all"*"useHttpPath"*) exit %d ;;
+esac
+exec %q "$@"
+`, exitCode, realGit)
+	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	globalConfig := filepath.Join(t.TempDir(), "global.config")
+	if err := os.WriteFile(globalConfig, nil, 0600); err != nil {
+		t.Fatalf("write isolated global git config: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 }
 
 // TestParseIssueCredentialData_SharedClassifierCoverage pins the canonical

--- a/shortcuts/apps/gitcred/gitconfig.go
+++ b/shortcuts/apps/gitcred/gitconfig.go
@@ -4,17 +4,58 @@
 package gitcred
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io/fs"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/internal/vfs" //nolint:depguard // resolving git's own global config path (home/XDG) is CLI-internal path discovery, matching store.go/lock.go.
+)
+
+type configValue struct {
+	Origin string
+	Value  string
+}
+
+type credentialConfigState struct {
+	Helpers        []configValue
+	UseHTTPPath    []configValue
+	WritableOrigin string
+}
+
+type managedKind uint8
+
+const (
+	managedNone managedKind = iota
+	managedAbsent
+	managedLegacy
+	managedCurrent
+	// managedForeign: the URL-scoped helper list contains only non-lark-cli
+	// helpers (all from the writable origin). lark-cli neither owns nor may
+	// overwrite it; UnsetHelper leaves it untouched.
+	managedForeign
+	// managedPartial: a lark-cli-owned residue that is neither the exact legacy
+	// nor current shape (e.g. the reset+helper pair written without useHttpPath,
+	// or a useHttpPath deleted out from under the helper). It is safe to
+	// re-normalize (SetHelper) or fully clean up (UnsetHelper).
+	managedPartial
+	// managedMixed: the URL-scoped helper list mixes lark-cli-owned values with
+	// foreign ones. SetHelper refuses it; UnsetHelper removes only the lark-cli
+	// values and reports that a foreign helper remains.
+	managedMixed
 )
 
 type GitConfig interface {
 	SetHelper(ctx context.Context, gitHTTPURL, appID string) error
-	UnsetHelper(ctx context.Context, gitHTTPURL string) error
+	UnsetHelper(ctx context.Context, gitHTTPURL, appID string) error
 }
 
 type GlobalGitConfig struct {
@@ -30,53 +71,259 @@ func (g GlobalGitConfig) SetHelper(ctx context.Context, gitHTTPURL, appID string
 	if err := validate.ResourceName(appID, "appID"); err != nil {
 		return err
 	}
-	helper := g.helperCommand(appID)
+	canonical := g.helperCommand(appID)
 	helperKey := gitCredentialKey(normalizedURL, "helper")
 	useHTTPPathKey := gitCredentialKey(normalizedURL, "useHttpPath")
-	previousHelper, hadHelper, err := gitConfigGet(ctx, helperKey)
+
+	writableOrigin, err := writableGlobalOrigin()
 	if err != nil {
 		return err
 	}
-	if hadHelper && previousHelper != helper && !g.isManagedHelper(previousHelper) {
-		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "git credential helper already configured for %s; refusing to overwrite non-lark helper", normalizedURL)
-	}
-	if err := exec.CommandContext(ctx, "git", "config", "--global", helperKey, helper).Run(); err != nil {
+	unlock, err := lockGlobalConfig(writableOrigin)
+	if err != nil {
 		return err
 	}
-	if err := exec.CommandContext(ctx, "git", "config", "--global", useHTTPPathKey, "true").Run(); err != nil {
-		if !hadHelper {
-			_ = exec.CommandContext(ctx, "git", "config", "--global", "--unset", helperKey).Run()
-		} else if previousHelper != helper {
-			_ = exec.CommandContext(ctx, "git", "config", "--global", helperKey, previousHelper).Run()
+	defer unlock()
+
+	snapshot, err := readCredentialConfig(ctx, normalizedURL)
+	if err != nil {
+		return err
+	}
+	if !setHelperAcceptsState(classifyManagedState(snapshot, canonical)) {
+		return gitConfigNotOwnedError(normalizedURL)
+	}
+	current, err := readCredentialConfig(ctx, normalizedURL)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(current, snapshot) {
+		return gitConfigChangedError(normalizedURL)
+	}
+
+	known := cloneCredentialConfigState(snapshot)
+	if err := gitConfigRewriteHelpersScoped(ctx, helperKey, configValuesOf(snapshot.Helpers), []string{"", canonical}, &known.Helpers, known.WritableOrigin); err != nil {
+		return g.finishSetFailure(ctx, normalizedURL, snapshot, known, err)
+	}
+	if err := gitConfigSet(ctx, useHTTPPathKey, "true"); err != nil {
+		return g.finishSetFailure(ctx, normalizedURL, snapshot, known, err)
+	}
+	known.UseHTTPPath = []configValue{{Origin: known.WritableOrigin, Value: "true"}}
+
+	// The empty-helper reset only clears helpers that parse BEFORE the lark-cli
+	// section. A generic credential.helper (or one from a later [include]) that
+	// parses AFTER our section still participates in get/store/erase for the
+	// URL. Detect that and relocate our section to the end of the writable file
+	// so the reset defeats every earlier helper; fail closed if the competing
+	// helper lives somewhere we must not edit.
+	safe, err := larkResetDefeatsLaterHelpers(ctx, normalizedURL, canonical)
+	if err != nil {
+		return g.finishSetFailure(ctx, normalizedURL, snapshot, known, err)
+	}
+	if !safe {
+		if err := repositionLarkSection(ctx, normalizedURL, canonical); err != nil {
+			return g.finishSetFailure(ctx, normalizedURL, snapshot, known, err)
+		}
+		safe, err = larkResetDefeatsLaterHelpers(ctx, normalizedURL, canonical)
+		if err != nil {
+			return g.finishSetFailure(ctx, normalizedURL, snapshot, known, err)
+		}
+		if !safe {
+			return g.finishSetFailure(ctx, normalizedURL, snapshot, known, gitConfigHelperOrderUnsafeError(normalizedURL))
+		}
+	}
+
+	readback, err := readCredentialConfig(ctx, normalizedURL)
+	if err != nil {
+		return g.finishSetFailure(ctx, normalizedURL, snapshot, known, err)
+	}
+	if !reflect.DeepEqual(readback, known) || classifyManagedState(readback, canonical) != managedCurrent {
+		return g.finishSetFailure(ctx, normalizedURL, snapshot, known, gitConfigChangedError(normalizedURL))
+	}
+	return nil
+}
+
+// setHelperAcceptsState reports whether SetHelper may (re)write the URL-scoped
+// configuration for a state. Absent/Legacy/Current/Partial are lark-cli-owned
+// (or empty) and safe to normalize; Foreign/Mixed/None belong to the user or a
+// third party and must not be overwritten.
+func setHelperAcceptsState(kind managedKind) bool {
+	switch kind {
+	case managedAbsent, managedLegacy, managedCurrent, managedPartial:
+		return true
+	default:
+		return false
+	}
+}
+
+func (g GlobalGitConfig) UnsetHelper(ctx context.Context, gitHTTPURL, appID string) error {
+	normalizedURL, err := NormalizeGitHTTPURL(gitHTTPURL)
+	if err != nil {
+		return err
+	}
+	appID = strings.TrimSpace(appID)
+	if err := validate.ResourceName(appID, "appID"); err != nil {
+		return err
+	}
+	canonical := g.helperCommand(appID)
+	helperKey := gitCredentialKey(normalizedURL, "helper")
+	useHTTPPathKey := gitCredentialKey(normalizedURL, "useHttpPath")
+
+	writableOrigin, err := writableGlobalOrigin()
+	if err != nil {
+		return err
+	}
+	unlock, err := lockGlobalConfig(writableOrigin)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	state, err := readCredentialConfig(ctx, normalizedURL)
+	if err != nil {
+		return err
+	}
+	switch classifyManagedState(state, canonical) {
+	case managedLegacy, managedCurrent, managedPartial:
+		return unsetOwnedHelper(ctx, helperKey, useHTTPPathKey, state)
+	case managedMixed:
+		return unsetMixedHelper(ctx, normalizedURL, helperKey, useHTTPPathKey, canonical, state)
+	default:
+		// Absent, Foreign, or unclassifiable: nothing lark-cli owns to remove.
+		return nil
+	}
+}
+
+// unsetOwnedHelper removes a fully lark-cli-owned URL-scoped configuration. It
+// deletes useHttpPath FIRST, then the helper list, so that if the second delete
+// fails the residue is still a lark-cli-recoverable state (helper present, no
+// useHttpPath = managedPartial) rather than a useHttpPath-only orphan that
+// SetHelper would refuse to re-init. On helper-delete failure it restores
+// useHttpPath best-effort and annotates the error.
+func unsetOwnedHelper(ctx context.Context, helperKey, useHTTPPathKey string, state credentialConfigState) error {
+	hadUseHTTPPath := len(state.UseHTTPPath) == 1
+	if hadUseHTTPPath {
+		if err := gitConfigUnsetAll(ctx, useHTTPPathKey); err != nil {
+			return err
+		}
+	}
+	if err := gitConfigUnsetAll(ctx, helperKey); err != nil {
+		if hadUseHTTPPath {
+			if restoreErr := gitConfigAdd(ctx, useHTTPPathKey, "true"); restoreErr != nil {
+				return withRollbackFailureHint(err)
+			}
 		}
 		return err
 	}
 	return nil
 }
 
-func (g GlobalGitConfig) UnsetHelper(ctx context.Context, gitHTTPURL string) error {
-	normalizedURL, err := NormalizeGitHTTPURL(gitHTTPURL)
-	if err != nil {
+// unsetMixedHelper removes only the lark-cli-owned values (the empty reset and
+// the canonical helper) from a helper list that also contains foreign helpers,
+// deletes the lark-cli useHttpPath, and returns a non-nil warning that a
+// foreign helper remains so callers surface it instead of reporting a clean
+// removal.
+func unsetMixedHelper(ctx context.Context, gitHTTPURL, helperKey, useHTTPPathKey, canonical string, state credentialConfigState) error {
+	if err := unsetHelperValueScoped(ctx, helperKey, ""); err != nil {
 		return err
 	}
-	helperKey := gitCredentialKey(normalizedURL, "helper")
-	useHTTPPathKey := gitCredentialKey(normalizedURL, "useHttpPath")
-	helper, found, err := gitConfigGet(ctx, helperKey)
-	if err != nil {
+	if err := unsetHelperValueScoped(ctx, helperKey, canonical); err != nil {
 		return err
 	}
-	if found {
-		if !g.isManagedHelper(helper) {
-			return nil
+	if len(state.UseHTTPPath) == 1 {
+		if err := gitConfigUnsetAll(ctx, useHTTPPathKey); err != nil {
+			return err
 		}
 	}
-	if err := gitConfigUnset(ctx, helperKey); err != nil {
+	return gitConfigForeignRemainsWarning(gitHTTPURL)
+}
+
+func (g GlobalGitConfig) finishSetFailure(ctx context.Context, gitHTTPURL string, snapshot, known credentialConfigState, first error) error {
+	if rollbackErr := rollbackIfUnchanged(ctx, gitHTTPURL, snapshot, known); rollbackErr != nil {
+		return withRollbackFailureHint(first)
+	}
+	return first
+}
+
+func rollbackIfUnchanged(ctx context.Context, gitHTTPURL string, snapshot, known credentialConfigState) error {
+	current, err := readCredentialConfig(ctx, gitHTTPURL)
+	if err != nil {
 		return err
 	}
-	if err := gitConfigUnset(ctx, useHTTPPathKey); err != nil {
+	if !reflect.DeepEqual(current, known) {
+		return nil
+	}
+	if err := gitConfigReplaceAll(ctx, gitCredentialKey(gitHTTPURL, "helper"), configValuesOf(snapshot.Helpers)); err != nil {
 		return err
 	}
-	return nil
+	return gitConfigReplaceAll(ctx, gitCredentialKey(gitHTTPURL, "useHttpPath"), configValuesOf(snapshot.UseHTTPPath))
+}
+
+func cloneCredentialConfigState(state credentialConfigState) credentialConfigState {
+	state.Helpers = append([]configValue(nil), state.Helpers...)
+	state.UseHTTPPath = append([]configValue(nil), state.UseHTTPPath...)
+	return state
+}
+
+func configValuesOf(values []configValue) []string {
+	result := make([]string, len(values))
+	for i := range values {
+		result[i] = values[i].Value
+	}
+	return result
+}
+
+func gitConfigNotOwnedError(gitHTTPURL string) error {
+	return errs.NewValidationError(
+		errs.SubtypeFailedPrecondition,
+		"git credential configuration for %s is not owned by lark-cli; refusing to overwrite it",
+		gitHTTPURL,
+	).WithHint("inspect the URL-scoped global Git credential.helper and credential.useHttpPath values, including included config files")
+}
+
+func gitConfigChangedError(gitHTTPURL string) error {
+	return errs.NewValidationError(
+		errs.SubtypeFailedPrecondition,
+		"git credential configuration for %s changed while it was being updated",
+		gitHTTPURL,
+	).WithHint("inspect the URL-scoped global Git credential settings and retry after concurrent changes stop")
+}
+
+func gitConfigHelperOrderUnsafeError(gitHTTPURL string) error {
+	return errs.NewValidationError(
+		errs.SubtypeFailedPrecondition,
+		"a generic Git credential.helper is applied after the lark-cli helper for %s, so the credential-helper reset cannot isolate it",
+		gitHTTPURL,
+	).WithHint("a global credential.helper (possibly from a later included config file) still participates for this URL; move or remove it, then retry")
+}
+
+func gitConfigSectionHasExtraKeysError(gitHTTPURL string) error {
+	return errs.NewValidationError(
+		errs.SubtypeFailedPrecondition,
+		"the URL-scoped git credential section for %s holds keys other than helper and useHttpPath, which cannot be safely relocated",
+		gitHTTPURL,
+	).WithHint("the credential-helper reset needs to move this section to the end of the global config, but that would discard the extra keys; remove them (e.g. credential.<url>.username) or move the lark-cli section manually, then retry")
+}
+
+func gitConfigForeignRemainsWarning(gitHTTPURL string) error {
+	return errs.NewValidationError(
+		errs.SubtypeFailedPrecondition,
+		"removed the lark-cli credential helper for %s but a third-party credential.helper remains",
+		gitHTTPURL,
+	).WithHint("the URL-scoped configuration also contained a non-lark-cli helper, which was left in place; remove it manually if it is no longer needed")
+}
+
+const rollbackFailureHint = "automatic rollback could not restore the previous Git credential configuration; inspect the URL-scoped global Git credential settings before retrying"
+
+func withRollbackFailureHint(err error) error {
+	var internalErr *errs.InternalError
+	if errors.As(err, &internalErr) {
+		return internalErr.WithHint(rollbackFailureHint)
+	}
+	var validationErr *errs.ValidationError
+	if errors.As(err, &validationErr) {
+		return validationErr.WithHint(rollbackFailureHint)
+	}
+	return err
 }
 
 func (g GlobalGitConfig) helperCommand(appID string) string {
@@ -86,35 +333,440 @@ func (g GlobalGitConfig) helperCommand(appID string) string {
 	return "!lark-cli apps git-credential-helper --app-id " + shellQuoteArg(appID)
 }
 
-func (g GlobalGitConfig) isManagedHelper(helper string) bool {
-	helper = strings.TrimSpace(helper)
-	if g.HelperCommand != "" {
-		return helper == g.HelperCommand
-	}
-	return strings.HasPrefix(helper, "!lark-cli apps git-credential-helper ")
-}
-
 func gitCredentialKey(gitHTTPURL, name string) string {
 	return "credential." + gitHTTPURL + "." + name
 }
 
-func gitConfigGet(ctx context.Context, key string) (string, bool, error) {
-	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--get", key).Output()
-	if err == nil {
-		return strings.TrimSpace(string(out)), true, nil
+func readCredentialConfig(ctx context.Context, gitHTTPURL string) (credentialConfigState, error) {
+	writableOrigin, err := writableGlobalOrigin()
+	if err != nil {
+		return credentialConfigState{}, err
 	}
-	if isGitConfigGetMissing(err) {
-		return "", false, nil
+	helpers, err := gitConfigGetAllOriginValues(ctx, gitCredentialKey(gitHTTPURL, "helper"))
+	if err != nil {
+		return credentialConfigState{}, err
 	}
-	return "", false, errs.NewInternalError(errs.SubtypeExternalTool, "git config get %s failed: %v", key, err).WithCause(err)
+	useHTTPPath, err := gitConfigGetAllOriginValues(ctx, gitCredentialKey(gitHTTPURL, "useHttpPath"))
+	if err != nil {
+		return credentialConfigState{}, err
+	}
+	return credentialConfigState{
+		Helpers:        helpers,
+		UseHTTPPath:    useHTTPPath,
+		WritableOrigin: writableOrigin,
+	}, nil
 }
 
-func gitConfigUnset(ctx context.Context, key string) error {
-	if err := exec.CommandContext(ctx, "git", "config", "--global", "--unset", key).Run(); err != nil {
-		if isGitConfigUnsetMissing(err) {
-			return nil
+func gitConfigGetAllOriginValues(ctx context.Context, key string) ([]configValue, error) {
+	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--includes", "--null", "--show-origin", "--get-all", key).Output()
+	if err == nil {
+		return parseOriginValues(out)
+	}
+	if isGitConfigGetMissing(err) {
+		return nil, nil
+	}
+	return nil, errs.NewInternalError(errs.SubtypeExternalTool, "git config get-all %s failed: %v", key, err).WithCause(err)
+}
+
+func parseOriginValues(raw []byte) ([]configValue, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if raw[len(raw)-1] != 0 {
+		return nil, errs.NewInternalError(errs.SubtypeExternalTool, "git config --show-origin returned output without a NUL terminator")
+	}
+	tokens := bytes.Split(raw[:len(raw)-1], []byte{0})
+	if len(tokens)%2 != 0 {
+		return nil, errs.NewInternalError(errs.SubtypeExternalTool, "git config --show-origin returned an incomplete origin/value pair")
+	}
+	values := make([]configValue, 0, len(tokens)/2)
+	for i := 0; i < len(tokens); i += 2 {
+		if len(tokens[i]) == 0 {
+			return nil, errs.NewInternalError(errs.SubtypeExternalTool, "git config --show-origin returned an empty origin")
 		}
-		return errs.NewInternalError(errs.SubtypeExternalTool, "git config unset %s failed: %v", key, err).WithCause(err)
+		values = append(values, configValue{Origin: canonicalOrigin(string(tokens[i])), Value: string(tokens[i+1])})
+	}
+	return values, nil
+}
+
+// larkResetDefeatsLaterHelpers reports whether the URL-scoped empty-helper
+// reset actually isolates the credential chain for gitHTTPURL. Git's empty
+// helper ("") clears only helpers that parse BEFORE it; a generic
+// credential.helper — or one from a later [include] — that parses AFTER the
+// lark-cli section still participates in get/store/erase. It returns true iff
+// the lark-cli canonical helper is the LAST credential helper git would apply
+// for the URL (i.e. no helper parses after it).
+func larkResetDefeatsLaterHelpers(ctx context.Context, gitHTTPURL, canonical string) (bool, error) {
+	order, err := readHelperFillOrder(ctx, gitHTTPURL)
+	if err != nil {
+		return false, err
+	}
+	lastLark := -1
+	lastAny := -1
+	for i, value := range order {
+		lastAny = i
+		if value == canonical {
+			lastLark = i
+		}
+	}
+	if lastLark < 0 {
+		return false, nil
+	}
+	return lastLark == lastAny, nil
+}
+
+// readHelperFillOrder returns, in git's parse (fill) order, the values of every
+// credential.helper that applies to gitHTTPURL: the generic credential.helper
+// and the exact URL-scoped credential.<url>.helper. Order is derived from
+// `git config --includes --show-origin -z --list`, which streams every entry in
+// true parse order across included files — the faithful oracle for the order in
+// which `git credential` invokes helpers (git config --get-urlmatch is not).
+func readHelperFillOrder(ctx context.Context, gitHTTPURL string) ([]string, error) {
+	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--includes", "--show-origin", "-z", "--list").Output()
+	if err != nil {
+		if isGitConfigGetMissing(err) {
+			return nil, nil
+		}
+		return nil, errs.NewInternalError(errs.SubtypeExternalTool, "git config --list failed: %v", err).WithCause(err)
+	}
+	genericKey := "credential.helper"
+	// Git lowercases the section and the final key component but preserves the
+	// subsection (the URL) verbatim, both when storing and when printing
+	// --list. gitCredentialKey already emits a lowercase section/component, so
+	// compare against it with the URL unchanged. Lowercasing the whole key would
+	// drop entries for URLs with an uppercase path segment (NormalizeGitHTTPURL
+	// preserves path case), wrongly making the reset look ineffective.
+	scopedKey := gitCredentialKey(gitHTTPURL, "helper")
+	var order []string
+	// Records are NUL-terminated; within each record the origin and the
+	// "key\nvalue" pair are separated by a NUL as well, so the stream is
+	// origin\0key\nvalue\0 repeating. Git lowercases the section and final key
+	// component but preserves the subsection (the URL) verbatim.
+	for _, record := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
+		if record == "" {
+			continue
+		}
+		keyValue := record
+		if idx := strings.IndexByte(record, 0); idx >= 0 {
+			keyValue = record[idx+1:]
+		}
+		key, value, ok := strings.Cut(keyValue, "\n")
+		if !ok {
+			continue
+		}
+		if key == genericKey || key == scopedKey {
+			order = append(order, value)
+		}
+	}
+	return order, nil
+}
+
+// repositionLarkSection moves the URL-scoped lark-cli credential section to the
+// end of the writable global config file by removing and re-adding it. This
+// makes the empty-helper reset parse AFTER any earlier generic helper (and
+// after earlier [include] directives), so the reset defeats them. Only the
+// writable file is touched; values that live in included files are unaffected.
+//
+// --remove-section drops every key in the section, but SetHelper only tracks
+// (and can roll back) helper and useHttpPath. If the user set any other key on
+// the same URL-scoped section (e.g. credential.<url>.username), repositioning
+// would silently discard it with no way to restore it, so we refuse and return
+// a typed validation error rather than destroying user config.
+func repositionLarkSection(ctx context.Context, gitHTTPURL, canonical string) error {
+	extra, err := sectionHasUntrackedKeys(ctx, gitHTTPURL)
+	if err != nil {
+		return err
+	}
+	if extra {
+		return gitConfigSectionHasExtraKeysError(gitHTTPURL)
+	}
+	if err := gitConfigRemoveSection(ctx, "credential."+gitHTTPURL); err != nil {
+		return err
+	}
+	helperKey := gitCredentialKey(gitHTTPURL, "helper")
+	if err := gitConfigAdd(ctx, helperKey, ""); err != nil {
+		return err
+	}
+	if err := gitConfigAdd(ctx, helperKey, canonical); err != nil {
+		return err
+	}
+	return gitConfigAdd(ctx, gitCredentialKey(gitHTTPURL, "useHttpPath"), "true")
+}
+
+// sectionHasUntrackedKeys reports whether the URL-scoped credential section in
+// the writable global config holds any key other than the ones SetHelper
+// tracks (helper, useHttpPath). Git lowercases the final key component, so the
+// comparison is against the lowercased names. A missing section (git exit 1) is
+// not an error and reports no extra keys.
+//
+// The scan uses --no-includes so it sees only keys in the writable file itself:
+// repositionLarkSection's --remove-section edits just that file, so a key that
+// lives only in an included config would not be discarded and must not trip the
+// "extra keys" refusal.
+func sectionHasUntrackedKeys(ctx context.Context, gitHTTPURL string) (bool, error) {
+	pattern := "^" + regexp.QuoteMeta("credential."+gitHTTPURL+".")
+	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--no-includes", "-z", "--name-only", "--get-regexp", pattern).Output()
+	if err != nil {
+		if isGitConfigGetMissing(err) {
+			return false, nil
+		}
+		return false, errs.NewInternalError(errs.SubtypeExternalTool, "git config get-regexp %s failed: %v", pattern, err).WithCause(err)
+	}
+	prefix := "credential." + gitHTTPURL + "."
+	for _, name := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
+		if name == "" {
+			continue
+		}
+		// Git lowercases the final key component but preserves the subsection
+		// (URL) verbatim, so strip the verbatim prefix and compare the component.
+		component := strings.ToLower(strings.TrimPrefix(name, prefix))
+		if component != "helper" && component != "usehttppath" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// canonicalOrigin normalizes a git config origin so origins produced by
+// git's --show-origin (echoed verbatim from GIT_CONFIG_GLOBAL / $HOME /
+// $XDG_CONFIG_HOME) compare equal to origins this package derives itself.
+// Git does not clean these paths, so a trailing-slash $HOME or a path with
+// embedded "./" or "//" yields e.g. "file:/home/u//.gitconfig" from git but
+// "file:/home/u/.gitconfig" from filepath.Join here; cleaning both keeps
+// ownership classification, readback verification, and rollback correct.
+// Relative GIT_CONFIG_GLOBAL values are read from the same env on both sides,
+// so cleaning (rather than absolutizing) is sufficient and avoids touching the
+// filesystem. Non-file origins (command line, blob) are left unchanged so they
+// never match a writable file origin.
+func canonicalOrigin(origin string) string {
+	path := strings.TrimPrefix(origin, "file:")
+	if path == origin {
+		return origin
+	}
+	return "file:" + filepath.Clean(path)
+}
+
+func writableGlobalOrigin() (string, error) {
+	if globalPath, ok := os.LookupEnv("GIT_CONFIG_GLOBAL"); ok && globalPath != "" {
+		return gitConfigFileOrigin(globalPath)
+	}
+
+	home, err := vfs.UserHomeDir()
+	if err != nil {
+		return "", errs.NewInternalError(errs.SubtypeFileIO, "resolve home directory for global git config: %v", err).WithCause(err)
+	}
+	if home == "" {
+		return "", errs.NewInternalError(errs.SubtypeFileIO, "resolve home directory for global git config: empty home directory")
+	}
+	homeConfig := filepath.Join(home, ".gitconfig")
+	homeExists, err := configFileExists(homeConfig)
+	if err != nil {
+		return "", err
+	}
+	if homeExists {
+		return gitConfigFileOrigin(homeConfig)
+	}
+
+	xdgHome, ok := os.LookupEnv("XDG_CONFIG_HOME")
+	if !ok || xdgHome == "" {
+		xdgHome = filepath.Join(home, ".config")
+	}
+	xdgConfig := filepath.Join(xdgHome, "git", "config")
+	xdgExists, err := configFileExists(xdgConfig)
+	if err != nil {
+		return "", err
+	}
+	if xdgExists {
+		return gitConfigFileOrigin(xdgConfig)
+	}
+	return gitConfigFileOrigin(homeConfig)
+}
+
+func configFileExists(path string) (bool, error) {
+	if _, err := vfs.Stat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, errs.NewInternalError(errs.SubtypeFileIO, "inspect global git config path %s: %v", path, err).WithCause(err)
+	}
+	return true, nil
+}
+
+func gitConfigFileOrigin(path string) (string, error) {
+	return canonicalOrigin("file:" + path), nil
+}
+
+func classifyManagedState(state credentialConfigState, canonical string) managedKind {
+	valuesFromWritableOrigin := func(values []configValue) bool {
+		for _, value := range values {
+			if value.Origin != state.WritableOrigin {
+				return false
+			}
+		}
+		return true
+	}
+	// Cross-origin / include-sourced values are never lark-cli-owned: we can
+	// only safely rewrite values that live in the single writable global file.
+	if !valuesFromWritableOrigin(state.Helpers) || !valuesFromWritableOrigin(state.UseHTTPPath) {
+		return managedNone
+	}
+	// useHttpPath must be absent or exactly one "true"; any other shape
+	// (false, duplicates, arbitrary value) is not a shape lark-cli writes.
+	useHTTPPathOwned := len(state.UseHTTPPath) == 0 ||
+		(len(state.UseHTTPPath) == 1 && strings.EqualFold(state.UseHTTPPath[0].Value, "true"))
+	if !useHTTPPathOwned {
+		return managedNone
+	}
+
+	if len(state.Helpers) == 0 {
+		if len(state.UseHTTPPath) == 0 {
+			return managedAbsent
+		}
+		// useHttpPath=true with no helper is a lark-cli residue (the helper was
+		// deleted but useHttpPath was not yet, or vice versa). Recoverable.
+		return managedPartial
+	}
+
+	var larkCanonical, larkReset, foreign int
+	for _, h := range state.Helpers {
+		switch h.Value {
+		case canonical:
+			larkCanonical++
+		case "":
+			larkReset++
+		default:
+			foreign++
+		}
+	}
+	switch {
+	case foreign > 0 && larkCanonical > 0:
+		return managedMixed
+	case foreign > 0:
+		// Only foreign helpers (a bare reset marker without our canonical helper
+		// is not treated as lark-owned): third-party configuration.
+		return managedForeign
+	case larkCanonical == 0:
+		// Helpers present but only bare reset markers: not a shape lark-cli
+		// writes on its own; leave it alone.
+		return managedNone
+	case len(state.Helpers) == 1 && larkReset == 0:
+		return managedLegacy
+	case len(state.Helpers) == 2 && state.Helpers[0].Value == "" && state.Helpers[1].Value == canonical && len(state.UseHTTPPath) == 1:
+		return managedCurrent
+	default:
+		// Canonical helper present in some other lark-cli arrangement (e.g. the
+		// reset+canonical pair written without useHttpPath): recoverable.
+		return managedPartial
+	}
+}
+
+func gitConfigReplaceAll(ctx context.Context, key string, values []string) error {
+	known := []configValue(nil)
+	return gitConfigReplaceAllTracked(ctx, key, values, &known, "")
+}
+
+func gitConfigReplaceAllTracked(ctx context.Context, key string, values []string, known *[]configValue, origin string) error {
+	if err := gitConfigUnsetAll(ctx, key); err != nil {
+		return err
+	}
+	*known = nil
+	for _, value := range values {
+		if err := gitConfigAdd(ctx, key, value); err != nil {
+			return err
+		}
+		*known = append(*known, configValue{Origin: origin, Value: value})
+	}
+	return nil
+}
+
+// gitConfigRewriteHelpersScoped rewrites the URL-scoped helper list from the
+// exact set of values observed in the ownership snapshot (oldValues) to the
+// desired list (newValues), deleting ONLY the known old values by exact match
+// rather than clearing the whole key.
+//
+// A whole-key --unset-all would also delete any helper a concurrent, non-lark
+// process inserted into the same list AFTER the ownership read but BEFORE this
+// rewrite — the subsequent re-add of the canonical pair would then leave a
+// readback that matches `known`, so the deletion of the third party's value
+// goes unnoticed and SetHelper returns success. Deleting only the snapshot's
+// own values leaves such an interloping helper in place, so the readback
+// diverges from `known` and SetHelper fails closed with the foreign value
+// preserved. oldValues comes from a snapshot the ownership gate already accepted
+// (Absent/Legacy/Current/Partial), so it contains only lark-cli-owned values
+// ("" and the canonical helper); deleting them by exact value never removes a
+// third party's helper.
+func gitConfigRewriteHelpersScoped(ctx context.Context, key string, oldValues, newValues []string, known *[]configValue, origin string) error {
+	for _, value := range dedupeStrings(oldValues) {
+		if err := unsetHelperValueScoped(ctx, key, value); err != nil {
+			return err
+		}
+	}
+	*known = nil
+	for _, value := range newValues {
+		if err := gitConfigAdd(ctx, key, value); err != nil {
+			return err
+		}
+		*known = append(*known, configValue{Origin: origin, Value: value})
+	}
+	return nil
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func gitConfigSet(ctx context.Context, key, value string) error {
+	return runGitConfig(ctx, "set", key, "--global", key, value)
+}
+
+func gitConfigAdd(ctx context.Context, key, value string) error {
+	return runGitConfig(ctx, "add", key, "--global", "--add", key, value)
+}
+
+func gitConfigUnsetAll(ctx context.Context, key string) error {
+	err := exec.CommandContext(ctx, "git", "config", "--global", "--unset-all", key).Run()
+	if err == nil || isGitConfigUnsetMissing(err) {
+		return nil
+	}
+	return errs.NewInternalError(errs.SubtypeExternalTool, "git config unset-all %s failed: %v", key, err).WithCause(err)
+}
+
+// unsetHelperValueScoped removes only the occurrences of key whose value equals
+// value exactly, leaving other values (foreign helpers) in place. It anchors a
+// QuoteMeta-escaped pattern so a value with regex metacharacters matches
+// literally. A no-match (git exit 5) is not an error.
+func unsetHelperValueScoped(ctx context.Context, key, value string) error {
+	pattern := "^" + regexp.QuoteMeta(value) + "$"
+	err := exec.CommandContext(ctx, "git", "config", "--global", "--unset-all", key, pattern).Run()
+	if err == nil || isGitConfigUnsetMissing(err) {
+		return nil
+	}
+	return errs.NewInternalError(errs.SubtypeExternalTool, "git config unset-all %s (value-scoped) failed: %v", key, err).WithCause(err)
+}
+
+// gitConfigRemoveSection removes an entire config section from the writable
+// global file. It is only used to reposition a section that is known to exist,
+// so any error is surfaced as an external-tool failure.
+func gitConfigRemoveSection(ctx context.Context, section string) error {
+	if err := exec.CommandContext(ctx, "git", "config", "--global", "--remove-section", section).Run(); err != nil {
+		return errs.NewInternalError(errs.SubtypeExternalTool, "git config remove-section %s failed: %v", section, err).WithCause(err)
+	}
+	return nil
+}
+
+func runGitConfig(ctx context.Context, operation, key string, args ...string) error {
+	commandArgs := append([]string{"config"}, args...)
+	if err := exec.CommandContext(ctx, "git", commandArgs...).Run(); err != nil {
+		return errs.NewInternalError(errs.SubtypeExternalTool, "git config %s %s failed: %v", operation, key, err).WithCause(err)
 	}
 	return nil
 }

--- a/shortcuts/apps/gitcred/gitconfig_test.go
+++ b/shortcuts/apps/gitcred/gitconfig_test.go
@@ -1,0 +1,1450 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package gitcred
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func TestClassifyCredentialConfig(t *testing.T) {
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	writable := "file:/tmp/global"
+	other := "file:/tmp/included"
+
+	tests := []struct {
+		name  string
+		state credentialConfigState
+		want  managedKind
+	}{
+		{
+			name:  "absent",
+			state: credentialConfigState{WritableOrigin: writable},
+			want:  managedAbsent,
+		},
+		{
+			name: "legacy without useHttpPath",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: canonical}},
+			},
+			want: managedLegacy,
+		},
+		{
+			name: "legacy with useHttpPath true",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: canonical}},
+				UseHTTPPath:    []configValue{{Origin: writable, Value: "TRUE"}},
+			},
+			want: managedLegacy,
+		},
+		{
+			name: "current",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers: []configValue{
+					{Origin: writable, Value: ""},
+					{Origin: writable, Value: canonical},
+				},
+				UseHTTPPath: []configValue{{Origin: writable, Value: "true"}},
+			},
+			want: managedCurrent,
+		},
+		{
+			name: "third party helper",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: "osxkeychain"}},
+			},
+			want: managedForeign,
+		},
+		{
+			name: "mixed helper",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers: []configValue{
+					{Origin: writable, Value: canonical},
+					{Origin: writable, Value: "osxkeychain"},
+				},
+			},
+			want: managedMixed,
+		},
+		{
+			name: "canonical helper with extra argument",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: canonical + " --extra"}},
+			},
+			want: managedForeign,
+		},
+		{
+			name: "different app id",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: "!lark-cli apps git-credential-helper --app-id 'app_other'"}},
+			},
+			want: managedForeign,
+		},
+		{
+			name: "useHttpPath false",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: canonical}},
+				UseHTTPPath:    []configValue{{Origin: writable, Value: "false"}},
+			},
+			want: managedNone,
+		},
+		{
+			name: "multiple useHttpPath values",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: canonical}},
+				UseHTTPPath: []configValue{
+					{Origin: writable, Value: "true"},
+					{Origin: writable, Value: "true"},
+				},
+			},
+			want: managedNone,
+		},
+		{
+			name: "current without useHttpPath",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers: []configValue{
+					{Origin: writable, Value: ""},
+					{Origin: writable, Value: canonical},
+				},
+			},
+			want: managedPartial,
+		},
+		{
+			name: "helper from include",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: other, Value: canonical}},
+			},
+			want: managedNone,
+		},
+		{
+			name: "useHttpPath from include",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: canonical}},
+				UseHTTPPath:    []configValue{{Origin: other, Value: "true"}},
+			},
+			want: managedNone,
+		},
+		{
+			name: "helpers span origins",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers: []configValue{
+					{Origin: writable, Value: ""},
+					{Origin: other, Value: canonical},
+				},
+				UseHTTPPath: []configValue{{Origin: writable, Value: "true"}},
+			},
+			want: managedNone,
+		},
+		{
+			name: "only useHttpPath",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				UseHTTPPath:    []configValue{{Origin: writable, Value: "true"}},
+			},
+			want: managedPartial,
+		},
+		{
+			name: "reset marker without canonical helper",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers:        []configValue{{Origin: writable, Value: ""}},
+			},
+			want: managedNone,
+		},
+		{
+			name: "partial reset plus canonical with false useHttpPath is not owned",
+			state: credentialConfigState{
+				WritableOrigin: writable,
+				Helpers: []configValue{
+					{Origin: writable, Value: ""},
+					{Origin: writable, Value: canonical},
+				},
+				UseHTTPPath: []configValue{{Origin: writable, Value: "false"}},
+			},
+			want: managedNone,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyManagedState(tc.state, canonical); got != tc.want {
+				t.Fatalf("classifyManagedState() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseOriginValuesPreservesEmptyValue(t *testing.T) {
+	raw := []byte("file:/tmp/global\x00\x00file:/tmp/global\x00!helper\x00")
+	want := []configValue{
+		{Origin: "file:/tmp/global", Value: ""},
+		{Origin: "file:/tmp/global", Value: "!helper"},
+	}
+
+	got, err := parseOriginValues(raw)
+	if err != nil {
+		t.Fatalf("parseOriginValues() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseOriginValues() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseOriginValuesRejectsMalformedOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "missing terminator", raw: []byte("file:/tmp/global\x00value")},
+		{name: "odd token count", raw: []byte("file:/tmp/global\x00value\x00extra\x00")},
+		{name: "empty origin", raw: []byte("\x00value\x00")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseOriginValues(tc.raw)
+			assertProblemSubtype(t, err, errs.SubtypeExternalTool)
+		})
+	}
+}
+
+func TestWritableGlobalOrigin(t *testing.T) {
+	tests := []struct {
+		name       string
+		globalEnv  string
+		homeConfig bool
+		xdgConfig  bool
+		wantPath   func(home, xdg, global string) string
+	}{
+		{
+			name:      "GIT_CONFIG_GLOBAL takes priority",
+			globalEnv: "custom/global.config",
+			wantPath: func(_, _, global string) string {
+				return global
+			},
+		},
+		{
+			name:       "home config takes priority over XDG",
+			homeConfig: true,
+			xdgConfig:  true,
+			wantPath: func(home, _, _ string) string {
+				return filepath.Join(home, ".gitconfig")
+			},
+		},
+		{
+			name:      "existing XDG config is writable origin",
+			xdgConfig: true,
+			wantPath: func(_, xdg, _ string) string {
+				return filepath.Join(xdg, "git", "config")
+			},
+		},
+		{
+			name: "home config is fallback",
+			wantPath: func(home, _, _ string) string {
+				return filepath.Join(home, ".gitconfig")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			home := filepath.Join(root, "home")
+			xdg := filepath.Join(root, "xdg")
+			global := ""
+			if tc.globalEnv != "" {
+				global = tc.globalEnv
+			}
+			if err := os.MkdirAll(home, 0o755); err != nil {
+				t.Fatalf("create home: %v", err)
+			}
+			if tc.homeConfig {
+				writeTestFile(t, filepath.Join(home, ".gitconfig"), nil)
+			}
+			if tc.xdgConfig {
+				writeTestFile(t, filepath.Join(xdg, "git", "config"), nil)
+			}
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv("XDG_CONFIG_HOME", xdg)
+			t.Setenv("GIT_CONFIG_GLOBAL", global)
+
+			got, err := writableGlobalOrigin()
+			if err != nil {
+				t.Fatalf("writableGlobalOrigin() error = %v", err)
+			}
+			wantPath := filepath.Clean(tc.wantPath(home, xdg, global))
+			if want := "file:" + wantPath; got != want {
+				t.Fatalf("writableGlobalOrigin() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestReadCredentialConfig(t *testing.T) {
+	root := t.TempDir()
+	globalPath := filepath.Join(root, "global.config")
+	includePath := filepath.Join(root, "included.config")
+	writeTestFile(t, includePath, []byte("[credential \"https://example.com/git/u/app.git\"]\n\thelper =\n\thelper = !included-helper\n"))
+	writeTestFile(t, globalPath, []byte("[include]\n\tpath = "+includePath+"\n[credential \"https://example.com/git/u/app.git\"]\n\tuseHttpPath = true\n"))
+	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	got, err := readCredentialConfig(context.Background(), "https://example.com/git/u/app.git")
+	if err != nil {
+		t.Fatalf("readCredentialConfig() error = %v", err)
+	}
+	want := credentialConfigState{
+		Helpers: []configValue{
+			{Origin: "file:" + includePath, Value: ""},
+			{Origin: "file:" + includePath, Value: "!included-helper"},
+		},
+		UseHTTPPath:    []configValue{{Origin: "file:" + globalPath, Value: "true"}},
+		WritableOrigin: "file:" + globalPath,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("readCredentialConfig() = %#v, want %#v", got, want)
+	}
+}
+
+func TestReadCredentialConfigTreatsExitOneAsMissing(t *testing.T) {
+	globalPath := filepath.Join(t.TempDir(), "missing.config")
+	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	got, err := readCredentialConfig(context.Background(), "https://example.com/git/u/app.git")
+	if err != nil {
+		t.Fatalf("readCredentialConfig() error = %v", err)
+	}
+	want := credentialConfigState{WritableOrigin: "file:" + globalPath}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("readCredentialConfig() = %#v, want %#v", got, want)
+	}
+}
+
+func TestReadCredentialConfigReturnsTypedExternalToolError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helper is a POSIX shell script")
+	}
+	binDir := t.TempDir()
+	writeTestFileMode(t, filepath.Join(binDir, "git"), []byte("#!/bin/sh\nexit 7\n"), 0o755)
+	t.Setenv("PATH", binDir)
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "global.config"))
+
+	_, err := readCredentialConfig(context.Background(), "https://example.com/git/u/app.git")
+	if err == nil {
+		t.Fatal("readCredentialConfig() error = nil, want git failure")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Subtype != errs.SubtypeExternalTool {
+		t.Fatalf("problem = %#v, ok = %v, want external_tool", problem, ok)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("error cause = %v, want git exit code 7", err)
+	}
+}
+
+func TestGlobalGitConfigWritesAndMigratesManagedStates(t *testing.T) {
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	url := "https://example.com/git/u/app.git"
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "absent"},
+		{name: "legacy", content: credentialConfigText(url, []string{canonical}, nil)},
+		{name: "current", content: credentialConfigText(url, []string{"", canonical}, []string{"true"})},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configureIsolatedGlobalGit(t, tc.content)
+			cfg := GlobalGitConfig{}
+			if err := cfg.SetHelper(context.Background(), url, "app_xxx"); err != nil {
+				t.Fatalf("SetHelper() error = %v", err)
+			}
+			state, err := readCredentialConfig(context.Background(), url)
+			if err != nil {
+				t.Fatalf("readCredentialConfig() error = %v", err)
+			}
+			if got := classifyManagedState(state, canonical); got != managedCurrent {
+				t.Fatalf("managed state = %v, want current; state=%#v", got, state)
+			}
+			if got := configValues(state.Helpers); !reflect.DeepEqual(got, []string{"", canonical}) {
+				t.Fatalf("helper values = %#v, want reset + canonical", got)
+			}
+		})
+	}
+}
+
+func TestGlobalGitConfigResetFirstHelperStopsGlobalStoreAndErase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helpers are POSIX shell scripts")
+	}
+	configureIsolatedGlobalGit(t, "")
+	root := t.TempDir()
+	globalLog := filepath.Join(root, "global.log")
+	scopedLog := filepath.Join(root, "scoped.log")
+	globalHelper := filepath.Join(root, "global-helper")
+	scopedHelper := filepath.Join(root, "scoped-helper")
+	writeTestFileMode(t, globalHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$GLOBAL_HELPER_LOG\"\ncat >/dev/null\n"), 0o700)
+	writeTestFileMode(t, scopedHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$SCOPED_HELPER_LOG\"\ncat >/dev/null\n"), 0o700)
+	t.Setenv("GLOBAL_HELPER_LOG", globalLog)
+	t.Setenv("SCOPED_HELPER_LOG", scopedLog)
+
+	globalCommand := "!" + shellQuoteArg(globalHelper)
+	if out, err := exec.Command("git", "config", "--global", "credential.helper", globalCommand).CombinedOutput(); err != nil {
+		t.Fatalf("configure global helper: %v: %s", err, out)
+	}
+	url := "https://example.com/git/u/app.git"
+	scopedCommand := "!" + shellQuoteArg(scopedHelper)
+	if err := (GlobalGitConfig{HelperCommand: scopedCommand}).SetHelper(context.Background(), url, "app_xxx"); err != nil {
+		t.Fatalf("SetHelper() error = %v", err)
+	}
+
+	credential := []byte("protocol=https\nhost=example.com\npath=git/u/app.git\nusername=x-access-token\npassword=test-only\n\n")
+	for _, operation := range []string{"approve", "reject"} {
+		cmd := exec.Command("git", "credential", operation)
+		cmd.Stdin = bytes.NewReader(credential)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git credential %s: %v: %s", operation, err, out)
+		}
+	}
+	if raw, err := os.ReadFile(scopedLog); err != nil || string(raw) != "store\nerase\n" {
+		t.Fatalf("scoped helper log = %q, err = %v, want store and erase", raw, err)
+	}
+	if raw, err := os.ReadFile(globalLog); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("global helper unexpectedly ran: log=%q err=%v", raw, err)
+	}
+}
+
+func TestGlobalGitConfigRollsBackWhenUseHTTPPathWriteFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test wrapper is a POSIX shell script")
+	}
+	url := "https://example.com/git/u/app.git"
+	configureIsolatedGlobalGit(t, "")
+	installGitConfigUseHTTPPathFailure(t, url, false, false)
+
+	err := (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+	assertExternalToolExit(t, err, 23)
+	state, readErr := readCredentialConfig(context.Background(), url)
+	if readErr != nil {
+		t.Fatalf("readCredentialConfig() error = %v", readErr)
+	}
+	if len(state.Helpers) != 0 || len(state.UseHTTPPath) != 0 {
+		t.Fatalf("failed transaction was not rolled back: %#v", state)
+	}
+}
+
+func TestGlobalGitConfigDoesNotRollbackOverExternalChange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test wrapper is a POSIX shell script")
+	}
+	url := "https://example.com/git/u/app.git"
+	configureIsolatedGlobalGit(t, "")
+	installGitConfigUseHTTPPathFailure(t, url, true, false)
+
+	err := (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+	assertExternalToolExit(t, err, 23)
+	state, readErr := readCredentialConfig(context.Background(), url)
+	if readErr != nil {
+		t.Fatalf("readCredentialConfig() error = %v", readErr)
+	}
+	want := []string{"", "!lark-cli apps git-credential-helper --app-id 'app_xxx'", "!external-change"}
+	if got := configValues(state.Helpers); !reflect.DeepEqual(got, want) {
+		t.Fatalf("helpers after external change = %#v, want preserved %#v", got, want)
+	}
+}
+
+func TestGlobalGitConfigRollbackFailurePreservesFirstTypedCauseAndStaticHint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test wrapper is a POSIX shell script")
+	}
+	url := "https://example.com/git/u/app.git"
+	configureIsolatedGlobalGit(t, "")
+	installGitConfigUseHTTPPathFailure(t, url, false, true)
+
+	err := (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+	assertExternalToolExit(t, err, 23)
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Hint != rollbackFailureHint {
+		t.Fatalf("problem = %#v, ok = %v, want static rollback hint", problem, ok)
+	}
+	if strings.Contains(err.Error(), "sensitive-rollback-detail") {
+		t.Fatalf("rollback error leaked command detail: %q", err.Error())
+	}
+}
+
+func TestGlobalGitConfigRefusesNonOwnedStates(t *testing.T) {
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	url := "https://example.com/git/u/app.git"
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "third party", content: credentialConfigText(url, []string{"osxkeychain"}, nil)},
+		{name: "mixed", content: credentialConfigText(url, []string{canonical, "osxkeychain"}, nil)},
+		{name: "useHttpPath false", content: credentialConfigText(url, []string{canonical}, []string{"false"})},
+		{name: "different app id", content: credentialConfigText(url, []string{"!lark-cli apps git-credential-helper --app-id 'app_other'"}, nil)},
+		{name: "extra helper argument", content: credentialConfigText(url, []string{canonical + " --extra"}, nil)},
+		{name: "command injection suffix", content: credentialConfigText(url, []string{canonical + " && /bin/false"}, nil)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := configureIsolatedGlobalGit(t, tc.content)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read config before SetHelper: %v", err)
+			}
+			err = (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+			assertProblemSubtype(t, err, errs.SubtypeFailedPrecondition)
+			after, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("read config after SetHelper: %v", readErr)
+			}
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("non-owned config changed:\nbefore=%s\nafter=%s", before, after)
+			}
+		})
+	}
+}
+
+func TestGlobalGitConfigRefusesManagedStateFromIncludedConfig(t *testing.T) {
+	url := "https://example.com/git/u/app.git"
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	root := t.TempDir()
+	globalPath := filepath.Join(root, "global.config")
+	includePath := filepath.Join(root, "included.config")
+	includeContent := credentialConfigText(url, []string{"", canonical}, []string{"true"})
+	writeTestFile(t, includePath, []byte(includeContent))
+	writeTestFile(t, globalPath, []byte(fmt.Sprintf("[include]\n\tpath = %s\n", includePath)))
+	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	beforeGlobal, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("read global config: %v", err)
+	}
+	beforeInclude, err := os.ReadFile(includePath)
+	if err != nil {
+		t.Fatalf("read included config: %v", err)
+	}
+	err = (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+	assertProblemSubtype(t, err, errs.SubtypeFailedPrecondition)
+	afterGlobal, _ := os.ReadFile(globalPath)
+	afterInclude, _ := os.ReadFile(includePath)
+	if !bytes.Equal(afterGlobal, beforeGlobal) || !bytes.Equal(afterInclude, beforeInclude) {
+		t.Fatalf("cross-origin config changed:\nglobal=%s\ninclude=%s", afterGlobal, afterInclude)
+	}
+}
+
+func TestGlobalGitConfigUnsetOnlyExactManagedState(t *testing.T) {
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	url := "https://example.com/git/u/app.git"
+	tests := []struct {
+		name        string
+		content     string
+		wantHelpers []string
+		wantUsePath []string
+	}{
+		{name: "legacy", content: credentialConfigText(url, []string{canonical}, nil)},
+		{name: "legacy with useHttpPath", content: credentialConfigText(url, []string{canonical}, []string{"true"})},
+		{name: "current", content: credentialConfigText(url, []string{"", canonical}, []string{"true"})},
+		{name: "different app", content: credentialConfigText(url, []string{"!lark-cli apps git-credential-helper --app-id 'app_other'"}, []string{"true"}), wantHelpers: []string{"!lark-cli apps git-credential-helper --app-id 'app_other'"}, wantUsePath: []string{"true"}},
+		{name: "only useHttpPath", content: credentialConfigText(url, nil, []string{"true"})},
+		{name: "managed helper with false useHttpPath", content: credentialConfigText(url, []string{canonical}, []string{"false"}), wantHelpers: []string{canonical}, wantUsePath: []string{"false"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configureIsolatedGlobalGit(t, tc.content)
+			if err := (GlobalGitConfig{}).UnsetHelper(context.Background(), url, "app_xxx"); err != nil {
+				t.Fatalf("UnsetHelper() error = %v", err)
+			}
+			state, err := readCredentialConfig(context.Background(), url)
+			if err != nil {
+				t.Fatalf("readCredentialConfig() error = %v", err)
+			}
+			if got := configValues(state.Helpers); !reflect.DeepEqual(got, tc.wantHelpers) {
+				t.Fatalf("helper values = %#v, want %#v", got, tc.wantHelpers)
+			}
+			if got := configValues(state.UseHTTPPath); !reflect.DeepEqual(got, tc.wantUsePath) {
+				t.Fatalf("useHttpPath values = %#v, want %#v", got, tc.wantUsePath)
+			}
+		})
+	}
+}
+
+// TestGlobalGitConfigMigratesWithNonCanonicalGlobalPath pins the fix for
+// non-canonical GIT_CONFIG_GLOBAL values. Git echoes the path verbatim in
+// --show-origin (e.g. "file:/tmp/x/./sub//global.config" for a path with
+// embedded "./" or "//"), so the writable origin this package derives must
+// normalize to the same cleaned form or a legacy managed helper is
+// misclassified as non-owned and migration is refused.
+func TestGlobalGitConfigMigratesWithNonCanonicalGlobalPath(t *testing.T) {
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	url := "https://example.com/git/u/app.git"
+	dir := t.TempDir()
+	cleanPath := filepath.Join(dir, "sub", "global.config")
+	writeTestFile(t, cleanPath, []byte(credentialConfigText(url, []string{canonical}, nil)))
+	// Point GIT_CONFIG_GLOBAL at the same file via a non-canonical path so git
+	// echoes the uncleaned form in --show-origin.
+	nonCanonical := filepath.Join(dir, "sub") + string(filepath.Separator) + "." + string(filepath.Separator) + "global.config"
+	t.Setenv("GIT_CONFIG_GLOBAL", nonCanonical)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	state, err := readCredentialConfig(context.Background(), url)
+	if err != nil {
+		t.Fatalf("readCredentialConfig() error = %v", err)
+	}
+	if got := classifyManagedState(state, canonical); got != managedLegacy {
+		t.Fatalf("managed state = %v, want legacy; state=%#v", got, state)
+	}
+	if err := (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx"); err != nil {
+		t.Fatalf("SetHelper() error = %v", err)
+	}
+	after, err := readCredentialConfig(context.Background(), url)
+	if err != nil {
+		t.Fatalf("readCredentialConfig() error = %v", err)
+	}
+	if got := classifyManagedState(after, canonical); got != managedCurrent {
+		t.Fatalf("managed state after migration = %v, want current; state=%#v", got, after)
+	}
+}
+
+// TestGlobalGitConfigResetFirstHelperStopsGlobalFill proves, through real
+// `git credential fill`, that after the empty-helper reset the earlier global
+// helper is never asked to return credentials for the scoped URL — closing the
+// durable-plumbing gap where only approve/reject (store/erase) were covered.
+func TestGlobalGitConfigResetFirstHelperStopsGlobalFill(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helpers are POSIX shell scripts")
+	}
+	configureIsolatedGlobalGit(t, "")
+	root := t.TempDir()
+	globalLog := filepath.Join(root, "global.log")
+	scopedLog := filepath.Join(root, "scoped.log")
+	globalHelper := filepath.Join(root, "global-helper")
+	scopedHelper := filepath.Join(root, "scoped-helper")
+	// The global helper returns a full credential on `get`; if the reset did
+	// not isolate it, fill would short-circuit here and never reach the scoped
+	// helper.
+	writeTestFileMode(t, globalHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$GLOBAL_HELPER_LOG\"\ncat >/dev/null\nif [ \"$1\" = get ]; then printf 'username=global-user\\npassword=global-pass\\n'; fi\n"), 0o700)
+	writeTestFileMode(t, scopedHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$SCOPED_HELPER_LOG\"\ncat >/dev/null\nif [ \"$1\" = get ]; then printf 'username=scoped-user\\npassword=scoped-pass\\n'; fi\n"), 0o700)
+	t.Setenv("GLOBAL_HELPER_LOG", globalLog)
+	t.Setenv("SCOPED_HELPER_LOG", scopedLog)
+
+	if out, err := exec.Command("git", "config", "--global", "credential.helper", "!"+shellQuoteArg(globalHelper)).CombinedOutput(); err != nil {
+		t.Fatalf("configure global helper: %v: %s", err, out)
+	}
+	url := "https://example.com/git/u/app.git"
+	if err := (GlobalGitConfig{HelperCommand: "!" + shellQuoteArg(scopedHelper)}).SetHelper(context.Background(), url, "app_xxx"); err != nil {
+		t.Fatalf("SetHelper() error = %v", err)
+	}
+
+	cmd := exec.Command("git", "credential", "fill")
+	cmd.Stdin = strings.NewReader("protocol=https\nhost=example.com\npath=git/u/app.git\n\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git credential fill: %v: %s", err, out)
+	}
+	if creds := parseCredentialFields(string(out)); creds["username"] != "scoped-user" || creds["password"] != "scoped-pass" {
+		t.Fatalf("fill returned %v, want scoped helper credential", creds)
+	}
+	if raw, err := os.ReadFile(scopedLog); err != nil || string(raw) != "get\n" {
+		t.Fatalf("scoped helper log = %q, err = %v, want single get", raw, err)
+	}
+	if raw, err := os.ReadFile(globalLog); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("global helper unexpectedly ran during fill: log=%q err=%v", raw, err)
+	}
+}
+
+func readLogLines(t *testing.T, path string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
+// TestGlobalGitConfigDefaultHelperShellQuotesAppID proves at execution level
+// that a shell-metacharacter-laden appID (permitted by validate.ResourceName,
+// which only blocks ?#% / control chars / traversal) is passed to the helper
+// as a single --app-id argument and does not execute an injected command. This
+// restores execution-level shell-quoting coverage for the default helper.
+func TestGlobalGitConfigDefaultHelperShellQuotesAppID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("helper resolution relies on a POSIX shell")
+	}
+	configureIsolatedGlobalGit(t, "")
+	root := t.TempDir()
+	argLog := filepath.Join(root, "args.log")
+	sentinel := filepath.Join(root, "pwned")
+	// Injecting a real lark-cli is out of scope; instead point the helper
+	// command at a fake `lark-cli` on PATH that records its literal arguments.
+	binDir := filepath.Join(root, "bin")
+	fakeCLI := filepath.Join(binDir, "lark-cli")
+	writeTestFileMode(t, fakeCLI, []byte("#!/bin/sh\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> \"$ARG_LOG\"; done\ncat >/dev/null\nfor a in \"$@\"; do if [ \"$a\" = get ]; then printf 'username=fake-user\\npassword=fake-pass\\n'; fi; done\n"), 0o700)
+	t.Setenv("ARG_LOG", argLog)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	appID := "app_xxx; touch " + sentinel
+	url := "https://example.com/git/u/app.git"
+	if err := (GlobalGitConfig{}).SetHelper(context.Background(), url, appID); err != nil {
+		t.Fatalf("SetHelper() error = %v", err)
+	}
+	cmd := exec.Command("git", "credential", "fill")
+	cmd.Stdin = strings.NewReader("protocol=https\nhost=example.com\npath=git/u/app.git\n\n")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git credential fill: %v: %s", err, out)
+	}
+	if _, err := os.Stat(sentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("injected command executed: sentinel exists (err=%v)", err)
+	}
+	args := readLogLines(t, argLog)
+	// The fake CLI receives: apps git-credential-helper --app-id <appID> get
+	foundArg := false
+	for i, a := range args {
+		if a == "--app-id" {
+			if i+1 >= len(args) || args[i+1] != appID {
+				t.Fatalf("--app-id argument = %q, want single literal %q; args=%#v", args[i+1:], appID, args)
+			}
+			foundArg = true
+		}
+	}
+	if !foundArg {
+		t.Fatalf("helper did not receive --app-id argument; args=%#v", args)
+	}
+}
+
+func parseCredentialFields(output string) map[string]string {
+	fields := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if key, value, ok := strings.Cut(line, "="); ok {
+			fields[key] = value
+		}
+	}
+	return fields
+}
+
+func configureIsolatedGlobalGit(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "global.config")
+	writeTestFile(t, path, []byte(content))
+	t.Setenv("GIT_CONFIG_GLOBAL", path)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	return path
+}
+
+func credentialConfigText(url string, helpers, useHTTPPath []string) string {
+	if len(helpers) == 0 && len(useHTTPPath) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("[credential \"")
+	b.WriteString(url)
+	b.WriteString("\"]\n")
+	for _, helper := range helpers {
+		b.WriteString("\thelper = ")
+		b.WriteString(helper)
+		b.WriteByte('\n')
+	}
+	for _, value := range useHTTPPath {
+		b.WriteString("\tuseHttpPath = ")
+		b.WriteString(value)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func configValues(values []configValue) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]string, len(values))
+	for i := range values {
+		result[i] = values[i].Value
+	}
+	return result
+}
+
+func assertProblemSubtype(t *testing.T, err error, subtype errs.Subtype) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want subtype %s", subtype)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Subtype != subtype {
+		t.Fatalf("problem = %#v, ok = %v, want subtype %s", problem, ok, subtype)
+	}
+}
+
+func assertExternalToolExit(t *testing.T, err error, exitCode int) {
+	t.Helper()
+	assertProblemSubtype(t, err, errs.SubtypeExternalTool)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != exitCode {
+		t.Fatalf("error cause = %v, want git exit code %d", err, exitCode)
+	}
+}
+
+func installGitConfigUseHTTPPathFailure(t *testing.T, url string, externalChange, rollbackFailure bool) {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find real git: %v", err)
+	}
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "config" ] && [ "$2" = "--global" ] && [ "$3" = "$GIT_TEST_USE_PATH_KEY" ] && [ "$4" = "true" ]; then
+  if [ "$GIT_TEST_EXTERNAL_CHANGE" = "1" ]; then
+    "$GIT_TEST_REAL_GIT" config --global --add "$GIT_TEST_HELPER_KEY" '!external-change'
+  fi
+  exit 23
+fi
+if [ "$GIT_TEST_ROLLBACK_FAILURE" = "1" ] && [ "$1" = "config" ] && [ "$2" = "--global" ] && [ "$3" = "--unset-all" ] && [ "$4" = "$GIT_TEST_HELPER_KEY" ]; then
+  if "$GIT_TEST_REAL_GIT" config --global --get-all "$GIT_TEST_HELPER_KEY" >/dev/null 2>&1; then
+    echo 'sensitive-rollback-detail' >&2
+    exit 24
+  fi
+fi
+exec "$GIT_TEST_REAL_GIT" "$@"
+`
+	writeTestFileMode(t, gitPath, []byte(script), 0o700)
+	t.Setenv("GIT_TEST_REAL_GIT", realGit)
+	t.Setenv("GIT_TEST_HELPER_KEY", gitCredentialKey(url, "helper"))
+	t.Setenv("GIT_TEST_USE_PATH_KEY", gitCredentialKey(url, "useHttpPath"))
+	t.Setenv("GIT_TEST_EXTERNAL_CHANGE", fmt.Sprint(boolToInt(externalChange)))
+	t.Setenv("GIT_TEST_ROLLBACK_FAILURE", fmt.Sprint(boolToInt(rollbackFailure)))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func writeTestFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	writeTestFileMode(t, path, data, 0o600)
+}
+
+func writeTestFileMode(t *testing.T, path string, data []byte, mode fs.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent directory: %v", err)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestGlobalGitConfigResetDefeatsLaterGlobalHelperOnFill proves through real
+// `git credential fill` (and store/erase) that when a generic
+// credential.helper is configured AFTER the URL-scoped lark-cli section — the
+// case an empty-helper reset alone does NOT isolate, because git applies
+// helpers in parse order — SetHelper repositions the lark-cli section so the
+// reset defeats the later helper. Covers both a textually-later [credential]
+// section and one sourced from a later [include].
+func TestGlobalGitConfigResetDefeatsLaterGlobalHelperOnFill(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helpers are POSIX shell scripts")
+	}
+	url := "https://example.com/git/u/app.git"
+	scopedSection := credentialConfigText(url, []string{"", "SCOPED_CMD"}, []string{"true"})
+
+	tests := []struct {
+		name    string
+		content func(globalCmd, includePath string) string
+	}{
+		{
+			name: "later generic section",
+			content: func(globalCmd, _ string) string {
+				return scopedSection + "[credential]\n\thelper = " + globalCmd + "\n"
+			},
+		},
+		{
+			name: "later include",
+			content: func(_, includePath string) string {
+				return scopedSection + "[include]\n\tpath = " + includePath + "\n"
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			globalLog := filepath.Join(root, "global.log")
+			scopedLog := filepath.Join(root, "scoped.log")
+			globalHelper := filepath.Join(root, "global-helper")
+			scopedHelper := filepath.Join(root, "scoped-helper")
+			writeTestFileMode(t, globalHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$GLOBAL_HELPER_LOG\"\ncat >/dev/null\nif [ \"$1\" = get ]; then printf 'username=global-user\\npassword=global-pass\\n'; fi\n"), 0o700)
+			writeTestFileMode(t, scopedHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$SCOPED_HELPER_LOG\"\ncat >/dev/null\nif [ \"$1\" = get ]; then printf 'username=scoped-user\\npassword=scoped-pass\\n'; fi\n"), 0o700)
+			t.Setenv("GLOBAL_HELPER_LOG", globalLog)
+			t.Setenv("SCOPED_HELPER_LOG", scopedLog)
+
+			globalCmd := "!" + shellQuoteArg(globalHelper)
+			scopedCmd := "!" + shellQuoteArg(scopedHelper)
+			includePath := filepath.Join(root, "included.config")
+			writeTestFile(t, includePath, []byte("[credential]\n\thelper = "+globalCmd+"\n"))
+
+			content := strings.ReplaceAll(tc.content(globalCmd, includePath), "SCOPED_CMD", scopedCmd)
+			configureIsolatedGlobalGit(t, content)
+
+			if err := (GlobalGitConfig{HelperCommand: scopedCmd}).SetHelper(context.Background(), url, "app_xxx"); err != nil {
+				t.Fatalf("SetHelper() error = %v", err)
+			}
+
+			// fill: the scoped helper answers; the later global helper must not run.
+			cmd := exec.Command("git", "credential", "fill")
+			cmd.Stdin = strings.NewReader("protocol=https\nhost=example.com\npath=git/u/app.git\n\n")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("git credential fill: %v: %s", err, out)
+			}
+			if creds := parseCredentialFields(string(out)); creds["username"] != "scoped-user" || creds["password"] != "scoped-pass" {
+				t.Fatalf("fill returned %v, want scoped helper credential", creds)
+			}
+
+			// store/erase invoke every helper in the list; the later global helper
+			// must not be reached for this URL.
+			credential := []byte("protocol=https\nhost=example.com\npath=git/u/app.git\nusername=x-access-token\npassword=test-only\n\n")
+			for _, operation := range []string{"approve", "reject"} {
+				op := exec.Command("git", "credential", operation)
+				op.Stdin = bytes.NewReader(credential)
+				if o, err := op.CombinedOutput(); err != nil {
+					t.Fatalf("git credential %s: %v: %s", operation, err, o)
+				}
+			}
+			if raw, err := os.ReadFile(globalLog); !errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("global helper unexpectedly ran: log=%q err=%v", raw, err)
+			}
+			if raw := readLogLines(t, scopedLog); !reflect.DeepEqual(raw, []string{"get", "store", "erase"}) {
+				t.Fatalf("scoped helper log = %#v, want get/store/erase", raw)
+			}
+		})
+	}
+}
+
+// TestGlobalGitConfigFailsClosedWhenLaterHelperCannotBeDefeated verifies the
+// fail-closed guarantee: if a generic credential.helper is applied AFTER the
+// lark-cli helper even after repositioning (i.e. it lives somewhere the writable
+// file cannot move past), SetHelper must return FailedPrecondition and restore
+// the prior configuration rather than leave a written-but-ineffective reset.
+//
+// Repositioning always wins within a single --global file, so to exercise the
+// residual un-defeatable case deterministically we wrap git to inject a phantom
+// later generic helper into every `--list` (the parse-order oracle), which no
+// on-disk reposition can remove. The real config file is otherwise unmodified,
+// so we can assert the lark-cli section was rolled back to its pre-write state.
+func TestGlobalGitConfigFailsClosedWhenLaterHelperCannotBeDefeated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test wrapper is a POSIX shell script")
+	}
+	url := "https://example.com/git/u/app.git"
+	globalPath := configureIsolatedGlobalGit(t, "")
+	installPhantomLaterHelper(t)
+
+	err := (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+	assertProblemSubtype(t, err, errs.SubtypeFailedPrecondition)
+	if !strings.Contains(err.Error(), "applied after") {
+		t.Fatalf("error = %v, want message mentioning a helper applied after the reset", err)
+	}
+
+	// The phantom exists only in --list output, so on-disk state must be rolled
+	// back to no lark-cli-owned credential configuration for the URL.
+	state, readErr := readCredentialConfig(context.Background(), url)
+	if readErr != nil {
+		t.Fatalf("readCredentialConfig() error = %v", readErr)
+	}
+	if got := classifyManagedState(state, "!lark-cli apps git-credential-helper --app-id 'app_xxx'"); got != managedAbsent {
+		t.Fatalf("state after fail-closed = %v (helpers=%#v), want absent", got, state.Helpers)
+	}
+	raw, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	if strings.Contains(string(raw), "lark-cli") {
+		t.Fatalf("lark-cli helper not rolled back from config file:\n%s", raw)
+	}
+}
+
+// installPhantomLaterHelper wraps git so that `git config ... -z --list` always
+// reports an extra generic credential.helper AFTER the real entries, modeling a
+// later-parsing helper that repositioning the writable file cannot defeat. All
+// other git invocations pass through unchanged.
+func installPhantomLaterHelper(t *testing.T) {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find real git: %v", err)
+	}
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "config" ] && [ "$2" = "--global" ] && [ "$3" = "--includes" ] && [ "$4" = "--show-origin" ] && [ "$5" = "-z" ] && [ "$6" = "--list" ]; then
+  "$GIT_TEST_REAL_GIT" "$@" || exit $?
+  printf 'file:/phantom\0credential.helper\n!phantom-later\0'
+  exit 0
+fi
+exec "$GIT_TEST_REAL_GIT" "$@"
+`
+	writeTestFileMode(t, gitPath, []byte(script), 0o700)
+	t.Setenv("GIT_TEST_REAL_GIT", realGit)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestGlobalGitConfigDetectsConcurrentHelperInsertion models a non-lark-cli
+// writer that inserts a foreign helper into the URL-scoped list during the
+// write window (after the reset unset, before readback). lockGlobalConfig
+// serializes lark-cli writers against each other but cannot stop an unrelated
+// process, so this must be caught by readback and fail closed with the foreign
+// value preserved — never silently overwritten.
+func TestGlobalGitConfigDetectsConcurrentHelperInsertion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test wrapper is a POSIX shell script")
+	}
+	url := "https://example.com/git/u/app.git"
+	configureIsolatedGlobalGit(t, "")
+	installGitConfigUseHTTPPathFailure(t, url, true, false)
+
+	err := (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+	assertExternalToolExit(t, err, 23)
+
+	state, readErr := readCredentialConfig(context.Background(), url)
+	if readErr != nil {
+		t.Fatalf("readCredentialConfig() error = %v", readErr)
+	}
+	foundForeign := false
+	for _, h := range state.Helpers {
+		if h.Value == "!external-change" {
+			foundForeign = true
+		}
+	}
+	if !foundForeign {
+		t.Fatalf("concurrently inserted foreign helper was lost: %#v", state.Helpers)
+	}
+}
+
+// TestGlobalGitConfigPreservesForeignHelperInsertedBeforeReset models the
+// narrower race the previous whole-key --unset-all could not survive: a
+// non-lark-cli process inserts a foreign helper into the URL-scoped list AFTER
+// the ownership read but BEFORE lark-cli begins rewriting the helper list. A
+// whole-key --unset-all would delete that foreign value and the canonical
+// re-add would leave a readback matching `known`, so the third party's write
+// would vanish and SetHelper would (wrongly) report success. Because the
+// rewrite now deletes only the snapshot's own values, the foreign helper
+// survives, readback diverges from `known`, and SetHelper fails closed with the
+// foreign value preserved.
+func TestGlobalGitConfigPreservesForeignHelperInsertedBeforeReset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test wrapper is a POSIX shell script")
+	}
+	url := "https://example.com/git/u/app.git"
+	configureIsolatedGlobalGit(t, "")
+	installForeignHelperBeforeFirstHelperAdd(t, url)
+
+	err := (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+	assertProblemSubtype(t, err, errs.SubtypeFailedPrecondition)
+
+	state, readErr := readCredentialConfig(context.Background(), url)
+	if readErr != nil {
+		t.Fatalf("readCredentialConfig() error = %v", readErr)
+	}
+	foundForeign := false
+	for _, h := range state.Helpers {
+		if h.Value == "!external-race" {
+			foundForeign = true
+		}
+	}
+	if !foundForeign {
+		t.Fatalf("foreign helper inserted before the reset was silently deleted: %#v", state.Helpers)
+	}
+}
+
+// installForeignHelperBeforeFirstHelperAdd wraps git so that the FIRST time
+// lark-cli runs `git config --global --add <helperKey> ""` (the empty reset
+// marker that begins the helper rewrite), a foreign helper is first inserted
+// into the same list via real git. This deterministically reproduces a
+// concurrent non-lark writer landing in the window between the ownership read
+// and the helper rewrite. All other git invocations pass through unchanged.
+func installForeignHelperBeforeFirstHelperAdd(t *testing.T, url string) {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find real git: %v", err)
+	}
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "config" ] && [ "$2" = "--global" ] && [ "$3" = "--add" ] && [ "$4" = "$GIT_TEST_HELPER_KEY" ] && [ -z "$5" ]; then
+  if [ ! -f "$GIT_TEST_FLAG" ]; then
+    : > "$GIT_TEST_FLAG"
+    "$GIT_TEST_REAL_GIT" config --global --add "$GIT_TEST_HELPER_KEY" '!external-race'
+  fi
+fi
+exec "$GIT_TEST_REAL_GIT" "$@"
+`
+	writeTestFileMode(t, gitPath, []byte(script), 0o700)
+	t.Setenv("GIT_TEST_REAL_GIT", realGit)
+	t.Setenv("GIT_TEST_HELPER_KEY", gitCredentialKey(url, "helper"))
+	t.Setenv("GIT_TEST_FLAG", filepath.Join(binDir, "flag"))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestLockGlobalConfigSerializesWriters runs concurrent SetHelper calls for the
+// same app ID against the same global config file. lockGlobalConfig must
+// serialize the read-modify-write so the writes do not interleave: the final
+// config is exactly one valid managedCurrent state ([reset, canonical] + one
+// useHttpPath), never duplicated or torn helper values.
+func TestLockGlobalConfigSerializesWriters(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cross-process file lock behavior is validated on POSIX")
+	}
+	url := "https://example.com/git/u/app.git"
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	configureIsolatedGlobalGit(t, "")
+
+	const writers = 4
+	var wg sync.WaitGroup
+	errCh := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- (GlobalGitConfig{}).SetHelper(context.Background(), url, "app_xxx")
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent SetHelper() error = %v", err)
+		}
+	}
+
+	state, err := readCredentialConfig(context.Background(), url)
+	if err != nil {
+		t.Fatalf("readCredentialConfig() error = %v", err)
+	}
+	if got := configValues(state.Helpers); !reflect.DeepEqual(got, []string{"", canonical}) {
+		t.Fatalf("final helpers = %#v, want exactly [reset, canonical] (no torn/duplicated writes)", got)
+	}
+	if got := configValues(state.UseHTTPPath); !reflect.DeepEqual(got, []string{"true"}) {
+		t.Fatalf("final useHttpPath = %#v, want exactly [true]", got)
+	}
+	if got := classifyManagedState(state, canonical); got != managedCurrent {
+		t.Fatalf("final managed state = %v, want current; state=%#v", got, state)
+	}
+}
+
+// TestUnsetHelperUseHTTPPathDeleteFailureLeavesRecoverableState proves the new
+// delete order (useHttpPath first, then helper) keeps the residue recoverable
+// when the helper delete fails: the leftover helper (without useHttpPath) still
+// classifies as a lark-cli-owned state, so a later SetHelper can re-normalize
+// it — unlike the old order, which could leave a useHttpPath-only orphan that
+// SetHelper refuses.
+func TestUnsetHelperUseHTTPPathDeleteFailureLeavesRecoverableState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test wrapper is a POSIX shell script")
+	}
+	url := "https://example.com/git/u/app.git"
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	configureIsolatedGlobalGit(t, credentialConfigText(url, []string{"", canonical}, []string{"true"}))
+	installGitConfigHelperUnsetFailure(t, url, 29)
+
+	err := (GlobalGitConfig{}).UnsetHelper(context.Background(), url, "app_xxx")
+	assertExternalToolExit(t, err, 29)
+
+	state, readErr := readCredentialConfig(context.Background(), url)
+	if readErr != nil {
+		t.Fatalf("readCredentialConfig() error = %v", readErr)
+	}
+	// The helper delete failed; useHttpPath was deleted first and then restored
+	// best-effort. Whatever the exact residue, it must be a lark-cli-owned
+	// (recoverable) state — never a useHttpPath-only orphan (managedNone) that a
+	// later SetHelper would refuse to re-init.
+	kind := classifyManagedState(state, canonical)
+	if kind != managedLegacy && kind != managedCurrent && kind != managedPartial {
+		t.Fatalf("residue classified %v, want a recoverable lark-cli-owned state; state=%#v", kind, state)
+	}
+	if len(state.Helpers) == 0 {
+		t.Fatalf("helper delete failure lost the helper list, leaving an unrecoverable residue; state=%#v", state)
+	}
+	// A recoverable residue is one SetHelper's ownership gate accepts; assert
+	// that directly rather than re-running SetHelper under the injected fault
+	// (whose whole-key helper unset SetHelper's own reset would also trip).
+	if !setHelperAcceptsState(kind) {
+		t.Fatalf("SetHelper would refuse to re-init residue classified %v; state=%#v", kind, state)
+	}
+}
+
+// TestUnsetHelperMixedOwnedRemovesOnlyLarkValues proves that when the URL-scoped
+// helper list mixes the lark-cli values with a foreign helper, UnsetHelper
+// removes only the lark-cli values (the empty reset and the canonical helper)
+// and the lark-cli useHttpPath, leaves the foreign helper intact, and returns a
+// non-nil warning so callers surface that a foreign helper remains.
+func TestUnsetHelperMixedOwnedRemovesOnlyLarkValues(t *testing.T) {
+	url := "https://example.com/git/u/app.git"
+	canonical := "!lark-cli apps git-credential-helper --app-id 'app_xxx'"
+	configureIsolatedGlobalGit(t, credentialConfigText(url, []string{"", canonical, "osxkeychain"}, []string{"true"}))
+
+	err := (GlobalGitConfig{}).UnsetHelper(context.Background(), url, "app_xxx")
+	assertProblemSubtype(t, err, errs.SubtypeFailedPrecondition)
+
+	state, readErr := readCredentialConfig(context.Background(), url)
+	if readErr != nil {
+		t.Fatalf("readCredentialConfig() error = %v", readErr)
+	}
+	if got := configValues(state.Helpers); !reflect.DeepEqual(got, []string{"osxkeychain"}) {
+		t.Fatalf("helpers after unset = %#v, want only the foreign helper", got)
+	}
+	if len(state.UseHTTPPath) != 0 {
+		t.Fatalf("lark-cli useHttpPath not removed: %#v", state.UseHTTPPath)
+	}
+}
+
+// installGitConfigHelperUnsetFailure wraps git so the URL-scoped helper
+// `--unset-all` (the whole-key form, with no value pattern) fails with exitCode,
+// while all other git invocations — including the useHttpPath unset — pass
+// through. Used to exercise UnsetHelper's helper-delete failure path.
+func installGitConfigHelperUnsetFailure(t *testing.T, url string, exitCode int) {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find real git: %v", err)
+	}
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "config" ] && [ "$2" = "--global" ] && [ "$3" = "--unset-all" ] && [ "$4" = "$GIT_TEST_HELPER_KEY" ] && [ -z "$5" ]; then
+  exit %d
+fi
+exec "$GIT_TEST_REAL_GIT" "$@"
+`, exitCode)
+	writeTestFileMode(t, gitPath, []byte(script), 0o700)
+	t.Setenv("GIT_TEST_REAL_GIT", realGit)
+	t.Setenv("GIT_TEST_HELPER_KEY", gitCredentialKey(url, "helper"))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestGlobalGitConfigResetDefeatsLaterHelperForUppercaseURLPath guards against
+// lowercasing the URL subsection when matching credential.helper entries in the
+// parse-order oracle. NormalizeGitHTTPURL preserves the URL path case, and git
+// stores/prints the subsection verbatim, so a URL with an uppercase path
+// segment must still be recognized as the lark-cli helper. If readHelperFillOrder
+// lowercased the scoped key, the lark helper would not be found in the order,
+// SetHelper would wrongly hit the fail-closed path, and this real fill would
+// return the later global helper's credential instead of the scoped one.
+func TestGlobalGitConfigResetDefeatsLaterHelperForUppercaseURLPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helpers are POSIX shell scripts")
+	}
+	url := "https://example.com/git/u/App.git"
+	root := t.TempDir()
+	globalLog := filepath.Join(root, "global.log")
+	scopedLog := filepath.Join(root, "scoped.log")
+	globalHelper := filepath.Join(root, "global-helper")
+	scopedHelper := filepath.Join(root, "scoped-helper")
+	writeTestFileMode(t, globalHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$GLOBAL_HELPER_LOG\"\ncat >/dev/null\nif [ \"$1\" = get ]; then printf 'username=global-user\\npassword=global-pass\\n'; fi\n"), 0o700)
+	writeTestFileMode(t, scopedHelper, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$SCOPED_HELPER_LOG\"\ncat >/dev/null\nif [ \"$1\" = get ]; then printf 'username=scoped-user\\npassword=scoped-pass\\n'; fi\n"), 0o700)
+	t.Setenv("GLOBAL_HELPER_LOG", globalLog)
+	t.Setenv("SCOPED_HELPER_LOG", scopedLog)
+
+	globalCmd := "!" + shellQuoteArg(globalHelper)
+	scopedCmd := "!" + shellQuoteArg(scopedHelper)
+	// lark-cli section first, generic helper AFTER it: only correct-case matching
+	// + repositioning isolates the scoped helper.
+	content := credentialConfigText(url, []string{"", scopedCmd}, []string{"true"}) +
+		"[credential]\n\thelper = " + globalCmd + "\n"
+	configureIsolatedGlobalGit(t, content)
+
+	if err := (GlobalGitConfig{HelperCommand: scopedCmd}).SetHelper(context.Background(), url, "app_xxx"); err != nil {
+		t.Fatalf("SetHelper() error = %v", err)
+	}
+
+	cmd := exec.Command("git", "credential", "fill")
+	cmd.Stdin = strings.NewReader("protocol=https\nhost=example.com\npath=git/u/App.git\n\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git credential fill: %v: %s", err, out)
+	}
+	if creds := parseCredentialFields(string(out)); creds["username"] != "scoped-user" || creds["password"] != "scoped-pass" {
+		t.Fatalf("fill returned %v, want scoped helper credential for uppercase-path URL", creds)
+	}
+	if raw, err := os.ReadFile(globalLog); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("global helper unexpectedly ran during fill: log=%q err=%v", raw, err)
+	}
+}
+
+// TestGlobalGitConfigRefusesToRepositionSectionWithExtraKeys verifies that when
+// the lark-cli section must be repositioned (a later generic helper exists) but
+// the URL-scoped section also holds an untracked key (e.g. username), SetHelper
+// refuses with a typed FailedPrecondition error instead of destroying that key
+// via --remove-section, and leaves the extra key intact.
+func TestGlobalGitConfigRefusesToRepositionSectionWithExtraKeys(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helpers are POSIX shell scripts")
+	}
+	url := "https://example.com/git/u/app.git"
+	scopedCmd := "!scoped-cmd"
+	globalCmd := "!global-cmd"
+	// lark-cli reset+canonical+useHttpPath, PLUS an untracked username key, and a
+	// later generic helper that forces repositioning.
+	content := "[credential \"" + url + "\"]\n" +
+		"\thelper = \n" +
+		"\thelper = " + scopedCmd + "\n" +
+		"\tuseHttpPath = true\n" +
+		"\tusername = alice\n" +
+		"[credential]\n\thelper = " + globalCmd + "\n"
+	configureIsolatedGlobalGit(t, content)
+
+	err := (GlobalGitConfig{HelperCommand: scopedCmd}).SetHelper(context.Background(), url, "app_xxx")
+	assertProblemSubtype(t, err, errs.SubtypeFailedPrecondition)
+
+	// The untracked username key must survive.
+	got, err := exec.Command("git", "config", "--global", "--get", gitCredentialKey(url, "username")).Output()
+	if err != nil {
+		t.Fatalf("username key was discarded: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "alice" {
+		t.Fatalf("username = %q, want preserved alice", got)
+	}
+}
+
+// TestGlobalGitConfigRepositionsWhenUntrackedKeyLivesOnlyInIncludedConfig proves
+// the untracked-key scan is scoped to the writable file (--no-includes): when
+// the only "extra" URL-scoped key (username) lives in an INCLUDED config —
+// which --remove-section never edits — repositioning must proceed and succeed,
+// not fail closed. The included username must survive untouched.
+func TestGlobalGitConfigRepositionsWhenUntrackedKeyLivesOnlyInIncludedConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test helpers are POSIX shell scripts")
+	}
+	url := "https://example.com/git/u/app.git"
+	scopedCmd := "!scoped-cmd"
+	globalCmd := "!global-cmd"
+	root := t.TempDir()
+	includePath := filepath.Join(root, "included.config")
+	// The included config holds the untracked username AND a later generic helper
+	// that forces repositioning of the writable lark-cli section.
+	writeTestFile(t, includePath, []byte(
+		"[credential \""+url+"\"]\n\tusername = alice\n"+
+			"[credential]\n\thelper = "+globalCmd+"\n"))
+	// The writable file holds only the lark-cli-tracked keys, then the include.
+	content := "[credential \"" + url + "\"]\n" +
+		"\thelper = \n" +
+		"\thelper = " + scopedCmd + "\n" +
+		"\tuseHttpPath = true\n" +
+		"[include]\n\tpath = " + includePath + "\n"
+	globalPath := configureIsolatedGlobalGit(t, content)
+
+	if err := (GlobalGitConfig{HelperCommand: scopedCmd}).SetHelper(context.Background(), url, "app_xxx"); err != nil {
+		t.Fatalf("SetHelper() error = %v, want success (untracked key is include-only)", err)
+	}
+
+	// The included username must be untouched (it lives outside the writable file).
+	afterInclude, err := os.ReadFile(includePath)
+	if err != nil {
+		t.Fatalf("read included config: %v", err)
+	}
+	if !strings.Contains(string(afterInclude), "username = alice") {
+		t.Fatalf("included username was modified:\n%s", afterInclude)
+	}
+
+	// The writable file must not have grown a username key from the include.
+	afterGlobal, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("read global config: %v", err)
+	}
+	if strings.Contains(string(afterGlobal), "username") {
+		t.Fatalf("writable file unexpectedly gained a username key:\n%s", afterGlobal)
+	}
+}
+
+// TestGlobalConfigLockNameResolvesRelativeOrigin proves the global-config lock
+// name is derived from an absolute path, so a relative GIT_CONFIG_GLOBAL maps to
+// the same lock regardless of the caller's working directory. Without absolute
+// resolution the name would embed the relative path verbatim and collide with a
+// different config file that happens to share that relative name from another
+// cwd.
+func TestGlobalConfigLockNameResolvesRelativeOrigin(t *testing.T) {
+	rel := globalConfigLockName("file:relative/global.config")
+	abs, err := filepath.Abs("relative/global.config")
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	want := "apps_git_credential_globalcfg_" + safeLockNameChars.ReplaceAllString(abs, "_") + ".lock"
+	if rel != want {
+		t.Fatalf("lock name = %q, want absolute-resolved %q", rel, want)
+	}
+	// An already-absolute origin must resolve to the same name (idempotent).
+	if got := globalConfigLockName("file:" + abs); got != want {
+		t.Fatalf("absolute origin lock name = %q, want %q", got, want)
+	}
+}
+
+// TestLockGlobalConfigWrapsAcquireFailureAsTypedError proves a lock-acquisition
+// failure (not just the mkdir failure) is returned as a typed InternalError with
+// SubtypeStorage, so SetHelper/UnsetHelper surface consistent metadata. It forces
+// the failure by pre-creating the lock file path as a directory, which makes the
+// underlying O_CREATE|O_RDWR open fail with a non-retryable error.
+func TestLockGlobalConfigWrapsAcquireFailureAsTypedError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX open-a-directory-for-write failing")
+	}
+	configDir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", configDir)
+
+	origin := "file:" + filepath.Join(t.TempDir(), "global.config")
+	lockPath := filepath.Join(configDir, "locks", filepath.Base(globalConfigLockName(origin)))
+	if err := os.MkdirAll(lockPath, 0o700); err != nil {
+		t.Fatalf("pre-create lock path as directory: %v", err)
+	}
+
+	unlock, err := lockGlobalConfig(origin)
+	if err == nil {
+		unlock()
+		t.Fatal("lockGlobalConfig() succeeded, want a typed acquisition failure")
+	}
+	assertProblemSubtype(t, err, errs.SubtypeStorage)
+}

--- a/shortcuts/apps/gitcred/gitcred_test.go
+++ b/shortcuts/apps/gitcred/gitcred_test.go
@@ -113,8 +113,8 @@ func (f *fakeGitConfig) SetHelper(ctx context.Context, gitHTTPURL, appID string)
 	return f.err
 }
 
-func (f *fakeGitConfig) UnsetHelper(ctx context.Context, gitHTTPURL string) error {
-	f.unset = append(f.unset, gitHTTPURL)
+func (f *fakeGitConfig) UnsetHelper(ctx context.Context, gitHTTPURL, appID string) error {
+	f.unset = append(f.unset, gitHTTPURL+" "+appID)
 	return f.err
 }
 
@@ -127,7 +127,7 @@ func (f splitFakeGitConfig) SetHelper(ctx context.Context, gitHTTPURL, appID str
 	return f.setErr
 }
 
-func (f splitFakeGitConfig) UnsetHelper(ctx context.Context, gitHTTPURL string) error {
+func (f splitFakeGitConfig) UnsetHelper(ctx context.Context, gitHTTPURL, appID string) error {
 	return f.unsetErr
 }
 
@@ -325,8 +325,8 @@ func TestManagerInitCleansOldURLHelperAfterRepositoryURLChanges(t *testing.T) {
 	if _, err := manager.Init(context.Background(), testProfile(), "app_xxx"); err != nil {
 		t.Fatalf("second Init returned error: %v", err)
 	}
-	if len(gitConfig.unset) != 1 || gitConfig.unset[0] != "https://example.com/git/u/old.git" {
-		t.Fatalf("git config unset = %#v, want old URL cleanup", gitConfig.unset)
+	if got, want := gitConfig.unset, []string{"https://example.com/git/u/old.git app_xxx"}; !slices.Equal(got, want) {
+		t.Fatalf("git config unset = %#v, want %#v", got, want)
 	}
 }
 
@@ -752,8 +752,8 @@ func TestRemoveDeletesMetadataSecretAndGitConfig(t *testing.T) {
 	if got := kc.values[result.Records[0].PATRef]; got != "" {
 		t.Fatalf("keychain PAT after remove = %q, want empty", got)
 	}
-	if len(gitConfig.unset) != 1 || gitConfig.unset[0] != "https://example.com/git/u/app.git" {
-		t.Fatalf("git config unset = %#v", gitConfig.unset)
+	if got, want := gitConfig.unset, []string{"https://example.com/git/u/app.git app_xxx"}; !slices.Equal(got, want) {
+		t.Fatalf("git config unset = %#v, want %#v", got, want)
 	}
 	record, err := manager.Store.FindByURL("https://example.com/git/u/app.git")
 	if err != nil {
@@ -807,8 +807,8 @@ func TestInitWorksAfterRemove(t *testing.T) {
 	if len(gitConfig.set) != 2 {
 		t.Fatalf("git config set calls = %#v, want initial and re-init", gitConfig.set)
 	}
-	if len(gitConfig.unset) != 1 {
-		t.Fatalf("git config unset calls = %#v, want remove cleanup", gitConfig.unset)
+	if got, want := gitConfig.unset, []string{"https://example.com/git/u/app.git app_xxx"}; !slices.Equal(got, want) {
+		t.Fatalf("git config unset calls = %#v, want %#v", got, want)
 	}
 }
 
@@ -948,186 +948,6 @@ func TestListReturnsStoreError(t *testing.T) {
 	}
 	if _, err := manager.List(); err == nil || !strings.Contains(err.Error(), "invalid git.json") {
 		t.Fatalf("List store error = %v", err)
-	}
-}
-
-func TestGlobalGitConfigSetAndUnsetHelper(t *testing.T) {
-	logPath := installFakeGit(t, 0)
-	cfg := GlobalGitConfig{HelperCommand: "!custom-helper"}
-	ctx := context.Background()
-
-	if err := cfg.SetHelper(ctx, "https://example.com/git/u/app.git", "app_xxx"); err != nil {
-		t.Fatalf("SetHelper returned error: %v", err)
-	}
-	if err := cfg.UnsetHelper(ctx, "https://example.com/git/u/app.git"); err != nil {
-		t.Fatalf("UnsetHelper returned error: %v", err)
-	}
-
-	log := readFileString(t, logPath)
-	for _, want := range []string{
-		"config --global credential.https://example.com/git/u/app.git.helper !custom-helper",
-		"config --global credential.https://example.com/git/u/app.git.useHttpPath true",
-		"config --global --unset credential.https://example.com/git/u/app.git.helper",
-		"config --global --unset credential.https://example.com/git/u/app.git.useHttpPath",
-	} {
-		if !strings.Contains(log, want) {
-			t.Fatalf("git log missing %q in:\n%s", want, log)
-		}
-	}
-}
-
-func TestGlobalGitConfigNormalizesCredentialKeyURL(t *testing.T) {
-	logPath := installFakeGit(t, 0)
-	cfg := GlobalGitConfig{HelperCommand: "!custom-helper"}
-	rawURL := "HTTPS://[2001:DB8::1]:443//repo.git?x=1"
-
-	if err := cfg.SetHelper(context.Background(), rawURL, "app_xxx"); err != nil {
-		t.Fatalf("SetHelper returned error: %v", err)
-	}
-	if err := cfg.UnsetHelper(context.Background(), rawURL); err != nil {
-		t.Fatalf("UnsetHelper returned error: %v", err)
-	}
-
-	log := readFileString(t, logPath)
-	for _, want := range []string{
-		"config --global credential.https://[2001:db8::1]/repo.git.helper !custom-helper",
-		"config --global credential.https://[2001:db8::1]/repo.git.useHttpPath true",
-		"config --global --unset credential.https://[2001:db8::1]/repo.git.helper",
-		"config --global --unset credential.https://[2001:db8::1]/repo.git.useHttpPath",
-	} {
-		if !strings.Contains(log, want) {
-			t.Fatalf("git log missing normalized key %q in:\n%s", want, log)
-		}
-	}
-}
-
-func TestGlobalGitConfigRollsBackHelperWhenUseHttpPathFails(t *testing.T) {
-	logPath := installFakeGit(t, 7)
-	err := (GlobalGitConfig{}).SetHelper(context.Background(), "https://example.com/git/u/app.git", "app_xxx")
-	if err == nil {
-		t.Fatal("SetHelper returned nil error, want git failure")
-	}
-	log := readFileString(t, logPath)
-	if !strings.Contains(log, "config --global --unset credential.https://example.com/git/u/app.git.helper") {
-		t.Fatalf("git log missing rollback unset:\n%s", log)
-	}
-}
-
-func TestGlobalGitConfigQuotesDefaultHelperAppID(t *testing.T) {
-	logPath := installFakeGit(t, 0)
-	appID := "app_xxx; touch /tmp/pwned"
-	if err := (GlobalGitConfig{}).SetHelper(context.Background(), "https://example.com/git/u/app.git", appID); err != nil {
-		t.Fatalf("SetHelper returned error: %v", err)
-	}
-	log := readFileString(t, logPath)
-	want := "helper !lark-cli apps git-credential-helper --app-id 'app_xxx; touch /tmp/pwned'"
-	if !strings.Contains(log, want) {
-		t.Fatalf("git log missing quoted helper %q in:\n%s", want, log)
-	}
-}
-
-func TestGlobalGitConfigReturnsFirstGitCommandError(t *testing.T) {
-	installAlwaysFailingGit(t)
-	err := (GlobalGitConfig{}).SetHelper(context.Background(), "https://example.com/git/u/app.git", "app_xxx")
-	if err == nil {
-		t.Fatal("SetHelper returned nil error, want first git command failure")
-	}
-}
-
-func TestGlobalGitConfigUnsetReportsUnexpectedErrors(t *testing.T) {
-	installAlwaysFailingGit(t)
-	err := (GlobalGitConfig{}).UnsetHelper(context.Background(), "https://example.com/git/u/app.git")
-	if err == nil || !strings.Contains(err.Error(), "get credential.https://example.com/git/u/app.git.helper") {
-		t.Fatalf("UnsetHelper error = %v", err)
-	}
-}
-
-func TestGlobalGitConfigDoesNotOverwriteOrUnsetNonLarkHelper(t *testing.T) {
-	logPath := installFakeGitWithGet(t, "!other-helper")
-	cfg := GlobalGitConfig{}
-	err := cfg.SetHelper(context.Background(), "https://example.com/git/u/app.git", "app_xxx")
-	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite non-lark helper") {
-		t.Fatalf("SetHelper error = %v", err)
-	}
-	if err := cfg.UnsetHelper(context.Background(), "https://example.com/git/u/app.git"); err != nil {
-		t.Fatalf("UnsetHelper returned error: %v", err)
-	}
-	log := readFileString(t, logPath)
-	for _, unwanted := range []string{
-		"credential.https://example.com/git/u/app.git.helper !lark-cli",
-		"--unset credential.https://example.com/git/u/app.git.helper",
-		"--unset credential.https://example.com/git/u/app.git.useHttpPath",
-	} {
-		if strings.Contains(log, unwanted) {
-			t.Fatalf("git log contains unwanted %q in:\n%s", unwanted, log)
-		}
-	}
-}
-
-func TestGlobalGitConfigUnsetIgnoresMissingManagedKeys(t *testing.T) {
-	logPath := installFakeGitWithGetAndUnsetExit(t, "!lark-cli apps git-credential-helper --app-id app_xxx", 5)
-	if err := (GlobalGitConfig{}).UnsetHelper(context.Background(), "https://example.com/git/u/app.git"); err != nil {
-		t.Fatalf("UnsetHelper returned error: %v", err)
-	}
-	log := readFileString(t, logPath)
-	for _, want := range []string{
-		"config --global --unset credential.https://example.com/git/u/app.git.helper",
-		"config --global --unset credential.https://example.com/git/u/app.git.useHttpPath",
-	} {
-		if !strings.Contains(log, want) {
-			t.Fatalf("git log missing %q in:\n%s", want, log)
-		}
-	}
-}
-
-func TestGlobalGitConfigAdditionalBranches(t *testing.T) {
-	if err := (GlobalGitConfig{}).SetHelper(context.Background(), "ssh://example.com/git/u/app.git", "app_xxx"); err == nil {
-		t.Fatal("SetHelper invalid URL returned nil error")
-	}
-	if err := (GlobalGitConfig{}).UnsetHelper(context.Background(), "ssh://example.com/git/u/app.git"); err == nil {
-		t.Fatal("UnsetHelper invalid URL returned nil error")
-	}
-
-	if err := (GlobalGitConfig{}).SetHelper(context.Background(), "https://example.com/git/u/app.git", "../bad"); err == nil {
-		t.Fatal("SetHelper invalid appID returned nil error")
-	}
-
-	installFakeGitSetFails(t)
-	if err := (GlobalGitConfig{}).SetHelper(context.Background(), "https://example.com/git/u/app.git", "app_xxx"); err == nil {
-		t.Fatal("SetHelper set failure returned nil error")
-	}
-
-	logPath := installFakeGitWithGetAndUseHTTPPathFailure(t, "!lark-cli apps git-credential-helper --app-id old_app", 7)
-	if err := (GlobalGitConfig{}).SetHelper(context.Background(), "https://example.com/git/u/app.git", "app_xxx"); err == nil {
-		t.Fatal("SetHelper useHttpPath failure returned nil error")
-	}
-	log := readFileString(t, logPath)
-	if !strings.Contains(log, "config --global credential.https://example.com/git/u/app.git.helper !lark-cli apps git-credential-helper --app-id old_app") {
-		t.Fatalf("git log missing previous helper restore:\n%s", log)
-	}
-
-	installFakeGitWithGetAndUnsetExit(t, "!lark-cli apps git-credential-helper --app-id app_xxx", 9)
-	if err := (GlobalGitConfig{}).UnsetHelper(context.Background(), "https://example.com/git/u/app.git"); err == nil || !strings.Contains(err.Error(), "unset credential.https://example.com/git/u/app.git.helper") {
-		t.Fatalf("UnsetHelper helper unset error = %v", err)
-	}
-
-	logPath = installFakeGitWithGetAndSecondUnsetFails(t, "!lark-cli apps git-credential-helper --app-id app_xxx")
-	if err := (GlobalGitConfig{}).UnsetHelper(context.Background(), "https://example.com/git/u/app.git"); err == nil || !strings.Contains(err.Error(), "unset credential.https://example.com/git/u/app.git.useHttpPath") {
-		t.Fatalf("UnsetHelper useHttpPath unset error = %v", err)
-	}
-	if !strings.Contains(readFileString(t, logPath), "--unset credential.https://example.com/git/u/app.git.useHttpPath") {
-		t.Fatalf("git log missing useHttpPath unset:\n%s", readFileString(t, logPath))
-	}
-
-	cfg := GlobalGitConfig{HelperCommand: "!custom-helper"}
-	if !cfg.isManagedHelper(" !custom-helper ") {
-		t.Fatal("custom helper should be managed")
-	}
-	if cfg.isManagedHelper("!other-helper") {
-		t.Fatal("other helper should not be managed")
-	}
-	if isGitConfigUnsetMissing(errors.New("plain error")) {
-		t.Fatal("plain error must not be treated as missing git config")
 	}
 }
 
@@ -2478,160 +2298,6 @@ func (w *failWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func installFakeGit(t *testing.T, failUseHTTPPathExit int) string {
-	t.Helper()
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "git.log")
-	gitPath := filepath.Join(dir, "git")
-	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> "$GIT_FAKE_LOG"
-case "$*" in
-  *"--get"*) exit 1 ;;
-esac
-case "$*" in
-  *useHttpPath*) exit %d ;;
-esac
-exit 0
-`, failUseHTTPPathExit)
-	if failUseHTTPPathExit == 0 {
-		script = `#!/bin/sh
-printf '%s\n' "$*" >> "$GIT_FAKE_LOG"
-case "$*" in
-  *"--get"*) exit 1 ;;
-esac
-exit 0
-`
-	}
-	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
-		t.Fatalf("write fake git: %v", err)
-	}
-	t.Setenv("GIT_FAKE_LOG", logPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return logPath
-}
-
-func installFakeGitWithGet(t *testing.T, value string) string {
-	t.Helper()
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "git.log")
-	gitPath := filepath.Join(dir, "git")
-	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> "$GIT_FAKE_LOG"
-case "$*" in
-  *"--get"*) printf '%%s\n' %s; exit 0 ;;
-esac
-exit 0
-`, shellQuoteArg(value))
-	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
-		t.Fatalf("write fake git: %v", err)
-	}
-	t.Setenv("GIT_FAKE_LOG", logPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return logPath
-}
-
-func installFakeGitWithGetAndUnsetExit(t *testing.T, value string, unsetExit int) string {
-	t.Helper()
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "git.log")
-	gitPath := filepath.Join(dir, "git")
-	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> "$GIT_FAKE_LOG"
-case "$*" in
-  *"--get"*) printf '%%s\n' %s; exit 0 ;;
-  *"--unset"*) exit %d ;;
-esac
-exit 0
-`, shellQuoteArg(value), unsetExit)
-	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
-		t.Fatalf("write fake git: %v", err)
-	}
-	t.Setenv("GIT_FAKE_LOG", logPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return logPath
-}
-
-func installFakeGitSetFails(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "git.log")
-	gitPath := filepath.Join(dir, "git")
-	script := `#!/bin/sh
-printf '%s\n' "$*" >> "$GIT_FAKE_LOG"
-case "$*" in
-  *"--get"*) exit 1 ;;
-  *".helper "*) exit 8 ;;
-esac
-exit 0
-`
-	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
-		t.Fatalf("write fake git: %v", err)
-	}
-	t.Setenv("GIT_FAKE_LOG", logPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return logPath
-}
-
-func installFakeGitWithGetAndUseHTTPPathFailure(t *testing.T, value string, useHTTPPathExit int) string {
-	t.Helper()
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "git.log")
-	gitPath := filepath.Join(dir, "git")
-	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> "$GIT_FAKE_LOG"
-case "$*" in
-  *"--get"*) printf '%%s\n' %s; exit 0 ;;
-  *"useHttpPath true"*) exit %d ;;
-esac
-exit 0
-`, shellQuoteArg(value), useHTTPPathExit)
-	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
-		t.Fatalf("write fake git: %v", err)
-	}
-	t.Setenv("GIT_FAKE_LOG", logPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return logPath
-}
-
-func installFakeGitWithGetAndSecondUnsetFails(t *testing.T, value string) string {
-	t.Helper()
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "git.log")
-	gitPath := filepath.Join(dir, "git")
-	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> "$GIT_FAKE_LOG"
-case "$*" in
-  *"--get"*) printf '%%s\n' %s; exit 0 ;;
-  *"--unset"*"useHttpPath"*) exit 9 ;;
-  *"--unset"*) exit 0 ;;
-esac
-exit 0
-`, shellQuoteArg(value))
-	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
-		t.Fatalf("write fake git: %v", err)
-	}
-	t.Setenv("GIT_FAKE_LOG", logPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return logPath
-}
-
-func installAlwaysFailingGit(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "git.log")
-	gitPath := filepath.Join(dir, "git")
-	script := `#!/bin/sh
-printf '%s\n' "$*" >> "$GIT_FAKE_LOG"
-exit 9
-`
-	if err := os.WriteFile(gitPath, []byte(script), 0700); err != nil {
-		t.Fatalf("write fake git: %v", err)
-	}
-	t.Setenv("GIT_FAKE_LOG", logPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return logPath
-}
-
 func makeDirReadOnly(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.Chmod(dir, 0500); err != nil {
@@ -2640,15 +2306,6 @@ func makeDirReadOnly(t *testing.T, dir string) {
 	t.Cleanup(func() {
 		_ = os.Chmod(dir, 0700)
 	})
-}
-
-func readFileString(t *testing.T, path string) string {
-	t.Helper()
-	data, err := os.ReadFile(path)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("read %s: %v", path, err)
-	}
-	return string(data)
 }
 
 var _ io.Reader = errorReader{}

--- a/shortcuts/apps/gitcred/helper.go
+++ b/shortcuts/apps/gitcred/helper.go
@@ -144,7 +144,7 @@ func (m *Manager) Init(ctx context.Context, profile ProfileContext, appID string
 		if err := m.GitConfig.SetHelper(ctx, url, appID); err != nil {
 			result.ConfigWarning = err.Error()
 		} else if previous != nil && previous.GitHTTPURL != "" && previous.GitHTTPURL != url {
-			if err := m.GitConfig.UnsetHelper(ctx, previous.GitHTTPURL); err != nil {
+			if err := m.GitConfig.UnsetHelper(ctx, previous.GitHTTPURL, previous.AppID); err != nil {
 				result.ConfigWarning = err.Error()
 			}
 		}
@@ -175,7 +175,7 @@ func (m *Manager) Remove(ctx context.Context, profile ProfileContext, appID stri
 			return nil, err
 		}
 		if m.GitConfig != nil {
-			if err := m.GitConfig.UnsetHelper(ctx, record.GitHTTPURL); err != nil {
+			if err := m.GitConfig.UnsetHelper(ctx, record.GitHTTPURL, record.AppID); err != nil {
 				result.ConfigWarning = err.Error()
 			}
 		}

--- a/shortcuts/apps/gitcred/lock.go
+++ b/shortcuts/apps/gitcred/lock.go
@@ -5,26 +5,34 @@
 //
 // Lock ordering convention — read this before adding any new lock acquisition:
 //
-//	ALWAYS acquire lockApp BEFORE lockURL. Never invert this order.
+//	ALWAYS acquire lockApp BEFORE lockGlobalConfig, and lockGlobalConfig
+//	BEFORE lockURL. Never invert this order.
 //
 // Rationale:
 //   - lockApp is a cross-process file lock with bounded timeout (2s) and a
 //     possible setup error; acquiring it first keeps the failure surface
 //     outside any in-process lock and avoids holding the in-process mutex
 //     while waiting on I/O / another process.
+//   - lockGlobalConfig is a cross-process file lock, keyed by the writable
+//     global Git config file path, that serializes the read-modify-write of
+//     that file across concurrent lark-cli processes. It sits below lockApp
+//     (which is finer-grained, per app) and above lockURL.
 //   - lockURL is an in-process sync.Mutex that never fails and blocks
-//     indefinitely; holding it while waiting on lockApp would risk
-//     deadlocking with a concurrent goroutine that held lockApp first.
+//     indefinitely; holding it while waiting on a file lock would risk
+//     deadlocking with a concurrent goroutine that held the file lock first.
 //
-// Paths that only manipulate per-app state (Init, Remove, Erase) only need
-// lockApp. Get() is the only path that touches per-URL state in addition to
-// per-app state, so it is the only caller that takes both locks.
+// Paths that only manipulate per-app state (Init, Remove, Erase) take lockApp.
+// SetHelper/UnsetHelper additionally take lockGlobalConfig because they perform
+// a read-modify-write on the shared global config file. Get() is the only path
+// that touches per-URL state in addition to per-app state, so it is the only
+// caller that takes lockURL.
 package gitcred
 
 import (
 	"errors"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -62,7 +70,51 @@ func lockApp(appID string) (func(), error) {
 		return nil, errs.NewInternalError(errs.SubtypeStorage, "create Git credential lock dir: %v", err).WithCause(err)
 	}
 	name := "apps_git_credential_" + safeLockNameChars.ReplaceAllString(appID, "_") + ".lock"
-	lock := lockfile.New(filepath.Join(dir, filepath.Base(name)))
+	return acquireFileLock(filepath.Join(dir, filepath.Base(name)))
+}
+
+// lockGlobalConfig acquires a cross-process file lock that serializes the
+// read-modify-write of the writable global Git config file identified by
+// origin (a git "file:" origin or a bare path). It is keyed by the config file
+// path so concurrent lark-cli processes editing the same global config are
+// serialized while edits to different config files proceed independently.
+//
+// Lock ordering: lockGlobalConfig must be taken AFTER lockApp and BEFORE
+// lockURL. See package comment for the full convention.
+func lockGlobalConfig(origin string) (func(), error) {
+	dir := filepath.Join(core.GetConfigDir(), "locks")
+	if err := vfs.MkdirAll(dir, 0700); err != nil {
+		return nil, errs.NewInternalError(errs.SubtypeStorage, "create Git credential lock dir: %v", err).WithCause(err)
+	}
+	name := globalConfigLockName(origin)
+	unlock, err := acquireFileLock(filepath.Join(dir, filepath.Base(name)))
+	if err != nil {
+		return nil, errs.NewInternalError(errs.SubtypeStorage, "acquire global Git config lock: %v", err).WithCause(err)
+	}
+	return unlock, nil
+}
+
+// globalConfigLockName derives the cross-process lock file name for a writable
+// global config origin. GIT_CONFIG_GLOBAL may be a relative path, which would
+// otherwise make the lock name (and therefore the lock file) depend on the
+// caller's working directory; joining it onto the current directory ensures
+// every process locking the same config file agrees on the lock regardless of
+// cwd. It falls back to the raw path if the cwd is unavailable.
+func globalConfigLockName(origin string) string {
+	path := strings.TrimPrefix(origin, "file:")
+	if !filepath.IsAbs(path) {
+		if cwd, err := vfs.Getwd(); err == nil {
+			path = filepath.Join(cwd, path)
+		}
+	}
+	return "apps_git_credential_globalcfg_" + safeLockNameChars.ReplaceAllString(path, "_") + ".lock"
+}
+
+// acquireFileLock takes the cross-process lock at lockPath, retrying on
+// contention until a 2s deadline. It returns an unlock function or an error if
+// the lock cannot be acquired within the timeout.
+func acquireFileLock(lockPath string) (func(), error) {
+	lock := lockfile.New(lockPath)
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		err := lock.TryLock()


### PR DESCRIPTION
## Summary

`apps +git-credential-init` previously configured a single URL-scoped Git
credential helper, which left other global helpers participating in
`get`/`store`/`erase` for the repo. This isolates the credential helper chain
so only lark-cli handles credentials for the configured repository URL.

## Changes

- Write the URL-scoped helper using Git's empty-helper reset semantics (reset
  the helper list, then add the lark-cli helper) together with
  `useHttpPath=true`, so earlier global helpers no longer participate for the
  repo URL.
- Verify ownership of the existing URL-scoped configuration before writing;
  third-party, mixed, cross-origin, or include-sourced values fail closed
  without modifying user config.
- Re-read the configuration after writing and roll back to the original values
  on a mid-write failure (unless an external change is detected).
- Validate and shell-quote the app id, and normalize config origins so a
  relative `GIT_CONFIG_GLOBAL` still matches.
- PAT issuance, SecretStore, and CLI output are unchanged.

## Review-driven correctness fixes

Three gaps were found in review and fixed in this PR:

1. **Later-parsing helpers were not isolated.** Git's empty-helper (`""`) reset
   only clears helpers that parse *before* the lark-cli section; a generic
   `credential.helper` (or one from a later `[include]`) that parses *after* it
   still participated in `get`/`store`/`erase`. `SetHelper` now verifies, using
   the faithful parse-order oracle (`git config --includes --show-origin -z
   --list`), that the lark-cli helper is last in fill order. If it is not, the
   section is repositioned to the end of the writable global file; if a
   competing helper lives in a file we must not edit, `SetHelper` fails closed
   with a `FailedPrecondition` error and restores the prior state — it never
   leaves a written-but-ineffective config.
2. **Concurrent read-modify-write could silently lose an `--add`.** The
   optimistic read followed by an unconditional `--unset-all` could drop a
   concurrent write. `SetHelper`/`UnsetHelper` now serialize the
   read-modify-write of the writable global config file under a new
   cross-process `lockGlobalConfig` (ordered after `lockApp`, before `lockURL`).
3. **Teardown could leave an unrecoverable or silently-wrong state.**
   `UnsetHelper` now deletes `useHttpPath` *before* the helper list, so a
   mid-teardown failure leaves a lark-cli-recoverable residue rather than a
   `useHttpPath`-only orphan that would block re-init. For a helper list that
   mixes lark-cli and third-party values, it removes only the lark-cli values
   and reports (non-fatally) that a third-party helper remains, instead of
   silently no-op'ing. The managed-state taxonomy gains `Foreign`/`Partial`/
   `Mixed` to drive these paths.

### Residual / known limitation

`lockGlobalConfig` serializes concurrent **lark-cli** writers on the same global
config file. It does not serialize non-lark-cli writers (e.g. a user running
`git config` concurrently); such a race is detected by the post-write readback,
which fails closed with `FailedPrecondition` rather than silently clobbering the
foreign change.

## Test Plan

- [x] `make unit-test`
- [x] `go vet ./...`, `gofmt`, `go mod tidy` (no changes)
- [x] `go test ./shortcuts/apps/gitcred/... -race`
- [x] Added unit tests covering ownership classification, reset semantics,
      rollback, cross-origin/include-source refusal, later-helper isolation and
      fail-closed, concurrent-writer serialization, recoverable teardown,
      mixed-owned cleanup, real `git credential fill`, and app-id shell-quoting
- [x] Sandbox end-to-end tests for the init flow and helper-chain reset
- [x] Manual verification of the URL-scoped config output

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git credential helper management to prevent interference with unrelated configurations.
  * Added safer validation, verification, and rollback when Git settings change.
  * Improved cleanup of outdated credential settings when credentials are changed or removed.
  * Added support for recognizing and migrating previously managed Git configurations.
  * Scoped credential cleanup to the appropriate application.
  * Improved handling of concurrent configuration changes, shared configuration files, and cleanup failures.

* **Tests**
  * Expanded coverage for Git configuration parsing, isolation, ownership, migration, ordering, failures, rollback, concurrency, and credential execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
