### PR TITLE
feat(whiteboard): add parse image shortcuts

### DIFF
--- a/errs/ERROR_CONTRACT.md
+++ b/errs/ERROR_CONTRACT.md
@@ -63,6 +63,7 @@ Typed errors render to **stderr** as one JSON object per process exit:
 | `error.log_id` | informational | upstream request id (server-side trace) |
 | `error.retryable` | wire-stable | `true` when present; omitted when `false` |
 | `error.retry_after_seconds` | per-Subtype-stable | upstream-provided minimum delay before retry; emitted when available for retryable `api/rate_limit` and HTTP-backed `network` errors |
+| `error.field_violations` | per-Subtype-stable | ordered field-level diagnostics on `APIError`; each item may carry string `field`, `value`, and `description` fields |
 | `error.param` | per-Subtype-stable | single offending parameter (`ValidationError`); see **Validation parameters** |
 | `error.params` | per-Subtype-stable | per-parameter validation detail array (`ValidationError`); see **Validation parameters** |
 | per-Subtype extension fields | per-Subtype-stable | e.g. `missing_scopes`, `console_url`, `challenge_url`; `console_url` is emitted for developer/admin recovery such as `app_scope_not_applied`, not user `missing_scope` |
@@ -78,6 +79,19 @@ envelope intentionally does not expose an implementation detail such as
 `retry_after_source`. Generic command dispatch does not replay a request
 automatically; a bounded operation such as multipart download may consume this
 field under its own idempotency and retry budget.
+
+For an upstream API response with `error.field_violations`, `BuildAPIError`
+keeps every valid item in order on `APIError.field_violations`. An item is
+valid when `field` or `description` is non-blank. Its `value` is retained only
+when the upstream value is a string; a non-string value becomes empty while
+the otherwise-valid violation remains. Values never enter the human-facing
+`hint`. API-error hint precedence is: valid field violations, then
+`error.details[].value`, then a non-blank nested `error.message`, then the
+subtype-specific `APIHint` fallback. A nested `error.message` promoted to
+`hint` remains human-readable upstream prose: consumers must not branch on its
+text. The top-level upstream `msg` remains `error.message` in the CLI envelope;
+the numeric `code`, `log_id`, and `troubleshooter` are unchanged by this
+enrichment.
 
 `SecurityPolicyError` renders through the same typed envelope as every
 other category. `error.type` is `"policy"`, `error.subtype` is one of

--- a/errs/marshal_test.go
+++ b/errs/marshal_test.go
@@ -158,10 +158,15 @@ func TestNetworkError_MarshalJSON(t *testing.T) {
 }
 
 func TestAPIError_MarshalJSON(t *testing.T) {
-	ae := &APIError{
+	ae := (&APIError{
 		Problem:           Problem{Category: CategoryAPI, Subtype: SubtypeRateLimit, Code: 99991400, Message: "slow", Retryable: true},
 		RetryAfterSeconds: 12,
-	}
+		FieldViolations: []APIFieldViolation{{
+			Field:       "nodes[0].type",
+			Value:       "42",
+			Description: "type is required",
+		}},
+	}).WithServerHint("server supplied detail")
 	b, _ := json.Marshal(ae)
 	s := string(b)
 	for _, want := range []string{
@@ -170,6 +175,8 @@ func TestAPIError_MarshalJSON(t *testing.T) {
 		`"code":99991400`,
 		`"retryable":true`,
 		`"retry_after_seconds":12`,
+		`"hint":"server supplied detail"`,
+		`"field_violations":[{"field":"nodes[0].type","value":"42","description":"type is required"}]`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("missing %q in %s", want, s)
@@ -178,11 +185,18 @@ func TestAPIError_MarshalJSON(t *testing.T) {
 	if strings.Contains(s, `"retry_after_source"`) {
 		t.Errorf("implementation detail retry_after_source must not be emitted: %s", s)
 	}
+	if strings.Contains(s, `"hint_source"`) {
+		t.Errorf("implementation detail hint_source must not be emitted: %s", s)
+	}
 
 	ae.RetryAfterSeconds = 0
+	ae.FieldViolations = nil
 	b, _ = json.Marshal(ae)
 	if strings.Contains(string(b), `"retry_after_seconds"`) {
 		t.Errorf("retry_after_seconds must be omitted when no precise delay was provided: %s", b)
+	}
+	if strings.Contains(string(b), `"field_violations"`) {
+		t.Errorf("field_violations must be omitted when empty: %s", b)
 	}
 }
 

--- a/errs/types.go
+++ b/errs/types.go
@@ -447,11 +447,30 @@ func (e *NetworkError) WithCause(cause error) *NetworkError {
 
 // ================================ APIError ===================================
 
+// APIFieldViolation is one field-level diagnostic returned by a Lark API.
+type APIFieldViolation struct {
+	Field       string `json:"field,omitempty"`
+	Value       string `json:"value,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type apiHintSource uint8
+
+const (
+	apiHintSourceUnknown apiHintSource = iota
+	apiHintSourceServer
+	apiHintSourceFallback
+)
+
 // APIError is the typed error for CategoryAPI (catch-all for classified Lark
 // API business errors). Cause preserves an optional wrapped sentinel for
 // errors.Is / errors.Unwrap; it is intentionally not serialized.
 type APIError struct {
 	Problem
+	FieldViolations []APIFieldViolation `json:"field_violations,omitempty"`
+	// hintSource distinguishes upstream diagnostics from context-free defaults
+	// for in-process callers. It is cloned with APIError but never serialized.
+	hintSource apiHintSource `json:"-"`
 	// RetryAfterSeconds is an upstream-provided minimum delay before another
 	// attempt. Zero means no precise delay was provided and omits the field.
 	RetryAfterSeconds int   `json:"retry_after_seconds,omitempty"`
@@ -486,7 +505,64 @@ func NewAPIError(subtype Subtype, format string, args ...any) *APIError {
 
 func (e *APIError) WithHint(format string, args ...any) *APIError {
 	e.Hint = formatMessage(format, args)
+	e.hintSource = apiHintSourceUnknown
 	return e
+}
+
+// WithServerHint records a hint lifted from the upstream API response. The
+// provenance is process-local and is intentionally omitted from the wire.
+func (e *APIError) WithServerHint(format string, args ...any) *APIError {
+	e.Hint = formatMessage(format, args)
+	e.hintSource = apiHintSourceServer
+	return e
+}
+
+// WithFallbackHint records a context-free default that a domain caller may
+// replace with more specific recovery guidance.
+func (e *APIError) WithFallbackHint(format string, args ...any) *APIError {
+	e.Hint = formatMessage(format, args)
+	e.hintSource = apiHintSourceFallback
+	return e
+}
+
+// AdoptHint copies both the human-readable hint and its process-local
+// provenance from another APIError. The provenance remains off the wire.
+func (e *APIError) AdoptHint(source *APIError) *APIError {
+	if e == nil {
+		return nil
+	}
+	if source == nil {
+		e.Hint = ""
+		e.hintSource = apiHintSourceUnknown
+		return e
+	}
+	e.Hint = source.Hint
+	e.hintSource = source.hintSource
+	return e
+}
+
+// AdoptServerDiagnostics copies hint provenance and, when present, an
+// independent snapshot of the source field violations. An empty source slice
+// leaves existing destination violations intact.
+func (e *APIError) AdoptServerDiagnostics(source *APIError) *APIError {
+	if e == nil {
+		return nil
+	}
+	e.AdoptHint(source)
+	if source != nil && len(source.FieldViolations) > 0 {
+		e.FieldViolations = slices.Clone(source.FieldViolations)
+	}
+	return e
+}
+
+// HintIsFromServer reports whether Hint was lifted from the upstream response.
+func (e *APIError) HintIsFromServer() bool {
+	return e != nil && e.hintSource == apiHintSourceServer
+}
+
+// HintIsFallback reports whether Hint is a caller-replaceable context-free default.
+func (e *APIError) HintIsFallback() bool {
+	return e != nil && e.hintSource == apiHintSourceFallback
 }
 
 func (e *APIError) WithLogID(logID string) *APIError {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -95,7 +95,7 @@ func ResolveEndpoints(brand LarkBrand) Endpoints {
 		}
 	default:
 		return Endpoints{
-			Open:     "https://open.feishu.cn",
+			Open:     "https://open.feishu-pre.cn",
 			Accounts: "https://accounts.feishu.cn",
 			MCP:      "https://mcp.feishu.cn",
 			AppLink:  "https://applink.feishu.cn",

--- a/internal/errclass/classify.go
+++ b/internal/errclass/classify.go
@@ -102,11 +102,13 @@ func BuildAPIError(resp map[string]any, cc ClassifyContext) error {
 	// so they are lifted into Problem.Hint — the sanctioned free-text recovery
 	// prompt — rather than fabricated structured params. Lifted before the
 	// category switch so any classified arm inherits it; the CategoryAPI arm
-	// below prefers this server detail over the context-free APIHint default.
+	// below prefers this server detail over nested error.message and the
+	// context-free APIHint default.
 	detailHint := liftErrorDetailValues(resp)
 	if detailHint != "" {
 		base.Hint = detailHint
 	}
+	errorMessageHint := liftErrorMessage(resp)
 
 	switch meta.Category {
 	case errs.CategoryAuthorization:
@@ -144,12 +146,26 @@ func BuildAPIError(resp map[string]any, cc ClassifyContext) error {
 			Action:  action,
 		}
 	case errs.CategoryAPI:
-		// A server-supplied detail (lifted into base.Hint above) wins over the
-		// context-free APIHint default; only fall back to APIHint when absent.
-		if base.Hint == "" {
+		fieldViolations := liftAPIFieldViolations(resp)
+		// Structured field violations are the strongest server diagnostic. Detail
+		// values are next, then nested error.message, then the context-free
+		// APIHint default.
+		if len(fieldViolations) > 0 {
+			base.Hint = apiFieldViolationHint(fieldViolations)
+		} else if detailHint == "" && errorMessageHint != "" {
+			base.Hint = errorMessageHint
+		} else if base.Hint == "" {
 			base.Hint = APIHint(base.Subtype) // "" for subtypes without a context-free default
 		}
-		return &errs.APIError{Problem: base}
+		apiErr := &errs.APIError{Problem: base, FieldViolations: fieldViolations}
+		switch {
+		case len(fieldViolations) > 0, detailHint != "", errorMessageHint != "":
+			return apiErr.WithServerHint("%s", base.Hint)
+		case base.Hint != "":
+			return apiErr.WithFallbackHint("%s", base.Hint)
+		default:
+			return apiErr
+		}
 	default:
 		// Fail closed: an unrecognized Category routes to InternalError
 		// instead of emitting an empty Problem on the wire.
@@ -163,6 +179,21 @@ func BuildAPIError(resp map[string]any, cc ClassifyContext) error {
 			},
 		}
 	}
+}
+
+// liftErrorMessage returns the upstream resp.error.message as a human-readable
+// hint fallback. Whitespace-only strings are absent; meaningful upstream text
+// is preserved exactly. Callers must not branch on this free-text value.
+func liftErrorMessage(resp map[string]any) string {
+	errBlock, ok := resp["error"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	message, _ := errBlock["message"].(string)
+	if strings.TrimSpace(message) == "" {
+		return ""
+	}
+	return message
 }
 
 // buildSecurityPolicyError extracts challenge_url and the hint from a Lark API
@@ -521,6 +552,60 @@ func liftErrorDetailValues(resp map[string]any) string {
 		}
 	}
 	return strings.Join(values, "; ")
+}
+
+// liftAPIFieldViolations preserves valid resp.error.field_violations entries
+// in upstream order. An entry is valid when field or description is a
+// non-blank string; malformed entries and malformed string fields are ignored.
+func liftAPIFieldViolations(resp map[string]any) []errs.APIFieldViolation {
+	errBlock, ok := resp["error"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := errBlock["field_violations"].([]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	out := make([]errs.APIFieldViolation, 0, len(raw))
+	for _, item := range raw {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		field, _ := entry["field"].(string)
+		value, _ := entry["value"].(string)
+		description, _ := entry["description"].(string)
+		if strings.TrimSpace(field) == "" {
+			field = ""
+		}
+		if strings.TrimSpace(description) == "" {
+			description = ""
+		}
+		if field == "" && description == "" {
+			continue
+		}
+		out = append(out, errs.APIFieldViolation{
+			Field:       field,
+			Value:       value,
+			Description: description,
+		})
+	}
+	return out
+}
+
+func apiFieldViolationHint(violations []errs.APIFieldViolation) string {
+	hints := make([]string, 0, len(violations))
+	for _, violation := range violations {
+		switch {
+		case violation.Field != "" && violation.Description != "":
+			hints = append(hints, violation.Field+": "+violation.Description)
+		case violation.Field != "":
+			hints = append(hints, violation.Field)
+		case violation.Description != "":
+			hints = append(hints, violation.Description)
+		}
+	}
+	return strings.Join(hints, "; ")
 }
 
 // extractMissingScopes walks resp["error"]["permission_violations"][].subject.

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -330,6 +332,226 @@ func TestBuildAPIError_DetailsMalformedShapesNoHint(t *testing.T) {
 			// With no liftable detail, the Hint must not echo a server detail.
 			if strings.Contains(p.Hint, "nope") {
 				t.Errorf("Hint should not lift a non-array details field, got %q", p.Hint)
+			}
+		})
+	}
+}
+
+func TestBuildAPIError_FieldViolationsPreserveOrderedStringValues(t *testing.T) {
+	for _, code := range []int{2890002, 99992402} {
+		t.Run(fmt.Sprintf("code_%d", code), func(t *testing.T) {
+			resp := map[string]any{
+				"code":   code,
+				"msg":    "exact upstream field validation message",
+				"log_id": "log-whiteboard-123",
+				"error": map[string]any{
+					"message":        "message fallback must lose",
+					"troubleshooter": "https://open.feishu.cn/document/troubleshooter/field-validation",
+					"field_violations": []any{
+						map[string]any{"field": "nodes[0].type", "value": "bad-type", "description": "type is required"},
+						"malformed entry",
+						map[string]any{"field": 42, "value": "ignored-with-invalid-item"},
+						map[string]any{"value": map[string]any{"nested": true}, "description": "description-only violation"},
+						map[string]any{"field": "nodes[2].id", "value": "bad-id"},
+					},
+					"details": []any{map[string]any{"value": "detail fallback must lose"}},
+				},
+			}
+
+			err := errclass.BuildAPIError(resp, errclass.ClassifyContext{})
+			var apiErr *errs.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("error type = %T, want *errs.APIError", err)
+			}
+			if apiErr.Category != errs.CategoryAPI || apiErr.Subtype != errs.SubtypeInvalidParameters {
+				t.Fatalf("problem = %+v, want api/invalid_parameters", apiErr.Problem)
+			}
+			if apiErr.Code != code || apiErr.Message != "exact upstream field validation message" || apiErr.LogID != "log-whiteboard-123" {
+				t.Fatalf("problem fields not preserved: %+v", apiErr.Problem)
+			}
+			if apiErr.Troubleshooter != "https://open.feishu.cn/document/troubleshooter/field-validation" {
+				t.Fatalf("Troubleshooter = %q", apiErr.Troubleshooter)
+			}
+			if len(apiErr.FieldViolations) != 3 {
+				t.Fatalf("FieldViolations = %#v, want three valid ordered items", apiErr.FieldViolations)
+			}
+			want := []errs.APIFieldViolation{
+				{Field: "nodes[0].type", Value: "bad-type", Description: "type is required"},
+				{Value: "", Description: "description-only violation"},
+				{Field: "nodes[2].id", Value: "bad-id"},
+			}
+			if !reflect.DeepEqual(apiErr.FieldViolations, want) {
+				t.Fatalf("FieldViolations = %#v, want %#v", apiErr.FieldViolations, want)
+			}
+			wantHint := "nodes[0].type: type is required; description-only violation; nodes[2].id"
+			if apiErr.Hint != wantHint {
+				t.Fatalf("Hint = %q, want %q", apiErr.Hint, wantHint)
+			}
+			if !apiErr.HintIsFromServer() {
+				t.Fatal("field violation hint must retain server provenance")
+			}
+			for _, valueText := range []string{"bad-type", "bad-id", "nested", "detail fallback must lose"} {
+				if strings.Contains(apiErr.Hint, valueText) {
+					t.Fatalf("Hint = %q, must not contain value/fallback %q", apiErr.Hint, valueText)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildAPIError_FieldViolationsNormalizePartialWhitespace(t *testing.T) {
+	err := errclass.BuildAPIError(map[string]any{
+		"code": 2890002,
+		"msg":  "invalid params",
+		"error": map[string]any{
+			"field_violations": []any{
+				map[string]any{
+					"field":       " \t ",
+					"value":       "v1",
+					"description": " description-only reason ",
+				},
+				map[string]any{
+					"field":       " nodes[1].type ",
+					"value":       "v2",
+					"description": "\n ",
+				},
+			},
+		},
+	}, errclass.ClassifyContext{})
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *errs.APIError", err)
+	}
+	want := []errs.APIFieldViolation{
+		{Value: "v1", Description: " description-only reason "},
+		{Field: " nodes[1].type ", Value: "v2"},
+	}
+	if !reflect.DeepEqual(apiErr.FieldViolations, want) {
+		t.Fatalf("FieldViolations = %#v, want %#v", apiErr.FieldViolations, want)
+	}
+	if got, wantHint := apiErr.Hint, " description-only reason ;  nodes[1].type "; got != wantHint {
+		t.Fatalf("Hint = %q, want %q", got, wantHint)
+	}
+	b, err := json.Marshal(apiErr)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	wantWire := "\"field_violations\":[{\"value\":\"v1\",\"description\":\" description-only reason \"},{\"field\":\" nodes[1].type \",\"value\":\"v2\"}]"
+	if !strings.Contains(string(b), wantWire) {
+		t.Fatalf("wire = %s, want substring %s", b, wantWire)
+	}
+}
+
+func TestBuildAPIError_HintPrecedenceWithoutValidFieldViolations(t *testing.T) {
+	t.Run("details before APIHint", func(t *testing.T) {
+		err := errclass.BuildAPIError(map[string]any{
+			"code": 1061045,
+			"msg":  "conflict",
+			"error": map[string]any{
+				"field_violations": []any{map[string]any{"field": 42, "description": false}},
+				"details":          []any{map[string]any{"value": "server detail"}},
+				"message":          "message fallback must lose",
+			},
+		}, errclass.ClassifyContext{})
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("error type = %T, want *errs.APIError", err)
+		}
+		if apiErr.Hint != "server detail" || len(apiErr.FieldViolations) != 0 {
+			t.Fatalf("APIError = %+v, want details hint and no violations", apiErr)
+		}
+		if !apiErr.HintIsFromServer() {
+			t.Fatal("details hint must retain server provenance")
+		}
+	})
+
+	t.Run("error.message before APIHint", func(t *testing.T) {
+		const wantHint = "Invalid request parameter: text_color_code. Invalid reason : text_color_code is required when text_color_type is system. Please check and modify accordingly."
+		err := errclass.BuildAPIError(map[string]any{
+			"code": 2890002,
+			"msg":  "text color code cannot be empty while type is system [@from@] arg error [@from@] whiteboard",
+			"error": map[string]any{
+				"message": wantHint,
+			},
+		}, errclass.ClassifyContext{})
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("error type = %T, want *errs.APIError", err)
+		}
+		if apiErr.Hint != wantHint {
+			t.Fatalf("Hint = %q, want error.message %q", apiErr.Hint, wantHint)
+		}
+		if !apiErr.HintIsFromServer() {
+			t.Fatal("error.message hint must retain server provenance")
+		}
+	})
+
+	t.Run("APIHint last", func(t *testing.T) {
+		err := errclass.BuildAPIError(map[string]any{
+			"code":  1061045,
+			"msg":   "conflict",
+			"error": map[string]any{"message": " \t\n "},
+		}, errclass.ClassifyContext{})
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("error type = %T, want *errs.APIError", err)
+		}
+		if got, want := apiErr.Hint, errclass.APIHint(errs.SubtypeConflict); got != want {
+			t.Fatalf("Hint = %q, want APIHint %q", got, want)
+		}
+		if !apiErr.HintIsFallback() {
+			t.Fatal("context-free APIHint must retain fallback provenance")
+		}
+	})
+}
+
+func TestBuildAPIError_WhitespaceFieldViolationsFallBack(t *testing.T) {
+	tests := []struct {
+		name     string
+		response map[string]any
+		wantHint string
+	}{
+		{
+			name: "details fallback",
+			response: map[string]any{
+				"code": 1470400,
+				"msg":  "invalid params",
+				"error": map[string]any{
+					"field_violations": []any{
+						map[string]any{"field": " \t ", "description": "\n "},
+					},
+					"details": []any{map[string]any{"value": "server detail fallback"}},
+				},
+			},
+			wantHint: "server detail fallback",
+		},
+		{
+			name: "APIHint fallback",
+			response: map[string]any{
+				"code": 1061045,
+				"msg":  "conflict",
+				"error": map[string]any{
+					"field_violations": []any{
+						map[string]any{"field": " \t ", "description": "\n "},
+					},
+				},
+			},
+			wantHint: errclass.APIHint(errs.SubtypeConflict),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errclass.BuildAPIError(tt.response, errclass.ClassifyContext{})
+			var apiErr *errs.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("error type = %T, want *errs.APIError", err)
+			}
+			if len(apiErr.FieldViolations) != 0 {
+				t.Fatalf("FieldViolations = %#v, want whitespace-only item ignored", apiErr.FieldViolations)
+			}
+			if apiErr.Hint != tt.wantHint {
+				t.Fatalf("Hint = %q, want fallback %q", apiErr.Hint, tt.wantHint)
 			}
 		})
 	}

--- a/internal/errclass/codemeta_whiteboard.go
+++ b/internal/errclass/codemeta_whiteboard.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package errclass
+
+import "github.com/larksuite/cli/errs"
+
+// whiteboardCodeMeta holds whiteboard-service Lark code -> CodeMeta mappings.
+var whiteboardCodeMeta = map[int]CodeMeta{
+	2890002: {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},
+}
+
+func init() { mergeCodeMeta(whiteboardCodeMeta, "whiteboard") }

--- a/internal/errclass/codemeta_whiteboard_test.go
+++ b/internal/errclass/codemeta_whiteboard_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package errclass
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func TestLookupCodeMeta_WhiteboardInvalidParameters(t *testing.T) {
+	for _, code := range []int{2890002, 99992402} {
+		meta, ok := LookupCodeMeta(code)
+		if !ok {
+			t.Fatalf("code %d not registered in codeMeta", code)
+		}
+		if meta.Category != errs.CategoryAPI || meta.Subtype != errs.SubtypeInvalidParameters || meta.Retryable {
+			t.Fatalf("code %d: got %+v, want Category=%v Subtype=%v Retryable=false",
+				code, meta, errs.CategoryAPI, errs.SubtypeInvalidParameters)
+		}
+	}
+}

--- a/internal/recovery/render.go
+++ b/internal/recovery/render.go
@@ -132,6 +132,7 @@ func CloneTyped(err error) (error, bool) {
 			return nil, false
 		}
 		clone := *original
+		clone.FieldViolations = slices.Clone(original.FieldViolations)
 		return &clone, true
 	case *errs.SecurityPolicyError:
 		if original == nil {

--- a/internal/recovery/render_test.go
+++ b/internal/recovery/render_test.go
@@ -103,7 +103,10 @@ func TestRenderClonesEveryConcreteTypedErrorAndPreservesWireExtensions(t *testin
 			original: &errs.APIError{
 				Problem:           problem(errs.CategoryAPI, errs.SubtypeRateLimit),
 				RetryAfterSeconds: 7,
-				Cause:             sentinel,
+				FieldViolations: []errs.APIFieldViolation{{
+					Field: "nodes[0].type", Value: "bad", Description: "type is required",
+				}},
+				Cause: sentinel,
 			},
 		},
 		{
@@ -279,15 +282,21 @@ func TestRenderDeepClonesSliceExtensions(t *testing.T) {
 		Problem: errs.Problem{Message: "message"},
 		Rules:   []string{"rule"},
 	}
+	api := &errs.APIError{
+		Problem:         errs.Problem{Message: "message"},
+		FieldViolations: []errs.APIFieldViolation{{Field: "nodes[0].type", Description: "required"}},
+	}
 
 	renderedValidation := Render(validation, nil).(*errs.ValidationError)
 	renderedPermission := Render(permission, nil).(*errs.PermissionError)
 	renderedContent := Render(content, nil).(*errs.ContentSafetyError)
+	renderedAPI := Render(api, nil).(*errs.APIError)
 	renderedValidation.Params[0].Suggestions[0] = "changed"
 	renderedPermission.MissingScopes[0] = "changed"
 	renderedPermission.RequestedScopes[0] = "changed"
 	renderedPermission.GrantedScopes[0] = "changed"
 	renderedContent.Rules[0] = "changed"
+	renderedAPI.FieldViolations[0].Field = "changed"
 
 	if validation.Params[0].Suggestions[0] != "--title" {
 		t.Error("ValidationError suggestions alias the source")
@@ -299,6 +308,44 @@ func TestRenderDeepClonesSliceExtensions(t *testing.T) {
 	}
 	if content.Rules[0] != "rule" {
 		t.Error("ContentSafetyError rules alias the source")
+	}
+	if api.FieldViolations[0].Field != "nodes[0].type" {
+		t.Error("APIError field violations alias the source")
+	}
+}
+
+func TestCloneTypedPreservesAPIHintSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		original *errs.APIError
+		check    func(*errs.APIError) bool
+	}{
+		{
+			name:     "server",
+			original: errs.NewAPIError(errs.SubtypeConflict, "conflict").WithServerHint("server detail"),
+			check:    (*errs.APIError).HintIsFromServer,
+		},
+		{
+			name:     "fallback",
+			original: errs.NewAPIError(errs.SubtypeConflict, "conflict").WithFallbackHint("generic hint"),
+			check:    (*errs.APIError).HintIsFallback,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloned, ok := CloneTyped(tt.original)
+			if !ok {
+				t.Fatal("CloneTyped returned !ok")
+			}
+			apiErr, ok := cloned.(*errs.APIError)
+			if !ok {
+				t.Fatalf("clone type = %T, want *errs.APIError", cloned)
+			}
+			if !tt.check(apiErr) {
+				t.Fatalf("clone lost %s hint provenance", tt.name)
+			}
+		})
 	}
 }
 

--- a/shortcuts/base/base_errors.go
+++ b/shortcuts/base/base_errors.go
@@ -153,21 +153,49 @@ func baseAPIErrorFromResult(resultMap map[string]interface{}, cc errclass.Classi
 	if resultMap == nil {
 		return errs.NewInternalError(errs.SubtypeInvalidResponse, "API returned a malformed response envelope")
 	}
-	if msg := extractDataErrorMessage(resultMap); msg != "" {
-		resultMap["msg"] = msg
-	}
 	hint := extractErrorHint(resultMap)
-	if logID := extractBaseErrorLogID(resultMap); logID != "" {
-		resultMap["log_id"] = logID
-	}
-	err := errclass.BuildAPIError(resultMap, cc)
+	err := errclass.BuildAPIError(projectBaseAPIErrorResult(resultMap), cc)
 	if err == nil {
 		return nil
 	}
-	if p, ok := errs.ProblemOf(err); ok && hint != "" {
-		p.Hint = hint
+	var apiErr *errs.APIError
+	hasFieldViolations := errors.As(err, &apiErr) && len(apiErr.FieldViolations) > 0
+	if p, ok := errs.ProblemOf(err); ok && hint != "" && !hasFieldViolations {
+		if apiErr != nil {
+			apiErr.WithServerHint("%s", hint)
+		} else {
+			p.Hint = hint
+		}
 	}
 	return err
+}
+
+func projectBaseAPIErrorResult(resultMap map[string]interface{}) map[string]interface{} {
+	projected := make(map[string]interface{}, len(resultMap)+1)
+	for key, value := range resultMap {
+		projected[key] = value
+	}
+
+	topError, _ := resultMap["error"].(map[string]interface{})
+	data, _ := resultMap["data"].(map[string]interface{})
+	dataError, _ := data["error"].(map[string]interface{})
+	if len(topError) > 0 || len(dataError) > 0 {
+		merged := make(map[string]interface{}, len(topError)+len(dataError))
+		for key, value := range dataError {
+			merged[key] = value
+		}
+		for key, value := range topError {
+			merged[key] = value
+		}
+		projected["error"] = merged
+	}
+	if msg := extractDataErrorMessage(resultMap); msg != "" {
+		projected["msg"] = msg
+	}
+	if logID := extractBaseErrorLogID(resultMap); logID != "" {
+		projected["log_id"] = logID
+	}
+	return projected
 }
 
 func enrichBaseAPIErrorFromBody(err error, body []byte, cc errclass.ClassifyContext) error {
@@ -186,7 +214,12 @@ func enrichBaseAPIErrorFromBody(err error, body []byte, cc errclass.ClassifyCont
 	dst, _ := errs.ProblemOf(err)
 	if src != nil && dst != nil {
 		dst.Message = src.Message
-		dst.Hint = src.Hint
+		var srcAPI, dstAPI *errs.APIError
+		if errors.As(enriched, &srcAPI) && errors.As(err, &dstAPI) {
+			dstAPI.AdoptServerDiagnostics(srcAPI)
+		} else {
+			dst.Hint = src.Hint
+		}
 		// A body without log_id must not erase a header-derived LogID
 		// already carried by err.
 		if src.LogID != "" {
@@ -222,13 +255,13 @@ func extractBaseErrorLogID(resultMap map[string]interface{}) string {
 
 func extractErrorHint(resultMap map[string]interface{}) string {
 	if detail, ok := resultMap["error"].(map[string]interface{}); ok {
-		if hint := consumeStringField(detail, "hint"); hint != "" {
+		if hint := readStringField(detail, "hint"); hint != "" {
 			return hint
 		}
 	}
 	data, _ := resultMap["data"].(map[string]interface{})
 	if detail, ok := data["error"].(map[string]interface{}); ok {
-		if hint := consumeStringField(detail, "hint"); hint != "" {
+		if hint := readStringField(detail, "hint"); hint != "" {
 			return hint
 		}
 	}
@@ -238,17 +271,14 @@ func extractErrorHint(resultMap map[string]interface{}) string {
 func extractDataErrorMessage(resultMap map[string]interface{}) string {
 	data, _ := resultMap["data"].(map[string]interface{})
 	if detail, ok := data["error"].(map[string]interface{}); ok {
-		if message := consumeStringField(detail, "message"); message != "" {
+		if message := readStringField(detail, "message"); message != "" {
 			return message
 		}
 	}
 	return ""
 }
 
-func consumeStringField(src map[string]interface{}, key string) string {
+func readStringField(src map[string]interface{}, key string) string {
 	value, _ := src[key].(string)
-	if _, exists := src[key]; exists {
-		delete(src, key)
-	}
 	return strings.TrimSpace(value)
 }

--- a/shortcuts/base/base_errors_test.go
+++ b/shortcuts/base/base_errors_test.go
@@ -4,6 +4,8 @@
 package base
 
 import (
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -12,7 +14,16 @@ import (
 )
 
 func TestErrorDetailHelpers(t *testing.T) {
-	detail := map[string]interface{}{"message": "boom", "hint": "retry later"}
+	detail := map[string]interface{}{
+		"message": "boom",
+		"hint":    "retry later",
+		"extra":   "keep me",
+	}
+	wantDetail := map[string]interface{}{
+		"message": "boom",
+		"hint":    "retry later",
+		"extra":   "keep me",
+	}
 	if got := extractErrorHint(map[string]interface{}{"data": map[string]interface{}{"error": detail}}); got != "retry later" {
 		t.Fatalf("hint=%q", got)
 	}
@@ -21,6 +32,9 @@ func TestErrorDetailHelpers(t *testing.T) {
 	}
 	if got := extractDataErrorMessage(map[string]interface{}{"data": map[string]interface{}{}}); got != "" {
 		t.Fatalf("message=%q", got)
+	}
+	if !reflect.DeepEqual(detail, wantDetail) {
+		t.Fatalf("detail mutated: got %#v, want %#v", detail, wantDetail)
 	}
 }
 
@@ -91,6 +105,137 @@ func TestHandleBaseAPIResultPromotesBaseErrorFields(t *testing.T) {
 	if p.LogID != "20260508160000000000000000000000" {
 		t.Fatalf("logID=%q", p.LogID)
 	}
+}
+
+func TestHandleBaseAPIResultHintPrecedence(t *testing.T) {
+	t.Run("field violations win over Base hint", func(t *testing.T) {
+		errorBlock := map[string]interface{}{
+			"hint": "generic Base hint",
+			"field_violations": []interface{}{
+				map[string]interface{}{
+					"field":       "fields.Amount",
+					"description": "must be a number",
+				},
+			},
+		}
+		result := map[string]interface{}{
+			"code":  190001,
+			"msg":   "invalid field",
+			"error": errorBlock,
+		}
+
+		_, err := handleBaseAPIResultAny(result, nil, "update record")
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected typed error, got %T %v", err, err)
+		}
+		if got, want := apiErr.Hint, "fields.Amount: must be a number"; got != want {
+			t.Fatalf("hint = %q, want field violation hint %q", got, want)
+		}
+		if !apiErr.HintIsFromServer() {
+			t.Fatal("field violation hint must retain server provenance")
+		}
+		if !reflect.DeepEqual(errorBlock, map[string]interface{}{
+			"hint": "generic Base hint",
+			"field_violations": []interface{}{
+				map[string]interface{}{"field": "fields.Amount", "description": "must be a number"},
+			},
+		}) {
+			t.Fatalf("top-level error mutated: %#v", errorBlock)
+		}
+	})
+
+	t.Run("data.error field violations win without mutating caller", func(t *testing.T) {
+		dataError := map[string]interface{}{
+			"message": "data error message",
+			"hint":    "generic data Base hint",
+			"logid":   "data-log-id",
+			"field_violations": []interface{}{
+				map[string]interface{}{
+					"field":       "fields.Amount",
+					"description": "must be a number",
+				},
+			},
+			"extra_context": "keep me",
+		}
+		wantDataError := map[string]interface{}{
+			"message": "data error message",
+			"hint":    "generic data Base hint",
+			"logid":   "data-log-id",
+			"field_violations": []interface{}{
+				map[string]interface{}{
+					"field":       "fields.Amount",
+					"description": "must be a number",
+				},
+			},
+			"extra_context": "keep me",
+		}
+		topError := map[string]interface{}{
+			"troubleshooter": "https://example.test/base-troubleshooter",
+		}
+		result := map[string]interface{}{
+			"code":  190001,
+			"msg":   "outer message",
+			"error": topError,
+			"data":  map[string]interface{}{"error": dataError},
+		}
+
+		_, err := handleBaseAPIResultAny(result, nil, "update record")
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected *errs.APIError, got %T %v", err, err)
+		}
+		if apiErr.Message != "data error message" || apiErr.LogID != "data-log-id" {
+			t.Fatalf("problem = %+v, want projected data.error message/logid", apiErr.Problem)
+		}
+		if apiErr.Troubleshooter != "https://example.test/base-troubleshooter" {
+			t.Fatalf("Troubleshooter = %q", apiErr.Troubleshooter)
+		}
+		if got, want := apiErr.Hint, "fields.Amount: must be a number"; got != want {
+			t.Fatalf("Hint = %q, want field violation hint %q", got, want)
+		}
+		if len(apiErr.FieldViolations) != 1 || !apiErr.HintIsFromServer() {
+			t.Fatalf("APIError = %+v, want one server-provenance field violation", apiErr)
+		}
+		if result["msg"] != "outer message" {
+			t.Fatalf("caller msg mutated to %#v", result["msg"])
+		}
+		if _, exists := result["log_id"]; exists {
+			t.Fatalf("caller result gained top-level log_id: %#v", result)
+		}
+		if !reflect.DeepEqual(dataError, wantDataError) {
+			t.Fatalf("data.error mutated: got %#v, want %#v", dataError, wantDataError)
+		}
+		if !reflect.DeepEqual(topError, map[string]interface{}{
+			"troubleshooter": "https://example.test/base-troubleshooter",
+		}) {
+			t.Fatalf("top-level error mutated: %#v", topError)
+		}
+	})
+
+	t.Run("Base hint remains the fallback without violations", func(t *testing.T) {
+		errorBlock := map[string]interface{}{"hint": "generic Base hint"}
+		result := map[string]interface{}{
+			"code":  190001,
+			"msg":   "invalid field",
+			"error": errorBlock,
+		}
+
+		_, err := handleBaseAPIResultAny(result, nil, "update record")
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected typed error, got %T %v", err, err)
+		}
+		if got, want := apiErr.Hint, "generic Base hint"; got != want {
+			t.Fatalf("hint = %q, want Base hint %q", got, want)
+		}
+		if !apiErr.HintIsFromServer() {
+			t.Fatal("Base hint override must carry server provenance")
+		}
+		if !reflect.DeepEqual(errorBlock, map[string]interface{}{"hint": "generic Base hint"}) {
+			t.Fatalf("top-level error mutated: %#v", errorBlock)
+		}
+	})
 }
 
 func TestHandleBaseAPIResultClassifiesKnownPermissionCode(t *testing.T) {
@@ -179,6 +324,93 @@ func TestEnrichBaseAPIErrorFromBodyLogIDMerge(t *testing.T) {
 		}
 		if p.LogID != "body-log-id" {
 			t.Fatalf("logID=%q, want body-log-id", p.LogID)
+		}
+	})
+
+	t.Run("body hint adopts server provenance", func(t *testing.T) {
+		outer := errs.NewAPIError(errs.SubtypeConflict, "outer failure").
+			WithFallbackHint("outer fallback").
+			WithCode(190001)
+		body := []byte("{\"code\":190001,\"msg\":\"boom\",\"data\":{\"error\":{\"hint\":\"body server hint\"}}}")
+		err := enrichBaseAPIErrorFromBody(outer, body, errclass.ClassifyContext{})
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected *errs.APIError, got %T %v", err, err)
+		}
+		if apiErr != outer {
+			t.Fatal("enrichment must update and return the original typed error")
+		}
+		if apiErr.Hint != "body server hint" || !apiErr.HintIsFromServer() {
+			t.Fatalf("APIError = %+v, want body hint with server provenance", apiErr)
+		}
+	})
+
+	t.Run("body field violations replace outer diagnostics without aliasing", func(t *testing.T) {
+		outer := errs.NewAPIError(errs.SubtypeConflict, "outer failure").
+			WithFallbackHint("outer fallback").
+			WithCode(190001)
+		outer.FieldViolations = []errs.APIFieldViolation{{
+			Field: "old.field", Description: "old reason",
+		}}
+		body := []byte("{\"code\":190001,\"msg\":\"boom\",\"data\":{\"error\":{\"hint\":\"body generic hint\",\"field_violations\":[{\"field\":\"fields.Amount\",\"value\":\"abc\",\"description\":\"must be a number\"}]}}}")
+		err := enrichBaseAPIErrorFromBody(outer, body, errclass.ClassifyContext{})
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected *errs.APIError, got %T %v", err, err)
+		}
+		want := []errs.APIFieldViolation{{
+			Field: "fields.Amount", Value: "abc", Description: "must be a number",
+		}}
+		if apiErr.Hint != "fields.Amount: must be a number" || !apiErr.HintIsFromServer() {
+			t.Fatalf("APIError = %+v, want body field hint with server provenance", apiErr)
+		}
+		if !reflect.DeepEqual(apiErr.FieldViolations, want) {
+			t.Fatalf("FieldViolations = %#v, want %#v", apiErr.FieldViolations, want)
+		}
+
+		source := baseAPIErrorFromResult(map[string]interface{}{
+			"code": 190001,
+			"msg":  "boom",
+			"data": map[string]interface{}{
+				"error": map[string]interface{}{
+					"field_violations": []interface{}{
+						map[string]interface{}{
+							"field": "fields.Amount", "value": "abc", "description": "must be a number",
+						},
+					},
+				},
+			},
+		}, errclass.ClassifyContext{})
+		var sourceAPI *errs.APIError
+		if !errors.As(source, &sourceAPI) {
+			t.Fatalf("source = %T, want *errs.APIError", source)
+		}
+		adopted := errs.NewAPIError(errs.SubtypeConflict, "outer").AdoptServerDiagnostics(sourceAPI)
+		sourceAPI.FieldViolations[0].Field = "mutated.source"
+		if got := adopted.FieldViolations[0].Field; got != "fields.Amount" {
+			t.Fatalf("adopted violations alias source: got %q", got)
+		}
+	})
+
+	t.Run("body without field violations preserves outer diagnostics", func(t *testing.T) {
+		outer := errs.NewAPIError(errs.SubtypeConflict, "outer failure").
+			WithFallbackHint("outer fallback").
+			WithCode(190001)
+		outer.FieldViolations = []errs.APIFieldViolation{{
+			Field: "outer.field", Description: "outer reason",
+		}}
+		body := []byte("{\"code\":190001,\"msg\":\"boom\",\"data\":{\"error\":{\"hint\":\"body server hint\"}}}")
+		err := enrichBaseAPIErrorFromBody(outer, body, errclass.ClassifyContext{})
+		var apiErr *errs.APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("expected *errs.APIError, got %T %v", err, err)
+		}
+		if apiErr.Hint != "body server hint" || !apiErr.HintIsFromServer() {
+			t.Fatalf("APIError = %+v, want body hint with server provenance", apiErr)
+		}
+		want := []errs.APIFieldViolation{{Field: "outer.field", Description: "outer reason"}}
+		if !reflect.DeepEqual(apiErr.FieldViolations, want) {
+			t.Fatalf("FieldViolations = %#v, want preserved %#v", apiErr.FieldViolations, want)
 		}
 	})
 }

--- a/shortcuts/task/task_util.go
+++ b/shortcuts/task/task_util.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -102,8 +103,21 @@ func applyTaskAPIHint(err error) error {
 	if err == nil {
 		return nil
 	}
-	if p, ok := errs.ProblemOf(err); ok {
-		if hint := taskAPIHints[p.Code]; hint != "" {
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		return err
+	}
+	var apiErr *errs.APIError
+	if errors.As(err, &apiErr) && apiErr.HintIsFromServer() {
+		return err
+	}
+	if p.Hint != "" && (apiErr == nil || !apiErr.HintIsFallback()) {
+		return err
+	}
+	if hint := taskAPIHints[p.Code]; hint != "" {
+		if apiErr != nil {
+			apiErr.WithHint("%s", hint)
+		} else {
 			p.Hint = hint
 		}
 	}

--- a/shortcuts/task/task_util_test.go
+++ b/shortcuts/task/task_util_test.go
@@ -108,9 +108,84 @@ func TestHandleTaskApiResult_TypedMapping(t *testing.T) {
 			if p.Hint != taskAPIHints[tt.code] {
 				t.Errorf("hint = %q, want %q", p.Hint, taskAPIHints[tt.code])
 			}
+			var apiErr *errs.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("err = %T, want *errs.APIError", err)
+			}
+			if apiErr.HintIsFallback() || apiErr.HintIsFromServer() {
+				t.Errorf("task-specific hint retained stale BuildAPIError provenance")
+			}
 			// BuildAPIError uses the raw upstream msg as the message.
 			if !strings.Contains(err.Error(), "raw upstream detail") {
 				t.Errorf("message = %q, want raw upstream detail", err.Error())
+			}
+		})
+	}
+}
+
+func TestHandleTaskApiResult_PreservesBuildAPIErrorHint(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       int
+		errorBlock map[string]interface{}
+		wantHint   string
+	}{
+		{
+			name: "field violations",
+			code: ErrCodeTaskInvalidParams,
+			errorBlock: map[string]interface{}{
+				"field_violations": []interface{}{
+					map[string]interface{}{
+						"field":       "task.summary",
+						"description": "summary is required",
+					},
+				},
+			},
+			wantHint: "task.summary: summary is required",
+		},
+		{
+			name: "server details",
+			code: ErrCodeTaskInvalidParams,
+			errorBlock: map[string]interface{}{
+				"details": []interface{}{
+					map[string]interface{}{"value": "server-specific task validation detail"},
+				},
+			},
+			wantHint: "server-specific task validation detail",
+		},
+		{
+			name: "server detail equals generic APIHint",
+			code: ErrCodeTaskConflict,
+			errorBlock: map[string]interface{}{
+				"details": []interface{}{
+					map[string]interface{}{"value": errclass.APIHint(errs.SubtypeConflict)},
+				},
+			},
+			wantHint: errclass.APIHint(errs.SubtypeConflict),
+		},
+		{
+			name: "error.message equals generic APIHint",
+			code: ErrCodeTaskConflict,
+			errorBlock: map[string]interface{}{
+				"message": errclass.APIHint(errs.SubtypeConflict),
+			},
+			wantHint: errclass.APIHint(errs.SubtypeConflict),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := HandleTaskApiResult(map[string]interface{}{
+				"code":  float64(tt.code),
+				"msg":   "invalid task parameters",
+				"error": tt.errorBlock,
+			}, nil, "create task")
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("err = %T, want typed errs.* error", err)
+			}
+			if p.Hint != tt.wantHint {
+				t.Fatalf("hint = %q, want BuildAPIError hint %q", p.Hint, tt.wantHint)
 			}
 		})
 	}
@@ -190,6 +265,30 @@ func TestCallTaskAPITyped_TaskHint(t *testing.T) {
 	}
 	if p.Hint != taskAPIHints[ErrCodeTaskReminderExists] {
 		t.Errorf("hint = %q, want %q", p.Hint, taskAPIHints[ErrCodeTaskReminderExists])
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/task/v2/tasks/t-2",
+		Body: map[string]interface{}{
+			"code": float64(ErrCodeTaskConflict),
+			"msg":  "conflict",
+			"error": map[string]interface{}{
+				"message": errclass.APIHint(errs.SubtypeConflict),
+			},
+		},
+	})
+
+	_, err = callTaskAPITyped(rt, http.MethodGet, "/open-apis/task/v2/tasks/t-2", nil, nil)
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %T, want *errs.APIError", err)
+	}
+	if got, want := apiErr.Hint, errclass.APIHint(errs.SubtypeConflict); got != want {
+		t.Fatalf("hint = %q, want server error.message %q", got, want)
+	}
+	if !apiErr.HintIsFromServer() {
+		t.Fatal("error.message collision must retain server provenance")
 	}
 }
 

--- a/shortcuts/whiteboard/shortcuts.go
+++ b/shortcuts/whiteboard/shortcuts.go
@@ -14,6 +14,9 @@ func Shortcuts() []common.Shortcut {
 		WhiteboardUpdateOld,
 		WhiteboardExport,
 		WhiteboardQuery,
+		WhiteboardNodeCreate,
+		WhiteboardNodeUpdate,
+		WhiteboardNodeDelete,
 	}
 }
 

--- a/shortcuts/whiteboard/shortcuts.go
+++ b/shortcuts/whiteboard/shortcuts.go
@@ -17,6 +17,8 @@ func Shortcuts() []common.Shortcut {
 		WhiteboardNodeCreate,
 		WhiteboardNodeUpdate,
 		WhiteboardNodeDelete,
+		WhiteboardParseImage,
+		WhiteboardParseImageResult,
 	}
 }
 

--- a/shortcuts/whiteboard/whiteboard_node_common.go
+++ b/shortcuts/whiteboard/whiteboard_node_common.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+type whiteboardNodeBatchPayload struct {
+	Nodes []map[string]interface{} `json:"nodes"`
+}
+
+type whiteboardNodeBatchEnvelope struct {
+	Nodes []map[string]interface{}    `json:"nodes"`
+	Data  *whiteboardNodeBatchPayload `json:"data"`
+}
+
+func parseWhiteboardNodeBatchPayload(raw []byte, requireID bool) (whiteboardNodeBatchPayload, error) {
+	var document json.RawMessage
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return whiteboardNodeBatchPayload{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "unmarshal input json failed: %v", err).
+			WithParam("--source").
+			WithCause(err)
+	}
+
+	var envelope whiteboardNodeBatchEnvelope
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
+	if err := decoder.Decode(&envelope); err != nil {
+		return whiteboardNodeBatchPayload{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "unmarshal input json failed: %v", err).
+			WithParam("--source").
+			WithCause(err)
+	}
+	payload := whiteboardNodeBatchPayload{Nodes: envelope.Nodes}
+	if len(payload.Nodes) == 0 && envelope.Data != nil {
+		payload = *envelope.Data
+	}
+	if len(payload.Nodes) == 0 {
+		return whiteboardNodeBatchPayload{}, errs.NewValidationError(errs.SubtypeInvalidArgument, `--source must include non-empty "nodes"`).
+			WithParam("--source")
+	}
+	if requireID {
+		for i, node := range payload.Nodes {
+			id, ok := node["id"].(string)
+			if !ok || strings.TrimSpace(id) == "" {
+				return whiteboardNodeBatchPayload{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "nodes[%d].id must be a non-empty string", i).
+					WithParam("--source")
+			}
+		}
+	}
+	return payload, nil
+}
+
+func parseWhiteboardNodeIDs(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--node-ids is required").
+			WithParam("--node-ids")
+	}
+
+	parts := strings.Split(raw, ",")
+	ids := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for i, part := range parts {
+		id := strings.TrimSpace(part)
+		if id == "" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--node-ids item %d must not be empty", i+1).
+				WithParam("--node-ids")
+		}
+		if _, ok := seen[id]; ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "duplicate node id %q", id).
+				WithParam("--node-ids")
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func validateOptionalWhiteboardNodeIdempotentToken(raw string) error {
+	if err := common.RejectDangerousCharsTyped("--idempotent-token", raw); err != nil {
+		return err
+	}
+	if raw != "" && len(raw) < 10 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--idempotent-token must be at least 10 characters long.").
+			WithParam("--idempotent-token")
+	}
+	return nil
+}

--- a/shortcuts/whiteboard/whiteboard_node_common_test.go
+++ b/shortcuts/whiteboard/whiteboard_node_common_test.go
@@ -19,6 +19,8 @@ func TestShortcutsIncludesWhiteboardNodeCommands(t *testing.T) {
 		"+node-create",
 		"+node-update",
 		"+node-delete",
+		"+parse-image",
+		"+parse-image-result",
 	}
 
 	seen := make(map[string]bool, len(got))

--- a/shortcuts/whiteboard/whiteboard_node_common_test.go
+++ b/shortcuts/whiteboard/whiteboard_node_common_test.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestShortcutsIncludesWhiteboardNodeCommands(t *testing.T) {
+	t.Parallel()
+
+	got := Shortcuts()
+	want := []string{
+		"+update",
+		"+export",
+		"+query",
+		"+node-create",
+		"+node-update",
+		"+node-delete",
+	}
+
+	seen := make(map[string]bool, len(got))
+	for _, shortcut := range got {
+		if seen[shortcut.Command] {
+			t.Fatalf("duplicate shortcut command: %s", shortcut.Command)
+		}
+		seen[shortcut.Command] = true
+	}
+
+	for _, command := range want {
+		if !seen[command] {
+			t.Fatalf("missing shortcut command %q in Shortcuts()", command)
+		}
+	}
+}
+
+func TestParseWhiteboardNodeBatchPayload_MissingNodes(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeBatchPayload([]byte(`{}`), false)
+	assertValidationParam(t, err, "--source", false)
+}
+
+func TestParseWhiteboardNodeBatchPayload_EmptyNodes(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeBatchPayload([]byte(`{"nodes":[]}`), false)
+	assertValidationParam(t, err, "--source", false)
+}
+
+func TestParseWhiteboardNodeBatchPayload_AcceptsDataNodesEnvelope(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseWhiteboardNodeBatchPayload([]byte(`{"code":0,"msg":"success","data":{"nodes":[{"id":"node-1","text":{"text":"hello"},"custom":{"value":9007199254740993}}]}}`), true)
+	if err != nil {
+		t.Fatalf("parseWhiteboardNodeBatchPayload() error = %v", err)
+	}
+	if len(payload.Nodes) != 1 {
+		t.Fatalf("len(payload.Nodes) = %d, want 1", len(payload.Nodes))
+	}
+	node := payload.Nodes[0]
+	if got := node["id"]; got != "node-1" {
+		t.Fatalf("node[id] = %v, want node-1", got)
+	}
+	custom, ok := node["custom"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("node[custom] = %T, want map[string]interface{}", node["custom"])
+	}
+	if got := custom["value"]; got != json.Number("9007199254740993") {
+		t.Fatalf("node[custom][value] = %v, want 9007199254740993", got)
+	}
+}
+
+func TestParseWhiteboardNodeBatchPayload_PrefersTopLevelNodesOverEnvelope(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseWhiteboardNodeBatchPayload([]byte(`{"nodes":[{"id":"top"}],"data":{"nodes":[{"id":"nested"}]}}`), true)
+	if err != nil {
+		t.Fatalf("parseWhiteboardNodeBatchPayload() error = %v", err)
+	}
+	if len(payload.Nodes) != 1 || payload.Nodes[0]["id"] != "top" {
+		t.Fatalf("payload.Nodes = %#v, want top-level nodes", payload.Nodes)
+	}
+}
+
+func TestParseWhiteboardNodeBatchPayload_RejectsEmptyDataEnvelope(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeBatchPayload([]byte(`{"code":0,"data":{}}`), true)
+	assertValidationParam(t, err, "--source", false)
+}
+
+func TestParseWhiteboardNodeBatchPayload_InvalidJSONPreservesCause(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeBatchPayload([]byte(`not-json`), false)
+	assertValidationParam(t, err, "--source", true)
+}
+
+func TestParseWhiteboardNodeBatchPayload_RequireIDMissingID(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeBatchPayload([]byte(`{"nodes":[{"text":{"text":"x"}}]}`), true)
+	assertValidationParam(t, err, "--source", false)
+}
+
+func TestParseWhiteboardNodeBatchPayload_RequireIDBlankID(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeBatchPayload([]byte(`{"nodes":[{"id":"   ","text":{"text":"x"}}]}`), true)
+	assertValidationParam(t, err, "--source", false)
+}
+
+func TestParseWhiteboardNodeBatchPayload_PreservesArbitraryFields(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseWhiteboardNodeBatchPayload([]byte(`{"nodes":[{"id":"node-1","type":"shape","custom":{"x":1},"points":[1,2]}]}`), true)
+	if err != nil {
+		t.Fatalf("parseWhiteboardNodeBatchPayload() error = %v", err)
+	}
+	if len(payload.Nodes) != 1 {
+		t.Fatalf("len(payload.Nodes) = %d, want 1", len(payload.Nodes))
+	}
+	node := payload.Nodes[0]
+	if got := node["id"]; got != "node-1" {
+		t.Errorf("node[id] = %v, want node-1", got)
+	}
+	if got := node["type"]; got != "shape" {
+		t.Errorf("node[type] = %v, want shape", got)
+	}
+	custom, ok := node["custom"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("node[custom] = %T, want map[string]interface{}", node["custom"])
+	}
+	if got := custom["x"]; got != json.Number("1") {
+		t.Errorf("node[custom][x] = %v, want 1", got)
+	}
+	points, ok := node["points"].([]interface{})
+	if !ok {
+		t.Fatalf("node[points] = %T, want []interface{}", node["points"])
+	}
+	if len(points) != 2 || points[0] != json.Number("1") || points[1] != json.Number("2") {
+		t.Errorf("node[points] = %#v, want [1 2]", points)
+	}
+}
+
+func TestParseWhiteboardNodeBatchPayload_PreservesLargeIntegerPrecision(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseWhiteboardNodeBatchPayload([]byte(`{"nodes":[{"id":"node-1","custom":{"value":9007199254740993}}]}`), true)
+	if err != nil {
+		t.Fatalf("parseWhiteboardNodeBatchPayload() error = %v", err)
+	}
+
+	encoded, err := json.Marshal(whiteboardNodeCreateReq{Nodes: payload.Nodes})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if got, want := string(encoded), `{"nodes":[{"custom":{"value":9007199254740993},"id":"node-1"}]}`; got != want {
+		t.Fatalf("encoded payload = %s, want %s", got, want)
+	}
+}
+
+func TestParseWhiteboardNodeIDs_TrimsItems(t *testing.T) {
+	t.Parallel()
+
+	ids, err := parseWhiteboardNodeIDs(" nodeA, nodeB ,nodeC ")
+	if err != nil {
+		t.Fatalf("parseWhiteboardNodeIDs() error = %v", err)
+	}
+	want := []string{"nodeA", "nodeB", "nodeC"}
+	if len(ids) != len(want) {
+		t.Fatalf("len(ids) = %d, want %d", len(ids), len(want))
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Errorf("ids[%d] = %q, want %q", i, ids[i], want[i])
+		}
+	}
+}
+
+func TestParseWhiteboardNodeIDs_RejectsEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeIDs("   ")
+	assertValidationParam(t, err, "--node-ids", false)
+}
+
+func TestParseWhiteboardNodeIDs_RejectsEmptyItems(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeIDs("nodeA, ,nodeB")
+	assertValidationParam(t, err, "--node-ids", false)
+}
+
+func TestParseWhiteboardNodeIDs_RejectsDuplicateIDs(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseWhiteboardNodeIDs("nodeA,nodeB,nodeA")
+	assertValidationParam(t, err, "--node-ids", false)
+}
+
+func TestValidateOptionalWhiteboardNodeIdempotentToken_TooShort(t *testing.T) {
+	t.Parallel()
+
+	err := validateOptionalWhiteboardNodeIdempotentToken("short")
+	assertValidationParam(t, err, "--idempotent-token", false)
+}

--- a/shortcuts/whiteboard/whiteboard_node_create.go
+++ b/shortcuts/whiteboard/whiteboard_node_create.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var wbNodeCreateScopes = []string{"board:whiteboard:node:create"}
+var wbNodeCreateAuthTypes = []string{"user", "bot"}
+var wbNodeCreateFlags = []common.Flag{
+	{Name: "whiteboard-token", Desc: "whiteboard token of the whiteboard to create nodes in. You need edit permission on the whiteboard.", Required: true},
+	{Name: "source", Desc: `JSON payload containing a non-empty "nodes" array.`, Required: true, Input: []string{common.Stdin, common.File}},
+	{Name: "idempotent-token", Desc: "idempotent token to make create requests retry-safe. Default is empty. Minimum length is 10.", Required: false},
+}
+
+type whiteboardNodeCreateReq struct {
+	Nodes []map[string]interface{} `json:"nodes"`
+}
+
+func wbNodeCreateValidate(_ context.Context, runtime *common.RuntimeContext) error {
+	if err := common.RejectDangerousCharsTyped("--whiteboard-token", runtime.Str("whiteboard-token")); err != nil {
+		return err
+	}
+	if err := validateOptionalWhiteboardNodeIdempotentToken(runtime.Str("idempotent-token")); err != nil {
+		return err
+	}
+	_, err := parseWhiteboardNodeBatchPayload([]byte(runtime.Str("source")), false)
+	return err
+}
+
+func wbNodeCreateDryRun(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	payload, err := parseWhiteboardNodeBatchPayload([]byte(runtime.Str("source")), false)
+	if err != nil {
+		return common.NewDryRunAPI().Desc("parse input failed: " + err.Error())
+	}
+
+	dry := common.NewDryRunAPI().
+		POST(wbNodeCreateDryRunURL(runtime.Str("whiteboard-token"))).
+		Body(whiteboardNodeCreateReq{Nodes: payload.Nodes}).
+		Desc("create nodes in the whiteboard.")
+	if params := wbNodeCreateParams(runtime); len(params) > 0 {
+		dry.Params(params)
+	}
+	return dry
+}
+
+func wbNodeCreateExecute(_ context.Context, runtime *common.RuntimeContext) error {
+	payload, err := parseWhiteboardNodeBatchPayload([]byte(runtime.Str("source")), false)
+	if err != nil {
+		return err
+	}
+
+	data, err := runtime.CallAPITyped(
+		http.MethodPost,
+		wbNodeCreateURL(runtime.Str("whiteboard-token")),
+		wbNodeCreateParams(runtime),
+		whiteboardNodeCreateReq{Nodes: payload.Nodes},
+	)
+	if err != nil {
+		return err
+	}
+
+	nodeIDs, err := whiteboardNodeCreateIDs(data)
+	if err != nil {
+		return err
+	}
+	outData := map[string]string{}
+	if nodeIDs != nil {
+		outData["ids"] = strings.Join(nodeIDs, ",")
+	}
+	runtime.OutFormat(outData, nil, func(w io.Writer) {
+		if outData["ids"] != "" {
+			fmt.Fprintf(w, "%d new nodes created.\n", len(nodeIDs))
+		}
+		fmt.Fprintf(w, "Create whiteboard nodes success")
+	})
+	return nil
+}
+
+func wbNodeCreateURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", url.PathEscape(token))
+}
+
+func wbNodeCreateDryRunURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", common.MaskToken(url.PathEscape(token)))
+}
+
+func wbNodeCreateParams(runtime *common.RuntimeContext) map[string]interface{} {
+	params := map[string]interface{}{}
+	if token := runtime.Str("idempotent-token"); token != "" {
+		params["client_token"] = token
+	}
+	return params
+}
+
+func whiteboardNodeCreateIDs(data map[string]interface{}) ([]string, error) {
+	switch raw := data["ids"].(type) {
+	case nil:
+		return nil, wbInvalidResponse("create whiteboard nodes failed: data.ids must be a non-empty array of strings")
+	case []interface{}:
+		if len(raw) == 0 {
+			return nil, wbInvalidResponse("create whiteboard nodes failed: data.ids must be a non-empty array of strings")
+		}
+		out := make([]string, 0, len(raw))
+		for i, value := range raw {
+			id, ok := value.(string)
+			if !ok {
+				return nil, wbInvalidResponse("create whiteboard nodes failed: data.ids[%d] must be a string", i)
+			}
+			out = append(out, id)
+		}
+		return out, nil
+	case []string:
+		if len(raw) == 0 {
+			return nil, wbInvalidResponse("create whiteboard nodes failed: data.ids must be a non-empty array of strings")
+		}
+		return append([]string(nil), raw...), nil
+	default:
+		return nil, wbInvalidResponse("create whiteboard nodes failed: data.ids must be an array of strings")
+	}
+}
+
+// WhiteboardNodeCreate registers the `whiteboard +node-create` shortcut.
+var WhiteboardNodeCreate = common.Shortcut{
+	Service:     "whiteboard",
+	Command:     "+node-create",
+	Description: "Create nodes in an existing whiteboard.",
+	Risk:        "write",
+	Scopes:      wbNodeCreateScopes,
+	AuthTypes:   wbNodeCreateAuthTypes,
+	Flags:       wbNodeCreateFlags,
+	Validate:    wbNodeCreateValidate,
+	DryRun:      wbNodeCreateDryRun,
+	Execute:     wbNodeCreateExecute,
+}

--- a/shortcuts/whiteboard/whiteboard_node_create_test.go
+++ b/shortcuts/whiteboard/whiteboard_node_create_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestWhiteboardNodeCreateValidate_InvalidSourceTypedParam(t *testing.T) {
+	t.Parallel()
+
+	rt := newTestRuntime(map[string]string{
+		"whiteboard-token": "test-board",
+		"source":           "not-json",
+	}, nil)
+
+	err := wbNodeCreateValidate(context.Background(), rt)
+	assertValidationParam(t, err, "--source", true)
+}
+
+func TestWhiteboardNodeCreateDryRun_RequestShape(t *testing.T) {
+	t.Parallel()
+
+	rt := newTestRuntime(map[string]string{
+		"whiteboard-token": "test-board",
+		"idempotent-token": "create-token-12345",
+		"source":           `{"nodes":[{"id":"tmpNode","type":"composite_shape","x":0,"y":0,"width":260,"height":45,"text":{"text":"hello","font_weight":"regular","font_size":14,"horizontal_align":"center","vertical_align":"mid"},"style":{"border_color":"#3370ff","border_width":"narrow","border_style":"solid","fill_color":"#e8f3ff"},"composite_shape":{"type":"round_rect"}}]}`,
+	}, nil)
+
+	dryRun := wbNodeCreateDryRun(context.Background(), rt)
+	if dryRun == nil {
+		t.Fatal("wbNodeCreateDryRun() returned nil")
+	}
+
+	var got struct {
+		API []struct {
+			Method string                 `json:"method"`
+			URL    string                 `json:"url"`
+			Params map[string]interface{} `json:"params"`
+			Body   map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	data, err := json.Marshal(dryRun)
+	if err != nil {
+		t.Fatalf("marshal dry-run: %v", err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry-run: %v\njson=%s", err, string(data))
+	}
+	if len(got.API) != 1 {
+		t.Fatalf("api len = %d, want 1; json=%s", len(got.API), string(data))
+	}
+	if got.API[0].Method != "POST" {
+		t.Fatalf("method = %q, want POST", got.API[0].Method)
+	}
+	if got.API[0].URL != "/open-apis/board/v1/whiteboards/test...oard/nodes" {
+		t.Fatalf("url = %q, want node-create URL", got.API[0].URL)
+	}
+	if got.API[0].Params["client_token"] != "create-token-12345" {
+		t.Fatalf("params.client_token = %#v, want create-token-12345", got.API[0].Params["client_token"])
+	}
+	nodes, ok := got.API[0].Body["nodes"].([]interface{})
+	if !ok || len(nodes) != 1 {
+		t.Fatalf("body.nodes = %#v, want one node", got.API[0].Body["nodes"])
+	}
+	node, ok := nodes[0].(map[string]interface{})
+	if !ok || node["type"] != "composite_shape" {
+		t.Fatalf("body.nodes[0] = %#v, want type composite_shape", nodes[0])
+	}
+	if _, ok := node["composite_shape"].(map[string]interface{}); !ok {
+		t.Fatalf("body.nodes[0].composite_shape = %#v, want object", node["composite_shape"])
+	}
+}
+
+func TestWhiteboardNodeCreateExecute_PostsNodes(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"ids": []string{"node-1"},
+			},
+		},
+	}
+	reg.Register(stub)
+
+	source := `{"nodes":[{"id":"tmpNode","type":"composite_shape","x":0,"y":0,"width":260,"height":45,"text":{"text":"hello","font_weight":"regular","font_size":14,"horizontal_align":"center","vertical_align":"mid"},"style":{"border_color":"#3370ff","border_width":"narrow","border_style":"solid","fill_color":"#e8f3ff"},"composite_shape":{"type":"round_rect"}}]}`
+	args := []string{"+node-create", "--whiteboard-token", "test-board", "--source", source}
+	if err := runUpdateShortcut(t, WhiteboardNodeCreate, args, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v\nraw=%s", err, string(stub.CapturedBody))
+	}
+	nodes, ok := body["nodes"].([]interface{})
+	if !ok || len(nodes) != 1 {
+		t.Fatalf("body.nodes = %#v, want one node; body=%s", body["nodes"], string(stub.CapturedBody))
+	}
+	node, ok := nodes[0].(map[string]interface{})
+	if !ok || node["type"] != "composite_shape" {
+		t.Fatalf("body.nodes[0] = %#v, want type composite_shape", nodes[0])
+	}
+	if _, ok := node["composite_shape"].(map[string]interface{}); !ok {
+		t.Fatalf("body.nodes[0].composite_shape = %#v, want object", node["composite_shape"])
+	}
+	if !strings.Contains(stdout.String(), `"ids": "node-1"`) {
+		t.Fatalf("stdout=%s, want ids node-1", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeCreateExecute_RejectsMissingIDs(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{},
+		},
+	})
+
+	source := `{"nodes":[{"id":"tmpNode","type":"composite_shape","x":0,"y":0,"width":260,"height":45,"text":{"text":"hello","font_weight":"regular","font_size":14,"horizontal_align":"center","vertical_align":"mid"},"style":{"border_color":"#3370ff","border_width":"narrow","border_style":"solid","fill_color":"#e8f3ff"},"composite_shape":{"type":"round_rect"}}]}`
+	args := []string{"+node-create", "--whiteboard-token", "test-board", "--source", source}
+	err := runUpdateShortcut(t, WhiteboardNodeCreate, args, factory, stdout)
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error type = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+	}
+	if strings.Contains(stdout.String(), "success") {
+		t.Fatalf("stdout=%s, must not report success", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeCreateIDs_RejectsEmptyIDs(t *testing.T) {
+	t.Parallel()
+
+	_, err := whiteboardNodeCreateIDs(map[string]interface{}{"ids": []interface{}{}})
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error type = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+	}
+}
+
+func TestWhiteboardNodeCreateExecute_RejectsMalformedIDs(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"ids": []interface{}{"node-1", 2},
+			},
+		},
+	})
+
+	source := `{"nodes":[{"id":"tmpNode","type":"composite_shape","x":0,"y":0,"width":260,"height":45,"text":{"text":"hello","font_weight":"regular","font_size":14,"horizontal_align":"center","vertical_align":"mid"},"style":{"border_color":"#3370ff","border_width":"narrow","border_style":"solid","fill_color":"#e8f3ff"},"composite_shape":{"type":"round_rect"}}]}`
+	args := []string{"+node-create", "--whiteboard-token", "test-board", "--source", source}
+	err := runUpdateShortcut(t, WhiteboardNodeCreate, args, factory, stdout)
+	if err == nil {
+		t.Fatal("expected malformed ids error, got nil")
+	}
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error type = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+	}
+}

--- a/shortcuts/whiteboard/whiteboard_node_delete.go
+++ b/shortcuts/whiteboard/whiteboard_node_delete.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var wbNodeDeleteScopes = []string{"board:whiteboard:node:delete"}
+var wbNodeDeleteAuthTypes = []string{"user", "bot"}
+var wbNodeDeleteFlags = []common.Flag{
+	{Name: "whiteboard-token", Desc: "whiteboard token of the whiteboard to delete nodes from. You need edit permission on the whiteboard.", Required: true},
+	{Name: "node-ids", Desc: "comma-separated whiteboard node IDs to delete.", Required: true},
+	{Name: "idempotent-token", Desc: "idempotent token to make delete requests retry-safe. Default is empty. Minimum length is 10.", Required: false},
+}
+
+type whiteboardNodeDeleteReq struct {
+	IDs []string `json:"ids"`
+}
+
+func wbNodeDeleteValidate(_ context.Context, runtime *common.RuntimeContext) error {
+	if err := common.RejectDangerousCharsTyped("--whiteboard-token", runtime.Str("whiteboard-token")); err != nil {
+		return err
+	}
+	if err := validateOptionalWhiteboardNodeIdempotentToken(runtime.Str("idempotent-token")); err != nil {
+		return err
+	}
+	_, err := parseWhiteboardNodeIDs(runtime.Str("node-ids"))
+	return err
+}
+
+func wbNodeDeleteDryRun(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	ids, err := parseWhiteboardNodeIDs(runtime.Str("node-ids"))
+	if err != nil {
+		return common.NewDryRunAPI().Desc("parse node ids failed: " + err.Error())
+	}
+
+	dry := common.NewDryRunAPI().
+		DELETE(wbNodeDeleteDryRunURL(runtime.Str("whiteboard-token"))).
+		Body(whiteboardNodeDeleteReq{IDs: ids}).
+		Desc("delete nodes from the whiteboard.")
+	if params := wbNodeDeleteParams(runtime); len(params) > 0 {
+		dry.Params(params)
+	}
+	return dry
+}
+
+func wbNodeDeleteExecute(_ context.Context, runtime *common.RuntimeContext) error {
+	ids, err := parseWhiteboardNodeIDs(runtime.Str("node-ids"))
+	if err != nil {
+		return err
+	}
+
+	if _, err := runtime.CallAPITyped(
+		http.MethodDelete,
+		wbNodeDeleteURL(runtime.Str("whiteboard-token")),
+		wbNodeDeleteParams(runtime),
+		whiteboardNodeDeleteReq{IDs: ids},
+	); err != nil {
+		return err
+	}
+
+	outData := map[string]interface{}{
+		"ids":   strings.Join(ids, ","),
+		"count": len(ids),
+	}
+	runtime.OutFormat(outData, nil, func(w io.Writer) {
+		fmt.Fprintf(w, "%d nodes deleted.\n", len(ids))
+		fmt.Fprintf(w, "Delete whiteboard nodes success")
+	})
+	return nil
+}
+
+func wbNodeDeleteURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/batch_delete", url.PathEscape(token))
+}
+
+func wbNodeDeleteDryRunURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/batch_delete", common.MaskToken(url.PathEscape(token)))
+}
+
+func wbNodeDeleteParams(runtime *common.RuntimeContext) map[string]interface{} {
+	params := map[string]interface{}{}
+	if token := runtime.Str("idempotent-token"); token != "" {
+		params["client_token"] = token
+	}
+	return params
+}
+
+// WhiteboardNodeDelete registers the `whiteboard +node-delete` shortcut.
+var WhiteboardNodeDelete = common.Shortcut{
+	Service:     "whiteboard",
+	Command:     "+node-delete",
+	Description: "Delete nodes from an existing whiteboard.",
+	Risk:        "high-risk-write",
+	Scopes:      wbNodeDeleteScopes,
+	AuthTypes:   wbNodeDeleteAuthTypes,
+	Flags:       wbNodeDeleteFlags,
+	Validate:    wbNodeDeleteValidate,
+	DryRun:      wbNodeDeleteDryRun,
+	Execute:     wbNodeDeleteExecute,
+}

--- a/shortcuts/whiteboard/whiteboard_node_delete_test.go
+++ b/shortcuts/whiteboard/whiteboard_node_delete_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestWhiteboardNodeDeleteValidate_InvalidNodeIDsTypedParam(t *testing.T) {
+	t.Parallel()
+
+	rt := newTestRuntime(map[string]string{
+		"whiteboard-token": "test-board",
+		"node-ids":         "nodeA,,nodeB",
+	}, nil)
+
+	err := wbNodeDeleteValidate(context.Background(), rt)
+	assertValidationParam(t, err, "--node-ids", false)
+}
+
+func TestWhiteboardNodeDeleteMetadata_RiskHighRiskWrite(t *testing.T) {
+	t.Parallel()
+
+	if WhiteboardNodeDelete.Risk != "high-risk-write" {
+		t.Fatalf("Risk = %q, want high-risk-write", WhiteboardNodeDelete.Risk)
+	}
+}
+
+func TestWhiteboardNodeDeleteDryRun_RequestShape(t *testing.T) {
+	t.Parallel()
+
+	rt := newTestRuntime(map[string]string{
+		"whiteboard-token": "test-board",
+		"node-ids":         "nodeA,nodeB",
+		"idempotent-token": "delete-token-12345",
+	}, nil)
+
+	dryRun := wbNodeDeleteDryRun(context.Background(), rt)
+	if dryRun == nil {
+		t.Fatal("wbNodeDeleteDryRun() returned nil")
+	}
+
+	var got struct {
+		API []struct {
+			Method string                 `json:"method"`
+			URL    string                 `json:"url"`
+			Params map[string]interface{} `json:"params"`
+			Body   map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	data, err := json.Marshal(dryRun)
+	if err != nil {
+		t.Fatalf("marshal dry-run: %v", err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry-run: %v\njson=%s", err, string(data))
+	}
+	if len(got.API) != 1 {
+		t.Fatalf("api len = %d, want 1; json=%s", len(got.API), string(data))
+	}
+	if got.API[0].Method != "DELETE" {
+		t.Fatalf("method = %q, want DELETE", got.API[0].Method)
+	}
+	if got.API[0].URL != "/open-apis/board/v1/whiteboards/test...oard/nodes/batch_delete" {
+		t.Fatalf("url = %q, want masked node-delete URL", got.API[0].URL)
+	}
+	if got.API[0].Params["client_token"] != "delete-token-12345" {
+		t.Fatalf("params.client_token = %#v, want delete-token-12345", got.API[0].Params["client_token"])
+	}
+	ids, ok := got.API[0].Body["ids"].([]interface{})
+	if !ok || len(ids) != 2 {
+		t.Fatalf("body.ids = %#v, want two ids", got.API[0].Body["ids"])
+	}
+	if ids[0] != "nodeA" || ids[1] != "nodeB" {
+		t.Fatalf("body.ids = %#v, want [nodeA nodeB]", ids)
+	}
+}
+
+func TestWhiteboardNodeDeleteExecute_PostsIDs(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	stub := &httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes/batch_delete",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{},
+		},
+	}
+	reg.Register(stub)
+
+	args := []string{"+node-delete", "--whiteboard-token", "test-board", "--node-ids", "nodeA,nodeB"}
+	if err := runUpdateShortcut(t, WhiteboardNodeDelete, args, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v\nraw=%s", err, string(stub.CapturedBody))
+	}
+	ids, ok := body["ids"].([]interface{})
+	if !ok || len(ids) != 2 {
+		t.Fatalf("body.ids = %#v, want two ids; body=%s", body["ids"], string(stub.CapturedBody))
+	}
+	if ids[0] != "nodeA" || ids[1] != "nodeB" {
+		t.Fatalf("body.ids = %#v, want [nodeA nodeB]", ids)
+	}
+	if !strings.Contains(stdout.String(), `"ids": "nodeA,nodeB"`) {
+		t.Fatalf("stdout=%s, want ids nodeA,nodeB", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeDeleteExecute_RejectsNonObjectSuccessResponse(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method:  "DELETE",
+		URL:     "/open-apis/board/v1/whiteboards/test-board/nodes/batch_delete",
+		RawBody: []byte("[]"),
+	})
+
+	args := []string{"+node-delete", "--whiteboard-token", "test-board", "--node-ids", "nodeA"}
+	err := runUpdateShortcut(t, WhiteboardNodeDelete, args, factory, stdout)
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error type = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+	}
+	if strings.Contains(stdout.String(), "success") {
+		t.Fatalf("stdout=%s, must not report success", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeDeleteExecute_PreservesIdempotentToken(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	const token = "         x"
+	var capturedToken string
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes/batch_delete",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{},
+		},
+		OnMatch: func(req *http.Request) {
+			capturedToken = req.URL.Query().Get("client_token")
+		},
+	})
+
+	args := []string{"+node-delete", "--whiteboard-token", "test-board", "--node-ids", "nodeA", "--idempotent-token", token}
+	if err := runUpdateShortcut(t, WhiteboardNodeDelete, args, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if capturedToken != token {
+		t.Fatalf("client_token = %q, want %q", capturedToken, token)
+	}
+}

--- a/shortcuts/whiteboard/whiteboard_node_update.go
+++ b/shortcuts/whiteboard/whiteboard_node_update.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var wbNodeUpdateScopes = []string{"board:whiteboard:node:update"}
+var wbNodeUpdateAuthTypes = []string{"user", "bot"}
+var wbNodeUpdateFlags = []common.Flag{
+	{Name: "whiteboard-token", Desc: "whiteboard token of the whiteboard to update nodes in. You need edit permission on the whiteboard.", Required: true},
+	{Name: "source", Desc: `JSON payload containing a non-empty "nodes" array. Each node must include non-empty string "id" and "type" fields; for tolerance, unnormalized raw export/query responses with "data.nodes" are accepted, envelope fields are dropped, and valid WhiteboardNode fields are kept before calling batch_update.`, Required: true, Input: []string{common.Stdin, common.File}},
+	{Name: "idempotent-token", Desc: "idempotent token to make batch update requests retry-safe. Default is empty. Minimum length is 10.", Required: false},
+}
+
+func wbNodeUpdateValidate(_ context.Context, runtime *common.RuntimeContext) error {
+	if err := common.RejectDangerousCharsTyped("--whiteboard-token", runtime.Str("whiteboard-token")); err != nil {
+		return err
+	}
+	if err := validateOptionalWhiteboardNodeIdempotentToken(runtime.Str("idempotent-token")); err != nil {
+		return err
+	}
+	_, err := parseWhiteboardNodeUpdatePayload([]byte(runtime.Str("source")))
+	return err
+}
+
+func wbNodeUpdateDryRun(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	payload, err := parseWhiteboardNodeUpdatePayload([]byte(runtime.Str("source")))
+	if err != nil {
+		return common.NewDryRunAPI().Desc("parse input failed: " + err.Error())
+	}
+
+	dry := common.NewDryRunAPI().
+		PUT(wbNodeBatchUpdateDryRunURL(runtime.Str("whiteboard-token"))).
+		Body(whiteboardNodeBatchUpdateBody(payload)).
+		Desc("batch update nodes in the whiteboard.")
+	if params := wbNodeUpdateParams(runtime); len(params) > 0 {
+		dry.Params(params)
+	}
+	return dry
+}
+
+func wbNodeUpdateExecute(ctx context.Context, runtime *common.RuntimeContext) error {
+	payload, err := parseWhiteboardNodeUpdatePayload([]byte(runtime.Str("source")))
+	if err != nil {
+		return err
+	}
+
+	data, err := runtime.CallAPITyped(
+		http.MethodPut,
+		wbNodeBatchUpdateURL(runtime.Str("whiteboard-token")),
+		wbNodeUpdateParams(runtime),
+		whiteboardNodeBatchUpdateBody(payload),
+	)
+	if err != nil {
+		return err
+	}
+	updatedNodeIDs, err := whiteboardNodeUpdateIDs(data)
+	if err != nil {
+		return err
+	}
+
+	outData := map[string]interface{}{
+		"ids":   strings.Join(updatedNodeIDs, ","),
+		"count": len(updatedNodeIDs),
+	}
+	runtime.OutFormat(outData, nil, func(w io.Writer) {
+		fmt.Fprintf(w, "%d nodes updated.\n", len(updatedNodeIDs))
+		fmt.Fprintf(w, "Update whiteboard nodes success")
+	})
+	return nil
+}
+
+func parseWhiteboardNodeUpdatePayload(raw []byte) (whiteboardNodeBatchPayload, error) {
+	payload, err := parseWhiteboardNodeBatchPayload(raw, true)
+	if err != nil {
+		return whiteboardNodeBatchPayload{}, err
+	}
+	for i, node := range payload.Nodes {
+		nodeType, ok := node["type"].(string)
+		if ok && strings.TrimSpace(nodeType) != "" {
+			continue
+		}
+		name := fmt.Sprintf("nodes[%d].type", i)
+		return whiteboardNodeBatchPayload{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument, "%s must be a non-empty string", name,
+		).WithParam("--source").WithParams(errs.InvalidParam{
+			Name:   name,
+			Reason: "required by the current whiteboard.node gateway schema",
+		})
+	}
+	return payload, nil
+}
+
+func wbNodeBatchUpdateURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/batch_update", url.PathEscape(token))
+}
+
+func wbNodeBatchUpdateDryRunURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/batch_update", common.MaskToken(url.PathEscape(token)))
+}
+
+func wbNodeUpdateParams(runtime *common.RuntimeContext) map[string]interface{} {
+	params := map[string]interface{}{}
+	if token := runtime.Str("idempotent-token"); token != "" {
+		params["client_token"] = token
+	}
+	return params
+}
+
+func whiteboardNodeBatchUpdateBody(payload whiteboardNodeBatchPayload) map[string]interface{} {
+	return map[string]interface{}{"nodes": sanitizeWhiteboardNodeUpdateNodes(payload.Nodes)}
+}
+
+func whiteboardNodeUpdateIDs(data map[string]interface{}) ([]string, error) {
+	switch raw := data["ids"].(type) {
+	case nil:
+		return nil, wbInvalidResponse("update whiteboard nodes failed: data.ids must be a non-empty array of strings")
+	case []interface{}:
+		if len(raw) == 0 {
+			return nil, wbInvalidResponse("update whiteboard nodes failed: data.ids must be a non-empty array of strings")
+		}
+		out := make([]string, 0, len(raw))
+		for i, value := range raw {
+			id, ok := value.(string)
+			if !ok {
+				return nil, wbInvalidResponse("update whiteboard nodes failed: data.ids[%d] must be a string", i)
+			}
+			out = append(out, id)
+		}
+		return out, nil
+	case []string:
+		if len(raw) == 0 {
+			return nil, wbInvalidResponse("update whiteboard nodes failed: data.ids must be a non-empty array of strings")
+		}
+		return append([]string(nil), raw...), nil
+	default:
+		return nil, wbInvalidResponse("update whiteboard nodes failed: data.ids must be an array of strings")
+	}
+}
+
+// WhiteboardNodeUpdate registers the `whiteboard +node-update` shortcut.
+var WhiteboardNodeUpdate = common.Shortcut{
+	Service:     "whiteboard",
+	Command:     "+node-update",
+	Description: "Update nodes in an existing whiteboard.",
+	Risk:        "write",
+	Scopes:      wbNodeUpdateScopes,
+	AuthTypes:   wbNodeUpdateAuthTypes,
+	Flags:       wbNodeUpdateFlags,
+	Tips: []string{
+		`Prefer --source JSON with a non-empty top-level "nodes" array; each node must include non-empty string "id" and "type" fields.`,
+		`Execution sends one whiteboard.node batch_update request and preserves fields that belong to the WhiteboardNode contract.`,
+		`Unnormalized raw export/query responses are tolerated for robustness; response-only or internal extra fields are omitted from the update body.`,
+		`Use --idempotent-token for retry-safe batch_update requests; the token is sent as client_token only when provided.`,
+	},
+	Validate: wbNodeUpdateValidate,
+	DryRun:   wbNodeUpdateDryRun,
+	Execute:  wbNodeUpdateExecute,
+}

--- a/shortcuts/whiteboard/whiteboard_node_update_schema.go
+++ b/shortcuts/whiteboard/whiteboard_node_update_schema.go
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+type whiteboardNodeUpdateSchema map[string]whiteboardNodeUpdateSchema
+
+var wbNodeUpdatePointSchema = whiteboardNodeUpdateSchema{
+	"x": nil,
+	"y": nil,
+}
+
+var wbNodeUpdateRichTextElementTextStyleSchema = whiteboardNodeUpdateSchema{
+	"font_weight":                nil,
+	"font_size":                  nil,
+	"text_color":                 nil,
+	"text_background_color":      nil,
+	"line_through":               nil,
+	"underline":                  nil,
+	"italic":                     nil,
+	"dark_text_color":            nil,
+	"dark_text_background_color": nil,
+}
+
+var wbNodeUpdateRichTextElementTextSchema = whiteboardNodeUpdateSchema{
+	"text":       nil,
+	"text_style": wbNodeUpdateRichTextElementTextStyleSchema,
+}
+
+var wbNodeUpdateRichTextElementLinkSchema = whiteboardNodeUpdateSchema{
+	"herf":       nil,
+	"text":       nil,
+	"text_style": wbNodeUpdateRichTextElementTextStyleSchema,
+}
+
+var wbNodeUpdateRichTextElementMentionDocSchema = whiteboardNodeUpdateSchema{
+	"doc_url":    nil,
+	"text_style": wbNodeUpdateRichTextElementTextStyleSchema,
+}
+
+var wbNodeUpdateRichTextElementMentionUserSchema = whiteboardNodeUpdateSchema{
+	"user_id":    nil,
+	"text_style": wbNodeUpdateRichTextElementTextStyleSchema,
+}
+
+var wbNodeUpdateRichTextElementSchema = whiteboardNodeUpdateSchema{
+	"element_type":         nil,
+	"text_element":         wbNodeUpdateRichTextElementTextSchema,
+	"link_element":         wbNodeUpdateRichTextElementLinkSchema,
+	"mention_user_element": wbNodeUpdateRichTextElementMentionUserSchema,
+	"mention_doc_element":  wbNodeUpdateRichTextElementMentionDocSchema,
+}
+
+var wbNodeUpdateRichTextParagraphSchema = whiteboardNodeUpdateSchema{
+	"paragraph_type":   nil,
+	"elements":         wbNodeUpdateRichTextElementSchema,
+	"indent":           nil,
+	"list_begin_index": nil,
+	"quote":            nil,
+}
+
+var wbNodeUpdateRichTextSchema = whiteboardNodeUpdateSchema{
+	"paragraphs": wbNodeUpdateRichTextParagraphSchema,
+}
+
+var wbNodeUpdateTextSchema = whiteboardNodeUpdateSchema{
+	"text":                                  nil,
+	"font_weight":                           nil,
+	"font_size":                             nil,
+	"horizontal_align":                      nil,
+	"vertical_align":                        nil,
+	"text_color":                            nil,
+	"text_background_color":                 nil,
+	"line_through":                          nil,
+	"underline":                             nil,
+	"italic":                                nil,
+	"angle":                                 nil,
+	"theme_text_color_code":                 nil,
+	"theme_text_background_color_code":      nil,
+	"rich_text":                             wbNodeUpdateRichTextSchema,
+	"text_color_type":                       nil,
+	"text_background_color_type":            nil,
+	"dark_text_color":                       nil,
+	"dark_text_background_color":            nil,
+	"dark_theme_text_color_code":            nil,
+	"dark_theme_text_background_color_code": nil,
+}
+
+var wbNodeUpdateBorderRadiusSchema = whiteboardNodeUpdateSchema{
+	"top_left":     nil,
+	"top_right":    nil,
+	"bottom_right": nil,
+	"bottom_left":  nil,
+}
+
+var wbNodeUpdateShadowSchema = whiteboardNodeUpdateSchema{
+	"color":    nil,
+	"blur":     nil,
+	"offset_x": nil,
+	"offset_y": nil,
+	"opacity":  nil,
+}
+
+var wbNodeUpdateGradientStopSchema = whiteboardNodeUpdateSchema{
+	"position": nil,
+	"color":    nil,
+}
+
+var wbNodeUpdateFillGradientSchema = whiteboardNodeUpdateSchema{
+	"type":             nil,
+	"handle_positions": wbNodeUpdatePointSchema,
+	"stops":            wbNodeUpdateGradientStopSchema,
+}
+
+var wbNodeUpdateStyleSchema = whiteboardNodeUpdateSchema{
+	"fill_color":                   nil,
+	"fill_opacity":                 nil,
+	"border_width":                 nil,
+	"border_color":                 nil,
+	"border_opacity":               nil,
+	"h_flip":                       nil,
+	"v_flip":                       nil,
+	"border_style":                 nil,
+	"theme_fill_color_code":        nil,
+	"theme_border_color_code":      nil,
+	"fill_color_type":              nil,
+	"border_color_type":            nil,
+	"dark_fill_color":              nil,
+	"dark_border_color":            nil,
+	"dark_theme_fill_color_code":   nil,
+	"dark_theme_border_color_code": nil,
+	"border_dasharrays":            nil,
+	"border_radius":                wbNodeUpdateBorderRadiusSchema,
+	"shadow":                       wbNodeUpdateShadowSchema,
+	"inner_shadow":                 wbNodeUpdateShadowSchema,
+	"fill_gradient":                wbNodeUpdateFillGradientSchema,
+}
+
+var wbNodeUpdatePieSchema = whiteboardNodeUpdateSchema{
+	"start_radial_line_angle": nil,
+	"central_angle":           nil,
+	"radius":                  nil,
+	"sector_ratio":            nil,
+}
+
+var wbNodeUpdateTrapezoidSchema = whiteboardNodeUpdateSchema{
+	"top_length": nil,
+}
+
+var wbNodeUpdateCubeSchema = whiteboardNodeUpdateSchema{
+	"control_point": wbNodeUpdatePointSchema,
+}
+
+var wbNodeUpdateCompositeShapeSchema = whiteboardNodeUpdateSchema{
+	"type":          nil,
+	"pie":           wbNodeUpdatePieSchema,
+	"circular_ring": wbNodeUpdatePieSchema,
+	"trapezoid":     wbNodeUpdateTrapezoidSchema,
+	"cube":          wbNodeUpdateCubeSchema,
+}
+
+var wbNodeUpdateConnectorAttachedObjectSchema = whiteboardNodeUpdateSchema{
+	"id":       nil,
+	"snap_to":  nil,
+	"position": wbNodeUpdatePointSchema,
+}
+
+var wbNodeUpdateConnectorCaptionSchema = whiteboardNodeUpdateSchema{
+	"data": wbNodeUpdateTextSchema,
+}
+
+var wbNodeUpdateConnectorInfoSchema = whiteboardNodeUpdateSchema{
+	"attached_object": wbNodeUpdateConnectorAttachedObjectSchema,
+	"position":        wbNodeUpdatePointSchema,
+	"arrow_style":     nil,
+}
+
+var wbNodeUpdateConnectorSchema = whiteboardNodeUpdateSchema{
+	"start_object":           wbNodeUpdateConnectorAttachedObjectSchema,
+	"end_object":             wbNodeUpdateConnectorAttachedObjectSchema,
+	"captions":               wbNodeUpdateConnectorCaptionSchema,
+	"shape":                  nil,
+	"turning_points":         wbNodeUpdatePointSchema,
+	"start":                  wbNodeUpdateConnectorInfoSchema,
+	"end":                    wbNodeUpdateConnectorInfoSchema,
+	"caption_auto_direction": nil,
+	"caption_position":       nil,
+	"specified_coordinate":   nil,
+	"caption_position_type":  nil,
+}
+
+var wbNodeUpdateImageSchema = whiteboardNodeUpdateSchema{
+	"token": nil,
+}
+
+var wbNodeUpdateLifelineSchema = whiteboardNodeUpdateSchema{
+	"size": nil,
+	"type": nil,
+}
+
+var wbNodeUpdateMindMapSchema = whiteboardNodeUpdateSchema{
+	"parent_id": nil,
+}
+
+var wbNodeUpdateMindMapNodeSchema = whiteboardNodeUpdateSchema{
+	"parent_id":       nil,
+	"type":            nil,
+	"z_index":         nil,
+	"layout_position": nil,
+	"children":        nil,
+	"collapsed":       nil,
+}
+
+var wbNodeUpdateMindMapRootSchema = whiteboardNodeUpdateSchema{
+	"layout":         nil,
+	"type":           nil,
+	"line_style":     nil,
+	"up_children":    nil,
+	"down_children":  nil,
+	"left_children":  nil,
+	"right_children": nil,
+}
+
+var wbNodeUpdatePaintSchema = whiteboardNodeUpdateSchema{
+	"type":  nil,
+	"lines": wbNodeUpdatePointSchema,
+	"width": nil,
+	"color": nil,
+}
+
+var wbNodeUpdateSectionSchema = whiteboardNodeUpdateSchema{
+	"title": nil,
+}
+
+var wbNodeUpdateStickyNoteSchema = whiteboardNodeUpdateSchema{
+	"user_id":          nil,
+	"show_author_info": nil,
+}
+
+var wbNodeUpdateSvgSchema = whiteboardNodeUpdateSchema{
+	"svg_code": nil,
+	"key":      nil,
+	"type":     nil,
+}
+
+var wbNodeUpdateTableCellMergeInfoSchema = whiteboardNodeUpdateSchema{
+	"row_span": nil,
+	"col_span": nil,
+}
+
+var wbNodeUpdateTableCellSchema = whiteboardNodeUpdateSchema{
+	"row_index":  nil,
+	"col_index":  nil,
+	"merge_info": wbNodeUpdateTableCellMergeInfoSchema,
+	"children":   nil,
+	"text":       wbNodeUpdateTextSchema,
+	"style":      wbNodeUpdateStyleSchema,
+}
+
+var wbNodeUpdateTableMetaSchema = whiteboardNodeUpdateSchema{
+	"row_num":   nil,
+	"col_num":   nil,
+	"style":     wbNodeUpdateStyleSchema,
+	"text":      wbNodeUpdateTextSchema,
+	"row_sizes": nil,
+	"col_sizes": nil,
+}
+
+var wbNodeUpdateTableSchema = whiteboardNodeUpdateSchema{
+	"meta":  wbNodeUpdateTableMetaSchema,
+	"title": nil,
+	"cells": wbNodeUpdateTableCellSchema,
+}
+
+var wbNodeUpdateSyntaxSchema = whiteboardNodeUpdateSchema{
+	"syntax_type": nil,
+	"code":        nil,
+	"style_type":  nil,
+}
+
+var wbNodeUpdateSchema = whiteboardNodeUpdateSchema{
+	"id":              nil,
+	"type":            nil,
+	"parent_id":       nil,
+	"children":        nil,
+	"x":               nil,
+	"y":               nil,
+	"angle":           nil,
+	"height":          nil,
+	"text":            wbNodeUpdateTextSchema,
+	"style":           wbNodeUpdateStyleSchema,
+	"image":           wbNodeUpdateImageSchema,
+	"composite_shape": wbNodeUpdateCompositeShapeSchema,
+	"connector":       wbNodeUpdateConnectorSchema,
+	"width":           nil,
+	"section":         wbNodeUpdateSectionSchema,
+	"table":           wbNodeUpdateTableSchema,
+	"mind_map":        wbNodeUpdateMindMapSchema,
+	"locked":          nil,
+	"z_index":         nil,
+	"lifeline":        wbNodeUpdateLifelineSchema,
+	"paint":           wbNodeUpdatePaintSchema,
+	"svg":             wbNodeUpdateSvgSchema,
+	"sticky_note":     wbNodeUpdateStickyNoteSchema,
+	"mind_map_node":   wbNodeUpdateMindMapNodeSchema,
+	"mind_map_root":   wbNodeUpdateMindMapRootSchema,
+	"syntax":          wbNodeUpdateSyntaxSchema,
+}
+
+func sanitizeWhiteboardNodeUpdateNodes(nodes []map[string]interface{}) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(nodes))
+	for _, node := range nodes {
+		out = append(out, sanitizeWhiteboardNodeUpdateObject(node, wbNodeUpdateSchema))
+	}
+	return out
+}
+
+func sanitizeWhiteboardNodeUpdateObject(input map[string]interface{}, schema whiteboardNodeUpdateSchema) map[string]interface{} {
+	out := make(map[string]interface{}, len(input))
+	for key, value := range input {
+		fieldSchema, ok := schema[key]
+		if !ok {
+			continue
+		}
+		out[key] = sanitizeWhiteboardNodeUpdateValue(value, fieldSchema)
+	}
+	return out
+}
+
+func sanitizeWhiteboardNodeUpdateValue(value interface{}, schema whiteboardNodeUpdateSchema) interface{} {
+	if schema == nil {
+		return value
+	}
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return sanitizeWhiteboardNodeUpdateObject(typed, schema)
+	case []interface{}:
+		out := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, sanitizeWhiteboardNodeUpdateValue(item, schema))
+		}
+		return out
+	default:
+		return value
+	}
+}

--- a/shortcuts/whiteboard/whiteboard_node_update_test.go
+++ b/shortcuts/whiteboard/whiteboard_node_update_test.go
@@ -1,0 +1,560 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestWhiteboardNodeUpdateValidate_SourceMissingIDTypedParam(t *testing.T) {
+	t.Parallel()
+
+	rt := newTestRuntime(map[string]string{
+		"whiteboard-token": "test-board",
+		"source":           `{"nodes":[{"type":"text_shape","text":{"text":"hello"}}]}`,
+	}, nil)
+
+	err := wbNodeUpdateValidate(context.Background(), rt)
+	assertValidationParam(t, err, "--source", false)
+}
+
+func TestWhiteboardNodeUpdateDryRun_RequestShape(t *testing.T) {
+	t.Parallel()
+
+	rt := newTestRuntime(map[string]string{
+		"whiteboard-token": "test-board",
+		"idempotent-token": "update-token-12345",
+		"source": `{"nodes":[` +
+			`{"id":"nodeA","type":"future_gateway_type","text":{"text":"hello A"}},` +
+			`{"id":"nodeB","type":"text_shape","text":{"text":"hello B"}}` +
+			`]}`,
+	}, nil)
+
+	dryRun := wbNodeUpdateDryRun(context.Background(), rt)
+	if dryRun == nil {
+		t.Fatal("wbNodeUpdateDryRun() returned nil")
+	}
+
+	var got struct {
+		API []struct {
+			Method string                 `json:"method"`
+			URL    string                 `json:"url"`
+			Params map[string]interface{} `json:"params"`
+			Body   map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	data, err := json.Marshal(dryRun)
+	if err != nil {
+		t.Fatalf("marshal dry-run: %v", err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry-run: %v\njson=%s", err, string(data))
+	}
+	if len(got.API) != 1 {
+		t.Fatalf("api len = %d, want 1; json=%s", len(got.API), string(data))
+	}
+	if got.API[0].Method != "PUT" {
+		t.Fatalf("method = %q, want PUT", got.API[0].Method)
+	}
+	if got.API[0].URL != "/open-apis/board/v1/whiteboards/test...oard/nodes/batch_update" {
+		t.Fatalf("url = %q, want masked batch_update URL", got.API[0].URL)
+	}
+	if got.API[0].Params["client_token"] != "update-token-12345" {
+		t.Fatalf("params.client_token = %#v, want update-token-12345", got.API[0].Params["client_token"])
+	}
+	nodes, ok := got.API[0].Body["nodes"].([]interface{})
+	if !ok || len(nodes) != 2 {
+		t.Fatalf("body.nodes = %#v, want two nodes", got.API[0].Body["nodes"])
+	}
+	wantText := []string{"hello A", "hello B"}
+	for i := range nodes {
+		node, ok := nodes[i].(map[string]interface{})
+		if !ok {
+			t.Fatalf("body.nodes[%d] = %T, want map; nodes=%#v", i, nodes[i], nodes)
+		}
+		if node["id"] != []string{"nodeA", "nodeB"}[i] {
+			t.Fatalf("body.nodes[%d].id = %#v", i, node["id"])
+		}
+		wantType := []string{"future_gateway_type", "text_shape"}[i]
+		if node["type"] != wantType {
+			t.Fatalf("body.nodes[%d].type = %#v, want %q", i, node["type"], wantType)
+		}
+		text, ok := node["text"].(map[string]interface{})
+		if !ok || text["text"] != wantText[i] {
+			t.Fatalf("body.nodes[%d].text = %#v, want text %q", i, node["text"], wantText[i])
+		}
+	}
+}
+
+func TestWhiteboardNodeUpdateExecute_RejectsMissingOrInvalidTypeBeforeHTTP(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "missing", source: `{"nodes":[{"id":"nodeA"}]}`},
+		{name: "empty", source: `{"nodes":[{"id":"nodeA","type":""}]}`},
+		{name: "blank", source: `{"nodes":[{"id":"nodeA","type":"   "}]}`},
+		{name: "non-string", source: `{"nodes":[{"id":"nodeA","type":42}]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, stdout, reg := newUpdateExecuteFactory(t)
+			requestCount := 0
+			reg.Register(&httpmock.Stub{
+				Method:   http.MethodPut,
+				URL:      "/open-apis/board/v1/whiteboards/test-board/nodes/batch_update",
+				Optional: true,
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "success",
+					"data": map[string]interface{}{"ids": []string{"nodeA"}},
+				},
+				OnMatch: func(*http.Request) { requestCount++ },
+			})
+
+			err := runUpdateShortcut(t, WhiteboardNodeUpdate, []string{
+				"+node-update",
+				"--whiteboard-token", "test-board",
+				"--source", tt.source,
+			}, factory, stdout)
+
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error type = %T, want *errs.ValidationError", err)
+			}
+			if validationErr.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("Subtype = %q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+			}
+			if validationErr.Param != "--source" {
+				t.Fatalf("Param = %q, want --source", validationErr.Param)
+			}
+			if len(validationErr.Params) != 1 {
+				t.Fatalf("Params = %#v, want one item", validationErr.Params)
+			}
+			if got, want := validationErr.Params[0].Name, "nodes[0].type"; got != want {
+				t.Fatalf("Params[0].Name = %q, want %q", got, want)
+			}
+			if got, want := validationErr.Params[0].Reason, "required by the current whiteboard.node gateway schema"; got != want {
+				t.Fatalf("Params[0].Reason = %q, want %q", got, want)
+			}
+			if requestCount != 0 {
+				t.Fatalf("HTTP request count = %d, want 0", requestCount)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+		})
+	}
+}
+
+func TestWhiteboardNodeUpdateBody_PreservesV1DataTypeFields(t *testing.T) {
+	t.Parallel()
+
+	payload, err := parseWhiteboardNodeBatchPayload([]byte(`{"nodes":[{
+		"id":"nodeA",
+		"type":"text_shape",
+		"parent_id":"parentA",
+		"x":1,
+		"y":2,
+		"width":100,
+		"height":50,
+		"locked":false,
+		"z_index":3,
+		"children":["childA"],
+		"created_at":123,
+		"unknown_top":{"x":1},
+		"text":{
+			"text":"hello",
+			"content":"legacy alias must not be sent",
+			"font_size":14,
+			"theme_text_color_code":2,
+			"theme_text_background_color_code":3,
+			"text_color_type":1,
+			"text_background_color_type":0,
+			"dark_text_color":"#111111",
+			"dark_text_background_color":"#222222",
+			"dark_theme_text_color_code":4,
+			"dark_theme_text_background_color_code":5,
+			"rich_text":{
+				"paragraphs":[{
+					"paragraph_type":0,
+					"elements":[{
+						"element_type":0,
+						"text_element":{
+							"text":"hello",
+							"text_style":{
+								"font_size":14,
+								"dark_text_color":"#333333",
+								"dark_text_background_color":"#444444",
+								"extra_style":true
+							}
+						},
+						"extra_element":true
+					}],
+					"extra_paragraph":true
+				}],
+				"extra_rich_text":true
+			}
+		},
+		"style":{
+			"fill_color":"#ffffff",
+			"theme_fill_color_code":6,
+			"theme_border_color_code":7,
+			"fill_color_type":1,
+			"border_color_type":0,
+			"dark_fill_color":"#000000",
+			"dark_border_color":"#010101",
+			"dark_theme_fill_color_code":8,
+			"dark_theme_border_color_code":9,
+			"border_dasharrays":[4,2],
+			"border_radius":{"top_left":4,"unexpected":9},
+			"shadow":{"color":"#999999","blur":8,"offset_x":1,"offset_y":2,"opacity":0.5,"extra":1},
+			"fill_gradient":{
+				"type":"linear-gradient",
+				"handle_positions":[{"x":0,"y":0,"extra":1}],
+				"stops":[{"position":0,"color":"#fff","extra":1}]
+			},
+			"extra_style":true
+		},
+		"connector":{
+			"turning_points":[{"x":1,"y":2,"extra":3}],
+			"start_object":{"id":"nodeB","position":{"x":4,"y":5,"extra":6},"extra_object":true},
+			"extra_connector":true
+		},
+		"syntax":{"syntax_type":"svg","code":"<svg/>","style_type":"default","extra_syntax":true}
+	}]}`), true)
+	if err != nil {
+		t.Fatalf("parseWhiteboardNodeBatchPayload() error = %v", err)
+	}
+
+	body := whiteboardNodeBatchUpdateBody(payload)
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	got := string(data)
+	for _, banned := range []string{
+		"created_at",
+		"unknown_top",
+		"content",
+		"extra_style",
+		"extra_rich_text",
+		"extra_paragraph",
+		"extra_element",
+		"unexpected",
+		"extra_connector",
+		"extra_object",
+		"extra_syntax",
+	} {
+		if strings.Contains(got, banned) {
+			t.Fatalf("sanitized body still contains %q: %s", banned, got)
+		}
+	}
+	for _, want := range []string{
+		`"id":"nodeA"`,
+		`"parent_id":"parentA"`,
+		`"text":"hello"`,
+		`"font_size":14`,
+		`"theme_text_color_code":2`,
+		`"theme_text_background_color_code":3`,
+		`"text_color_type":1`,
+		`"text_background_color_type":0`,
+		`"dark_text_color":"#111111"`,
+		`"dark_text_background_color":"#222222"`,
+		`"dark_theme_text_color_code":4`,
+		`"dark_theme_text_background_color_code":5`,
+		`"dark_text_color":"#333333"`,
+		`"dark_text_background_color":"#444444"`,
+		`"theme_fill_color_code":6`,
+		`"theme_border_color_code":7`,
+		`"fill_color_type":1`,
+		`"border_color_type":0`,
+		`"dark_fill_color":"#000000"`,
+		`"dark_border_color":"#010101"`,
+		`"dark_theme_fill_color_code":8`,
+		`"dark_theme_border_color_code":9`,
+		`"border_dasharrays":[4,2]`,
+		`"border_radius":{"top_left":4}`,
+		`"shadow":{"blur":8,"color":"#999999","offset_x":1,"offset_y":2,"opacity":0.5}`,
+		`"fill_gradient"`,
+		`"turning_points":[{"x":1,"y":2}]`,
+		`"syntax":{"code":"\u003csvg/\u003e","style_type":"default","syntax_type":"svg"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("sanitized body missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestWhiteboardNodeUpdateExecute_BatchUpdatesNodes(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	var capturedQuery string
+	stub := &httpmock.Stub{
+		Method: "PUT",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes/batch_update",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"ids": []string{"nodeA", "nodeB"},
+			},
+		},
+		OnMatch: func(req *http.Request) {
+			capturedQuery = req.URL.RawQuery
+		},
+	}
+	reg.Register(stub)
+
+	source := `{"nodes":[` +
+		`{"id":"nodeA","type":"text_shape","text":{"text":"hello A"}},` +
+		`{"id":"nodeB","type":"text_shape","text":{"text":"hello B"}}` +
+		`]}`
+	args := []string{"+node-update", "--whiteboard-token", "test-board", "--source", source, "--idempotent-token", "update-token-12345"}
+	if err := runUpdateShortcut(t, WhiteboardNodeUpdate, args, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+
+	assertNodeBatchUpdateCapturedBody(t, stub.CapturedBody, []string{"hello A", "hello B"})
+	if !strings.Contains(capturedQuery, "client_token=update-token-12345") {
+		t.Fatalf("query = %q, want client_token", capturedQuery)
+	}
+	if !strings.Contains(stdout.String(), `"ids": "nodeA,nodeB"`) {
+		t.Fatalf("stdout=%s, want ids nodeA,nodeB", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"count": 2`) {
+		t.Fatalf("stdout=%s, want count 2", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeUpdateExecute_WithoutIdempotentTokenOmitsClientToken(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	var capturedQuery string
+	stub := &httpmock.Stub{
+		Method: "PUT",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes/batch_update",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"ids": []string{"nodeA"},
+			},
+		},
+		OnMatch: func(req *http.Request) {
+			capturedQuery = req.URL.RawQuery
+		},
+	}
+	reg.Register(stub)
+
+	source := `{"nodes":[{"id":"nodeA","type":"text_shape","text":{"text":"hello A"}}]}`
+	args := []string{"+node-update", "--whiteboard-token", "test-board", "--source", source}
+	if err := runUpdateShortcut(t, WhiteboardNodeUpdate, args, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if capturedQuery != "" {
+		t.Fatalf("query = %q, want empty when --idempotent-token is absent", capturedQuery)
+	}
+}
+
+func TestWhiteboardNodeUpdateExecute_BatchFailureReturnsAPIError(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "PUT",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes/batch_update",
+		Body: map[string]interface{}{
+			"code": 2890002,
+			"msg":  "text color code cannot be empty while type is system [@from@] arg error [@from@] whiteboard",
+			"error": map[string]interface{}{
+				"message":        "Invalid request parameter: text_color_code. Invalid reason : text_color_code is required when text_color_type is system. Please check and modify accordingly.",
+				"log_id":         "whiteboard-log-2890002",
+				"troubleshooter": "https://open.feishu.cn/document/troubleshooter/whiteboard-node",
+			},
+		},
+	})
+
+	source := `{"nodes":[` +
+		`{"id":"nodeA","type":"text_shape","text":{"text":"hello A"}},` +
+		`{"id":"nodeB","type":"text_shape","text":{"text":"hello B"}}` +
+		`]}`
+	args := []string{"+node-update", "--whiteboard-token", "test-board", "--source", source}
+	err := runUpdateShortcut(t, WhiteboardNodeUpdate, args, factory, stdout)
+	if err == nil {
+		t.Fatal("expected batch update failure error, got nil")
+	}
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T: %v, want *errs.APIError reachable via errors.As", err, err)
+	}
+	if apiErr.Category != errs.CategoryAPI || apiErr.Subtype != errs.SubtypeInvalidParameters {
+		t.Fatalf("problem = %+v, want api/invalid_parameters", apiErr.Problem)
+	}
+	if apiErr.Code != 2890002 {
+		t.Fatalf("Code = %d, want 2890002", apiErr.Code)
+	}
+	if apiErr.Message != "text color code cannot be empty while type is system [@from@] arg error [@from@] whiteboard" {
+		t.Fatalf("Message = %q", apiErr.Message)
+	}
+	if apiErr.LogID != "whiteboard-log-2890002" {
+		t.Fatalf("LogID = %q", apiErr.LogID)
+	}
+	if apiErr.Troubleshooter != "https://open.feishu.cn/document/troubleshooter/whiteboard-node" {
+		t.Fatalf("Troubleshooter = %q", apiErr.Troubleshooter)
+	}
+	if got, want := apiErr.Hint, "Invalid request parameter: text_color_code. Invalid reason : text_color_code is required when text_color_type is system. Please check and modify accordingly."; got != want {
+		t.Fatalf("Hint = %q, want %q", got, want)
+	}
+	if !apiErr.HintIsFromServer() {
+		t.Fatal("error.message hint must retain server provenance")
+	}
+	if len(apiErr.FieldViolations) != 0 {
+		t.Fatalf("FieldViolations = %#v, want none in standard OGW envelope", apiErr.FieldViolations)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no success output", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeUpdateExecute_FieldViolationsReturnAPIError(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "PUT",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes/batch_update",
+		Body: map[string]interface{}{
+			"code":   99992402,
+			"msg":    "field validation failed",
+			"log_id": "whiteboard-log-99992402",
+			"error": map[string]interface{}{
+				"field_violations": []interface{}{
+					map[string]interface{}{
+						"field":       "nodes[0].type",
+						"value":       "42",
+						"description": "type must match the node payload",
+					},
+				},
+			},
+		},
+	})
+
+	source := "{\"nodes\":[{\"id\":\"nodeA\",\"type\":\"text_shape\",\"text\":{\"text\":\"hello A\"}}]}"
+	err := runUpdateShortcut(t, WhiteboardNodeUpdate, []string{
+		"+node-update", "--whiteboard-token", "test-board", "--source", source,
+	}, factory, stdout)
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T: %v, want *errs.APIError", err, err)
+	}
+	if apiErr.Code != 99992402 || apiErr.Subtype != errs.SubtypeInvalidParameters {
+		t.Fatalf("problem = %+v, want code 99992402 api/invalid_parameters", apiErr.Problem)
+	}
+	if got, want := apiErr.Hint, "nodes[0].type: type must match the node payload"; got != want {
+		t.Fatalf("Hint = %q, want %q", got, want)
+	}
+	if !apiErr.HintIsFromServer() {
+		t.Fatal("field violation hint must retain server provenance")
+	}
+	if len(apiErr.FieldViolations) != 1 {
+		t.Fatalf("FieldViolations = %#v, want one item", apiErr.FieldViolations)
+	}
+	violation := apiErr.FieldViolations[0]
+	if violation.Field != "nodes[0].type" || violation.Value != "42" || violation.Description != "type must match the node payload" {
+		t.Fatalf("FieldViolations[0] = %#v", violation)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no success output", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeUpdateExecute_RejectsMissingIDs(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "PUT",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/nodes/batch_update",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{},
+		},
+	})
+
+	source := `{"nodes":[{"id":"nodeA","type":"text_shape","text":{"text":"hello A"}}]}`
+	args := []string{"+node-update", "--whiteboard-token", "test-board", "--source", source}
+	err := runUpdateShortcut(t, WhiteboardNodeUpdate, args, factory, stdout)
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error type = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+	}
+	if strings.Contains(stdout.String(), "success") {
+		t.Fatalf("stdout=%s, must not report success", stdout.String())
+	}
+}
+
+func TestWhiteboardNodeUpdateIDs_RejectsEmptyIDs(t *testing.T) {
+	t.Parallel()
+
+	_, err := whiteboardNodeUpdateIDs(map[string]interface{}{"ids": []interface{}{}})
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error type = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+	}
+}
+
+func TestWhiteboardNodeUpdateTips_MentionTemporaryNonAtomicBehavior(t *testing.T) {
+	t.Parallel()
+
+	tips := strings.Join(WhiteboardNodeUpdate.Tips, "\n")
+	for _, want := range []string{"batch_update", "client_token", "one whiteboard.node batch_update request"} {
+		if !strings.Contains(tips, want) {
+			t.Fatalf("tips = %q, want substring %q", tips, want)
+		}
+	}
+	for _, banned := range []string{"fans out", "non-atomic", "Temporary behavior"} {
+		if strings.Contains(tips, banned) {
+			t.Fatalf("tips = %q, should not contain old fan-out wording %q", tips, banned)
+		}
+	}
+}
+
+func assertNodeBatchUpdateCapturedBody(t *testing.T, raw []byte, wantContent []string) {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v\nraw=%s", err, string(raw))
+	}
+	nodes, ok := body["nodes"].([]interface{})
+	if !ok || len(nodes) != len(wantContent) {
+		t.Fatalf("body.nodes = %#v, want %d nodes; body=%s", body["nodes"], len(wantContent), string(raw))
+	}
+	for i, rawNode := range nodes {
+		node, ok := rawNode.(map[string]interface{})
+		if !ok {
+			t.Fatalf("body.nodes[%d] = %T, want map; body=%s", i, rawNode, string(raw))
+		}
+		if _, exists := node["id"]; !exists {
+			t.Fatalf("body.nodes[%d].id absent; body=%s", i, string(raw))
+		}
+		text, ok := node["text"].(map[string]interface{})
+		if !ok || text["text"] != wantContent[i] {
+			t.Fatalf("body.nodes[%d].text = %#v, want text %q; body=%s", i, node["text"], wantContent[i], string(raw))
+		}
+	}
+}

--- a/shortcuts/whiteboard/whiteboard_parse_image.go
+++ b/shortcuts/whiteboard/whiteboard_parse_image.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var wbParseImageScopes = []string{"board:whiteboard:node:create"}
+var wbParseImageAuthTypes = []string{"user"}
+var wbParseImageFlags = []common.Flag{
+	{Name: "whiteboard-token", Desc: "whiteboard token of the target whiteboard. You need edit permission on the whiteboard.", Required: true},
+	{Name: "image", Desc: "local image path to parse into whiteboard content. Supports PNG, JPG, JPEG, GIF, and WEBP. Shorthand: -i.", Required: true},
+	{Name: "overwrite", Desc: "overwrite existing whiteboard content instead of appending. Default is false.", Required: false, Type: "bool"},
+	{Name: "mode", Desc: "Canvas Agent mode. Empty defaults to flash on the server.", Required: false, Enum: []string{parseImageModeMini, parseImageModeFlash, parseImageModeAgentic, parseImageModeAgenticMax}},
+	{Name: "idempotent-token", Desc: "idempotent token for the submit request. Default is a generated UUID. Minimum length is 10 when provided.", Required: false},
+}
+
+func wbParseImageValidate(_ context.Context, runtime *common.RuntimeContext) error {
+	if err := common.RejectDangerousCharsTyped("--whiteboard-token", runtime.Str("whiteboard-token")); err != nil {
+		return err
+	}
+	if err := validateParseImageFilePath(runtime.Str("image")); err != nil {
+		return err
+	}
+	if runtime.Changed("mode") && strings.TrimSpace(runtime.Str("mode")) == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--mode must be one of mini, flash, agentic, agentic_max").
+			WithParam("--mode")
+	}
+	if _, err := normalizeParseImageMode(runtime.Str("mode")); err != nil {
+		return err
+	}
+	_, err := normalizeParseImageIdempotentToken(runtime.Str("idempotent-token"))
+	return err
+}
+
+func wbParseImageDryRun(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	clientToken, err := normalizeParseImageIdempotentToken(runtime.Str("idempotent-token"))
+	if err != nil {
+		return common.NewDryRunAPI().Desc("invalid idempotent token: " + err.Error())
+	}
+	mode, err := normalizeParseImageMode(runtime.Str("mode"))
+	if err != nil {
+		return common.NewDryRunAPI().Desc("invalid mode: " + err.Error())
+	}
+	body := map[string]interface{}{
+		"image_file":   "@" + runtime.Str("image"),
+		"overwrite":    runtime.Bool("overwrite"),
+		"client_token": clientToken,
+	}
+	if mode != "" {
+		body["mode"] = mode
+	}
+	return common.NewDryRunAPI().
+		POST(wbParseImageDryRunURL(runtime.Str("whiteboard-token"))).
+		Body(body).
+		Desc("submit one image for automatic parse and write into the whiteboard.")
+}
+
+func wbParseImageExecute(_ context.Context, runtime *common.RuntimeContext) error {
+	imagePath := runtime.Str("image")
+	clientToken, err := normalizeParseImageIdempotentToken(runtime.Str("idempotent-token"))
+	if err != nil {
+		return err
+	}
+	mode, err := normalizeParseImageMode(runtime.Str("mode"))
+	if err != nil {
+		return err
+	}
+	info, err := runtime.FileIO().Stat(imagePath)
+	if err != nil {
+		return parseImageInputError(err)
+	}
+	formFields := map[string]any{
+		"overwrite":    runtime.Bool("overwrite"),
+		"client_token": clientToken,
+	}
+	if mode != "" {
+		formFields["mode"] = mode
+	}
+	fd, err := cmdutil.BuildFormdata(
+		runtime.FileIO(),
+		"image_file",
+		imagePath,
+		false,
+		nil,
+		formFields,
+	)
+	if err != nil {
+		return parseImageInputError(err)
+	}
+
+	fmt.Fprintf(runtime.IO().ErrOut, "Submitting image for ParseImage: %s (%s)\n", filepath.Base(imagePath), common.FormatSize(info.Size()))
+
+	resp, err := runtime.DoAPI(&larkcore.ApiReq{
+		HttpMethod: "POST",
+		ApiPath:    wbParseImageURL(runtime.Str("whiteboard-token")),
+		Body:       fd,
+	}, larkcore.WithFileUpload())
+	if err != nil {
+		return wrapWbNetworkErr(err, "submit parse image failed: %v", err)
+	}
+	data, err := runtime.ClassifyAPIResponse(resp)
+	if err != nil {
+		return err
+	}
+	taskID := common.GetString(data, "task_id")
+	status := common.GetString(data, "status")
+	if taskID == "" || status == "" {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "parse image submit response missing task_id or status")
+	}
+	out := map[string]interface{}{
+		"task_id":      taskID,
+		"status":       status,
+		"next_command": parseImageResultCommand(runtime.Str("whiteboard-token"), taskID),
+	}
+	runtime.OutFormat(out, nil, func(w io.Writer) {
+		fmt.Fprintf(w, "ParseImage submitted: task_id=%s status=%s\n", taskID, status)
+		fmt.Fprintf(w, "Next: %s", out["next_command"])
+	})
+	return nil
+}
+
+func parseImageResultCommand(whiteboardToken, taskID string) string {
+	return fmt.Sprintf("lark-cli whiteboard +parse-image-result --whiteboard-token %s --task-id %s --as user", whiteboardToken, taskID)
+}
+
+func installParseImageShorthand(cmd *cobra.Command) {
+	cmd.Flags().StringP("image-short", "i", "", "shorthand for --image")
+	_ = cmd.Flags().MarkHidden("image-short")
+	previous := cmd.PreRunE
+	cmd.PreRunE = func(c *cobra.Command, args []string) error {
+		if previous != nil {
+			if err := previous(c, args); err != nil {
+				return err
+			}
+		}
+		if c.Flags().Changed("image-short") && !c.Flags().Changed("image") {
+			value, _ := c.Flags().GetString("image-short")
+			return c.Flags().Set("image", value)
+		}
+		return nil
+	}
+}
+
+// WhiteboardParseImage registers the `whiteboard +parse-image` shortcut.
+var WhiteboardParseImage = common.Shortcut{
+	Service:     "whiteboard",
+	Command:     "+parse-image",
+	Description: "Submit one image for automatic parsing and writing into an existing whiteboard.",
+	Risk:        "write",
+	Scopes:      wbParseImageScopes,
+	AuthTypes:   wbParseImageAuthTypes,
+	Flags:       wbParseImageFlags,
+	Validate:    wbParseImageValidate,
+	DryRun:      wbParseImageDryRun,
+	Execute:     wbParseImageExecute,
+	PostMount:   installParseImageShorthand,
+}

--- a/shortcuts/whiteboard/whiteboard_parse_image_common.go
+++ b/shortcuts/whiteboard/whiteboard_parse_image_common.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const (
+	defaultParseImageResultTimeout  = 20 * time.Minute
+	defaultParseImageResultInterval = 10 * time.Second
+)
+
+var wbParseImageExts = map[string]bool{
+	".png":  true,
+	".jpg":  true,
+	".jpeg": true,
+	".gif":  true,
+	".webp": true,
+}
+
+const (
+	parseImageModeMini       = "mini"
+	parseImageModeFlash      = "flash"
+	parseImageModeAgentic    = "agentic"
+	parseImageModeAgenticMax = "agentic_max"
+)
+
+func wbParseImageURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/parse_image", url.PathEscape(token))
+}
+
+func wbParseImageDryRunURL(token string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/parse_image", common.MaskToken(url.PathEscape(token)))
+}
+
+func wbParseImageResultURL(token, taskID string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/parse_image/%s", url.PathEscape(token), url.PathEscape(taskID))
+}
+
+func wbParseImageResultDryRunURL(token, taskID string) string {
+	return fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/parse_image/%s", common.MaskToken(url.PathEscape(token)), url.PathEscape(taskID))
+}
+
+func validateParseImageFilePath(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--image is required").WithParam("--image")
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	if !wbParseImageExts[ext] {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--image must be an image (supported: PNG, JPG, JPEG, GIF, WEBP), got %q", ext).
+			WithParam("--image")
+	}
+	return nil
+}
+
+func normalizeParseImageIdempotentToken(raw string) (string, error) {
+	token := strings.TrimSpace(raw)
+	if err := common.RejectDangerousCharsTyped("--idempotent-token", token); err != nil {
+		return "", err
+	}
+	if token != "" && len(token) < 10 {
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--idempotent-token must be at least 10 characters long.").
+			WithParam("--idempotent-token")
+	}
+	if token == "" {
+		token = uuid.NewString()
+	}
+	return token, nil
+}
+
+func normalizeParseImageMode(raw string) (string, error) {
+	mode := strings.TrimSpace(raw)
+	switch mode {
+	case "", parseImageModeMini, parseImageModeFlash, parseImageModeAgentic, parseImageModeAgenticMax:
+		return mode, nil
+	default:
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--mode must be one of mini, flash, agentic, agentic_max").
+			WithParam("--mode")
+	}
+}
+
+func validateParseImageTaskID(taskID string) error {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--task-id is required").WithParam("--task-id")
+	}
+	parsed, err := strconv.ParseInt(taskID, 10, 64)
+	if err != nil || parsed <= 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--task-id must be a positive integer").
+			WithParam("--task-id")
+	}
+	return nil
+}
+
+func parsePositiveDuration(raw, flag string) (time.Duration, error) {
+	d, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil || d <= 0 {
+		return 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s must be a positive duration such as 10s or 20m", flag).
+			WithParam(flag)
+	}
+	return d, nil
+}
+
+func parseImageInputError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, fileio.ErrPathValidation) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe --image path: %s", err).
+			WithParam("--image").
+			WithCause(err)
+	}
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, "cannot read --image: %s", err).
+		WithParam("--image").
+		WithCause(err)
+}

--- a/shortcuts/whiteboard/whiteboard_parse_image_result.go
+++ b/shortcuts/whiteboard/whiteboard_parse_image_result.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var wbParseImageResultScopes = []string{"board:whiteboard:node:read"}
+var wbParseImageResultAuthTypes = []string{"user"}
+var wbParseImageResultFlags = []common.Flag{
+	{Name: "whiteboard-token", Desc: "whiteboard token used when the parse-image task was submitted.", Required: true},
+	{Name: "task-id", Desc: "task ID returned by whiteboard +parse-image.", Required: true},
+	{Name: "wait", Desc: "poll until the task succeeds or timeout is reached. Default is false.", Required: false, Type: "bool"},
+	{Name: "timeout", Desc: "maximum wait duration when --wait is set. Default is 20m.", Required: false, Default: "20m"},
+	{Name: "interval", Desc: "poll interval when --wait is set. Default is 10s.", Required: false, Default: "10s"},
+}
+
+func wbParseImageResultValidate(_ context.Context, runtime *common.RuntimeContext) error {
+	if err := common.RejectDangerousCharsTyped("--whiteboard-token", runtime.Str("whiteboard-token")); err != nil {
+		return err
+	}
+	if err := common.RejectDangerousCharsTyped("--task-id", runtime.Str("task-id")); err != nil {
+		return err
+	}
+	if err := validateParseImageTaskID(runtime.Str("task-id")); err != nil {
+		return err
+	}
+	if _, err := parsePositiveDuration(runtime.Str("timeout"), "--timeout"); err != nil {
+		return err
+	}
+	if _, err := parsePositiveDuration(runtime.Str("interval"), "--interval"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func wbParseImageResultDryRun(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	return common.NewDryRunAPI().
+		GET(wbParseImageResultDryRunURL(runtime.Str("whiteboard-token"), runtime.Str("task-id"))).
+		Desc("query ParseImage task result for the whiteboard.")
+}
+
+func wbParseImageResultExecute(ctx context.Context, runtime *common.RuntimeContext) error {
+	timeout, err := parsePositiveDuration(runtime.Str("timeout"), "--timeout")
+	if err != nil {
+		return err
+	}
+	interval, err := parsePositiveDuration(runtime.Str("interval"), "--interval")
+	if err != nil {
+		return err
+	}
+	if !runtime.Bool("wait") {
+		data, err := queryParseImageResult(runtime)
+		if err != nil {
+			return err
+		}
+		outputParseImageResult(runtime, data)
+		return nil
+	}
+	return waitParseImageResult(ctx, runtime, timeout, interval)
+}
+
+func queryParseImageResult(runtime *common.RuntimeContext) (map[string]interface{}, error) {
+	return runtime.CallAPITyped(
+		"GET",
+		wbParseImageResultURL(runtime.Str("whiteboard-token"), runtime.Str("task-id")),
+		nil,
+		nil,
+	)
+}
+
+func waitParseImageResult(ctx context.Context, runtime *common.RuntimeContext, timeout, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		data, err := queryParseImageResult(runtime)
+		if err != nil {
+			return err
+		}
+		status := common.GetString(data, "status")
+		switch status {
+		case "succeeded":
+			outputParseImageResult(runtime, data)
+			return nil
+		case "pending", "running":
+			if time.Now().Add(interval).After(deadline) {
+				return errs.NewNetworkError(errs.SubtypeNetworkTimeout, "timed out waiting for ParseImage task %s after %s", runtime.Str("task-id"), timeout).
+					WithRetryable().
+					WithHint("retry status lookup with: %s", parseImageResultCommand(runtime.Str("whiteboard-token"), runtime.Str("task-id")))
+			}
+			select {
+			case <-ctx.Done():
+				return errs.NewNetworkError(errs.SubtypeNetworkTimeout, "cancelled while waiting for ParseImage task %s", runtime.Str("task-id")).
+					WithCause(ctx.Err()).
+					WithRetryable().
+					WithHint("retry status lookup with: %s", parseImageResultCommand(runtime.Str("whiteboard-token"), runtime.Str("task-id")))
+			case <-time.After(interval):
+			}
+		default:
+			outputParseImageResult(runtime, data)
+			return nil
+		}
+	}
+}
+
+func outputParseImageResult(runtime *common.RuntimeContext, data map[string]interface{}) {
+	runtime.OutFormat(data, nil, func(w io.Writer) {
+		fmt.Fprintf(w, "ParseImage task %s status=%s", common.GetString(data, "task_id"), common.GetString(data, "status"))
+	})
+}
+
+// WhiteboardParseImageResult registers the `whiteboard +parse-image-result` shortcut.
+var WhiteboardParseImageResult = common.Shortcut{
+	Service:     "whiteboard",
+	Command:     "+parse-image-result",
+	Description: "Query ParseImage task result for an existing whiteboard.",
+	Risk:        "read",
+	Scopes:      wbParseImageResultScopes,
+	AuthTypes:   wbParseImageResultAuthTypes,
+	Flags:       wbParseImageResultFlags,
+	Validate:    wbParseImageResultValidate,
+	DryRun:      wbParseImageResultDryRun,
+	Execute:     wbParseImageResultExecute,
+}

--- a/shortcuts/whiteboard/whiteboard_parse_image_result_test.go
+++ b/shortcuts/whiteboard/whiteboard_parse_image_result_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func runParseImageResultShortcut(t *testing.T, args []string, factory *cmdutil.Factory, stdout *bytes.Buffer) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "whiteboard"}
+	WhiteboardParseImageResult.Mount(parent, factory)
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if stdout != nil {
+		stdout.Reset()
+	}
+	return parent.Execute()
+}
+
+func TestWhiteboardParseImageResultDryRun_RequestShape(t *testing.T) {
+	factory, stdout, _ := parseImageTestFactory(t)
+
+	err := runParseImageResultShortcut(t, []string{
+		"+parse-image-result",
+		"--whiteboard-token", "test-board",
+		"--task-id", "7670001",
+		"--dry-run",
+		"--as", "user",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "GET") {
+		t.Fatalf("dry-run output should contain GET, got: %s", out)
+	}
+	if !strings.Contains(out, "/open-apis/board/v1/whiteboards/test...oard/parse_image/7670001") {
+		t.Fatalf("dry-run output should contain masked parse_image result URL, got: %s", out)
+	}
+}
+
+func TestWhiteboardParseImageResultExecute_OutputsSucceededResult(t *testing.T) {
+	factory, stdout, reg := parseImageTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/parse_image/7670001",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"task_id":           "7670001",
+				"status":            "succeeded",
+				"ids":               []string{"o1:abc", "o1:def"},
+				"extra":             map[string]interface{}{"connector": []string{"o1:def"}},
+				"previous_revision": "128",
+			},
+		},
+	})
+
+	err := runParseImageResultShortcut(t, []string{
+		"+parse-image-result",
+		"--whiteboard-token", "test-board",
+		"--task-id", "7670001",
+		"--as", "user",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeParseImageEnvelope(t, stdout)
+	if data["task_id"] != "7670001" || data["status"] != "succeeded" || data["previous_revision"] != "128" {
+		t.Fatalf("unexpected output data: %#v", data)
+	}
+	ids, ok := data["ids"].([]interface{})
+	if !ok || len(ids) != 2 {
+		t.Fatalf("ids = %#v, want two ids", data["ids"])
+	}
+}
+
+func TestWhiteboardParseImageResultWaitPollsUntilSucceeded(t *testing.T) {
+	factory, stdout, reg := parseImageTestFactory(t)
+	running := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/parse_image/7670001",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"task_id": "7670001",
+				"status":  "running",
+			},
+		},
+	}
+	success := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/parse_image/7670001",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"task_id":           "7670001",
+				"status":            "succeeded",
+				"ids":               []string{"o1:abc"},
+				"previous_revision": "129",
+			},
+		},
+	}
+	reg.Register(running)
+	reg.Register(success)
+
+	err := runParseImageResultShortcut(t, []string{
+		"+parse-image-result",
+		"--whiteboard-token", "test-board",
+		"--task-id", "7670001",
+		"--wait",
+		"--timeout", "2s",
+		"--interval", "1ms",
+		"--as", "user",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeParseImageEnvelope(t, stdout)
+	if data["status"] != "succeeded" || data["previous_revision"] != "129" {
+		t.Fatalf("unexpected output data: %#v", data)
+	}
+	if running.CapturedBody == nil || success.CapturedBody == nil {
+		t.Fatalf("expected one running poll and one success poll")
+	}
+}
+
+func TestWhiteboardParseImageResultValidateRejectsBadTaskID(t *testing.T) {
+	factory, stdout, _ := parseImageTestFactory(t)
+	err := runParseImageResultShortcut(t, []string{
+		"+parse-image-result",
+		"--whiteboard-token", "test-board",
+		"--task-id", "not-a-number",
+		"--as", "user",
+	}, factory, stdout)
+	assertValidationParam(t, err, "--task-id", false)
+}
+
+func TestWhiteboardParseImageResultWaitTimeoutReturnsTypedError(t *testing.T) {
+	factory, stdout, reg := parseImageTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/board/v1/whiteboards/test-board/parse_image/7670001",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"task_id": "7670001",
+				"status":  "running",
+			},
+		},
+	})
+
+	err := runParseImageResultShortcut(t, []string{
+		"+parse-image-result",
+		"--whiteboard-token", "test-board",
+		"--task-id", "7670001",
+		"--wait",
+		"--timeout", "1ms",
+		"--interval", "1ms",
+		"--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	var networkErr *errs.NetworkError
+	if !errors.As(err, &networkErr) {
+		t.Fatalf("error type = %T, want *errs.NetworkError", err)
+	}
+	if networkErr.Subtype != errs.SubtypeNetworkTimeout {
+		t.Fatalf("Subtype = %q, want %q", networkErr.Subtype, errs.SubtypeNetworkTimeout)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || !strings.Contains(problem.Hint, "+parse-image-result") {
+		t.Fatalf("error hint should contain resumable result command, got problem=%+v err=%v", problem, err)
+	}
+}
+
+func decodeParseImageResultBody(t *testing.T, raw []byte) map[string]interface{} {
+	t.Helper()
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode body: %v\nraw=%s", err, string(raw))
+	}
+	return out
+}

--- a/shortcuts/whiteboard/whiteboard_parse_image_test.go
+++ b/shortcuts/whiteboard/whiteboard_parse_image_test.go
@@ -1,0 +1,322 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"mime"
+	"mime/multipart"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func runParseImageShortcut(t *testing.T, args []string, factory *cmdutil.Factory, stdout *bytes.Buffer) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "whiteboard"}
+	WhiteboardParseImage.Mount(parent, factory)
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if stdout != nil {
+		stdout.Reset()
+	}
+	return parent.Execute()
+}
+
+func parseImageTestFactory(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *httpmock.Registry) {
+	t.Helper()
+	cfg := &core.CliConfig{
+		AppID:      "test-parse-image",
+		AppSecret:  "test-secret",
+		Brand:      core.BrandFeishu,
+		UserOpenId: "ou_testuser",
+	}
+	factory, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+	return factory, stdout, reg
+}
+
+func TestWhiteboardParseImageDryRun_RequestShape(t *testing.T) {
+	factory, stdout, _ := parseImageTestFactory(t)
+
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"--image", "./diagram.png",
+		"--mode", "agentic_max",
+		"--idempotent-token", "parse-token-12345",
+		"--overwrite",
+		"--dry-run",
+		"--as", "user",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "POST") {
+		t.Fatalf("dry-run output should contain POST, got: %s", out)
+	}
+	if !strings.Contains(out, "/open-apis/board/v1/whiteboards/test...oard/parse_image") {
+		t.Fatalf("dry-run output should contain masked parse_image URL, got: %s", out)
+	}
+	if !strings.Contains(out, "image_file") || !strings.Contains(out, "@./diagram.png") {
+		t.Fatalf("dry-run output should describe image_file form upload, got: %s", out)
+	}
+	if !strings.Contains(out, "parse-token-12345") || !strings.Contains(out, "overwrite") || !strings.Contains(out, "agentic_max") {
+		t.Fatalf("dry-run output should include client_token, overwrite, and mode, got: %s", out)
+	}
+}
+
+func TestWhiteboardParseImageDryRun_OmitsModeByDefault(t *testing.T) {
+	factory, stdout, _ := parseImageTestFactory(t)
+
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"--image", "./diagram.png",
+		"--idempotent-token", "parse-token-12345",
+		"--dry-run",
+		"--as", "user",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stdout.String(), `"mode"`) {
+		t.Fatalf("dry-run mode should be omitted when --mode is not provided: %s", stdout.String())
+	}
+}
+
+func TestWhiteboardParseImageExecute_PostsMultipartAndOutputsNextCommand(t *testing.T) {
+	factory, stdout, reg := parseImageTestFactory(t)
+	tmpDir := t.TempDir()
+	cmdutil.TestChdir(t, tmpDir)
+	if err := os.WriteFile("diagram.png", []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 'x'}, 0o644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/parse_image",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"task_id": "7670001",
+				"status":  "pending",
+			},
+		},
+	}
+	reg.Register(stub)
+
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"--image", "./diagram.png",
+		"--mode", "agentic",
+		"--idempotent-token", "parse-token-12345",
+		"--overwrite",
+		"--as", "user",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := decodeParseImageMultipart(t, stub)
+	if got := body.Fields["client_token"]; got != "parse-token-12345" {
+		t.Fatalf("client_token = %q, want parse-token-12345", got)
+	}
+	if got := body.Fields["overwrite"]; got != "true" {
+		t.Fatalf("overwrite = %q, want true", got)
+	}
+	if got := body.Fields["mode"]; got != "agentic" {
+		t.Fatalf("mode = %q, want agentic", got)
+	}
+	if got := string(body.Files["image_file"]); !strings.Contains(got, "PNG") {
+		t.Fatalf("image_file body = %q, want PNG bytes", got)
+	}
+	if got := body.Names["image_file"]; got != "diagram.png" {
+		t.Fatalf("image_file filename = %q, want diagram.png", got)
+	}
+
+	data := decodeParseImageEnvelope(t, stdout)
+	if data["task_id"] != "7670001" || data["status"] != "pending" {
+		t.Fatalf("unexpected output data: %#v", data)
+	}
+	next, _ := data["next_command"].(string)
+	if !strings.Contains(next, "whiteboard +parse-image-result") ||
+		!strings.Contains(next, "--whiteboard-token test-board") ||
+		!strings.Contains(next, "--task-id 7670001") {
+		t.Fatalf("next_command = %q, want parse-image-result resume command", next)
+	}
+}
+
+func TestWhiteboardParseImageExecute_AcceptsImageShorthand(t *testing.T) {
+	factory, stdout, reg := parseImageTestFactory(t)
+	tmpDir := t.TempDir()
+	cmdutil.TestChdir(t, tmpDir)
+	if err := os.WriteFile("diagram.png", []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}, 0o644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/parse_image",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"task_id": "7670002",
+				"status":  "pending",
+			},
+		},
+	}
+	reg.Register(stub)
+
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"-i", "./diagram.png",
+		"--idempotent-token", "parse-token-12345",
+		"--as", "user",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeParseImageEnvelope(t, stdout)
+	if data["task_id"] != "7670002" {
+		t.Fatalf("task_id = %#v, want 7670002", data["task_id"])
+	}
+	body := decodeParseImageMultipart(t, stub)
+	if _, ok := body.Fields["mode"]; ok {
+		t.Fatalf("mode should be omitted when --mode is not provided: %#v", body.Fields)
+	}
+}
+
+func TestWhiteboardParseImageValidateRejectsUnsupportedImage(t *testing.T) {
+	factory, stdout, _ := parseImageTestFactory(t)
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"--image", "./diagram.pdf",
+		"--as", "user",
+	}, factory, stdout)
+	assertValidationParam(t, err, "--image", false)
+}
+
+func TestWhiteboardParseImageValidateRejectsInvalidMode(t *testing.T) {
+	factory, stdout, _ := parseImageTestFactory(t)
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"--image", "./diagram.png",
+		"--mode", "slow",
+		"--as", "user",
+	}, factory, stdout)
+	assertValidationParam(t, err, "--mode", false)
+}
+
+func TestWhiteboardParseImageValidateRejectsExplicitEmptyMode(t *testing.T) {
+	factory, stdout, _ := parseImageTestFactory(t)
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"--image", "./diagram.png",
+		"--mode=",
+		"--as", "user",
+	}, factory, stdout)
+	assertValidationParam(t, err, "--mode", false)
+}
+
+func TestWhiteboardParseImageExecuteRejectsMissingTaskID(t *testing.T) {
+	factory, stdout, reg := parseImageTestFactory(t)
+	tmpDir := t.TempDir()
+	cmdutil.TestChdir(t, tmpDir)
+	if err := os.WriteFile("diagram.png", []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}, 0o644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/board/v1/whiteboards/test-board/parse_image",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := runParseImageShortcut(t, []string{
+		"+parse-image",
+		"--whiteboard-token", "test-board",
+		"--image", "./diagram.png",
+		"--idempotent-token", "parse-token-12345",
+		"--as", "user",
+	}, factory, stdout)
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("error type = %T, want *errs.InternalError", err)
+	}
+	if internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+	}
+}
+
+type capturedParseImageMultipart struct {
+	Fields map[string]string
+	Files  map[string][]byte
+	Names  map[string]string
+}
+
+func decodeParseImageMultipart(t *testing.T, stub *httpmock.Stub) capturedParseImageMultipart {
+	t.Helper()
+	contentType := stub.CapturedHeaders.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse content-type %q: %v", contentType, err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("content type = %q, want multipart/form-data", mediaType)
+	}
+	reader := multipart.NewReader(bytes.NewReader(stub.CapturedBody), params["boundary"])
+	body := capturedParseImageMultipart{Fields: map[string]string{}, Files: map[string][]byte{}, Names: map[string]string{}}
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			break
+		}
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(part); err != nil {
+			t.Fatalf("read multipart part: %v", err)
+		}
+		if part.FileName() != "" {
+			body.Files[part.FormName()] = buf.Bytes()
+			body.Names[part.FormName()] = part.FileName()
+		} else {
+			body.Fields[part.FormName()] = buf.String()
+		}
+	}
+	return body
+}
+
+func decodeParseImageEnvelope(t *testing.T, stdout *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	var envelope struct {
+		OK   bool                   `json:"ok"`
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode stdout envelope: %v\nstdout=%s", err, stdout.String())
+	}
+	if !envelope.OK {
+		t.Fatalf("ok = false, stdout=%s", stdout.String())
+	}
+	return envelope.Data
+}

--- a/skills/lark-whiteboard/SKILL.md
+++ b/skills/lark-whiteboard/SKILL.md
@@ -2,7 +2,7 @@
 name: lark-whiteboard
 version: 1.0.0
 description: >
-  飞书画板：查询和编辑飞书云文档中的画板。支持导出画板为预览图片、导出原始节点结构、使用多种格式更新画板内容。
+  飞书画板：查询和编辑飞书云文档中的画板。支持导出画板为预览图片、导出原始节点结构、使用多种格式更新画板内容，并支持按节点增量创建、更新和删除。
   当用户需要查看画板内容、导出画板图片、编辑画板时使用此 skill。不负责：飞书云文档内容编辑（lark-doc）、文档内嵌电子表格/Base（lark-sheets / lark-base）。
 metadata:
   requires:
@@ -14,42 +14,40 @@ metadata:
 > - 运行 `lark-cli --version`，确认可用，无需询问用户。
 > - 运行 `npx -y @larksuite/whiteboard-cli@^0.2.13 -v`，确认可用，无需询问用户。
 
-**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理**
-
----
+**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理和 `--as user` / `--as bot` 的差异。**
 
 ## 快速决策
 
-**身份**：画板操作默认使用 `--as user`。仅当需要以应用身份上传时使用 `--as bot`。
+路由前必须按顺序完成以下准备：
 
-> 先判断「只读还是写入」，再在对应表内按上到下匹配，**命中即停**。
+1. 用[范围守卫](references/lark-whiteboard-workflow.md#范围守卫)判断用户要操作文档结构还是同一画布；范围不明时先澄清。
+2. 先[拆分复合请求](references/lark-whiteboard-workflow.md#请求原子化)，再逐个原子操作匹配；first-match 只对单个原子操作生效。
+3. 任何写操作都先读取实际 board state；用户声称画板为空只能作为线索。
+4. 按 `lark-shared` 的身份选择原则和目标资源权限选择 `user` 或 `bot`：用户个人空间或以用户权限分享的资源优先 `user`，应用自有、明确授权给应用的资源或 bot-only 环境使用 `bot`。确定后在读取、请求预览、写入和验证中保持同一身份。
 
-### A. 只读 · 查看 / 导出（不改画板）
-
-| 用户需求 | 行动 |
+| 原子目标 | 入口 |
 |---|---|
-| 查看画板内容 / 导出图片 | [`+export --output-type preview`](references/lark-whiteboard-export.md)                       |
-| 导出 SVG 矢量图 | [`+export --output-type svg`](references/lark-whiteboard-export.md)                       |
-| 提取画板的 Mermaid/PlantUML 源码 | [`+export --output-type source`](references/lark-whiteboard-export.md) |
+| 查看、导出、获取源码或原始节点，不改变画板 | `read/export` → [`+export`](references/lark-whiteboard-export.md) |
+| 向已确认的空白画板写入第一批内容 | `initialize` → [创作 Workflow](references/lark-whiteboard-workflow.md#创作-workflow) |
+| 向非空画板只新增内容，不修改既有内容 | `append` → [编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow) |
+| 只修改既有内容 | `patch` → [编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow) |
+| 只删除既有内容 | `delete` → [编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow) |
+| 丢弃非空画板的全部旧内容并写入完整最终状态 | `replace` → [编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow) |
 
-### B. 写入 · 创作 / 编辑（会改画板，命中即停）
-
-| 场景 | 行动 | 写入方式 | 对原内容 |
-|---|---|---|---|
-| 用户**已提供** Mermaid/PlantUML/SVG 代码，或明确指定用该格式 | 使用该代码 → [`+update`](references/lark-whiteboard-update.md)，`--input_format` 取单值 `mermaid` / `plantuml` / `svg`；写入非空已有画板并需要 overwrite 时，先确认会整板重建；若 SVG 用于修改已有画板，先走 [`routes/svg-edit.md`](routes/svg-edit.md) 有损确认 | overwrite / append | 按用户要求 |
-| 从零新建复杂图表（架构/流程/组织等） | → **[§ 创作 Workflow](references/lark-whiteboard-workflow.md#创作-workflow)** | 首次写入 | — |
-| 修改 / 增补已有画板 | → **[§ 编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow)** | 见该表 | 见该表 |
+输入格式、输入是否就绪、目标是否已定位，只能缩小已经选定的操作如何执行，不能成为新的主路由。当前 Shortcut 的可执行边界、确认规则和禁止 fallback 统一由 [Workflow](references/lark-whiteboard-workflow.md) 决定。
 
 ## Shortcuts
 
-| Shortcut                                          | 说明 |
-|---------------------------------------------------|---|
-| [`+export`](references/lark-whiteboard-export.md) | 导出画板为预览图片、SVG 矢量图、代码或原始节点结构。 |
-| [`+update`](references/lark-whiteboard-update.md) | 更新画板，支持 PlantUML、Mermaid、SVG 或 OpenAPI 原生格式 |
-
----
+| Shortcut | 说明 |
+|---|---|
+| [`+export`](references/lark-whiteboard-export.md) | 导出 preview、SVG、代码或原始节点结构。 |
+| [`+update`](references/lark-whiteboard-update.md) | 初始化空白画板、向非空画板追加新内容，或在明确整板替换时覆盖完整内容。 |
+| [`+node-create`](references/lark-whiteboard-node-create.md) | 向已有画板追加已编译的 OpenAPI 节点。 |
+| [`+node-update`](references/lark-whiteboard-node-update.md) | 按精确 node id 批量更新已有节点字段。 |
+| [`+node-delete`](references/lark-whiteboard-node-delete.md) | 按已确认的 node id 删除节点；真实执行需要 `--yes`。 |
 
 ## 不在本 skill 范围
-- 文档内容编辑 → lark-doc [lark-doc](../lark-doc/SKILL.md)
-- 在文档中创建画板 → [lark-doc-whiteboard.md](../lark-doc/references/lark-doc-whiteboard.md)
+
+- 文档内容编辑 → [lark-doc](../lark-doc/SKILL.md)
+- 在文档中创建、插入或移动画板 block → [lark-doc-whiteboard.md](../lark-doc/references/lark-doc-whiteboard.md)
 - 表格 / Base 操作 → [lark-sheets](../lark-sheets/SKILL.md) / [lark-base](../lark-base/SKILL.md)

--- a/skills/lark-whiteboard/SKILL.md
+++ b/skills/lark-whiteboard/SKILL.md
@@ -2,7 +2,7 @@
 name: lark-whiteboard
 version: 1.0.0
 description: >
-  飞书画板：查询和编辑飞书云文档中的画板。支持导出画板为预览图片、导出原始节点结构、使用多种格式更新画板内容，并支持按节点增量创建、更新和删除。
+  飞书画板：查询和编辑飞书云文档中的画板。支持导出画板为预览图片、导出原始节点结构、使用多种格式更新画板内容，按节点增量创建、更新和删除，并支持把本地图片提交给 ParseImage 自动解析写入画板。
   当用户需要查看画板内容、导出画板图片、编辑画板时使用此 skill。不负责：飞书云文档内容编辑（lark-doc）、文档内嵌电子表格/Base（lark-sheets / lark-base）。
 metadata:
   requires:
@@ -33,6 +33,7 @@ metadata:
 | 只修改既有内容 | `patch` → [编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow) |
 | 只删除既有内容 | `delete` → [编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow) |
 | 丢弃非空画板的全部旧内容并写入完整最终状态 | `replace` → [编辑 Workflow](references/lark-whiteboard-workflow.md#编辑-workflow) |
+| 把一张本地图片解析成画板内容并自动写入目标画板 | `parse-image` → [`+parse-image`](references/lark-whiteboard-parse-image.md) |
 
 输入格式、输入是否就绪、目标是否已定位，只能缩小已经选定的操作如何执行，不能成为新的主路由。当前 Shortcut 的可执行边界、确认规则和禁止 fallback 统一由 [Workflow](references/lark-whiteboard-workflow.md) 决定。
 
@@ -45,6 +46,8 @@ metadata:
 | [`+node-create`](references/lark-whiteboard-node-create.md) | 向已有画板追加已编译的 OpenAPI 节点。 |
 | [`+node-update`](references/lark-whiteboard-node-update.md) | 按精确 node id 批量更新已有节点字段。 |
 | [`+node-delete`](references/lark-whiteboard-node-delete.md) | 按已确认的 node id 删除节点；真实执行需要 `--yes`。 |
+| [`+parse-image`](references/lark-whiteboard-parse-image.md) | 提交一张本地图片，由服务端自动解析并写入目标画板。 |
+| [`+parse-image-result`](references/lark-whiteboard-parse-image.md#parse-image-result) | 查询或等待 ParseImage 任务结果。 |
 
 ## 不在本 skill 范围
 

--- a/skills/lark-whiteboard/references/lark-whiteboard-export.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-export.md
@@ -1,6 +1,6 @@
 # whiteboard +export（导出画板）
 
-> **前置条件：** 先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+> **前置条件：** 若本操作链尚未读取 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md)，先读取并确定 `<identity>` 为 `user` 或 `bot`；否则复用已确定身份。以下命令在同一条操作链中保持同一身份。
 
 导出画板内容，支持导出为预览图片、SVG 矢量图、提取 PlantUML/Mermaid 代码，或获取飞书 OpenAPI 原生画板节点格式。
 
@@ -10,16 +10,19 @@
 |----------------------|----|------------------------------------------------------------------------|
 | `--whiteboard-token` | 是  | 画板 token，需要拥有画板的读权限                                                    |
 | `--output-type`      | 是  | 输出格式：`preview`（预览图片）、`svg`（SVG 矢量图）、`source`（PlantUML/Mermaid 代码）、`raw`（OpenAPI 原生画板节点格式） |
-| `--output`           | 否  | 输出路径。当 `--output-type preview` 时必填；当 `--output-type svg/source/raw` 时可选，不填则直接输出到终端 |
+| `--output`           | 否  | 输出路径。当 `--output-type preview` 时必填，推荐传入无后缀路径；当 `--output-type svg/source/raw` 时可选，不填则直接输出到终端 |
 | `--overwrite`        | 否  | 覆盖已存在的文件，默认为 false                                                     |
+
+这里的 `+export --overwrite` 只覆盖 `--output` 指向的本地输出文件，不改变远端画板。它与 [`+update --overwrite`](./lark-whiteboard-update.md#replace非空画板) 的整板替换语义完全不同。
 
 ## 输出格式
 
-- `preview`：预览图片。保存时会根据接口实际返回的 `Content-Type` 决定扩展名，例如 `image/jpeg` 会保存为 `.jpg`。
-- `svg`：导出画板为标准 SVG 矢量图。可用于 SVG 编辑后回写画板（见 [`routes/svg-edit.md`](../routes/svg-edit.md)）。注意：导出为纯视觉快照，思维导图层级、表格结构、连接器绑定等语义信息会丢失。
-- `source`：PlantUML/Mermaid 代码。仅限画板内有且仅有一个 PlantUML/Mermaid 图时，才可导出代码，否则会在返回值中告知不存在/有多个节点。
-- `raw`：飞书 OpenAPI 原生画板节点格式。这一 json 格式不适合直接编辑复杂布局或内容，建议仅限于需要修改简单的文本内容/颜色等细节时使用。需要进行更复杂的设计/修改时，建议参考 [§ 编辑 Workflow](lark-whiteboard-workflow.md#编辑-workflow)。
-  - **需编辑后回写时，导出务必加 `--output <file>` 写入文件**：文件内容可直接作为 `+update` 的输入；直接输出到终端的结果会多一层 `{ ok, identity, data }` 包装，`+update` 无法解析。
+- `preview`：预览图片。用于查看当前画布视觉状态、布局和写后效果。推荐使用 `--output ./preview` 这类无后缀路径；CLI 会根据实际 `Content-Type` 补齐 `.png` 或 `.jpg`。
+- `svg`：标准 SVG 矢量图。用于离线查看、视觉对比或本地视觉证据。它是纯视觉快照，不代表原生节点语义；思维导图层级、表格结构、连接器绑定等信息不能从 SVG 中可靠恢复。
+- `source`：PlantUML/Mermaid 代码。仅限画板内有且仅有一个 PlantUML/Mermaid 图时，才可导出代码；否则返回值会说明不存在源码或存在多个源码节点。
+- `raw`：飞书 OpenAPI 原生画板节点格式。用于读取 board state、定位 `data.nodes[].id`、核对节点字段和作为写入前事实依据。`raw` 导出本身不代表写入语义；不要把完整导出快照手改后交给 `+update raw` 声称局部修改，因为 `+update raw` 会创建新节点并重新分配 ID。
+
+导出只负责读取和保存当前状态。后续 append、patch、delete 或 replace 的写入语义见 [Workflow](./lark-whiteboard-workflow.md)。
 
 ## 示例
 
@@ -29,7 +32,8 @@
 lark-cli whiteboard +export \
   --whiteboard-token "wbcnxxxxxxxx" \
   --output-type preview \
-  --output ./preview
+  --output ./preview \
+  --as <identity>
 ```
 
 ### 示例 2：提取画板中的代码并直接输出
@@ -37,7 +41,8 @@ lark-cli whiteboard +export \
 ```bash
 lark-cli whiteboard +export \
   --whiteboard-token "wbcnxxxxxxxx" \
-  --output-type source
+  --output-type source \
+  --as <identity>
 ```
 
 ### 示例 3：导出画板为 SVG 矢量图
@@ -47,7 +52,7 @@ lark-cli whiteboard +export \
   --whiteboard-token "wbcnxxxxxxxx" \
   --output-type svg \
   --output ./whiteboard.svg \
-  --as user
+  --as <identity>
 ```
 
 ### 示例 4：导出画板原始节点结构到文件
@@ -57,5 +62,6 @@ lark-cli whiteboard +export \
   --whiteboard-token "wbcnxxxxxxxx" \
   --output-type raw \
   --output ./nodes.json \
-  --overwrite
+  --overwrite \
+  --as <identity>
 ```

--- a/skills/lark-whiteboard/references/lark-whiteboard-node-create.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-node-create.md
@@ -1,0 +1,104 @@
+# whiteboard +node-create
+
+> **前置条件:** 若本操作链尚未读取 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md)，先读取并确定 `<identity>`；否则复用已确定身份。命令同时支持 `user` 和 `bot`，并在读取、请求预览、写入和验证中保持一致。
+
+向已有画板追加 OpenAPI 节点。它适合局部新增已编译好的节点，不适合从零创作复杂图表。
+
+## 适用场景
+
+- 已经知道 `whiteboard-token`，且所选身份拥有画板编辑权限。
+- 已经有可追加的 OpenAPI `nodes[]`。
+- 需要向已有画板追加节点，而不是覆盖整图。
+
+## 不适用场景
+
+- 从零创作复杂图表，或需要自动布局、批量排版、复杂连线计算。
+- 只有 DSL / Mermaid / SVG，还没有转换成 OpenAPI 节点。
+- 只想在文档正文里插入或移动画板 block，这属于 `lark-doc`。
+- 需要修改或删除已有节点；分别使用 `+node-update` 或 `+node-delete`。
+- 需要遮住旧文字、覆盖旧标题、隐藏误放节点或用新增说明节点代替编辑已有节点；这些都是 patch 失败后的视觉补救，不属于 append。
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `--whiteboard-token` | 是 | 画板 token。 |
+| `--source` | 是 | JSON，必须包含非空 `nodes` 数组。支持 `@path` 文件读取或 `-` stdin。 |
+| `--idempotent-token` | 否 | 幂等 token，最少 10 个字符。重试同一次逻辑新增时复用同一个值。 |
+
+## 输入
+
+`nodes[]` 必须是飞书 OpenAPI 画板节点，不是 whiteboard-cli DSL。不要把 `{"type":"shape","shape":...}` 这类 DSL 节点直接传给本命令。
+
+推荐先用 `npx -y @larksuite/whiteboard-cli@^0.2.13 --to openapi --format json` 生成 OpenAPI 结果，再整理成 `{ "nodes": [...] }`。
+
+如果上游产物是 `CliResponse` envelope（例如顶层包含 `code` / `data.result.nodes`），先抽取 `data.result.nodes` 并整理成顶层 `{ "nodes": [...] }`；不要把 envelope 当作 `nodes[]` payload 直接传给本命令。
+
+```json
+{
+  "nodes": [
+    {
+      "id": "tmpNode",
+      "type": "composite_shape",
+      "x": 0,
+      "y": 0,
+      "width": 260,
+      "height": 45,
+      "text": {
+        "text": "hello",
+        "font_weight": "regular",
+        "font_size": 14,
+        "horizontal_align": "center",
+        "vertical_align": "mid"
+      },
+      "style": {
+        "border_color": "#3370ff",
+        "border_width": "narrow",
+        "border_style": "solid",
+        "fill_color": "#e8f3ff"
+      },
+      "composite_shape": {
+        "type": "round_rect"
+      }
+    }
+  ]
+}
+```
+
+## 示例
+
+```bash
+lark-cli whiteboard +node-create \
+  --whiteboard-token <whiteboard_token> \
+  --source @./nodes.json \
+  --idempotent-token <10+字符唯一串> \
+  --as <identity> \
+  --dry-run
+
+lark-cli whiteboard +node-create \
+  --whiteboard-token <whiteboard_token> \
+  --source @./nodes.json \
+  --idempotent-token <同一个幂等串> \
+  --as <identity>
+```
+
+## 输出
+
+JSON 输出使用 `data.ids`，多个 id 用逗号拼接:
+
+```json
+{
+  "data": {
+    "ids": "o2:5"
+  }
+}
+```
+
+## Safety
+
+- 写入前先用 `--dry-run` 检查 method、URL、params 和 body。dry-run 只执行本地校验并打印请求预览，不请求画板 OpenAPI。
+- 对手写节点尤其要先 dry-run；它只能验证请求结构，不能证明节点语义一定可插入。
+- 请求预览、真实执行和重试复用同一 `nodes.json`、幂等 token 和身份。
+- 写后用 `+export --output-type raw` 或 preview 读回，确认旧内容仍在、新节点已出现，且新节点没有明显覆盖旧内容。
+- 如果新增内容有“在 X 旁边/右侧/下方/某列/某阶段”等 anchor 要求，写前记录 anchor bbox 和预计新增 bbox；写后确认新增节点仍在目标区域。
+- 复杂图表继续走 `whiteboard-cli -> Workflow` 路径，不要把 `+node-create` 当作默认创作入口。

--- a/skills/lark-whiteboard/references/lark-whiteboard-node-delete.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-node-delete.md
@@ -1,0 +1,77 @@
+# whiteboard +node-delete
+
+> **前置条件:** 若本操作链尚未读取 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md)，先读取并确定 `<identity>`；否则复用已确定身份。命令同时支持 `user` 和 `bot`，并在读取、请求预览、写入和验证中保持一致。
+
+按 node id 删除已有节点。这是高风险写操作，只能删除已经确认的目标节点。
+
+## 适用场景
+
+- 已经知道 `whiteboard-token`，且所选身份拥有画板编辑权限。
+- 已经确认要删除的 node id。
+- 需要删除已有画板中的局部节点。
+
+## 不适用场景
+
+- 不知道或无法唯一确认目标 node id。
+- 只是想隐藏、移动或更新节点。
+- 需要整体替换画板。
+
+## 定位节点
+
+先导出 raw 节点结构:
+
+```bash
+lark-cli whiteboard +export \
+  --whiteboard-token <whiteboard_token> \
+  --output-type raw \
+  --as <identity>
+```
+
+从返回的 `data.nodes[].id` 读取目标 node id。不要删除从 ambient context 或最近消息猜测出来的节点。
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `--whiteboard-token` | 是 | 画板 token。 |
+| `--node-ids` | 是 | 要删除的 node id，多个 id 用英文逗号分隔。 |
+| `--idempotent-token` | 否 | 幂等 token，最少 10 个字符。重试同一次逻辑删除时复用同一个值。 |
+| `--yes` | 真实执行需要 | 高风险写操作确认。先 dry-run 并核对目标，取得删除批准后再传。 |
+
+## 示例
+
+```bash
+lark-cli whiteboard +node-delete \
+  --whiteboard-token <whiteboard_token> \
+  --node-ids <node_id_1>,<node_id_2> \
+  --idempotent-token <10+字符唯一串> \
+  --as <identity> \
+  --dry-run
+
+lark-cli whiteboard +node-delete \
+  --whiteboard-token <whiteboard_token> \
+  --node-ids <node_id_1>,<node_id_2> \
+  --idempotent-token <同一个幂等串> \
+  --as <identity> \
+  --yes
+```
+
+## 输出
+
+```json
+{
+  "data": {
+    "ids": "o2:5,o2:6",
+    "count": 2
+  }
+}
+```
+
+## Safety
+
+- 删除前必须用 `+export --output-type raw` 确认 node id。
+- 先运行 `--dry-run`，检查 method 是 `DELETE`、URL 是 `/nodes/batch_delete`、body 是 `{"ids":[...]}`。dry-run 只生成本地请求预览，不请求画板 OpenAPI。
+- 向用户展示精确 node id 和删除请求；只有确认目标并取得删除批准后才传 `--yes`。
+- 请求预览、真实执行和重试复用同一 node id 列表、幂等 token 和身份。
+- 写后用 raw 或 preview 读回，确认目标节点已删除且未选中内容未被意外删除。
+- 不要因为用户说“删掉这个”就删除最近消息里的节点；缺少 node id 时先导出 raw 或要求定位依据。

--- a/skills/lark-whiteboard/references/lark-whiteboard-node-update.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-node-update.md
@@ -1,0 +1,129 @@
+# whiteboard +node-update
+
+> **前置条件:** 若本操作链尚未读取 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md)，先读取并确定 `<identity>`；否则复用已确定身份。命令同时支持 `user` 和 `bot`，并在读取、请求预览、写入和验证中保持一致。
+
+按 node id 更新已有节点字段。CLI 输入是批量形态，执行层会发起一次 `batch_update` OpenAPI 请求。
+
+## 适用场景
+
+- 已经知道 `whiteboard-token`，且所选身份拥有画板编辑权限。
+- 已经知道目标 node id。
+- 需要局部修改文字、颜色、样式、位置等节点字段。
+
+## 不适用场景
+
+- 不知道或无法唯一确认目标 node id。
+- 需要重绘复杂图表、重新布局整板，或在未知几何状态下承诺无碰撞。
+- 想替换整个画板内容。
+
+## 定位节点
+
+先导出 raw 节点结构:
+
+```bash
+lark-cli whiteboard +export \
+  --whiteboard-token <whiteboard_token> \
+  --output-type raw \
+  --as <identity>
+```
+
+从返回的 `data.nodes[]` 读取目标 node id 和 type。当前 gateway contract 要求每个 update item 同时包含原节点的 `id` 与 `type`；其余只保留待修改字段。省略其他字段表示不修改，不要用默认值填充未指定字段，也不要根据 id 猜 type。
+
+文本节点是例外：只改文案时，不要只发送 `text: { "text": "新文案" }` 后假设样式会被保留。可以从 raw 中复制目标节点原有的 `text` 子对象作为起点，再替换其中的文案字段。CLI 会按当前 whiteboard node OpenAPI 结构保留正式字段；不要在 prompt 中手工枚举可写字段。raw 文本相等也不能证明 preview 中仍可读，所以文本替换后仍要看预览。
+
+如果已经持有 `+export --output-type raw` 或 nodes OpenAPI 返回的完整 raw node，优先整理成顶层 `{ "nodes": [...] }`。`+node-update` 在发送 `batch_update` 前会剥离 response envelope、明显非 node 字段和无法映射到 whiteboard node OpenAPI 结构的噪声；正式 node 字段不应被误删。构造 payload 时仍应尽量只表达本次显式修改，避免把整个画板快照当成 patch；最终以 dry-run body 为真实发送预览。
+
+兼容性只用于提高容错：如果上游误把未清洗的 raw/export 响应整体传给 `--source`，CLI 会尝试提取其中的 `data.nodes`。不要为了使用这个兼容能力主动构造 response envelope。
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `--whiteboard-token` | 是 | 画板 token。 |
+| `--source` | 是 | JSON，推荐包含顶层非空 `nodes` 数组，每个 node 必须包含 raw 中的 `id` 和 `type`。为容错也会识别未清洗 raw/export 响应中的 `data.nodes`。支持 `@path` 文件读取或 `-` stdin。 |
+| `--idempotent-token` | 否 | 幂等 token，最少 10 个字符；非空时作为 `client_token` 随 `batch_update` 请求发送。 |
+
+## 输入
+
+CLI 输入保持批量形态:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "o2:5",
+      "type": "composite_shape",
+      "style": {
+        "fill_color": "#F54A45"
+      }
+    }
+  ]
+}
+```
+
+文本替换示例，保留目标节点原有 `text` 样式，只替换文案:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "o2:5",
+      "type": "composite_shape",
+      "text": {
+        "text": "新标题",
+        "font_size": 18,
+        "text_color": "#f1f5f9",
+        "horizontal_align": "center",
+        "vertical_align": "mid"
+      }
+    }
+  ]
+}
+```
+
+示例里的样式字段应来自目标节点 raw 或用户明确要求，不要凭空套默认值。写后必须依赖 preview 验证可读性，不能只依据 raw 文本判断成功。
+
+执行时所有节点保持在同一请求中:
+
+- `PUT /open-apis/board/v1/whiteboards/:whiteboard_id/nodes/batch_update`。
+- body 为 `{"nodes": [...]}`，节点内的 `id` 会保留；response envelope 和非 node 噪声不会发送给 `batch_update`。
+- 如果输入误带 response envelope，只会提取 `data.nodes`；`code/msg/ok` 等 envelope 字段不会发送给 `batch_update`。
+- `--idempotent-token` 非空时，query 参数带 `client_token=<token>`。
+
+## 示例
+
+```bash
+lark-cli whiteboard +node-update \
+  --whiteboard-token <whiteboard_token> \
+  --source @./node-updates.json \
+  --idempotent-token <10+字符唯一串> \
+  --as <identity> \
+  --dry-run
+
+lark-cli whiteboard +node-update \
+  --whiteboard-token <whiteboard_token> \
+  --source @./node-updates.json \
+  --idempotent-token <同一个幂等串> \
+  --as <identity>
+```
+
+## 输出
+
+```json
+{
+  "data": {
+    "ids": "o2:5",
+    "count": 1
+  }
+}
+```
+
+## Safety
+
+- 多节点更新前先使用 `--dry-run` 检查 `batch_update` method、URL、params 和 body。dry-run 只执行本地校验并打印请求预览，不请求画板 OpenAPI。
+- 请求预览、真实执行和重试复用同一 `node-updates.json`、幂等 token 和身份。
+- 用完整 raw node 写回时，以 dry-run body 为准确认哪些字段会真正发送。dry-run 只证明本地请求形状，不证明服务端接受这些字段。
+- 文本替换写后必须导出 preview 检查可读性、层级和原容器样式；只看到 raw 文案变更不能声称完成。深色背景、强调卡片、标题和标签尤其要确认对比度没有被服务端主题色归一化破坏。
+- `batch_update` 写前会统一校验，但结构性字段可能分阶段应用。如服务端提示未完整完成，必须读回所有请求 node id 确认状态。
+- 真实执行失败时，先读取 `error.field_violations[]` 的字段路径和原因，再看 hint 与 log_id；只围绕该字段和同一修改意图做一次可验证调整。没有字段详情或调整后仍失败就停止并报告能力边界，不要在 minimal/full/raw/envelope 之间多轮盲试。
+- 不要在节点更新失败时自动回退到 `+node-create` 遮罩、SVG Edit、raw create 或 `+update --overwrite`。只有用户另行明确要求替换整个画板时，才能进入 replace workflow。

--- a/skills/lark-whiteboard/references/lark-whiteboard-parse-image.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-parse-image.md
@@ -1,0 +1,108 @@
+# whiteboard +parse-image
+
+> **前置条件:** 先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。首版 ParseImage shortcut 只使用 `--as user`。
+
+提交一张本地图片，由服务端自动解析成画板内容并写入目标画板。该能力走 Engine 后台任务: CLI 只提交图片和查询任务状态，不下载 SVG，不调用本地 `whiteboard-cli` 做图片解析。
+
+## 适用场景
+
+- 用户明确要把图片内容解析成可写入飞书画板的内容。
+- 已经有目标画板 token。
+- 输入是一张本地图片文件。
+
+## 不适用场景
+
+- 用户只想把图片作为图片节点插入画板。
+- 用户只想导出或拿到 SVG。
+- 用户要编辑已有节点字段、删除节点或追加已编译 OpenAPI 节点；分别使用 `+node-update`、`+node-delete`、`+node-create`。
+- 用户要在文档正文里创建或移动画板 block；交给 `lark-doc`。
+
+## parse-image 参数
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `--whiteboard-token` | 是 | 目标画板 token。 |
+| `--image` / `-i` | 是 | 本地图片路径，支持 PNG、JPG、JPEG、GIF、WEBP。 |
+| `--overwrite` | 否 | 是否覆盖现有画板内容。默认 false，即追加。 |
+| `--mode` | 否 | Canvas Agent 模式，可选 `mini`、`flash`、`agentic`、`agentic_max`；不传时服务端默认 `flash`。 |
+| `--idempotent-token` | 否 | 幂等 token。未传时 CLI 自动生成。 |
+
+## parse-image 示例
+
+先预览请求:
+
+```bash
+lark-cli whiteboard +parse-image \
+  --whiteboard-token <whiteboard_token> \
+  --image ./input.png \
+  --as user \
+  --dry-run
+```
+
+提交任务:
+
+```bash
+lark-cli whiteboard +parse-image \
+  --whiteboard-token <whiteboard_token> \
+  --image ./input.png \
+  --mode agentic_max \
+  --as user
+```
+
+覆盖写入时必须显式传 `--overwrite`:
+
+```bash
+lark-cli whiteboard +parse-image \
+  --whiteboard-token <whiteboard_token> \
+  --image ./input.png \
+  --overwrite \
+  --as user
+```
+
+提交成功输出 `task_id`、`status` 和可恢复命令 `next_command`。`status=pending` 只表示任务已创建，不表示画板已经写入完成。
+
+## parse-image-result
+
+查询或等待 ParseImage 任务结果。
+
+### 参数
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `--whiteboard-token` | 是 | 提交任务时的目标画板 token。 |
+| `--task-id` | 是 | `+parse-image` 返回的 task id。 |
+| `--wait` | 否 | 持续轮询直到成功或超时。默认 false。 |
+| `--timeout` | 否 | `--wait` 的整体超时时间，默认 `20m`。 |
+| `--interval` | 否 | `--wait` 的轮询间隔，默认 `10s`。 |
+
+### 示例
+
+单次查询:
+
+```bash
+lark-cli whiteboard +parse-image-result \
+  --whiteboard-token <whiteboard_token> \
+  --task-id <task_id> \
+  --as user
+```
+
+等待完成:
+
+```bash
+lark-cli whiteboard +parse-image-result \
+  --whiteboard-token <whiteboard_token> \
+  --task-id <task_id> \
+  --wait \
+  --as user
+```
+
+成功时输出 `ids`、`extra` 和 `previous_revision`。如果还在处理中，输出 `pending` 或 `running`。失败时保持结构化错误，不返回 SVG、TOS URL、Canvas 原始错误或完整画板数据。
+
+## Safety
+
+- `+parse-image` 是 `write` 风险命令；`+parse-image-result` 是 `read` 风险命令。
+- 不要把 `+parse-image` 的提交成功当成最终写入成功；必须用 result 或后续 `+export` 验证。
+- 不要自动把追加失败改成覆盖写入。
+- 不要使用旧 `image2svg` 设计；本 skill 不新增也不调用 `image2svg` shortcut。
+- 不要手工处理中间 SVG/TOS URL；这些属于服务端内部实现。
+- 等待超时不代表任务失败。保留 `task_id`，之后继续用 `+parse-image-result` 查询。

--- a/skills/lark-whiteboard/references/lark-whiteboard-update.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-update.md
@@ -1,122 +1,137 @@
-# whiteboard +update（更新画板）
+# whiteboard +update
 
-> **前置条件：** 先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+> **前置条件：** 若本操作链尚未读取 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md)，先读取并确定 `<identity>` 为 `user` 或 `bot`；否则复用已确定身份。同一次读取、请求预览、写入和验证必须保持同一身份。
 
-更新画板内容，支持四种输入格式：
+`+update` 向画板**创建**输入内容，是否清空旧内容由 `--overwrite` 决定：
 
-- `raw`：飞书 OpenAPI 原生画板节点格式，不推荐直接编辑。
-- `plantuml`：PlantUML 代码
-- `mermaid`：Mermaid 代码
-- `svg`：SVG 文本
+- `initialize`：向已确认的空白画板写入第一批内容，不使用 `--overwrite`。
+- `append`：向非空画板新增内容并保留旧内容，不使用 `--overwrite`。
+- `replace`：用户明确接受丢弃非空画板全部旧状态后，使用 `--overwrite` 写入完整最终 artifact。
 
-输入内容可以通过管道从 stdin 读取，或通过 `--source` 指定文件。
+它不是节点级 patch 或 delete 的执行器；对应操作分别使用 [`+node-update`](./lark-whiteboard-node-update.md) 和 [`+node-delete`](./lark-whiteboard-node-delete.md)。完整路由、能力边界、确认和写后读回规则见 [`lark-whiteboard-workflow.md`](./lark-whiteboard-workflow.md)。
 
 ## 参数
 
-| 参数                   | 必填 | 说明                                         |
-|----------------------|----|--------------------------------------------|
-| `--whiteboard-token` | 是  | 画板 token，需要拥有画板的编辑权限                       |
-| `--idempotent-token` | 否  | 幂等 token，确保更新操作幂等；最少 10 个字符，建议使用时间戳 + 场景标识拼接（如 `1744800000-board-1`）。同一次逻辑更新只生成一次该 token，重试时须原样复用；切勿在每次重试时重新生成时间戳或幂等 key，否则会重复写入 |
-| `--overwrite`        | 否  | 写入模式：带上则覆盖更新（写入前删除画板所有现有内容再写入）；省略则为增量追加（保留原有内容，新内容叠加写入）。默认 false（增量追加）|
-| `--source`           | 是  | 输入画板内容，支持使用 `@path` 从文件读取，或 `-` 从 stdin 读取 |
-| `--input_format`     | 否  | 输入格式：`raw`、`plantuml`、`mermaid`、`svg`，默认为 `raw`  |
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `--whiteboard-token` | 是 | 画板 token，需要拥有编辑权限。 |
+| `--idempotent-token` | 否 | 幂等 token，最少 10 个字符；同一次逻辑写入的 dry-run、真实执行和重试复用同一个值。 |
+| `--overwrite` | 否 | 写入前删除全部现有内容；只有 replace 可以使用。 |
+| `--source` | 是 | 输入内容，支持 `@path` 文件或 `-` stdin。 |
+| `--input_format` | 否 | `raw`、`plantuml`、`mermaid` 或 `svg`，默认 `raw`。 |
 
-### 以 raw (OpenAPI 原生画板节点格式) 创作
+`--dry-run` 是全局参数，只执行 CLI 当前具备的本地校验并打印请求形状，不调用画板 OpenAPI。它可以发现 raw payload 的本地解析错误，但不能验证 PlantUML、Mermaid 或 SVG 的服务端解析与渲染结果。
 
-**不要以直接生成 json 语法的方式创作 raw 格式的飞书 OpenAPI 原生画板节点参数**
+## initialize（空白画板）
 
-思维导图，时序图，类图，饼图，流程图等图表推荐使用 Mermaid/PlantUML 语法绘制。
-
-而当需要绘制架构图，组织架构图，泳道图，对比图，鱼骨图，柱状图，折线图，树状图，漏斗图，金字塔图，循环/飞轮图，里程碑或其他较为复杂的图表时，推荐参考 [§ 渲染 & 写入画板](lark-whiteboard-workflow.md#渲染--写入画板) 使用 whiteboard-cli 工具创作。
-
-## 示例
-
-### 示例 1：使用 PlantUML 代码更新画板（从 stdin 读取）
+Workflow 必须先用 raw 确认 blank。先对最终 artifact 生成本地请求预览，真实写入前立即再次读取；状态变为 nonempty 或 unknown 时停止。
 
 ```bash
-# 编写 PlantUML 代码
-cat > diagram.puml << 'EOF'
-@startuml
-Alice -> Bob: Hello
-Bob -> Alice: Hi
-@enduml
-EOF
-
-# 通过管道传递给命令
-cat diagram.puml | lark-cli whiteboard +update \
-  --whiteboard-token <画板Token> \
-  --input_format plantuml --source -\
-  --overwrite --as user
-```
-
-### 示例 2：使用 Mermaid 代码更新画板（从文件读取）
-
-```bash
-# 编写 Mermaid 代码
-cat > diagram.mmd << 'EOF'
-graph TD
-    A[开始] --> B{判断}
-    B -->|是| C[处理]
-    B -->|否| D[结束]
-    C --> D
-EOF
-
-# 从文件读取并更新
 lark-cli whiteboard +update \
-  --whiteboard-token <画板Token> \
-  --input_format mermaid \
+  --whiteboard-token <board_token> \
   --source @./diagram.mmd \
-  --overwrite --as user
-```
-
-### 示例 3：使用 whiteboard-cli 生成 OpenAPI 格式并写入画板
-
-whiteboard-cli 工具的具体用法请参考 [§ 渲染 & 写入画板](lark-whiteboard-workflow.md#渲染--写入画板)
-
-```bash
-# 使用 whiteboard-cli 生成 OpenAPI 格式并通过管道传递
-npx -y @larksuite/whiteboard-cli@^0.2.13 -i <产物文件> --to openapi --format json \
-  | lark-cli whiteboard +update \
-    --whiteboard-token <画板Token> \
-    --source - --input_format raw \
-    --idempotent-token <10+字符唯一串> \
-    --as user
-```
-
-### 示例 4：先生成产物文件，再从文件读取更新
-
-whiteboard-cli 工具的具体用法请参考 [§ 渲染 & 写入画板](lark-whiteboard-workflow.md#渲染--写入画板)
-
-```bash
-# 生成 OpenAPI 格式到文件
-npx -y @larksuite/whiteboard-cli@^0.2.13 -i <DSL 文件> --to openapi --format json -o ./temp.json
-
-# 从文件读取并更新
-lark-cli whiteboard +update \
-  --whiteboard-token <画板Token> \
+  --input_format mermaid \
   --idempotent-token <10+字符唯一串> \
-  --input_format raw \
-  --source @./temp.json \
-  --overwrite --as user
+  --dry-run \
+  --as <identity>
+
+lark-cli whiteboard +update \
+  --whiteboard-token <board_token> \
+  --source @./diagram.mmd \
+  --input_format mermaid \
+  --idempotent-token <同一个幂等串> \
+  --as <identity>
 ```
 
-### 示例 5：使用 SVG 写入画板（从文件读取）
+写后通过 raw 或 preview 验证。当前接口没有 revision/CAS 条件，空白检查是 best-effort，不能声称原子保证。
 
-适用于从零创建（直接写入 SVG）和编辑现有画板（编辑工作流详见 [`../routes/svg-edit.md`](../routes/svg-edit.md)）。
+## append（非空画板）
+
+append 不传 `--overwrite`。本命令适合直接写入 Mermaid / PlantUML / SVG source 的普通追加；已编译的 OpenAPI `nodes[]` 优先使用 [`+node-create`](./lark-whiteboard-node-create.md)。两条路径都不得修改、删除或复用既有节点 ID。
+
+如果非空画板的请求包含“在 X 旁边/右侧/下方/某列/某阶段”等相对位置要求，source append 通常不够安全，因为它不能在写前给出最终节点 bbox。此时应优先生成可定位的 OpenAPI `nodes[]` 并走 `+node-create`；无法生成时进入 workflow 的能力边界。不得为了满足位置要求把 append 改成 `--overwrite`。
 
 ```bash
-# 编写或导出 SVG 文件
-cat > diagram.svg << 'EOF'
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
-  <rect x="10" y="10" width="80" height="40" fill="#4A90E2"/>
-  <text x="50" y="35" text-anchor="middle" fill="#fff">Hello</text>
-</svg>
-EOF
-
-# 从文件读取并更新
 lark-cli whiteboard +update \
-  --whiteboard-token <画板Token> \
+  --whiteboard-token <board_token> \
+  --source @./addition.svg \
   --input_format svg \
-  --source @./diagram.svg \
-  --overwrite --as user
+  --idempotent-token <10+字符唯一串> \
+  --dry-run \
+  --as <identity>
+
+lark-cli whiteboard +update \
+  --whiteboard-token <board_token> \
+  --source @./addition.svg \
+  --input_format svg \
+  --idempotent-token <同一个幂等串> \
+  --as <identity>
 ```
+
+写后验证旧内容仍在、新内容出现，且新内容没有明显覆盖旧内容。存在相对位置要求时，还要验证新增节点 bbox 与目标 anchor bbox 的关系。追加失败或位置不符合预期时停止，不得自动整板覆盖。
+
+DSL 产物需要先转换为 OpenAPI `nodes[]`，然后交给 `+node-create`：
+
+```bash
+npx -y @larksuite/whiteboard-cli@^0.2.13 -i ./diagram.json --to openapi --format json -o ./compiled-nodes.json
+
+lark-cli whiteboard +node-create \
+  --whiteboard-token <board_token> \
+  --source @./compiled-nodes.json \
+  --idempotent-token <10+字符唯一串> \
+  --dry-run \
+  --as <identity>
+```
+
+本地请求预览生成后，复用同一个 `compiled-nodes.json`、幂等 token 和身份执行 `+node-create`。
+
+## replace（非空画板）
+
+只有 replace 可以使用 `+update --overwrite`。执行前必须：
+
+1. 用户明确要求或接受按 replace 准备完整 artifact。
+2. 完整最终 artifact 已完成适用的 preview/check。
+3. 对最终 artifact 执行 `--dry-run`，生成不发请求的本地请求预览。
+4. 展示最终结果、将丢失的旧节点、ID、层级、引用和交互语义，以及精确覆盖请求。
+5. 在上述证据都确定后取得 final overwrite approval。
+
+```bash
+lark-cli whiteboard +update \
+  --whiteboard-token <board_token> \
+  --source @./final.svg \
+  --input_format svg \
+  --idempotent-token <10+字符唯一串> \
+  --overwrite \
+  --dry-run \
+  --as <identity>
+
+lark-cli whiteboard +update \
+  --whiteboard-token <board_token> \
+  --source @./final.svg \
+  --input_format svg \
+  --idempotent-token <同一个幂等串> \
+  --overwrite \
+  --as <identity>
+```
+
+写后立即导出 preview 或 raw 验证。
+
+## 输入格式边界
+
+- `raw` 是 OpenAPI 原生**创建节点**格式。服务端会重新分配节点 ID；已编译 `nodes[]` 优先用 `+node-create`，不要编辑导出的 raw 并回传来声称 patch/delete。
+- `mermaid` / `plantuml` / `svg` 由远端转换，可用于 initialize、普通 append 或 replace。完整源码不会自动决定写入语义；当用户要求保留原图并在指定位置新增时，源码写入不能升级为 replace。
+- `whiteboard-cli` 当前不能本地渲染或编译 PlantUML；`--dry-run` 也不请求服务端，因此真实写入是第一次服务端解析。执行前必须披露该限制；用户要求写前视觉或服务端解析证明时停止。完整规则见 [已有输入与格式约束](./lark-whiteboard-workflow.md#已有输入与格式约束)。
+- 对单一 Mermaid/PlantUML 图做源码 round-trip 实际是 replace，详见 [Source Round-Trip](./lark-whiteboard-workflow.md#source-round-trip)。
+- 复杂图表的生成、渲染与检查见 [渲染 & 写入画板](./lark-whiteboard-workflow.md#渲染--写入画板)。
+
+## Safety
+
+- 所有写入先用 `--dry-run` 生成本地请求预览，并让检查、请求预览和真实执行复用同一 artifact。
+- 同一次逻辑写入只生成一个幂等 token，重试不得重新生成。
+- initialize/append 不传 `--overwrite`；replace 之外不得传 `--overwrite`。
+- source append 无法满足指定位置时停止或改用可定位的 OpenAPI `nodes[]`；不得用 `--overwrite` 作为位置兜底。
+- patch/delete 分别使用 `+node-update` / `+node-delete`；不得用 raw 创建或 replace 伪装成功。
+- append 失败时不得自动回退到 SVG Edit、清空画板或 replace。
+- patch 失败时不得自动回退到 `+node-create` 遮罩、SVG Edit、raw create 或 replace。
+- source 写入超时、无响应或结果不明时，先读回当前画板判断是否已经生效；不得盲目重试并重新生成幂等 token。
+- 写后通过 raw 或 preview 读回，不只根据退出码声称成功。

--- a/skills/lark-whiteboard/references/lark-whiteboard-workflow.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-workflow.md
@@ -62,8 +62,70 @@ lark-cli whiteboard +export \
 | patch | `+node-update` | 必须已唯一定位 node id，并准备只包含待修改字段的 OpenAPI payload。 |
 | delete | `+node-delete` | 必须通过 raw 确认 node id，dry-run 后取得删除批准，真实执行传 `--yes`。 |
 | replace | `+update --overwrite` | 丢弃非空画板的全部旧状态，必须经过覆盖确认。 |
+| parse-image | `+parse-image` / `+parse-image-result` | 服务端把一张本地图片解析成画板内容并自动写入目标画板；不返回 SVG，不走本地 `whiteboard-cli`。 |
 
 `+update --input_format raw` 仍调用创建节点接口：输入 ID 只用于本批次关系标识，服务端会重新分配 ID。它不能更新或删除现有节点；对应操作必须使用 `+node-update` 和 `+node-delete`。
+
+## ParseImage Workflow
+
+ParseImage 只用于“把一张本地图片里的结构解析成目标画板内容”。它不是图片节点上传，也不是旧 `image2svg` 原型。
+
+适用条件：
+
+- 用户提供本地图片路径，或上下文中已有可访问的本地图片文件。
+- 用户目标是让服务端自动解析图片内容并写入某个已有画板。
+- 已定位 `whiteboard-token`。
+
+不适用条件：
+
+- 只想把图片作为图片/素材插入画板。
+- 只想得到 SVG、TOS URL 或中间解析产物。
+- 想用本地 `whiteboard-cli` 从图片生成节点；当前本路径不做本地图片解析。
+
+执行步骤：
+
+1. 按 `lark-shared` 选择身份；首版 `+parse-image` 只使用 `--as user`。
+2. 若目标画板可能已有内容，默认 `overwrite=false` 追加。只有用户明确要求覆盖/替换，才传 `--overwrite`。
+3. 如需指定 Canvas Agent 模式，传 `--mode mini|flash|agentic|agentic_max`；不传时服务端默认 `flash`。
+4. 先 dry-run:
+
+```bash
+lark-cli whiteboard +parse-image \
+  --whiteboard-token <board_token> \
+  --image <local_image_path> \
+  --as user \
+  --dry-run
+```
+
+5. 真实提交:
+
+```bash
+lark-cli whiteboard +parse-image \
+  --whiteboard-token <board_token> \
+  --image <local_image_path> \
+  --as user
+```
+
+6. 提交成功只表示服务端任务已创建，不表示画板已经写入完成。记录返回的 `task_id` 和 `next_command`。
+7. 用户明确要求等待、评测要求同轮闭环，或需要最终写入证据时，调用:
+
+```bash
+lark-cli whiteboard +parse-image-result \
+  --whiteboard-token <board_token> \
+  --task-id <task_id> \
+  --wait \
+  --as user
+```
+
+8. 成功后如需证明画板内容，继续用 `+export --output-type raw` 或 preview 验证。
+
+禁止事项：
+
+- 不使用 `image2svg` shortcut；本仓不新增该 shortcut。
+- 不下载 SVG 或 TOS URL 交给 agent 手工处理。
+- 不用 `whiteboard-cli` 作为 ParseImage 的本地替代路径。
+- 不把 submit 的 `pending` 结果报告为画板写入完成。
+- `+parse-image-result` 只是查询/等待，不触发写入；后台写入由 Engine worker 自动完成。
 
 ## 创作 Workflow
 

--- a/skills/lark-whiteboard/references/lark-whiteboard-workflow.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-workflow.md
@@ -1,89 +1,279 @@
 # 画板创作/编辑工作流
 
+本 Workflow 是 `lark-whiteboard` 唯一的远端写入编排入口。`SKILL.md` 只选择原子操作，`routes/*.md` 只生成和检查本地产物，Shortcut reference 只描述单个命令契约。
+
+## 范围守卫
+
+先判断用户要操作的是文档结构还是同一画布：
+
+| Scope | Owner | Rule |
+|---|---|---|
+| 从已有文档链接解析 whiteboard token | `lark-whiteboard` 的只读准备阶段 | 可读取文档并提取已有 token，不修改文档 block。 |
+| 新建、插入、移动或删除文档中的画板 block | `lark-doc` | 切换到 `lark-doc`，完成 block 操作后再交回 token。 |
+| 查看或修改某个既有画板内部内容 | `lark-whiteboard` | 进入后续路由。 |
+| “下方/旁边/后面”的 anchor 可能同时指文档 block 和画布节点 | 先澄清 | 未明确 scope 前不得写文档或画板。 |
+
+不能只根据相对位置词一律澄清。“在节点 A 下方”已有明确 canvas anchor；只有 anchor 属于文档还是画布无法判断时才澄清。
+
+## 请求原子化
+
+first-match 前先把复合请求拆成有序原子操作。例如：
+
+```text
+“把标题改成 Q3，删除右上角的废弃节点，再导出图片”
+->
+1. patch 标题节点
+2. delete 废弃节点
+3. read/export 最终预览
+```
+
+- 保留用户明确表达的顺序。
+- 后续操作依赖前序结果时，先验证前序结果，再重新读取当前 board state。
+- 任一操作失败时停止依赖它的后续写操作，报告已完成、失败和未执行部分；不要声称事务回滚。
+- 不为减少命令数把 append、patch 或 delete 自动折叠成 replace。
+
+## 写前事实
+
+任何写操作都先读取实际画板状态：
+
+先按 `lark-shared` 和目标资源权限确定 `<identity>` 为 `user` 或 `bot`，并在状态读取、请求预览、真实写入和写后验证中保持一致。
+
+```bash
+lark-cli whiteboard +export \
+  --whiteboard-token <board_token> \
+  --output-type raw \
+  --as <identity>
+```
+
+默认 JSON envelope 中 `ok === true`，并且满足以下任一条件时，画板才是 `blank`：
+
+- `data.nodes` 是空数组。
+- `data.msg === "whiteboard is empty"`。
+
+`data.nodes` 是非空数组时为 `nonempty`。命令失败、响应格式异常或缺少上述合法空白证据时为 `unknown`，必须停止写入。用户声称“这是空白画板”只能作为线索。
+
+## 主操作与当前能力
+
+| Operation | 当前执行器 | 边界 |
+|---|---|---|
+| read/export | `+export` | 按 preview、svg、source、raw 选择输出。 |
+| initialize | `+update`，不带 `--overwrite` | 仅限已确认 blank 的画板。 |
+| append | OpenAPI `nodes[]` 用 `+node-create`；Mermaid / PlantUML / SVG source 只能用于不要求锚点放置的普通追加，且不带 `--overwrite` | 只创建新内容；不修改或删除既有节点。 |
+| patch | `+node-update` | 必须已唯一定位 node id，并准备只包含待修改字段的 OpenAPI payload。 |
+| delete | `+node-delete` | 必须通过 raw 确认 node id，dry-run 后取得删除批准，真实执行传 `--yes`。 |
+| replace | `+update --overwrite` | 丢弃非空画板的全部旧状态，必须经过覆盖确认。 |
+
+`+update --input_format raw` 仍调用创建节点接口：输入 ID 只用于本批次关系标识，服务端会重新分配 ID。它不能更新或删除现有节点；对应操作必须使用 `+node-update` 和 `+node-delete`。
+
 ## 创作 Workflow
 
-> 此 workflow 用于**独立创作一个画板**。
-> 需要在文档中批量创建多个画板时，由 lark-doc 负责调度，见 `lark-doc` 技能的 `references/lark-doc-whiteboard.md`。
+### Step 1：获取 board_token
 
-**Step 1：获取 board_token**
-
-| 用户给了什么 | 怎么获取 |
+| 用户给了什么 | 怎么处理 |
 |---|---|
-| 直接给了 whiteboard token（`wbcnXXX`）| 直接使用 |
-| 文档 URL 或 doc_id，文档中已有画板 | `lark-cli docs +fetch --doc <URL> --as user`，从返回的 `<whiteboard token="xxx"/>` 提取 |
-| 文档 URL 或 doc_id，需要新建画板 | `lark-cli docs +update --doc <doc_id> --command append --content '<whiteboard type="blank"></whiteboard>' --as user`，从响应 `data.new_blocks[0].block_token` 取得（`block_type == "whiteboard"` 的那条；参数详见 lark-doc SKILL.md）|
+| whiteboard token（`wbcnXXX`） | 直接使用。 |
+| 文档 URL，文档中已有画板 | 只读获取文档内容，从 `<whiteboard token="..."/>` 提取 token。 |
+| 文档 URL，需要新建画板 | 切换到 `lark-doc` 创建空白画板 block；本 Skill 不直接修改文档结构。 |
 
-**Step 2：渲染 & 写入**
+`lark-doc` 创建 block 后必须把 token 和 canvas goal 交回本 Skill。
 
-→ 进入 **[§ 渲染 & 写入画板](#渲染--写入画板)** 章节，按流程完成后直接返回结果给用户。
+### Step 2：确认 initialize
 
----
+用 raw 确认 board state。只有 `blank` 才能进入 initialize；`nonempty` 时重新判断用户要 append 还是 replace，`unknown` 时停止。
+
+### Step 3：生成与检查产物
+
+进入[渲染 & 写入画板](#渲染--写入画板)，按 route 生成 artifact 和检查证据。
+
+### Step 4：写入与验证
+
+使用 `+update`，不得传 `--overwrite`。先 dry-run，真实写入前立即再次确认 blank，再复用同一 artifact 和幂等 token 执行。写后导出 raw 或 preview 验证。
+
+当前接口没有 revision/CAS 条件，空白检查是 best-effort，不能声称原子保证。
 
 ## 编辑 Workflow
 
-**Step 1：获取 board_token**（同创作 Workflow Step 1）
+### append
 
-**Step 2：探测可编辑性 / 是否由代码绘制**
+append 只创建新内容并保留现有节点：
 
-- `+export --output-type source` — 能返回单一 Mermaid/PlantUML 源码，说明画板由代码绘制、可走路径①；返回无代码/多图则走路径②③④
+1. raw 确认目标为 `nonempty`。
+2. 确认请求不要求修改、删除或复用既有节点 ID。
+3. 生成并检查独立 artifact，然后按 artifact contract 选择唯一执行器：
+   - 已编译 OpenAPI `nodes[]`（包括 DSL 转换结果）用 `+node-create`。
+   - Mermaid / PlantUML / SVG source 只有在普通追加、不要求相对既有节点放置时，才能用不带 `--overwrite` 的 `+update`。
+4. 用户说“在 X 旁边/附近/下方/上方/某列/某阶段/某泳道/某象限”时，默认这是 canvas 空间约束，而不是普通追加。必须先用 raw 定位 anchor 节点或同组节点 bbox，再用可验证的 OpenAPI payload 放置新增节点，并在写后验证新增 bbox 仍在目标区域。
+5. 如果相对放置、无碰撞证明或跨新旧节点连接缺少可验证的最终 OpenAPI payload，进入[能力边界](#能力边界)。不得改用 source `+update` 或 `--overwrite` 来绕过定位能力。
+6. 对最终 artifact 执行所选命令的 dry-run；不要传 `--overwrite`。
+7. 复用同一 artifact、幂等 token 和身份执行，再用 raw 或 preview 验证既有内容仍在、新内容出现，且新增内容没有明显覆盖旧内容。存在 anchor 要求时，同时验证新增节点 bbox 与 anchor bbox 的关系。
 
-**Step 3：选编辑路径**（按上到下匹配，命中即停；用户有明确指定则以用户为准）
+Mermaid、PlantUML 和 SVG 可直接使用对应 `--input_format`。DSL 必须先由 `whiteboard-cli` 转成 OpenAPI `nodes[]`。导出的现有 raw 不得作为 append 输入；否则会复制节点，而不是修改节点。
 
-| 路径 | 命中条件 | 怎么改 | 写入方式 | 是否有损 |
-|---|---|---|---|---|
-| ①源码重构 | `+export source` 返回单一 Mermaid/PlantUML（即画板由代码绘制） | 在源码上改 → 按源码类型用 `+update --input_format mermaid` 或 `+update --input_format plantuml` | overwrite（整板重建） | ⚠️ **非严格无损，执行前确认** |
-| ②属性微调 | 只改已有节点的文字/颜色 | `+export --output-type raw --output <file>`（**必须写入文件**）→ 编辑文件中目标节点字段；如只能用 `+update --input_format raw --source @<file> --overwrite` 写回，先说明会整板重建并等待用户确认 | overwrite（整板重建） | ⚠️ **有损风险，未确认不得执行** |
-| ③增量追加 | 在原图基础上新增图/元素，保留原内容 | `+export --output-type preview` → 理解原图 → `+export --output-type raw` → 确定新节点坐标 → [§ 渲染 & 写入画板](#渲染--写入画板) 创作&写入 | append（**不加 `--overwrite`**） | 无损（原节点不动） |
-| ④结构重绘 | 需几何变动/增删元素/结构调整/混合编辑 | [`../routes/svg-edit.md`](../routes/svg-edit.md) | overwrite（清空重来） | ⚠️ **有损，必须先经用户确认** |
+### patch
 
-**⚠️ 止损**：一条路径最多试 2 轮，不行就换条路径尝试一次；仍不行就停下，如实告诉用户卡点，不要在各路径间反复横跳。
+已有节点的字段级修改使用 `+node-update`:
 
----
+1. 用 raw 唯一定位每个目标 node id，并读取同一节点的 type；目标不唯一时停止并要求定位依据。
+2. 构造 `{ "nodes": [...] }`，每个 item 至少包含 raw 中的 `id` 和 `type`，其余只表达这次要改的内容。省略其他字段表示不修改，不得用默认值填充，也不要根据 id 猜 type。可以把目标 raw node 或原 `text` 子对象作为输入起点；`+node-update` 按当前 whiteboard node OpenAPI 结构保留正式字段，并剥离 response envelope 和非 node 噪声。不要在 prompt 中手工枚举可写字段。
+3. 对最终 payload 执行 `+node-update --dry-run`，检查 `batch_update` URL、params 和 body。dry-run body 才是实际会发给服务端的字段集合；如果目标改动没有出现在 dry-run body 中，说明 payload 结构或 CLI 投影有问题，不要继续真实写入。
+4. 复用同一 payload、幂等 token 和身份真实执行。
+5. 用 raw 读回所有目标 node id，验证显式修改字段已经变化，未请求字段不能因默认值被覆盖。如服务端提示未完整完成，不得只依据部分成功响应声称整批成功。文本替换还必须导出 preview，确认文字可读、层级正确，并保留原容器的颜色和强调关系；服务端把颜色字段归一化为 theme code 时，以 preview 可读性为完成依据。
+6. 真实执行失败时，先读取 `error.field_violations[]` 的字段路径和原因，再看 hint 与 log_id；只围绕该字段和同一修改意图做一次可验证调整。没有字段详情或调整后仍失败就停止并报告能力边界；不得自动改用 `+node-create` 遮罩旧节点、SVG Edit、raw create 或 `+update --overwrite`，也不要在 minimal/full/raw/envelope 之间多轮盲试。
+
+对单一 Mermaid/PlantUML 代码图的源码重写仍属于 [Source Round-Trip](#source-round-trip)，它实际是 replace，不得用 `+node-update` 伪装。无法生成安全的节点级 payload 时进入[能力边界](#能力边界)，不自动转 replace。
+
+### delete
+
+已有节点的精确删除使用 `+node-delete`:
+
+1. 用 raw 确认精确 node id；不能根据 ambient context 或最近消息猜测。
+2. 对最终 id 列表执行 `+node-delete --dry-run`，检查 `DELETE /nodes/batch_delete` 和 body。
+3. 展示精确 node id 与删除请求，取得这次删除的批准。
+4. 复用同一 id 列表、幂等 token 和身份，传 `--yes` 真实执行。
+5. 用 raw 或 preview 读回，确认目标已删除且未选中内容未被意外删除。
+
+“删除全部节点”在用户语义上仍是 delete，不得因最终为空就自动改写为 `+update --overwrite`。
+
+### replace
+
+replace 用完整最终 artifact 丢弃非空画板的全部旧状态：
+
+1. raw 确认当前为 `nonempty`；preview 只用于视觉核对和损失展示，不能替代 board state 证据。
+2. 生成完整最终 artifact，并完成当前格式可用的 preview/check。
+3. 对同一 artifact 执行 `+update --overwrite --dry-run`，生成不发请求的本地请求预览。
+4. 展示最终结果、会丢失的旧节点、ID、层级、连接、资源及交互语义，以及精确覆盖请求，再取得 final overwrite approval。
+5. 批准后立即用 raw 复查 board state；目标、状态、artifact 或身份变化时重新 preflight 和确认。
+6. 复用同一 artifact、幂等 token 和身份执行 `+update --overwrite`。
+7. 写后立即导出 raw 或 preview 验证。
 
 ## 渲染 & 写入画板
 
 ### 渲染路由
 
-**先自报身份**：按训练来源，你属于哪一家？`Claude` / `Gemini` / `GPT` / `GLM` / `Doubao 或 Seed` / `Other`。身份决定 SVG / DSL 分流（不同家族对这两种表达语言的能力不均衡），不要跳过这一步。
+**先确定模型家族**：按训练来源选择 `Claude` / `Gemini` / `GPT` / `GLM` / `Doubao 或 Seed` / `Other`。模型家族只决定本地产物表达方式，不改变 mutation semantics，也不是 `--as user/bot` 的认证身份。
 
-**然后按当前产物类型 / 图表类型 × 身份选路径**，读对应文件按其完整 workflow 执行（含读 scene 指南、生成内容、渲染审查、交付）：
+先处理用户显式格式约束：
 
-当前产物路由按上到下匹配, 命中即停:
+- 用户明确要求 Mermaid、PlantUML、SVG、DSL 或 OpenAPI nodes 时，优先使用该 artifact 路径。
+- 显式格式只约束本地产物或 source 类型，不能改变 mutation semantics。例如“用 SVG 修改已有画板”仍必须是 patch 或 replace，不能因为选择 SVG 就自动 append 或 overwrite。
+- 显式格式不可满足当前 mutation 的安全边界时，进入[能力边界](#能力边界)，不要改走另一个写入语义。
 
-| 图表类型               | 身份                                  | 路径                                             |
-|--------------------|-------------------------------------|------------------------------------------------|
-| 当前要生成/追加的内容包含 @用户提及或图片/配图 | 任何身份                                | [`../routes/dsl.md`](../routes/dsl.md)         |
-| 思维导图、时序图、类图、饼图、甘特图 | 任何身份                                | [`../routes/mermaid.md`](../routes/mermaid.md) |
-| 鱼骨图、金字塔图、流程图    | `Doubao` / `Seed`                   | [`../routes/dsl.md`](../routes/dsl.md)         |
-| 其他图表               | `Claude` / `Gemini` / `GPT` / `GLM` / `Doubao` / `Seed`  | [`../routes/svg.md`](../routes/svg.md)         |
-| 其他图表               | `Other`                             | [`../routes/dsl.md`](../routes/dsl.md)         |
+没有显式格式约束时，按上到下匹配，命中即停：
 
-> **⚠️ SVG 路径失败回退**：走 `routes/svg.md` 时，碰到以下情况之一 → **丢弃当前 SVG，改读 `routes/dsl.md` 从零重画，不要逐行修补**：
-> - 渲染命令直接报错（语法级崩溃，不是 `--check` 的 warn/error）
-> - 两轮改写仍无法消除 `--check` 的 `text-overflow` error
-> - 目测 PNG 视觉严重错乱（文字大面积溢出、元素重叠压住关键信息、布局整体崩溃）
->
-> SVG 源码修补常常引入新 bug，换 DSL 从零重画往往更稳。这是 SVG 路径自由发挥的硬兜底，不要侵入 `routes/svg.md` 的创作流程。
+| 图表类型 | 模型家族 | 路径 |
+|---|---|---|
+| 当前要生成/追加的内容包含 @用户提及或图片/配图 | 任何身份 | [`../routes/dsl.md`](../routes/dsl.md) |
+| 思维导图、时序图、类图、饼图、甘特图 | 任何身份 | [`../routes/mermaid.md`](../routes/mermaid.md) |
+| 鱼骨图、金字塔图、流程图 | `Doubao` / `Seed` | [`../routes/dsl.md`](../routes/dsl.md) |
+| 其他图表 | `Claude` / `Gemini` / `GPT` / `GLM` / `Doubao` / `Seed` | [`../routes/svg.md`](../routes/svg.md) |
+| 其他图表 | `Other` | [`../routes/dsl.md`](../routes/dsl.md) |
 
-### 产物规范
+SVG route 在写入前发生语法崩溃、两轮仍有 `text-overflow` error，或 preview 严重错乱时，可以丢弃本地 SVG 并从零改走 DSL。该 fallback 只替换本地产物，不能改变 append/replace 语义或绕过写入门槛。
 
-产物目录：`./diagrams/YYYY-MM-DDTHHMMSS/`（本地时间，不含冒号和时区后缀）。如用户指定路径，以用户为准。
+### Artifact Contract
 
-目录内固定文件名：
+route 只交回：
 
-```
-diagram.svg           ← SVG 源码（SVG 路径）
-diagram.mmd           ← Mermaid 源码（Mermaid 路径）
-diagram.json          ← DSL 源文件（DSL 路径） / OpenAPI JSON（SVG 路径从 diagram.svg 导出）
-diagram.gen.cjs       ← 坐标计算脚本（仅 DSL 脚本构建方式）
-diagram.png           ← 渲染结果
-```
+- source 文本或文件路径。
+- 当前格式可用的 preview/check 结果。
+- 人工视觉审查结论。
+- 可选的 compiled OpenAPI nodes；若提供，后续 dry-run 与真实写入必须复用同一份 payload。
 
-### 写入画板
+route 不读取目标画板、不选择 mutation semantics、不执行远端写入，也不自行报告远端成功。
 
-写入画板时按最终产物类型选择 `+update --input_format`：
+交给 `+node-create` 的 artifact 必须是顶层 `{ "nodes": [...] }` 或该命令明确支持的等价输入。`whiteboard-cli --to openapi --format json` 的 `CliResponse` envelope 只有在被执行器明确支持时才能直接传入；否则必须先整理为 `{ "nodes": data.result.nodes }`。不得把 route 的本地成功响应 envelope 当成已可写入的节点 payload。
 
-- Mermaid / PlantUML / SVG 产物直接写入时，`--input_format` 取单值 `mermaid` / `plantuml` / `svg`；写入非空已有画板并需要 overwrite 时，先确认会整板重建；SVG 修改已有画板时先走 [`../routes/svg-edit.md`](../routes/svg-edit.md) 的确认 workflow。
-- 只有 DSL 产物或已明确需要 OpenAPI 原生节点格式时，才先用 `npx -y @larksuite/whiteboard-cli@^0.2.13 --to openapi --format json` 转换，再用 `raw` 写入。
+### 已有输入与格式约束
 
-具体命令示例、`--overwrite`、`--idempotent-token` 和 `--as user/bot` 的使用方式，统一参考 [`whiteboard +update`](./lark-whiteboard-update.md)。
+用户提供完整 source 或 OpenAPI nodes，只能跳过生成步骤，不能跳过 board state、preview/check、dry-run、确认或写后验证。
+
+- 非空画板收到完整 Mermaid/PlantUML/SVG，但用户没有说明 append 还是 replace：必须先澄清 mutation intent。
+- `raw` 只适合消费可信生成器的创建 payload；禁止手改导出的 raw 后用 `+update` 声称 patch。
+- `whiteboard-cli` 当前不能本地渲染 PlantUML。`+update --dry-run` 也只生成本地请求预览，不验证服务端解析；真实写入是第一次服务端解析。执行前必须明确缺少写前几何 preview 和服务端解析证明，用户要求其中任一证明时停止。
+
+### 原生语义约束
+
+用户明确要求“原生表格 / 原生思维导图 / Mermaid 源码 / PlantUML 源码 / 可继续按源码维护”时，不能只用普通形状、文本和连线模拟后声称满足原生可编辑性。
+
+- 如果输入本身是 Mermaid/PlantUML source，保留源码路径；对既有单一源码图的修改走 [Source Round-Trip](#source-round-trip)，并说明 replace 语义。
+- 如果只能生成普通 OpenAPI nodes 或 SVG 来模拟表格、思维导图、Mermaid/PlantUML，必须把它标为视觉降级；用户没有接受降级时进入[能力边界](#能力边界)，不写入。
+- 写后验证不能只看视觉接近；需要核对目标是否仍具备用户要求的原生结构或源码级维护入口。无法核对时报告能力边界。
+
+### 写入策略
+
+| Operation | Preservation | Confirmation |
+|---|---|---|
+| initialize | 只写已确认 blank 的画板，不覆盖 | 原始明确写入请求即可。 |
+| append | 只创建新内容，不覆盖、不修改既有节点 | 原始明确追加请求即可；精确放置要求必须先通过能力边界。 |
+| patch | 只更新已定位 node id 的显式字段 | 原始明确修改请求即可；目标或字段不明时先澄清。 |
+| delete | 只删除已确认的 node id | dry-run 后展示精确目标，取得删除批准并传 `--yes`。 |
+| replace | 丢弃非空画板完整旧状态 | 本地请求预览后展示最终 preview、损失和精确覆盖请求，再取得 final overwrite approval。 |
+
+所有可执行写操作共享以下规则：
+
+- `--dry-run` 只执行本地校验和请求预览，不调用画板 OpenAPI，也不证明服务端会接受或正确渲染 artifact。
+- 先生成本地请求预览，再真实执行；请求预览不是对未说明破坏性效果的授权。
+- 检查、请求预览和真实执行复用同一 artifact；同一次逻辑写入只生成一个幂等 token，重试必须复用。
+- 确认后如果目标、artifact 或 board state 变化，重新 preflight；replace 需要重新确认。
+- 写后用 raw 或 preview 读回，不只看命令退出码。
+- append 失败时不得自动使用 SVG Edit、清空画板或 `+update --overwrite`。
+- patch 失败时不得自动使用 `+node-create` 遮罩、SVG Edit、raw create 或 `+update --overwrite`。
+- source append 不能因为无法表达“放到右侧/旁边/某列”就升级成 replace；没有明确覆盖授权时，`--overwrite` 是破坏性操作。
+- source 写入超时、无响应或结果不明时，先用 raw/preview 读回判断是否已经生效；不得盲目重试并重新生成幂等 token。
+
+具体参数和命令示例见 [`+update`](./lark-whiteboard-update.md)、[`+node-create`](./lark-whiteboard-node-create.md)、[`+node-update`](./lark-whiteboard-node-update.md) 和 [`+node-delete`](./lark-whiteboard-node-delete.md)。
+
+## Source Round-Trip
+
+`+export --output-type source` 不是修改已有画板的默认第一步。只有同时满足以下条件，才能提出 source round-trip：
+
+1. 导出确认目标是单一 Mermaid 或 PlantUML 代码图。
+2. 用户要修改的是该代码图本身，不是在旁边追加独立内容。
+3. 没有额外非源码内容需要保留，或用户接受丢弃它们。
+4. 编辑后源码完成当前格式可用的检查。
+
+该路径实际是 replace，不是 patch。必须先说明整板替换语义并取得同意，再进入 replace。Mermaid 可先本地 render/check；PlantUML 遵守[已有输入与格式约束](#已有输入与格式约束)中的 preview 限制。
+
+source replace 执行后如果结果不明，先读回当前画板并与目标 artifact 对比；不能直接再次写入同一整图或改用 append 补救。
+
+## 能力边界
+
+当前 Skill 不能完成以下请求：
+
+- 无法唯一定位 node id，或无法构造安全 OpenAPI payload 的高层级结构修改。
+- 在复杂非空画板的指定位置插入或移动图形，同时证明无碰撞并保留全部连接语义、层级、资源和交互属性。
+- 非空画板中要求“新增到右侧/旁边/下方/某列”等相对位置，但当前只有 Mermaid/PlantUML/SVG source，无法生成带最终 bbox 的 OpenAPI payload。
+- 在没有对应原生写入能力时，承诺生成原生表格、原生思维导图、Mermaid/PlantUML 源码级可维护节点；普通形状模拟只能作为用户明确接受的视觉降级。
+
+遇到能力边界时保持原画板不变，并提供与用户目标相符的选项：
+
+1. 交给 `lark-doc` 新建独立画板，再 initialize 新内容。
+2. 原内容可完整重建且用户接受损失时，生成完整 artifact 后走 replace。
+3. 不写入，等待具备所需高层级转换或联合几何检查能力后再处理。
+
+禁止把 raw ID 复用、根节点 offset、SVG Edit、清空画板或整板覆盖作为自动兜底。
+
+## SVG Edit
+
+[`svg-edit`](../routes/svg-edit.md) 是视觉重建路径，只能服务 replace，不能服务 append、patch 或 delete，也不能承诺保留节点语义。
+
+它有两个独立确认阶段：
+
+1. semantic-loss route consent：开始本地编辑前说明 node ID、连接语义、层级、表格、mention、锁定和评论等会丢失。
+2. final overwrite gate：完成 edited SVG、preview/check 和本地请求预览后，展示最终视觉结果与精确整板覆盖请求，再取得写入批准。
+
+第一阶段不是远端写入授权。任一阶段拒绝都不得写入。
+
+## lark-doc 交接
+
+`lark-doc` 负责文档结构，`lark-whiteboard` 负责画布内容。本 Skill 不直接创建、移动或删除文档 block。
+
+`lark-doc` 创建或插入画板 block 后，至少交回：
+
+- `board_token`。
+- 用户的 canvas goal。
+- 用户提供的源码或结构化数据。
+- mutation intent，例如 initialize、append 或 replace。
+- placement requirement，例如 document-level 或 canvas-level。
+
+如果 initialize 失败，返回空白 token、失败阶段和可重试信息，不自行删除 block，也不把空白画板误报为完成。

--- a/skills/lark-whiteboard/routes/dsl.md
+++ b/skills/lark-whiteboard/routes/dsl.md
@@ -23,19 +23,28 @@ Step 2: 生成完整 DSL（含颜色）
     2. 将脚本保存为 diagram.gen.cjs（必须 .cjs 后缀，脚本用 require() 写，.js 在 ESM 项目下会崩），执行 node diagram.gen.cjs 产出 diagram.json
     3. 用产出的 diagram.json 进入 Step 3
 
-Step 3: 渲染 & 审查 → 交付
+Step 3: 渲染 & 审查 → 交回 Workflow
   - 渲染前自查（见下方检查清单）
   - 渲染 PNG（仅用于预览验证，不是最终产物）：npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.json -o diagram.png
+  - 几何检查：npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.json --check
   - 检查：信息完整？布局合理？配色协调？文字无截断？连线无交叉？
   - 有问题 → 按症状表修复 → 重新渲染（最多 2 轮）
   - 2 轮后仍有严重问题 → 考虑走 Mermaid 路径兜底
-  - 写入画板：用 whiteboard-cli 将 diagram.json 转换为 OpenAPI 格式并 pipe 给 +update：
-      npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.json --to openapi --format json \
-        | lark-cli whiteboard +update --whiteboard-token <board_token> \
-            --source - --input_format raw --idempotent-token <时间戳+标识> --as user
-      → 完整 dry-run / 确认流程见 [§ 写入画板](../references/lark-whiteboard-workflow.md#写入画板)
-  - 交付：向用户报告 board_token 写入成功
+  - 生成 compiled nodes：npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.json --to openapi --format json -o compiled-nodes.json
+  - 把 source、preview/check 和 compiled nodes 交回中央 Workflow
+  - 不在 route 内读取目标画板、选择 mutation semantics、执行远端写入或报告远端成功
 ```
+
+## Artifact Contract
+
+本 route 交回 [`lark-whiteboard-workflow.md`](../references/lark-whiteboard-workflow.md#渲染--写入画板)：
+
+- `diagram.json`：DSL source。
+- `diagram.png`：本地 preview。
+- 本地 `--check` 结果和人工视觉审查结论。
+- `compiled-nodes.json`：同一 source 转换出的 OpenAPI 创建 payload。
+
+compiled nodes 只证明独立产物可生成，不证明它已满足非空画板的精确放置或新旧联合碰撞要求。Workflow 决定 initialize、append 或 replace，并负责本地请求预览、确认、远端写入和读回。
 
 **布局策略快速判断**（详见 `elements/layout.md`）：
 

--- a/skills/lark-whiteboard/routes/mermaid.md
+++ b/skills/lark-whiteboard/routes/mermaid.md
@@ -4,24 +4,29 @@
 
 ## Workflow
 
-```
+```text
 Step 1: 读取知识
-  - 读 scenes/mermaid.md — Mermaid 语法和使用方式
+  - 读 scenes/mermaid.md，了解 Mermaid 语法和使用方式
 
 Step 2: 生成 Mermaid
-  - 按 mermaid.md 的语法编写 .mmd 文件
-  - 只输出纯 Mermaid 语法文本
+  - 创建 ./diagrams/YYYY-MM-DDTHHMMSS/
+  - 把纯 Mermaid 语法保存为 diagram.mmd
 
-Step 3: 渲染验证 & 写入画板 & 交付
-  1. 创建产物目录 ./diagrams/YYYY-MM-DDTHHMMSS/
-  2. 保存为 diagram.mmd
-  3. 渲染（仅用于预览验证，PNG 不是最终产物）：
-       npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.mmd -o diagram.png
-  4. 审查 PNG，有问题修改后重新渲染（最多 2 轮）
-  5. 写入画板：用 whiteboard-cli 将 diagram.mmd 转换为 OpenAPI 格式并 pipe 给 +update：
-       npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.mmd --to openapi --format json \
-         | lark-cli whiteboard +update --whiteboard-token <board_token> \
-             --source - --input_format raw --idempotent-token <时间戳+标识> --as user
-       → 完整 dry-run / 确认流程见 [§ 写入画板](../references/lark-whiteboard-workflow.md#写入画板)
-  6. 交付：向用户报告 board_token 写入成功
+Step 3: 渲染审查并交回 Workflow
+  - 渲染 preview：npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.mmd -o diagram.png
+  - 审查 PNG，有问题修改后重新渲染，最多 2 轮
+  - 检查：npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.mmd --check
+  - 按需生成 compiled nodes：npx -y @larksuite/whiteboard-cli@^0.2.13 -i diagram.mmd --to openapi --format json -o compiled-nodes.json
+  - 不在 route 内读取目标画板、选择 mutation semantics、执行远端写入或报告远端成功
 ```
+
+## Artifact Contract
+
+本 route 交回 [`lark-whiteboard-workflow.md`](../references/lark-whiteboard-workflow.md#渲染--写入画板)：
+
+- `diagram.mmd`：Mermaid source。
+- `diagram.png`：本地 preview。
+- 本地 `--check` 结果和人工视觉审查结论。
+- 可选 `compiled-nodes.json`：同一 source 转换出的 OpenAPI 创建 payload。
+
+Workflow 决定 initialize、append 或 replace，并负责本地请求预览、确认、远端写入和读回。

--- a/skills/lark-whiteboard/routes/svg-edit.md
+++ b/skills/lark-whiteboard/routes/svg-edit.md
@@ -14,7 +14,7 @@ SVG 导出是**纯视觉快照**，再次导入后画板语义（思维导图层
 
 ## Workflow
 
-### 0. 用户确认（强制）
+### 0. Semantic-loss route consent（强制）
 
 执行任何编辑前，先判断**紧邻的上一条用户消息**是否已明确确认有损编辑：
 
@@ -23,7 +23,9 @@ SVG 导出是**纯视觉快照**，再次导入后画板语义（思维导图层
 
 > SVG 编辑只保证视觉层面对齐，画板语义（层级/节点类型/思维导图结构/表格结构/连线绑定/容器类型/mention 等）将不可恢复，是否继续？
 
-这是**知情确认**（动手前让用户对语义丢失止损）；真正的破坏性写入在 Step 4 还会再经 `--overwrite` dry-run 确认一次，二者职责不同、都不可省。
+这是**知情确认**（动手前让用户对语义丢失止损）；真正的破坏性写入还必须回到中央 Workflow 的 replace 分支，经 `--overwrite` dry-run 和 final overwrite gate 确认。二者职责不同、都不可省。
+
+**用户未确认前不得执行后续步骤。** 这一步只允许开始有损的本地 artifact 编辑，不是远端覆盖授权。
 
 ### 1. 导出当前画板 SVG
 
@@ -32,7 +34,7 @@ lark-cli whiteboard +export \
   --whiteboard-token <TOKEN> \
   --output-type svg \
   --output <dir>/original.svg \
-  --as user
+  --as <identity>
 ```
 
 ### 2. 编辑 SVG
@@ -65,24 +67,20 @@ npx -y @larksuite/whiteboard-cli@^0.2.13 -i <dir>/edited.svg -f svg --check
 结合 PNG 视觉效果和 `--check` 报告进行调整，有问题则修改 SVG 后重新渲染（最多 2 轮）。
 - SVG 本地渲染预览时，画板中的图片因 session 原因无法正常显示，属于预期内的行为。
 
-### 4. 写回画板
+### 4. 交回 Workflow
 
-`--overwrite` 会清空原画板内容，确认后再执行
+本 route 到此停止。把编辑产物、preview、检查结果和语义损失摘要交回中央 Workflow，由 replace 分支生成不发请求的本地请求预览、展示精确覆盖请求并取得 final overwrite approval。
 
-```bash
-# dry-run 探测
-lark-cli whiteboard +update \
-  --whiteboard-token <TOKEN> \
-  --source @<dir>/edited.svg \
-  --input_format svg \
-  --idempotent-token <10+字符唯一串> \
-  --overwrite --dry-run --as user
+route 不直接写远端画板，也不把第一阶段 consent 当作最终授权。
 
-# 用户确认后执行
-lark-cli whiteboard +update \
-  --whiteboard-token <TOKEN> \
-  --source @<dir>/edited.svg \
-  --input_format svg \
-  --idempotent-token <10+字符唯一串> \
-  --overwrite --as user
-```
+## Artifact Contract
+
+本 route 交回 [`lark-whiteboard-workflow.md`](../references/lark-whiteboard-workflow.md#svg-edit)：
+
+- `original.svg`：导出的原始视觉快照，仅作为本地编辑输入。
+- `edited.svg`：完整 replace artifact。
+- `edited.png`：最终本地 preview。
+- 本地 `--check` 结果和人工视觉审查结论。
+- 语义损失摘要：node ID、连接语义、层级、表格、mention、锁定、评论等不再保留。
+
+本 route 只服务 replace。append、patch 或 delete 不得在失败后自动转入本 route。

--- a/skills/lark-whiteboard/routes/svg.md
+++ b/skills/lark-whiteboard/routes/svg.md
@@ -39,6 +39,17 @@
 
 `npx -y @larksuite/whiteboard-cli@^0.2.13 --check` 检测 `text-overflow` 和 `node-overlap`, 并结合视觉效果(查看 PNG)进行调整
 
+## Artifact Contract
+
+本 route 交回 [`lark-whiteboard-workflow.md`](../references/lark-whiteboard-workflow.md#渲染--写入画板)：
+
+- `diagram.svg`：SVG source。
+- `diagram.png`：本地 preview。
+- 本地 `--check` 结果和人工视觉审查结论。
+- 可选 `diagram.json`：同一 source 转换出的 OpenAPI 创建 payload。
+
+本 route 不读取目标画板、不决定 mutation semantics，也不执行远端写入。Workflow 决定 initialize、append 或 replace，并负责本地请求预览、确认、远端写入和读回。
+
 ## 画板怎么处理 SVG
 
 画板的 svg-parser 把可识别元素转成可编辑节点, 其余降级为内嵌图片(渲染没问题, 虽然不可编辑, 但是可以正常显示)；但非阴影用途的 `<filter>` / `<clipPath>` 等装饰特性画板不支持（见下方⚠️）

--- a/tests/cli_e2e/whiteboard/whiteboard_node_create_dryrun_test.go
+++ b/tests/cli_e2e/whiteboard/whiteboard_node_create_dryrun_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhiteboardNodeCreateDryRun_RequestShape(t *testing.T) {
+	setWhiteboardDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"whiteboard", "+node-create",
+			"--whiteboard-token", "wbcnCreateDryRun",
+			"--source", `{"nodes":[{"id":"tmpNode","type":"composite_shape","x":0,"y":0,"width":260,"height":45,"text":{"text":"hello","font_weight":"regular","font_size":14,"horizontal_align":"center","vertical_align":"mid"},"style":{"border_color":"#3370ff","border_width":"narrow","border_style":"solid","fill_color":"#e8f3ff"},"composite_shape":{"type":"round_rect"}}]}`,
+			"--idempotent-token", "create-token-12345",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, int64(1), clie2e.DryRunGet(out, "api.#").Int(), out)
+	require.Equal(t, "POST", clie2e.DryRunGet(out, "api.0.method").String(), out)
+	gotURL := clie2e.DryRunGet(out, "api.0.url").String()
+	if !strings.HasPrefix(gotURL, "/open-apis/board/v1/whiteboards/") || !strings.HasSuffix(gotURL, "/nodes") || strings.Contains(gotURL, "wbcnCreateDryRun") {
+		t.Fatalf("url=%q, want masked board whiteboard nodes URL\nstdout:\n%s", gotURL, out)
+	}
+	require.Equal(t, "create-token-12345", clie2e.DryRunGet(out, "api.0.params.client_token").String(), out)
+	require.Equal(t, "composite_shape", clie2e.DryRunGet(out, "api.0.body.nodes.0.type").String(), out)
+	require.Equal(t, "round_rect", clie2e.DryRunGet(out, "api.0.body.nodes.0.composite_shape.type").String(), out)
+}

--- a/tests/cli_e2e/whiteboard/whiteboard_node_delete_dryrun_test.go
+++ b/tests/cli_e2e/whiteboard/whiteboard_node_delete_dryrun_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhiteboardNodeDeleteDryRun_RequestShape(t *testing.T) {
+	setWhiteboardDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"whiteboard", "+node-delete",
+			"--whiteboard-token", "wbcnDeleteDryRun",
+			"--node-ids", "nodeA,nodeB",
+			"--idempotent-token", "delete-token-12345",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, int64(1), clie2e.DryRunGet(out, "api.#").Int(), out)
+	require.Equal(t, "DELETE", clie2e.DryRunGet(out, "api.0.method").String(), out)
+	gotURL := clie2e.DryRunGet(out, "api.0.url").String()
+	if !strings.HasPrefix(gotURL, "/open-apis/board/v1/whiteboards/") ||
+		!strings.HasSuffix(gotURL, "/nodes/batch_delete") ||
+		strings.Contains(gotURL, "wbcnDeleteDryRun") {
+		t.Fatalf("url=%q, want masked board whiteboard batch delete URL\nstdout:\n%s", gotURL, out)
+	}
+	require.Equal(t, "delete-token-12345", clie2e.DryRunGet(out, "api.0.params.client_token").String(), out)
+	require.Equal(t, "nodeA", clie2e.DryRunGet(out, "api.0.body.ids.0").String(), out)
+	require.Equal(t, "nodeB", clie2e.DryRunGet(out, "api.0.body.ids.1").String(), out)
+}

--- a/tests/cli_e2e/whiteboard/whiteboard_node_update_dryrun_test.go
+++ b/tests/cli_e2e/whiteboard/whiteboard_node_update_dryrun_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhiteboardNodeUpdateDryRun_RequestShape(t *testing.T) {
+	setWhiteboardDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"whiteboard", "+node-update",
+			"--whiteboard-token", "wbcnUpdateDryRun",
+			"--source", `{"code":0,"msg":"success","data":{"nodes":[{"id":"nodeA","type":"text_shape","text":{"text":"hello A","content":"drop me"},"extra":true},{"id":"nodeB","type":"text_shape","text":{"text":"hello B"}}]}}`,
+			"--idempotent-token", "update-token-12345",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, int64(1), clie2e.DryRunGet(out, "api.#").Int(), out)
+	require.Equal(t, "PUT", clie2e.DryRunGet(out, "api.0.method").String(), out)
+	gotURL := clie2e.DryRunGet(out, "api.0.url").String()
+	if !strings.HasPrefix(gotURL, "/open-apis/board/v1/whiteboards/") ||
+		!strings.HasSuffix(gotURL, "/nodes/batch_update") ||
+		strings.Contains(gotURL, "wbcnUpdateDryRun") {
+		t.Fatalf("url=%q, want masked board whiteboard batch update URL\nstdout:\n%s", gotURL, out)
+	}
+	require.Equal(t, "update-token-12345", clie2e.DryRunGet(out, "api.0.params.client_token").String(), out)
+	require.Equal(t, "nodeA", clie2e.DryRunGet(out, "api.0.body.nodes.0.id").String(), out)
+	require.Equal(t, "hello A", clie2e.DryRunGet(out, "api.0.body.nodes.0.text.text").String(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.0.body.nodes.0.text.content").Exists(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.0.body.nodes.0.extra").Exists(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.0.body.code").Exists(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.0.body.data").Exists(), out)
+	require.Equal(t, "nodeB", clie2e.DryRunGet(out, "api.0.body.nodes.1.id").String(), out)
+	require.Equal(t, "hello B", clie2e.DryRunGet(out, "api.0.body.nodes.1.text.text").String(), out)
+}

--- a/tests/cli_e2e/whiteboard/whiteboard_node_workflow_test.go
+++ b/tests/cli_e2e/whiteboard/whiteboard_node_workflow_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestWhiteboardNodeLiveWorkflow(t *testing.T) {
+	whiteboardToken := os.Getenv("LARK_WHITEBOARD_E2E_TOKEN")
+	if whiteboardToken == "" {
+		t.Skip("skipped: LARK_WHITEBOARD_E2E_TOKEN not set")
+	}
+	clie2e.SkipWithoutUserToken(t)
+
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	createdText := "lark-cli whiteboard node create " + suffix
+	updatedText := "lark-cli whiteboard node update " + suffix
+	nodeID := ""
+
+	parentT.Cleanup(func() {
+		if nodeID == "" {
+			return
+		}
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+
+		result, err := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+			Args: []string{
+				"whiteboard", "+node-delete",
+				"--whiteboard-token", whiteboardToken,
+				"--node-ids", nodeID,
+				"--idempotent-token", "wb-node-cleanup-" + suffix,
+			},
+			DefaultAs: "user",
+			Yes:       true,
+		})
+		clie2e.ReportCleanupFailure(parentT, "delete whiteboard node "+nodeID, result, err)
+	})
+
+	createSource := marshalWhiteboardNodeSource(t, map[string]interface{}{
+		"id":     "tmpNode",
+		"type":   "composite_shape",
+		"x":      0,
+		"y":      0,
+		"width":  260,
+		"height": 45,
+		"text": map[string]interface{}{
+			"text":             createdText,
+			"font_weight":      "regular",
+			"font_size":        14,
+			"horizontal_align": "center",
+			"vertical_align":   "mid",
+		},
+		"style": map[string]interface{}{
+			"border_color": "#3370ff",
+			"border_width": "narrow",
+			"border_style": "solid",
+			"fill_color":   "#e8f3ff",
+		},
+		"composite_shape": map[string]interface{}{"type": "round_rect"},
+	})
+	createResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"whiteboard", "+node-create",
+			"--whiteboard-token", whiteboardToken,
+			"--source", createSource,
+			"--idempotent-token", "wb-node-create-" + suffix,
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	createResult.AssertExitCode(t, 0)
+	createResult.AssertStdoutStatus(t, true)
+	nodeID = gjson.Get(createResult.Stdout, "data.ids").String()
+	require.NotEmpty(t, nodeID, "stdout:\n%s", createResult.Stdout)
+	require.NotContains(t, nodeID, ",", "single-node create must return one id; stdout:\n%s", createResult.Stdout)
+
+	updateSource := marshalWhiteboardNodeSource(t, map[string]interface{}{
+		"id":   nodeID,
+		"type": "composite_shape",
+		"text": map[string]interface{}{
+			"text":             updatedText,
+			"font_weight":      "regular",
+			"font_size":        14,
+			"horizontal_align": "center",
+			"vertical_align":   "mid",
+		},
+	})
+	updateResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"whiteboard", "+node-update",
+			"--whiteboard-token", whiteboardToken,
+			"--source", updateSource,
+			"--idempotent-token", "wb-node-update-" + suffix,
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	updateResult.AssertExitCode(t, 0)
+	updateResult.AssertStdoutStatus(t, true)
+	require.Equal(t, nodeID, gjson.Get(updateResult.Stdout, "data.ids").String(), updateResult.Stdout)
+	require.Equal(t, int64(1), gjson.Get(updateResult.Stdout, "data.count").Int(), updateResult.Stdout)
+
+	var readbackStdout string
+	err = clie2e.WaitForCondition(ctx, clie2e.WaitOptions{
+		Timeout:  30 * time.Second,
+		Interval: 2 * time.Second,
+		TimeoutError: func() error {
+			return fmt.Errorf("updated whiteboard node %s was not visible in raw export", nodeID)
+		},
+	}, func() (bool, error) {
+		result, runErr := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"whiteboard", "+export",
+				"--whiteboard-token", whiteboardToken,
+				"--output-type", "raw",
+			},
+			DefaultAs: "user",
+			Format:    "json",
+		})
+		if runErr != nil {
+			return false, runErr
+		}
+		if result.ExitCode != 0 || !gjson.Get(result.Stdout, "status").Bool() {
+			return false, fmt.Errorf("raw export failed: exit=%d stdout=%s stderr=%s", result.ExitCode, result.Stdout, result.Stderr)
+		}
+		readbackStdout = result.Stdout
+		node := whiteboardNodeByID(result.Stdout, nodeID)
+		return node.Exists() && node.Get("text.text").String() == updatedText, nil
+	})
+	require.NoError(t, err, "last raw export:\n%s", readbackStdout)
+
+	deleteResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"whiteboard", "+node-delete",
+			"--whiteboard-token", whiteboardToken,
+			"--node-ids", nodeID,
+			"--idempotent-token", "wb-node-delete-" + suffix,
+		},
+		DefaultAs: "user",
+		Yes:       true,
+	})
+	require.NoError(t, err)
+	deleteResult.AssertExitCode(t, 0)
+	if deleteResult.ExitCode == 0 {
+		nodeID = ""
+	}
+	deleteResult.AssertStdoutStatus(t, true)
+	require.Equal(t, int64(1), gjson.Get(deleteResult.Stdout, "data.count").Int(), deleteResult.Stdout)
+}
+
+func marshalWhiteboardNodeSource(t *testing.T, node map[string]interface{}) string {
+	t.Helper()
+
+	payload, err := json.Marshal(map[string]interface{}{"nodes": []interface{}{node}})
+	require.NoError(t, err)
+	return string(payload)
+}
+
+func whiteboardNodeByID(stdout, nodeID string) gjson.Result {
+	for _, node := range gjson.Get(stdout, "data.nodes").Array() {
+		if node.Get("id").String() == nodeID {
+			return node
+		}
+	}
+	return gjson.Result{}
+}

--- a/tests/cli_e2e/whiteboard/whiteboard_parse_image_dryrun_test.go
+++ b/tests/cli_e2e/whiteboard/whiteboard_parse_image_dryrun_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhiteboardParseImageDryRun_RequestShapes(t *testing.T) {
+	setWhiteboardDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	t.Run("submit", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"whiteboard", "+parse-image",
+				"--whiteboard-token", "wbcnParseImageDryRun",
+				"--image", "./input.png",
+				"--mode", "agentic",
+				"--idempotent-token", "parse-token-12345",
+				"--overwrite",
+				"--dry-run",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		out := result.Stdout
+		if got := clie2e.DryRunGet(out, "api.0.method").String(); got != "POST" {
+			t.Fatalf("method=%q, want POST\nstdout:\n%s", got, out)
+		}
+		gotURL := clie2e.DryRunGet(out, "api.0.url").String()
+		if !strings.HasPrefix(gotURL, "/open-apis/board/v1/whiteboards/") || !strings.HasSuffix(gotURL, "/parse_image") {
+			t.Fatalf("url=%q, want parse_image submit URL\nstdout:\n%s", gotURL, out)
+		}
+		if got := clie2e.DryRunGet(out, "api.0.body.image_file").String(); got != "@./input.png" {
+			t.Fatalf("body.image_file=%q, want @./input.png\nstdout:\n%s", got, out)
+		}
+		if got := clie2e.DryRunGet(out, "api.0.body.client_token").String(); got != "parse-token-12345" {
+			t.Fatalf("body.client_token=%q, want parse-token-12345\nstdout:\n%s", got, out)
+		}
+		if got := clie2e.DryRunGet(out, "api.0.body.overwrite").Bool(); !got {
+			t.Fatalf("body.overwrite=%v, want true\nstdout:\n%s", got, out)
+		}
+		if got := clie2e.DryRunGet(out, "api.0.body.mode").String(); got != "agentic" {
+			t.Fatalf("body.mode=%q, want agentic\nstdout:\n%s", got, out)
+		}
+	})
+
+	t.Run("result", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"whiteboard", "+parse-image-result",
+				"--whiteboard-token", "wbcnParseImageDryRun",
+				"--task-id", "7670001",
+				"--dry-run",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		out := result.Stdout
+		if got := clie2e.DryRunGet(out, "api.0.method").String(); got != "GET" {
+			t.Fatalf("method=%q, want GET\nstdout:\n%s", got, out)
+		}
+		gotURL := clie2e.DryRunGet(out, "api.0.url").String()
+		if !strings.HasPrefix(gotURL, "/open-apis/board/v1/whiteboards/") || !strings.HasSuffix(gotURL, "/parse_image/7670001") {
+			t.Fatalf("url=%q, want parse_image result URL\nstdout:\n%s", gotURL, out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `whiteboard +parse-image` for user-mode multipart ParseImage submit.
- Add `whiteboard +parse-image-result` for one-shot or `--wait` task result polling.
- Document the ParseImage workflow in `lark-whiteboard` skill docs and add dry-run E2E coverage.

## Test Plan
- `make build`
- `go test ./shortcuts/whiteboard -run 'ParseImage' -v`\n- `go test ./shortcuts/whiteboard -v`\n- `go test ./tests/cli_e2e/whiteboard -run 'ParseImageDryRun' -v`\n- `go test ./cmd ./shortcuts/whiteboard -run 'ParseImage|Shortcuts|Unknown'`\n- `git diff --check`\n