### PR TITLE
feat(base): improve field update completion signals

### DIFF
--- a/shortcuts/base/base_dryrun_ops_test.go
+++ b/shortcuts/base/base_dryrun_ops_test.go
@@ -85,6 +85,12 @@ func TestDryRunFieldOps(t *testing.T) {
 		map[string]int{"offset": 3, "limit": 30},
 	)
 	assertDryRunContains(t, dryRunFieldGet(ctx, rt), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/fields/fld_1")
+	fieldGetAliasRT := newBaseTestRuntime(
+		map[string]string{"base-token": "app_x", "table-id": "tbl_1", "field-id-or-name": "Amount"},
+		nil,
+		nil,
+	)
+	assertDryRunContains(t, dryRunFieldGet(ctx, fieldGetAliasRT), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/fields/Amount")
 	assertDryRunContains(t, dryRunFieldCreate(ctx, rt), "POST /open-apis/base/v3/bases/app_x/tables/tbl_1/fields")
 
 	arrayRT := newBaseTestRuntime(
@@ -117,6 +123,18 @@ func TestDryRunFieldOps(t *testing.T) {
 	if out := autoNumberDR.Format(); strings.Contains(out, "auto_serial") || strings.Contains(out, "reformat_existing_records") || strings.Contains(out, "/open-apis/bitable/v1/") {
 		t.Fatalf("auto_number dry-run must stay on v3 field JSON, got:\n%s", out)
 	}
+
+	reformatRT := newBaseTestRuntime(
+		map[string]string{
+			"base-token": "app_x",
+			"table-id":   "tbl_1",
+			"field-id":   "fld_1",
+			"json":       `{"name":"编号","type":"auto_number","style":{"rules":[{"type":"text","text":"TASK-"},{"type":"created_time","date_format":"yyyyMM"},{"type":"text","text":"-"},{"type":"incremental_number","length":4}]}}`,
+		},
+		map[string]bool{"reformat-existing-records": true},
+		nil,
+	)
+	assertDryRunContains(t, dryRunFieldUpdate(ctx, reformatRT), "PUT /open-apis/bitable/v1/apps/app_x/tables/tbl_1/fields/fld_1", `"field_name":"编号"`, `"type":1005`, `"reformat_existing_records":true`, `"type":"system_number"`, `"value":"4"`)
 }
 
 func TestDryRunRecordOps(t *testing.T) {

--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -906,7 +906,7 @@ func TestFieldUpdateResultAlwaysRecommendsReadback(t *testing.T) {
 	}
 }
 
-func TestBaseFieldExecuteUpdateNoopReturnsAPIError(t *testing.T) {
+func TestBaseFieldExecuteUpdateNoop(t *testing.T) {
 	factory, stdout, reg := newExecuteFactory(t)
 	reg.Register(&httpmock.Stub{
 		Method: "PUT",
@@ -916,23 +916,17 @@ func TestBaseFieldExecuteUpdateNoopReturnsAPIError(t *testing.T) {
 			"msg":  "no operation produced",
 		},
 	})
-	err := runShortcut(t, BaseFieldUpdate, []string{"+field-update", "--base-token", "app_x", "--table-id", "tbl_x", "--field-id", "fld_x", "--json", `{"name":"Amount","type":"number"}`, "--yes"}, factory, stdout)
-	if err == nil {
-		t.Fatal("expected the API no-op response to surface as an error, got nil")
+	if err := runShortcut(t, BaseFieldUpdate, []string{"+field-update", "--base-token", "app_x", "--table-id", "tbl_x", "--field-id", "fld_x", "--json", `{"name":"Amount","type":"number"}`, "--yes"}, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
 	}
-	p, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected a typed API error, got %T %v", err, err)
+	got := stdout.String()
+	for _, want := range []string{`"updated": false`, `"noop": true`, `"field_ref": "fld_x"`, `"current_matches_submitted": true`, `"field_get_recommended": false`, `"field_get_required": false`, `"next_step": "done"`, `"verification_hint"`, `"submitted_field"`, `"name": "Amount"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, got)
+		}
 	}
-	if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeUnknown || p.Code != 800070003 {
-		t.Fatalf("category/subtype/code=%s/%s/%d", p.Category, p.Subtype, p.Code)
-	}
-	var apiErr *errs.APIError
-	if !errors.As(err, &apiErr) {
-		t.Fatalf("expected APIError, got %T %v", err, err)
-	}
-	if got := stdout.String(); strings.TrimSpace(got) != "" {
-		t.Fatalf("no success envelope should be emitted on a no-op API error:\n%s", got)
+	if strings.Contains(got, `"id": "fld_x"`) {
+		t.Fatalf("stdout must not synthesize a field id from --field-id:\n%s", got)
 	}
 }
 
@@ -983,53 +977,114 @@ func TestBaseFieldExecuteUpdateAutoNumberUsesV3FieldJSON(t *testing.T) {
 	}
 }
 
-func TestBaseFieldExecuteUpdateDoesNotRejectExtraJSONKeys(t *testing.T) {
+func TestBaseFieldExecuteUpdateReformatExistingAutoNumber(t *testing.T) {
 	factory, stdout, reg := newExecuteFactory(t)
 	stub := &httpmock.Stub{
 		Method: "PUT",
-		URL:    "/open-apis/base/v3/bases/app_x/tables/tbl_x/fields/fld_x",
+		URL:    "/open-apis/bitable/v1/apps/app_x/tables/tbl_x/fields/fld_x",
 		Body: map[string]interface{}{
 			"code": 0,
-			"data": map[string]interface{}{"id": "fld_x", "name": "编号", "type": "auto_number"},
+			"data": map[string]interface{}{
+				"field": map[string]interface{}{"field_id": "fld_x", "field_name": "编号", "type": 1005},
+			},
 		},
 	}
 	reg.Register(stub)
-	// Unknown v3 keys are forwarded unchanged; the server remains the source of
-	// truth for whether a field-update property is supported.
-	jsonBody := `{"name":"编号","type":"auto_number","style":{"rules":[{"type":"incremental_number","length":4}]},"reformat_existing_records":true}`
-	if err := runShortcut(t, BaseFieldUpdate, []string{"+field-update", "--base-token", "app_x", "--table-id", "tbl_x", "--field-id", "fld_x", "--json", jsonBody, "--yes"}, factory, stdout); err != nil {
+	jsonBody := `{"name":"编号","type":"auto_number","style":{"rules":[{"type":"text","text":"TASK-"},{"type":"created_time","date_format":"yyyyMM"},{"type":"text","text":"-"},{"type":"incremental_number","length":4}]}}`
+	if err := runShortcut(t, BaseFieldUpdate, []string{"+field-update", "--base-token", "app_x", "--table-id", "tbl_x", "--field-id", "fld_x", "--json", jsonBody, "--reformat-existing-records", "--yes"}, factory, stdout); err != nil {
 		t.Fatalf("err=%v", err)
 	}
-	if gotBody := string(stub.CapturedBody); !strings.Contains(gotBody, `"reformat_existing_records":true`) {
-		t.Fatalf("request body must preserve unknown v3 key:\n%s", gotBody)
+	gotBody := string(stub.CapturedBody)
+	for _, want := range []string{
+		`"field_name":"编号"`,
+		`"type":1005`,
+		`"reformat_existing_records":true`,
+		`"type":"system_number"`,
+		`"value":"4"`,
+	} {
+		if !strings.Contains(gotBody, want) {
+			t.Fatalf("request body missing %q:\n%s", want, gotBody)
+		}
 	}
-	if got := stdout.String(); !strings.Contains(got, `"updated": true`) {
-		t.Fatalf("expected successful update, got: %s", got)
+	got := stdout.String()
+	for _, want := range []string{`"updated": true`, `"reformat_existing_records": true`, `"fld_x"`, `"field_get_recommended": false`, `"field_get_required": false`, `"next_step": "done"`, `"verification_hint"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, got)
+		}
 	}
 }
 
-func TestBaseFieldValidateAllowsRatingMaxAboveLimit(t *testing.T) {
-	ctx := context.Background()
+func TestBaseFieldExecuteUpdateReformatExistingAutoNumberRejectsUnsupportedDateFormat(t *testing.T) {
+	factory, stdout, _ := newExecuteFactory(t)
+	jsonBody := `{"name":"编号","type":"auto_number","style":{"rules":[{"type":"created_time","date_format":"yyMM"},{"type":"incremental_number","length":4}]}}`
+	err := runShortcut(t, BaseFieldUpdate, []string{"+field-update", "--base-token", "app_x", "--table-id", "tbl_x", "--field-id", "fld_x", "--json", jsonBody, "--reformat-existing-records", "--yes"}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T %v", err, err)
+	}
+	if p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("category/subtype=%s/%s", p.Category, p.Subtype)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T %v", err, err)
+	}
+	if validationErr.Param != "--json" {
+		t.Fatalf("param=%q, want --json", validationErr.Param)
+	}
+	if !strings.Contains(err.Error(), "use yyyyMMdd or yyyyMM") {
+		t.Fatalf("error did not include recovery hint: %v", err)
+	}
+}
+
+func TestBaseFieldExecuteRejectsRatingMaxAboveLimit(t *testing.T) {
 	tests := []struct {
 		name     string
 		shortcut common.Shortcut
-		runtime  *common.RuntimeContext
+		args     []string
 	}{
 		{
 			name:     "create",
 			shortcut: BaseFieldCreate,
-			runtime:  newBaseTestRuntime(map[string]string{"base-token": "app_x", "table-id": "tbl_x", "json": `{"name":"评分","type":"number","style":{"type":"rating","icon":"star","min":0,"max":20}}`}, nil, nil),
+			args:     []string{"+field-create", "--base-token", "app_x", "--table-id", "tbl_x", "--json", `{"name":"评分","type":"number","style":{"type":"rating","icon":"star","min":0,"max":20}}`},
 		},
 		{
 			name:     "update",
 			shortcut: BaseFieldUpdate,
-			runtime:  newBaseTestRuntime(map[string]string{"base-token": "app_x", "table-id": "tbl_x", "field-id": "fld_x", "json": `{"name":"评分","type":"number","style":{"type":"rating","icon":"star","min":0,"max":20}}`}, nil, nil),
+			args:     []string{"+field-update", "--base-token", "app_x", "--table-id", "tbl_x", "--field-id", "fld_x", "--json", `{"name":"评分","type":"number","style":{"type":"rating","icon":"star","min":0,"max":20}}`, "--yes"},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.shortcut.Validate(ctx, tc.runtime); err != nil {
-				t.Fatalf("rating max above 10 should not be blocked by CLI validation: %v", err)
+			factory, stdout, _ := newExecuteFactory(t)
+			err := runShortcut(t, tc.shortcut, tc.args, factory, stdout)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed problem, got %T %v", err, err)
+			}
+			if p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("category/subtype=%s/%s", p.Category, p.Subtype)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("expected ValidationError, got %T %v", err, err)
+			}
+			if validationErr.Param != "--json" {
+				t.Fatalf("param=%q, want --json", validationErr.Param)
+			}
+			for _, want := range []string{"rating max must be <= 10", "plain number/progress field"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error missing %q: %v", want, err)
+				}
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout must stay empty on validation failure, got %s", stdout.String())
 			}
 		})
 	}

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -507,6 +507,37 @@ func TestBaseRecordProjectionAliasesAreHidden(t *testing.T) {
 	}
 }
 
+func TestBaseFieldGetAliasIsHidden(t *testing.T) {
+	parent := &cobra.Command{Use: "base"}
+	BaseFieldGet.Mount(parent, &cmdutil.Factory{})
+	cmd := parent.Commands()[0]
+	flag := cmd.Flags().Lookup("field-id-or-name")
+	if flag == nil {
+		t.Fatal("flag --field-id-or-name missing")
+	}
+	if !flag.Hidden {
+		t.Fatal("flag --field-id-or-name must be hidden")
+	}
+	if strings.Contains(cmd.Flags().FlagUsages(), "--field-id-or-name") {
+		t.Fatalf("help should not include hidden --field-id-or-name:\n%s", cmd.Flags().FlagUsages())
+	}
+	if err := cmd.ParseFlags([]string{"--base-token", "b", "--table-id", "t"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := cmd.ValidateFlagGroups(); err == nil || !strings.Contains(err.Error(), "at least one of the flags") {
+		t.Fatalf("expected field selector one-required group error, got %v", err)
+	}
+	if err := cmd.Flags().Set("field-id", "fld_1"); err != nil {
+		t.Fatalf("set field-id: %v", err)
+	}
+	if err := cmd.Flags().Set("field-id-or-name", "Amount"); err != nil {
+		t.Fatalf("set field-id-or-name: %v", err)
+	}
+	if err := cmd.ValidateFlagGroups(); err == nil || !strings.Contains(err.Error(), "none of the others can be") {
+		t.Fatalf("expected field selector mutual exclusion group error, got %v", err)
+	}
+}
+
 func TestBaseDashboardHelpGuidesAgents(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1024,14 +1055,12 @@ func TestBaseFieldUpdateHelpGuidesAgents(t *testing.T) {
 	help := cmd.Flags().FlagUsages()
 	wantHelp := []string{
 		"complete field definition JSON object; update uses full PUT semantics, not a patch",
+		"auto_number only: regenerate existing record numbers",
 	}
 	for _, want := range wantHelp {
 		if !strings.Contains(help, want) {
 			t.Fatalf("flag help missing %q:\n%s", want, help)
 		}
-	}
-	if strings.Contains(help, "reformat-existing-records") {
-		t.Fatalf("+field-update must not expose a --reformat-existing-records flag:\n%s", help)
 	}
 
 	tips := strings.Join(cmdutil.GetTips(cmd), "\n")
@@ -1039,8 +1068,9 @@ func TestBaseFieldUpdateHelpGuidesAgents(t *testing.T) {
 		`lark-cli base +field-update --base-token <base_token> --table-id <table_id> --field-id "Status" --json '{"name":"Status","type":"text"}' --yes`,
 		`"type":"select","multiple":false,"options":[{"name":"Todo"},{"name":"Done"}]`,
 		`Example auto_number update: lark-cli base +field-update`,
-		`When --json.type is "auto_number", updating the numbering rules also reapplies them to existing numbers`,
-		"just submit the target field definition and do not add extra low-level parameters",
+		"--reformat-existing-records",
+		`When --json.type is "auto_number", pass --reformat-existing-records to also regenerate existing record numbers`,
+		"do not put low-level reformat_existing_records inside --json",
 		"full field-definition PUT semantics",
 		"Read the current field first with +field-get",
 		"Type conversion is allowlist-based",
@@ -1052,9 +1082,6 @@ func TestBaseFieldUpdateHelpGuidesAgents(t *testing.T) {
 		if !strings.Contains(tips, want) {
 			t.Fatalf("tips missing %q:\n%s", want, tips)
 		}
-	}
-	if strings.Contains(tips, "--reformat-existing-records") {
-		t.Fatalf("+field-update tips must not ask agents to pass --reformat-existing-records:\n%s", tips)
 	}
 }
 
@@ -1178,6 +1205,15 @@ func assertHelpOrder(t *testing.T, help string, before string, after string) {
 
 func TestBaseFieldValidate(t *testing.T) {
 	ctx := context.Background()
+	if err := BaseFieldGet.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t"}, nil, nil)); err == nil || !strings.Contains(err.Error(), "--field-id is required") {
+		t.Fatalf("err=%v", err)
+	}
+	if err := BaseFieldGet.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id-or-name": "Amount"}, nil, nil)); err != nil {
+		t.Fatalf("field get alias validate err=%v", err)
+	}
+	if err := BaseFieldGet.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id": "fld_1", "field-id-or-name": "Amount"}, nil, nil)); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("err=%v", err)
+	}
 	if err := BaseFieldCreate.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "json": "{"}, nil, nil)); err == nil || !strings.Contains(err.Error(), "--json invalid JSON object") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1214,6 +1250,15 @@ func TestBaseFieldValidate(t *testing.T) {
 	autoNumberJSON := `{"name":"编号","type":"auto_number","style":{"rules":[{"type":"text","text":"TASK-"},{"type":"created_time","date_format":"yyyyMM"},{"type":"incremental_number","length":4}]}}`
 	if err := BaseFieldUpdate.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id": "fld_1", "json": autoNumberJSON}, nil, nil)); err != nil {
 		t.Fatalf("auto number update validate err=%v", err)
+	}
+	if err := BaseFieldUpdate.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id": "fld_1", "json": autoNumberJSON}, map[string]bool{"reformat-existing-records": true}, nil)); err != nil {
+		t.Fatalf("auto number reformat validate err=%v", err)
+	}
+	if err := BaseFieldUpdate.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id": "fld_1", "json": `{"name":"Amount","type":"number"}`}, map[string]bool{"reformat-existing-records": true}, nil)); err == nil || !strings.Contains(err.Error(), "--json.type") {
+		t.Fatalf("err=%v", err)
+	}
+	if err := BaseFieldUpdate.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id": "fld_1", "json": `{"name":"编号","type":"auto_number","style":{"rules":[],"reformat_existing_records":true}}`}, nil, nil)); err == nil || !strings.Contains(err.Error(), "--reformat-existing-records") {
+		t.Fatalf("err=%v", err)
 	}
 }
 

--- a/shortcuts/base/field_get.go
+++ b/shortcuts/base/field_get.go
@@ -5,8 +5,10 @@ package base
 
 import (
 	"context"
+	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
 )
 
 var BaseFieldGet = common.Shortcut{
@@ -16,14 +18,62 @@ var BaseFieldGet = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{"base:field:read"},
 	AuthTypes:   authTypes(),
-	Flags:       []common.Flag{baseTokenFlag(true), tableRefFlag(true), fieldRefFlag(true)},
+	Flags: []common.Flag{
+		baseTokenFlag(true),
+		tableRefFlag(true),
+		fieldRefFlag(false),
+		{Name: "field-id-or-name", Desc: "hidden alias for --field-id", Hidden: true},
+	},
 	Tips: []string{
 		`Example: lark-cli base +field-get --base-token <base_token> --table-id <table_id> --field-id "Status"`,
 		"field-id accepts a field ID (fld...) or the field name from the current table.",
 		"Returns full field configuration; use it as the baseline before +field-update.",
 	},
+	PostMount: func(cmd *cobra.Command) {
+		cmd.MarkFlagsOneRequired("field-id", "field-id-or-name")
+		cmd.MarkFlagsMutuallyExclusive("field-id", "field-id-or-name")
+		previousPreRunE := cmd.PreRunE
+		cmd.PreRunE = func(c *cobra.Command, args []string) error {
+			if previousPreRunE != nil {
+				if err := previousPreRunE(c, args); err != nil {
+					return err
+				}
+			}
+			fieldIDSet := c.Flags().Changed("field-id")
+			aliasSet := c.Flags().Changed("field-id-or-name")
+			if !fieldIDSet && !aliasSet {
+				return baseFlagErrorf("--field-id is required")
+			}
+			if fieldIDSet && aliasSet {
+				return baseFlagErrorf("--field-id and --field-id-or-name are mutually exclusive; use --field-id")
+			}
+			return nil
+		}
+	},
+	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+		return validateFieldGet(runtime)
+	},
 	DryRun: dryRunFieldGet,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return executeFieldGet(runtime)
 	},
+}
+
+func fieldGetRef(runtime *common.RuntimeContext) string {
+	if fieldRef := strings.TrimSpace(runtime.Str("field-id")); fieldRef != "" {
+		return fieldRef
+	}
+	return strings.TrimSpace(runtime.Str("field-id-or-name"))
+}
+
+func validateFieldGet(runtime *common.RuntimeContext) error {
+	fieldID := strings.TrimSpace(runtime.Str("field-id"))
+	alias := strings.TrimSpace(runtime.Str("field-id-or-name"))
+	if fieldID == "" && alias == "" {
+		return baseFlagErrorf("--field-id is required")
+	}
+	if fieldID != "" && alias != "" {
+		return baseFlagErrorf("--field-id and --field-id-or-name are mutually exclusive; use --field-id")
+	}
+	return nil
 }

--- a/shortcuts/base/field_ops.go
+++ b/shortcuts/base/field_ops.go
@@ -9,8 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+const baseFieldUpdateNoopCode = 800070003
 
 var fieldCreateBatchDelay = time.Second
 
@@ -32,7 +35,7 @@ func dryRunFieldGet(_ context.Context, runtime *common.RuntimeContext) *common.D
 		GET("/open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id").
 		Set("base_token", runtime.Str("base-token")).
 		Set("table_id", baseTableID(runtime)).
-		Set("field_id", runtime.Str("field-id"))
+		Set("field_id", fieldGetRef(runtime))
 }
 
 func dryRunFieldCreate(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
@@ -55,6 +58,21 @@ func dryRunFieldUpdate(_ context.Context, runtime *common.RuntimeContext) *commo
 	body, err := parseJSONObject(pc, runtime.Str("json"), "json")
 	if err != nil {
 		return common.NewDryRunAPI().Desc(fmt.Sprintf("dry-run validation failed: %v", err))
+	}
+	if err := validateRatingFieldLimit(body); err != nil {
+		return common.NewDryRunAPI().Desc(fmt.Sprintf("dry-run validation failed: %v", err))
+	}
+	if runtime.Bool("reformat-existing-records") {
+		body, err := buildAutoNumberReformatBody(body)
+		if err != nil {
+			return common.NewDryRunAPI().Desc(fmt.Sprintf("dry-run validation failed: %v", err))
+		}
+		return common.NewDryRunAPI().
+			PUT("/open-apis/bitable/v1/apps/:base_token/tables/:table_id/fields/:field_id").
+			Body(body).
+			Set("base_token", runtime.Str("base-token")).
+			Set("table_id", baseTableID(runtime)).
+			Set("field_id", runtime.Str("field-id"))
 	}
 	return common.NewDryRunAPI().
 		PUT("/open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id").
@@ -112,6 +130,9 @@ func validateFieldCreate(runtime *common.RuntimeContext) error {
 		return err
 	}
 	for _, body := range bodies {
+		if err := validateRatingFieldLimit(body); err != nil {
+			return err
+		}
 		if err := validateFormulaLookupGuideAck(runtime, "+field-create", body); err != nil {
 			return err
 		}
@@ -124,7 +145,39 @@ func validateFieldUpdate(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
+	if runtime.Bool("reformat-existing-records") {
+		if _, err := buildAutoNumberReformatBody(body); err != nil {
+			return err
+		}
+	} else if containsAutoNumberReformatKey(body) {
+		return baseFlagErrorf("--reformat-existing-records is required for auto_number existing-record regeneration; remove reformat_existing_records from --json and pass --reformat-existing-records")
+	}
+	if err := validateRatingFieldLimit(body); err != nil {
+		return err
+	}
 	return validateFormulaLookupGuideAck(runtime, "+field-update", body)
+}
+
+func validateRatingFieldLimit(body map[string]interface{}) error {
+	if fieldType := strings.ToLower(strings.TrimSpace(common.GetString(body, "type"))); fieldType != "number" {
+		return nil
+	}
+	style, _ := body["style"].(map[string]interface{})
+	if style == nil {
+		return nil
+	}
+	if styleType := strings.ToLower(strings.TrimSpace(common.GetString(style, "type"))); styleType != "rating" {
+		return nil
+	}
+	maxValue, ok := style["max"]
+	if !ok {
+		return nil
+	}
+	max := toInt(maxValue)
+	if max > 10 {
+		return baseFlagErrorf("--json.style.max %d is not supported for rating fields; rating max must be <= 10. To represent 0-20, report that rating fields do not support that range or ask whether to use a plain number/progress field instead", max)
+	}
+	return nil
 }
 
 func executeFieldList(runtime *common.RuntimeContext) error {
@@ -147,7 +200,7 @@ func executeFieldList(runtime *common.RuntimeContext) error {
 func executeFieldGet(runtime *common.RuntimeContext) error {
 	baseToken := runtime.Str("base-token")
 	tableIDValue := baseTableID(runtime)
-	fieldRef := runtime.Str("field-id")
+	fieldRef := fieldGetRef(runtime)
 	data, err := baseV3Call(runtime, "GET", baseV3Path("bases", baseToken, "tables", tableIDValue, "fields", fieldRef), nil, nil)
 	if err != nil {
 		return err
@@ -200,8 +253,37 @@ func executeFieldUpdate(runtime *common.RuntimeContext) error {
 		return err
 	}
 	fieldRef := runtime.Str("field-id")
+	if runtime.Bool("reformat-existing-records") {
+		body, err := buildAutoNumberReformatBody(body)
+		if err != nil {
+			return err
+		}
+		data, err := baseV3Call(runtime, "PUT", bitableV1Path("apps", baseToken, "tables", tableIDValue, "fields", fieldRef), nil, body)
+		if err != nil {
+			return err
+		}
+		field := interface{}(data)
+		if inner, ok := data["field"]; ok {
+			field = inner
+		}
+		runtime.Out(fieldUpdateNoReadbackResult(map[string]interface{}{"field": field, "updated": true, "reformat_existing_records": true}), nil)
+		return nil
+	}
 	data, err := baseV3Call(runtime, "PUT", baseV3Path("bases", baseToken, "tables", tableIDValue, "fields", fieldRef), nil, body)
 	if err != nil {
+		if isFieldUpdateNoop(err) {
+			submittedField := cloneMap(body)
+			runtime.Out(fieldUpdateNoReadbackResult(map[string]interface{}{
+				"submitted_field":           submittedField,
+				"field_ref":                 fieldRef,
+				"updated":                   false,
+				"noop":                      true,
+				"current_matches_submitted": true,
+				"field_get_required":        false,
+				"message":                   "requested field update produced no changes; current field already matched the submitted definition",
+			}), nil)
+			return nil
+		}
 		return err
 	}
 	runtime.Out(fieldUpdateResult(map[string]interface{}{"field": data, "updated": true}, body), nil)
@@ -235,6 +317,45 @@ func fieldUpdateResult(result map[string]interface{}, submitted map[string]inter
 	submittedType := normalizeFieldType(common.GetString(submitted, "type"))
 	readbackRecommended, reason := fieldUpdateReadbackRecommendation(returnedType, submittedType)
 	return attachFieldReadbackRecommendation(result, readbackRecommended, reason)
+}
+
+func fieldUpdateNoReadbackResult(result map[string]interface{}) map[string]interface{} {
+	result["field_get_recommended"] = false
+	result["field_get_required"] = false
+	result["next_step"] = "done"
+	result["verification_hint"] = "result already verifies target state; skip +field-get or repeat +field-update unless extra properties are needed"
+	return result
+}
+
+func isFieldUpdateNoop(err error) bool {
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		return false
+	}
+	return problem.Code == baseFieldUpdateNoopCode &&
+		strings.Contains(strings.ToLower(problem.Message), "no operation produced")
+}
+
+func containsAutoNumberReformatKey(value interface{}) bool {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		for key, child := range v {
+			switch strings.ToLower(strings.TrimSpace(key)) {
+			case "reformat_existing_records", "reformat_existing_record", "apply_for_existing_records":
+				return true
+			}
+			if containsAutoNumberReformatKey(child) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, child := range v {
+			if containsAutoNumberReformatKey(child) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func fieldUpdateReadbackRecommendation(returnedType, submittedType string) (bool, string) {
@@ -340,4 +461,107 @@ func executeFieldSearchOptions(runtime *common.RuntimeContext) error {
 		"total":      total,
 	}, nil)
 	return nil
+}
+
+func buildAutoNumberReformatBody(body map[string]interface{}) (map[string]interface{}, error) {
+	if body == nil {
+		return nil, baseFlagErrorf("--json must be a JSON object")
+	}
+	if fieldType := strings.ToLower(strings.TrimSpace(common.GetString(body, "type"))); fieldType != "auto_number" {
+		return nil, baseFlagErrorf("--reformat-existing-records requires --json.type to be \"auto_number\"")
+	}
+	fieldName := strings.TrimSpace(common.GetString(body, "name"))
+	if fieldName == "" {
+		return nil, baseFlagErrorf("--json.name is required with --reformat-existing-records")
+	}
+	if autoSerial := autoSerialProperty(body); autoSerial != nil {
+		autoSerial = cloneMap(autoSerial)
+		if strings.TrimSpace(common.GetString(autoSerial, "type")) == "" {
+			autoSerial["type"] = "custom"
+		}
+		autoSerial["reformat_existing_records"] = true
+		return map[string]interface{}{
+			"field_name": fieldName,
+			"type":       1005,
+			"property": map[string]interface{}{
+				"auto_serial": autoSerial,
+			},
+		}, nil
+	}
+	rules, err := autoNumberStyleRules(body)
+	if err != nil {
+		return nil, err
+	}
+	options := make([]interface{}, 0, len(rules))
+	for idx, item := range rules {
+		rule, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, baseFlagErrorf("--json.style.rules[%d] must be an object", idx)
+		}
+		option, err := autoNumberRuleToV1Option(rule, idx)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, option)
+	}
+	return map[string]interface{}{
+		"field_name": fieldName,
+		"type":       1005,
+		"property": map[string]interface{}{
+			"auto_serial": map[string]interface{}{
+				"type":                      "custom",
+				"reformat_existing_records": true,
+				"options":                   options,
+			},
+		},
+	}, nil
+}
+
+func autoSerialProperty(body map[string]interface{}) map[string]interface{} {
+	property, _ := body["property"].(map[string]interface{})
+	if property == nil {
+		return nil
+	}
+	autoSerial, _ := property["auto_serial"].(map[string]interface{})
+	if autoSerial == nil {
+		return nil
+	}
+	return autoSerial
+}
+
+func autoNumberStyleRules(body map[string]interface{}) ([]interface{}, error) {
+	style, _ := body["style"].(map[string]interface{})
+	if style == nil {
+		return nil, baseFlagErrorf("--json.style.rules is required with --reformat-existing-records")
+	}
+	rules, _ := style["rules"].([]interface{})
+	if len(rules) == 0 {
+		return nil, baseFlagErrorf("--json.style.rules must contain at least one rule with --reformat-existing-records")
+	}
+	return rules, nil
+}
+
+func autoNumberRuleToV1Option(rule map[string]interface{}, idx int) (map[string]interface{}, error) {
+	ruleType := strings.ToLower(strings.TrimSpace(common.GetString(rule, "type")))
+	switch ruleType {
+	case "text":
+		return map[string]interface{}{"type": "fixed_text", "value": common.GetString(rule, "text")}, nil
+	case "created_time":
+		format := strings.TrimSpace(common.GetString(rule, "date_format"))
+		if format == "" {
+			format = "yyyyMMdd"
+		}
+		if format == "yyMM" {
+			return nil, baseFlagErrorf("--json.style.rules[%d].date_format %q is not supported with --reformat-existing-records; use yyyyMMdd or yyyyMM", idx, format)
+		}
+		return map[string]interface{}{"type": "created_time", "value": format}, nil
+	case "incremental_number":
+		length := toInt(rule["length"])
+		if length <= 0 {
+			length = 3
+		}
+		return map[string]interface{}{"type": "system_number", "value": fmt.Sprintf("%d", length)}, nil
+	default:
+		return nil, baseFlagErrorf("--json.style.rules[%d].type %q is not supported with --reformat-existing-records; use text, created_time, or incremental_number", idx, ruleType)
+	}
 }

--- a/shortcuts/base/field_update.go
+++ b/shortcuts/base/field_update.go
@@ -21,6 +21,7 @@ var BaseFieldUpdate = common.Shortcut{
 		tableRefFlag(true),
 		fieldRefFlag(true),
 		{Name: "json", Desc: "complete field definition JSON object; update uses full PUT semantics, not a patch", Required: true},
+		{Name: "reformat-existing-records", Type: "bool", Desc: "auto_number only: regenerate existing record numbers when updating numbering rules; do not put reformat_existing_records inside --json"},
 		{Name: "i-have-read-guide", Type: "bool", Desc: "acknowledge reading formula/lookup guide before creating or updating those field types", Hidden: true},
 	},
 	Tips: []string{
@@ -28,8 +29,9 @@ var BaseFieldUpdate = common.Shortcut{
 		`Example text: lark-cli base +field-update --base-token <base_token> --table-id <table_id> --field-id "Status" --json '{"name":"Status","type":"text"}' --yes`,
 		`Example select: lark-cli base +field-update --base-token <base_token> --table-id <table_id> --field-id "Status" --json '{"name":"Status","type":"select","multiple":false,"options":[{"name":"Todo"},{"name":"Done"}]}' --yes`,
 		`Example auto_number update: lark-cli base +field-update --base-token <base_token> --table-id <table_id> --field-id "编号" --json '{"name":"编号","type":"auto_number","style":{"rules":[{"type":"text","text":"TASK-"},{"type":"created_time","date_format":"yyyyMM"},{"type":"text","text":"-"},{"type":"incremental_number","length":4}]}}' --yes`,
+		`Example auto_number reformat existing records: lark-cli base +field-update --base-token <base_token> --table-id <table_id> --field-id "编号" --json '{"name":"编号","type":"auto_number","style":{"rules":[{"type":"text","text":"TASK-"},{"type":"created_time","date_format":"yyyyMM"},{"type":"text","text":"-"},{"type":"incremental_number","length":4}]}}' --reformat-existing-records --yes`,
 		"Update uses full field-definition PUT semantics. Read the current field first with +field-get, then send the target state.",
-		`When --json.type is "auto_number", updating the numbering rules also reapplies them to existing numbers; just submit the target field definition and do not add extra low-level parameters.`,
+		`When --json.type is "auto_number", pass --reformat-existing-records to also regenerate existing record numbers; do not put low-level reformat_existing_records inside --json.`,
 		"Type conversion is allowlist-based: only use CLI for safe conversions; otherwise migrate through a new field, or ask the user to finish high-risk conversions in the web UI.",
 		"Formula and lookup updates require reading the corresponding guide first.",
 		"Agent hint: use the lark-base skill's field-update guide for JSON shape, type-conversion rules, and limits.",

--- a/shortcuts/base/helpers.go
+++ b/shortcuts/base/helpers.go
@@ -25,6 +25,7 @@ import (
 const (
 	batchSize         = 500
 	baseV3ServicePath = "/open-apis/base/v3"
+	bitableV1PathRoot = "/open-apis/bitable/v1"
 )
 
 type fieldTypeSpec struct {
@@ -376,6 +377,14 @@ func buildTableFieldBodies(rawFields string, rawFieldSpecs string) ([]interface{
 }
 
 func baseV3Path(parts ...string) string {
+	return escapedAPIPath(baseV3ServicePath, parts...)
+}
+
+func bitableV1Path(parts ...string) string {
+	return escapedAPIPath(bitableV1PathRoot, parts...)
+}
+
+func escapedAPIPath(root string, parts ...string) string {
 	clean := make([]string, 0, len(parts))
 	for _, part := range parts {
 		part = strings.Trim(part, "/")
@@ -383,7 +392,7 @@ func baseV3Path(parts ...string) string {
 			clean = append(clean, url.PathEscape(part))
 		}
 	}
-	return baseV3ServicePath + "/" + strings.Join(clean, "/")
+	return root + "/" + strings.Join(clean, "/")
 }
 
 func baseV3Raw(runtime *common.RuntimeContext, method, path string, params map[string]interface{}, data interface{}) (map[string]interface{}, error) {

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -28,9 +28,9 @@ metadata:
 
 ## 使用边界
 
-- Base 业务操作只使用 `lark-cli base +...` shortcut，不使用旧聚合式 `+table / +field / +record / +view / +history / +workspace`。
+- Base 业务只用 `lark-cli base +...` shortcut，不查旧聚合命令、`lark-cli schema`、bytedcli 或裸 API；无对应 shortcut 先判不支持。
 - 执行 update 前必须先查当前 shortcut 的 `--help` 或对应 reference。若命令要求完整配置，首次请求必须基于可信的当前配置执行 read-modify-write：只修改用户明确指定的内容，保留其他仍适用的可写配置，并按命令要求的结构提交。若命令支持局部／delta update，按其契约提交最小合法 payload；不得以不完整请求试错补参。
-- Base CLI/OpenAPI 当前不支持视图行高、冻结列、列宽等 UI-only 外观设置。遇到这类需求，说明能力边界并停止，不要猜测未文档化参数或改走 raw API。
+- Base CLI/OpenAPI 当前不支持视图行高、记录高度、密度、冻结列、列宽、TableManager 等 UI-only 外观设置。遇到这类需求，定位表/视图后说明能力边界并停止，不要猜测未文档化参数或改走 raw API。
 - 本地文件与 Base 之间的导入/导出转 `lark-drive`，具体格式、参数、路径限制和仅结构导出规则由 `lark-drive` 负责；导入完成后再回到 Base 命令。
 - 在线复制 Base 使用 `+base-copy`，不要绕行导出/导入。
 - 认证、初始化、scope、身份切换、权限不足恢复属于 `lark-shared`；Base 文档只保留会影响 Base 路径选择的权限规则。

--- a/skills/lark-base/references/lark-base-field-json.md
+++ b/skills/lark-base/references/lark-base-field-json.md
@@ -184,7 +184,8 @@
 - `icon` 默认 `star`
 - `icon` 可用：`star`、`heart`、`thumbsup`、`fire`、`smile`、`lightning`、`flower`、`number`
 - `min` 取值 `0..1`，默认 `1`
-- `max` 默认 `5`；常见或已文档化的范围为 `1..10`，但 CLI 不强制上限为 `10`。如果用户明确需要更大评分范围，优先确认平台能力或用 `+field-create/update --dry-run` 检查请求形状；平台拒绝后再建议改用普通数字或进度字段。
+- `max` 取值 `1..10`，默认 `5`
+- `max > 10` 是平台硬限制；0-20 评分不支持，不要尝试写入，改问是否用普通数字或进度字段表示
 
 ```json
 {
@@ -472,6 +473,7 @@
 
 默认值 / 约束：
 - `date_format` 可用：`yyyyMMdd`、`yyyyMM`、`yyMM`、`MMdd`、`yyyy`、`MM`、`dd`
+- 开启 `+field-update --reformat-existing-records` 时优先用 `yyyyMMdd` 或 `yyyyMM`；`yyMM` 会被已有记录重排接口拒绝
 
 ```json
 { "type": "created_time", "date_format": "yyyyMMdd" }

--- a/skills/lark-base/references/lark-base-field-update.md
+++ b/skills/lark-base/references/lark-base-field-update.md
@@ -26,6 +26,7 @@ lark-cli base +field-update \
   --table-id <table_id> \
   --field-id <field_id> \
   --json '{"name":"编号","type":"auto_number","style":{"rules":[{"type":"text","text":"TASK-"},{"type":"created_time","date_format":"yyyyMM"},{"type":"text","text":"-"},{"type":"incremental_number","length":4}]}}' \
+  --reformat-existing-records \
   --yes
 ```
 
@@ -37,6 +38,7 @@ lark-cli base +field-update \
 | `--table-id <id_or_name>` | 是 | 表 ID 或表名 |
 | `--field-id <id_or_name>` | 是 | 字段 ID 或字段名 |
 | `--json <body>` | 是 | 字段属性 JSON 对象 |
+| `--reformat-existing-records` | 否 | 仅 `auto_number` 可用：更新编号规则时重排已有记录编号；不要把 `reformat_existing_records` 放进 `--json` |
 | `--yes` | 是 | 确认执行高风险字段更新 |
 
 > 这是**高风险写入操作**。`+field-update` 使用 `PUT` 全量字段定义语义；改变字段类型或关键配置可能影响整列已有数据的解释、展示或可用性。CLI 层要求显式传 `--yes`；如果用户已经明确目标和期望更新，可直接执行并带上 `--yes`。
@@ -49,7 +51,13 @@ lark-cli base +field-update \
 PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 ```
 
-当 `--json.type` 是 `auto_number` 时，仍然走同一个 v3 字段更新接口：更新自动编号规则后，接口现状就会把新规则应用到已有编号（这是接口默认行为，只是 agent 通常不知道），因此**不需要**任何额外开关或参数。只需要正常提交目标自动编号字段定义即可；如果用户要求“将修改用于已有编号”，直接执行这次 `+field-update` 就能达到效果，不要在 `--json` 里额外添加任何参数去“触发”重排。
+当需要把新的 `auto_number` 编号规则应用到已有记录时，传 `--reformat-existing-records`。命令会把 v3 字段 JSON 转成 bitable v1 的自动编号重排请求：
+
+```
+PUT /open-apis/bitable/v1/apps/:base_token/tables/:table_id/fields/:field_id
+```
+
+不要在 `--json` 里额外添加 `reformat_existing_records`、`reformat_existing_record` 或 `apply_for_existing_records`；这些低层开关必须用 `--reformat-existing-records` 表达。
 
 ## JSON 值规范
 
@@ -62,6 +70,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
   - 不能把非 `link` 字段改成 `link`，也不能把 `link` 改成非 `link`。
   - 现有 `link` 字段的 `bidirectional` 不能改。
 - `auto_number` 更新的 `style.rules` 支持 `text`、`created_time`、`incremental_number`。
+- `auto_number` 使用 `--reformat-existing-records` 时，`created_time.date_format` 优先用 `yyyyMMdd` 或 `yyyyMM`；`yyMM` 会被重排接口拒绝。
 
 **推荐更新示例**
 
@@ -95,7 +104,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 - 返回 `field` 和 `updated: true`。
 - `updated:true` 只表示更新请求成功，不表示字段结构、已有记录值或下游能力已经完成验证。`+field-update` 无法知道更新前的字段类型，因此成功响应会推荐执行 `+field-get`；若发生类型转换，还要抽样读取记录值。
 - 如果响应中的 `field.type` 与提交的 `type` 不一致，必须把它当作待核验的类型不匹配；不能返回完成态，也不能只根据其中任一类型推断更新成功。
-- 如果 API 报告本次更新没有产生任何变更（no-op），命令会如实返回该错误；这通常说明目标字段已是期望状态，不要机械重试同一份 `+field-update`。需要确认当前字段完整状态时执行 `+field-get`。
+- 如果返回 `noop:true`、`current_matches_submitted:true`、`field_get_required:false`，表示当前字段已匹配 `submitted_field`；只为确认字段结构时不要再调用 `+field-get`。
 - 如果返回 `field_get_recommended:true` 或 `next_step:"field_get"`，按提示读回字段；`auto_number` 更新后还应抽样读记录值确认编号已按新规则生成。
 
 ## 工作流
@@ -103,7 +112,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 
 1. 建议先用 `+field-get` 拉现状，再做最小化修改。
 2. `formula/lookup` 类型更新前先阅读对应指南。
-3. 如果更新 `auto_number`，理解为“更新编号规则，同时把新规则应用到已有编号”；执行后按返回提示读回字段并在必要时抽样记录值。
+3. 如果更新 `auto_number` 且用户要求应用到已有编号，传 `--reformat-existing-records`；执行后按返回提示读回字段并在必要时抽样记录值。
 4. 如果这次更新会改变字段 `type` 先按下方“字段类型变更规则”判断能否执行。如果不修改 `type`，大多数场景都相对安全。
 
 ## 字段类型变更规则
@@ -170,7 +179,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 ### 完成态验证
 
 - `FieldReadback`: 读回字段结构，确认 `type` / `multiple` / `style` / `options`
-- `NoopReadback`: `+field-update` 返回 no-op 错误时，只能说明 API 报告没有产生变更；可以跳过重复 update，但不能替代 `FieldReadback`
+- `NoopReadback`: `+field-update` 返回 `noop:true` 且 `field_get_required:false` 时，字段结构已匹配提交定义，等同完成 `FieldReadback`
 - `ValueReadback`: 抽样读回转换后的单元格值
 - `DownstreamReadback`: 若涉及看板 / 分组 / 排序 / lookup / 公式，继续读回结果
 - `CompletionRule`: 结构、值、下游能力都正确，才能回复“已完成”

--- a/tests/cli_e2e/base/base_field_dryrun_test.go
+++ b/tests/cli_e2e/base/base_field_dryrun_test.go
@@ -5,12 +5,40 @@ package base
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
+
+func TestBaseFieldGetDryRunAcceptsFieldIDOrNameAlias(t *testing.T) {
+	result := runBaseDryRun(t, 0,
+		"base", "+field-get",
+		"--base-token", "app_x",
+		"--table-id", "tbl_x",
+		"--field-id-or-name", "Amount",
+	)
+
+	out := result.Stdout
+	require.Equal(t, "GET", gjson.Get(out, "data.api.0.method").String(), out)
+	require.Equal(t, "/open-apis/base/v3/bases/app_x/tables/tbl_x/fields/Amount", gjson.Get(out, "data.api.0.url").String(), out)
+	require.Equal(t, "Amount", gjson.Get(out, "data.field_id").String(), out)
+}
+
+func TestBaseFieldGetDryRunRequiresFieldSelectorBeforeRun(t *testing.T) {
+	result := runBaseDryRun(t, 2,
+		"base", "+field-get",
+		"--base-token", "app_x",
+		"--table-id", "tbl_x",
+	)
+	require.Empty(t, strings.TrimSpace(result.Stdout), result.Stdout)
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "--field-id", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "--field-id is required")
+}
 
 func TestBaseFieldCreateDryRunArrayCompat(t *testing.T) {
 	setBaseDryRunConfigEnv(t)

--- a/tests/cli_e2e/base/base_field_update_dryrun_test.go
+++ b/tests/cli_e2e/base/base_field_update_dryrun_test.go
@@ -4,6 +4,7 @@
 package base
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,8 +34,31 @@ func TestBaseFieldUpdateAutoNumberDryRun(t *testing.T) {
 	require.NotContains(t, out, "/open-apis/bitable/v1/", out)
 }
 
-func TestBaseFieldUpdateDryRunAllowsRatingMaxAboveLimit(t *testing.T) {
+func TestBaseFieldUpdateAutoNumberReformatDryRun(t *testing.T) {
 	result := runBaseDryRun(t, 0,
+		"base", "+field-update",
+		"--base-token", "app_x",
+		"--table-id", "tbl_x",
+		"--field-id", "fld_x",
+		"--json", `{"name":"编号","type":"auto_number","style":{"rules":[{"type":"text","text":"TASK-"},{"type":"created_time","date_format":"yyyyMM"},{"type":"text","text":"-"},{"type":"incremental_number","length":4}]}}`,
+		"--reformat-existing-records",
+		"--yes",
+	)
+
+	out := result.Stdout
+	require.Equal(t, "/open-apis/bitable/v1/apps/app_x/tables/tbl_x/fields/fld_x", gjson.Get(out, "data.api.0.url").String(), out)
+	require.Equal(t, "PUT", gjson.Get(out, "data.api.0.method").String(), out)
+	require.Equal(t, "编号", gjson.Get(out, "data.api.0.body.field_name").String(), out)
+	require.Equal(t, int64(1005), gjson.Get(out, "data.api.0.body.type").Int(), out)
+	require.True(t, gjson.Get(out, "data.api.0.body.property.auto_serial.reformat_existing_records").Bool(), out)
+	require.Equal(t, "fixed_text", gjson.Get(out, "data.api.0.body.property.auto_serial.options.0.type").String(), out)
+	require.Equal(t, "created_time", gjson.Get(out, "data.api.0.body.property.auto_serial.options.1.type").String(), out)
+	require.Equal(t, "system_number", gjson.Get(out, "data.api.0.body.property.auto_serial.options.3.type").String(), out)
+	require.Equal(t, "4", gjson.Get(out, "data.api.0.body.property.auto_serial.options.3.value").String(), out)
+}
+
+func TestBaseFieldUpdateDryRunRejectsRatingMaxAboveLimit(t *testing.T) {
+	result := runBaseDryRun(t, 2,
 		"base", "+field-update",
 		"--base-token", "app_x",
 		"--table-id", "tbl_x",
@@ -43,10 +67,13 @@ func TestBaseFieldUpdateDryRunAllowsRatingMaxAboveLimit(t *testing.T) {
 		"--yes",
 	)
 
-	out := result.Stdout
-	require.Equal(t, "/open-apis/base/v3/bases/app_x/tables/tbl_x/fields/fld_x", gjson.Get(out, "data.api.0.url").String(), out)
-	require.Equal(t, "PUT", gjson.Get(out, "data.api.0.method").String(), out)
-	require.Equal(t, "评分", gjson.Get(out, "data.api.0.body.name").String(), out)
-	require.Equal(t, "rating", gjson.Get(out, "data.api.0.body.style.type").String(), out)
-	require.Equal(t, int64(20), gjson.Get(out, "data.api.0.body.style.max").Int(), out)
+	require.Empty(t, strings.TrimSpace(result.Stdout), result.Stdout)
+	errMsg := gjson.Get(result.Stderr, "error.message").String()
+	for _, want := range []string{"--json.style.max", "rating max must be <= 10", "plain number/progress field"} {
+		if !strings.Contains(errMsg, want) {
+			t.Fatalf("expected %q in dry-run error, got %q\nstderr:\n%s", want, errMsg, result.Stderr)
+		}
+	}
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "--json", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
 }


### PR DESCRIPTION
## Summary
Improve Base field shortcut behavior for field lookup aliases, field update no-op handling, auto-number reformatting, and rating validation.

## Changes
- Add a hidden `--field-id-or-name` compatibility alias for `base +field-get` while keeping `--field-id` as the public flag.
- Treat no-op field update API responses as successful completion signals and expose submitted field metadata without synthesizing field IDs.
- Add explicit `--reformat-existing-records` support for auto-number updates, including bitable v1 request conversion and dry-run coverage.
- Reject rating fields with `max > 10` and update Base skill references for the new field-update workflow.

## Test Plan
- `git diff --check`

## Related Issues
Auto research task: 01KWNBD6WC5QZ2YTZZBB6CTZ37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Find Base fields using either their ID or name.
  * Reformat existing auto-number records with the new `--reformat-existing-records` option.
* **Bug Fixes**
  * No-op field updates are now reported as successful without changes.
  * Invalid rating limits and unsupported auto-number date formats are rejected before execution.
  * Dry-run validation now mirrors actual field operations.
* **Documentation**
  * Updated guidance for Base shortcuts, auto-number reformatting, rating limits, and supported date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->