### PR TITLE
fix(im): unpin search identity after bot support landed

### DIFF
--- a/affordance/im.md
+++ b/affordance/im.md
@@ -142,13 +142,13 @@ lark-cli im +messages-resources-download --message-id om_xxx --file-key img_v3_x
 - `lark-im/references/lark-im-messages-resources-download.md`
 
 ## +messages-search
-Use this user-only shortcut to find messages across conversations by keyword or structured filters.
+Use this to find messages across conversations by keyword or structured filters.
 
 ### Examples
 
 **Search messages by keyword**
 ```bash
-lark-cli im +messages-search --as user --query "project progress"
+lark-cli im +messages-search --query "project progress"
 ```
 
 ### Skills

--- a/internal/affordance/im_source_test.go
+++ b/internal/affordance/im_source_test.go
@@ -32,13 +32,7 @@ var imAffordanceExamples = []imAffordanceExample{
 	{method: "+messages-mget", command: "lark-cli im +messages-mget --message-ids om_xxx", source: "lark-im/references/lark-im-messages-mget.md"},
 	{method: "+messages-reply", command: `lark-cli im +messages-reply --message-id om_xxx --text "Received"`, source: "lark-im/references/lark-im-messages-reply.md"},
 	{method: "+messages-resources-download", command: "lark-cli im +messages-resources-download --message-id om_xxx --file-key img_v3_xxx --type image", source: "lark-im/references/lark-im-messages-resources-download.md"},
-	{
-		method:        "+messages-search",
-		command:       `lark-cli im +messages-search --as user --query "project progress"`,
-		source:        "lark-im/references/lark-im-messages-search.md",
-		sourceCommand: `lark-cli im +messages-search --query "project progress"`,
-		derivation:    "explicit-user",
-	},
+	{method: "+messages-search", command: `lark-cli im +messages-search --query "project progress"`, source: "lark-im/references/lark-im-messages-search.md"},
 	{method: "+messages-send", command: `lark-cli im +messages-send --chat-id oc_xxx --text "Hello"`, source: "lark-im/references/lark-im-messages-send.md"},
 	{method: "+threads-messages-list", command: "lark-cli im +threads-messages-list --thread omt_xxx", source: "lark-im/references/lark-im-threads-messages-list.md"},
 	{method: "+flag-create", command: "lark-cli im +flag-create --as user --message-id om_xxx", source: "lark-im/references/lark-im-flag-create.md"},
@@ -138,11 +132,6 @@ func TestIMAffordanceExamplesTraceToCurrentSkill(t *testing.T) {
 				switch tt.derivation {
 				case "materialize-chat-id":
 					materialized = strings.ReplaceAll(materialized, "<chat_id from step 2>", "oc_xxx")
-				case "explicit-user":
-					if !strings.Contains(string(source), "User identity only") {
-						t.Fatal("derived --as user is not backed by the source identity contract")
-					}
-					materialized = strings.Replace(materialized, "+messages-search", "+messages-search --as user", 1)
 				case "first-page":
 					materialized = strings.Replace(materialized, `,"page_token":"<PAGE_TOKEN>"`, "", 1)
 				default:

--- a/skills/lark-im/references/lark-im-message-enrichment.md
+++ b/skills/lark-im/references/lark-im-message-enrichment.md
@@ -36,7 +36,7 @@ Use `--download-resources` when you want the binaries on disk in one pass; other
 
 ## Scope requirement
 
-The default enrichment requires `im:message.reactions:read`, already declared in each shortcut's `UserScopes` / `BotScopes` (or `Scopes` for the user-only search command), so the framework's pre-flight check surfaces a `missing_scope` error before the request is sent. Bots that were registered before this scope was added need an incremental authorization in the Feishu developer console; users can run:
+The default enrichment requires `im:message.reactions:read`, already declared in each shortcut's `UserScopes` / `BotScopes` (or `Scopes` for the search command), so the framework's pre-flight check surfaces a `missing_scope` error before the request is sent. Bots that were registered before this scope was added need an incremental authorization in the Feishu developer console; users can run:
 
 ```bash
 lark-cli auth login --scope "im:message.reactions:read"

--- a/skills/lark-im/references/lark-im-messages-search.md
+++ b/skills/lark-im/references/lark-im-messages-search.md
@@ -6,8 +6,6 @@ Search Feishu messages across conversations. This shortcut automatically perform
 
 By default each result message also carries a `reactions` block (counts + details from `im.reactions.batch_query`) when the server has reactions for it, and `update_time` for messages that were actually edited. With `--page-all`, every page is enriched; pass `--no-reactions` to skip the extra round-trip. See [message enrichment](lark-im-message-enrichment.md) for the full contract.
 
-> **User identity only** (`--as user`). Bot identity is not supported.
-
 This skill maps to the shortcut: `lark-cli im +messages-search` (internally calls `POST /open-apis/im/v1/messages/search` + batched `GET /open-apis/im/v1/messages/mget`, then batch-fetches chat context).
 
 ## Commands
@@ -84,7 +82,7 @@ lark-cli im +messages-search --query "test" --dry-run
 | `--page-all` | No | Automatically paginate through all result pages (up to 40 pages) |
 | `--page-limit <n>` | No | Max pages to fetch when auto-pagination is enabled (default 20, max 40). Setting it explicitly also enables auto-pagination |
 | `--format <fmt>` | No | Output format: `json` (default) / `pretty` / `table` / `ndjson` / `csv` |
-| `--as <identity>` | No | Identity type (defaults to and only supports `user`) |
+| `--as <identity>` | No | Identity type: `user` or `bot` |
 | `--dry-run` | No | Print the request only, do not execute it |
 
 ## Core Constraints


### PR DESCRIPTION
## Summary

`main` unit tests are red since #2194 (`b546516b`) and stay red on `50b4c688`, blocking every open PR (e.g. #2203). #2194 extended `im +messages-search` to `AuthTypes: {"user", "bot"}` but did not update the affordance example or the skill reference, both of which still assert user-only. This PR closes that gap.

The failing assertion:

```
--- FAIL: TestAllIMShortcutsUseAffordanceExamples/+messages-search
    shortcuts/im/affordance_migration_test.go:53:
    dual-identity shortcut example must leave identity to user intent:
    lark-cli im +messages-search --as user --query "project progress"
```

Bisect over `main`: `960bdf6d` (#2199, added the guard) ok → `fcdef499` ok → **`b546516b` (#2194) FAIL** → `50b4c688` FAIL. `main`'s own push CI shows the same transition. #2194's PR checks were green because its run (`31003425323`, `run_attempt=3`) was created at 2026-08-05T11:55Z against `base_sha=0848a5b4`, a tree that predates #2199 — the re-run reused that stale merge ref, so the new guard never executed.

## Changes

- `affordance/im.md`: drop `--as user` from the `+messages-search` example and the stale "user-only" wording. Nothing is added in their place — which identities a shortcut accepts is already structured metadata.
- `internal/affordance/im_source_test.go`: update the audited example and remove the now-unused `explicit-user` derivation, whose whole job was asserting the source doc said "User identity only".
- `skills/lark-im/references/lark-im-messages-search.md`: delete the header callout "**User identity only**. Bot identity is not supported." and correct the `--as` row in the flag table. Both contradicted the code *and* line 166 of the same file, which #2194 updated to tell agents to run `--as bot`. The callout is deleted rather than reworded: identity support is already carried by `--as` and the shortcut metadata, and generic "do not pin `--as`" guidance belongs in `lark-shared`, not in every reference.
- `skills/lark-im/references/lark-im-message-enrichment.md`: drop "user-only" from the scope note describing the search command's `Scopes` field.

No production code changes — `AuthTypes` and the search behaviour from #2194 are untouched.

## Test Plan

- [x] `go test -race -count=1 ./cmd/... ./internal/... ./shortcuts/... ./extension/...` — all green (reproduced the failure on clean `50b4c688` first)
- [x] `node scripts/skill-format-check/index.js` — passed
- [x] `gofmt`/`go vet` clean on touched packages
- [x] Swept every `--as user` in `affordance/im.md` against each shortcut's `AuthTypes`: the remaining ones are genuinely user-only (`+flag-*`, `+feed-*`) or raw API commands not covered by the guard

## Related Issues

- Unblocks #2203 and any other PR based on current `main`
- Follow-up for #2194's author: the reverted commit `34ddb5bf` ("validate bot search filters and enrichment scopes") means bot-identity filter/scope limits are still unvalidated; `shortcuts/minutes` got the same `AuthTypes` extension but has no `affordance/minutes.md` yet, so nothing guards it there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Message search now supports both user and bot identities.
  - Searches can use the configured identity without requiring an explicit identity option.

- **Documentation**
  - Updated message search guidance and examples to reflect the available identity options.
  - Clarified when to specify a user or bot identity.
  - Updated scope documentation and audit examples for identity-based searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

