### PR TITLE
fix: improve rate limit recovery

### DIFF
--- a/errs/ERROR_CONTRACT.md
+++ b/errs/ERROR_CONTRACT.md
@@ -62,9 +62,20 @@ Typed errors render to **stderr** as one JSON object per process exit:
 | `error.hint` | informational | actionable recovery guidance |
 | `error.log_id` | informational | upstream request id (server-side trace) |
 | `error.retryable` | wire-stable | `true` when present; omitted when `false` |
+| `error.retry_after_seconds` | per-Subtype-stable | upstream-provided minimum delay before retry; emitted when available for retryable `api/rate_limit` errors |
 | `error.param` | per-Subtype-stable | single offending parameter (`ValidationError`); see **Validation parameters** |
 | `error.params` | per-Subtype-stable | per-parameter validation detail array (`ValidationError`); see **Validation parameters** |
 | per-Subtype extension fields | per-Subtype-stable | e.g. `missing_scopes`, `console_url`, `challenge_url`; `console_url` is emitted for developer/admin recovery such as `app_scope_not_applied`, not user `missing_scope` |
+
+For retryable `type=api, subtype=rate_limit`, the CLI may emit
+`retry_after_seconds` when the upstream response supplies a precise delay. For
+TAT HTTP 429 responses, the delay uses Lark's `x-ogw-ratelimit-reset` header,
+then a numeric `Retry-After` value. If neither header contains a valid delay,
+the field is omitted and the hint recommends exponential backoff with jitter.
+The envelope intentionally does not expose an implementation detail such as
+`retry_after_source`, and the CLI does not automatically replay the request.
+HTTP 429 classification is currently added only to TAT fetching; other API
+transports retain their existing behavior.
 
 `SecurityPolicyError` renders through the same typed envelope as every
 other category. `error.type` is `"policy"`, `error.subtype` is one of
@@ -284,7 +295,7 @@ esac
 ```
 
 Unknown fields are forward-compatible additions: ignore, don't fail.
-Branch only on `type`, `subtype`, `code`, `retryable`, and declared
+Branch only on `type`, `subtype`, `code`, `retryable`, `retry_after_seconds`, and declared
 extension fields — `message` is human-readable prose that may be
 reworded without notice.
 

--- a/errs/marshal_test.go
+++ b/errs/marshal_test.go
@@ -157,7 +157,8 @@ func TestNetworkError_MarshalJSON(t *testing.T) {
 
 func TestAPIError_MarshalJSON(t *testing.T) {
 	ae := &APIError{
-		Problem: Problem{Category: CategoryAPI, Subtype: SubtypeRateLimit, Code: 99991400, Message: "slow", Retryable: true},
+		Problem:           Problem{Category: CategoryAPI, Subtype: SubtypeRateLimit, Code: 99991400, Message: "slow", Retryable: true},
+		RetryAfterSeconds: 12,
 	}
 	b, _ := json.Marshal(ae)
 	s := string(b)
@@ -166,10 +167,20 @@ func TestAPIError_MarshalJSON(t *testing.T) {
 		`"subtype":"rate_limit"`,
 		`"code":99991400`,
 		`"retryable":true`,
+		`"retry_after_seconds":12`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("missing %q in %s", want, s)
 		}
+	}
+	if strings.Contains(s, `"retry_after_source"`) {
+		t.Errorf("implementation detail retry_after_source must not be emitted: %s", s)
+	}
+
+	ae.RetryAfterSeconds = 0
+	b, _ = json.Marshal(ae)
+	if strings.Contains(string(b), `"retry_after_seconds"`) {
+		t.Errorf("retry_after_seconds must be omitted when no precise delay was provided: %s", b)
 	}
 }
 

--- a/errs/types.go
+++ b/errs/types.go
@@ -444,7 +444,10 @@ func (e *NetworkError) WithCause(cause error) *NetworkError {
 // errors.Is / errors.Unwrap; it is intentionally not serialized.
 type APIError struct {
 	Problem
-	Cause error `json:"-"`
+	// RetryAfterSeconds is an upstream-provided minimum delay before another
+	// attempt. Zero means no precise delay was provided and omits the field.
+	RetryAfterSeconds int   `json:"retry_after_seconds,omitempty"`
+	Cause             error `json:"-"`
 }
 
 // Unwrap is nil-receiver safe; see ValidationError.Unwrap.

--- a/internal/credential/tat_fetch.go
+++ b/internal/credential/tat_fetch.go
@@ -6,14 +6,25 @@ package credential
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/core"
 )
+
+type tatResponse struct {
+	Code             int    `json:"code"`
+	AccessToken      string `json:"access_token"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	Msg              string `json:"msg"`
+}
 
 // FetchTAT performs a single HTTP POST to mint a tenant access token via the
 // unified OAuth 2.0 Token Endpoint ({accounts}/oauth/v3/token) using the
@@ -27,8 +38,9 @@ import (
 // doResolveTAT (and thus every token-resolving command) produces, so callers
 // see one consistent envelope. Transport failures, unreadable/unparseable
 // bodies, and transient server-side failures (5xx / server_error) are returned
-// raw (untyped), leaving them ambiguous; a caller can use errs.IsTyped to tell a
-// deterministic credential rejection apart from upstream/transport noise.
+// raw (untyped), leaving them ambiguous. HTTP 429 is the exception: it carries
+// typed retry metadata so callers can back off instead of treating it as a
+// credential rejection.
 //
 // The caller owns the context timeout.
 func FetchTAT(ctx context.Context, httpClient *http.Client, brand core.LarkBrand, appID, appSecret string) (string, error) {
@@ -56,14 +68,37 @@ func FetchTAT(ctx context.Context, httpClient *http.Client, brand core.LarkBrand
 	if err != nil {
 		return "", fmt.Errorf("failed to read TAT response: %w", err)
 	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		var rateLimitErr *errs.APIError
+		var result tatResponse
+		if json.Unmarshal(body, &result) == nil {
+			desc := result.ErrorDescription
+			if desc == "" {
+				desc = result.Msg
+			}
+			classified := classifyTATResponseCode(result.Code, result.Error, desc, string(brand), appID)
+			var apiErr *errs.APIError
+			if errors.As(classified, &apiErr) &&
+				apiErr.Subtype == errs.SubtypeRateLimit && apiErr.Retryable {
+				rateLimitErr = apiErr
+			}
+		}
 
-	var result struct {
-		Code             int    `json:"code"`
-		AccessToken      string `json:"access_token"`
-		Error            string `json:"error"`
-		ErrorDescription string `json:"error_description"`
-		Msg              string `json:"msg"`
+		if rateLimitErr == nil {
+			rateLimitErr = errs.NewAPIError(errs.SubtypeRateLimit, "TAT endpoint rate limited (HTTP 429)").
+				WithCode(http.StatusTooManyRequests).
+				WithRetryable()
+		}
+		if retryAfter := tatRetryAfterSeconds(resp.Header); retryAfter > 0 {
+			rateLimitErr.RetryAfterSeconds = retryAfter
+			rateLimitErr.Hint = fmt.Sprintf("wait at least %d seconds before retrying; if throttling continues, use exponential backoff with jitter", retryAfter)
+		} else {
+			rateLimitErr.Hint = "use exponential backoff with jitter when retrying"
+		}
+		return "", rateLimitErr
 	}
+
+	var result tatResponse
 	if err := json.Unmarshal(body, &result); err != nil {
 		// An unparseable body is ambiguous (covers non-JSON error pages and
 		// truncated payloads); stay untyped so probe callers treat it as noise.
@@ -76,10 +111,10 @@ func FetchTAT(ctx context.Context, httpClient *http.Client, brand core.LarkBrand
 
 	// Transient/server-side failures stay untyped so probe callers stay silent and
 	// retryers can back off; only deterministic client rejections are typed. Covers
-	// 5xx, HTTP 429 rate-limit, and the OAuth transient error strings (server_error,
-	// temporarily_unavailable, slow_down) — matching the legacy "non-2xx is noise"
-	// behavior so a rate-limited probe is not surfaced as a hard credential error.
-	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests ||
+	// 5xx and the OAuth transient error strings (server_error,
+	// temporarily_unavailable, slow_down). HTTP 429 was already returned above
+	// as a typed rate-limit error with retry guidance and an upstream delay when available.
+	if resp.StatusCode >= 500 ||
 		result.Error == "server_error" || result.Error == "temporarily_unavailable" ||
 		result.Error == "slow_down" {
 		return "", fmt.Errorf("TAT endpoint transient failure (HTTP %d, code=%d, error=%q): %s",
@@ -99,4 +134,14 @@ func FetchTAT(ctx context.Context, httpClient *http.Client, brand core.LarkBrand
 		desc = result.Msg
 	}
 	return "", classifyTATResponseCode(result.Code, result.Error, desc, string(brand), appID)
+}
+
+func tatRetryAfterSeconds(header http.Header) int {
+	for _, name := range []string{"X-Ogw-Ratelimit-Reset", "Retry-After"} {
+		seconds, err := strconv.Atoi(strings.TrimSpace(header.Get(name)))
+		if err == nil && seconds > 0 {
+			return seconds
+		}
+	}
+	return 0
 }

--- a/internal/credential/tat_fetch_test.go
+++ b/internal/credential/tat_fetch_test.go
@@ -18,11 +18,12 @@ import (
 
 // stubRoundTripper lets us assert request shape and return canned responses.
 type stubRoundTripper struct {
-	gotReq   *http.Request
-	gotBody  string
-	respCode int
-	respBody string
-	err      error
+	gotReq     *http.Request
+	gotBody    string
+	respCode   int
+	respBody   string
+	respHeader http.Header
+	err        error
 }
 
 func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -34,10 +35,14 @@ func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	if s.err != nil {
 		return nil, s.err
 	}
+	header := make(http.Header)
+	if s.respHeader != nil {
+		header = s.respHeader.Clone()
+	}
 	return &http.Response{
 		StatusCode: s.respCode,
 		Body:       io.NopCloser(strings.NewReader(s.respBody)),
-		Header:     make(http.Header),
+		Header:     header,
 	}, nil
 }
 
@@ -174,31 +179,80 @@ func TestFetchTAT_ServerError_Untyped(t *testing.T) {
 	}
 }
 
-// Rate-limiting is transient, not a deterministic credential rejection — an HTTP
-// 429 (even with a parseable OAuth body) and the OAuth slow_down error must both
-// stay UNTYPED so a rate-limited probe stays silent and retryers can back off.
-func TestFetchTAT_RateLimit_Untyped(t *testing.T) {
-	cases := []struct {
-		name string
-		code int
-		body string
+// HTTP 429 is actionable even while fetching TAT: surface a typed rate-limit
+// error and carry the platform reset interval instead of misreporting a bad
+// credential or returning an opaque transient error.
+func TestFetchTAT_HTTP429_TypedRateLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		header    http.Header
+		wantCode  int
+		wantDelay int
 	}{
-		{"http 429", 429, `{"code":99991400,"error":"too_many_requests","error_description":"rate limit exceeded"}`},
-		{"oauth slow_down", 200, `{"error":"slow_down","error_description":"polling too fast"}`},
+		{
+			name:      "platform envelope",
+			body:      `{"code":99991400,"error":"too_many_requests","error_description":"rate limit exceeded"}`,
+			header:    http.Header{"X-Ogw-Ratelimit-Reset": []string{"8"}, "Retry-After": []string{"4"}},
+			wantCode:  99991400,
+			wantDelay: 8,
+		},
+		{
+			name:      "standard retry-after fallback",
+			body:      `{"error":"too_many_requests"}`,
+			header:    http.Header{"Retry-After": []string{"4"}},
+			wantCode:  http.StatusTooManyRequests,
+			wantDelay: 4,
+		},
+		{
+			name:      "non-JSON gateway response",
+			body:      "rate limit exceeded",
+			wantCode:  http.StatusTooManyRequests,
+			wantDelay: 0,
+		},
 	}
-	for _, tc := range cases {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rt := &stubRoundTripper{respCode: tc.code, respBody: tc.body}
+			rt := &stubRoundTripper{
+				respCode:   http.StatusTooManyRequests,
+				respBody:   tc.body,
+				respHeader: tc.header,
+			}
 			hc := &http.Client{Transport: rt}
 
 			_, err := FetchTAT(context.Background(), hc, core.BrandFeishu, "cli_app", "secret_x")
-			if err == nil {
-				t.Fatal("expected error for rate-limit")
+			var apiErr *errs.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("HTTP 429 error = %T %v, want *errs.APIError", err, err)
 			}
-			if errs.IsTyped(err) {
-				t.Errorf("rate-limit must be UNTYPED (transient), got typed %T %v", err, err)
+			if apiErr.Subtype != errs.SubtypeRateLimit || !apiErr.Retryable {
+				t.Fatalf("problem = %+v, want retryable api/rate_limit", apiErr.Problem)
+			}
+			if apiErr.Code != tc.wantCode {
+				t.Fatalf("code = %d, want %d", apiErr.Code, tc.wantCode)
+			}
+			if apiErr.RetryAfterSeconds != tc.wantDelay {
+				t.Fatalf("retry_after_seconds = %v, want %d", apiErr.RetryAfterSeconds, tc.wantDelay)
+			}
+			if !strings.Contains(apiErr.Hint, "exponential backoff with jitter") {
+				t.Fatalf("hint = %q, want backoff guidance", apiErr.Hint)
 			}
 		})
+	}
+}
+
+// OAuth slow_down without HTTP 429 remains an ambiguous transient response;
+// it has no OpenAPI reset header from which to produce precise retry metadata.
+func TestFetchTAT_OAuthSlowDown_Untyped(t *testing.T) {
+	rt := &stubRoundTripper{respCode: 200, respBody: `{"error":"slow_down","error_description":"polling too fast"}`}
+	hc := &http.Client{Transport: rt}
+
+	_, err := FetchTAT(context.Background(), hc, core.BrandFeishu, "cli_app", "secret_x")
+	if err == nil {
+		t.Fatal("expected error for slow_down")
+	}
+	if errs.IsTyped(err) {
+		t.Errorf("slow_down without HTTP 429 must stay untyped, got %T %v", err, err)
 	}
 }
 

--- a/internal/recovery/render_test.go
+++ b/internal/recovery/render_test.go
@@ -100,8 +100,9 @@ func TestRenderClonesEveryConcreteTypedErrorAndPreservesWireExtensions(t *testin
 		{
 			name: "api",
 			original: &errs.APIError{
-				Problem: problem(errs.CategoryAPI, errs.SubtypeRateLimit),
-				Cause:   sentinel,
+				Problem:           problem(errs.CategoryAPI, errs.SubtypeRateLimit),
+				RetryAfterSeconds: 7,
+				Cause:             sentinel,
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
Improve rate-limit error recovery while keeping the change narrowly scoped.

## Changes
- Return structured retry guidance for rate-limited requests.
- Preserve upstream retry timing when available.
- Add contract and regression coverage.

## Test Plan
- [x] Relevant unit tests pass
- [x] Build and static checks pass

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API errors can now include a `retry_after_seconds` value to indicate when a retry may be appropriate.
  - HTTP 429 rate-limit responses preserve retry timing from supported response headers or provide fallback backoff guidance.
  - Retryable rate-limit errors are now distinguishable from other transient errors.

- **Documentation**
  - Added guidance on interpreting retry timing, exponential backoff with jitter, and cases where no delay is available.
  - Clarified that automatic retries are not performed and HTTP 429 handling currently applies to TAT fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->