### PR TITLE
fix(wiki): correct copy semantics and rename routing

### DIFF
--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -549,6 +549,15 @@ func TestWikiNodeCopyDeclaredHighRiskWrite(t *testing.T) {
 	}
 }
 
+func TestWikiNodeCopyDeclaresNodeOnlySemantics(t *testing.T) {
+	t.Parallel()
+
+	tips := strings.Join(WikiNodeCopy.Tips, " ")
+	if !strings.Contains(tips, "current node only") || !strings.Contains(tips, "descendant nodes are not copied") {
+		t.Fatalf("WikiNodeCopy.Tips = %q, want explicit non-recursive copy guidance", tips)
+	}
+}
+
 func TestWikiNodeCopyCopiesNodeToTargetSpace(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 

--- a/shortcuts/wiki/wiki_node_copy.go
+++ b/shortcuts/wiki/wiki_node_copy.go
@@ -33,6 +33,7 @@ var WikiNodeCopy = common.Shortcut{
 	Tips: []string{
 		"At least one of --target-space-id or --target-parent-node-token must be provided.",
 		"Omit --title to keep the original node title in the copy.",
+		"This shortcut copies the current node only; descendant nodes are not copied.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateOptionalResourceName(strings.TrimSpace(runtime.Str("space-id")), "--space-id"); err != nil {

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -36,6 +36,7 @@ metadata:
   - 用户明确选定后再执行 `lark-cli wiki +delete-space --space-id <ID> --yes`（高风险写操作，必须显式 `--yes`）。
   - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki +node-get` 解析出 `data.space_id` 再传。
 - 用户要在知识库中创建新节点，优先使用 `lark-cli wiki +node-create`。
+- 用户要**原地重命名 Wiki 节点 / 修改节点标题**：使用 `lark-cli drive +update-title --url '<wiki_url>' --title '<new_title>'`。该命令保留同一个 `node_token`，并会根据 API 返回给出准确的缺失 scope 和授权提示；不要探索 raw `wiki.nodes` 的 `update_title` 端点，也不要通过复制或新建第二个节点实现改名。
 - 用户要列出 Wiki 节点：先用 `wiki +space-list --as user` 拿数字 `space_id`，再用 `wiki +node-list --space-id <space_id>`。不要把 wiki URL、node token、doc token、名称直接当 `--space-id`。钻子节点时 `--parent-node-token` 必须是 wiki node token；如果用户给的是 docx/sheet/base URL，先用 `wiki +node-get --node-token <url>` 解析出 `node_token`。
 - `wiki +node-list` 命中 `invalid_parameters`、`not_found`、`permission_denied` 时，不要重复调用同一参数；按 hint 修 `space_id` / `parent_node_token` / 权限。只有 `rate_limit` 才做退避重试。
 - 用户说“给知识库添加成员/管理员”：先把目标解析成“用户 / 群 / 部门 / 应用”四类之一，再决定 `--member-type`，不要先调 `wiki +member-add` 再根据报错反推类型。

--- a/skills/lark-wiki/references/lark-wiki-node-copy.md
+++ b/skills/lark-wiki/references/lark-wiki-node-copy.md
@@ -1,6 +1,6 @@
 # lark-wiki +node-copy
 
-Copy a wiki node (including its content) to a target space or under a target parent node. Used for cross-space migration.
+Copy one Wiki node, including that node's content, to a target space or under a target parent node. Descendant nodes are not copied.
 
 > ⚠️ **High-risk write** — the upstream API is flagged `danger: true`, so this shortcut requires explicit `--yes` confirmation before issuing the request. Forgetting `--yes` returns a `confirmation_required` error and the copy is **not** performed.
 
@@ -46,26 +46,11 @@ lark-cli wiki +node-copy \
 }
 ```
 
-## Migration workflow
-
-To migrate a subtree from one space to another:
-
-```bash
-# 1. List nodes in the source space
-lark-cli wiki +node-list --space-id source_space_id
-
-# 2. Copy each node to the target space
-lark-cli wiki +node-copy \
-  --space-id <source_space_id> \
-  --node-token wikcn_EXAMPLE_TOKEN \
-  --target-space-id <target_space_id> \
-  --yes
-```
-
 ## Notes
 
-- Copying is recursive — the subtree under the node is also copied.
-- There is no native move API; migration = copy to target + (manually delete source if needed).
+- Copying is non-recursive: only the requested node and its content are copied.
+- Descendant nodes must be copied separately.
+- To move an existing Wiki node without keeping the source, use [`wiki +move`](lark-wiki-move.md) instead of copy-then-delete.
 
 ## Required Scope
 


### PR DESCRIPTION
## Summary

Fix two deterministic Wiki agent failures: `+node-copy` was documented as recursive even though it copies only the requested node, and Wiki rename tasks were not routed to the existing `drive +update-title` shortcut.

## Changes

- Clarify in `+node-copy` help and the lark-wiki reference that copying is non-recursive.
- Route in-place Wiki node renames to `drive +update-title` in the lark-wiki Skill, so agents avoid raw API probing and receive the shortcut's scope recovery hints.
- Replace the stale copy-then-delete migration note with the existing `wiki +move` shortcut.

## Test Plan

- [x] Unit tests pass (`make unit-test`)
- [x] Wiki shortcut unit tests pass (`go test ./shortcuts/wiki`)
- [x] Manual live verification: copied a real parent node with one child and confirmed the copied node had zero children
- [x] Manual live verification: renamed a newly created Wiki node with `drive +update-title` and confirmed the same `node_token` returned the new title
- [x] `go vet ./...`
- [x] `gofmt -l .` returns no files
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] golangci-lint reports 0 issues

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki node copying now copies only the selected node and its content, excluding descendants.
* **Documentation**
  * Added guidance for renaming Wiki nodes in place while preserving their existing identifiers.
  * Clarified authorization and scope feedback for title updates.
  * Updated migration guidance to handle descendants separately and use Wiki move functionality when relocating nodes.
* **Tests**
  * Added coverage confirming that Wiki node copies are non-recursive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->