### PR TITLE
fix(apps): harden signed URL downloads

### DIFF
--- a/shortcuts/apps/apps_file_download.go
+++ b/shortcuts/apps/apps_file_download.go
@@ -7,14 +7,22 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"path"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/download"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+const appsFileDownloadPartSize = 32 * 1024 * 1024
+
+func openAppsFileDownload(ctx context.Context, signedURL string) (*download.Stream, error) {
+	urlTransport := download.URL(newFileTransferClient(), signedURL)
+	source := download.ImmutableSource(urlTransport)
+	return download.Open(ctx, source, download.Options{PartSize: appsFileDownloadPartSize})
+}
 
 // AppsFileDownload downloads a file to a local path via a signed URL。
 //
@@ -83,30 +91,17 @@ var AppsFileDownload = common.Shortcut{
 				out = "download"
 			}
 		}
-		req, err := http.NewRequestWithContext(rctx.Ctx(), http.MethodGet, signedURL, nil) //nolint:forbidigo // GET from a presigned object-storage URL bypasses the Lark gateway; raw HTTP required (not a Lark API call).
+		stream, err := openAppsFileDownload(ctx, signedURL)
 		if err != nil {
-			return errs.NewNetworkError(errs.SubtypeNetworkTransport, "build download request").WithCause(err)
+			return err
 		}
-		resp, err := newFileTransferClient().Do(req) //nolint:forbidigo // see above: direct presigned-URL download, RuntimeContext.DoAPI does not apply.
-		if err != nil {
-			// dial/transport 失败是典型可重试场景。
-			return errs.NewNetworkError(errs.SubtypeNetworkTransport, "download failed").WithCause(err).WithRetryable()
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode >= 400 {
-			io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-			// 5xx 是上游瞬时故障，标 retryable；4xx（如签名过期）需重新签名而非盲重试，不标。
-			if resp.StatusCode >= 500 {
-				return errs.NewNetworkError(errs.SubtypeNetworkServer, "download failed: HTTP %d", resp.StatusCode).WithRetryable()
-			}
-			return errs.NewNetworkError(errs.SubtypeNetworkTransport, "download failed: HTTP %d", resp.StatusCode)
-		}
+		defer stream.Body.Close()
 		saved, err := rctx.FileIO().Save(out, fileio.SaveOptions{
-			ContentType:   resp.Header.Get("Content-Type"),
-			ContentLength: resp.ContentLength,
-		}, resp.Body)
+			ContentType:   stream.Header.Get("Content-Type"),
+			ContentLength: stream.ContentLength,
+		}, stream.Body)
 		if err != nil {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output: %v", err).WithParam("--output").WithCause(err)
+			return common.WrapSaveErrorTyped(err)
 		}
 		resolved, perr := rctx.FileIO().ResolvePath(out)
 		if perr != nil || resolved == "" {

--- a/shortcuts/apps/apps_file_download_test.go
+++ b/shortcuts/apps/apps_file_download_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
@@ -50,12 +51,23 @@ func TestAppsFileDownload_DryRunSignsFirst(t *testing.T) {
 
 // sign → 客户端 GET presigned signed_url → 落盘 --output。
 func TestAppsFileDownload_EndToEnd(t *testing.T) {
+	var requests atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
+		if got, want := r.Header.Get("Range"), "bytes=0-33554431"; got != want {
+			t.Errorf("Range = %q, want %q", got, want)
+		}
+		if got := r.Header.Get("Accept-Encoding"); got != "identity" {
+			t.Errorf("Accept-Encoding = %q, want identity", got)
+		}
 		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Range", "bytes 0-6/7")
+		w.Header().Set("Content-Length", "7")
+		w.WriteHeader(http.StatusPartialContent)
 		io.WriteString(w, "PNGDATA")
 	}))
 	defer srv.Close()
@@ -85,6 +97,80 @@ func TestAppsFileDownload_EndToEnd(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"size_bytes": 7`) {
 		t.Errorf("output json missing size_bytes:7\n%s", stdout.String())
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("download requests = %d, want 1", got)
+	}
+}
+
+func TestAppsFileDownload_RetriesTransientPresignedFailure(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		io.WriteString(w, "recovered")
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: fileSignURLForDownload,
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"signed_url": srv.URL}},
+	})
+	if err := runAppsShortcut(t, AppsFileDownload,
+		[]string{"+file-download", "--app-id", "app_x", "--path", "/retry.bin", "--output", "out.bin", "--as", "user"}, factory, stdout); err != nil {
+		t.Fatalf("execute err=%v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "out.bin"))
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if got, want := string(data), "recovered"; got != want {
+		t.Fatalf("downloaded content = %q, want %q", got, want)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("download requests = %d, want 2", got)
+	}
+}
+
+func TestAppsFileDownload_PreservesNetworkBodyFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "10")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "short")
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: fileSignURLForDownload,
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"signed_url": srv.URL}},
+	})
+	err := runAppsShortcut(t, AppsFileDownload,
+		[]string{"+file-download", "--app-id", "app_x", "--path", "/short.bin", "--output", "out.bin", "--as", "user"}, factory, stdout)
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryNetwork {
+		t.Fatalf("error = %T %v, want typed network error", err, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "out.bin")); !os.IsNotExist(statErr) {
+		t.Fatalf("partial output exists after body failure: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- route `apps +file-download` signed URLs through the shared validated download pipeline
- use 32 MiB ranged reads for immutable Apps objects while automatically applying strong ETag/`If-Range` validation when available
- preserve network/timeout error types through atomic FileIO saves and retry transient transport/server failures

## Why

The previous direct `http.Client.Do` path issued one unvalidated full-body request. It could not resume a failed body, had no progress-based idle timeout, accepted unexpected response encoding, and could report a network body failure as an output validation error.

Apps storage paths identify immutable uploaded objects, and the current object store supports byte ranges and strong ETags. Reusing `internal/download` keeps HTTP policy, representation consistency, retry, exact-length validation, and streaming output in their existing owners without adding Apps-specific transport logic.

## Impact

Successful CLI output and flags are unchanged. Files up to the Apps 100 MiB limit use at most four 32 MiB range requests; servers that ignore Range continue through the returned full response.

## Validation

- `go test ./shortcuts/apps ./internal/download ./internal/vfs/localfileio ./shortcuts/common ./tests/cli_e2e/apps -count=1`
- `go test -race ./shortcuts/apps ./internal/download ./internal/vfs/localfileio -count=1`
- repeated Apps download tests (20 normal runs, 5 race runs) and download package tests (10 runs)
- `go vet ./shortcuts/apps ./internal/download`
- full CLI build and `git diff --check`
- real Apps storage uploads/downloads at 1, 40, 70, and 99 MiB: HTTP/2 range responses, strong ETag/`If-Range`, exact request counts (1/2/3/4), and matching SHA-256 checksums


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file download reliability by supporting transient download failures and retries.
  * Preserved typed network errors for clearer failure handling.
  * Prevented incomplete files from being left behind when downloads fail.
  * Improved handling of large downloads through ranged streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->