### PR TITLE
feat: profile selection from environment with source-aware errors

### DIFF
--- a/cmd/auth/list.go
+++ b/cmd/auth/list.go
@@ -83,8 +83,14 @@ func authListRunWithRecovery(opts *ListOptions, projector *recovery.Projector) e
 		return nil
 	}
 
-	app := multi.CurrentAppConfig(f.Invocation.Profile)
-	if app == nil || len(app.Users) == 0 {
+	// A selector that matches no profile is an input error, not an empty
+	// account: reporting it as not_logged_in (exit 0) would steer the caller
+	// into auth login against a profile that does not exist.
+	app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+	if err != nil {
+		return err
+	}
+	if len(app.Users) == 0 {
 		if opts.JSON {
 			output.PrintJson(f.IOStreams.Out, map[string]interface{}{
 				"ok":     true,

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -58,8 +58,14 @@ func authLogoutRun(opts *LogoutOptions) error {
 		return nil
 	}
 
-	app := multi.CurrentAppConfig(f.Invocation.Profile)
-	if app == nil || len(app.Users) == 0 {
+	// A selector that matches no profile is an input error, not a logged-out
+	// state: "not_logged_in" (exit 0) would hide a stale --profile or
+	// LARKSUITE_CLI_PROFILE value from the caller.
+	app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+	if err != nil {
+		return err
+	}
+	if len(app.Users) == 0 {
 		if opts.JSON {
 			output.PrintJson(f.IOStreams.Out, map[string]interface{}{
 				"ok":        true,

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -6,8 +6,10 @@ package cmd
 import (
 	"errors"
 	"io"
+	"os"
 
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/envvars"
 	"github.com/spf13/pflag"
 )
 
@@ -26,5 +28,18 @@ func BootstrapInvocationContext(args []string) (cmdutil.InvocationContext, error
 	if err := fs.Parse(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
 		return cmdutil.InvocationContext{}, err
 	}
-	return cmdutil.InvocationContext{Profile: globals.Profile}, nil
+	// Resolve the session-level default only at the process boundary. Core
+	// config and credential packages consume the immutable invocation context
+	// and remain independent of ambient environment state. An explicitly empty
+	// --profile= remains a flag selection and suppresses the environment value.
+	if fs.Changed("profile") {
+		return cmdutil.InvocationContext{Profile: globals.Profile}, nil
+	}
+	if profile := os.Getenv(envvars.CliProfile); profile != "" {
+		return cmdutil.InvocationContext{
+			Profile:                profile,
+			ProfileFromEnvironment: true,
+		}, nil
+	}
+	return cmdutil.InvocationContext{}, nil
 }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
 	"github.com/spf13/pflag"
 )
@@ -33,13 +34,16 @@ func BootstrapInvocationContext(args []string) (cmdutil.InvocationContext, error
 	// and remain independent of ambient environment state. An explicitly empty
 	// --profile= remains a flag selection and suppresses the environment value.
 	if fs.Changed("profile") {
-		return cmdutil.InvocationContext{Profile: globals.Profile}, nil
+		return cmdutil.InvocationContext{
+			Profile:       globals.Profile,
+			ProfileSource: core.ProfileFromFlag,
+		}, nil
 	}
 	if profile := os.Getenv(envvars.CliProfile); profile != "" {
 		return cmdutil.InvocationContext{
-			Profile:                profile,
-			ProfileFromEnvironment: true,
+			Profile:       profile,
+			ProfileSource: core.ProfileFromEnvironment,
 		}, nil
 	}
-	return cmdutil.InvocationContext{}, nil
+	return cmdutil.InvocationContext{ProfileSource: core.ProfileFromConfig}, nil
 }

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -6,6 +6,8 @@ package cmd
 import (
 	"errors"
 	"testing"
+
+	"github.com/larksuite/cli/internal/envvars"
 )
 
 func TestBootstrapInvocationContext_ProfileFlag(t *testing.T) {
@@ -45,6 +47,7 @@ func TestBootstrapInvocationContext_MissingProfileValue(t *testing.T) {
 }
 
 func TestBootstrapInvocationContext_HelpFlag(t *testing.T) {
+	t.Setenv(envvars.CliProfile, "")
 	inv, err := BootstrapInvocationContext([]string{"--help"})
 	if err != nil {
 		t.Fatalf("--help should not error, got: %v", err)
@@ -55,6 +58,7 @@ func TestBootstrapInvocationContext_HelpFlag(t *testing.T) {
 }
 
 func TestBootstrapInvocationContext_ShortHelp(t *testing.T) {
+	t.Setenv(envvars.CliProfile, "")
 	inv, err := BootstrapInvocationContext([]string{"-h"})
 	if err != nil {
 		t.Fatalf("-h should not error, got: %v", err)
@@ -71,6 +75,32 @@ func TestBootstrapInvocationContext_HelpWithProfile(t *testing.T) {
 	}
 	if inv.Profile != "target" {
 		t.Fatalf("profile = %q, want %q", inv.Profile, "target")
+	}
+}
+
+func TestBootstrapInvocationContext_ProfilePrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		environment         string
+		args                []string
+		wantProfile         string
+		wantFromEnvironment bool
+	}{
+		{"environment default", "session", []string{"whoami"}, "session", true},
+		{"flag overrides environment", "session", []string{"whoami", "--profile", "command"}, "command", false},
+		{"empty flag suppresses environment", "session", []string{"whoami", "--profile="}, "", false},
+		{"empty environment is unset", "", []string{"whoami"}, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envvars.CliProfile, tc.environment)
+			inv, err := BootstrapInvocationContext(tc.args)
+			if err != nil {
+				t.Fatalf("BootstrapInvocationContext() error = %v", err)
+			}
+			if inv.Profile != tc.wantProfile || inv.ProfileFromEnvironment != tc.wantFromEnvironment {
+				t.Fatalf("profile = %q, fromEnvironment = %v", inv.Profile, inv.ProfileFromEnvironment)
+			}
+		})
 	}
 }
 

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
 )
 
@@ -80,16 +81,16 @@ func TestBootstrapInvocationContext_HelpWithProfile(t *testing.T) {
 
 func TestBootstrapInvocationContext_ProfilePrecedence(t *testing.T) {
 	for _, tc := range []struct {
-		name                string
-		environment         string
-		args                []string
-		wantProfile         string
-		wantFromEnvironment bool
+		name        string
+		environment string
+		args        []string
+		wantProfile string
+		wantSource  core.ProfileSource
 	}{
-		{"environment default", "session", []string{"whoami"}, "session", true},
-		{"flag overrides environment", "session", []string{"whoami", "--profile", "command"}, "command", false},
-		{"empty flag suppresses environment", "session", []string{"whoami", "--profile="}, "", false},
-		{"empty environment is unset", "", []string{"whoami"}, "", false},
+		{"environment default", "session", []string{"whoami"}, "session", core.ProfileFromEnvironment},
+		{"flag overrides environment", "session", []string{"whoami", "--profile", "command"}, "command", core.ProfileFromFlag},
+		{"empty flag suppresses environment", "session", []string{"whoami", "--profile="}, "", core.ProfileFromFlag},
+		{"empty environment is unset", "", []string{"whoami"}, "", core.ProfileFromConfig},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(envvars.CliProfile, tc.environment)
@@ -97,8 +98,8 @@ func TestBootstrapInvocationContext_ProfilePrecedence(t *testing.T) {
 			if err != nil {
 				t.Fatalf("BootstrapInvocationContext() error = %v", err)
 			}
-			if inv.Profile != tc.wantProfile || inv.ProfileFromEnvironment != tc.wantFromEnvironment {
-				t.Fatalf("profile = %q, fromEnvironment = %v", inv.Profile, inv.ProfileFromEnvironment)
+			if inv.Profile != tc.wantProfile || inv.ProfileSource != tc.wantSource {
+				t.Fatalf("profile = %q, source = %v, want %q / %v", inv.Profile, inv.ProfileSource, tc.wantProfile, tc.wantSource)
 			}
 		})
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -357,6 +357,15 @@ func buildInternalWithConfig(ctx context.Context, inv cmdutil.InvocationContext,
 	runtime.skillReferences = skillResolution.References
 	f.SkillReferences = skillResolution.References
 
+	// Global flags and their environment equivalents belong to the same
+	// distribution capability. Flag tokens are rejected by applyPluginFlagGate;
+	// install the equivalent guard for an environment-origin profile before
+	// hooks, Startup, or business commands can observe the invocation.
+	if installEnvironmentProfileGate(rootCmd, inv, runtime.surface) {
+		recordInventory(installResult)
+		return finalizeFailedBuild(runtime, rootCmd)
+	}
+
 	// Install hooks only on business commands. The concealment-specific help
 	// command is attached afterwards, preserving Cobra's historical contract
 	// that help is not observed or wrapped by plugins.

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -132,8 +132,20 @@ func TestConfigShowRun_NoActiveProfileReturnsStructuredError(t *testing.T) {
 	if gotCode := output.ExitCodeOf(err); gotCode != output.ExitAuth {
 		t.Errorf("exit code = %d, want %d", gotCode, output.ExitAuth)
 	}
-	if !strings.Contains(err.Error(), "no active profile") {
-		t.Fatalf("error = %v, want to contain 'no active profile'", err)
+	// The dangling persisted reference must be named — the generic
+	// "no active profile" wording hid which input was broken.
+	if !strings.Contains(err.Error(), `profile "missing" not found`) {
+		t.Fatalf("error = %v, want the dangling currentApp named", err)
+	}
+	var cfgErr *errs.ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected *errs.ConfigError, got %T", err)
+	}
+	if cfgErr.Field != "currentApp" {
+		t.Errorf("field = %q, want currentApp", cfgErr.Field)
+	}
+	if strings.Contains(cfgErr.Hint, "config init") {
+		t.Errorf("hint = %q, must not suggest config init while intact profiles exist", cfgErr.Hint)
 	}
 }
 
@@ -609,7 +621,7 @@ func TestConfigShowRun_ProfileHintUsesBuildLocalSurface(t *testing.T) {
 		t.Fatal("Render must clone the typed error")
 	}
 	if strings.Contains(concealed.Hint, "profile list") ||
-		!strings.Contains(concealed.Hint, "select or configure an available profile") {
+		!strings.Contains(concealed.Hint, "select an available profile") {
 		t.Errorf("concealed hint = %q, want target-free profile recovery", concealed.Hint)
 	}
 

--- a/cmd/config/default_as.go
+++ b/cmd/config/default_as.go
@@ -25,9 +25,9 @@ func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			app := multi.CurrentAppConfig(f.Invocation.Profile)
-			if app == nil {
-				return core.NoActiveProfileError()
+			app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+			if err != nil {
+				return err
 			}
 
 			if len(args) == 0 {

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -65,14 +65,19 @@ func configShowRun(opts *ConfigShowOptions) error {
 		}
 		users = strings.Join(userStrs, ", ")
 	}
+	// profileSource says which channel picked this profile (config | flag |
+	// environment) — with a session-level LARKSUITE_CLI_PROFILE in play, the
+	// effective profile and the persisted default can legitimately differ.
+	_, effectiveSource := config.EffectiveProfile(f.Invocation.Profile, f.Invocation.ProfileSource)
 	output.PrintJson(f.IOStreams.Out, map[string]interface{}{
-		"workspace": core.CurrentWorkspace().Display(),
-		"profile":   app.ProfileName(),
-		"appId":     app.AppId,
-		"appSecret": "****",
-		"brand":     app.Brand,
-		"lang":      app.Lang,
-		"users":     users,
+		"workspace":     core.CurrentWorkspace().Display(),
+		"profile":       app.ProfileName(),
+		"profileSource": effectiveSource.String(),
+		"appId":         app.AppId,
+		"appSecret":     "****",
+		"brand":         app.Brand,
+		"lang":          app.Lang,
+		"users":         users,
 	})
 	fmt.Fprintf(f.IOStreams.ErrOut, "\nConfig file path: %s\n", core.GetConfigPath())
 	return nil

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -13,7 +13,6 @@ import (
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
-	"github.com/larksuite/cli/internal/recovery"
 	"github.com/spf13/cobra"
 )
 
@@ -54,16 +53,9 @@ func configShowRun(opts *ConfigShowOptions) error {
 	if config == nil || len(config.Apps) == 0 {
 		return core.NotConfiguredError()
 	}
-	app := config.CurrentAppConfig(f.Invocation.Profile)
-	if app == nil {
-		hint := recovery.Join("",
-			recovery.Command(recovery.TargetProfileList, "run: lark-cli profile list")).
-			WithFallback("select or configure an available profile through this distribution")
-		return recovery.Annotate(
-			errs.NewConfigError(errs.SubtypeNotConfigured, "no active profile").
-				WithHint("%s", hint.String()),
-			hint,
-		)
+	app, err := config.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+	if err != nil {
+		return err
 	}
 	users := "(no logged-in users)"
 	if len(app.Users) > 0 {

--- a/cmd/config/strict_mode.go
+++ b/cmd/config/strict_mode.go
@@ -43,22 +43,24 @@ explicit user confirmation — never run on your own initiative.`,
 			}
 
 			if reset {
-				app := multi.CurrentAppConfig(f.Invocation.Profile)
-				if app == nil {
-					return core.NoActiveProfileError()
+				app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+				if err != nil {
+					return err
 				}
 				return resetStrictMode(f, multi, app, global, args)
 			}
 			if len(args) == 0 {
-				app := multi.CurrentAppConfig(f.Invocation.Profile)
-				if app == nil {
-					return core.NoActiveProfileError()
+				app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+				if err != nil {
+					return err
 				}
 				return showStrictMode(cmd.Context(), f, multi, app)
 			}
+			// --global tolerates a missing profile: the mutation targets the
+			// shared scope, so only the profile-scoped path requires one.
 			app := multi.CurrentAppConfig(f.Invocation.Profile)
 			if !global && app == nil {
-				return core.NoActiveProfileError()
+				return multi.ProfileNotFoundError(f.Invocation.Profile, f.Invocation.ProfileSource)
 			}
 			return setStrictMode(f, multi, app, args[0], global)
 		},
@@ -138,7 +140,7 @@ func setStrictMode(f *cmdutil.Factory, multi *core.MultiAppConfig, app *core.App
 		}
 	} else {
 		if app == nil {
-			return core.NoActiveProfileError()
+			return multi.ProfileNotFoundError(f.Invocation.Profile, f.Invocation.ProfileSource)
 		}
 		app.StrictMode = &mode
 	}

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/larksuite/cli/internal/build"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/internal/identitydiag"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/recovery"
@@ -129,6 +130,20 @@ func doctorRun(opts *DoctorOptions, projector *recovery.Projector) error {
 		return finishDoctor(f, checks)
 	}
 	checks = append(checks, pass("app_resolved", fmt.Sprintf("app: %s (%s)", cfg.AppID, cfg.Brand)))
+
+	// An external credential provider resolves the account without consulting
+	// profiles at all, so an explicit selector is silently inert. Say so:
+	// nothing else in the session will. ProfileName is only populated by the
+	// built-in config-backed provider, which makes it the provider telltale.
+	if f.Invocation.Profile != "" && cfg.ProfileName == "" {
+		selector := "--profile"
+		if f.Invocation.ProfileSource == core.ProfileFromEnvironment {
+			selector = envvars.CliProfile
+		}
+		checks = append(checks, warn("profile_selector",
+			fmt.Sprintf("%s=%q is ignored: credentials are provided externally", selector, f.Invocation.Profile),
+			fmt.Sprintf("unset %s, or remove the external credential variables to select accounts by profile", selector)))
+	}
 
 	ep := core.ResolveEndpoints(cfg.Brand)
 

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -253,3 +253,83 @@ func TestDoctor_ExternalProvider_IdentityReadyHintNotBlockedCommand(t *testing.T
 		t.Fatalf("user_identity hint not external-appropriate: %q", user.Hint)
 	}
 }
+
+func TestDoctorRun_WarnsWhenExternalProviderIgnoresProfileSelector(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	if err := core.SaveMultiAppConfig(&core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps:       []core.AppConfig{{Name: "default", AppId: "cli_x", AppSecret: core.PlainSecret("secret"), Brand: core.BrandFeishu}},
+	}); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	// An external provider leaves ProfileName empty — the telltale that the
+	// profile selector had no effect on account resolution.
+	cfg := &core.CliConfig{AppID: "cli_x", Brand: core.BrandFeishu, SupportedIdentities: uint8(extcred.SupportsBot | extcred.SupportsUser)}
+	cred := credential.NewCredentialProvider(
+		[]extcred.Provider{&fakeExtProvider{name: "corp-sso", account: &extcred.Account{AppID: "cli_x"}}},
+		nil, nil,
+		func() (*http.Client, error) { return nil, nil },
+	)
+	out := &bytes.Buffer{}
+	f := &cmdutil.Factory{
+		Config:     func() (*core.CliConfig, error) { return cfg, nil },
+		Credential: cred,
+		Invocation: cmdutil.InvocationContext{Profile: "session", ProfileSource: core.ProfileFromEnvironment},
+		IOStreams:  &cmdutil.IOStreams{Out: out, ErrOut: &bytes.Buffer{}},
+	}
+
+	_ = doctorRun(&DoctorOptions{Factory: f, Ctx: context.Background(), Offline: true}, nil)
+	var got struct {
+		Checks []checkResult `json:"checks"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, out.String())
+	}
+
+	selector := findCheck(t, got.Checks, "profile_selector")
+	if selector.Status != "warn" {
+		t.Fatalf("profile_selector status = %q, want warn", selector.Status)
+	}
+	for _, want := range []string{"LARKSUITE_CLI_PROFILE", `"session"`, "ignored"} {
+		if !strings.Contains(selector.Message, want) {
+			t.Errorf("message = %q, missing %q", selector.Message, want)
+		}
+	}
+	if !strings.Contains(selector.Hint, "unset LARKSUITE_CLI_PROFILE") {
+		t.Errorf("hint = %q, want unset guidance", selector.Hint)
+	}
+}
+
+func TestDoctorRun_NoSelectorWarningForBuiltinProvider(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	if err := core.SaveMultiAppConfig(&core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps:       []core.AppConfig{{Name: "default", AppId: "cli_x", AppSecret: core.PlainSecret("secret"), Brand: core.BrandFeishu}},
+	}); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	// Built-in resolution populates ProfileName: the selector took effect.
+	cfg := &core.CliConfig{AppID: "cli_x", ProfileName: "default", Brand: core.BrandFeishu, SupportedIdentities: uint8(extcred.SupportsBot | extcred.SupportsUser)}
+	out := &bytes.Buffer{}
+	f := &cmdutil.Factory{
+		Config:     func() (*core.CliConfig, error) { return cfg, nil },
+		Credential: credential.NewCredentialProvider(nil, nil, nil, func() (*http.Client, error) { return nil, nil }),
+		Invocation: cmdutil.InvocationContext{Profile: "default", ProfileSource: core.ProfileFromEnvironment},
+		IOStreams:  &cmdutil.IOStreams{Out: out, ErrOut: &bytes.Buffer{}},
+	}
+
+	_ = doctorRun(&DoctorOptions{Factory: f, Ctx: context.Background(), Offline: true}, nil)
+	var got struct {
+		Checks []checkResult `json:"checks"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, out.String())
+	}
+	for _, c := range got.Checks {
+		if c.Name == "profile_selector" {
+			t.Fatalf("unexpected profile_selector check for builtin-resolved profile: %+v", c)
+		}
+	}
+}

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -271,13 +271,9 @@ func TestDoctorRun_WarnsWhenExternalProviderIgnoresProfileSelector(t *testing.T)
 		nil, nil,
 		func() (*http.Client, error) { return nil, nil },
 	)
-	out := &bytes.Buffer{}
-	f := &cmdutil.Factory{
-		Config:     func() (*core.CliConfig, error) { return cfg, nil },
-		Credential: cred,
-		Invocation: cmdutil.InvocationContext{Profile: "session", ProfileSource: core.ProfileFromEnvironment},
-		IOStreams:  &cmdutil.IOStreams{Out: out, ErrOut: &bytes.Buffer{}},
-	}
+	f, out, _, _ := cmdutil.TestFactory(t, cfg)
+	f.Credential = cred
+	f.Invocation = cmdutil.InvocationContext{Profile: "session", ProfileSource: core.ProfileFromEnvironment}
 
 	_ = doctorRun(&DoctorOptions{Factory: f, Ctx: context.Background(), Offline: true}, nil)
 	var got struct {
@@ -312,13 +308,8 @@ func TestDoctorRun_NoSelectorWarningForBuiltinProvider(t *testing.T) {
 
 	// Built-in resolution populates ProfileName: the selector took effect.
 	cfg := &core.CliConfig{AppID: "cli_x", ProfileName: "default", Brand: core.BrandFeishu, SupportedIdentities: uint8(extcred.SupportsBot | extcred.SupportsUser)}
-	out := &bytes.Buffer{}
-	f := &cmdutil.Factory{
-		Config:     func() (*core.CliConfig, error) { return cfg, nil },
-		Credential: credential.NewCredentialProvider(nil, nil, nil, func() (*http.Client, error) { return nil, nil }),
-		Invocation: cmdutil.InvocationContext{Profile: "default", ProfileSource: core.ProfileFromEnvironment},
-		IOStreams:  &cmdutil.IOStreams{Out: out, ErrOut: &bytes.Buffer{}},
-	}
+	f, out, _, _ := cmdutil.TestFactory(t, cfg)
+	f.Invocation = cmdutil.InvocationContext{Profile: "default", ProfileSource: core.ProfileFromEnvironment}
 
 	_ = doctorRun(&DoctorOptions{Factory: f, Ctx: context.Background(), Offline: true}, nil)
 	var got struct {
@@ -330,6 +321,41 @@ func TestDoctorRun_NoSelectorWarningForBuiltinProvider(t *testing.T) {
 	for _, c := range got.Checks {
 		if c.Name == "profile_selector" {
 			t.Fatalf("unexpected profile_selector check for builtin-resolved profile: %+v", c)
+		}
+	}
+}
+
+func TestDoctorRun_NoSelectorWarningForPersistedDefault(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	if err := core.SaveMultiAppConfig(&core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps:       []core.AppConfig{{Name: "default", AppId: "cli_x", AppSecret: core.PlainSecret("secret"), Brand: core.BrandFeishu}},
+	}); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	// A persisted currentApp is not an explicit selector: bootstrap leaves
+	// Invocation.Profile empty for ProfileFromConfig, so even with an external
+	// provider there is no user input for the warning to point at.
+	cfg := &core.CliConfig{AppID: "cli_x", Brand: core.BrandFeishu, SupportedIdentities: uint8(extcred.SupportsBot | extcred.SupportsUser)}
+	f, out, _, _ := cmdutil.TestFactory(t, cfg)
+	f.Credential = credential.NewCredentialProvider(
+		[]extcred.Provider{&fakeExtProvider{name: "corp-sso", account: &extcred.Account{AppID: "cli_x"}}},
+		nil, nil,
+		func() (*http.Client, error) { return nil, nil },
+	)
+	f.Invocation = cmdutil.InvocationContext{ProfileSource: core.ProfileFromConfig}
+
+	_ = doctorRun(&DoctorOptions{Factory: f, Ctx: context.Background(), Offline: true}, nil)
+	var got struct {
+		Checks []checkResult `json:"checks"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, out.String())
+	}
+	for _, c := range got.Checks {
+		if c.Name == "profile_selector" {
+			t.Fatalf("unexpected profile_selector check for persisted default: %+v", c)
 		}
 	}
 }

--- a/cmd/flag_gate.go
+++ b/cmd/flag_gate.go
@@ -6,10 +6,12 @@ package cmd
 import (
 	"errors"
 
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/envvars"
+	"github.com/larksuite/cli/internal/surface"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"github.com/larksuite/cli/internal/surface"
 )
 
 // globalFlagTargets maps each root persistent flag to the command capability
@@ -41,6 +43,34 @@ func applyPluginFlagGate(root *cobra.Command, plan *surface.Plan) {
 		fl.Annotations[flagGateAnnotation] = []string{"true"}
 		fl.Value = &gatedFlagValue{name: flagName, inner: fl.Value}
 	}
+}
+
+// installEnvironmentProfileGate applies the profile capability decision to
+// the environment equivalent of --profile. A gated pflag Value can reject an
+// argv token, but an environment selector has no token for Cobra to parse, so
+// it needs an invocation guard of its own. The return value reports whether a
+// guard was installed so Build can stop before plugin Startup.
+func installEnvironmentProfileGate(
+	root *cobra.Command,
+	inv cmdutil.InvocationContext,
+	plan *surface.Plan,
+) bool {
+	if !inv.ProfileFromEnvironment ||
+		plan.CanReference(surface.CommandProfile) {
+		return false
+	}
+
+	makeErr := func() error {
+		return errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"environment variable %q is not supported by this build",
+			envvars.CliProfile,
+		).
+			WithParam(envvars.CliProfile).
+			WithHint("remove %s from the process environment and retry", envvars.CliProfile)
+	}
+	installFatalGuard(root, makeErr)
+	return true
 }
 
 func isPolicyGatedFlag(fl *pflag.Flag) bool {

--- a/cmd/flag_gate.go
+++ b/cmd/flag_gate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/internal/surface"
 	"github.com/spf13/cobra"
@@ -55,7 +56,7 @@ func installEnvironmentProfileGate(
 	inv cmdutil.InvocationContext,
 	plan *surface.Plan,
 ) bool {
-	if !inv.ProfileFromEnvironment ||
+	if inv.ProfileSource != core.ProfileFromEnvironment ||
 		plan.CanReference(surface.CommandProfile) {
 		return false
 	}

--- a/cmd/presentation_test.go
+++ b/cmd/presentation_test.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -670,15 +671,30 @@ func TestExecuteEnvironmentProfileConcealmentFailsBeforeLifecycle(t *testing.T) 
 	if code != output.ExitValidation || stdout != "" {
 		t.Fatalf("environment profile gate: exit=%d stdout=%q stderr=%s", code, stdout, stderr)
 	}
-	for _, want := range []string{
-		`"subtype": "invalid_argument"`,
-		`"param": "` + envvars.CliProfile + `"`,
-		`environment variable \"` + envvars.CliProfile + `\" is not supported by this build`,
-		`remove ` + envvars.CliProfile + ` from the process environment and retry`,
-	} {
-		if !strings.Contains(stderr, want) {
-			t.Errorf("stderr missing %q:\n%s", want, stderr)
-		}
+	var envelope struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Type    errs.Category `json:"type"`
+			Subtype errs.Subtype  `json:"subtype"`
+			Message string        `json:"message"`
+			Hint    string        `json:"hint"`
+			Param   string        `json:"param"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(stderr), &envelope); err != nil {
+		t.Fatalf("stderr is not a JSON envelope: %v\n%s", err, stderr)
+	}
+	if envelope.OK ||
+		envelope.Error.Type != errs.CategoryValidation ||
+		envelope.Error.Subtype != errs.SubtypeInvalidArgument ||
+		envelope.Error.Param != envvars.CliProfile {
+		t.Errorf("envelope = %+v, want ok=false validation/invalid_argument param=%s", envelope, envvars.CliProfile)
+	}
+	if want := `environment variable "` + envvars.CliProfile + `" is not supported by this build`; !strings.Contains(envelope.Error.Message, want) {
+		t.Errorf("message = %q, missing %q", envelope.Error.Message, want)
+	}
+	if want := "remove " + envvars.CliProfile + " from the process environment and retry"; !strings.Contains(envelope.Error.Hint, want) {
+		t.Errorf("hint = %q, missing %q", envelope.Error.Hint, want)
 	}
 	if startups != 0 || shutdowns != 0 {
 		t.Fatalf("invalid environment profile emitted lifecycle events: startup=%d shutdown=%d", startups, shutdowns)

--- a/cmd/presentation_test.go
+++ b/cmd/presentation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/larksuite/cli/internal/cmdpolicy"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/deprecation"
+	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/recovery"
 	"github.com/larksuite/cli/internal/skillscheck"
@@ -640,6 +641,48 @@ func TestExecuteProfileBootstrapPreservesDefaultAndDefersOnlyForOptIn(t *testing
 			t.Fatalf("concealed --profile: exit=%d stderr=%s", code, stderr)
 		}
 	})
+}
+
+func TestExecuteEnvironmentProfileConcealmentFailsBeforeLifecycle(t *testing.T) {
+	tmpHome(t)
+	t.Setenv(envvars.CliProfile, "session")
+	t.Setenv("LARKSUITE_CLI_NO_UPDATE_NOTIFIER", "1")
+	t.Setenv("LARKSUITE_CLI_NO_SKILLS_NOTIFIER", "1")
+
+	var startups, shutdowns int
+	registerRestriction(t, []string{"profile", "profile/**"}, func(builder *platform.Builder) *platform.Builder {
+		return builder.
+			On(platform.Startup, "startup", func(context.Context, *platform.LifecycleContext) error {
+				startups++
+				return nil
+			}).
+			On(platform.Shutdown, "shutdown", func(context.Context, *platform.LifecycleContext) error {
+				shutdowns++
+				return nil
+			})
+	})
+
+	code, stdout, stderr := executeWithCapturedOS(
+		t,
+		[]BuildOption{ConcealRestrictedCommands()},
+		"--version",
+	)
+	if code != output.ExitValidation || stdout != "" {
+		t.Fatalf("environment profile gate: exit=%d stdout=%q stderr=%s", code, stdout, stderr)
+	}
+	for _, want := range []string{
+		`"subtype": "invalid_argument"`,
+		`"param": "` + envvars.CliProfile + `"`,
+		`environment variable \"` + envvars.CliProfile + `\" is not supported by this build`,
+		`remove ` + envvars.CliProfile + ` from the process environment and retry`,
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+	if startups != 0 || shutdowns != 0 {
+		t.Fatalf("invalid environment profile emitted lifecycle events: startup=%d shutdown=%d", startups, shutdowns)
+	}
 }
 
 func TestExecuteWithOptionsAppliesEachBuildOptionOnce(t *testing.T) {

--- a/cmd/profile/list.go
+++ b/cmd/profile/list.go
@@ -5,6 +5,7 @@ package profile
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -16,14 +17,20 @@ import (
 	"github.com/larksuite/cli/internal/output"
 )
 
-// profileListItem is the JSON output for a single profile entry.
+// profileListItem is the JSON output for a single profile entry. Active and
+// Effective answer different questions and may disagree: Active marks the
+// persisted default (who applies when no selector is present), Effective
+// marks the profile this very invocation resolved to — a --profile flag or
+// LARKSUITE_CLI_PROFILE overrides the default without touching it.
 type profileListItem struct {
-	Name        string         `json:"name"`
-	AppID       string         `json:"appId"`
-	Brand       core.LarkBrand `json:"brand"`
-	Active      bool           `json:"active"`
-	User        string         `json:"user,omitempty"`
-	TokenStatus string         `json:"tokenStatus,omitempty"`
+	Name            string         `json:"name"`
+	AppID           string         `json:"appId"`
+	Brand           core.LarkBrand `json:"brand"`
+	Active          bool           `json:"active"`
+	Effective       bool           `json:"effective,omitempty"`
+	EffectiveSource string         `json:"effectiveSource,omitempty"` // config | flag | environment
+	User            string         `json:"user,omitempty"`
+	TokenStatus     string         `json:"tokenStatus,omitempty"`
 }
 
 // NewCmdProfileList creates the profile list subcommand.
@@ -53,11 +60,22 @@ func profileListRun(f *cmdutil.Factory) error {
 		return nil
 	}
 
-	// Intentionally uses "" to show the persistent active profile, not the ephemeral --profile override.
+	// Active reports the persisted default on purpose (CurrentAppConfig("")),
+	// never the ephemeral override; Effective carries the override dimension.
 	currentApp := multi.CurrentAppConfig("")
 	currentName := ""
 	if currentApp != nil {
 		currentName = currentApp.ProfileName()
+	}
+	effectiveApp, effectiveSource := multi.EffectiveProfile(f.Invocation.Profile, f.Invocation.ProfileSource)
+	effectiveName := ""
+	if effectiveApp != nil {
+		effectiveName = effectiveApp.ProfileName()
+	} else if f.Invocation.Profile != "" {
+		// The selector is dangling. The list itself is the recovery surface,
+		// so stay exit 0 — but say why no entry is marked effective.
+		fmt.Fprintf(f.IOStreams.ErrOut, "Warning: %s=%q does not match any profile\n",
+			f.Invocation.ProfileSource.SelectorLabel(), f.Invocation.Profile)
 	}
 
 	items := make([]profileListItem, 0, len(multi.Apps))
@@ -70,6 +88,10 @@ func profileListRun(f *cmdutil.Factory) error {
 			AppID:  app.AppId,
 			Brand:  app.Brand,
 			Active: name == currentName,
+		}
+		if effectiveApp != nil && name == effectiveName {
+			item.Effective = true
+			item.EffectiveSource = effectiveSource.String()
 		}
 
 		if len(app.Users) > 0 {

--- a/cmd/profile/profile_test.go
+++ b/cmd/profile/profile_test.go
@@ -683,3 +683,178 @@ func TestProfileListRun_InvalidConfigReturnsValidationError(t *testing.T) {
 		t.Fatal("cause = nil, want wrapped load error")
 	}
 }
+
+func TestProfileListRun_MarksEffectiveOverride(t *testing.T) {
+	setupProfileConfigDir(t)
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: core.PlainSecret("s1"), Brand: core.BrandFeishu},
+			{Name: "target", AppId: "app-target", AppSecret: core.PlainSecret("s2"), Brand: core.BrandFeishu},
+		},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	f, stdout, stderr, _ := cmdutil.TestFactory(t, nil)
+	f.Invocation = cmdutil.InvocationContext{Profile: "target", ProfileSource: core.ProfileFromEnvironment}
+	if err := profileListRun(f); err != nil {
+		t.Fatalf("profileListRun() error = %v", err)
+	}
+
+	var got []profileListItem
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output=%s", err, stdout.String())
+	}
+	// Active stays on the persisted default; Effective moves with the
+	// override. Both dimensions must be visible at once — their disagreement
+	// IS the information.
+	if !got[0].Active || got[0].Effective {
+		t.Fatalf("got[0] = %#v, want persisted default active but not effective", got[0])
+	}
+	if got[1].Active || !got[1].Effective || got[1].EffectiveSource != "environment" {
+		t.Fatalf("got[1] = %#v, want effective via environment", got[1])
+	}
+	if stderr.String() != "" {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestProfileListRun_EffectiveFollowsPersistedDefault(t *testing.T) {
+	setupProfileConfigDir(t)
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: core.PlainSecret("s1"), Brand: core.BrandFeishu},
+		},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	if err := profileListRun(f); err != nil {
+		t.Fatalf("profileListRun() error = %v", err)
+	}
+	var got []profileListItem
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !got[0].Active || !got[0].Effective || got[0].EffectiveSource != "config" {
+		t.Fatalf("got[0] = %#v, want active and effective via config", got[0])
+	}
+}
+
+func TestProfileListRun_DanglingSelectorWarnsOnStderr(t *testing.T) {
+	setupProfileConfigDir(t)
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: core.PlainSecret("s1"), Brand: core.BrandFeishu},
+		},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	f, stdout, stderr, _ := cmdutil.TestFactory(t, nil)
+	f.Invocation = cmdutil.InvocationContext{Profile: "ghost", ProfileSource: core.ProfileFromEnvironment}
+	// The list is the recovery surface for a dangling selector: it must keep
+	// rendering (exit 0) and explain on stderr why nothing is effective.
+	if err := profileListRun(f); err != nil {
+		t.Fatalf("profileListRun() error = %v", err)
+	}
+	var got []profileListItem
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	for _, item := range got {
+		if item.Effective {
+			t.Fatalf("no entry may be effective under a dangling selector: %#v", item)
+		}
+	}
+	for _, want := range []string{"Warning:", "LARKSUITE_CLI_PROFILE", `"ghost"`, "does not match any profile"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestProfileUseRun_WarnsWhenEnvironmentShadows(t *testing.T) {
+	baseConfig := func(t *testing.T) {
+		t.Helper()
+		setupProfileConfigDir(t)
+		multi := &core.MultiAppConfig{
+			CurrentApp: "default",
+			Apps: []core.AppConfig{
+				{Name: "default", AppId: "app-default", AppSecret: core.PlainSecret("s1"), Brand: core.BrandFeishu},
+				{Name: "session", AppId: "app-session", AppSecret: core.PlainSecret("s2"), Brand: core.BrandFeishu},
+				{Name: "other", AppId: "app-other", AppSecret: core.PlainSecret("s3"), Brand: core.BrandFeishu},
+			},
+		}
+		if err := core.SaveMultiAppConfig(multi); err != nil {
+			t.Fatalf("SaveMultiAppConfig() error = %v", err)
+		}
+	}
+	envInvocation := cmdutil.InvocationContext{Profile: "session", ProfileSource: core.ProfileFromEnvironment}
+
+	t.Run("already-on short circuit still warns", func(t *testing.T) {
+		baseConfig(t)
+		f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+		f.Invocation = envInvocation
+		if err := profileUseRun(f, "default"); err != nil {
+			t.Fatalf("profileUseRun() error = %v", err)
+		}
+		// "Already on default" alone would be a lie for this shell: the
+		// session override decides every subsequent command.
+		if !strings.Contains(stderr.String(), `Already on profile "default"`) {
+			t.Fatalf("missing short-circuit line:\n%s", stderr.String())
+		}
+		for _, want := range []string{"Warning:", "LARKSUITE_CLI_PROFILE", `"session"`, "until you unset it"} {
+			if !strings.Contains(stderr.String(), want) {
+				t.Errorf("stderr missing %q:\n%s", want, stderr.String())
+			}
+		}
+	})
+
+	t.Run("successful switch still warns", func(t *testing.T) {
+		baseConfig(t)
+		f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+		f.Invocation = envInvocation
+		if err := profileUseRun(f, "other"); err != nil {
+			t.Fatalf("profileUseRun() error = %v", err)
+		}
+		saved, err := core.LoadMultiAppConfig()
+		if err != nil || saved.CurrentApp != "other" {
+			t.Fatalf("persisted currentApp = %q (%v), want other", saved.CurrentApp, err)
+		}
+		if !strings.Contains(stderr.String(), "Switched to profile") ||
+			!strings.Contains(stderr.String(), "until you unset it") {
+			t.Errorf("switch must persist AND disclose the shadow:\n%s", stderr.String())
+		}
+	})
+
+	t.Run("no warning when environment matches the target", func(t *testing.T) {
+		baseConfig(t)
+		f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+		f.Invocation = envInvocation
+		if err := profileUseRun(f, "session"); err != nil {
+			t.Fatalf("profileUseRun() error = %v", err)
+		}
+		if strings.Contains(stderr.String(), "Warning:") {
+			t.Errorf("no shadow warning expected when env matches target:\n%s", stderr.String())
+		}
+	})
+
+	t.Run("no warning without environment override", func(t *testing.T) {
+		baseConfig(t)
+		f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+		if err := profileUseRun(f, "other"); err != nil {
+			t.Fatalf("profileUseRun() error = %v", err)
+		}
+		if strings.Contains(stderr.String(), "Warning:") {
+			t.Errorf("no warning expected without env override:\n%s", stderr.String())
+		}
+	})
+}

--- a/cmd/profile/profile_test.go
+++ b/cmd/profile/profile_test.go
@@ -721,6 +721,40 @@ func TestProfileListRun_MarksEffectiveOverride(t *testing.T) {
 	}
 }
 
+func TestProfileListRun_MarksEffectiveOverrideFromFlag(t *testing.T) {
+	setupProfileConfigDir(t)
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: core.PlainSecret("s1"), Brand: core.BrandFeishu},
+			{Name: "target", AppId: "app-target", AppSecret: core.PlainSecret("s2"), Brand: core.BrandFeishu},
+		},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	f, stdout, stderr, _ := cmdutil.TestFactory(t, nil)
+	f.Invocation = cmdutil.InvocationContext{Profile: "target", ProfileSource: core.ProfileFromFlag}
+	if err := profileListRun(f); err != nil {
+		t.Fatalf("profileListRun() error = %v", err)
+	}
+
+	var got []profileListItem
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output=%s", err, stdout.String())
+	}
+	if !got[0].Active || got[0].Effective {
+		t.Fatalf("got[0] = %#v, want persisted default active but not effective", got[0])
+	}
+	if got[1].Active || !got[1].Effective || got[1].EffectiveSource != "flag" {
+		t.Fatalf("got[1] = %#v, want effective via flag", got[1])
+	}
+	if stderr.String() != "" {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
 func TestProfileListRun_EffectiveFollowsPersistedDefault(t *testing.T) {
 	setupProfileConfigDir(t)
 	multi := &core.MultiAppConfig{

--- a/cmd/profile/use.go
+++ b/cmd/profile/use.go
@@ -12,6 +12,7 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/internal/output"
 )
 
@@ -58,6 +59,7 @@ func profileUseRun(f *cmdutil.Factory, name string) error {
 	currentApp := multi.CurrentAppConfig("")
 	if currentApp != nil && currentApp.ProfileName() == targetName {
 		fmt.Fprintf(f.IOStreams.ErrOut, "Already on profile %q\n", targetName)
+		warnShadowedByEnvironment(f, targetName)
 		return nil
 	}
 
@@ -72,5 +74,21 @@ func profileUseRun(f *cmdutil.Factory, name string) error {
 	}
 
 	output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("Switched to profile %q (%s, %s)", targetName, app.AppId, app.Brand))
+	warnShadowedByEnvironment(f, targetName)
 	return nil
+}
+
+// warnShadowedByEnvironment tells the user when the persistent default they
+// just set (or confirmed) is not what this shell will actually use: use
+// writes the persisted state, but a set LARKSUITE_CLI_PROFILE keeps
+// overriding every subsequent command. Only the environment source warns —
+// a --profile flag ends with this invocation and shadows nothing after it.
+func warnShadowedByEnvironment(f *cmdutil.Factory, targetName string) {
+	if f.Invocation.ProfileSource != core.ProfileFromEnvironment ||
+		f.Invocation.Profile == targetName {
+		return
+	}
+	fmt.Fprintf(f.IOStreams.ErrOut,
+		"Warning: %s=%q is set — commands in this shell keep using %q until you unset it\n",
+		envvars.CliProfile, f.Invocation.Profile, f.Invocation.Profile)
 }

--- a/cmd/profile_env_integration_test.go
+++ b/cmd/profile_env_integration_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/larksuite/cli/extension/platform"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+func TestExecuteProfileSelectorPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		envProfile  string
+		args        []string
+		wantProfile string
+	}{
+		{"environment selects profile", "session", []string{"config", "show"}, "session"},
+		{"flag overrides environment", "session", []string{"config", "show", "--profile", "default"}, "default"},
+		{"empty flag uses persisted default", "session", []string{"config", "show", "--profile="}, "default"},
+		{"empty environment uses persisted default", "", []string{"config", "show"}, "default"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpHome(t)
+			platform.ResetForTesting()
+			t.Cleanup(platform.ResetForTesting)
+			t.Setenv(envvars.CliProfile, tc.envProfile)
+			t.Setenv(envvars.CliAppID, "")
+			t.Setenv(envvars.CliAppSecret, "")
+			t.Setenv(envvars.CliUserAccessToken, "")
+			t.Setenv(envvars.CliTenantAccessToken, "")
+			t.Setenv("LARKSUITE_CLI_NO_UPDATE_NOTIFIER", "1")
+			t.Setenv("LARKSUITE_CLI_NO_SKILLS_NOTIFIER", "1")
+
+			multi := &core.MultiAppConfig{
+				CurrentApp: "default",
+				Apps: []core.AppConfig{
+					{Name: "default", AppId: "app-default", AppSecret: core.PlainSecret("secret-default"), Brand: core.BrandFeishu},
+					{Name: "session", AppId: "app-session", AppSecret: core.PlainSecret("secret-session"), Brand: core.BrandFeishu},
+				},
+			}
+			if err := core.SaveMultiAppConfig(multi); err != nil {
+				t.Fatalf("SaveMultiAppConfig() error = %v", err)
+			}
+
+			code, stdout, stderr := executeWithCapturedOS(t, nil, tc.args...)
+			if code != 0 {
+				t.Fatalf("ExecuteWithOptions() exit=%d stderr=%s", code, stderr)
+			}
+			var result struct {
+				Profile string `json:"profile"`
+				AppID   string `json:"appId"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("decode stdout: %v\nstdout: %s", err, stdout)
+			}
+			if result.Profile != tc.wantProfile || result.AppID != "app-"+tc.wantProfile {
+				t.Fatalf("config show = %+v, want profile %q", result, tc.wantProfile)
+			}
+			saved, err := core.LoadMultiAppConfig()
+			if err != nil {
+				t.Fatalf("LoadMultiAppConfig() error = %v", err)
+			}
+			if saved.CurrentApp != "default" {
+				t.Fatalf("ephemeral selector persisted currentApp = %q", saved.CurrentApp)
+			}
+		})
+	}
+}

--- a/cmd/profile_env_integration_test.go
+++ b/cmd/profile_env_integration_test.go
@@ -5,11 +5,13 @@ package cmd
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/extension/platform"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
+	"github.com/larksuite/cli/internal/output"
 )
 
 func TestExecuteProfileSelectorPrecedence(t *testing.T) {
@@ -67,6 +69,63 @@ func TestExecuteProfileSelectorPrecedence(t *testing.T) {
 			}
 			if saved.CurrentApp != "default" {
 				t.Fatalf("ephemeral selector persisted currentApp = %q", saved.CurrentApp)
+			}
+		})
+	}
+}
+
+func TestExecuteEnvironmentProfileNotFoundNamesTheVariable(t *testing.T) {
+	tmpHome(t)
+	platform.ResetForTesting()
+	t.Cleanup(platform.ResetForTesting)
+	t.Setenv(envvars.CliProfile, "ghost")
+	t.Setenv(envvars.CliAppID, "")
+	t.Setenv(envvars.CliAppSecret, "")
+	t.Setenv(envvars.CliUserAccessToken, "")
+	t.Setenv(envvars.CliTenantAccessToken, "")
+	t.Setenv("LARKSUITE_CLI_NO_UPDATE_NOTIFIER", "1")
+	t.Setenv("LARKSUITE_CLI_NO_SKILLS_NOTIFIER", "1")
+
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: core.PlainSecret("secret-default"), Brand: core.BrandFeishu},
+		},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	// config default-as previously answered this input error with the generic
+	// "no active profile" + a `config init --new` hint — active misdirection
+	// for an agent: init is a destructive OAuth setup flow while an intact
+	// profile sits in config.json. The envelope must name the environment
+	// variable and steer toward unsetting or fixing it.
+	for _, target := range [][]string{
+		{"config", "default-as"},
+		{"config", "show"},
+		{"auth", "list", "--json"},
+	} {
+		t.Run(target[len(target)-1], func(t *testing.T) {
+			code, stdout, stderr := executeWithCapturedOS(t, nil, target...)
+			if code != output.ExitAuth {
+				t.Fatalf("exit = %d, want %d\nstdout: %s\nstderr: %s", code, output.ExitAuth, stdout, stderr)
+			}
+			for _, want := range []string{
+				`profile \"ghost\" not found`,
+				`"field": "` + envvars.CliProfile + `"`,
+				"unset " + envvars.CliProfile,
+			} {
+				if !strings.Contains(stderr, want) {
+					t.Errorf("stderr missing %q:\n%s", want, stderr)
+				}
+			}
+			if strings.Contains(stderr, "config init") {
+				t.Errorf("stderr must not steer to config init:\n%s", stderr)
+			}
+			// auth list must not disguise the input error as an empty account.
+			if strings.Contains(stdout, "not_logged_in") {
+				t.Errorf("stdout still reports not_logged_in:\n%s", stdout)
 			}
 		})
 	}

--- a/cmd/profile_env_integration_test.go
+++ b/cmd/profile_env_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/platform"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
@@ -116,17 +117,33 @@ func TestExecuteEnvironmentProfileNotFoundNamesTheVariable(t *testing.T) {
 			if code != output.ExitAuth {
 				t.Fatalf("exit = %d, want %d\nstdout: %s\nstderr: %s", code, output.ExitAuth, stdout, stderr)
 			}
-			for _, want := range []string{
-				`profile \"ghost\" not found`,
-				`"field": "` + envvars.CliProfile + `"`,
-				"unset " + envvars.CliProfile,
-			} {
-				if !strings.Contains(stderr, want) {
-					t.Errorf("stderr missing %q:\n%s", want, stderr)
-				}
+			var envelope struct {
+				OK    bool `json:"ok"`
+				Error struct {
+					Type    errs.Category `json:"type"`
+					Subtype errs.Subtype  `json:"subtype"`
+					Message string        `json:"message"`
+					Hint    string        `json:"hint"`
+					Field   string        `json:"field"`
+				} `json:"error"`
 			}
-			if strings.Contains(stderr, "config init") {
-				t.Errorf("stderr must not steer to config init:\n%s", stderr)
+			if err := json.Unmarshal([]byte(stderr), &envelope); err != nil {
+				t.Fatalf("stderr is not a JSON envelope: %v\n%s", err, stderr)
+			}
+			if envelope.OK ||
+				envelope.Error.Type != errs.CategoryConfig ||
+				envelope.Error.Subtype != errs.SubtypeNotConfigured ||
+				envelope.Error.Field != envvars.CliProfile {
+				t.Errorf("envelope = %+v, want ok=false config/not_configured field=%s", envelope, envvars.CliProfile)
+			}
+			if want := `profile "ghost" not found`; envelope.Error.Message != want {
+				t.Errorf("message = %q, want %q", envelope.Error.Message, want)
+			}
+			if !strings.Contains(envelope.Error.Hint, "unset "+envvars.CliProfile) {
+				t.Errorf("hint = %q, want unset guidance", envelope.Error.Hint)
+			}
+			if strings.Contains(envelope.Error.Hint, "config init") {
+				t.Errorf("hint must not steer to config init: %q", envelope.Error.Hint)
 			}
 			// auth list must not disguise the input error as an empty account.
 			if strings.Contains(stdout, "not_logged_in") {

--- a/cmd/profile_env_integration_test.go
+++ b/cmd/profile_env_integration_test.go
@@ -20,11 +20,12 @@ func TestExecuteProfileSelectorPrecedence(t *testing.T) {
 		envProfile  string
 		args        []string
 		wantProfile string
+		wantSource  string
 	}{
-		{"environment selects profile", "session", []string{"config", "show"}, "session"},
-		{"flag overrides environment", "session", []string{"config", "show", "--profile", "default"}, "default"},
-		{"empty flag uses persisted default", "session", []string{"config", "show", "--profile="}, "default"},
-		{"empty environment uses persisted default", "", []string{"config", "show"}, "default"},
+		{"environment selects profile", "session", []string{"config", "show"}, "session", "environment"},
+		{"flag overrides environment", "session", []string{"config", "show", "--profile", "default"}, "default", "flag"},
+		{"empty flag uses persisted default", "session", []string{"config", "show", "--profile="}, "default", "config"},
+		{"empty environment uses persisted default", "", []string{"config", "show"}, "default", "config"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpHome(t)
@@ -54,14 +55,18 @@ func TestExecuteProfileSelectorPrecedence(t *testing.T) {
 				t.Fatalf("ExecuteWithOptions() exit=%d stderr=%s", code, stderr)
 			}
 			var result struct {
-				Profile string `json:"profile"`
-				AppID   string `json:"appId"`
+				Profile       string `json:"profile"`
+				ProfileSource string `json:"profileSource"`
+				AppID         string `json:"appId"`
 			}
 			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
 				t.Fatalf("decode stdout: %v\nstdout: %s", err, stdout)
 			}
 			if result.Profile != tc.wantProfile || result.AppID != "app-"+tc.wantProfile {
 				t.Fatalf("config show = %+v, want profile %q", result, tc.wantProfile)
+			}
+			if result.ProfileSource != tc.wantSource {
+				t.Fatalf("profileSource = %q, want %q", result.ProfileSource, tc.wantSource)
 			}
 			saved, err := core.LoadMultiAppConfig()
 			if err != nil {

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -26,14 +26,18 @@ import (
 	"github.com/larksuite/cli/internal/transport"
 )
 
+// InvocationContext is the immutable per-invocation input resolved at the
+// process boundary, before the command tree is built. Profile carries the
+// selected profile name; ProfileSource records which channel selected it so
+// downstream gating, errors, and status output can name the actual input.
+type InvocationContext struct {
+	Profile       string
+	ProfileSource core.ProfileSource
+}
+
 // Factory holds shared dependencies injected into every command.
 // All function fields are lazily initialized and cached after first call.
 // In tests, replace any field to stub out external dependencies.
-type InvocationContext struct {
-	Profile                string
-	ProfileFromEnvironment bool // distinguishes ambient input for distribution capability gating
-}
-
 type Factory struct {
 	Config     func() (*core.CliConfig, error) // lazily loads app config from Credential
 	HttpClient func() (*http.Client, error)    // policy-routed HTTP client for direct requests

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -30,7 +30,8 @@ import (
 // All function fields are lazily initialized and cached after first call.
 // In tests, replace any field to stub out external dependencies.
 type InvocationContext struct {
-	Profile string
+	Profile                string
+	ProfileFromEnvironment bool // distinguishes ambient input for distribution capability gating
 }
 
 type Factory struct {

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -79,10 +79,11 @@ func NewDefault(streams *IOStreams, inv InvocationContext) *Factory {
 	// Phase 2: Credential (sole data source)
 	// Keychain is read via closure so callers can replace f.Keychain after construction.
 	f.Credential = buildCredentialProvider(credentialDeps{
-		Keychain:   func() keychain.KeychainAccess { return f.Keychain },
-		Profile:    inv.Profile,
-		HttpClient: f.HttpClient,
-		ErrOut:     f.IOStreams.ErrOut,
+		Keychain:      func() keychain.KeychainAccess { return f.Keychain },
+		Profile:       inv.Profile,
+		ProfileSource: inv.ProfileSource,
+		HttpClient:    f.HttpClient,
+		ErrOut:        f.IOStreams.ErrOut,
 	})
 
 	// Phase 3: Runtime config contains resolved account data only.
@@ -272,15 +273,16 @@ func buildSDKHTTPTransport(base http.RoundTripper, platform bool) http.RoundTrip
 }
 
 type credentialDeps struct {
-	Keychain   func() keychain.KeychainAccess
-	Profile    string
-	HttpClient func() (*http.Client, error)
-	ErrOut     io.Writer
+	Keychain      func() keychain.KeychainAccess
+	Profile       string
+	ProfileSource core.ProfileSource
+	HttpClient    func() (*http.Client, error)
+	ErrOut        io.Writer
 }
 
 func buildCredentialProvider(deps credentialDeps) *credential.CredentialProvider {
 	providers := extcred.Providers()
-	defaultAcct := credential.NewDefaultAccountProvider(deps.Keychain, deps.Profile)
+	defaultAcct := credential.NewDefaultAccountProvider(deps.Keychain, deps.Profile, deps.ProfileSource)
 	defaultToken := credential.NewDefaultTokenProvider(defaultAcct, deps.HttpClient, deps.ErrOut)
 	// NOTE: Do not pass deps.ErrOut as warnOut. Credential resolution
 	// happens before the command runs, so any plain-text warning written

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -93,6 +93,25 @@ func (m *MultiAppConfig) CurrentAppConfig(profileOverride string) *AppConfig {
 	return nil
 }
 
+// EffectiveProfile resolves which profile this invocation actually uses and
+// which channel decided that. It is the single definition of "effective" for
+// status output (config show, profile list, profile use warnings); the
+// persisted CurrentApp answers a different question — which profile applies
+// when no selector is present — and must not be conflated with it.
+//
+// A nil app with a non-empty selector means the selector is dangling; the
+// caller decides between an error (RequireAppConfig) and a warning (listing
+// commands, which are the user's recovery surface).
+func (m *MultiAppConfig) EffectiveProfile(profile string, source ProfileSource) (*AppConfig, ProfileSource) {
+	app := m.CurrentAppConfig(profile)
+	if profile != "" {
+		return app, source
+	}
+	// An empty selector value (including an explicit --profile=) defers to
+	// the persisted state, so the persisted channel is what decided.
+	return app, ProfileFromConfig
+}
+
 // FindApp looks up an app by name, then by appId. Returns nil if not found.
 // Name match takes priority: if profile A has Name "X" and profile B has AppId "X",
 // FindApp("X") returns profile A.

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/larksuite/cli/errs"
@@ -243,16 +242,19 @@ func RequireConfigForProfile(kc keychain.KeychainAccess, profileOverride string)
 	if err != nil || raw == nil || len(raw.Apps) == 0 {
 		return nil, NotConfiguredError()
 	}
-	return ResolveConfigFromMulti(raw, kc, profileOverride)
+	// This legacy wrapper has no channel information for its override; the
+	// flag wording is the safe default (it never misattributes to the env).
+	return ResolveConfigFromMulti(raw, kc, profileOverride, ProfileFromFlag)
 }
 
 // ResolveConfigFromMulti resolves a single-app config from an already-loaded MultiAppConfig.
 // This avoids re-reading the config file when the caller has already loaded it.
-func ResolveConfigFromMulti(raw *MultiAppConfig, kc keychain.KeychainAccess, profileOverride string) (*CliConfig, error) {
-	app := raw.CurrentAppConfig(profileOverride)
-	if app == nil {
-		return nil, errs.NewConfigError(errs.SubtypeNotConfigured, "profile %q not found", profileOverride).
-			WithHint("available profiles: %s", formatProfileNames(raw.ProfileNames()))
+// source records which channel selected profileOverride so a resolution
+// failure can name the input the user must fix.
+func ResolveConfigFromMulti(raw *MultiAppConfig, kc keychain.KeychainAccess, profileOverride string, source ProfileSource) (*CliConfig, error) {
+	app, err := raw.RequireAppConfig(profileOverride, source)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := ValidateSecretKeyMatch(app.AppId, app.AppSecret); err != nil {
@@ -305,12 +307,4 @@ func RequireAuthForProfile(kc keychain.KeychainAccess, profileOverride string) (
 		)
 	}
 	return cfg, nil
-}
-
-// formatProfileNames joins profile names for display.
-func formatProfileNames(names []string) string {
-	if len(names) == 0 {
-		return "(none)"
-	}
-	return strings.Join(names, ", ")
 }

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -105,7 +105,7 @@ func TestResolveConfigFromMulti_RejectsSecretKeyMismatch(t *testing.T) {
 		},
 	}
 
-	_, err := ResolveConfigFromMulti(raw, nil, "")
+	_, err := ResolveConfigFromMulti(raw, nil, "", ProfileFromConfig)
 	if err == nil {
 		t.Fatal("expected error for mismatched appId and appSecret keychain key")
 	}
@@ -129,7 +129,7 @@ func TestResolveConfigFromMulti_AcceptsPlainSecret(t *testing.T) {
 		},
 	}
 
-	cfg, err := ResolveConfigFromMulti(raw, nil, "")
+	cfg, err := ResolveConfigFromMulti(raw, nil, "", ProfileFromConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestResolveConfigFromMulti_CarriesLang(t *testing.T) {
 		},
 	}
 
-	cfg, err := ResolveConfigFromMulti(raw, nil, "")
+	cfg, err := ResolveConfigFromMulti(raw, nil, "", ProfileFromConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestResolveConfigFromMulti_MatchingKeychainRefPassesValidation(t *testing.T
 		},
 	}
 
-	_, err := ResolveConfigFromMulti(raw, stubKeychain{}, "")
+	_, err := ResolveConfigFromMulti(raw, stubKeychain{}, "", ProfileFromConfig)
 	if err == nil {
 		// stubKeychain returns ErrNotFound, so we expect a keychain error,
 		// but NOT a mismatch error — that's the point of this test.
@@ -206,7 +206,7 @@ func TestResolveConfigFromMulti_DoesNotUseEnvProfileFallback(t *testing.T) {
 		},
 	}
 
-	cfg, err := ResolveConfigFromMulti(raw, nil, "")
+	cfg, err := ResolveConfigFromMulti(raw, nil, "", ProfileFromConfig)
 	if err != nil {
 		t.Fatalf("ResolveConfigFromMulti() error = %v", err)
 	}
@@ -244,7 +244,7 @@ func TestResolveConfigFromMulti_NormalizesBrand(t *testing.T) {
 		AppSecret: PlainSecret("test-secret"),
 		Brand:     LarkBrand(" LARK "),
 	}}}
-	cfg, err := ResolveConfigFromMulti(multi, nil, "")
+	cfg, err := ResolveConfigFromMulti(multi, nil, "", ProfileFromConfig)
 	if err != nil {
 		t.Fatalf("ResolveConfigFromMulti error = %v", err)
 	}

--- a/internal/core/notconfigured.go
+++ b/internal/core/notconfigured.go
@@ -5,9 +5,12 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/internal/recovery"
 )
 
@@ -112,6 +115,65 @@ func reconfigureHint() string {
 		return "please run `lark-cli config init` to reconfigure"
 	}
 	return agentBindHint
+}
+
+// RequireAppConfig resolves the profile selection to an app entry, or returns
+// a typed error naming the input that must change. Use it wherever
+// CurrentAppConfig's nil is a user-visible failure: the bare nil folds three
+// distinct causes — a bad explicit selector, a dangling persisted currentApp,
+// and a genuinely empty config — that need three different recoveries.
+func (m *MultiAppConfig) RequireAppConfig(profile string, source ProfileSource) (*AppConfig, error) {
+	if app := m.CurrentAppConfig(profile); app != nil {
+		return app, nil
+	}
+	return nil, m.ProfileNotFoundError(profile, source)
+}
+
+// ProfileNotFoundError is the typed error behind RequireAppConfig, exported
+// separately for call sites that keep their own nil tolerance (e.g. a
+// --global branch that proceeds without a profile).
+//
+// The selector split matters most for the environment case: the variable may
+// have been exported long before the failing command, so the error must name
+// LARKSUITE_CLI_PROFILE explicitly — nothing in what the user just typed
+// points at it. config init is never suggested here; the remaining profiles
+// are intact and re-initializing would be destructive misdirection.
+func (m *MultiAppConfig) ProfileNotFoundError(profile string, source ProfileSource) error {
+	if profile == "" && m.CurrentApp == "" {
+		// Nothing was selected and nothing is selectable: genuinely unconfigured.
+		return NotConfiguredError()
+	}
+	available := strings.Join(m.ProfileNames(), ", ")
+	if profile == "" {
+		// No explicit selector involved: the persisted default itself is a
+		// dangling reference, so recovery is re-pointing the persisted state.
+		hint := recovery.Join("",
+			recovery.Command(recovery.TargetProfileList,
+				fmt.Sprintf("config.json currentApp %q matches no profile; run `lark-cli profile list`, then switch with `lark-cli profile use <name>` (available: %s)", m.CurrentApp, available))).
+			WithFallback("the persisted default profile no longer exists; select an available profile through this distribution")
+		return recovery.Annotate(
+			errs.NewConfigError(errs.SubtypeNotConfigured, "profile %q not found", m.CurrentApp).
+				WithField("currentApp").
+				WithHint("%s", hint.String()),
+			hint,
+		)
+	}
+	selector := "--profile"
+	action := fmt.Sprintf("pass one of: %s", available)
+	if source == ProfileFromEnvironment {
+		selector = envvars.CliProfile
+		action = fmt.Sprintf("unset %s or set it to one of: %s", envvars.CliProfile, available)
+	}
+	hint := recovery.Join("",
+		recovery.Command(recovery.TargetProfileList,
+			fmt.Sprintf("%s selected profile %q, which does not exist; %s (run `lark-cli profile list` for details)", selector, profile, action))).
+		WithFallback(fmt.Sprintf("%s selected profile %q, which does not exist; %s", selector, profile, action))
+	return recovery.Annotate(
+		errs.NewConfigError(errs.SubtypeNotConfigured, "profile %q not found", profile).
+			WithField(selector).
+			WithHint("%s", hint.String()),
+		hint,
+	)
 }
 
 // NoActiveProfileError mirrors NotConfiguredError for the related

--- a/internal/core/notconfigured.go
+++ b/internal/core/notconfigured.go
@@ -158,10 +158,12 @@ func (m *MultiAppConfig) ProfileNotFoundError(profile string, source ProfileSour
 			hint,
 		)
 	}
-	selector := "--profile"
+	selector := source.SelectorLabel()
+	if selector == "" {
+		selector = "--profile" // defensive: an explicit value implies a selector channel
+	}
 	action := fmt.Sprintf("pass one of: %s", available)
 	if source == ProfileFromEnvironment {
-		selector = envvars.CliProfile
 		action = fmt.Sprintf("unset %s or set it to one of: %s", envvars.CliProfile, available)
 	}
 	hint := recovery.Join("",

--- a/internal/core/notconfigured_test.go
+++ b/internal/core/notconfigured_test.go
@@ -203,3 +203,136 @@ func TestLoadOrNotConfigured_CorruptFile_PreservesCause(t *testing.T) {
 		t.Error("Cause must wrap the underlying load error for errors.Is/Unwrap")
 	}
 }
+
+func TestProfileNotFoundError_NamesSelectorAndSource(t *testing.T) {
+	multi := &MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: PlainSecret("s1"), Brand: BrandFeishu},
+			{Name: "session", AppId: "app-session", AppSecret: PlainSecret("s2"), Brand: BrandFeishu},
+		},
+	}
+
+	for _, tc := range []struct {
+		name         string
+		profile      string
+		source       ProfileSource
+		wantMessage  string
+		wantField    string
+		wantHintSubs []string
+	}{
+		{
+			name:        "environment selector",
+			profile:     "ghost",
+			source:      ProfileFromEnvironment,
+			wantMessage: `profile "ghost" not found`,
+			wantField:   "LARKSUITE_CLI_PROFILE",
+			wantHintSubs: []string{
+				`LARKSUITE_CLI_PROFILE selected profile "ghost"`,
+				"unset LARKSUITE_CLI_PROFILE",
+				"default, session",
+			},
+		},
+		{
+			name:        "flag selector",
+			profile:     "ghost",
+			source:      ProfileFromFlag,
+			wantMessage: `profile "ghost" not found`,
+			wantField:   "--profile",
+			wantHintSubs: []string{
+				`--profile selected profile "ghost"`,
+				"default, session",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := multi.RequireAppConfig(tc.profile, tc.source)
+			var cfgErr *errs.ConfigError
+			if !errors.As(err, &cfgErr) {
+				t.Fatalf("expected *errs.ConfigError, got %T %v", err, err)
+			}
+			if cfgErr.Subtype != errs.SubtypeNotConfigured {
+				t.Errorf("subtype = %q, want not_configured", cfgErr.Subtype)
+			}
+			if cfgErr.Message != tc.wantMessage {
+				t.Errorf("message = %q, want %q", cfgErr.Message, tc.wantMessage)
+			}
+			if cfgErr.Field != tc.wantField {
+				t.Errorf("field = %q, want %q", cfgErr.Field, tc.wantField)
+			}
+			for _, sub := range tc.wantHintSubs {
+				if !strings.Contains(cfgErr.Hint, sub) {
+					t.Errorf("hint = %q, missing %q", cfgErr.Hint, sub)
+				}
+			}
+			// The remaining profiles are intact; re-initializing would be
+			// destructive misdirection for both selector sources.
+			if strings.Contains(cfgErr.Hint, "config init") {
+				t.Errorf("hint must not suggest config init; got %q", cfgErr.Hint)
+			}
+		})
+	}
+}
+
+func TestProfileNotFoundError_DanglingCurrentApp(t *testing.T) {
+	multi := &MultiAppConfig{
+		CurrentApp: "renamed-away",
+		Apps: []AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: PlainSecret("s1"), Brand: BrandFeishu},
+		},
+	}
+	_, err := multi.RequireAppConfig("", ProfileFromConfig)
+	var cfgErr *errs.ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected *errs.ConfigError, got %T %v", err, err)
+	}
+	if cfgErr.Message != `profile "renamed-away" not found` {
+		t.Errorf("message = %q, want the dangling currentApp named", cfgErr.Message)
+	}
+	if cfgErr.Field != "currentApp" {
+		t.Errorf("field = %q, want currentApp", cfgErr.Field)
+	}
+	for _, sub := range []string{"currentApp", "profile use", "default"} {
+		if !strings.Contains(cfgErr.Hint, sub) {
+			t.Errorf("hint = %q, missing %q", cfgErr.Hint, sub)
+		}
+	}
+	if strings.Contains(cfgErr.Hint, "config init") {
+		t.Errorf("hint must not suggest config init; got %q", cfgErr.Hint)
+	}
+}
+
+func TestProfileNotFoundError_EmptyConfigFallsBackToNotConfigured(t *testing.T) {
+	saveAndRestoreWorkspace(t)
+	SetCurrentWorkspace(WorkspaceLocal)
+	multi := &MultiAppConfig{}
+	_, err := multi.RequireAppConfig("", ProfileFromConfig)
+	var cfgErr *errs.ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected *errs.ConfigError, got %T %v", err, err)
+	}
+	if cfgErr.Message != "not configured" {
+		t.Errorf("message = %q, want the NotConfiguredError fallback", cfgErr.Message)
+	}
+	if !strings.Contains(cfgErr.Hint, "config init") {
+		t.Errorf("empty config is the one case where init IS the fix; hint = %q", cfgErr.Hint)
+	}
+}
+
+func TestRequireAppConfig_ResolvesExisting(t *testing.T) {
+	multi := &MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []AppConfig{
+			{Name: "default", AppId: "app-default", AppSecret: PlainSecret("s1"), Brand: BrandFeishu},
+			{Name: "session", AppId: "app-session", AppSecret: PlainSecret("s2"), Brand: BrandFeishu},
+		},
+	}
+	app, err := multi.RequireAppConfig("session", ProfileFromEnvironment)
+	if err != nil || app == nil || app.AppId != "app-session" {
+		t.Fatalf("RequireAppConfig() = %v, %v; want app-session", app, err)
+	}
+	app, err = multi.RequireAppConfig("", ProfileFromConfig)
+	if err != nil || app == nil || app.AppId != "app-default" {
+		t.Fatalf("RequireAppConfig() persisted = %v, %v; want app-default", app, err)
+	}
+}

--- a/internal/core/notconfigured_test.go
+++ b/internal/core/notconfigured_test.go
@@ -251,8 +251,12 @@ func TestProfileNotFoundError_NamesSelectorAndSource(t *testing.T) {
 			if !errors.As(err, &cfgErr) {
 				t.Fatalf("expected *errs.ConfigError, got %T %v", err, err)
 			}
-			if cfgErr.Subtype != errs.SubtypeNotConfigured {
-				t.Errorf("subtype = %q, want not_configured", cfgErr.Subtype)
+			problem, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("ProblemOf(%T) = _, false; want typed problem", err)
+			}
+			if problem.Category != errs.CategoryConfig || problem.Subtype != errs.SubtypeNotConfigured {
+				t.Errorf("problem = %s/%s, want config/not_configured", problem.Category, problem.Subtype)
 			}
 			if cfgErr.Message != tc.wantMessage {
 				t.Errorf("message = %q, want %q", cfgErr.Message, tc.wantMessage)
@@ -286,6 +290,13 @@ func TestProfileNotFoundError_DanglingCurrentApp(t *testing.T) {
 	if !errors.As(err, &cfgErr) {
 		t.Fatalf("expected *errs.ConfigError, got %T %v", err, err)
 	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf(%T) = _, false; want typed problem", err)
+	}
+	if problem.Category != errs.CategoryConfig || problem.Subtype != errs.SubtypeNotConfigured {
+		t.Errorf("problem = %s/%s, want config/not_configured", problem.Category, problem.Subtype)
+	}
 	if cfgErr.Message != `profile "renamed-away" not found` {
 		t.Errorf("message = %q, want the dangling currentApp named", cfgErr.Message)
 	}
@@ -310,6 +321,13 @@ func TestProfileNotFoundError_EmptyConfigFallsBackToNotConfigured(t *testing.T) 
 	var cfgErr *errs.ConfigError
 	if !errors.As(err, &cfgErr) {
 		t.Fatalf("expected *errs.ConfigError, got %T %v", err, err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf(%T) = _, false; want typed problem", err)
+	}
+	if problem.Category != errs.CategoryConfig || problem.Subtype != errs.SubtypeNotConfigured {
+		t.Errorf("problem = %s/%s, want config/not_configured", problem.Category, problem.Subtype)
 	}
 	if cfgErr.Message != "not configured" {
 		t.Errorf("message = %q, want the NotConfiguredError fallback", cfgErr.Message)

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -6,6 +6,8 @@ package core
 import (
 	"net/url"
 	"strings"
+
+	"github.com/larksuite/cli/internal/envvars"
 )
 
 // LarkBrand represents the Lark platform brand.
@@ -38,6 +40,33 @@ const (
 	ProfileFromFlag                             // --profile on this invocation (including --profile=)
 	ProfileFromEnvironment                      // LARKSUITE_CLI_PROFILE
 )
+
+// String is the wire form used in machine-readable status output
+// (e.g. profile list's effectiveSource).
+func (s ProfileSource) String() string {
+	switch s {
+	case ProfileFromFlag:
+		return "flag"
+	case ProfileFromEnvironment:
+		return "environment"
+	default:
+		return "config"
+	}
+}
+
+// SelectorLabel returns the user-facing name of the explicit input channel —
+// the flag token or the environment variable name. Empty for the persisted
+// default, which has no selector to point at.
+func (s ProfileSource) SelectorLabel() string {
+	switch s {
+	case ProfileFromFlag:
+		return "--profile"
+	case ProfileFromEnvironment:
+		return envvars.CliProfile
+	default:
+		return ""
+	}
+}
 
 // OAuthTokenV3Path is the unified OAuth 2.0 Token Endpoint path on the accounts
 // domain. It serves every grant type (client_credentials for TAT,

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -27,6 +27,18 @@ func ParseBrand(value string) LarkBrand {
 	return BrandFeishu
 }
 
+// ProfileSource identifies which input channel selected the invocation's
+// profile. Errors and status output use it to point at the thing the user
+// must actually fix: an argv flag they just typed, an environment variable
+// that may have been exported long ago, or the persisted config default.
+type ProfileSource uint8
+
+const (
+	ProfileFromConfig      ProfileSource = iota // no explicit selector; persisted currentApp applies
+	ProfileFromFlag                             // --profile on this invocation (including --profile=)
+	ProfileFromEnvironment                      // LARKSUITE_CLI_PROFILE
+)
+
 // OAuthTokenV3Path is the unified OAuth 2.0 Token Endpoint path on the accounts
 // domain. It serves every grant type (client_credentials for TAT,
 // authorization_code / device_code / refresh_token for UAT) and replaces the

--- a/internal/credential/default_provider.go
+++ b/internal/credential/default_provider.go
@@ -62,15 +62,16 @@ func classifyTATResponseCode(code int, oauthErr, errDesc, brand, appID string) e
 
 // DefaultAccountProvider resolves account from config.json via keychain.
 type DefaultAccountProvider struct {
-	keychain func() keychain.KeychainAccess
-	profile  string
+	keychain      func() keychain.KeychainAccess
+	profile       string
+	profileSource core.ProfileSource
 }
 
-func NewDefaultAccountProvider(kc func() keychain.KeychainAccess, profile string) *DefaultAccountProvider {
+func NewDefaultAccountProvider(kc func() keychain.KeychainAccess, profile string, source core.ProfileSource) *DefaultAccountProvider {
 	if kc == nil {
 		kc = keychain.Default
 	}
-	return &DefaultAccountProvider{keychain: kc, profile: profile}
+	return &DefaultAccountProvider{keychain: kc, profile: profile, profileSource: source}
 }
 
 func (p *DefaultAccountProvider) ResolveAccount(ctx context.Context) (*Account, error) {
@@ -80,7 +81,7 @@ func (p *DefaultAccountProvider) ResolveAccount(ctx context.Context) (*Account, 
 		return nil, core.NotConfiguredError()
 	}
 
-	cfg, err := core.ResolveConfigFromMulti(multi, p.keychain(), p.profile)
+	cfg, err := core.ResolveConfigFromMulti(multi, p.keychain(), p.profile, p.profileSource)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/credential/integration_test.go
+++ b/internal/credential/integration_test.go
@@ -101,7 +101,7 @@ func TestFullChain_ConfigStrictMode(t *testing.T) {
 	}
 
 	ep := &envprovider.Provider{}
-	defaultAcct := credential.NewDefaultAccountProvider(func() keychain.KeychainAccess { return &noopKC{} }, "")
+	defaultAcct := credential.NewDefaultAccountProvider(func() keychain.KeychainAccess { return &noopKC{} }, "", core.ProfileFromConfig)
 
 	cp := credential.NewCredentialProvider(
 		[]extcred.Provider{ep},
@@ -141,7 +141,7 @@ func TestFullChain_LangSurvivesProductionPath(t *testing.T) {
 		t.Fatalf("SaveMultiAppConfig: %v", err)
 	}
 
-	defaultAcct := credential.NewDefaultAccountProvider(func() keychain.KeychainAccess { return &noopKC{} }, "")
+	defaultAcct := credential.NewDefaultAccountProvider(func() keychain.KeychainAccess { return &noopKC{} }, "", core.ProfileFromConfig)
 	acct, err := defaultAcct.ResolveAccount(context.Background())
 	if err != nil {
 		t.Fatalf("ResolveAccount: %v", err)

--- a/internal/envvars/envvars.go
+++ b/internal/envvars/envvars.go
@@ -10,6 +10,7 @@ const (
 	CliUserAccessToken   = "LARKSUITE_CLI_USER_ACCESS_TOKEN"
 	CliTenantAccessToken = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN"
 	CliDefaultAs         = "LARKSUITE_CLI_DEFAULT_AS"
+	CliProfile           = "LARKSUITE_CLI_PROFILE"
 	CliStrictMode        = "LARKSUITE_CLI_STRICT_MODE"
 
 	// Sidecar proxy (auth proxy mode)


### PR DESCRIPTION
## What

Profile selection can now come from the environment (`LARKSUITE_CLI_PROFILE`), and every place that resolves a profile now knows *which channel selected it* — flag, environment, or the persisted default — so failures name the actual selector instead of guessing.

Four commits, one functional unit:

1. **`feat: support profile selection from environment`** — resolve the env var at the process boundary (single `os.Getenv` consumption point in bootstrap), with precedence `--profile` flag > non-empty env > persisted `currentApp`. Restricted builds reject an environment-origin profile through the same distribution gate that already rejects the flag, before hooks or lifecycle events can observe the invocation.
2. **`refactor: carry profile selection source in the invocation context`** — `InvocationContext` carries `ProfileSource` alongside `Profile`; no behavior change on its own.
3. **`fix: name the profile selector in resolution failures`** — when the selected profile doesn't resolve, errors state which selector chose it and list the available profiles, instead of the previous generic (and sometimes misleading) messages.
4. **`feat: surface the effective profile beside the persisted default`** — status output distinguishes "what is persisted" from "what is in effect for this invocation".

## Contract changes (intentional, reviewer-relevant)

- `auth list` / `auth logout` with a dangling persisted selector (`currentApp` pointing at a profile that no longer exists): previously returned success-shaped output (`"ok": true`, empty users) at exit 0; now fail with a named config error at exit 3. The old behavior actively masked a broken default.
- `config show` adds a `profileSource` field; `profile list` adds `effective` / `effectiveSource` fields. Purely additive — with no env var and no flag, `config show` output differs from main by exactly the one added field, and `auth list` / `doctor` are byte-identical.
- Profile-resolution errors may carry a `field` key naming the selector (existing envelope key, newly populated here).
- Errors and hints now name the real selector value (fixes cases on main where the broken value was shown as an empty string, or where the hint suggested `config init --new` while valid profiles existed).

## Verification

- Full test suite, `go vet`, and `-race -count=1` across `cmd/internal/shortcuts/extension` green; `golangci-lint run --new-from-rev=origin/main` clean.
- Dry-run e2e suites pass against a binary built from this branch.
- A/B against a baseline `main` binary: 824 help paths, full `schema` output (42k lines), and shell completions byte-identical; 62 populated-config scenarios across `config`/`profile`/`auth`/`doctor`/`whoami` and 36 error paths audited — every difference traces to the contract changes listed above, none outside them.
- Environment variable is intentionally undocumented in user-facing help; verified it leaks into no help/schema/completion text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile selection now follows clear precedence: command-line flag, environment variable, then saved configuration.
  * Profile listings identify the effective profile and its selection source.
  * Added warnings when environment-selected profiles override saved or requested profiles.
* **Bug Fixes**
  * Invalid or missing profiles now produce specific errors and recovery guidance instead of misleading unauthenticated or unconfigured messages.
  * Commands requiring profiles now stop safely when profile selection is unsupported or unavailable.
  * Diagnostic checks warn when external providers ignore profile selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->