### PR TITLE
chore: release v1.0.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.84] - 2026-08-05
+
+### Features
+
+- **calendar**: allow bot auth for search-event (#2186)
+- **extension**: present restricted commands as absent and trim skills (#1837)
+- add Base table copy shortcuts (#2019)
+- **slides**: support explicit screenshot output paths (#2180)
+- profile selection from environment with source-aware errors (#2198)
+- migrate application and IM guidance to affordance (#2199)
+
+### Bug Fixes
+
+- **slides**: bind lint issues to source XML nodes (#2179)
+- **drive**: stop export polling on rate limits (#2192)
+- make agent recovery and concealment reliable (#2189)
+- surface retry metadata for TAT rate limits (#2200)
+
+### Documentation
+
+- **slides**: temporarily route skill guidance back to +replace-pages (#2187)
+- **calendar**: clarify attendee resolution to avoid type guessing (#2195)
+- **wiki**: route node resolution through shortcut (#2132)
+
 ## [v1.0.83] - 2026-08-04
 
 ### Features
@@ -1798,6 +1822,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.84]: https://github.com/larksuite/cli/releases/tag/v1.0.84
 [v1.0.83]: https://github.com/larksuite/cli/releases/tag/v1.0.83
 [v1.0.82]: https://github.com/larksuite/cli/releases/tag/v1.0.82
 [v1.0.81]: https://github.com/larksuite/cli/releases/tag/v1.0.81

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larksuite/cli",
-      "version": "1.0.83",
+      "version": "1.0.84",
       "cpu": [
         "x64",
         "arm64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.83` |
| Release version | `1.0.84` |
| Tag | `v1.0.84` |
| Branch | `release/v1.0.84` |
| Date | `2026-08-05` |

## Changes

- feat(calendar): allow bot auth for search-event (#2186)
- docs(slides): temporarily route skill guidance back to +replace-pages (#2187)
- feat(extension): present restricted commands as absent and trim skills (#1837)
- feat: add Base table copy shortcuts (#2019)
- feat(slides): support explicit screenshot output paths (#2180)
- fix(slides): bind lint issues to source XML nodes (#2179)
- fix(drive): stop export polling on rate limits (#2192)
- fix: make agent recovery and concealment reliable (#2189)
- docs(calendar): clarify attendee resolution to avoid type guessing (#2195)
- docs(wiki): route node resolution through shortcut (#2132)
- feat: profile selection from environment with source-aware errors (#2198)
- feat: migrate application and IM guidance to affordance (#2199)
- fix: surface retry metadata for TAT rate limits (#2200)

## Files Changed

- `package.json`
- `package-lock.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional and package metadata versions match
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the v1.0.84 release entry and reference link.

* **Bug Fixes**
  * Included the latest fixes in the release notes.

* **Documentation**
  * Updated the changelog with the v1.0.84 release details.

* **Chores**
  * Bumped the package version to 1.0.84.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->