### PR TITLE
feat: migrate application and IM guidance to affordance

### DIFF
--- a/affordance/application.md
+++ b/affordance/application.md
@@ -1,0 +1,65 @@
+# application
+
+## +slash-command-list
+Use this to inspect the current app's slash commands and obtain a stable `command_id` before an update or deletion.
+
+### Tips
+- The upstream API returns all commands at once (maximum 100 per app); there is no pagination.
+
+### Examples
+
+**List all slash commands of the currently bound app**
+```bash
+lark-cli application +slash-command-list
+```
+
+## +slash-command-create
+Use this for a new command name. On a name collision, update the existing command only when that is the user's intent.
+
+### Avoid when
+- The command already exists and the user wants to edit it → use [[+slash-command-update]].
+
+### Tips
+- Changes may take about five minutes to appear in clients because of client-side caching; the server updates immediately.
+
+### Examples
+
+**Create a localized slash command**
+```bash
+lark-cli application +slash-command-create --command greet --description "say hi" --description-i18n zh_cn=问候
+```
+
+## +slash-command-update
+Use this to change description, localized descriptions, or icon while retaining the command name and `command_id`.
+
+### Prerequisites
+- Pass `--command-id` from [[+slash-command-list]], or pass `--command` to let the CLI resolve the current id by name with a live list request.
+
+### Tips
+- PATCH is field-level partial: fields you do not pass are preserved server-side.
+- The command name cannot be changed. Renaming means deleting and recreating the command, which produces a new `command_id`.
+
+### Examples
+
+**Update by name (the CLI resolves the current command id first)**
+```bash
+lark-cli application +slash-command-update --command greet --description "new text"
+```
+
+## +slash-command-delete
+Use this only after the user explicitly confirms the target and the irreversible deletion.
+
+### Prerequisites
+- Explicit user confirmation is required before passing `--yes`; an agent must not self-approve the deletion.
+- Pass `--command-id` from [[+slash-command-list]], or pass `--command` to let the CLI resolve the current id by name with a live list request.
+
+### Tips
+- Deleted commands may linger in clients for about five minutes because of client-side caching.
+- Recreating the same command name produces a new `command_id`.
+
+### Examples
+
+**Delete by name after explicit user confirmation**
+```bash
+lark-cli application +slash-command-delete --command greet --yes
+```

--- a/affordance/im.md
+++ b/affordance/im.md
@@ -476,9 +476,9 @@ Use this raw method only for standalone message ids; message-reading shortcuts a
 
 ### Examples
 
-**Query reactions for two messages**
+**Query the first page of reactions for two messages**
 ```bash
-lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy","page_token":"<PAGE_TOKEN>"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'
+lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'
 ```
 
 ### Skills

--- a/affordance/im.md
+++ b/affordance/im.md
@@ -1,0 +1,485 @@
+# im
+> skill: lark-im
+
+## +chat-create
+Use this when a new group or topic chat is needed. Choose the calling identity deliberately because it affects ownership and member visibility.
+
+### Avoid when
+- The chat already exists and only its name or description should change → use [[+chat-update]].
+
+### Examples
+
+**Create a private group with the configured identity**
+```bash
+lark-cli im +chat-create --name "My Group"
+```
+
+### Skills
+- `lark-im/references/lark-im-chat-create.md`
+- `lark-im/references/lark-im-chat-identity.md`
+
+## +chat-list
+Use this to enumerate chats the current identity has joined.
+
+### Avoid when
+- Looking up a group by name or member → use [[+chat-search]].
+
+### Examples
+
+**List joined group chats**
+```bash
+lark-cli im +chat-list
+```
+
+### Skills
+- `lark-im/references/lark-im-chat-list.md`
+
+## +chat-members-list
+Use this instead of the raw member methods when you need users and bots separated and truncation reported explicitly.
+
+### Tips
+- Default fetches a single page; pass --page-all to walk every page.
+- With --page-all and no explicit --page-size, the max page size is used to minimize round-trips.
+- truncations[] in the result means the server capped a bucket due to security config — the member list is incomplete.
+
+### Examples
+
+**List one page of users and bots**
+```bash
+lark-cli im +chat-members-list --chat-id oc_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-chat-members-list.md`
+
+## +chat-messages-list
+Use this for message history when the conversation is already known.
+
+### Avoid when
+- Searching across conversations → use [[+messages-search]].
+- Fetching full details for known message ids → use [[+messages-mget]].
+
+### Examples
+
+**List messages in a group chat**
+```bash
+lark-cli im +chat-messages-list --chat-id oc_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-chat-messages-list.md`
+
+## +chat-search
+Use this to resolve a visible group name or member set to a stable chat_id before another operation.
+
+### Examples
+
+**Search visible groups by keyword**
+```bash
+lark-cli im +chat-search --query "project"
+```
+
+### Skills
+- `lark-im/references/lark-im-chat-search.md`
+
+## +chat-update
+Use this for name or description changes after identifying the group and an owner/admin-capable identity.
+
+### Examples
+
+**Rename a group**
+```bash
+lark-cli im +chat-update --chat-id oc_xxx --name "New Group Name"
+```
+
+### Skills
+- `lark-im/references/lark-im-chat-update.md`
+- `lark-im/references/lark-im-chat-identity.md`
+
+## +messages-mget
+Use this when one or more message_ids are already known and full message details are needed.
+
+### Avoid when
+- Discovering messages by chat or keyword → use [[+chat-messages-list]] or [[+messages-search]].
+
+### Examples
+
+**Fetch one known message**
+```bash
+lark-cli im +messages-mget --message-ids om_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-messages-mget.md`
+
+## +messages-reply
+Use this when the response must remain attached to a specific message or thread.
+
+### Prerequisites
+- Confirm the target message, reply content, and sending identity before sending.
+
+### Examples
+
+**Reply with plain text using the configured identity**
+```bash
+lark-cli im +messages-reply --message-id om_xxx --text "Received"
+```
+
+### Skills
+- `lark-im/references/lark-im-messages-reply.md`
+
+## +messages-resources-download
+Use this after a read command exposes a message_id and matching file_key and the binary content is actually needed.
+
+### Examples
+
+**Download an image resource to the current directory**
+```bash
+lark-cli im +messages-resources-download --message-id om_xxx --file-key img_v3_xxx --type image
+```
+
+### Skills
+- `lark-im/references/lark-im-messages-resources-download.md`
+
+## +messages-search
+Use this user-only shortcut to find messages across conversations by keyword or structured filters.
+
+### Examples
+
+**Search messages by keyword**
+```bash
+lark-cli im +messages-search --as user --query "project progress"
+```
+
+### Skills
+- `lark-im/references/lark-im-messages-search.md`
+
+## +messages-send
+Use this for new outbound content. Select text, markdown, exact JSON, or one media flag according to the content shape.
+
+### Prerequisites
+- Confirm the recipient, content, and sending identity before sending.
+
+### Tips
+- Do not pin user or bot in a generic call: both are supported, and the sender must match the user's intent.
+
+### Examples
+
+**Send plain text using the configured identity**
+```bash
+lark-cli im +messages-send --chat-id oc_xxx --text "Hello"
+```
+
+### Skills
+- `lark-im/references/lark-im-messages-send.md`
+
+## +threads-messages-list
+Use this when a message or thread id is known and the replies inside that thread are needed.
+
+### Examples
+
+**List replies in a thread**
+```bash
+lark-cli im +threads-messages-list --thread omt_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-threads-messages-list.md`
+
+## +flag-create
+Use this for a personal bookmark, not a chat-visible pin.
+
+### Examples
+
+**Bookmark a message at the default message layer**
+```bash
+lark-cli im +flag-create --as user --message-id om_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-flag-create.md`
+
+## +flag-cancel
+Use this to remove a personal bookmark. Omitting --flag-type performs the skill's best-effort double-cancel across message and feed layers.
+
+### Examples
+
+**Remove both bookmark layers when discoverable**
+```bash
+lark-cli im +flag-cancel --as user --message-id om_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-flag-cancel.md`
+
+## +flag-list
+Use this to inspect the current user's bookmarks.
+
+### Tips
+- Results are oldest first; when has_more=true, paginate before treating the final item or count as authoritative.
+
+### Examples
+
+**Fetch the first page of bookmarks**
+```bash
+lark-cli im +flag-list --as user
+```
+
+### Skills
+- `lark-im/references/lark-im-flag-list.md`
+
+## +feed-shortcut-create
+Use this to pin one or more chats in the current user's feed sidebar.
+
+### Prerequisites
+- Resolve each chat_id with [[+chat-search]] or [[+chat-list]] first.
+
+### Examples
+
+**Pin one chat at the top of the feed**
+```bash
+lark-cli im +feed-shortcut-create --as user --chat-id oc_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-shortcut-create.md`
+
+## +feed-shortcut-remove
+Use this to unpin one or more chats from the current user's feed sidebar.
+
+### Examples
+
+**Unpin one chat**
+```bash
+lark-cli im +feed-shortcut-remove --as user --chat-id oc_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-shortcut-remove.md`
+
+## +feed-shortcut-list
+Use this to inspect the current user's feed shortcuts.
+
+### Tips
+- This fetches one page only. Continue with the returned page_token until has_more=false; if a token becomes invalid after the list changes, restart without it.
+
+### Examples
+
+**Fetch the first page**
+```bash
+lark-cli im +feed-shortcut-list --as user
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-shortcut-list.md`
+
+## +feed-group-list
+Use this to discover the current user's feed-group ids; --page-all merges both live and soft-deleted groups.
+
+### Examples
+
+**Fetch the first page of feed groups**
+```bash
+lark-cli im +feed-group-list --as user
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-group-list.md`
+
+## +feed-group-list-item
+Use this to enumerate every feed card in a known group and enrich chat cards with chat_name.
+
+### Examples
+
+**List one feed group's first page**
+```bash
+lark-cli im +feed-group-list-item --as user --feed-group-id ofg_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-group-list-item.md`
+
+## +feed-group-query-item
+Use this lightweight lookup when the feed-group id and chat ids are already known.
+
+### Avoid when
+- Discovering all cards in a group → use [[+feed-group-list-item]].
+
+### Examples
+
+**Look up two known chat cards**
+```bash
+lark-cli im +feed-group-query-item --as user --feed-group-id ofg_xxx --feed-id oc_a,oc_b
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-group-query-item.md`
+
+## chat.members create
+Use this raw method for the skill's two-step recovery flow when a bot-created group cannot invite users because they are invisible to the bot.
+
+### Prerequisites
+- Create the group first, then add members as a user who is already in that group.
+
+### Examples
+
+**Add reachable users and report invalid ids separately**
+```bash
+lark-cli im chat.members create --params '{"chat_id":"oc_xxx","member_id_type":"open_id","succeed_type":1}' --data '{"id_list":["ou_aaa","ou_bbb"]}' --as user
+```
+
+### Skills
+- `lark-im/references/lark-im-chat-create.md`
+- `lark-im/references/lark-im-chat-identity.md`
+
+## feed.groups create
+Use this raw method to create a feed group; prefer a normal group unless membership must be rule-derived.
+
+### Examples
+
+**Create an empty normal feed group**
+```bash
+lark-cli im feed.groups create --as user --data '{"feed_group_creator":{"type":"normal","name":"Releases"}}'
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-groups.md`
+
+## feed.groups update
+Use this raw method to rename a feed group or replace its rules; restrict update_fields to what actually changes.
+
+### Examples
+
+**Rename only, leaving rules untouched**
+```bash
+lark-cli im feed.groups update --as user --params '{"feed_group_id":"ofg_xxx"}' --data '{"feed_group_updater":{"name":"测试标签名称","update_fields":[1]}}'
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-groups.md`
+
+## feed.groups delete
+Use this raw method only when the user intends to delete the identified feed group.
+
+### Prerequisites
+- Confirm the exact feed_group_id and deletion intent before executing.
+
+### Examples
+
+**Delete one feed group**
+```bash
+lark-cli im feed.groups delete --as user --params '{"feed_group_id":"ofg_xxx"}'
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-groups.md`
+
+## feed.groups batch_query
+Use this instead of listing when the feed-group ids are already known; consume both live and soft-deleted result arrays.
+
+### Examples
+
+**Look up two feed groups by id**
+```bash
+lark-cli im feed.groups batch_query --as user --params '{"user_id_type":"open_id"}' --data '{"group_ids":["ofg_xxx","ofg_yyy"]}'
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-groups.md`
+
+## feed.groups batch_add_item
+Use this raw method to add known chat cards to a normal feed group.
+
+### Examples
+
+**Add two chats to a feed group**
+```bash
+lark-cli im feed.groups batch_add_item --as user --params '{"feed_group_id":"ofg_xxx"}' --data '{"items":[{"feed_id":"oc_xxx","feed_type":"chat"},{"feed_id":"oc_yyy","feed_type":"chat"}]}'
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-groups.md`
+
+## feed.groups batch_remove_item
+Use this raw method to remove known chat cards from a normal feed group.
+
+### Examples
+
+**Remove one chat from a feed group**
+```bash
+lark-cli im feed.groups batch_remove_item --as user --params '{"feed_group_id":"ofg_xxx"}' --data '{"items":[{"feed_id":"oc_xxx","feed_type":"chat"}]}'
+```
+
+### Skills
+- `lark-im/references/lark-im-feed-groups.md`
+
+## images create
+Use this raw upload when an image_key must be reused.
+
+### Avoid when
+- Sending an image once → use [[+messages-send]] --image to upload and send in one step.
+
+### Examples
+
+**Upload a local message image**
+```bash
+lark-cli im images create --data '{"image_type":"message"}' --file ./diagram.png
+```
+
+### Skills
+- `lark-im/references/lark-im-messages-send.md`
+
+## reactions create
+Use this raw method to add an emoji reaction, not a text reply.
+
+### Examples
+
+**Add a smile reaction**
+```bash
+lark-cli im reactions create --params '{"message_id":"om_xxx"}' --data '{"reaction_type":{"emoji_type":"SMILE"}}'
+```
+
+### Skills
+- `lark-im/references/lark-im-reactions.md`
+
+## reactions list
+Use this raw method for reaction records on one standalone message; message-reading shortcuts already enrich reactions automatically.
+
+### Examples
+
+**List reactions on one message**
+```bash
+lark-cli im reactions list --params '{"message_id":"om_xxx"}'
+```
+
+### Skills
+- `lark-im/references/lark-im-reactions.md`
+
+## reactions delete
+Use this raw method only for a reaction created by the calling identity.
+
+### Prerequisites
+- Obtain reaction_id from [[reactions list]] or the [[reactions create]] response.
+
+### Examples
+
+**Delete one reaction record**
+```bash
+lark-cli im reactions delete --params '{"message_id":"om_xxx","reaction_id":"ZCaCIjUBVVWSrm5L-3ZTw_xxx"}'
+```
+
+### Skills
+- `lark-im/references/lark-im-reactions.md`
+
+## reactions batch_query
+Use this raw method only for standalone message ids; message-reading shortcuts already attach reactions.
+
+### Examples
+
+**Query reactions for two messages**
+```bash
+lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy","page_token":"<PAGE_TOKEN>"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'
+```
+
+### Skills
+- `lark-im/references/lark-im-reactions.md`

--- a/internal/affordance/application_source_test.go
+++ b/internal/affordance/application_source_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package affordance
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func TestApplicationAffordanceExamples(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	tests := []struct {
+		method  string
+		command string
+	}{
+		{method: "+slash-command-list", command: "lark-cli application +slash-command-list"},
+		{method: "+slash-command-create", command: `lark-cli application +slash-command-create --command greet --description "say hi" --description-i18n zh_cn=问候`},
+		{method: "+slash-command-update", command: `lark-cli application +slash-command-update --command greet --description "new text"`},
+		{method: "+slash-command-delete", command: "lark-cli application +slash-command-delete --command greet --yes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			raw, ok := For("application", tt.method)
+			if !ok {
+				t.Fatalf("For(application, %s) ok=false", tt.method)
+			}
+			a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+			if !ok {
+				t.Fatalf("application %s affordance did not parse", tt.method)
+			}
+			if len(a.Examples) != 1 || a.Examples[0].Command != tt.command {
+				t.Fatalf("examples = %#v, want one command %q", a.Examples, tt.command)
+			}
+			if strings.Contains(a.Examples[0].Command, "--as ") {
+				t.Fatalf("dual-identity application example must not pin an identity: %q", a.Examples[0].Command)
+			}
+			if len(a.Tips) == 0 {
+				t.Fatal("migration must keep operational guidance in structured Tips")
+			}
+		})
+	}
+}
+
+func TestApplicationAffordanceDecisionAndSafetyGuidance(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	create := parsedApplicationAffordance(t, "+slash-command-create")
+	if !containsItem(create.AvoidWhen, "already exists") || !containsItem(create.AvoidWhen, "+slash-command-update") {
+		t.Fatalf("create guidance must route ordinary edits to update: %v", create.AvoidWhen)
+	}
+
+	update := parsedApplicationAffordance(t, "+slash-command-update")
+	if !containsItem(update.Prerequisites, "--command-id") || !containsItem(update.Prerequisites, "live list request") {
+		t.Fatalf("update prerequisites must explain id and by-name target paths: %v", update.Prerequisites)
+	}
+
+	deleteCommand := parsedApplicationAffordance(t, "+slash-command-delete")
+	if !containsItem(deleteCommand.Prerequisites, "Explicit user confirmation") ||
+		!containsItem(deleteCommand.Prerequisites, "must not self-approve") {
+		t.Fatalf("delete prerequisites must preserve the confirmation boundary: %v", deleteCommand.Prerequisites)
+	}
+}
+
+func TestApplicationAffordanceDoesNotDuplicateRuntimeRecovery(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	for _, method := range []string{
+		"+slash-command-list",
+		"+slash-command-create",
+		"+slash-command-update",
+		"+slash-command-delete",
+	} {
+		raw, ok := For("application", method)
+		if !ok {
+			t.Fatalf("For(application, %s) ok=false", method)
+		}
+		for _, forbidden := range []string{"Permissions and recovery", "auth login", "console_url", "missing_scopes"} {
+			if strings.Contains(string(raw), forbidden) {
+				t.Errorf("%s affordance duplicates runtime recovery %q: %s", method, forbidden, raw)
+			}
+		}
+	}
+}
+
+func parsedApplicationAffordance(t *testing.T, method string) meta.Affordance {
+	t.Helper()
+	raw, ok := For("application", method)
+	if !ok {
+		t.Fatalf("For(application, %s) ok=false", method)
+	}
+	a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+	if !ok {
+		t.Fatalf("application %s affordance did not parse", method)
+	}
+	return a
+}
+
+func containsItem(items []string, want string) bool {
+	for _, item := range items {
+		if strings.Contains(item, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/affordance/im_source_test.go
+++ b/internal/affordance/im_source_test.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package affordance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/larksuite/cli/internal/meta"
+	"github.com/larksuite/cli/internal/registry"
+)
+
+type imAffordanceExample struct {
+	method        string
+	command       string
+	source        string
+	sourceCommand string
+	derivation    string
+}
+
+var imAffordanceExamples = []imAffordanceExample{
+	{method: "+chat-create", command: `lark-cli im +chat-create --name "My Group"`, source: "lark-im/references/lark-im-chat-create.md"},
+	{method: "+chat-list", command: "lark-cli im +chat-list", source: "lark-im/references/lark-im-chat-list.md"},
+	{method: "+chat-members-list", command: "lark-cli im +chat-members-list --chat-id oc_xxx", source: "lark-im/references/lark-im-chat-members-list.md"},
+	{method: "+chat-messages-list", command: "lark-cli im +chat-messages-list --chat-id oc_xxx", source: "lark-im/references/lark-im-chat-messages-list.md"},
+	{method: "+chat-search", command: `lark-cli im +chat-search --query "project"`, source: "lark-im/references/lark-im-chat-search.md"},
+	{method: "+chat-update", command: `lark-cli im +chat-update --chat-id oc_xxx --name "New Group Name"`, source: "lark-im/references/lark-im-chat-update.md"},
+	{method: "+messages-mget", command: "lark-cli im +messages-mget --message-ids om_xxx", source: "lark-im/references/lark-im-messages-mget.md"},
+	{method: "+messages-reply", command: `lark-cli im +messages-reply --message-id om_xxx --text "Received"`, source: "lark-im/references/lark-im-messages-reply.md"},
+	{method: "+messages-resources-download", command: "lark-cli im +messages-resources-download --message-id om_xxx --file-key img_v3_xxx --type image", source: "lark-im/references/lark-im-messages-resources-download.md"},
+	{
+		method:        "+messages-search",
+		command:       `lark-cli im +messages-search --as user --query "project progress"`,
+		source:        "lark-im/references/lark-im-messages-search.md",
+		sourceCommand: `lark-cli im +messages-search --query "project progress"`,
+		derivation:    "explicit-user",
+	},
+	{method: "+messages-send", command: `lark-cli im +messages-send --chat-id oc_xxx --text "Hello"`, source: "lark-im/references/lark-im-messages-send.md"},
+	{method: "+threads-messages-list", command: "lark-cli im +threads-messages-list --thread omt_xxx", source: "lark-im/references/lark-im-threads-messages-list.md"},
+	{method: "+flag-create", command: "lark-cli im +flag-create --as user --message-id om_xxx", source: "lark-im/references/lark-im-flag-create.md"},
+	{method: "+flag-cancel", command: "lark-cli im +flag-cancel --as user --message-id om_xxx", source: "lark-im/references/lark-im-flag-cancel.md"},
+	{method: "+flag-list", command: "lark-cli im +flag-list --as user", source: "lark-im/references/lark-im-flag-list.md"},
+	{method: "+feed-shortcut-create", command: "lark-cli im +feed-shortcut-create --as user --chat-id oc_xxx", source: "lark-im/references/lark-im-feed-shortcut-create.md"},
+	{method: "+feed-shortcut-remove", command: "lark-cli im +feed-shortcut-remove --as user --chat-id oc_xxx", source: "lark-im/references/lark-im-feed-shortcut-remove.md"},
+	{method: "+feed-shortcut-list", command: "lark-cli im +feed-shortcut-list --as user", source: "lark-im/references/lark-im-feed-shortcut-list.md"},
+	{method: "+feed-group-list", command: "lark-cli im +feed-group-list --as user", source: "lark-im/references/lark-im-feed-group-list.md"},
+	{method: "+feed-group-list-item", command: "lark-cli im +feed-group-list-item --as user --feed-group-id ofg_xxx", source: "lark-im/references/lark-im-feed-group-list-item.md"},
+	{method: "+feed-group-query-item", command: "lark-cli im +feed-group-query-item --as user --feed-group-id ofg_xxx --feed-id oc_a,oc_b", source: "lark-im/references/lark-im-feed-group-query-item.md"},
+	{
+		method:        "chat.members.create",
+		command:       `lark-cli im chat.members create --params '{"chat_id":"oc_xxx","member_id_type":"open_id","succeed_type":1}' --data '{"id_list":["ou_aaa","ou_bbb"]}' --as user`,
+		source:        "lark-im/references/lark-im-chat-create.md",
+		sourceCommand: `lark-cli im chat.members create --params '{"chat_id":"<chat_id from step 2>","member_id_type":"open_id","succeed_type":1}' --data '{"id_list":["ou_aaa","ou_bbb"]}' --as user`,
+		derivation:    "materialize-chat-id",
+	},
+	{method: "feed.groups.create", command: `lark-cli im feed.groups create --as user --data '{"feed_group_creator":{"type":"normal","name":"Releases"}}'`, source: "lark-im/references/lark-im-feed-groups.md"},
+	{method: "feed.groups.update", command: `lark-cli im feed.groups update --as user --params '{"feed_group_id":"ofg_xxx"}' --data '{"feed_group_updater":{"name":"测试标签名称","update_fields":[1]}}'`, source: "lark-im/references/lark-im-feed-groups.md"},
+	{method: "feed.groups.delete", command: `lark-cli im feed.groups delete --as user --params '{"feed_group_id":"ofg_xxx"}'`, source: "lark-im/references/lark-im-feed-groups.md"},
+	{method: "feed.groups.batch_query", command: `lark-cli im feed.groups batch_query --as user --params '{"user_id_type":"open_id"}' --data '{"group_ids":["ofg_xxx","ofg_yyy"]}'`, source: "lark-im/references/lark-im-feed-groups.md"},
+	{method: "feed.groups.batch_add_item", command: `lark-cli im feed.groups batch_add_item --as user --params '{"feed_group_id":"ofg_xxx"}' --data '{"items":[{"feed_id":"oc_xxx","feed_type":"chat"},{"feed_id":"oc_yyy","feed_type":"chat"}]}'`, source: "lark-im/references/lark-im-feed-groups.md"},
+	{method: "feed.groups.batch_remove_item", command: `lark-cli im feed.groups batch_remove_item --as user --params '{"feed_group_id":"ofg_xxx"}' --data '{"items":[{"feed_id":"oc_xxx","feed_type":"chat"}]}'`, source: "lark-im/references/lark-im-feed-groups.md"},
+	{method: "images.create", command: `lark-cli im images create --data '{"image_type":"message"}' --file ./diagram.png`, source: "lark-im/references/lark-im-messages-send.md"},
+	{method: "reactions.create", command: `lark-cli im reactions create --params '{"message_id":"om_xxx"}' --data '{"reaction_type":{"emoji_type":"SMILE"}}'`, source: "lark-im/references/lark-im-reactions.md"},
+	{method: "reactions.list", command: `lark-cli im reactions list --params '{"message_id":"om_xxx"}'`, source: "lark-im/references/lark-im-reactions.md"},
+	{method: "reactions.delete", command: `lark-cli im reactions delete --params '{"message_id":"om_xxx","reaction_id":"ZCaCIjUBVVWSrm5L-3ZTw_xxx"}'`, source: "lark-im/references/lark-im-reactions.md"},
+	{method: "reactions.batch_query", command: `lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy","page_token":"<PAGE_TOKEN>"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'`, source: "lark-im/references/lark-im-reactions.md"},
+}
+
+func TestIMAffordanceExamplesTraceToCurrentSkill(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	if got, ok := DomainSkill("im"); !ok || got != "lark-im" {
+		t.Fatalf("DomainSkill(im) = (%q, %v), want (lark-im, true)", got, ok)
+	}
+	if got, want := len(imAffordanceExamples), 33; got != want {
+		t.Fatalf("audited IM example count = %d, want %d", got, want)
+	}
+	affordanceSource, err := os.ReadFile("../../affordance/im.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedDomain := parseDomainMD(affordanceSource, commandFormResolver("im"))
+	if got, want := len(parsedDomain.methods), len(imAffordanceExamples); got != want {
+		t.Fatalf("parsed IM affordance entries = %d, audited examples = %d", got, want)
+	}
+	audited := make(map[string]bool, len(imAffordanceExamples))
+	shortcutCount := 0
+	for _, example := range imAffordanceExamples {
+		audited[example.method] = true
+		if strings.HasPrefix(example.method, "+") {
+			shortcutCount++
+		}
+	}
+	if shortcutCount != 21 || len(imAffordanceExamples)-shortcutCount != 12 {
+		t.Fatalf("audited split = %d shortcuts / %d raw, want 21 / 12", shortcutCount, len(imAffordanceExamples)-shortcutCount)
+	}
+	for method := range parsedDomain.methods {
+		if !audited[method] {
+			t.Errorf("IM affordance entry %s bypasses the skill-source audit table", method)
+		}
+	}
+
+	for _, tt := range imAffordanceExamples {
+		t.Run(tt.method, func(t *testing.T) {
+			a := parsedIMAffordance(t, tt.method)
+			if len(a.Examples) != 1 || a.Examples[0].Command != tt.command {
+				t.Fatalf("examples = %#v, want one command %q", a.Examples, tt.command)
+			}
+			if !containsExact(a.Skills, "lark-im") || !containsExact(a.Skills, tt.source) {
+				t.Fatalf("skills = %v, want lark-im and %s", a.Skills, tt.source)
+			}
+
+			source, err := os.ReadFile(filepath.Join("../../skills", tt.source))
+			if err != nil {
+				t.Fatalf("read source skill reference: %v", err)
+			}
+			sourceCommand := tt.sourceCommand
+			if sourceCommand == "" {
+				sourceCommand = tt.command
+			}
+			if !strings.Contains(compactSkillText(string(source)), compactSkillText(sourceCommand)) {
+				t.Fatalf("example source %s does not contain audited command %q", tt.source, sourceCommand)
+			}
+			if tt.derivation != "" {
+				materialized := tt.sourceCommand
+				switch tt.derivation {
+				case "materialize-chat-id":
+					materialized = strings.ReplaceAll(materialized, "<chat_id from step 2>", "oc_xxx")
+				case "explicit-user":
+					if !strings.Contains(string(source), "User identity only") {
+						t.Fatal("derived --as user is not backed by the source identity contract")
+					}
+					materialized = strings.Replace(materialized, "+messages-search", "+messages-search --as user", 1)
+				default:
+					t.Fatalf("unknown audited derivation %q", tt.derivation)
+				}
+				if materialized != tt.command {
+					t.Fatalf("affordance command is not the audited placeholder materialization:\n got: %s\nwant: %s", tt.command, materialized)
+				}
+			}
+		})
+	}
+}
+
+func TestIMAffordanceDoesNotDuplicateRuntimeRecovery(t *testing.T) {
+	source, err := os.ReadFile("../../affordance/im.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"Permissions and recovery", "auth login", "missing_scopes", "console_url"} {
+		if strings.Contains(string(source), forbidden) {
+			t.Errorf("IM affordance duplicates runtime recovery %q", forbidden)
+		}
+	}
+}
+
+func TestIMAffordancePreservesOutboundAndDeleteIntentBoundaries(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	for method, requiredItems := range map[string][]string{
+		"+messages-send":  {"recipient", "content", "identity"},
+		"+messages-reply": {"target message", "content", "identity"},
+	} {
+		prerequisites := parsedIMAffordance(t, method).Prerequisites
+		for _, required := range requiredItems {
+			if !containsItem(prerequisites, required) {
+				t.Errorf("%s prerequisites must require confirmed %s: %v", method, required, prerequisites)
+			}
+		}
+	}
+	deleteGroup := parsedIMAffordance(t, "feed.groups.delete")
+	if !containsItem(deleteGroup.Prerequisites, "exact feed_group_id") || !containsItem(deleteGroup.Prerequisites, "deletion intent") {
+		t.Fatalf("feed.groups.delete must preserve the explicit target/intent boundary: %v", deleteGroup.Prerequisites)
+	}
+}
+
+func TestIMImageUploadExamplesPreserveIdentityChoice(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	for _, path := range []string{
+		"../../skills/lark-im/references/lark-im-messages-send.md",
+		"../../skills/lark-im/references/lark-im-messages-reply.md",
+	} {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		count := 0
+		for _, line := range strings.Split(string(source), "\n") {
+			if !strings.HasPrefix(strings.TrimSpace(line), "lark-cli im images create ") {
+				continue
+			}
+			count++
+			if strings.Contains(line, " --as ") {
+				t.Errorf("dual-identity images.create skill example must preserve identity choice in %s: %s", path, line)
+			}
+		}
+		if count != 2 {
+			t.Errorf("images.create examples in %s = %d, want 2 audited upload steps", path, count)
+		}
+	}
+
+	image := parsedIMAffordance(t, "images.create")
+	if len(image.Examples) != 1 || strings.Contains(image.Examples[0].Command, " --as ") {
+		t.Fatalf("images.create affordance must preserve the caller's user/bot identity choice: %#v", image.Examples)
+	}
+	for _, useWhen := range image.UseWhen {
+		if strings.Contains(strings.ToLower(useWhen), "bot-only") {
+			t.Fatalf("images.create affordance must not repeat the stale bot-only description: %v", image.UseWhen)
+		}
+	}
+}
+
+func TestIMImageUploadMetadataSupportsBothIdentities(t *testing.T) {
+	if len(registry.EmbeddedServicesTyped()) == 0 {
+		t.Skip("generated API metadata is not embedded in this bare-module test run")
+	}
+	target, err := registry.EmbeddedCatalog().Resolve([]string{"im", "images", "create"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Method == nil {
+		t.Fatal("im.images.create resolved without a method")
+	}
+	method := target.Method.Method
+	if !method.SupportsToken(meta.TokenUser) || !method.SupportsToken(meta.TokenTenant) {
+		t.Fatalf("im.images.create accessTokens = %v, want both user and tenant", method.AccessTokens)
+	}
+}
+
+func parsedIMAffordance(t *testing.T, method string) meta.Affordance {
+	t.Helper()
+	raw, ok := For("im", method)
+	if !ok {
+		t.Fatalf("For(im, %s) ok=false", method)
+	}
+	a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+	if !ok {
+		t.Fatalf("im %s affordance did not parse", method)
+	}
+	return a
+}
+
+func containsExact(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func compactSkillText(value string) string {
+	value = strings.ReplaceAll(value, "\\\r\n", "")
+	value = strings.ReplaceAll(value, "\\\n", "")
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, value)
+}

--- a/internal/affordance/im_source_test.go
+++ b/internal/affordance/im_source_test.go
@@ -67,7 +67,13 @@ var imAffordanceExamples = []imAffordanceExample{
 	{method: "reactions.create", command: `lark-cli im reactions create --params '{"message_id":"om_xxx"}' --data '{"reaction_type":{"emoji_type":"SMILE"}}'`, source: "lark-im/references/lark-im-reactions.md"},
 	{method: "reactions.list", command: `lark-cli im reactions list --params '{"message_id":"om_xxx"}'`, source: "lark-im/references/lark-im-reactions.md"},
 	{method: "reactions.delete", command: `lark-cli im reactions delete --params '{"message_id":"om_xxx","reaction_id":"ZCaCIjUBVVWSrm5L-3ZTw_xxx"}'`, source: "lark-im/references/lark-im-reactions.md"},
-	{method: "reactions.batch_query", command: `lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy","page_token":"<PAGE_TOKEN>"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'`, source: "lark-im/references/lark-im-reactions.md"},
+	{
+		method:        "reactions.batch_query",
+		command:       `lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'`,
+		source:        "lark-im/references/lark-im-reactions.md",
+		sourceCommand: `lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy","page_token":"<PAGE_TOKEN>"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'`,
+		derivation:    "first-page",
+	},
 }
 
 func TestIMAffordanceExamplesTraceToCurrentSkill(t *testing.T) {
@@ -137,6 +143,8 @@ func TestIMAffordanceExamplesTraceToCurrentSkill(t *testing.T) {
 						t.Fatal("derived --as user is not backed by the source identity contract")
 					}
 					materialized = strings.Replace(materialized, "+messages-search", "+messages-search --as user", 1)
+				case "first-page":
+					materialized = strings.Replace(materialized, `,"page_token":"<PAGE_TOKEN>"`, "", 1)
 				default:
 					t.Fatalf("unknown audited derivation %q", tt.derivation)
 				}

--- a/internal/schema/assembler_test.go
+++ b/internal/schema/assembler_test.go
@@ -399,7 +399,7 @@ func TestBuildMeta_FullFields(t *testing.T) {
 			"im:resource:upload",
 			"im:resource",
 		},
-		"accessTokens": []interface{}{"tenant"},
+		"accessTokens": []interface{}{"user", "tenant"},
 		"docUrl":       "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/image/create",
 	}
 	m := buildMeta(meta.FromMap(method))
@@ -413,8 +413,8 @@ func TestBuildMeta_FullFields(t *testing.T) {
 	if !m.Danger {
 		t.Errorf("Danger = false, want true")
 	}
-	if !reflect.DeepEqual(m.AccessTokens, []string{"bot"}) {
-		t.Errorf("AccessTokens = %v, want [bot]", m.AccessTokens)
+	if !reflect.DeepEqual(m.AccessTokens, []string{"bot", "user"}) {
+		t.Errorf("AccessTokens = %v, want [bot user]", m.AccessTokens)
 	}
 	if m.DocURL == "" {
 		t.Errorf("DocURL should be present for im.images.create")

--- a/shortcuts/application/affordance_migration_test.go
+++ b/shortcuts/application/affordance_migration_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package application
+
+import "testing"
+
+func TestSlashCommandGuidanceLivesInAffordance(t *testing.T) {
+	for _, shortcut := range Shortcuts() {
+		if len(shortcut.Tips) != 0 {
+			t.Errorf("%s still has Go Tips; keep application usage guidance in affordance/application.md", shortcut.Command)
+		}
+	}
+}

--- a/shortcuts/application/slash_command_create.go
+++ b/shortcuts/application/slash_command_create.go
@@ -31,11 +31,6 @@ var SlashCommandCreate = common.Shortcut{
 		{Name: "icon-key", Desc: "icon key (server default: skill_outlined; invalid keys are rejected server-side with code 40000031)"},
 		{Name: "force", Type: "bool", Desc: "on name collision, resolve the existing command by name and update it in place"},
 	},
-	Tips: []string{
-		`lark-cli application +slash-command-create --command greet --description "say hi" --description-i18n zh_cn=问候 --as bot`,
-		"changes take ~5 minutes to appear in clients (client-side cache); the server updates immediately",
-		"user identity needs explicit authorization first: lark-cli auth login --scope application:app_slash_command:write",
-	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateCommandName(runtime.Str("command"), "--command"); err != nil {
 			return err
@@ -83,7 +78,7 @@ var SlashCommandCreate = common.Shortcut{
 			if !runtime.Bool("force") {
 				p, _ := errs.ProblemOf(err)
 				rewrapped := errs.NewAPIError(errs.SubtypeAlreadyExists, "slash command %q already exists", name).
-					WithHint("rerun with --force to update it, or use `lark-cli application +slash-command-update --command %q`", name).
+					WithHint("use `lark-cli application +slash-command-update --command %q` for an ordinary edit; do not add --force unless the user explicitly intends this create request as an idempotent rerun that may update the existing same-name command", name).
 					WithCause(err)
 				if p.Code != 0 {
 					rewrapped = rewrapped.WithCode(p.Code)

--- a/shortcuts/application/slash_command_create_test.go
+++ b/shortcuts/application/slash_command_create_test.go
@@ -109,6 +109,10 @@ func TestSlashCommandCreate_ConflictNoForce(t *testing.T) {
 	if !strings.Contains(p.Hint, "--force") || !strings.Contains(p.Hint, "+slash-command-update") {
 		t.Fatalf("hint must offer --force and update, got %q", p.Hint)
 	}
+	if !strings.Contains(p.Hint, "do not add --force unless the user explicitly intends") ||
+		!strings.Contains(p.Hint, "idempotent rerun") {
+		t.Fatalf("hint must prevent mechanical --force recovery, got %q", p.Hint)
+	}
 	var apiErr *errs.APIError
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("rewrapped error must be *errs.APIError, got %T", err)

--- a/shortcuts/application/slash_command_delete.go
+++ b/shortcuts/application/slash_command_delete.go
@@ -29,10 +29,6 @@ var SlashCommandDelete = common.Shortcut{
 		{Name: "command-id", Desc: "target command_id; mutually exclusive with --command"},
 		{Name: "command", Desc: "target command name WITHOUT leading slash (resolved via live list, needs read scope); mutually exclusive with --command-id"},
 	},
-	Tips: []string{
-		"lark-cli application +slash-command-delete --command greet --yes --as bot",
-		"deleted commands may linger in clients for ~5 minutes (client cache)",
-	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		id := strings.TrimSpace(runtime.Str("command-id"))
 		name := strings.TrimSpace(runtime.Str("command"))

--- a/shortcuts/application/slash_command_list.go
+++ b/shortcuts/application/slash_command_list.go
@@ -19,11 +19,6 @@ var SlashCommandList = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{"application:app_slash_command:read"},
 	AuthTypes:   []string{"bot", "user"},
-	Tips: []string{
-		"lark-cli application +slash-command-list --as bot",
-		"user identity needs explicit authorization first: lark-cli auth login --scope application:app_slash_command:read",
-		"the upstream API returns all commands at once (max 100 per app, no pagination)",
-	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		return common.NewDryRunAPI().
 			Desc("List all slash commands of the current bound app (read-only)").

--- a/shortcuts/application/slash_command_update.go
+++ b/shortcuts/application/slash_command_update.go
@@ -64,11 +64,6 @@ var SlashCommandUpdate = common.Shortcut{
 		{Name: "description-i18n", Type: "string_array", Desc: "localized description, repeatable <lang>=<text>; REPLACES the whole i18n map (missing languages are dropped); requires --description"},
 		{Name: "icon-key", Desc: "new icon key (invalid keys rejected server-side with code 40000031)"},
 	},
-	Tips: []string{
-		`lark-cli application +slash-command-update --command greet --description "new text" --as bot`,
-		"PATCH is field-level partial: fields you do not pass are preserved server-side",
-		"the command NAME itself cannot be changed (API limitation): rename = delete + create (new command_id)",
-	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return validateUpdateTarget(runtime)
 	},

--- a/shortcuts/im/affordance_migration_test.go
+++ b/shortcuts/im/affordance_migration_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/affordance"
+	"github.com/larksuite/cli/internal/meta"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var imAffordanceFlagToken = regexp.MustCompile(`--[a-z][a-z0-9-]*`)
+
+var imFrameworkFlags = map[string]bool{
+	"--as": true, "--dry-run": true, "--format": true, "--json": true, "--jq": true, "--yes": true,
+}
+
+func TestAllIMShortcutsUseAffordanceExamples(t *testing.T) {
+	affordance.SetSource(os.DirFS("../../affordance"))
+	t.Cleanup(func() { affordance.SetSource(nil) })
+
+	shortcuts := Shortcuts()
+	if got, want := len(shortcuts), 21; got != want {
+		t.Fatalf("registered IM shortcuts = %d, want audited count %d", got, want)
+	}
+
+	for _, sc := range shortcuts {
+		t.Run(sc.Command, func(t *testing.T) {
+			for _, tip := range sc.Tips {
+				if strings.Contains(tip, "lark-cli im ") {
+					t.Fatalf("copyable example is still mixed into Go Tips: %q", tip)
+				}
+			}
+
+			raw, ok := affordance.For("im", sc.Command)
+			if !ok {
+				t.Fatalf("missing affordance for registered shortcut %s", sc.Command)
+			}
+			parsed, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+			if !ok || len(parsed.Examples) != 1 {
+				t.Fatalf("%s examples = %#v, want exactly one", sc.Command, parsed.Examples)
+			}
+			example := parsed.Examples[0].Command
+			if !strings.HasPrefix(example, "lark-cli im "+sc.Command) {
+				t.Fatalf("example does not invoke its shortcut: %q", example)
+			}
+			assertIMExampleFlagsExist(t, sc, example)
+			assertIMExampleIdentity(t, sc, example)
+			assertIMFirstExampleCoversRequiredFlags(t, sc, example)
+		})
+	}
+}
+
+func TestChatMembersTipsMovedToAffordance(t *testing.T) {
+	if len(ImChatMembersList.Tips) != 0 {
+		t.Fatalf("Go Tips must be empty after migration, got %v", ImChatMembersList.Tips)
+	}
+
+	affordance.SetSource(os.DirFS("../../affordance"))
+	t.Cleanup(func() { affordance.SetSource(nil) })
+	raw, ok := affordance.For("im", "+chat-members-list")
+	if !ok {
+		t.Fatal("missing +chat-members-list affordance")
+	}
+	parsed, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+	if !ok {
+		t.Fatal("+chat-members-list affordance did not parse")
+	}
+	want := []string{
+		"Default fetches a single page; pass --page-all to walk every page.",
+		"With --page-all and no explicit --page-size, the max page size is used to minimize round-trips.",
+		"truncations[] in the result means the server capped a bucket due to security config — the member list is incomplete.",
+	}
+	if strings.Join(parsed.Tips, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("migrated tips = %v, want %v", parsed.Tips, want)
+	}
+}
+
+func assertIMExampleFlagsExist(t *testing.T, sc common.Shortcut, example string) {
+	t.Helper()
+	declared := map[string]bool{}
+	for _, flag := range sc.Flags {
+		declared["--"+flag.Name] = true
+	}
+	for _, token := range imAffordanceFlagToken.FindAllString(example, -1) {
+		if !declared[token] && !imFrameworkFlags[token] {
+			t.Errorf("example uses undeclared flag %s: %s", token, example)
+		}
+	}
+}
+
+func assertIMExampleIdentity(t *testing.T, sc common.Shortcut, example string) {
+	t.Helper()
+	allowed := map[string]bool{}
+	for _, identity := range sc.AuthTypes {
+		allowed[identity] = true
+	}
+	identity := explicitIdentity(example)
+	if len(allowed) == 1 {
+		if identity == "" {
+			t.Errorf("single-identity shortcut example must pin its identity: %s", example)
+			return
+		}
+		if !allowed[identity] {
+			t.Errorf("example pins unsupported identity %q: %s", identity, example)
+		}
+		return
+	}
+	if allowed["user"] && allowed["bot"] && identity != "" {
+		t.Errorf("dual-identity shortcut example must leave identity to user intent: %s", example)
+	}
+}
+
+func assertIMFirstExampleCoversRequiredFlags(t *testing.T, sc common.Shortcut, example string) {
+	t.Helper()
+	tokens := map[string]bool{}
+	for _, token := range imAffordanceFlagToken.FindAllString(example, -1) {
+		tokens[token] = true
+	}
+	for _, flag := range sc.Flags {
+		if flag.Required && !tokens["--"+flag.Name] {
+			t.Errorf("first example does not cover required flag --%s: %s", flag.Name, example)
+		}
+	}
+}
+
+func explicitIdentity(example string) string {
+	fields := strings.Fields(example)
+	for i, field := range fields {
+		if field == "--as" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+		if strings.HasPrefix(field, "--as=") {
+			return strings.TrimPrefix(field, "--as=")
+		}
+	}
+	return ""
+}

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -55,11 +55,6 @@ var ImChatMembersList = common.Shortcut{
 		{Name: "page-limit", Type: "int", Default: "10", Desc: "max pages to fetch with --page-all (default 10, 0 = unlimited)"},
 		{Name: "page-delay", Type: "int", Default: fmt.Sprintf("%d", chatMembersListDefaultPageDelay), Desc: "delay in ms between pages when --page-all (0 = no delay)"},
 	},
-	Tips: []string{
-		"Default fetches a single page; pass --page-all to walk every page.",
-		"With --page-all and no explicit --page-size, the max page size is used to minimize round-trips.",
-		"truncations[] in the result means the server capped a bucket due to security config — the member list is incomplete.",
-	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		chatID := strings.TrimSpace(runtime.Str("chat-id"))
 		if chatID == "" {


### PR DESCRIPTION
## Summary

Migrate Application and IM command-selection guidance from legacy Go `Tips` into structured affordance overlays, so AI agents see source-backed examples, decision guidance, and safety prerequisites directly in leaf help and schema output. Runtime permission and recovery guidance remains owned by typed CLI errors instead of being duplicated in static help.

## Changes

- Add affordance entries for all 4 Application shortcuts, all 21 IM shortcuts, and 12 raw IM methods with copyable examples verified against the current `lark-im` skill sources.
- Move the remaining Application examples and IM chat-member operational tips out of Go `Tips`, with contract tests that prevent guidance from drifting back into mixed sources.
- Preserve identity and safety intent: dual-identity examples stay neutral, user-only examples are explicit, outbound actions require confirmed target/content/identity, and destructive operations retain confirmation boundaries.
- Pin `im images create`'s structured user-and-bot access-token contract without changing the IM skills, and make the reactions batch-query example a valid first-page request without a placeholder page token.
- Add source-trace, relationship, help-rendering, required-flag, identity, and recovery regression coverage.

## Test Plan

- [x] Unit tests pass (`make unit-test`)
- [x] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected
- [x] `go vet ./...`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] Clean-clone `gofmt -l .` produces no output
- [x] Clean-clone golangci-lint reports 0 issues against the latest `main`
- [x] `make quality-gate QUALITY_GATE_CHANGED_FROM=origin/main` passes (two existing bounded-list warnings only)
- [x] 37/37 leaf help pages render the audited example exactly; 57/57 meaningful bot/user dry-run variants pass
- [x] Application and IM dry-run E2E suites pass
- [x] Five help-only agent evaluations complete 62/62 positive dry-run attempts and recover from wrong identity, malformed JSON, and missing confirmation

No live API writes were performed; this change affects help/affordance guidance and its contracts.

## Review Notes

The fetched metadata description for `im images create` still says bot-only even though its structured `accessTokens`, schema, flags, and user dry-run all support both user and bot. This mismatch is pre-existing in the generated metadata source, is not introduced by this PR, and should be corrected there separately rather than by editing `lark-im` or duplicating recovery text in affordance.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CLI guidance for listing, creating, updating, and deleting application slash commands.
  - Added a comprehensive IM skill guide covering chats, messages, threads, media, reactions, bookmarks, and feed shortcuts.
- **Bug Fixes**
  - Improved slash-command creation conflict messaging, including safer guidance for intentional reruns.
- **Documentation**
  - Centralized usage guidance and examples in dedicated documentation.
- **Tests**
  - Added validation for command guidance, safety rules, identity handling, and documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->