### PR TITLE
docs(calendar): clarify attendee resolution to avoid type guessing

### DIFF
--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -190,7 +190,7 @@ lark-cli contact +search-user --query <query> --as user
 lark-cli im +chat-search --query <query> --as user
 ```
 
-> 搜索用户接口不支持 bot 身份，必须用 `--as user`；搜到的 `ou_` open_id 用于日程参与人操作（如添加日程参与人）。
+> 搜索用户/群不支持 bot 身份，必须用 `--as user`。**解析不到或类型不明确时，向用户澄清该参会人类型，不要靠名字形态硬猜类型。**
 
 ## 不在本 skill 范围
 


### PR DESCRIPTION
## Summary
When adding calendar attendees, an agent should resolve a name into an ID and, if that fails, ask the user to clarify the attendee type — not guess the type from the name shape. This reworks the note under the cross-domain search commands in the `lark-calendar` skill to make that explicit.

## Changes
- Reword the note under **常用其他域命令** in `skills/lark-calendar/SKILL.md`:
  - Broaden "search users doesn't support bot identity" to cover **both user and chat search** (`必须用 --as user`).
  - Replace the `ou_` open_id usage sentence with an explicit rule: when a name **cannot be resolved or its type is ambiguous, ask the user to clarify the attendee type instead of inferring it from the name shape**.

## Motivation
An evaluation case (`cli_calendar_ext_001`) failed because a meeting-room attendee — given only as a long, informal name — was searched as a user, then guessed to be a bot. The agent then triggered an unrelated `search:bot` device authorization and stalled on a QR-code prompt, so no event was ever created. The root cause was guessing the attendee type from the name shape; this doc change steers agents to clarify with the user instead.

## Test Plan
- [x] Docs-only change to a skill markdown file; no code paths affected.
- [ ] N/A — no unit/e2e tests apply to this skill content change.

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated calendar participant search guidance to support both users and groups.
  * Clarified that ambiguous or unresolved participant types require confirmation rather than inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->