### PR TITLE
feat: add comment-aware document fetch

### DIFF
--- a/shortcuts/doc/docs_fetch.go
+++ b/shortcuts/doc/docs_fetch.go
@@ -15,13 +15,14 @@ func v1FetchFlags() []common.Flag {
 }
 
 var DocsFetch = common.Shortcut{
-	Service:     "docs",
-	Command:     "+fetch",
-	Description: "Fetch Lark document content",
-	Risk:        "read",
-	Scopes:      []string{"docx:document:readonly"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:           "docs",
+	Command:           "+fetch",
+	Description:       "Fetch Lark document content",
+	Risk:              "read",
+	Scopes:            []string{"docx:document:readonly"},
+	ConditionalScopes: []string{"docs:document.comment:read"},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
 	Flags: concatFlags(
 		[]common.Flag{
 			docsAPIVersionCompatFlag(),

--- a/shortcuts/doc/docs_fetch_im_markdown_test.go
+++ b/shortcuts/doc/docs_fetch_im_markdown_test.go
@@ -70,26 +70,6 @@ func TestApplyFetchIMMarkdown(t *testing.T) {
 	}
 }
 
-func TestConvertToIMMarkdownPreservesCommentReferenceShells(t *testing.T) {
-	t.Parallel()
-
-	input := `<fragment mode="range">` + "\n" +
-		`<comment-ref refs="c1"/>paragraph` + "\n" +
-		`- <comment-ref refs="c1 c2"/>list item` + "\n" +
-		`| <comment-ref refs="c3"/>cell | other |` + "\n" +
-		`</fragment>`
-	got := convertToIMMarkdown(input, imMarkdownContext{})
-	for _, marker := range []string{
-		`<comment-ref refs="c1"/>`,
-		`<comment-ref refs="c1 c2"/>`,
-		`<comment-ref refs="c3"/>`,
-	} {
-		if strings.Count(got, marker) != 1 {
-			t.Fatalf("comment marker %q was not preserved exactly once: %q", marker, got)
-		}
-	}
-}
-
 func TestConvertToIMMarkdownTitle(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/doc/docs_fetch_im_markdown_test.go
+++ b/shortcuts/doc/docs_fetch_im_markdown_test.go
@@ -70,6 +70,26 @@ func TestApplyFetchIMMarkdown(t *testing.T) {
 	}
 }
 
+func TestConvertToIMMarkdownPreservesCommentReferenceShells(t *testing.T) {
+	t.Parallel()
+
+	input := `<fragment mode="range">` + "\n" +
+		`<comment-ref refs="c1"/>paragraph` + "\n" +
+		`- <comment-ref refs="c1 c2"/>list item` + "\n" +
+		`| <comment-ref refs="c3"/>cell | other |` + "\n" +
+		`</fragment>`
+	got := convertToIMMarkdown(input, imMarkdownContext{})
+	for _, marker := range []string{
+		`<comment-ref refs="c1"/>`,
+		`<comment-ref refs="c1 c2"/>`,
+		`<comment-ref refs="c3"/>`,
+	} {
+		if strings.Count(got, marker) != 1 {
+			t.Fatalf("comment marker %q was not preserved exactly once: %q", marker, got)
+		}
+	}
+}
+
 func TestConvertToIMMarkdownTitle(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -34,7 +34,7 @@ func v2FetchFlags() []common.Flag {
 		{Name: "context-before", Desc: "range/keyword/section context: sibling blocks before selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "context-after", Desc: "range/keyword/section context: sibling blocks after selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "max-depth", Desc: "outline heading level cap; other scopes subtree depth where -1 is unlimited and 0 is block only", Type: "int", Default: "-1"},
-		{Name: "comments", Desc: "include visible unresolved local and whole-document comments; local comments are linked through comment-refs", Type: "bool"},
+		{Name: "comments", Desc: "include visible unresolved local and whole-document comments using bot identity; local comments are linked through comment-refs", Type: "bool"},
 	}
 }
 
@@ -54,10 +54,20 @@ func validateFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if err := validateFetchCommentOutput(runtime); err != nil {
 		return err
 	}
+	if err := validateFetchCommentIdentity(runtime); err != nil {
+		return err
+	}
 	if shouldIncludeFetchComments(runtime) {
 		return runtime.EnsureScopes([]string{docsFetchCommentReadScope})
 	}
 	return nil
+}
+
+func validateFetchCommentIdentity(runtime *common.RuntimeContext) error {
+	if !shouldIncludeFetchComments(runtime) || runtime.IsBot() {
+		return nil
+	}
+	return common.ValidationErrorf("--comments currently requires bot identity; use --as bot").WithParam("--as")
 }
 
 func validateFetchCommentOutput(runtime *common.RuntimeContext) error {

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -14,7 +14,11 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-const docsFetchExtraParam = `{"enable_user_cite_reference_map":true,"return_html5_block_data":true}`
+const (
+	docsFetchCommentReadScope   = "docs:document.comment:read"
+	docsFetchExtraParam         = `{"enable_user_cite_reference_map":true,"return_html5_block_data":true}`
+	docsFetchCommentsExtraParam = `{"enable_user_cite_reference_map":true,"include_comments":true,"return_html5_block_data":true}`
+)
 
 // v2FetchFlags returns the flag definitions for the v2 (OpenAPI) fetch path.
 func v2FetchFlags() []common.Flag {
@@ -30,6 +34,7 @@ func v2FetchFlags() []common.Flag {
 		{Name: "context-before", Desc: "range/keyword/section context: sibling blocks before selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "context-after", Desc: "range/keyword/section context: sibling blocks after selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "max-depth", Desc: "outline heading level cap; other scopes subtree depth where -1 is unlimited and 0 is block only", Type: "int", Default: "-1"},
+		{Name: "comments", Desc: "include visible unresolved local and whole-document comments; local comments are linked through comment-refs", Type: "bool"},
 	}
 }
 
@@ -45,6 +50,9 @@ func validateFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 	}
 	if err := validateReadModeFlags(runtime); err != nil {
 		return err
+	}
+	if shouldIncludeFetchComments(runtime) {
+		return runtime.EnsureScopes([]string{docsFetchCommentReadScope})
 	}
 	return nil
 }
@@ -94,7 +102,7 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
 	body := map[string]interface{}{
 		"format":      effectiveFetchFormat(runtime),
-		"extra_param": docsFetchExtraParam,
+		"extra_param": buildFetchExtraParam(runtime),
 	}
 	if v := runtime.Int("revision-id"); v > 0 {
 		body["revision_id"] = v
@@ -129,6 +137,19 @@ func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
 	injectDocsScene(runtime, body)
 
 	return body
+}
+
+func buildFetchExtraParam(runtime *common.RuntimeContext) string {
+	if shouldIncludeFetchComments(runtime) {
+		return docsFetchCommentsExtraParam
+	}
+	return docsFetchExtraParam
+}
+
+func shouldIncludeFetchComments(runtime *common.RuntimeContext) bool {
+	// Outline is a directory-only view and intentionally performs no comment
+	// query, even when a caller reuses a flag bundle containing --comments.
+	return runtime.Bool("comments") && effectiveFetchReadMode(runtime) != "outline"
 }
 
 func effectiveFetchFormat(runtime *common.RuntimeContext) string {

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -34,7 +34,7 @@ func v2FetchFlags() []common.Flag {
 		{Name: "context-before", Desc: "range/keyword/section context: sibling blocks before selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "context-after", Desc: "range/keyword/section context: sibling blocks after selected top-level blocks", Type: "int", Default: "0"},
 		{Name: "max-depth", Desc: "outline heading level cap; other scopes subtree depth where -1 is unlimited and 0 is block only", Type: "int", Default: "-1"},
-		{Name: "comments", Desc: "include visible unresolved local and whole-document comments using bot identity; local comments are linked through comment-refs", Type: "bool"},
+		{Name: "comments", Desc: "include visible unresolved local and whole-document comments in XML or Markdown using bot identity; local comments are linked through comment-refs", Type: "bool"},
 	}
 }
 
@@ -49,6 +49,9 @@ func validateFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 		return err
 	}
 	if err := validateReadModeFlags(runtime); err != nil {
+		return err
+	}
+	if err := validateFetchCommentDocFormat(runtime); err != nil {
 		return err
 	}
 	if err := validateFetchCommentOutput(runtime); err != nil {
@@ -68,6 +71,13 @@ func validateFetchCommentIdentity(runtime *common.RuntimeContext) error {
 		return nil
 	}
 	return common.ValidationErrorf("--comments currently requires bot identity; use --as bot").WithParam("--as")
+}
+
+func validateFetchCommentDocFormat(runtime *common.RuntimeContext) error {
+	if !shouldIncludeFetchComments(runtime) || !isIMMarkdownFetch(runtime) {
+		return nil
+	}
+	return common.ValidationErrorf("--comments supports only XML or Markdown; IM Markdown remains unchanged. Use --doc-format markdown, or omit --comments").WithParam("--doc-format")
 }
 
 func validateFetchCommentOutput(runtime *common.RuntimeContext) error {

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -51,8 +51,25 @@ func validateFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if err := validateReadModeFlags(runtime); err != nil {
 		return err
 	}
+	if err := validateFetchCommentOutput(runtime); err != nil {
+		return err
+	}
 	if shouldIncludeFetchComments(runtime) {
 		return runtime.EnsureScopes([]string{docsFetchCommentReadScope})
+	}
+	return nil
+}
+
+func validateFetchCommentOutput(runtime *common.RuntimeContext) error {
+	if !shouldIncludeFetchComments(runtime) {
+		return nil
+	}
+	outputFormat := strings.TrimSpace(runtime.Format)
+	if outputFormat == "" {
+		outputFormat = strings.TrimSpace(runtime.Str("format"))
+	}
+	if outputFormat != "json" {
+		return common.ValidationErrorf("--comments requires JSON output because %s output cannot losslessly preserve document.content together with the comment reference_map; use --format json", outputFormat).WithParam("--format")
 	}
 	return nil
 }

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -619,6 +619,60 @@ func TestDocsFetchDeclaresCommentReadConditionalScope(t *testing.T) {
 	}
 }
 
+func TestValidateFetchCommentOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		outputFormat string
+		docFormat    string
+		scope        string
+		comments     bool
+		wantErr      bool
+	}{
+		{name: "xml pretty loses sidecar", outputFormat: "pretty", docFormat: "xml", scope: "full", comments: true, wantErr: true},
+		{name: "markdown pretty loses sidecar", outputFormat: "pretty", docFormat: "markdown", scope: "keyword", comments: true, wantErr: true},
+		{name: "table truncates nested document", outputFormat: "table", docFormat: "xml", scope: "full", comments: true, wantErr: true},
+		{name: "csv cannot preserve nested document", outputFormat: "csv", docFormat: "xml", scope: "full", comments: true, wantErr: true},
+		{name: "ndjson is not the documented lossless contract", outputFormat: "ndjson", docFormat: "xml", scope: "full", comments: true, wantErr: true},
+		{name: "yaml is not the lossless comment contract", outputFormat: "yaml", docFormat: "xml", scope: "full", comments: true, wantErr: true},
+		{name: "json preserves sidecar", outputFormat: "json", docFormat: "xml", scope: "full", comments: true},
+		{name: "outline intentionally has no comments", outputFormat: "pretty", docFormat: "xml", scope: "outline", comments: true},
+		{name: "comments disabled", outputFormat: "pretty", docFormat: "xml", scope: "full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runtime := newFetchBodyTestRuntime(context.Background())
+			runtime.Format = tt.outputFormat
+			mustSetFetchFlag(t, runtime, "doc-format", tt.docFormat)
+			mustSetFetchFlag(t, runtime, "scope", tt.scope)
+			if tt.scope == "keyword" {
+				mustSetFetchFlag(t, runtime, "keyword", "commented")
+			}
+			if tt.comments {
+				mustSetFetchFlag(t, runtime, "comments", "true")
+			}
+
+			err := validateFetchCommentOutput(runtime)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("validateFetchCommentOutput() succeeded, want validation error")
+				}
+				assertValidationContract(t, err, errs.SubtypeInvalidArgument, "--format")
+				if !strings.Contains(err.Error(), "reference_map") || !strings.Contains(err.Error(), "--format json") {
+					t.Fatalf("error does not explain the lossless alternative: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateFetchCommentOutput() err=%v", err)
+			}
+		})
+	}
+}
+
 func TestDocsFetchV2ReferenceMapFlagIsNotAvailable(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -580,6 +580,45 @@ func TestBuildFetchBodyIncludesFetchExtraParamByDefault(t *testing.T) {
 	}
 }
 
+func TestBuildFetchBodyIncludesCommentsOnlyWhenEffective(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name         string
+		scope        string
+		wantComments bool
+	}{
+		{name: "full", scope: "full", wantComments: true},
+		{name: "partial", scope: "keyword", wantComments: true},
+		{name: "outline directory", scope: "outline", wantComments: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runtime := newFetchBodyTestRuntime(context.Background())
+			mustSetFetchFlag(t, runtime, "comments", "true")
+			mustSetFetchFlag(t, runtime, "scope", tt.scope)
+			if tt.scope == "keyword" {
+				mustSetFetchFlag(t, runtime, "keyword", "commented")
+			}
+			body := buildFetchBody(runtime)
+			var got map[string]bool
+			if err := json.Unmarshal([]byte(body["extra_param"].(string)), &got); err != nil {
+				t.Fatalf("decode extra_param: %v", err)
+			}
+			if got["include_comments"] != tt.wantComments {
+				t.Fatalf("include_comments=%v, want %v in %#v", got["include_comments"], tt.wantComments, got)
+			}
+		})
+	}
+}
+
+func TestDocsFetchDeclaresCommentReadConditionalScope(t *testing.T) {
+	t.Parallel()
+	if !reflect.DeepEqual(DocsFetch.ConditionalScopes, []string{docsFetchCommentReadScope}) {
+		t.Fatalf("ConditionalScopes=%v, want [%q]", DocsFetch.ConditionalScopes, docsFetchCommentReadScope)
+	}
+}
+
 func TestDocsFetchV2ReferenceMapFlagIsNotAvailable(t *testing.T) {
 	t.Parallel()
 
@@ -963,6 +1002,7 @@ func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd.Flags().Int("context-before", fetchDefaultInt("context-before"), "")
 	cmd.Flags().Int("context-after", fetchDefaultInt("context-after"), "")
 	cmd.Flags().Int("max-depth", fetchDefaultInt("max-depth"), "")
+	cmd.Flags().Bool("comments", false, "")
 	return common.TestNewRuntimeContextWithCtx(ctx, cmd, nil)
 }
 
@@ -1019,6 +1059,7 @@ func newFetchShortcutTestRuntime(t *testing.T, apiVersion string, setFlags map[s
 	cmd.Flags().Int("context-before", fetchDefaultInt("context-before"), "")
 	cmd.Flags().Int("context-after", fetchDefaultInt("context-after"), "")
 	cmd.Flags().Int("max-depth", fetchDefaultInt("max-depth"), "")
+	cmd.Flags().Bool("comments", false, "")
 	cmd.Flags().String("offset", "", "")
 	cmd.Flags().String("limit", "", "")
 	if apiVersion != "" {

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -673,6 +673,50 @@ func TestValidateFetchCommentOutput(t *testing.T) {
 	}
 }
 
+func TestValidateFetchCommentIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		identity core.Identity
+		scope    string
+		comments bool
+		wantErr  bool
+	}{
+		{name: "bot comments", identity: core.AsBot, scope: "full", comments: true},
+		{name: "user comments rejected", identity: core.AsUser, scope: "full", comments: true, wantErr: true},
+		{name: "user outline has no effective comments", identity: core.AsUser, scope: "outline", comments: true},
+		{name: "user without comments", identity: core.AsUser, scope: "full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			base := newFetchBodyTestRuntime(context.Background())
+			runtime := common.TestNewRuntimeContextWithIdentity(base.Cmd, nil, tt.identity)
+			mustSetFetchFlag(t, runtime, "scope", tt.scope)
+			if tt.comments {
+				mustSetFetchFlag(t, runtime, "comments", "true")
+			}
+
+			err := validateFetchCommentIdentity(runtime)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("validateFetchCommentIdentity() succeeded, want validation error")
+				}
+				assertValidationContract(t, err, errs.SubtypeInvalidArgument, "--as")
+				if !strings.Contains(err.Error(), "--as bot") {
+					t.Fatalf("error does not explain the supported identity: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateFetchCommentIdentity() err=%v", err)
+			}
+		})
+	}
+}
+
 func TestDocsFetchV2ReferenceMapFlagIsNotAvailable(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -509,6 +509,51 @@ func TestValidateFetchV2RejectsInvalidDocAndScope(t *testing.T) {
 	}
 }
 
+func TestValidateFetchV2RejectsInvalidCommentCombinations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		identity  core.Identity
+		format    string
+		wantParam string
+	}{
+		{name: "lossy output", identity: core.AsBot, format: "pretty", wantParam: "--format"},
+		{name: "user identity", identity: core.AsUser, format: "json", wantParam: "--as"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			base := newFetchBodyTestRuntime(context.Background())
+			runtime := common.TestNewRuntimeContextWithIdentity(base.Cmd, nil, tt.identity)
+			runtime.Format = tt.format
+			mustSetFetchFlag(t, runtime, "comments", "true")
+
+			err := validateFetchV2(context.Background(), runtime)
+			if err == nil {
+				t.Fatal("validateFetchV2() succeeded, want validation error")
+			}
+			assertValidationContract(t, err, errs.SubtypeInvalidArgument, tt.wantParam)
+		})
+	}
+}
+
+func TestValidateFetchV2CommentsRunsConditionalScopeCheck(t *testing.T) {
+	t.Parallel()
+
+	config := &core.CliConfig{AppID: "test-app"}
+	factory, _, _, _ := cmdutil.TestFactory(t, config)
+	base := newFetchBodyTestRuntime(context.Background())
+	runtime := common.TestNewRuntimeContextForAPI(context.Background(), base.Cmd, config, factory, core.AsBot)
+	runtime.Format = "json"
+	mustSetFetchFlag(t, runtime, "comments", "true")
+
+	if err := validateFetchV2(context.Background(), runtime); err != nil {
+		t.Fatalf("validateFetchV2() err=%v", err)
+	}
+}
+
 func TestAddFetchDetailDowngradeWarningNoops(t *testing.T) {
 	t.Parallel()
 
@@ -637,6 +682,7 @@ func TestValidateFetchCommentOutput(t *testing.T) {
 		{name: "ndjson is not the documented lossless contract", outputFormat: "ndjson", docFormat: "xml", scope: "full", comments: true, wantErr: true},
 		{name: "yaml is not the lossless comment contract", outputFormat: "yaml", docFormat: "xml", scope: "full", comments: true, wantErr: true},
 		{name: "json preserves sidecar", outputFormat: "json", docFormat: "xml", scope: "full", comments: true},
+		{name: "json flag fallback preserves sidecar", docFormat: "xml", scope: "full", comments: true},
 		{name: "outline intentionally has no comments", outputFormat: "pretty", docFormat: "xml", scope: "outline", comments: true},
 		{name: "comments disabled", outputFormat: "pretty", docFormat: "xml", scope: "full"},
 	}
@@ -1088,6 +1134,7 @@ func TestDocsFetchRejectsLegacyFlags(t *testing.T) {
 
 func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd := &cobra.Command{Use: "+fetch"}
+	cmd.Flags().String("format", "json", "")
 	cmd.Flags().String("doc", "doxcnFetchDryRun", "")
 	cmd.Flags().String("doc-format", fetchDefault("doc-format"), "")
 	cmd.Flags().String("detail", fetchDefault("detail"), "")

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -516,10 +516,12 @@ func TestValidateFetchV2RejectsInvalidCommentCombinations(t *testing.T) {
 		name      string
 		identity  core.Identity
 		format    string
+		docFormat string
 		wantParam string
 	}{
 		{name: "lossy output", identity: core.AsBot, format: "pretty", wantParam: "--format"},
 		{name: "user identity", identity: core.AsUser, format: "json", wantParam: "--as"},
+		{name: "IM Markdown", identity: core.AsBot, format: "json", docFormat: "im-markdown", wantParam: "--doc-format"},
 	}
 
 	for _, tt := range tests {
@@ -529,12 +531,60 @@ func TestValidateFetchV2RejectsInvalidCommentCombinations(t *testing.T) {
 			runtime := common.TestNewRuntimeContextWithIdentity(base.Cmd, nil, tt.identity)
 			runtime.Format = tt.format
 			mustSetFetchFlag(t, runtime, "comments", "true")
+			if tt.docFormat != "" {
+				mustSetFetchFlag(t, runtime, "doc-format", tt.docFormat)
+			}
 
 			err := validateFetchV2(context.Background(), runtime)
 			if err == nil {
 				t.Fatal("validateFetchV2() succeeded, want validation error")
 			}
 			assertValidationContract(t, err, errs.SubtypeInvalidArgument, tt.wantParam)
+		})
+	}
+}
+
+func TestValidateFetchCommentDocFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		docFormat string
+		scope     string
+		comments  bool
+		wantErr   bool
+	}{
+		{name: "XML comments", docFormat: "xml", scope: "full", comments: true},
+		{name: "Markdown comments", docFormat: "markdown", scope: "full", comments: true},
+		{name: "IM Markdown comments rejected", docFormat: "im-markdown", scope: "full", comments: true, wantErr: true},
+		{name: "IM Markdown without comments unchanged", docFormat: "im-markdown", scope: "full"},
+		{name: "IM Markdown outline has no effective comments", docFormat: "im-markdown", scope: "outline", comments: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runtime := newFetchBodyTestRuntime(context.Background())
+			mustSetFetchFlag(t, runtime, "doc-format", tt.docFormat)
+			mustSetFetchFlag(t, runtime, "scope", tt.scope)
+			if tt.comments {
+				mustSetFetchFlag(t, runtime, "comments", "true")
+			}
+
+			err := validateFetchCommentDocFormat(runtime)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("validateFetchCommentDocFormat() succeeded, want validation error")
+				}
+				assertValidationContract(t, err, errs.SubtypeInvalidArgument, "--doc-format")
+				if !strings.Contains(err.Error(), "XML or Markdown") || !strings.Contains(err.Error(), "IM Markdown remains unchanged") {
+					t.Fatalf("error does not explain the supported formats and compatibility boundary: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateFetchCommentDocFormat() err=%v", err)
+			}
 		})
 	}
 }

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -14,13 +14,13 @@ metadata:
 
 **CRITICAL：先判断场景，再读取该场景的参考文件；不要在任务开始时一次性读取全部参考文件。每个文件只在首次进入对应阶段时读取一次。**
 
-**身份：文档操作推荐显式指定 `--as user`。**
+**身份：文档操作推荐显式指定 `--as user`。当前 `docs +fetch --comments` 例外：服务端尚不能可信校验 user access token 的精确评论 scope，按读取参考暂用 `--as bot`，不要尝试绕过安全拒绝。**
 
 **所有表示本地文件的 `@path` 均使用 `@./xxx` 形式的相对路径，并以运行 `lark-cli` 时的当前工作目录（CWD）为基准。**
 
 ### 文档内容
 
-- **读取 / 摘要 — [`+fetch`](references/lark-doc-fetch.md)**：先读参考再获取文档。
+- **读取 / 摘要 — [`+fetch`](references/lark-doc-fetch.md)**：先读参考再获取文档；需要把正文与可见未解决评论一起交给模型时，使用 `--comments`。
 - **从零创作 — [`创建工作流`](references/lark-doc-create-workflow.md)**：先完整执行创建工作流，**简单任务不是跳过的理由**；
 - **导入 / 空文档 — [`+create`](references/lark-doc-create.md)**：仅创建空文档或原样导入用户提供的完整内容时，跳过创建工作流。
 - **编辑 / block 直达链接 — [`+update`](references/lark-doc-update.md)**：语义改写、润色、重组、补写或排版均按 update 参考完成。
@@ -46,4 +46,4 @@ metadata:
 ## 不在本 Skill 范围
 
 - **Drive 文件级操作**：找文档、导入导出、云空间文件上传 / 下载 / 权限管理 → [`lark-drive`](../lark-drive/SKILL.md)。复制文档、创建副本或另存为副本时，按其指引使用 `lark-cli drive files copy`；不要用 `docs +fetch` + `docs +create` 重建正文。
-- **文档评论**：添加、查看、回复评论或增删 reaction → [`lark-drive`](../lark-drive/SKILL.md)。
+- **独立评论操作**：添加、分页查看、回复评论或增删 reaction → [`lark-drive`](../lark-drive/SKILL.md)；只需在读取正文时附带紧凑评论上下文，可使用 `docs +fetch --comments`。

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -8,6 +8,9 @@
 # 读取整篇文档
 lark-cli docs +fetch --doc "文档URL或token"
 
+# 读取正文，并附带可见的未解决评论；JSON 会同时保留正文和评论 sidecar
+lark-cli docs +fetch --doc "文档URL或token" --comments --format json --as bot
+
 # 按 URL 中的 #share 锚点局部读取
 lark-cli docs +fetch --doc '文档URL#share-anchor'
 
@@ -26,6 +29,7 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 |`--doc`|是|文档 URL 或 token，支持 `/docx/`、`/wiki/` 和带 `#share-...` 的选区链接|
 |`--doc-format`|否|`xml`（默认）\| `markdown` \| `im-markdown`（供后续 `lark-im` 场景使用）|
 |`--detail`|否|`simple`（默认）\| `with-ids` \| `full`|
+|`--comments`|否|附带当前身份可见的未解决评论；默认关闭，须使用 `--format json` 保留评论 sidecar|
 |`--revision-id`|否|文档版本号；`-1` 表示最新版本（默认）|
 |`--scope`|否|`outline` \| `range` \| `keyword` \| `section`；省略则读取整篇|
 |`--start-block-id`|否|`range` 的起点，或 `section` 的锚点（`section` 必填）|
@@ -98,6 +102,44 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 }
 ```
 `content` 的格式由 `--doc-format` 决定。`reference_map` 是正文引用数据的结构化 sidecar：一级键 `block_type` 表示引用所在的块类型，二级键 `ref` 对应正文中的临时引用；每个引用的值是由 `real-attr-key` 和 `real-attr-value` 组成的真实属性映射，具体属性由块类型决定。没有提取数据时，`reference_map` 可能为空。`content` 和 `reference_map` 属于同一份响应，保留或回放内容时应配套处理。`tips` 给出安全回放或降级提示。`im-markdown` 仅用于获取内容后在 `lark-im` 场景下使用。设置 `--scope` 时会被 `<fragment>` 包裹，详见上文"局部读取的输出结构"。
+
+### 理解 `--comments` 的返回
+
+评论采用紧凑、只读的 AI 上下文，不代替 `drive +list-comments` 等完整评论 API：
+
+- XML 正文中的局部评论落点使用 `comment-refs="c1 c2"`；同一条评论跨多个 block 时会在这些 block 上重复同一个 ref。
+- `reference_map.comment.<ref>.data` 保存局部讨论；`reference_map.document-comment.<ref>.data` 保存全文讨论。
+- 讨论只表达引用文本、消息、图片占位和 reaction，不返回稳定评论 ID、状态或完整格式。需要继续回复、解决或精确管理评论时，改用 `lark-drive` 评论命令。
+- 全文读取返回局部评论和全文评论；`keyword` / `range` / `section` 只返回与片段相交的局部评论，不返回全文评论；`outline` 即使传了 `--comments` 也不查询评论。
+- Markdown / IM Markdown 使用轻量 XML 壳 `<comment-ref refs="c1 c2"/>` 精确标记落点；重复文本、跨 block、列表和表格都不需要依靠 `<quote>` 猜位置。壳中的 ref 与 `reference_map.comment` 一一对应。
+- 指定历史 `--revision-id` 时，正文来自该历史版本；评论是“当前仍可见、仍未解决”的快照投影到这份正文。局部评论仅在该 revision 能解析到锚点时返回，全文评论仅在全文读取时返回；它不是历史时刻的评论回放。
+- 必须使用 `--format json`；其它展示格式无法无损保留正文与 `reference_map`（例如 `pretty` 只输出正文、`table` 会截断嵌套值），因此 CLI 会直接拒绝这些组合。
+- 评论或锚点依赖不可用时，正文仍正常返回，评论整体省略，并在 `tips` 中出现 `comments_omitted:<reason>`。
+
+当前服务端能够完整校验 tenant access token（`--as bot`）的评论 scope。user access token 的精确 token scope 尚未由网关可信透传，因此 `--as user` 的评论读取会安全拒绝；完成 OGW 条件鉴权后再开放，不能用普通 user/app/tenant 授权状态代替本 token scope。
+
+```xml
+<p comment-refs="c1">评论引用的正文</p>
+```
+
+Markdown / IM Markdown 中同一落点写作：
+
+```xml
+<comment-ref refs="c1"/>评论引用的正文
+```
+
+对应的 `reference_map.comment.c1.data`：
+
+```xml
+<discussion timezone="Asia/Shanghai">
+<quote>评论引用的正文</quote>
+<message t="2026-07-23 16:50" u="曹杰">
+问题一：在职转移会删除协作者权限
+<img/>
+<reaction>👍 方树煜、曹杰</reaction>
+</message>
+</discussion>
+```
 
 ### 理解局部读取结果
 

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -114,7 +114,7 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 - reaction 属于 best-effort 展示信息；当一次读取需要 hydrate 超过 1000 条评论时会整体省略 reaction，以限制下游时延，评论正文和引用关系仍完整返回。
 - Markdown / IM Markdown 使用轻量 XML 壳 `<comment-ref refs="c1 c2"/>` 精确标记落点；重复文本、跨 block、列表和表格都不需要依靠 `<quote>` 猜位置。壳中的 ref 与 `reference_map.comment` 一一对应。
 - 指定历史 `--revision-id` 时，正文来自该历史版本；评论是“当前仍可见、仍未解决”的快照投影到这份正文。局部评论仅在该 revision 能解析到锚点时返回，全文评论仅在全文读取时返回；它不是历史时刻的评论回放。
-- 必须使用 `--format json`；其它展示格式无法无损保留正文与 `reference_map`（例如 `pretty` 只输出正文、`table` 会截断嵌套值），因此 CLI 会直接拒绝这些组合。
+- 必须使用 `--format json`；其它展示格式无法无损保留正文与 `reference_map`（例如 `pretty` 只输出正文），因此 CLI 会直接拒绝这些组合。
 - 评论或锚点依赖不可用时，正文仍正常返回，评论整体省略，并在 `tips` 中出现 `comments_omitted:<reason>`。
 
 当前服务端能够完整校验 tenant access token（`--as bot`）的评论 scope。user access token 的精确 token scope 尚未由网关可信透传，因此 `--as user` 的评论读取会安全拒绝；完成 OGW 条件鉴权后再开放，不能用普通 user/app/tenant 授权状态代替本 token scope。

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -29,7 +29,7 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 |`--doc`|是|文档 URL 或 token，支持 `/docx/`、`/wiki/` 和带 `#share-...` 的选区链接|
 |`--doc-format`|否|`xml`（默认）\| `markdown` \| `im-markdown`（供后续 `lark-im` 场景使用）|
 |`--detail`|否|`simple`（默认）\| `with-ids` \| `full`|
-|`--comments`|否|附带机器人身份可见的未解决评论；默认关闭，当前须使用 `--as bot --format json` 保留评论 sidecar|
+|`--comments`|否|附带机器人身份可见的未解决评论；仅支持 `xml` / `markdown`，默认关闭，当前须使用 `--as bot --format json` 保留评论 sidecar|
 |`--revision-id`|否|文档版本号；`-1` 表示最新版本（默认）|
 |`--scope`|否|`outline` \| `range` \| `keyword` \| `section`；省略则读取整篇|
 |`--start-block-id`|否|`range` 的起点，或 `section` 的锚点（`section` 必填）|
@@ -112,7 +112,8 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 - 讨论只表达引用文本、消息、图片占位和 reaction，不返回稳定评论 ID、状态或完整格式。需要继续回复、解决或精确管理评论时，改用 `lark-drive` 评论命令。
 - 全文读取返回局部评论和全文评论；`keyword` / `range` / `section` 只返回与片段相交的局部评论，不返回全文评论；`outline` 即使传了 `--comments` 也不查询评论。
 - reaction 属于 best-effort 展示信息；当一次读取需要 hydrate 超过 1000 条评论时会整体省略 reaction，以限制下游时延，评论正文和引用关系仍完整返回。
-- Markdown / IM Markdown 使用轻量 XML 壳 `<comment-ref refs="c1 c2"/>` 精确标记落点；重复文本、跨 block、列表和表格都不需要依靠 `<quote>` 猜位置。壳中的 ref 与 `reference_map.comment` 一一对应。
+- Markdown 使用轻量 XML 壳 `<comment-ref refs="c1 c2"/>` 精确标记落点；重复文本、跨 block、列表和表格都不需要依靠 `<quote>` 猜位置。壳中的 ref 与 `reference_map.comment` 一一对应。
+- 评论导出不改变 IM Markdown 协议；有效评论读取与 `--doc-format im-markdown` 组合时 CLI 会直接拒绝。需要评论时使用 `xml` 或 `markdown`；需要原有 IM 消息转换时省略 `--comments`。
 - 指定历史 `--revision-id` 时，正文来自该历史版本；评论是“当前仍可见、仍未解决”的快照投影到这份正文。局部评论仅在该 revision 能解析到锚点时返回，全文评论仅在全文读取时返回；它不是历史时刻的评论回放。
 - 必须使用 `--format json`；其它展示格式无法无损保留正文与 `reference_map`（例如 `pretty` 只输出正文），因此 CLI 会直接拒绝这些组合。
 - 评论或锚点依赖不可用时，正文仍正常返回，评论整体省略，并在 `tips` 中出现 `comments_omitted:<reason>`。
@@ -123,7 +124,7 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 <p comment-refs="c1">评论引用的正文</p>
 ```
 
-Markdown / IM Markdown 中同一落点写作：
+Markdown 中同一落点写作：
 
 ```xml
 <comment-ref refs="c1"/>评论引用的正文

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -29,7 +29,7 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 |`--doc`|是|文档 URL 或 token，支持 `/docx/`、`/wiki/` 和带 `#share-...` 的选区链接|
 |`--doc-format`|否|`xml`（默认）\| `markdown` \| `im-markdown`（供后续 `lark-im` 场景使用）|
 |`--detail`|否|`simple`（默认）\| `with-ids` \| `full`|
-|`--comments`|否|附带当前身份可见的未解决评论；默认关闭，须使用 `--format json` 保留评论 sidecar|
+|`--comments`|否|附带机器人身份可见的未解决评论；默认关闭，当前须使用 `--as bot --format json` 保留评论 sidecar|
 |`--revision-id`|否|文档版本号；`-1` 表示最新版本（默认）|
 |`--scope`|否|`outline` \| `range` \| `keyword` \| `section`；省略则读取整篇|
 |`--start-block-id`|否|`range` 的起点，或 `section` 的锚点（`section` 必填）|
@@ -111,6 +111,7 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 - `reference_map.comment.<ref>.data` 保存局部讨论；`reference_map.document-comment.<ref>.data` 保存全文讨论。
 - 讨论只表达引用文本、消息、图片占位和 reaction，不返回稳定评论 ID、状态或完整格式。需要继续回复、解决或精确管理评论时，改用 `lark-drive` 评论命令。
 - 全文读取返回局部评论和全文评论；`keyword` / `range` / `section` 只返回与片段相交的局部评论，不返回全文评论；`outline` 即使传了 `--comments` 也不查询评论。
+- reaction 属于 best-effort 展示信息；当一次读取需要 hydrate 超过 1000 条评论时会整体省略 reaction，以限制下游时延，评论正文和引用关系仍完整返回。
 - Markdown / IM Markdown 使用轻量 XML 壳 `<comment-ref refs="c1 c2"/>` 精确标记落点；重复文本、跨 block、列表和表格都不需要依靠 `<quote>` 猜位置。壳中的 ref 与 `reference_map.comment` 一一对应。
 - 指定历史 `--revision-id` 时，正文来自该历史版本；评论是“当前仍可见、仍未解决”的快照投影到这份正文。局部评论仅在该 revision 能解析到锚点时返回，全文评论仅在全文读取时返回；它不是历史时刻的评论回放。
 - 必须使用 `--format json`；其它展示格式无法无损保留正文与 `reference_map`（例如 `pretty` 只输出正文、`table` 会截断嵌套值），因此 CLI 会直接拒绝这些组合。

--- a/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestDocsFetchCommentsWorkflow creates its own document and comments so the
+// opt-in fetch contract can be exercised without a long-lived shared fixture.
+// It is gated because the live credential needs both comment read and write
+// scopes, which are intentionally absent from the default test app.
+func TestDocsFetchCommentsWorkflow(t *testing.T) {
+	clie2e.SkipWithoutUserToken(t)
+	if os.Getenv("LARK_DOCS_FETCH_COMMENTS_E2E") == "" {
+		t.Skip("set LARK_DOCS_FETCH_COMMENTS_E2E=1 to run the document comment fetch workflow")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	t.Cleanup(cancel)
+	parentT := t
+	const defaultAs = "user"
+	suffix := clie2e.GenerateSuffix()
+	anchorText := "comment anchor " + suffix
+	localText := "local review " + suffix
+	wholeText := "whole document review " + suffix
+
+	folderToken := drive.CreateDriveFolder(t, parentT, ctx, "lark-cli-e2e-fetch-comments-"+suffix, defaultAs, "")
+	docToken := createDocWithRetry(t, parentT, ctx, folderToken, "fetch comments "+suffix, anchorText+"\n\nsecondary block", defaultAs)
+
+	addDocComment(t, ctx, docToken, localText, "--selection-with-ellipsis", anchorText)
+	addDocComment(t, ctx, docToken, wholeText, "--full-comment")
+
+	var fetched *clie2e.Result
+	t.Run("xml full", func(t *testing.T) {
+		var err error
+		fetched, err = clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+			Args:      []string{"docs", "+fetch", "--doc", docToken, "--comments", "--doc-format", "xml"},
+			DefaultAs: defaultAs,
+		}, clie2e.RetryOptions{ShouldRetry: func(result *clie2e.Result) bool {
+			return result == nil || result.ExitCode != 0 ||
+				!strings.Contains(gjson.Get(result.Stdout, "data.document.content").String(), "comment-refs=") ||
+				!docsFetchReferenceGroupContains(result.Stdout, "comment", localText) ||
+				!docsFetchReferenceGroupContains(result.Stdout, "document-comment", wholeText)
+		}})
+		require.NoError(t, err)
+		fetched.AssertExitCode(t, 0)
+		fetched.AssertStdoutStatus(t, true)
+		if !strings.Contains(gjson.Get(fetched.Stdout, "data.document.content").String(), "comment-refs=") {
+			t.Fatalf("local comment marker missing:\n%s", fetched.Stdout)
+		}
+		if !docsFetchReferenceGroupContains(fetched.Stdout, "comment", localText) ||
+			!docsFetchReferenceGroupContains(fetched.Stdout, "document-comment", wholeText) {
+			t.Fatalf("comment reference groups missing:\n%s", fetched.Stdout)
+		}
+	})
+
+	t.Run("default remains comment free", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"docs", "+fetch", "--doc", docToken, "--doc-format", "xml"},
+			DefaultAs: defaultAs,
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		content := gjson.Get(result.Stdout, "data.document.content").String()
+		if strings.Contains(content, "comment-refs=") || docsFetchReferenceGroupExists(result.Stdout, "comment") || docsFetchReferenceGroupExists(result.Stdout, "document-comment") {
+			t.Fatalf("comments must remain opt-in:\n%s", result.Stdout)
+		}
+	})
+
+	t.Run("partial returns only intersecting local discussion", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"docs", "+fetch", "--doc", docToken, "--comments", "--doc-format", "xml",
+				"--scope", "keyword", "--keyword", anchorText,
+			},
+			DefaultAs: defaultAs,
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		if !docsFetchReferenceGroupContains(result.Stdout, "comment", localText) || docsFetchReferenceGroupExists(result.Stdout, "document-comment") {
+			t.Fatalf("partial comment filtering mismatch:\n%s", result.Stdout)
+		}
+	})
+
+	t.Run("markdown uses sidecar without body annotations", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"docs", "+fetch", "--doc", docToken, "--comments", "--doc-format", "markdown"},
+			DefaultAs: defaultAs,
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		content := gjson.Get(result.Stdout, "data.document.content").String()
+		if strings.Contains(content, "comment-refs") ||
+			!docsFetchReferenceGroupContains(result.Stdout, "comment", localText) ||
+			!docsFetchReferenceGroupContains(result.Stdout, "document-comment", wholeText) {
+			t.Fatalf("markdown comment sidecar mismatch:\n%s", result.Stdout)
+		}
+	})
+}
+
+func addDocComment(t *testing.T, ctx context.Context, docToken, text string, locationArgs ...string) {
+	t.Helper()
+	content, err := json.Marshal([]map[string]string{{"type": "text", "text": text}})
+	require.NoError(t, err)
+	args := []string{
+		"drive", "+add-comment",
+		"--doc", docToken,
+		"--type", "docx",
+		"--content", string(content),
+	}
+	args = append(args, locationArgs...)
+	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{Args: args, DefaultAs: "user"}, clie2e.RetryOptions{})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+}
+
+func docsFetchReferenceGroupExists(stdout, group string) bool {
+	return gjson.Get(stdout, "data.document.reference_map").Get(group).Exists()
+}
+
+func docsFetchReferenceGroupContains(stdout, group, text string) bool {
+	for _, entry := range gjson.Get(stdout, "data.document.reference_map").Get(group).Map() {
+		if strings.Contains(entry.Get("data").String(), text) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
@@ -22,7 +22,7 @@ import (
 // It is gated because the live credential needs both comment read and write
 // scopes, which are intentionally absent from the default test app.
 func TestDocsFetchCommentsWorkflow(t *testing.T) {
-	clie2e.SkipWithoutUserToken(t)
+	clie2e.SkipWithoutTenantAccessToken(t)
 	if os.Getenv("LARK_DOCS_FETCH_COMMENTS_E2E") == "" {
 		t.Skip("set LARK_DOCS_FETCH_COMMENTS_E2E=1 to run the document comment fetch workflow")
 	}
@@ -30,7 +30,7 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	t.Cleanup(cancel)
 	parentT := t
-	const defaultAs = "user"
+	const defaultAs = "bot"
 	suffix := clie2e.GenerateSuffix()
 	anchorText := "comment anchor " + suffix
 	localText := "local review " + suffix
@@ -39,8 +39,8 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 	folderToken := drive.CreateDriveFolder(t, parentT, ctx, "lark-cli-e2e-fetch-comments-"+suffix, defaultAs, "")
 	docToken := createDocWithRetry(t, parentT, ctx, folderToken, "fetch comments "+suffix, anchorText+"\n\nsecondary block", defaultAs)
 
-	addDocComment(t, ctx, docToken, localText, "--selection-with-ellipsis", anchorText)
-	addDocComment(t, ctx, docToken, wholeText, "--full-comment")
+	addDocComment(t, ctx, defaultAs, docToken, localText, "--selection-with-ellipsis", anchorText)
+	addDocComment(t, ctx, defaultAs, docToken, wholeText, "--full-comment")
 
 	var fetched *clie2e.Result
 	t.Run("xml full", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 		}
 	})
 
-	t.Run("markdown uses sidecar without body annotations", func(t *testing.T) {
+	t.Run("markdown uses precise reference shells", func(t *testing.T) {
 		result, err := clie2e.RunCmd(ctx, clie2e.Request{
 			Args:      []string{"docs", "+fetch", "--doc", docToken, "--comments", "--doc-format", "markdown"},
 			DefaultAs: defaultAs,
@@ -102,7 +102,7 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)
 		content := gjson.Get(result.Stdout, "data.document.content").String()
-		if strings.Contains(content, "comment-refs") ||
+		if strings.Contains(content, "comment-refs") || !strings.Contains(content, `<comment-ref refs="`) ||
 			!docsFetchReferenceGroupContains(result.Stdout, "comment", localText) ||
 			!docsFetchReferenceGroupContains(result.Stdout, "document-comment", wholeText) {
 			t.Fatalf("markdown comment sidecar mismatch:\n%s", result.Stdout)
@@ -110,7 +110,7 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 	})
 }
 
-func addDocComment(t *testing.T, ctx context.Context, docToken, text string, locationArgs ...string) {
+func addDocComment(t *testing.T, ctx context.Context, defaultAs, docToken, text string, locationArgs ...string) {
 	t.Helper()
 	content, err := json.Marshal([]map[string]string{{"type": "text", "text": text}})
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func addDocComment(t *testing.T, ctx context.Context, docToken, text string, loc
 		"--content", string(content),
 	}
 	args = append(args, locationArgs...)
-	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{Args: args, DefaultAs: "user"}, clie2e.RetryOptions{})
+	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{Args: args, DefaultAs: defaultAs}, clie2e.RetryOptions{})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
 	result.AssertStdoutStatus(t, true)

--- a/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
@@ -6,7 +6,10 @@ package docs
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
+	"io"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -64,6 +67,7 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 			!docsFetchReferenceGroupContains(fetched.Stdout, "document-comment", wholeText) {
 			t.Fatalf("comment reference groups missing:\n%s", fetched.Stdout)
 		}
+		assertDocsFetchCommentContract(t, fetched.Stdout, "xml", localText, wholeText)
 	})
 
 	t.Run("default remains comment free", func(t *testing.T) {
@@ -92,6 +96,7 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 		if !docsFetchReferenceGroupContains(result.Stdout, "comment", localText) || docsFetchReferenceGroupExists(result.Stdout, "document-comment") {
 			t.Fatalf("partial comment filtering mismatch:\n%s", result.Stdout)
 		}
+		assertDocsFetchCommentContract(t, result.Stdout, "xml", localText, "")
 	})
 
 	t.Run("markdown uses precise reference shells", func(t *testing.T) {
@@ -107,7 +112,170 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 			!docsFetchReferenceGroupContains(result.Stdout, "document-comment", wholeText) {
 			t.Fatalf("markdown comment sidecar mismatch:\n%s", result.Stdout)
 		}
+		assertDocsFetchCommentContract(t, result.Stdout, "markdown", localText, wholeText)
 	})
+}
+
+type docsFetchCommentEnvelope struct {
+	Data struct {
+		Document struct {
+			Content      string                                        `json:"content"`
+			ReferenceMap map[string]map[string]docsFetchReferenceEntry `json:"reference_map"`
+		} `json:"document"`
+	} `json:"data"`
+}
+
+type docsFetchReferenceEntry struct {
+	Data string `json:"data"`
+}
+
+var docsFetchCommentShellPattern = regexp.MustCompile(`<comment-ref\b[^>]*?/>`)
+
+func assertDocsFetchCommentContract(t *testing.T, stdout, markerMode, localText, wholeText string) {
+	t.Helper()
+
+	var envelope docsFetchCommentEnvelope
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope))
+	document := envelope.Data.Document
+	localEntries := document.ReferenceMap["comment"]
+	documentEntries := document.ReferenceMap["document-comment"]
+	require.Len(t, localEntries, 1, "fixture creates exactly one local comment")
+	if wholeText == "" {
+		require.Empty(t, documentEntries, "partial fetch must omit whole-document comments")
+	} else {
+		require.Len(t, documentEntries, 1, "fixture creates exactly one whole-document comment")
+	}
+
+	localKeys := make(map[string]struct{}, len(localEntries))
+	for key, entry := range localEntries {
+		if !regexp.MustCompile(`^c[1-9][0-9]*$`).MatchString(key) {
+			t.Fatalf("local comment key %q is not an opaque cN surrogate", key)
+		}
+		localKeys[key] = struct{}{}
+		assertDiscussionXML(t, entry.Data, false)
+	}
+	if !docsFetchReferenceGroupContains(stdout, "comment", localText) {
+		t.Fatalf("local discussion does not contain %q", localText)
+	}
+	for key, entry := range documentEntries {
+		if !regexp.MustCompile(`^d[1-9][0-9]*$`).MatchString(key) {
+			t.Fatalf("document comment key %q is not an opaque dN surrogate", key)
+		}
+		assertDiscussionXML(t, entry.Data, true)
+	}
+	if wholeText != "" && !docsFetchReferenceGroupContains(stdout, "document-comment", wholeText) {
+		t.Fatalf("whole-document discussion does not contain %q", wholeText)
+	}
+
+	var bodyRefs map[string]struct{}
+	switch markerMode {
+	case "xml":
+		bodyRefs = collectCommentRefsFromXML(t, document.Content, true)
+		if strings.Contains(document.Content, "<comment-ref") {
+			t.Fatal("DocxXML output must use comment-refs attributes, not Markdown shells")
+		}
+	case "markdown":
+		if strings.Contains(document.Content, "comment-refs=") {
+			t.Fatal("Markdown output must not contain DocxXML comment-refs attributes")
+		}
+		shells := docsFetchCommentShellPattern.FindAllString(document.Content, -1)
+		bodyRefs = collectCommentRefsFromXML(t, strings.Join(shells, ""), false)
+	default:
+		t.Fatalf("unsupported marker mode %q", markerMode)
+	}
+	require.Equal(t, localKeys, bodyRefs, "body refs and local sidecar keys must form an exact closure")
+}
+
+func collectCommentRefsFromXML(t *testing.T, fragment string, includeBlockAttrs bool) map[string]struct{} {
+	t.Helper()
+
+	refs := make(map[string]struct{})
+	decoder := xml.NewDecoder(strings.NewReader("<root>" + fragment + "</root>"))
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err, "comment marker XML must be well-formed")
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		for _, attr := range start.Attr {
+			isRefAttr := start.Name.Local == "comment-ref" && attr.Name.Local == "refs"
+			isRefAttr = isRefAttr || (includeBlockAttrs && attr.Name.Local == "comment-refs")
+			if !isRefAttr {
+				continue
+			}
+			for _, ref := range strings.Fields(attr.Value) {
+				refs[ref] = struct{}{}
+			}
+		}
+	}
+	return refs
+}
+
+func assertDiscussionXML(t *testing.T, data string, documentScope bool) {
+	t.Helper()
+
+	allowedChildren := map[string]bool{"quote": true, "message": true, "img": true, "reaction": true}
+	allowedAttrs := map[string]map[string]bool{
+		"discussion": {"scope": true, "timezone": true},
+		"quote":      {},
+		"message":    {"t": true, "u": true},
+		"img":        {},
+		"reaction":   {},
+	}
+	decoder := xml.NewDecoder(strings.NewReader(data))
+	depth := 0
+	sawRoot := false
+	sawQuote := false
+	scope := ""
+	timezone := ""
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err, "discussion sidecar must be well-formed XML")
+		switch typed := token.(type) {
+		case xml.StartElement:
+			if depth == 0 {
+				require.False(t, sawRoot, "discussion sidecar must have one root")
+				require.Equal(t, "discussion", typed.Name.Local)
+				sawRoot = true
+			} else if !allowedChildren[typed.Name.Local] {
+				t.Fatalf("unexpected discussion element <%s>", typed.Name.Local)
+			}
+			for _, attr := range typed.Attr {
+				if !allowedAttrs[typed.Name.Local][attr.Name.Local] {
+					t.Fatalf("unexpected %s attribute %q", typed.Name.Local, attr.Name.Local)
+				}
+				if typed.Name.Local == "discussion" && attr.Name.Local == "scope" {
+					scope = attr.Value
+				}
+				if typed.Name.Local == "discussion" && attr.Name.Local == "timezone" {
+					timezone = attr.Value
+				}
+			}
+			if typed.Name.Local == "quote" {
+				sawQuote = true
+			}
+			depth++
+		case xml.EndElement:
+			depth--
+			require.GreaterOrEqual(t, depth, 0)
+		}
+	}
+	require.True(t, sawRoot)
+	require.Zero(t, depth)
+	require.Equal(t, "Asia/Shanghai", timezone)
+	if documentScope {
+		require.Equal(t, "document", scope)
+		require.False(t, sawQuote, "whole-document discussions must not repeat a quote")
+	} else {
+		require.Empty(t, scope)
+	}
 }
 
 func addDocComment(t *testing.T, ctx context.Context, defaultAs, docToken, text string, locationArgs ...string) {

--- a/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_comments_workflow_test.go
@@ -39,6 +39,8 @@ func TestDocsFetchCommentsWorkflow(t *testing.T) {
 	localText := "local review " + suffix
 	wholeText := "whole document review " + suffix
 
+	// Both creation helpers register parentT cleanup immediately. Cleanup is
+	// LIFO, so the document is deleted before its containing folder.
 	folderToken := drive.CreateDriveFolder(t, parentT, ctx, "lark-cli-e2e-fetch-comments-"+suffix, defaultAs, "")
 	docToken := createDocWithRetry(t, parentT, ctx, folderToken, "fetch comments "+suffix, anchorText+"\n\nsecondary block", defaultAs)
 

--- a/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
@@ -11,6 +11,7 @@ import (
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestDocsFetchDryRunCommentsOptIn(t *testing.T) {
@@ -36,6 +37,30 @@ func TestDocsFetchDryRunCommentsOptIn(t *testing.T) {
 	if !extra["include_comments"] {
 		t.Fatalf("include_comments missing from extra_param=%s\nstdout:\n%s", raw, result.Stdout)
 	}
+}
+
+func TestDocsFetchCommentsRejectsLossyOutputBeforeDryRun(t *testing.T) {
+	setDocsDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+fetch",
+			"--doc", "doxcnDryRunComments",
+			"--comments",
+			"--format", "pretty",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Empty(t, result.Stdout, "validation failure must not emit a dry-run request")
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Equal(t, "--format", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "--format json", result.Stderr)
 }
 
 func TestDocsFetchDryRunIgnoresAPIVersionCompatFlag(t *testing.T) {

--- a/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
@@ -63,6 +63,31 @@ func TestDocsFetchCommentsRejectsLossyOutputBeforeDryRun(t *testing.T) {
 	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "--format json", result.Stderr)
 }
 
+func TestDocsFetchCommentsRejectsIMMarkdownBeforeDryRun(t *testing.T) {
+	setDocsDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+fetch",
+			"--doc", "doxcnDryRunComments",
+			"--comments",
+			"--doc-format", "im-markdown",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Empty(t, result.Stdout, "validation failure must not emit a dry-run request")
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Equal(t, "--doc-format", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "XML or Markdown", result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "IM Markdown remains unchanged", result.Stderr)
+}
+
 func TestDocsFetchDryRunIgnoresAPIVersionCompatFlag(t *testing.T) {
 	setDocsDryRunEnv(t)
 

--- a/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_fetch_dryrun_test.go
@@ -5,12 +5,38 @@ package docs
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDocsFetchDryRunCommentsOptIn(t *testing.T) {
+	setDocsDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+fetch",
+			"--doc", "doxcnDryRunComments",
+			"--comments",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	raw := clie2e.DryRunGet(result.Stdout, "api.0.body.extra_param").String()
+	var extra map[string]bool
+	require.NoError(t, json.Unmarshal([]byte(raw), &extra))
+	if !extra["include_comments"] {
+		t.Fatalf("include_comments missing from extra_param=%s\nstdout:\n%s", raw, result.Stdout)
+	}
+}
 
 func TestDocsFetchDryRunIgnoresAPIVersionCompatFlag(t *testing.T) {
 	setDocsDryRunEnv(t)


### PR DESCRIPTION
## Summary

Add opt-in, AI-friendly visible comment context to `docs +fetch` while preserving the existing comment-free default and the existing IM Markdown behavior.

## Contract

- `--comments` is effective only for non-outline reads and requires `--format json` plus `--as bot`.
- XML anchors use `comment-refs="c1 c2"`; Markdown uses `<comment-ref refs="c1 c2"/>`.
- Comment export supports only `xml` and `markdown`. `im-markdown` remains unchanged; an effective `--comments --doc-format im-markdown` combination is rejected before any API request.
- Local and whole-document discussions live in `reference_map.comment` and `reference_map.document-comment`.
- Full fetch returns local plus whole-document comments; partial fetch returns only intersecting local comments; outline performs no comment request.
- Historical revisions mean historical content plus the current visible unresolved comment snapshot projected onto that revision.

## Implementation

- Send `include_comments` only when comments are effective and require the conditional comment-read scope.
- Reject lossy output, user-token, and IM Markdown comment combinations before any API request.
- Preserve precise marker associations in XML and Markdown, including lists and tables.
- Leave the production IM Markdown converter untouched.
- Add unit, mounted dry-run and gated self-contained live workflow coverage with document-before-folder cleanup.

## Validation

- [x] Remote build, full unit suite, vet, formatting, dependency tidiness, changed-line lint, script gates, example builds and plugin E2E.
- [x] BOE `boe_sun_ai_test` real-document matrix: 15 local + 806 whole-document discussions with exact marker/sidecar closure in XML and Markdown.
- [x] IM Markdown without comments is byte-for-byte identical before and after the boundary correction on the real BOE document.
- [x] `--comments --doc-format im-markdown` returns a typed `--doc-format` validation error before the request.
- [x] Full integration packages for docs and IM passed. Two unrelated Drive live cleanup cases were blocked by the test app missing `drive:drive` / `space:document:delete`; no comment-fetch package failed.
- [x] Full CI, CodeQL, CodeRabbit, and Codecov passed for head `0377b32d` (evidence: CI `31239377111`, CodeQL `31239322520`).

## Dependencies and boundaries

- SDK MR: https://code.byted.org/lark/office_ai_sdk/merge_requests/210
- ai_edit MR: https://code.byted.org/ccm-platform/ai_edit/merge_requests/197
- DevFlow: https://devflow.bytedance.net/space/0/task/474859/develop?tabKey=Develop
- No Engine, IDL, generated code or OGW change.
- The SDK reuses Engine's existing revision-aware `OpenAPIListBlockByCommentIDs` only for comment-ID-to-block association. Comment headers and discussion content come from the comment service (`GetCommentByNote` and `APIBatchGetComment`).
- User tokens remain fail-closed until a trusted conditional scope contract exists.

## Related Issues

- None
