### PR TITLE
fix(registry): describe the attendance and mindnotes domains

### DIFF
--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/recovery"
 	"github.com/larksuite/cli/internal/registry"
+	"github.com/larksuite/cli/shortcuts"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/zalando/go-keyring"
 )
@@ -306,6 +307,54 @@ func TestGetDomainMetadata_HasTitleAndDescription(t *testing.T) {
 	for _, dm := range domains {
 		if dm.Title == "" {
 			t.Errorf("domain %q has empty Title", dm.Name)
+		}
+	}
+}
+
+// TestEveryRegisteredDomain_HasBilingualDescription reconciles every registered
+// business domain against service_descriptions.json.
+//
+// TestGetDomainMetadata_HasTitleAndDescription does not cover this. It asserts on
+// buildDomainMeta's output, which falls back to the typed service spec when the
+// config has no entry — and that spec carries one string for both languages. So a
+// domain missing from the config still passes it, while rendering (for example) a
+// Chinese description in English `--help`. attendance and mindnotes shipped that
+// way. Asserting on the registry getters checks the config itself, before any
+// fallback can paper over the gap.
+//
+// EmbeddedServicesTyped is the overlay-free parse, so this stays deterministic
+// whatever ~/.lark-cli/cache/remote_meta.json happens to hold on the machine.
+// A domain that only ever arrives via remote overlay is out of reach here.
+func TestEveryRegisteredDomain_HasBilingualDescription(t *testing.T) {
+	origin := make(map[string]string) // domain name → where it is registered
+	for _, svc := range registry.EmbeddedServicesTyped() {
+		origin[svc.Name] = "embedded API meta"
+	}
+	for _, sc := range shortcuts.AllShortcuts() {
+		if _, ok := origin[sc.Service]; !ok {
+			origin[sc.Service] = "shortcut registration"
+		}
+	}
+	if len(origin) == 0 {
+		t.Fatal("no registered domains found — the reconciliation would be vacuous")
+	}
+
+	names := make([]string, 0, len(origin))
+	for name := range origin {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		for _, lang := range []string{"en", "zh"} {
+			if registry.GetServiceTitle(name, lang) == "" {
+				t.Errorf("domain %q (registered via %s) has no %s title in service_descriptions.json",
+					name, origin[name], lang)
+			}
+			if registry.GetServiceDescription(name, lang) == "" {
+				t.Errorf("domain %q (registered via %s) has no %s description in service_descriptions.json",
+					name, origin[name], lang)
+			}
 		}
 	}
 }

--- a/internal/registry/service_descriptions.json
+++ b/internal/registry/service_descriptions.json
@@ -11,6 +11,10 @@
     "en": { "title": "Apps", "description": "Develop, deploy HTML, web pages and applications" },
     "zh": { "title": "应用", "description": "开发、部署 HTML、Web 页面和应用" }
   },
+  "attendance": {
+    "en": { "title": "Attendance", "description": "Attendance check-in result query" },
+    "zh": { "title": "考勤打卡", "description": "考勤打卡结果查询" }
+  },
   "base": {
     "en": { "title": "Base", "description": "Table, field, record, view, dashboard, workflow, form, role & permission management" },
     "zh": { "title": "多维表格", "description": "数据表、字段、记录、视图、仪表盘、自动化流程、表单、角色权限管理" }
@@ -46,6 +50,10 @@
   "markdown": {
     "en": { "title": "Markdown", "description": "Drive-native Markdown file create, fetch, and overwrite" },
     "zh": { "title": "Markdown", "description": "Drive 原生 Markdown 文件的创建、读取和覆盖更新" }
+  },
+  "mindnotes": {
+    "en": { "title": "Mindnote", "description": "Mindnote node listing, creation, and update" },
+    "zh": { "title": "思维笔记", "description": "思维笔记节点查询、创建和更新" }
   },
   "minutes": {
     "en": { "title": "Minutes", "description": "Minutes content and metadata retrieval" },


### PR DESCRIPTION
## Summary

`internal/registry/service_descriptions.json` is the description table for every business domain the CLI exposes, but two registered domains were missing from it: `attendance` and `mindnotes`. Both are reachable today — `lark-cli attendance user_tasks query` and `lark-cli mindnotes nodes create` run, and both are offered by `auth login --domain` — so the omission surfaced directly in help output.

With no entry, `registry.GetServiceTitle`/`GetServiceDescription` return `""` and `buildDomainMeta` (`cmd/auth/login_interactive.go:95`) falls back to the typed service spec, which carries a single string for both languages:

```
$ lark-cli --help            # before
  attendance  attendance record query
  mindnotes   思维笔记节点列表查看、节点创建/更新
```

```
$ lark-cli --help            # after
  attendance  Attendance check-in result query
  mindnotes   Mindnote node listing, creation, and update
```

A full two-way reconciliation found nothing else: the 21 pre-existing keys all map to live registered domains, so nothing is removed.

## Changes

- `internal/registry/service_descriptions.json`: add bilingual `attendance` and `mindnotes` entries, inserted in the file's existing alphabetical positions.

  Neither gets an `auth_domain`. Both own a top-level scope namespace (`attendance:task:readonly`, `mindnote:node:create`/`mindnote:node:read`), and folding a domain in removes it from the `auth login` domain picker, so they stay independently selectable. `whiteboard` remains the only domain folded into `docs`.

- `cmd/auth/login_test.go`: add `TestEveryRegisteredDomain_HasBilingualDescription`, which walks `registry.EmbeddedServicesTyped()` plus `shortcuts.AllShortcuts()` and asserts both languages resolve for every registered domain.

  The pre-existing `TestGetDomainMetadata_HasTitleAndDescription` could not catch this class of bug: it asserts on `buildDomainMeta`'s output, and the spec fallback had already made that non-empty. The new test asserts on the registry getters, i.e. the config itself, before any fallback can paper over the gap. Failures name the domain and where it is registered.

  It reads `EmbeddedServicesTyped` (the overlay-free parse) rather than `ServicesTyped`, so the result does not depend on whatever `~/.lark-cli/cache/remote_meta.json` holds on the machine — otherwise CI and a developer box could disagree. The stated cost is that a domain arriving only via remote overlay is out of its reach; that is recorded in the test comment rather than left implicit.

No production code paths change — this is a data entry plus a test.

## Test Plan

- [x] `go test -count=1 ./cmd/... ./internal/... ./shortcuts/...` — all green
- [x] Confirmed the new test is not vacuous: with the JSON change stashed it fails, naming exactly the two domains across all four assertions

  ```
  --- FAIL: TestEveryRegisteredDomain_HasBilingualDescription
      domain "attendance" (registered via embedded API meta) has no en title in service_descriptions.json
      domain "mindnotes"  (registered via embedded API meta) has no zh description in service_descriptions.json
      ...
  ```
- [x] Rebuilt and checked `lark-cli --help` renders English for both domains (output above)
- [x] `lark-cli auth login --help` still lists `attendance` and `mindnotes` as independent selectable domains, confirming no accidental fold
- [x] Two-way set diff of `--help` domains against the JSON keys: 23 vs 23, both directions empty
- [x] `gofmt` and `go vet` clean on touched packages; JSON validates

## Related Issues

- None. Follow-up worth considering separately: the `buildDomainMeta` fallback itself is what let a Chinese description render in English help. This PR fixes the two affected domains but leaves that mechanism in place, so the same failure mode returns if a future domain ships without an entry — the new test guards the embedded set, not the remote-overlay set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese titles and descriptions for the Attendance and Mindnotes services.
  * Expanded service metadata coverage to support clearer bilingual service information.

* **Tests**
  * Added validation ensuring all registered services provide both English and Chinese titles and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->