### PR TITLE
feat(drive): add wiki url/token support to +download and +preview

### DIFF
--- a/shortcuts/drive/drive_download.go
+++ b/shortcuts/drive/drive_download.go
@@ -112,26 +112,32 @@ var DriveDownload = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{"drive:file:download", common.DrivePermissionMemberAuthScope},
 	// Metadata is only required when --output is omitted and the CLI needs the
-	// remote title as the pre-download fallback filename.
-	ConditionalScopes: []string{driveMetadataReadScope},
+	// remote title as the pre-download fallback filename. The wiki scope is only
+	// required when the caller passes a wiki node (--wiki-token or a /wiki/ URL)
+	// that must be resolved to the underlying file token.
+	ConditionalScopes: []string{driveMetadataReadScope, driveWikiNodeRetrieveScope},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "file-token", Desc: "file token", Required: true},
+		{Name: "file-token", Desc: "Drive file token"},
+		{Name: "url", Desc: "Drive file URL, or a wiki node URL that wraps an uploaded file (resolved to the underlying file token)"},
+		{Name: "wiki-token", Desc: "wiki node token wrapping an uploaded file (resolved to the underlying file token)"},
 		{Name: "output", Desc: "local save path"},
 		{Name: "overwrite", Type: "bool", Desc: "overwrite existing output file"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		fileToken := runtime.Str("file-token")
-		outputPath := runtime.Str("output")
-
-		if err := validate.ResourceName(fileToken, "--file-token"); err != nil {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam("--file-token")
+		source, err := normalizeDriveFileSource(runtime.Str("file-token"), runtime.Str("url"), runtime.Str("wiki-token"))
+		if err != nil {
+			return err
 		}
-		if outputPath == "" {
-			if err := runtime.EnsureScopes([]string{driveMetadataReadScope}); err != nil {
+		if source.NeedsWikiResolution() {
+			if err := runtime.EnsureScopes([]string{driveWikiNodeRetrieveScope}); err != nil {
 				return err
 			}
-			return nil
+		}
+
+		outputPath := runtime.Str("output")
+		if outputPath == "" {
+			return runtime.EnsureScopes([]string{driveMetadataReadScope})
 		}
 		if _, resolveErr := runtime.ResolveSavePath(outputPath); resolveErr != nil {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe output path: %s", resolveErr).WithParam("--output")
@@ -139,20 +145,38 @@ var DriveDownload = common.Shortcut{
 		return nil
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		fileToken := runtime.Str("file-token")
+		source, err := normalizeDriveFileSource(runtime.Str("file-token"), runtime.Str("url"), runtime.Str("wiki-token"))
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+
 		outputPath := runtime.Str("output")
-		plan := common.AddDriveFileExportPermissionDryRun(
-			common.NewDryRunAPI(),
+		plan := common.NewDryRunAPI()
+		step := 1
+
+		fileToken := source.FileToken
+		if source.NeedsWikiResolution() {
+			plan.GET("/open-apis/wiki/v2/spaces/get_node").
+				Desc(fmt.Sprintf("[%d] Resolve wiki node to the underlying Drive file token (obj_type must be file)", step)).
+				Params(map[string]interface{}{"token": source.WikiToken})
+			plan.Set("wiki_token", source.WikiToken)
+			fileToken = "obj_token_from_wiki_node"
+			step++
+		}
+
+		common.AddDriveFileExportPermissionDryRun(
+			plan,
 			fileToken,
-			"[1] Check whether the current identity can export the Drive file",
+			fmt.Sprintf("[%d] Check whether the current identity can export the Drive file", step),
 		)
-		downloadDesc := "[2] Download file bytes to the explicit output path"
+		step++
+
+		downloadDesc := fmt.Sprintf("[%d] Download file bytes to the explicit output path", step)
 		if outputPath == "" {
 			outputPath = "<Content-Disposition filename | metadata title | token>"
-			downloadDesc = "[3] Download file bytes; Content-Disposition filename wins over metadata title when present"
 			plan.
 				POST("/open-apis/drive/v1/metas/batch_query").
-				Desc("[2] Resolve metadata title before downloading; fails before the download request if metadata scope is missing").
+				Desc(fmt.Sprintf("[%d] Resolve metadata title before downloading; fails before the download request if metadata scope is missing", step)).
 				Body(map[string]interface{}{
 					"request_docs": []map[string]interface{}{
 						{
@@ -161,6 +185,8 @@ var DriveDownload = common.Shortcut{
 						},
 					},
 				})
+			step++
+			downloadDesc = fmt.Sprintf("[%d] Download file bytes; Content-Disposition filename wins over metadata title when present", step)
 		}
 		return plan.
 			GET("/open-apis/drive/v1/files/:file_token/download").
@@ -169,7 +195,22 @@ var DriveDownload = common.Shortcut{
 			Set("output", outputPath)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		fileToken := runtime.Str("file-token")
+		source, err := normalizeDriveFileSource(runtime.Str("file-token"), runtime.Str("url"), runtime.Str("wiki-token"))
+		if err != nil {
+			return err
+		}
+
+		fileToken := source.FileToken
+		var wikiResolution driveFileWikiResolution
+		if source.NeedsWikiResolution() {
+			resolvedToken, resolution, resolveErr := resolveDriveFileWikiSource(ctx, runtime, source)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			fileToken = resolvedToken
+			wikiResolution = resolution
+		}
+
 		outputPath := runtime.Str("output")
 		overwrite := runtime.Bool("overwrite")
 
@@ -244,10 +285,10 @@ var DriveDownload = common.Shortcut{
 		if savedPath == "" {
 			savedPath = outputPath
 		}
-		runtime.Out(map[string]interface{}{
+		runtime.Out(annotateDriveFileWikiOutput(map[string]interface{}{
 			"saved_path": savedPath,
 			"size_bytes": result.Size(),
-		}, nil)
+		}, wikiResolution), nil)
 		return nil
 	},
 }

--- a/shortcuts/drive/drive_file_source.go
+++ b/shortcuts/drive/drive_file_source.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// driveWikiNodeRetrieveScope is required only when the caller passes a wiki node
+// (via --wiki-token or a /wiki/ URL) that must be resolved to the underlying
+// Drive file token through GET /wiki/v2/spaces/get_node.
+const driveWikiNodeRetrieveScope = "wiki:node:retrieve"
+
+// driveFileSource is the normalized input for shortcuts that operate on a Drive
+// file (download / preview). Exactly one of FileToken or WikiToken is set:
+// FileToken is ready to use directly, while WikiToken must first be resolved to
+// an underlying file token via resolveDriveFileWikiSource.
+type driveFileSource struct {
+	// FileToken is a direct Drive file token (from --file-token or a Drive
+	// file URL). Empty when the input is a wiki node needing resolution.
+	FileToken string
+	// WikiToken is a wiki node token (from --wiki-token or a /wiki/ URL) that
+	// must be resolved to a file token before use.
+	WikiToken string
+	// InputParam records which flag supplied the input, so downstream errors
+	// point at the parameter the user actually set.
+	InputParam string
+}
+
+// NeedsWikiResolution reports whether the input is a wiki node that must be
+// resolved to an underlying Drive file token before the file operation runs.
+func (s driveFileSource) NeedsWikiResolution() bool {
+	return s.WikiToken != ""
+}
+
+// driveFileWikiResolution captures the get_node resolution result so it can be
+// echoed back in the command output for traceability.
+type driveFileWikiResolution struct {
+	Resolved  bool
+	WikiToken string
+	ObjToken  string
+	ObjType   string
+}
+
+// normalizeDriveFileSource validates the --file-token / --url / --wiki-token
+// trio (exactly one required) and classifies the input into a driveFileSource.
+// A /wiki/ URL or a bare --wiki-token is flagged for get_node resolution; a
+// Drive file token or file URL is used directly. Non-file document URLs are
+// rejected with a typed validation error rather than silently coerced, because
+// download/preview only operate on Drive files.
+func normalizeDriveFileSource(fileToken, rawURL, wikiToken string) (driveFileSource, error) {
+	fileToken = strings.TrimSpace(fileToken)
+	rawURL = strings.TrimSpace(rawURL)
+	wikiToken = strings.TrimSpace(wikiToken)
+
+	provided := 0
+	for _, v := range []string{fileToken, rawURL, wikiToken} {
+		if v != "" {
+			provided++
+		}
+	}
+	if provided == 0 {
+		return driveFileSource{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"one of --file-token, --url, or --wiki-token is required",
+		).WithParam("--file-token")
+	}
+	if provided > 1 {
+		return driveFileSource{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--file-token, --url, and --wiki-token are mutually exclusive",
+		).WithParam(firstProvidedDriveFileSourceParam(fileToken, rawURL, wikiToken))
+	}
+
+	if fileToken != "" {
+		if err := validate.ResourceName(fileToken, "--file-token"); err != nil {
+			return driveFileSource{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam("--file-token")
+		}
+		return driveFileSource{FileToken: fileToken, InputParam: "--file-token"}, nil
+	}
+
+	if wikiToken != "" {
+		if err := validate.ResourceName(wikiToken, "--wiki-token"); err != nil {
+			return driveFileSource{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam("--wiki-token")
+		}
+		return driveFileSource{WikiToken: wikiToken, InputParam: "--wiki-token"}, nil
+	}
+
+	ref, ok := common.ParseResourceURL(rawURL)
+	if !ok {
+		return driveFileSource{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"unsupported --url %q: use a Drive file URL or a wiki node URL",
+			rawURL,
+		).WithParam("--url")
+	}
+	switch ref.Type {
+	case "file":
+		if err := validate.ResourceName(ref.Token, "--url"); err != nil {
+			return driveFileSource{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam("--url")
+		}
+		return driveFileSource{FileToken: ref.Token, InputParam: "--url"}, nil
+	case "wiki":
+		if err := validate.ResourceName(ref.Token, "--url"); err != nil {
+			return driveFileSource{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam("--url")
+		}
+		return driveFileSource{WikiToken: ref.Token, InputParam: "--url"}, nil
+	default:
+		return driveFileSource{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--url resolved to type %q, but download/preview only support Drive file URLs or wiki nodes that wrap a file",
+			ref.Type,
+		).
+			WithParam("--url").
+			WithHint("for doc/docx/sheet/bitable/slides documents, use drive +export instead")
+	}
+}
+
+// firstProvidedDriveFileSourceParam returns the flag name of the first non-empty
+// source among --file-token / --url / --wiki-token, in that order. It is used to
+// attribute a mutual-exclusion error to a flag the caller actually supplied, so
+// an agent parsing error.param acts on real input rather than a flag that was
+// never set.
+func firstProvidedDriveFileSourceParam(fileToken, rawURL, wikiToken string) string {
+	switch {
+	case fileToken != "":
+		return "--file-token"
+	case rawURL != "":
+		return "--url"
+	default:
+		return "--wiki-token"
+	}
+}
+
+// resolveDriveFileWikiSource resolves a wiki node to its underlying Drive file
+// token via GET /wiki/v2/spaces/get_node. Because download/preview only operate
+// on Drive files, a node that wraps a document type (docx/sheet/bitable/slides)
+// is rejected with a typed validation error pointing the user at drive +export.
+func resolveDriveFileWikiSource(ctx context.Context, runtime *common.RuntimeContext, source driveFileSource) (string, driveFileWikiResolution, error) {
+	wikiToken := strings.TrimSpace(source.WikiToken)
+	param := source.InputParam
+	if param == "" {
+		param = "--wiki-token"
+	}
+
+	fmt.Fprintf(runtime.IO().ErrOut, "Resolving wiki node: %s\n", common.MaskToken(wikiToken))
+	data, err := driveInspectCallWithRetry(ctx, func() (map[string]interface{}, error) {
+		return runtime.CallAPITyped(
+			"GET",
+			"/open-apis/wiki/v2/spaces/get_node",
+			map[string]interface{}{"token": wikiToken},
+			nil,
+		)
+	})
+	if err != nil {
+		return "", driveFileWikiResolution{}, err
+	}
+
+	node := common.GetMap(data, "node")
+	objType := common.GetString(node, "obj_type")
+	objToken := common.GetString(node, "obj_token")
+	if objType == "" || objToken == "" {
+		return "", driveFileWikiResolution{}, errs.NewInternalError(
+			errs.SubtypeInvalidResponse,
+			"wiki get_node returned incomplete node data (obj_type=%q, obj_token=%q)",
+			objType,
+			objToken,
+		)
+	}
+	if objType != "file" {
+		return "", driveFileWikiResolution{}, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"wiki node resolved to %q, but download/preview only support wiki nodes that wrap an uploaded Drive file",
+			objType,
+		).
+			WithParam(param).
+			WithHint("for doc/docx/sheet/bitable/slides documents, use drive +export instead")
+	}
+
+	fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to file: %s\n", common.MaskToken(objToken))
+	return objToken, driveFileWikiResolution{
+		Resolved:  true,
+		WikiToken: wikiToken,
+		ObjToken:  objToken,
+		ObjType:   objType,
+	}, nil
+}
+
+// annotateDriveFileWikiOutput echoes the wiki resolution into the command
+// output so callers can trace which node produced the file token.
+func annotateDriveFileWikiOutput(out map[string]interface{}, resolution driveFileWikiResolution) map[string]interface{} {
+	if !resolution.Resolved {
+		return out
+	}
+	out["wiki_token"] = resolution.WikiToken
+	out["wiki_node"] = map[string]interface{}{
+		"obj_token": resolution.ObjToken,
+		"obj_type":  resolution.ObjType,
+	}
+	return out
+}

--- a/shortcuts/drive/drive_file_source_test.go
+++ b/shortcuts/drive/drive_file_source_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func TestNormalizeDriveFileSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileToken   string
+		url         string
+		wikiToken   string
+		wantFile    string
+		wantWiki    string
+		wantParam   string
+		wantErrSub  errs.Subtype
+		wantErrPara string
+	}{
+		{
+			name:      "bare file token",
+			fileToken: "boxcnFileToken",
+			wantFile:  "boxcnFileToken",
+			wantParam: "--file-token",
+		},
+		{
+			name:      "drive file url",
+			url:       "https://example.feishu.cn/file/boxcnFileToken",
+			wantFile:  "boxcnFileToken",
+			wantParam: "--url",
+		},
+		{
+			name:      "wiki url flagged for resolution",
+			url:       "https://example.feishu.cn/wiki/wikiNodeToken",
+			wantWiki:  "wikiNodeToken",
+			wantParam: "--url",
+		},
+		{
+			name:      "bare wiki token flagged for resolution",
+			wikiToken: "wikiNodeToken",
+			wantWiki:  "wikiNodeToken",
+			wantParam: "--wiki-token",
+		},
+		{
+			name:        "no input",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--file-token",
+		},
+		{
+			name:        "mutually exclusive file and wiki",
+			fileToken:   "boxcnFileToken",
+			wikiToken:   "wikiNodeToken",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--file-token",
+		},
+		{
+			name:        "mutually exclusive file and url",
+			fileToken:   "boxcnFileToken",
+			url:         "https://example.feishu.cn/file/boxcnFileToken",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--file-token",
+		},
+		{
+			name:        "mutually exclusive url and wiki",
+			url:         "https://example.feishu.cn/wiki/wikiNodeToken",
+			wikiToken:   "wikiNodeToken",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--url",
+		},
+		{
+			name:        "non-file document url rejected",
+			url:         "https://example.feishu.cn/docx/docxToken",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--url",
+		},
+		{
+			name:        "file url path traversal rejected",
+			url:         "https://example.feishu.cn/file/../admin",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--url",
+		},
+		{
+			name:        "file url percent-encoded traversal rejected",
+			url:         "https://example.feishu.cn/file/%2e%2e/admin",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--url",
+		},
+		{
+			name:        "wiki url path traversal rejected",
+			url:         "https://example.feishu.cn/wiki/../admin",
+			wantErrSub:  errs.SubtypeInvalidArgument,
+			wantErrPara: "--url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source, err := normalizeDriveFileSource(tt.fileToken, tt.url, tt.wikiToken)
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error, got source %+v", source)
+				}
+				problem, ok := errs.ProblemOf(err)
+				if !ok {
+					t.Fatalf("expected typed error, got %v", err)
+				}
+				if problem.Category != errs.CategoryValidation {
+					t.Fatalf("category=%q, want %q", problem.Category, errs.CategoryValidation)
+				}
+				if problem.Subtype != tt.wantErrSub {
+					t.Fatalf("subtype=%q, want %q", problem.Subtype, tt.wantErrSub)
+				}
+				var verr *errs.ValidationError
+				if !errors.As(err, &verr) {
+					t.Fatalf("expected *errs.ValidationError, got %T", err)
+				}
+				if verr.Param != tt.wantErrPara {
+					t.Fatalf("param=%q, want %q", verr.Param, tt.wantErrPara)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if source.FileToken != tt.wantFile {
+				t.Fatalf("FileToken=%q, want %q", source.FileToken, tt.wantFile)
+			}
+			if source.WikiToken != tt.wantWiki {
+				t.Fatalf("WikiToken=%q, want %q", source.WikiToken, tt.wantWiki)
+			}
+			if source.InputParam != tt.wantParam {
+				t.Fatalf("InputParam=%q, want %q", source.InputParam, tt.wantParam)
+			}
+			if source.NeedsWikiResolution() != (tt.wantWiki != "") {
+				t.Fatalf("NeedsWikiResolution=%v, want %v", source.NeedsWikiResolution(), tt.wantWiki != "")
+			}
+		})
+	}
+}
+
+func TestAnnotateDriveFileWikiOutput(t *testing.T) {
+	base := map[string]interface{}{"saved_path": "/tmp/x"}
+
+	// Unresolved: passthrough untouched — the wiki keys must be absent, not
+	// present-with-nil (which would serialize as "wiki_token": null).
+	got := annotateDriveFileWikiOutput(base, driveFileWikiResolution{})
+	if _, ok := got["wiki_token"]; ok {
+		t.Fatalf("expected no wiki_token key when unresolved, got %+v", got)
+	}
+	if _, ok := got["wiki_node"]; ok {
+		t.Fatalf("expected no wiki_node key when unresolved, got %+v", got)
+	}
+
+	out := annotateDriveFileWikiOutput(map[string]interface{}{"saved_path": "/tmp/x"}, driveFileWikiResolution{
+		Resolved:  true,
+		WikiToken: "wikiNodeToken",
+		ObjToken:  "boxcnFileToken",
+		ObjType:   "file",
+	})
+	if out["wiki_token"] != "wikiNodeToken" {
+		t.Fatalf("wiki_token=%v, want wikiNodeToken", out["wiki_token"])
+	}
+	node, ok := out["wiki_node"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("wiki_node missing or wrong type: %+v", out["wiki_node"])
+	}
+	if node["obj_token"] != "boxcnFileToken" || node["obj_type"] != "file" {
+		t.Fatalf("wiki_node=%+v, want obj_token=boxcnFileToken obj_type=file", node)
+	}
+}

--- a/shortcuts/drive/drive_preview.go
+++ b/shortcuts/drive/drive_preview.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/larksuite/cli/errs"
-	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -19,9 +17,15 @@ var DrivePreview = common.Shortcut{
 	Description: "View or download Drive file content, or list and fetch available preview artifacts",
 	Risk:        "read",
 	Scopes:      []string{"drive:file:download"},
-	AuthTypes:   []string{"user", "bot"},
+	// The wiki scope is only required when the caller passes a wiki node
+	// (--wiki-token or a /wiki/ URL) that must be resolved to the underlying
+	// file token before previewing.
+	ConditionalScopes: []string{driveWikiNodeRetrieveScope},
+	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "file-token", Desc: "Drive file token", Required: true},
+		{Name: "file-token", Desc: "Drive file token"},
+		{Name: "url", Desc: "Drive file URL, or a wiki node URL that wraps an uploaded file (resolved to the underlying file token)"},
+		{Name: "wiki-token", Desc: "wiki node token wrapping an uploaded file (resolved to the underlying file token)"},
 		{Name: "type", Desc: "preview type to download: pdf | html | text | image | source_file"},
 		{Name: "version", Desc: "optional file version"},
 		{Name: "list-only", Type: "bool", Desc: "list preview candidates without downloading"},
@@ -29,8 +33,14 @@ var DrivePreview = common.Shortcut{
 		{Name: "if-exists", Desc: "output conflict policy: error | overwrite | rename", Default: drivePreviewIfExistsError, Enum: []string{drivePreviewIfExistsError, drivePreviewIfExistsOverwrite, drivePreviewIfExistsRename}},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if err := validate.ResourceName(runtime.Str("file-token"), "--file-token"); err != nil {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam("--file-token")
+		source, err := normalizeDriveFileSource(runtime.Str("file-token"), runtime.Str("url"), runtime.Str("wiki-token"))
+		if err != nil {
+			return err
+		}
+		if source.NeedsWikiResolution() {
+			if err := runtime.EnsureScopes([]string{driveWikiNodeRetrieveScope}); err != nil {
+				return err
+			}
 		}
 		if err := validateDrivePreviewMode(runtime.Str("type"), runtime.Bool("list-only"), runtime.Str("output"), "type"); err != nil {
 			return err
@@ -38,9 +48,30 @@ var DrivePreview = common.Shortcut{
 		return validateDrivePreviewIfExists(runtime.Str("if-exists"))
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		fileToken := runtime.Str("file-token")
+		source, err := normalizeDriveFileSource(runtime.Str("file-token"), runtime.Str("url"), runtime.Str("wiki-token"))
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		fileToken := source.FileToken
+		wiki := source.NeedsWikiResolution()
+		if wiki {
+			fileToken = "obj_token_from_wiki_node"
+		}
 		version := strings.TrimSpace(runtime.Str("version"))
 		requestedType := strings.TrimSpace(runtime.Str("type"))
+
+		// planWikiResolution prepends the wiki get_node step (and echoes the
+		// wiki token) so the preview steps are numbered after it.
+		planWikiResolution := func(dry *common.DryRunAPI) {
+			if !wiki {
+				return
+			}
+			dry.GET("/open-apis/wiki/v2/spaces/get_node").
+				Desc("[0] Resolve wiki node to the underlying Drive file token (obj_type must be file)").
+				Params(map[string]interface{}{"token": source.WikiToken})
+			dry.Set("wiki_token", source.WikiToken)
+		}
+
 		if requestedType == "source_file" {
 			downloadParams := map[string]interface{}{
 				"preview_type": drivePreviewTypeSourceFile,
@@ -48,7 +79,9 @@ var DrivePreview = common.Shortcut{
 			if version != "" {
 				downloadParams["version"] = version
 			}
-			return common.NewDryRunAPI().
+			dry := common.NewDryRunAPI()
+			planWikiResolution(dry)
+			return dry.
 				GET("/open-apis/drive/v1/medias/:file_token/preview_download").
 				Desc("Download the source file artifact").
 				Params(downloadParams).
@@ -63,7 +96,9 @@ var DrivePreview = common.Shortcut{
 		if version != "" {
 			body["version"] = version
 		}
-		dry := common.NewDryRunAPI().
+		dry := common.NewDryRunAPI()
+		planWikiResolution(dry)
+		dry.
 			POST("/open-apis/drive/v1/medias/:file_token/preview_result").
 			Desc("[1] Fetch preview candidates for a Drive file").
 			Set("file_token", fileToken)
@@ -90,7 +125,20 @@ var DrivePreview = common.Shortcut{
 			Set("output", runtime.Str("output"))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		fileToken := runtime.Str("file-token")
+		source, err := normalizeDriveFileSource(runtime.Str("file-token"), runtime.Str("url"), runtime.Str("wiki-token"))
+		if err != nil {
+			return err
+		}
+		fileToken := source.FileToken
+		var wikiResolution driveFileWikiResolution
+		if source.NeedsWikiResolution() {
+			resolvedToken, resolution, resolveErr := resolveDriveFileWikiSource(ctx, runtime, source)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			fileToken = resolvedToken
+			wikiResolution = resolution
+		}
 		version := strings.TrimSpace(runtime.Str("version"))
 		requestedType := strings.TrimSpace(runtime.Str("type"))
 		outputPath := runtime.Str("output")
@@ -110,7 +158,7 @@ var DrivePreview = common.Shortcut{
 			result["mode"] = "download"
 			result["file_token"] = fileToken
 			result["selected_type"] = "source_file"
-			runtime.Out(result, nil)
+			runtime.Out(annotateDriveFileWikiOutput(result, wikiResolution), nil)
 			return nil
 		}
 
@@ -123,7 +171,7 @@ var DrivePreview = common.Shortcut{
 			return err
 		}
 		if runtime.Bool("list-only") {
-			runtime.Out(buildDrivePreviewListOutput(fileToken, candidates), nil)
+			runtime.Out(annotateDriveFileWikiOutput(buildDrivePreviewListOutput(fileToken, candidates), wikiResolution), nil)
 			return nil
 		}
 
@@ -147,7 +195,7 @@ var DrivePreview = common.Shortcut{
 		result["mode"] = "download"
 		result["file_token"] = fileToken
 		result["selected_type"] = candidate.Type
-		runtime.Out(result, nil)
+		runtime.Out(annotateDriveFileWikiOutput(result, wikiResolution), nil)
 		return nil
 	},
 }

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -43,7 +43,7 @@ metadata:
 - 用户要查看、下载、回滚或删除文件的**历史版本**，使用 `drive +version-history`、`drive +version-get`、`drive +version-revert`、`drive +version-delete`；这组命令同时支持 `--as user` 和 `--as bot`，自动化场景优先 `--as bot`。
 - 用户要把本地 `.xlsx` / `.xls` / `.csv` 导入成电子表格，使用 `lark-cli drive +import --type sheet`。
 - 用户要在云空间（云盘/云存储）里新建文件夹，优先使用 `lark-cli drive +create-folder`。
-- 用户要查看或下载文件内容，或者查看文件可用预览格式并获取 PDF / HTML / 文本 / 图片等转换预览产物，使用 `lark-cli drive +preview`。
+- 用户要查看或下载文件内容，或者查看文件可用预览格式并获取 PDF / HTML / 文本 / 图片等转换预览产物，使用 `lark-cli drive +preview`。`+preview` 和 `+download` 都支持 `--file-token` / `--url` / `--wiki-token` 三选一（Wiki 会解析到底层 `file`）；但两者只处理 Drive **文件**，若目标是 docx/sheet/bitable/slides 等在线文档，改用 `drive +export`。
 - 用户要获取某个文件的封面图，优先使用 `lark-cli drive +cover`；先 `--list-only` 看规格，再选 `--spec` 下载。
 - 用户要导出云文档时，优先使用 `lark-cli drive +export --url '<文档 URL>' --file-extension <格式>`；详细参数、Wiki token 和错误码处理见 [`references/lark-drive-export.md`](references/lark-drive-export.md)。
 - 用户要把本地文件上传到知识库 / 文档库里的某个 wiki 节点下时，仍然使用 `lark-cli drive +upload --wiki-token <wiki_token>`；不要误切到 `wiki` 域命令。

--- a/skills/lark-drive/references/lark-drive-download.md
+++ b/skills/lark-drive/references/lark-drive-download.md
@@ -3,7 +3,7 @@
 
 > **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
 
-从飞书云空间（云盘/云存储）下载文件到本地。
+从飞书云空间（云盘/云存储）下载文件到本地。下载对象是 Drive **文件**（上传的 PDF/zip/图片/音视频等文件），以及支持 Wiki URL / Wiki token。
 
 ## 命令
 
@@ -13,7 +13,26 @@ lark-cli drive +download --file-token boxbc_xxx --output ./report.pdf
 
 # 只提供 token，默认保存到当前目录
 lark-cli drive +download --file-token boxbc_xxx
+
+# 直接传 URL，CLI 自动解析类型和 token
+lark-cli drive +download --url "https://example.feishu.cn/file/<FILE_TOKEN>" --output ./report.pdf
+
+# Wiki URL 也可直接传，CLI 会先解析到底层 obj_token/obj_type（obj_type 必须是 file）
+lark-cli drive +download --url "https://example.feishu.cn/wiki/<WIKI_NODE_TOKEN>" --output ./report.pdf
+
+# 只有裸 Wiki node token 时，显式传 --wiki-token，让 CLI 先解析底层文件
+lark-cli drive +download --wiki-token "<WIKI_NODE_TOKEN>" --output ./report.pdf
 ```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--file-token` | 条件必填 | Drive 文件 token；与 `--url` / `--wiki-token` 三选一 |
+| `--url` | 条件必填 | 飞书文件 URL 或 Wiki URL；CLI 自动解析类型和 token |
+| `--wiki-token` | 条件必填 | 裸 Wiki node token；CLI 先解析到底层 Drive 文件 |
+| `--output` | 否 | 本地输出路径；不传时默认保存到当前目录 |
+| `--overwrite` | 否 | 覆盖已存在的输出文件；不传时目标已存在会报错 |
 
 ## URL 解析
 
@@ -25,10 +44,17 @@ https://xxx.feishu.cn/drive/file/boxbc_xxx
                                   file_token
 ```
 
+Wiki URL / 裸 Wiki node token 会先解析到底层文档，解析后会在输出里附带 `wiki_token` 和 `wiki_node`（含底层 `obj_token`/`obj_type`）。
+
+## 关键约束
+
+- Wiki 节点解析后的 `obj_type` 必须是 `file`；不确定 token 类型时，先用 `lark-cli drive +inspect --url <TOKEN> --type wiki` 检查。
+
 ## 排障
 
 - 如果返回 `permission_denied`，或最终下载返回 `HTTP 403`，按错误 `hint` 使用 `lark-cli drive +preview --file-token <FILE_TOKEN> --type source_file --output <path>` 获取预览产物。
 - 如果返回限流错误，停止立即重试，稍后按指数退避重试。
+- 如果目标（或 Wiki 解析出的底层文档）是 `docx` / `sheet` / `bitable` / `slides` 等在线文档，`+download` 无法直接下载，会返回 typed validation error；改用 [lark-drive-export](lark-drive-export.md) 渲染成 pdf / xlsx / pptx / markdown 等格式。
 
 ## 参考
 

--- a/skills/lark-drive/references/lark-drive-preview.md
+++ b/skills/lark-drive/references/lark-drive-preview.md
@@ -2,7 +2,7 @@
 
 > **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、权限处理和安全规则。
 
-查看或下载 Drive 文件内容，或列出并获取文件可用的预览产物。这个 shortcut 不猜测默认类型：
+查看或下载 Drive 文件内容，或列出并获取文件可用的预览产物。对象是 Drive **文件**，也支持 Wiki URL / node token（CLI 先把 Wiki 节点解析到底层文件，`obj_type` 必须是 `file`）。这个 shortcut 不猜测默认类型：
 
 - 如果只需要查看或下载文件内容，或不关心 PDF/text/image 等转换预览，优先使用 `--type source_file --output <path>`
 - 只想看候选项时，用 `--list-only`
@@ -19,6 +19,22 @@ lark-cli drive +preview \
   --file-token "<FILE_TOKEN>" \
   --type source_file \
   --output ./artifacts/source
+
+# 推荐：直接传 URL，CLI 自动解析类型和 token
+lark-cli drive +preview \
+  --url "https://example.feishu.cn/file/<FILE_TOKEN>" \
+  --list-only
+
+# Wiki URL 也可直接传，CLI 会先解析到底层 obj_token/obj_type（obj_type 必须是 file）
+lark-cli drive +preview \
+  --url "https://example.feishu.cn/wiki/<WIKI_NODE_TOKEN>" \
+  --type source_file \
+  --output ./artifacts/source
+
+# 只有裸 Wiki node token 时，显式传 --wiki-token
+lark-cli drive +preview \
+  --wiki-token "<WIKI_NODE_TOKEN>" \
+  --list-only
 
 # 列出可用预览候选项
 lark-cli drive +preview \
@@ -50,7 +66,9 @@ lark-cli drive +preview \
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--file-token` | 是 | Drive 文件 token |
+| `--file-token` | 条件必填 | Drive 文件 token；与 `--url` / `--wiki-token` 三选一 |
+| `--url` | 条件必填 | 飞书文件 URL 或 Wiki URL；CLI 自动解析类型和 token |
+| `--wiki-token` | 条件必填 | 裸 Wiki node token；CLI 先解析到底层 Drive 文件 |
 | `--type` | 条件必填 | 预览类型；优先使用 `--list-only` 返回的 `type`，如 `pdf` / `html` / `text` / `png` / `jpg` / `source_file` |
 | `--version` | 否 | 文件版本号 |
 | `--list-only` | 否 | 仅返回候选项，不下载 |
@@ -90,6 +108,7 @@ lark-cli drive +preview \
 - `--type source_file` 用于查看文件内容，不依赖 `--list-only` 返回的候选项；它适合读取或保存源内容，不等同于 PDF/text/image 等转换预览
 - 候选项状态来自后端 `preview_status` 枚举，例如 `READY` / `PROCESSING` / `FAILED` / `NO_SUPPORT`
 - 本地文件名在未显式带扩展名时，会结合响应头自动补扩展名
+- Wiki URL / 裸 Wiki node token 会先解析到底层文档，解析后会在输出里附带 `wiki_token` 和 `wiki_node`（含底层 `obj_token`/`obj_type`）；`obj_type` 必须是 `file`。如果 Wiki 指向 `docx` / `sheet` / `bitable` / `slides` 等在线文档，`+preview` 无法直接处理，CLI 会返回 typed validation error，并在 hint 中提示改用 [lark-drive-export](lark-drive-export.md)
 
 ### 参考
 

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -112,7 +112,8 @@ lark-cli wiki <resource> <method> [flags]  # 调用 API
 
 ## 不在本 skill 范围
 
-- 上传 / 下载文件到知识库节点下 → [`lark-drive`](../lark-drive/SKILL.md)（`drive +upload --wiki-token`）
+- 上传文件到知识库节点下 → [`lark-drive`](../lark-drive/SKILL.md)（`drive +upload --wiki-token`）
+- 下载 Wiki 节点对应的文件（底层 `obj_type` 为 `file`）→ [`lark-drive`](../lark-drive/SKILL.md)：`drive +download --wiki-token <node_token>` 或 `drive +download --url <wiki_url>`（CLI 会先把 Wiki 节点解析到底层文件再下载）；底层是 `docx`/`sheet`/`bitable`/`slides` 等在线文档时改用 `drive +export`
 - 编辑文档正文内容 → [`lark-doc`](../lark-doc/SKILL.md)
 - 表格 / 多维表格数据操作 → [`lark-sheets`](../lark-sheets/SKILL.md) / [`lark-base`](../lark-base/SKILL.md)
 - 按名称搜索文档 / Wiki / 表格文件、评论与权限管理 → [`lark-drive`](../lark-drive/SKILL.md)

--- a/tests/cli_e2e/drive/drive_download_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_download_dryrun_test.go
@@ -109,3 +109,121 @@ func TestDriveDownloadDryRun_ExplicitOutputSkipsMetadata(t *testing.T) {
 		t.Fatalf("output=%q, want explicit output\nstdout:\n%s", got, out)
 	}
 }
+
+// TestDriveDownloadDryRun_WikiURLResolvesBeforeDownload verifies a /wiki/ URL
+// prepends a get_node resolution step ahead of the metadata + download steps.
+func TestDriveDownloadDryRun_WikiURLResolvesBeforeDownload(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+download",
+			"--url", "https://example.feishu.cn/wiki/wikiDryRunDownload",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := clie2e.DryRunGet(out, "api.#").Int(); got != 4 {
+		t.Fatalf("api count=%d, want 4 (get_node + permission auth + metadata + download)\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.method").String(); got != "GET" {
+		t.Fatalf("api.0.method=%q, want GET\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
+		t.Fatalf("api.0.url=%q, want wiki get_node\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "wikiDryRunDownload" {
+		t.Fatalf("api.0.params.token=%q, want wiki token\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "wiki_token").String(); got != "wikiDryRunDownload" {
+		t.Fatalf("wiki_token=%q, want wiki token\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.1.url").String(); got != "/open-apis/drive/v1/permissions/obj_token_from_wiki_node/members/auth" {
+		t.Fatalf("api.1.url=%q, want permission auth on resolved token\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.2.url").String(); got != "/open-apis/drive/v1/metas/batch_query" {
+		t.Fatalf("api.2.url=%q, want metadata batch_query\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.3.url").String(); got != "/open-apis/drive/v1/files/obj_token_from_wiki_node/download" {
+		t.Fatalf("api.3.url=%q, want download from resolved token\nstdout:\n%s", got, out)
+	}
+}
+
+// TestDriveDownloadDryRun_WikiTokenExplicitOutput verifies --wiki-token with an
+// explicit output plans get_node then the permission check and download,
+// skipping the metadata lookup.
+func TestDriveDownloadDryRun_WikiTokenExplicitOutput(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+download",
+			"--wiki-token", "wikiDryRunDownload",
+			"--output", "./artifacts/report.bin",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := clie2e.DryRunGet(out, "api.#").Int(); got != 3 {
+		t.Fatalf("api count=%d, want 3 (get_node + permission auth + download)\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
+		t.Fatalf("api.0.url=%q, want wiki get_node\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.1.url").String(); got != "/open-apis/drive/v1/permissions/obj_token_from_wiki_node/members/auth" {
+		t.Fatalf("api.1.url=%q, want permission auth on resolved token\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.2.url").String(); got != "/open-apis/drive/v1/files/obj_token_from_wiki_node/download" {
+		t.Fatalf("api.2.url=%q, want download from resolved token\nstdout:\n%s", got, out)
+	}
+}
+
+// TestDriveDownloadDryRun_RejectsMutuallyExclusiveInputs verifies passing more
+// than one source flag fails validation instead of silently picking one.
+func TestDriveDownloadDryRun_RejectsMutuallyExclusiveInputs(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+download",
+			"--file-token", "fileDryRunDownload",
+			"--wiki-token", "wikiDryRunDownload",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	if result.Stdout != "" {
+		t.Fatalf("stdout must stay empty on validation failure, got:\n%s", result.Stdout)
+	}
+	if got := clie2e.DryRunGet(result.Stderr, "error.type").String(); got != "validation" {
+		t.Fatalf("error.type=%q, want validation\nstderr:\n%s", got, result.Stderr)
+	}
+	if got := clie2e.DryRunGet(result.Stderr, "error.subtype").String(); got != "invalid_argument" {
+		t.Fatalf("error.subtype=%q, want invalid_argument\nstderr:\n%s", got, result.Stderr)
+	}
+	if got := clie2e.DryRunGet(result.Stderr, "error.param").String(); got != "--file-token" {
+		t.Fatalf("error.param=%q, want --file-token\nstderr:\n%s", got, result.Stderr)
+	}
+	if got := clie2e.DryRunGet(result.Stderr, "error.message").String(); got == "" {
+		t.Fatalf("error.message must be non-empty\nstderr:\n%s", result.Stderr)
+	}
+}

--- a/tests/cli_e2e/drive/drive_preview_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_preview_dryrun_test.go
@@ -142,6 +142,80 @@ func TestDrivePreviewDryRun_SourceFile(t *testing.T) {
 	}
 }
 
+// TestDrivePreviewDryRun_WikiURLResolvesBeforePreview verifies a /wiki/ URL
+// prepends a get_node resolution step ahead of the preview_result step.
+func TestDrivePreviewDryRun_WikiURLResolvesBeforePreview(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+preview",
+			"--url", "https://example.feishu.cn/wiki/wikiDryRunPreview",
+			"--list-only",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := clie2e.DryRunGet(out, "api.#").Int(); got != 2 {
+		t.Fatalf("api count=%d, want 2 (get_node + preview_result)\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
+		t.Fatalf("api.0.url=%q, want wiki get_node\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "wikiDryRunPreview" {
+		t.Fatalf("api.0.params.token=%q, want wiki token\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "wiki_token").String(); got != "wikiDryRunPreview" {
+		t.Fatalf("wiki_token=%q, want wiki token\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.1.url").String(); got != "/open-apis/drive/v1/medias/obj_token_from_wiki_node/preview_result" {
+		t.Fatalf("api.1.url=%q, want preview_result from resolved token\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "mode").String(); got != "list" {
+		t.Fatalf("mode=%q, want list\nstdout:\n%s", got, out)
+	}
+}
+
+// TestDrivePreviewDryRun_WikiTokenSourceFile verifies --wiki-token feeds the
+// source_file download path via the resolved file token.
+func TestDrivePreviewDryRun_WikiTokenSourceFile(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+preview",
+			"--wiki-token", "wikiDryRunPreview",
+			"--type", "source_file",
+			"--output", "./artifacts/source",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := clie2e.DryRunGet(out, "api.#").Int(); got != 2 {
+		t.Fatalf("api count=%d, want 2 (get_node + preview_download)\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
+		t.Fatalf("api.0.url=%q, want wiki get_node\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.1.url").String(); got != "/open-apis/drive/v1/medias/obj_token_from_wiki_node/preview_download" {
+		t.Fatalf("api.1.url=%q, want preview_download from resolved token\nstdout:\n%s", got, out)
+	}
+}
+
 // TestDriveCoverDryRun_Download verifies cover dry-run request structure for
 // download mode.
 func TestDriveCoverDryRun_Download(t *testing.T) {

--- a/tests/cli_e2e/wiki/drive_wiki_source_workflow_test.go
+++ b/tests/cli_e2e/wiki/drive_wiki_source_workflow_test.go
@@ -1,0 +1,332 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	drivee2e "github.com/larksuite/cli/tests/cli_e2e/drive"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestDrive_DownloadPreviewWikiSourceWorkflow exercises the live wiki-source
+// path added to drive +download / +preview end to end: it uploads a fixture
+// file, moves it into Wiki to produce a node whose get_node resolves to
+// obj_type=="file", then downloads and previews that file through both a
+// --wiki-token and a /wiki/ --url. It also pins the contract that a wiki node
+// wrapping a document (the docx parent host) is rejected with a typed
+// validation error pointing at drive +export. The whole flow is self-contained
+// and skips when the bot lacks the required Drive/Wiki scopes.
+func TestDrive_DownloadPreviewWikiSourceWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	fixtureContent := "drive download/preview wiki source workflow " + suffix + "\n"
+
+	// 1) Isolated Drive folder to stage the fixture (skip on missing scope).
+	folderToken := createDriveFolderOrSkipWikiSource(t, parentT, ctx, "lark-cli-e2e-drive-wiki-src-"+suffix)
+
+	// 2) Upload the fixture file we will later reach through a wiki node.
+	fileToken := uploadWikiSourceFixture(t, parentT, ctx, folderToken, "wiki-source.txt", fixtureContent)
+
+	// 3) Parent wiki node (a docx origin node) that both hosts the moved file
+	//    and doubles as the document-node rejection fixture. Its cleanup deletes
+	//    child nodes recursively, so the moved file node is reclaimed with it.
+	_, parentNode := createWikiNodeUnderAnyHost(t, parentT, ctx, "lark-cli-e2e-drive-wiki-src-node-"+suffix)
+	spaceID := parentNode.Get("space_id").String()
+	docNodeToken := parentNode.Get("node_token").String()
+	require.NotEmpty(t, spaceID, "parent wiki node must expose space_id; node:\n%s", parentNode.Raw)
+	require.NotEmpty(t, docNodeToken, "parent wiki node must expose node_token; node:\n%s", parentNode.Raw)
+
+	// 4) Move the Drive file into Wiki -> a wiki node whose get_node resolves to
+	//    obj_type=="file". This is exactly the shape drive +download / +preview
+	//    must accept.
+	fileNodeToken := moveDriveFileIntoWikiOrSkip(t, ctx, spaceID, docNodeToken, fileToken)
+	wikiURL := "https://example.feishu.cn/wiki/" + fileNodeToken
+
+	t.Run("download via wiki token", func(t *testing.T) {
+		assertWikiSourceDownload(t, ctx, []string{"--wiki-token", fileNodeToken}, fileNodeToken, fixtureContent)
+	})
+
+	t.Run("download via wiki url", func(t *testing.T) {
+		assertWikiSourceDownload(t, ctx, []string{"--url", wikiURL}, fileNodeToken, fixtureContent)
+	})
+
+	t.Run("preview source file via wiki token", func(t *testing.T) {
+		workDir := t.TempDir()
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"drive", "+preview",
+				"--wiki-token", fileNodeToken,
+				"--type", "source_file",
+				"--output", "./artifacts/wiki-preview",
+			},
+			WorkDir:   workDir,
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		if result.ExitCode != 0 && isWikiSourceScopeSkip(result) {
+			t.Skipf("skip wiki preview due to missing scope:\n%s", strings.TrimSpace(result.Stderr))
+		}
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+
+		stdout := result.Stdout
+		require.Equal(t, "source_file", gjson.Get(stdout, "data.selected_type").String(), "stdout:\n%s", stdout)
+		require.Equal(t, fileNodeToken, gjson.Get(stdout, "data.wiki_token").String(), "stdout:\n%s", stdout)
+		require.Equal(t, "file", gjson.Get(stdout, "data.wiki_node.obj_type").String(), "stdout:\n%s", stdout)
+		require.NotEmpty(t, gjson.Get(stdout, "data.wiki_node.obj_token").String(), "stdout:\n%s", stdout)
+
+		outputPath := gjson.Get(stdout, "data.output_path").String()
+		require.NotEmpty(t, outputPath, "preview source file should return output_path\nstdout:\n%s", stdout)
+		data, readErr := os.ReadFile(outputPath)
+		require.NoError(t, readErr)
+		require.Equal(t, fixtureContent, string(data), "preview source content mismatch")
+	})
+
+	t.Run("rejects wiki node that wraps a document", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"drive", "+download",
+				"--wiki-token", docNodeToken,
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		if result.ExitCode != 0 && isWikiSourceScopeSkip(result) {
+			t.Skipf("skip document-node rejection due to missing scope:\n%s", strings.TrimSpace(result.Stderr))
+		}
+
+		result.AssertExitCode(t, 2)
+		if strings.TrimSpace(result.Stdout) != "" {
+			t.Fatalf("stdout must stay empty on validation failure, got:\n%s", result.Stdout)
+		}
+		require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), "stderr:\n%s", result.Stderr)
+		require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), "stderr:\n%s", result.Stderr)
+		require.Equal(t, "--wiki-token", gjson.Get(result.Stderr, "error.param").String(), "stderr:\n%s", result.Stderr)
+		require.NotEmpty(t, gjson.Get(result.Stderr, "error.message").String(), "stderr:\n%s", result.Stderr)
+		require.Contains(t, gjson.Get(result.Stderr, "error.hint").String(), "+export", "stderr:\n%s", result.Stderr)
+	})
+}
+
+// assertWikiSourceDownload runs drive +download for a wiki source (token or URL)
+// and verifies the resolution annotation plus the downloaded bytes.
+func assertWikiSourceDownload(t *testing.T, ctx context.Context, sourceArgs []string, wantWikiToken, wantContent string) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	args := append([]string{"drive", "+download"}, sourceArgs...)
+	args = append(args, "--output", "downloaded.txt", "--overwrite")
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      args,
+		WorkDir:   workDir,
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	if result.ExitCode != 0 && isWikiSourceScopeSkip(result) {
+		t.Skipf("skip wiki download due to missing scope:\n%s", strings.TrimSpace(result.Stderr))
+	}
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+
+	stdout := result.Stdout
+	require.Equal(t, wantWikiToken, gjson.Get(stdout, "data.wiki_token").String(), "stdout:\n%s", stdout)
+	require.Equal(t, "file", gjson.Get(stdout, "data.wiki_node.obj_type").String(), "stdout:\n%s", stdout)
+	require.NotEmpty(t, gjson.Get(stdout, "data.wiki_node.obj_token").String(), "stdout:\n%s", stdout)
+
+	require.NotEmpty(t, gjson.Get(stdout, "data.saved_path").String(), "download should return saved_path\nstdout:\n%s", stdout)
+	data, readErr := os.ReadFile(filepath.Join(workDir, "downloaded.txt"))
+	require.NoError(t, readErr)
+	require.Equal(t, wantContent, string(data), "downloaded content mismatch")
+}
+
+// moveDriveFileIntoWikiOrSkip moves an uploaded Drive file under a wiki parent
+// node and returns the resulting wiki node token (obj_type=="file"). It handles
+// both the immediate and async move responses and skips when scopes are missing.
+func moveDriveFileIntoWikiOrSkip(t *testing.T, ctx context.Context, spaceID, parentNodeToken, fileToken string) string {
+	t.Helper()
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"wiki", "+move",
+			"--obj-type", "file",
+			"--obj-token", fileToken,
+			"--target-space-id", spaceID,
+			"--target-parent-token", parentNodeToken,
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	if result.ExitCode != 0 && isWikiSourceScopeSkip(result) {
+		t.Skipf("skip wiki source workflow: move file into wiki needs scopes:\n%s", strings.TrimSpace(result.Stderr))
+	}
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+
+	nodeToken := gjson.Get(result.Stdout, "data.node_token").String()
+	if nodeToken != "" {
+		return nodeToken
+	}
+
+	taskID := gjson.Get(result.Stdout, "data.task_id").String()
+	require.NotEmpty(t, taskID, "wiki move must return node_token or task_id\nstdout:\n%s", result.Stdout)
+	return waitWikiMoveNodeReady(t, ctx, taskID)
+}
+
+// waitWikiMoveNodeReady polls drive +task_result until the async docs-to-wiki
+// move finishes and returns the resulting wiki node token.
+func waitWikiMoveNodeReady(t *testing.T, ctx context.Context, taskID string) string {
+	t.Helper()
+
+	var nodeToken string
+	err := clie2e.WaitForCondition(ctx, clie2e.WaitOptions{
+		Timeout:  90 * time.Second,
+		Interval: 3 * time.Second,
+		TimeoutError: func() error {
+			return fmt.Errorf("wiki move task %s did not finish", taskID)
+		},
+	}, func() (bool, error) {
+		result, runErr := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"drive", "+task_result",
+				"--scenario", "wiki_move",
+				"--task-id", taskID,
+			},
+			DefaultAs: "bot",
+		})
+		if runErr != nil {
+			return false, runErr
+		}
+		if result.ExitCode != 0 {
+			return false, fmt.Errorf(
+				"query wiki move task failed: exit=%d stdout=%s stderr=%s",
+				result.ExitCode, result.Stdout, result.Stderr,
+			)
+		}
+		parsed := gjson.Parse(result.Stdout)
+		if parsed.Get("data.failed").Bool() {
+			return false, fmt.Errorf("wiki move task %s failed: %s", taskID, parsed.Get("data.status_msg").String())
+		}
+		if parsed.Get("data.ready").Bool() {
+			nodeToken = parsed.Get("data.node_token").String()
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, nodeToken, "async wiki move must yield a node_token")
+	return nodeToken
+}
+
+// createDriveFolderOrSkipWikiSource creates a staging Drive folder for the wiki
+// source workflow, skipping when the bot lacks the folder-create scope.
+func createDriveFolderOrSkipWikiSource(t *testing.T, parentT *testing.T, ctx context.Context, name string) string {
+	t.Helper()
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"drive", "+create-folder", "--name", name},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	if result.ExitCode != 0 && isWikiSourceScopeSkip(result) {
+		t.Skipf("skip wiki source workflow: create folder needs scope:\n%s", strings.TrimSpace(result.Stderr))
+	}
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+
+	folderToken := gjson.Get(result.Stdout, "data.folder_token").String()
+	require.NotEmpty(t, folderToken, "drive folder token should not be empty\nstdout:\n%s", result.Stdout)
+
+	parentT.Cleanup(func() {
+		cleanupCtx, cancel := clie2e.CleanupContext()
+		defer cancel()
+
+		deleteResult, deleteErr := drivee2e.DeleteDriveResourceAndVerify(cleanupCtx, folderToken, "folder", "bot")
+		clie2e.ReportCleanupFailure(parentT, "delete drive folder "+folderToken, deleteResult, deleteErr)
+	})
+
+	return folderToken
+}
+
+// uploadWikiSourceFixture uploads a text fixture into Drive and registers
+// cleanup for the underlying file token. After the file is moved into Wiki the
+// delete resolves as already-gone, which DeleteDriveResourceAndVerify tolerates,
+// so this cleanup also covers the skip path where the move never happens.
+func uploadWikiSourceFixture(t *testing.T, parentT *testing.T, ctx context.Context, folderToken, uploadName, content string) string {
+	t.Helper()
+
+	workDir := t.TempDir()
+	relPath := "wiki-fixture.txt"
+	if err := os.WriteFile(filepath.Join(workDir, relPath), []byte(content), 0o644); err != nil {
+		t.Fatalf("write wiki source fixture: %v", err)
+	}
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+upload",
+			"--file", relPath,
+			"--folder-token", folderToken,
+			"--name", uploadName,
+		},
+		WorkDir:   workDir,
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	if result.ExitCode != 0 && isWikiSourceScopeSkip(result) {
+		t.Skipf("skip wiki source workflow: upload needs scope:\n%s", strings.TrimSpace(result.Stderr))
+	}
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+
+	fileToken := gjson.Get(result.Stdout, "data.file_token").String()
+	require.NotEmpty(t, fileToken, "uploaded file should have a token\nstdout:\n%s", result.Stdout)
+
+	parentT.Cleanup(func() {
+		cleanupCtx, cancel := clie2e.CleanupContext()
+		defer cancel()
+
+		deleteResult, deleteErr := drivee2e.DeleteDriveResourceAndVerify(cleanupCtx, fileToken, "file", "bot")
+		clie2e.ReportCleanupFailure(parentT, "delete drive file "+fileToken, deleteResult, deleteErr)
+	})
+
+	return fileToken
+}
+
+// isWikiSourceScopeSkip reports whether a failed result was caused by a missing
+// bot scope, so the live workflow can skip instead of failing on tenants that
+// have not granted the required Drive/Wiki permissions.
+func isWikiSourceScopeSkip(result *clie2e.Result) bool {
+	if result == nil {
+		return false
+	}
+	combined := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	for _, marker := range []string{
+		"app scope not enabled",
+		"99991672",
+		"missing_scopes",
+		"wiki:node:move",
+		"wiki:node:read",
+		"wiki:space:read",
+		"wiki:node:retrieve",
+		"space:folder:create",
+		"drive:file:upload",
+	} {
+		if strings.Contains(combined, marker) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->
Extend +download and +preview to accept --url and --wiki-token in addition to --file-token (mutually exclusive). Wiki nodes are resolved to their underlying object; only file-backed nodes are supported, and non-file documents (docx/sheet/bitable/slides) return a typed validation error hinting to use +export.

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drive preview and download now accept file URLs, Wiki URLs, and Wiki node tokens alongside file tokens.
  * Wiki references are automatically resolved to the underlying Drive file.
  * Results include Wiki-resolution details when applicable.

* **Bug Fixes**
  * Improved validation for conflicting, malformed, unsupported, or non-file inputs.
  * Online documents now provide clearer guidance to use the export command.

* **Documentation**
  * Updated Drive command guidance and examples for the new input options and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->