### PR TITLE
fix(drive): stop export polling on rate limits

### DIFF
--- a/shortcuts/drive/drive_errors.go
+++ b/shortcuts/drive/drive_errors.go
@@ -100,3 +100,43 @@ func appendDriveExportRecoveryHint(err error, hint string) error {
 	}
 	return errs.NewInternalError(errs.SubtypeSDKError, "%s", err.Error()).WithHint(hint).WithCause(err)
 }
+
+// driveExportIsRateLimit follows the same typed-error inspection pattern as
+// driveInspectShouldRetry, but export status polling uses the signal to stop.
+// Continuing to poll after a rate-limit response only amplifies the throttling.
+func driveExportIsRateLimit(err error) bool {
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem == nil {
+		return false
+	}
+	return problem.Subtype == errs.SubtypeRateLimit || problem.Code == 99991400
+}
+
+// withDriveExportRateLimitRecovery preserves the upstream typed rate-limit
+// error while giving agents a resumable, task-aware recovery path. The export
+// task already exists at this point, so callers must reuse its ticket instead
+// of creating a duplicate task with drive +export.
+func withDriveExportRateLimitRecovery(err error, ticket, fileToken string) error {
+	if !driveExportIsRateLimit(err) {
+		return err
+	}
+
+	hint := fmt.Sprintf(
+		"export task status lookup was rate limited (ticket=%s); stop polling and wait at least 1 minute before retrying with: %s\nif rate limiting continues, use exponential backoff starting at 1 minute instead of retrying immediately; do not run `lark-cli drive +export` again because the export task already exists",
+		ticket,
+		driveExportTaskResultCommand(ticket, fileToken),
+	)
+	return appendDriveExportRecoveryHint(err, hint)
+}
+
+// withDriveExportCreateRateLimitRecovery handles throttling before the export
+// task exists. There is no ticket to resume, so callers must retry the original
+// export command after backing off instead of invoking drive +task_result.
+func withDriveExportCreateRateLimitRecovery(err error) error {
+	if !driveExportIsRateLimit(err) {
+		return err
+	}
+
+	const hint = "export task creation was rate limited before a ticket was issued; stop and wait at least 1 minute, then rerun the same `lark-cli drive +export` command\nif rate limiting continues, use exponential backoff starting at 1 minute instead of retrying immediately; do not run `lark-cli drive +task_result` because no export ticket exists yet"
+	return appendDriveExportRecoveryHint(err, hint)
+}

--- a/shortcuts/drive/drive_export.go
+++ b/shortcuts/drive/drive_export.go
@@ -295,6 +295,9 @@ func RunExport(ctx context.Context, runtime *common.RuntimeContext, p ExportPara
 
 		status, err := getDriveExportStatus(runtime, spec.Token, ticket)
 		if err != nil {
+			if driveExportIsRateLimit(err) {
+				return withDriveExportRateLimitRecovery(err, ticket, spec.Token)
+			}
 			// Treat polling failures as transient so short-lived backend hiccups
 			// do not immediately fail an otherwise healthy export task.
 			lastPollErr = err

--- a/shortcuts/drive/drive_export_common.go
+++ b/shortcuts/drive/drive_export_common.go
@@ -422,7 +422,7 @@ func buildDriveExportTaskBody(spec driveExportSpec) map[string]interface{} {
 func createDriveExportTask(runtime *common.RuntimeContext, spec driveExportSpec) (string, error) {
 	data, err := runtime.CallAPITyped("POST", "/open-apis/drive/v1/export_tasks", nil, buildDriveExportTaskBody(spec))
 	if err != nil {
-		return "", err
+		return "", withDriveExportCreateRateLimitRecovery(err)
 	}
 
 	ticket := common.GetString(data, "ticket")

--- a/shortcuts/drive/drive_export_test.go
+++ b/shortcuts/drive/drive_export_test.go
@@ -1377,6 +1377,179 @@ func TestDriveExportPollErrorsReturnLastErrorWithRecoveryHint(t *testing.T) {
 	}
 }
 
+func TestDriveExportRateLimitStopsPollingAndSuggestsOneMinuteBackoff(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ticket": "tk_rate_limited"},
+		},
+	})
+	pollStub := &httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/drive/v1/export_tasks/tk_rate_limited",
+		Status:   http.StatusTooManyRequests,
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 99991400,
+			"msg":  "request trigger frequency limit",
+		},
+	}
+	reg.Register(pollStub)
+
+	prevAttempts, prevInterval := driveExportPollAttempts, driveExportPollInterval
+	driveExportPollAttempts, driveExportPollInterval = 3, 0
+	t.Cleanup(func() {
+		driveExportPollAttempts, driveExportPollInterval = prevAttempts, prevInterval
+	})
+
+	err := mountAndRunDrive(t, DriveExport, []string{
+		"+export",
+		"--token", "docx123",
+		"--doc-type", "docx",
+		"--file-extension", "pdf",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected rate-limit error, got nil")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout should stay empty on rate limit: %s", stdout.String())
+	}
+	if got := len(pollStub.CapturedBodies); got != 1 {
+		t.Fatalf("export status poll count = %d, want 1 after rate limit", got)
+	}
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed rate-limit error, got %T (%v)", err, err)
+	}
+	if problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeRateLimit || problem.Code != 99991400 || !problem.Retryable {
+		t.Fatalf("problem = %+v, want api/rate_limit code 99991400 retryable", problem)
+	}
+	for _, want := range []string{
+		"wait at least 1 minute",
+		"exponential backoff starting at 1 minute",
+		"lark-cli drive +task_result --scenario export --ticket tk_rate_limited --file-token docx123",
+		"do not run `lark-cli drive +export` again",
+	} {
+		if !strings.Contains(problem.Hint, want) {
+			t.Fatalf("hint missing %q: %q", want, problem.Hint)
+		}
+	}
+}
+
+func TestDriveExportCreateRateLimitSuggestsRetryingOriginalCommand(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	createStub := &httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Status: http.StatusTooManyRequests,
+		Body: map[string]interface{}{
+			"code": 99991400,
+			"msg":  "request trigger frequency limit",
+		},
+	}
+	reg.Register(createStub)
+
+	err := mountAndRunDrive(t, DriveExport, []string{
+		"+export",
+		"--token", "docx123",
+		"--doc-type", "docx",
+		"--file-extension", "pdf",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected rate-limit error, got nil")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout should stay empty on rate limit: %s", stdout.String())
+	}
+	if got := len(createStub.CapturedBodies); got != 1 {
+		t.Fatalf("export task creation count = %d, want 1", got)
+	}
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed rate-limit error, got %T (%v)", err, err)
+	}
+	if problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeRateLimit || problem.Code != 99991400 || !problem.Retryable {
+		t.Fatalf("problem = %+v, want api/rate_limit code 99991400 retryable", problem)
+	}
+	for _, want := range []string{
+		"before a ticket was issued",
+		"wait at least 1 minute",
+		"rerun the same `lark-cli drive +export` command",
+		"exponential backoff starting at 1 minute",
+		"do not run `lark-cli drive +task_result`",
+	} {
+		if !strings.Contains(problem.Hint, want) {
+			t.Fatalf("hint missing %q: %q", want, problem.Hint)
+		}
+	}
+	if strings.Contains(problem.Hint, "--ticket") {
+		t.Fatalf("creation hint must not invent a ticket: %q", problem.Hint)
+	}
+}
+
+func TestDriveExportRateLimitAfterObservedStatusReturnsError(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ticket": "tk_processing_then_limited"},
+		},
+	})
+	pendingStub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/export_tasks/tk_processing_then_limited",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"result": map[string]interface{}{"job_status": 2},
+			},
+		},
+	}
+	reg.Register(pendingStub)
+	rateLimitStub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/export_tasks/tk_processing_then_limited",
+		Body: map[string]interface{}{
+			"code": 99991400,
+			"msg":  "request trigger frequency limit",
+		},
+	}
+	reg.Register(rateLimitStub)
+
+	prevAttempts, prevInterval := driveExportPollAttempts, driveExportPollInterval
+	driveExportPollAttempts, driveExportPollInterval = 3, 0
+	t.Cleanup(func() {
+		driveExportPollAttempts, driveExportPollInterval = prevAttempts, prevInterval
+	})
+
+	err := mountAndRunDrive(t, DriveExport, []string{
+		"+export",
+		"--token", "docx123",
+		"--doc-type", "docx",
+		"--file-extension", "pdf",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected rate-limit error after processing status, got nil")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("rate limit must not be hidden by a timed-out success envelope: %s", stdout.String())
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Subtype != errs.SubtypeRateLimit || problem.Code != 99991400 {
+		t.Fatalf("problem = %+v, ok=%v, want rate_limit code 99991400", problem, ok)
+	}
+}
+
 func TestDriveExportDownloadUsesProvidedFileName(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{

--- a/shortcuts/drive/drive_task_result.go
+++ b/shortcuts/drive/drive_task_result.go
@@ -206,7 +206,7 @@ func queryImportTaskAndAutoGrantPermission(runtime *common.RuntimeContext, ticke
 func queryExportTask(runtime *common.RuntimeContext, ticket, fileToken string) (map[string]interface{}, error) {
 	status, err := getDriveExportStatus(runtime, fileToken, ticket)
 	if err != nil {
-		return nil, err
+		return nil, withDriveExportRateLimitRecovery(err, ticket, fileToken)
 	}
 
 	return map[string]interface{}{

--- a/shortcuts/drive/drive_task_result_test.go
+++ b/shortcuts/drive/drive_task_result_test.go
@@ -154,6 +154,49 @@ func TestDriveTaskResultDryRunExportIncludesTokenParam(t *testing.T) {
 	}
 }
 
+func TestDriveTaskResultExportRateLimitSuggestsOneMinuteBackoff(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/export_tasks/tk_export_limited",
+		Body: map[string]interface{}{
+			"code": 99991400,
+			"msg":  "request trigger frequency limit",
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveTaskResult, []string{
+		"+task_result",
+		"--scenario", "export",
+		"--ticket", "tk_export_limited",
+		"--file-token", "docx123",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected rate-limit error, got nil")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout should stay empty on rate limit: %s", stdout.String())
+	}
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed rate-limit error, got %T (%v)", err, err)
+	}
+	if problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeRateLimit || problem.Code != 99991400 || !problem.Retryable {
+		t.Fatalf("problem = %+v, want api/rate_limit code 99991400 retryable", problem)
+	}
+	for _, want := range []string{
+		"wait at least 1 minute",
+		"exponential backoff starting at 1 minute",
+		"lark-cli drive +task_result --scenario export --ticket tk_export_limited --file-token docx123",
+	} {
+		if !strings.Contains(problem.Hint, want) {
+			t.Fatalf("hint missing %q: %q", want, problem.Hint)
+		}
+	}
+}
+
 func TestDriveTaskResultImportIncludesReadyFlags(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -46,6 +46,7 @@ metadata:
 - 用户要查看或下载文件内容，或者查看文件可用预览格式并获取 PDF / HTML / 文本 / 图片等转换预览产物，使用 `lark-cli drive +preview`。
 - 用户要获取某个文件的封面图，优先使用 `lark-cli drive +cover`；先 `--list-only` 看规格，再选 `--spec` 下载。
 - 用户要导出云文档时，优先使用 `lark-cli drive +export --url '<文档 URL>' --file-extension <格式>`；详细参数、Wiki token 和错误码处理见 [`references/lark-drive-export.md`](references/lark-drive-export.md)。
+- 导出遇到 `rate_limit` / `99991400` 时，按错误 `hint` 退避：没有 `ticket` 就至少等 1 分钟后重跑原 `drive +export`；已有 `ticket` 就只用 `drive +task_result --scenario export` 续查。持续限频时从 1 分钟开始指数退避，不要立即重试或重复创建任务。
 - 用户要把本地文件上传到知识库 / 文档库里的某个 wiki 节点下时，仍然使用 `lark-cli drive +upload --wiki-token <wiki_token>`；不要误切到 `wiki` 域命令。
 - `lark-base` 只负责导入完成后的 Base 内部操作（表、字段、记录、视图），不要在“本地文件 -> Base”这一步提前切到 `lark-base`。
 - 用户给的是 wiki URL / token，且后续还没明确底层资源类型时，先用 `lark-cli drive +inspect` 解包；`+inspect` 失败后不要自动切到别的写接口继续尝试，先按错误提示处理权限、scope 或链接问题。

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -46,7 +46,6 @@ metadata:
 - 用户要查看或下载文件内容，或者查看文件可用预览格式并获取 PDF / HTML / 文本 / 图片等转换预览产物，使用 `lark-cli drive +preview`。
 - 用户要获取某个文件的封面图，优先使用 `lark-cli drive +cover`；先 `--list-only` 看规格，再选 `--spec` 下载。
 - 用户要导出云文档时，优先使用 `lark-cli drive +export --url '<文档 URL>' --file-extension <格式>`；详细参数、Wiki token 和错误码处理见 [`references/lark-drive-export.md`](references/lark-drive-export.md)。
-- 导出遇到 `rate_limit` / `99991400` 时，按错误 `hint` 退避：没有 `ticket` 就至少等 1 分钟后重跑原 `drive +export`；已有 `ticket` 就只用 `drive +task_result --scenario export` 续查。持续限频时从 1 分钟开始指数退避，不要立即重试或重复创建任务。
 - 用户要把本地文件上传到知识库 / 文档库里的某个 wiki 节点下时，仍然使用 `lark-cli drive +upload --wiki-token <wiki_token>`；不要误切到 `wiki` 域命令。
 - `lark-base` 只负责导入完成后的 Base 内部操作（表、字段、记录、视图），不要在“本地文件 -> Base”这一步提前切到 `lark-base`。
 - 用户给的是 wiki URL / token，且后续还没明确底层资源类型时，先用 `lark-cli drive +inspect` 解包；`+inspect` 失败后不要自动切到别的写接口继续尝试，先按错误提示处理权限、scope 或链接问题。

--- a/skills/lark-drive/references/lark-drive-export.md
+++ b/skills/lark-drive/references/lark-drive-export.md
@@ -136,6 +136,8 @@ lark-cli drive +export \
 - `--only-schema` 只支持 `bitable` 导出为 `.base`，用于仅导出表结构
 - 如果格式不匹配，CLI 会返回 typed validation error，并在 `hint` 中给出可重试的 `--file-extension` 建议；例如 `docx + csv` 会提示改用 `docx/pdf/markdown`，或改传 sheet/bitable URL
 - shortcut 内部固定有限轮询：最多 10 次，每次间隔 5 秒
+- 创建导出任务时收到 `rate_limit` / `99991400` 不会生成 `ticket`；至少等待 1 分钟后重跑原 `drive +export`，持续限频时从 1 分钟开始指数退避
+- 状态轮询一旦收到 `rate_limit` / `99991400` 会立即停止，不会继续消耗剩余轮询次数；错误会保留原始 typed metadata，并在 `hint` 中提供已有 `ticket` 的续查命令
 - 轮询超时不是失败；会返回 `ticket`、`timed_out=true` 和 `next_command`，供后续继续查询
 
 ## 错误码处理
@@ -144,6 +146,7 @@ lark-cli drive +export \
 |--------|------|----------|
 | `1069914` | token 非法或 token/type 不匹配；常见原因是把 Wiki node token 当作底层 `docx` / `sheet` / `bitable` token 使用，没有传 `--doc-type wiki` | 优先改用 `--url <Wiki URL>`；只有裸 Wiki token 时，用 `--token <WIKI_NODE_TOKEN> --doc-type wiki`。不确定 token 类型时，先用 `lark-cli drive +inspect --url <TOKEN> --type wiki` 检查是否能解包为 Wiki node；如果不是 Wiki token，再检查 token 来源、`--doc-type` 是否与实际资源类型一致 |
 | `1069902` | 没有当前导出任务所需权限 | 不要直接重试同一命令；先确认当前 `--as` 身份是否能访问该文档、是否有下载/导出权限，以及文档是否受分享、密级或租户策略限制。需要补权限时，让文档 owner 或管理员授权后再执行 |
+| `99991400` / `rate_limit` | OpenAPI 请求频率受限 | 立即停止并按错误 `hint` 处理：没有 `ticket` 时，至少等待 1 分钟后重跑原 `drive +export`；已有 `ticket` 时，只执行 `drive +task_result --scenario export` 续查，不要重复创建任务。持续限频时从 1 分钟开始指数退避 |
 | `99991679` | 缺少 OpenAPI scope | 按错误 envelope 中的 `missing_scopes` / `required_scope` / `hint` 补齐授权；常见方式是重新执行 `lark-cli auth login --scope "<缺失 scope>"`。补 scope 前不要反复重试导出命令 |
 
 ## 推荐续跑方式
@@ -160,6 +163,9 @@ lark-cli drive +task_result \
   --scenario export \
   --ticket "<TICKET>" \
   --file-token "<DOCX_TOKEN>"
+
+# 如果返回 rate_limit / 99991400：不要立即重试，也不要重新创建导出任务；
+# 至少等待 1 分钟后重试上面的 +task_result。若仍限频，以 1 分钟为起点继续指数退避。
 
 # 查到 file_token 后下载
 lark-cli drive +export-download \

--- a/skills/lark-drive/references/lark-drive-export.md
+++ b/skills/lark-drive/references/lark-drive-export.md
@@ -164,9 +164,6 @@ lark-cli drive +task_result \
   --ticket "<TICKET>" \
   --file-token "<DOCX_TOKEN>"
 
-# 如果返回 rate_limit / 99991400：不要立即重试，也不要重新创建导出任务；
-# 至少等待 1 分钟后重试上面的 +task_result。若仍限频，以 1 分钟为起点继续指数退避。
-
 # 查到 file_token 后下载
 lark-cli drive +export-download \
   --file-token "<EXPORTED_FILE_TOKEN>" \

--- a/skills/lark-drive/references/lark-drive-task-result.md
+++ b/skills/lark-drive/references/lark-drive-task-result.md
@@ -330,7 +330,7 @@ lark-cli drive +export --token <SOURCE_DOC_TOKEN> --doc-type docx --file-extensi
 lark-cli drive +task_result --scenario export --ticket <EXPORT_TICKET> --file-token <SOURCE_DOC_TOKEN>
 
 # 如果返回 rate_limit / 99991400：至少等待 1 分钟后重试同一条 +task_result；
-# 若仍限频，以 1 分钟为起点继续指数退避。不要重新执行 +export，复用原 ticket。
+# 若仍限频，以 1 分钟为起点继续指数退避。
 
 # 3. 拿到 file_token 后下载
 lark-cli drive +export-download --file-token <EXPORTED_FILE_TOKEN>

--- a/skills/lark-drive/references/lark-drive-task-result.md
+++ b/skills/lark-drive/references/lark-drive-task-result.md
@@ -329,6 +329,9 @@ lark-cli drive +export --token <SOURCE_DOC_TOKEN> --doc-type docx --file-extensi
 # 2. 继续查询导出结果
 lark-cli drive +task_result --scenario export --ticket <EXPORT_TICKET> --file-token <SOURCE_DOC_TOKEN>
 
+# 如果返回 rate_limit / 99991400：至少等待 1 分钟后重试同一条 +task_result；
+# 若仍限频，以 1 分钟为起点继续指数退避。不要重新执行 +export，复用原 ticket。
+
 # 3. 拿到 file_token 后下载
 lark-cli drive +export-download --file-token <EXPORTED_FILE_TOKEN>
 ```


### PR DESCRIPTION
## Summary

Stop Drive export task polling immediately when OpenAPI returns `rate_limit` / `99991400`, and give agents a task-aware one-minute backoff path.

## Changes

- Preserve the typed API error and stop consuming the remaining export polling attempts after rate limiting.
- Distinguish task creation throttling (no ticket: retry the original export after backoff) from status throttling (existing ticket: resume with `drive +task_result`).
- Add regression tests and concise lark-drive Skill guidance for one-minute exponential backoff.

## Test Plan

- [x] `go test ./shortcuts/drive -run '^(TestDriveExportCreateRateLimitSuggestsRetryingOriginalCommand|TestDriveExportRateLimitStopsPollingAndSuggestsOneMinuteBackoff|TestDriveExportRateLimitAfterObservedStatusReturnsError|TestDriveTaskResultExportRateLimitSuggestsOneMinuteBackoff)$' -count=1`
- [x] `git diff --check`
- [x] Existing `tests/cli_e2e/drive/drive_export_dryrun_test.go` covers the unchanged `drive +export` request shape.
- [ ] Live API verification was not run to avoid creating export tasks while the endpoint is being rate limited.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Drive export handling when rate limits occur during task creation or status checks.
  * Added clear recovery guidance, including waiting at least one minute and retrying with appropriate backoff.
  * Preserved existing tickets during throttled status checks and prevented unnecessary duplicate export attempts.

* **Documentation**
  * Added guidance for recovering from rate-limited Drive exports and task-result requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->