### PR TITLE
feat(base): add hidden --field-id-or-name alias for +field-get

### DIFF
--- a/shortcuts/base/base_dryrun_ops_test.go
+++ b/shortcuts/base/base_dryrun_ops_test.go
@@ -85,6 +85,12 @@ func TestDryRunFieldOps(t *testing.T) {
 		map[string]int{"offset": 3, "limit": 30},
 	)
 	assertDryRunContains(t, dryRunFieldGet(ctx, rt), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/fields/fld_1")
+	fieldGetAliasRT := newBaseTestRuntime(
+		map[string]string{"base-token": "app_x", "table-id": "tbl_1", "field-id-or-name": "Amount"},
+		nil,
+		nil,
+	)
+	assertDryRunContains(t, dryRunFieldGet(ctx, fieldGetAliasRT), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/fields/Amount")
 	assertDryRunContains(t, dryRunFieldCreate(ctx, rt), "POST /open-apis/base/v3/bases/app_x/tables/tbl_1/fields")
 
 	arrayRT := newBaseTestRuntime(

--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -1290,6 +1290,24 @@ func TestBaseFieldExecuteCRUD(t *testing.T) {
 		}
 	})
 
+	t.Run("get alias", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "GET",
+			URL:    "/open-apis/base/v3/bases/app_x/tables/tbl_x/fields/Amount",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{"id": "fld_amount", "name": "Amount", "type": "number"},
+			},
+		})
+		if err := runShortcut(t, BaseFieldGet, []string{"+field-get", "--base-token", "app_x", "--table-id", "tbl_x", "--field-id-or-name", "Amount"}, factory, stdout); err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `"field"`) || !strings.Contains(got, `"Amount"`) {
+			t.Fatalf("stdout=%s", got)
+		}
+	})
+
 	t.Run("create", func(t *testing.T) {
 		factory, stdout, reg := newExecuteFactory(t)
 		reg.Register(&httpmock.Stub{

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -507,6 +507,37 @@ func TestBaseRecordProjectionAliasesAreHidden(t *testing.T) {
 	}
 }
 
+func TestBaseFieldGetAliasIsHidden(t *testing.T) {
+	parent := &cobra.Command{Use: "base"}
+	BaseFieldGet.Mount(parent, &cmdutil.Factory{})
+	cmd := parent.Commands()[0]
+	flag := cmd.Flags().Lookup("field-id-or-name")
+	if flag == nil {
+		t.Fatal("flag --field-id-or-name missing")
+	}
+	if !flag.Hidden {
+		t.Fatal("flag --field-id-or-name must be hidden")
+	}
+	if strings.Contains(cmd.Flags().FlagUsages(), "--field-id-or-name") {
+		t.Fatalf("help should not include hidden --field-id-or-name:\n%s", cmd.Flags().FlagUsages())
+	}
+	if err := cmd.ParseFlags([]string{"--base-token", "b", "--table-id", "t"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := cmd.ValidateFlagGroups(); err == nil || !strings.Contains(err.Error(), "at least one of the flags") {
+		t.Fatalf("expected field selector one-required group error, got %v", err)
+	}
+	if err := cmd.Flags().Set("field-id", "fld_1"); err != nil {
+		t.Fatalf("set field-id: %v", err)
+	}
+	if err := cmd.Flags().Set("field-id-or-name", "Amount"); err != nil {
+		t.Fatalf("set field-id-or-name: %v", err)
+	}
+	if err := cmd.ValidateFlagGroups(); err == nil || !strings.Contains(err.Error(), "none of the others can be") {
+		t.Fatalf("expected field selector mutual exclusion group error, got %v", err)
+	}
+}
+
 func TestBaseDashboardHelpGuidesAgents(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1178,6 +1209,15 @@ func assertHelpOrder(t *testing.T, help string, before string, after string) {
 
 func TestBaseFieldValidate(t *testing.T) {
 	ctx := context.Background()
+	if err := BaseFieldGet.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t"}, nil, nil)); err == nil || !strings.Contains(err.Error(), "--field-id is required") {
+		t.Fatalf("err=%v", err)
+	}
+	if err := BaseFieldGet.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id-or-name": "Amount"}, nil, nil)); err != nil {
+		t.Fatalf("field get alias validate err=%v", err)
+	}
+	if err := BaseFieldGet.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "field-id": "fld_1", "field-id-or-name": "Amount"}, nil, nil)); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("err=%v", err)
+	}
 	if err := BaseFieldCreate.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "t", "json": "{"}, nil, nil)); err == nil || !strings.Contains(err.Error(), "--json invalid JSON object") {
 		t.Fatalf("err=%v", err)
 	}

--- a/shortcuts/base/field_get.go
+++ b/shortcuts/base/field_get.go
@@ -5,8 +5,10 @@ package base
 
 import (
 	"context"
+	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
 )
 
 var BaseFieldGet = common.Shortcut{
@@ -16,14 +18,62 @@ var BaseFieldGet = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{"base:field:read"},
 	AuthTypes:   authTypes(),
-	Flags:       []common.Flag{baseTokenFlag(true), tableRefFlag(true), fieldRefFlag(true)},
+	Flags: []common.Flag{
+		baseTokenFlag(true),
+		tableRefFlag(true),
+		fieldRefFlag(false),
+		{Name: "field-id-or-name", Desc: "hidden alias for --field-id", Hidden: true},
+	},
 	Tips: []string{
 		`Example: lark-cli base +field-get --base-token <base_token> --table-id <table_id> --field-id "Status"`,
 		"field-id accepts a field ID (fld...) or the field name from the current table.",
 		"Returns full field configuration; use it as the baseline before +field-update.",
 	},
+	PostMount: func(cmd *cobra.Command) {
+		cmd.MarkFlagsOneRequired("field-id", "field-id-or-name")
+		cmd.MarkFlagsMutuallyExclusive("field-id", "field-id-or-name")
+		previousPreRunE := cmd.PreRunE
+		cmd.PreRunE = func(c *cobra.Command, args []string) error {
+			if previousPreRunE != nil {
+				if err := previousPreRunE(c, args); err != nil {
+					return err
+				}
+			}
+			fieldIDSet := c.Flags().Changed("field-id")
+			aliasSet := c.Flags().Changed("field-id-or-name")
+			if !fieldIDSet && !aliasSet {
+				return baseFlagErrorf("--field-id is required")
+			}
+			if fieldIDSet && aliasSet {
+				return baseFlagErrorf("--field-id and --field-id-or-name are mutually exclusive; use --field-id")
+			}
+			return nil
+		}
+	},
+	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+		return validateFieldGet(runtime)
+	},
 	DryRun: dryRunFieldGet,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return executeFieldGet(runtime)
 	},
+}
+
+func fieldGetRef(runtime *common.RuntimeContext) string {
+	if fieldRef := strings.TrimSpace(runtime.Str("field-id")); fieldRef != "" {
+		return fieldRef
+	}
+	return strings.TrimSpace(runtime.Str("field-id-or-name"))
+}
+
+func validateFieldGet(runtime *common.RuntimeContext) error {
+	fieldID := strings.TrimSpace(runtime.Str("field-id"))
+	alias := strings.TrimSpace(runtime.Str("field-id-or-name"))
+	if fieldID == "" && alias == "" {
+		return baseFlagErrorf("--field-id is required")
+	}
+	if fieldID != "" && alias != "" {
+		return baseFlagErrorf("--field-id and --field-id-or-name are mutually exclusive; use --field-id")
+	}
+	return nil
 }

--- a/shortcuts/base/field_ops.go
+++ b/shortcuts/base/field_ops.go
@@ -32,7 +32,7 @@ func dryRunFieldGet(_ context.Context, runtime *common.RuntimeContext) *common.D
 		GET("/open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id").
 		Set("base_token", runtime.Str("base-token")).
 		Set("table_id", baseTableID(runtime)).
-		Set("field_id", runtime.Str("field-id"))
+		Set("field_id", fieldGetRef(runtime))
 }
 
 func dryRunFieldCreate(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
@@ -147,7 +147,7 @@ func executeFieldList(runtime *common.RuntimeContext) error {
 func executeFieldGet(runtime *common.RuntimeContext) error {
 	baseToken := runtime.Str("base-token")
 	tableIDValue := baseTableID(runtime)
-	fieldRef := runtime.Str("field-id")
+	fieldRef := fieldGetRef(runtime)
 	data, err := baseV3Call(runtime, "GET", baseV3Path("bases", baseToken, "tables", tableIDValue, "fields", fieldRef), nil, nil)
 	if err != nil {
 		return err

--- a/tests/cli_e2e/base/base_field_get_dryrun_test.go
+++ b/tests/cli_e2e/base/base_field_get_dryrun_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestBaseFieldGetDryRunAcceptsFieldIDOrNameAlias(t *testing.T) {
+	setBaseDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"base", "+field-get",
+			"--base-token", "app_x",
+			"--table-id", "tbl_x",
+			"--field-id-or-name", "Amount",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), out)
+	require.Equal(t, "/open-apis/base/v3/bases/app_x/tables/tbl_x/fields/Amount", clie2e.DryRunGet(out, "api.0.url").String(), out)
+	require.Equal(t, "Amount", clie2e.DryRunGet(out, "field_id").String(), out)
+}
+
+func TestBaseFieldGetDryRunRequiresFieldSelectorBeforeRun(t *testing.T) {
+	setBaseDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"base", "+field-get",
+			"--base-token", "app_x",
+			"--table-id", "tbl_x",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Empty(t, strings.TrimSpace(result.Stdout), result.Stdout)
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "--field-id", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "--field-id is required")
+}


### PR DESCRIPTION
## Summary
Add a hidden `--field-id-or-name` alias for `+field-get` so agents can explicitly request a field by ID or name while `--field-id` remains the canonical selector.

## Changes
- `+field-get` registers a hidden `--field-id-or-name` flag; it is mutually exclusive with `--field-id` and at least one selector is required.
- Dry-run and execute paths resolve the field reference from either flag via `fieldGetRef`.
- Added unit tests for the hidden flag, flag-group (one-required / mutual exclusion) behavior, and `Validate`; added a dry-run e2e test for the alias.

## Test Plan
- [x] `git diff --check` passes
- [x] New unit tests cover flag registration, group validation, and alias `Validate` behavior
- [x] New dry-run e2e test (`tests/cli_e2e/base/base_field_get_dryrun_test.go`) verifies the alias request shape
- [ ] CI: `make unit-test` / `go vet ./...` (not run in sync scope)

## Related Issues
Auto research task: 01KWNBD6WC5QZ2YTZZBB6CTZ37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Field retrieval now accepts either a field ID or field name.
  * Field names are resolved into the appropriate API request and returned field details.

* **Bug Fixes**
  * Added validation requiring exactly one field selector.
  * Invalid requests now provide clear errors when no selector or multiple selectors are supplied.

* **Tests**
  * Expanded coverage for name-based lookup, dry runs, validation, and hidden command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->