### PR TITLE
fix(minutes): make media downloads resilient

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -358,9 +358,20 @@ func openPartial(ctx context.Context, source Source, opts Options, retryWait *re
 	}
 	return &Stream{
 		Body:          newExactLengthReader(body, first.total),
-		Header:        resp.Header.Clone(),
+		Header:        assembledHeader(resp.Header, first.total),
 		ContentLength: first.total,
 	}, nil
+}
+
+// assembledHeader describes the whole stream rather than the first response it
+// was built from. Leaving the first part's framing in place would advertise a
+// Content-Length shorter than the bytes callers actually receive, and a
+// Content-Range covering only the opening slice.
+func assembledHeader(first http.Header, totalSize int64) http.Header {
+	header := first.Clone()
+	header.Set("Content-Length", strconv.FormatInt(totalSize, 10))
+	header.Del("Content-Range")
+	return header
 }
 
 type sequentialPartReader struct {

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -385,6 +385,38 @@ func TestOpenImmutableWithoutValidatorUsesExactRanges(t *testing.T) {
 	}
 }
 
+// Callers read Content-Type and Content-Disposition off the assembled stream,
+// so those must survive, while the first part's framing must not leak out as a
+// length shorter than the bytes actually delivered.
+func TestOpenReportsAssembledStreamHeaders(t *testing.T) {
+	full := []byte("abcdefgh")
+	stream, err := openTest(context.Background(), func(_ context.Context, req Request) (*http.Response, error) {
+		start := req.Range.Start
+		end := min(req.Range.End, int64(len(full))-1)
+		resp := testPartial(full[start:end+1], start, end, int64(len(full)), "")
+		resp.Header.Set("Content-Length", fmt.Sprint(end-start+1))
+		resp.Header.Set("Content-Type", "video/mp4")
+		return resp, nil
+	}, testOptions())
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer stream.Body.Close()
+
+	if stream.ContentLength != int64(len(full)) {
+		t.Fatalf("ContentLength = %d, want %d", stream.ContentLength, len(full))
+	}
+	if got, want := stream.Header.Get("Content-Length"), fmt.Sprint(len(full)); got != want {
+		t.Errorf("Content-Length header = %q, want %q (the whole stream, not the first part)", got, want)
+	}
+	if got := stream.Header.Get("Content-Range"); got != "" {
+		t.Errorf("Content-Range header = %q, want it dropped from the assembled stream", got)
+	}
+	if got := stream.Header.Get("Content-Type"); got != "video/mp4" {
+		t.Errorf("Content-Type header = %q, want it preserved", got)
+	}
+}
+
 func TestOpenMutableWithoutValidatorFallsBackBeforeDelivery(t *testing.T) {
 	payload := []byte("abcdefgh")
 	var requests []Request

--- a/shortcuts/minutes/minutes_download.go
+++ b/shortcuts/minutes/minutes_download.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -19,19 +18,20 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/download"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
 const (
-	// disableClientTimeout removes the global 30s client timeout for large media downloads.
-	// The download is bounded by the caller's context (e.g. Ctrl+C). A fixed timeout
-	// would cut off legitimate large file transfers.
+	// Keep the whole transfer unbounded; download.Open enforces idle timeouts.
 	disableClientTimeout = 0
 
 	maxBatchSize         = 50
 	maxDownloadRedirects = 5
+
+	minutesDownloadPartSize = 128 * 1024 * 1024
 )
 
 // validMinuteToken matches minute tokens: lowercase alphanumeric characters only.
@@ -307,29 +307,21 @@ func downloadMediaFile(ctx context.Context, client *http.Client, downloadURL, mi
 		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "blocked download URL: %s", err).WithCause(err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	transport := download.URL(client, downloadURL)
+	// A minute token identifies finalized recording bytes.
+	source := download.ImmutableSource(transport)
+	stream, err := download.Open(ctx, source, download.Options{
+		PartSize: minutesDownloadPartSize,
+	})
 	if err != nil {
-		return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "invalid download URL: %s", err).WithCause(err)
+		return nil, err
 	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "download failed: %s", err).WithCause(err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		if len(body) > 0 {
-			return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "download failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-		}
-		return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "download failed: HTTP %d", resp.StatusCode)
-	}
+	defer stream.Body.Close()
 
 	// resolve output path
 	outputPath := opts.outputPath
 	if outputPath == "" {
-		filename := resolveFilenameFromResponse(resp, minuteToken)
+		filename := resolveFilenameFromResponse(stream.Header, minuteToken)
 		// Deduplicate filenames in batch mode: prefix with token on collision.
 		if opts.usedNames != nil {
 			if opts.usedNames[filename] {
@@ -347,9 +339,9 @@ func downloadMediaFile(ctx context.Context, client *http.Client, downloadURL, mi
 	}
 
 	result, err := opts.fio.Save(outputPath, fileio.SaveOptions{
-		ContentType:   resp.Header.Get("Content-Type"),
-		ContentLength: resp.ContentLength,
-	}, resp.Body)
+		ContentType:   stream.Header.Get("Content-Type"),
+		ContentLength: stream.ContentLength,
+	}, stream.Body)
 	if err != nil {
 		return nil, common.WrapSaveErrorTyped(err)
 	}
@@ -362,15 +354,15 @@ func downloadMediaFile(ctx context.Context, client *http.Client, downloadURL, mi
 
 // resolveFilenameFromResponse derives the filename from HTTP response headers.
 // Priority: Content-Disposition filename > Content-Type extension > <token>.media.
-func resolveFilenameFromResponse(resp *http.Response, minuteToken string) string {
-	if cd := resp.Header.Get("Content-Disposition"); cd != "" {
+func resolveFilenameFromResponse(header http.Header, minuteToken string) string {
+	if cd := header.Get("Content-Disposition"); cd != "" {
 		if _, params, err := mime.ParseMediaType(cd); err == nil {
 			if filename := sanitizeServerFilename(params["filename"]); filename != "" {
 				return filename
 			}
 		}
 	}
-	if ext := extFromContentType(resp.Header.Get("Content-Type")); ext != "" {
+	if ext := extFromContentType(header.Get("Content-Type")); ext != "" {
 		return minuteToken + ext
 	}
 	return minuteToken + ".media"
@@ -398,10 +390,6 @@ var preferredExt = map[string]string{
 	"audio/mpeg": ".mp3",
 }
 
-// newDownloadClient wraps the base HTTP client with SSRF protection
-// (redirect safety + transport-level IP validation). When the base transport
-// is not *http.Transport (e.g. test mocks), it falls back to cloning
-// http.DefaultTransport via NewDownloadHTTPClient.
 // extFromContentType returns a file extension for the given Content-Type, or "" if unknown.
 func extFromContentType(contentType string) string {
 	if contentType == "" {

--- a/shortcuts/minutes/minutes_download_test.go
+++ b/shortcuts/minutes/minutes_download_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/download"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	internaltransport "github.com/larksuite/cli/internal/transport"
@@ -128,7 +129,7 @@ func TestResolveFilenameFromResponse_ContentDisposition(t *testing.T) {
 			"Content-Type":        []string{"video/mp4"},
 		},
 	}
-	got := resolveFilenameFromResponse(resp, "tok001")
+	got := resolveFilenameFromResponse(resp.Header, "tok001")
 	if got != "meeting_recording.mp4" {
 		t.Errorf("expected Content-Disposition filename, got %q", got)
 	}
@@ -140,7 +141,7 @@ func TestResolveFilenameFromResponse_ContentType(t *testing.T) {
 			"Content-Type": []string{"video/mp4"},
 		},
 	}
-	got := resolveFilenameFromResponse(resp, "tok001")
+	got := resolveFilenameFromResponse(resp.Header, "tok001")
 	if !strings.HasPrefix(got, "tok001") {
 		t.Errorf("expected token prefix, got %q", got)
 	}
@@ -151,7 +152,7 @@ func TestResolveFilenameFromResponse_ContentType(t *testing.T) {
 
 func TestResolveFilenameFromResponse_Fallback(t *testing.T) {
 	resp := &http.Response{Header: http.Header{}}
-	got := resolveFilenameFromResponse(resp, "tok001")
+	got := resolveFilenameFromResponse(resp.Header, "tok001")
 	if got != "tok001.media" {
 		t.Errorf("expected fallback %q, got %q", "tok001.media", got)
 	}
@@ -164,7 +165,7 @@ func TestResolveFilenameFromResponse_InvalidContentDisposition(t *testing.T) {
 			"Content-Type":        []string{"audio/mpeg"},
 		},
 	}
-	got := resolveFilenameFromResponse(resp, "tok001")
+	got := resolveFilenameFromResponse(resp.Header, "tok001")
 	if !strings.HasPrefix(got, "tok001") {
 		t.Errorf("expected token prefix from Content-Type fallback, got %q", got)
 	}
@@ -187,7 +188,7 @@ func TestResolveFilenameFromResponse_RejectsTraversalInDisposition(t *testing.T)
 				"Content-Disposition": []string{tt.disposition},
 			},
 		}
-		got := resolveFilenameFromResponse(resp, "tok001")
+		got := resolveFilenameFromResponse(resp.Header, "tok001")
 		if got != tt.wantBase {
 			t.Errorf("disposition=%q: got %q, want %q", tt.disposition, got, tt.wantBase)
 		}
@@ -239,11 +240,17 @@ func TestDownloadUsesExternalRequestClass(t *testing.T) {
 			Request:    req,
 		}, nil
 	})
+	var rangeHeader, encodingHeader string
 	external := minutesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		payload := []byte("media")
+		rangeHeader = req.Header.Get("Range")
+		encodingHeader = req.Header.Get("Accept-Encoding")
 		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Header:        http.Header{"Content-Type": []string{"video/mp4"}},
+			StatusCode: http.StatusPartialContent,
+			Header: http.Header{
+				"Content-Type":  []string{"video/mp4"},
+				"Content-Range": []string{"bytes 0-4/5"},
+			},
 			Body:          io.NopCloser(bytes.NewReader(payload)),
 			ContentLength: int64(len(payload)),
 			Request:       req,
@@ -268,6 +275,61 @@ func TestDownloadUsesExternalRequestClass(t *testing.T) {
 	if got := string(data); got != "media" {
 		t.Fatalf("downloaded content = %q, want external payload", got)
 	}
+	if rangeHeader != "bytes=0-134217727" || encodingHeader != "identity" {
+		t.Fatalf("download headers = Range %q, Accept-Encoding %q", rangeHeader, encodingHeader)
+	}
+}
+
+func TestDownloadRejectsInvalidResponseBodies(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  http.Header
+		body    string
+		subtype errs.Subtype
+	}{
+		{
+			name:    "truncated",
+			header:  http.Header{"Content-Length": []string{"10"}},
+			body:    "short",
+			subtype: errs.SubtypeNetworkProtocol,
+		},
+		{
+			name:    "encoded",
+			header:  http.Header{"Content-Encoding": []string{"gzip"}},
+			body:    "compressed",
+			subtype: errs.SubtypeNetworkProtocol,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chdir(t, t.TempDir())
+			f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+			reg.Register(mediaStub("tok001", "https://example.com/media"))
+			f.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: minutesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode:    http.StatusOK,
+						Header:        tt.header,
+						Body:          io.NopCloser(strings.NewReader(tt.body)),
+						ContentLength: 10,
+						Request:       req,
+					}, nil
+				})}, nil
+			}
+
+			err := mountAndRun(t, MinutesDownload, []string{
+				"+download", "--minute-tokens", "tok001", "--output", "out.media", "--as", "bot",
+			}, f, nil)
+			var networkErr *errs.NetworkError
+			if !errors.As(err, &networkErr) || networkErr.Subtype != tt.subtype {
+				t.Fatalf("error = %T %v, want network/%s", err, err, tt.subtype)
+			}
+			if _, statErr := os.Stat("out.media"); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("partial output should not exist: %v", statErr)
+			}
+		})
+	}
 }
 
 func TestResolveFilenameFromResponse_EmptyDispositionFilename(t *testing.T) {
@@ -277,7 +339,7 @@ func TestResolveFilenameFromResponse_EmptyDispositionFilename(t *testing.T) {
 			"Content-Type":        []string{"video/mp4"},
 		},
 	}
-	got := resolveFilenameFromResponse(resp, "tok001")
+	got := resolveFilenameFromResponse(resp.Header, "tok001")
 	if got == "" {
 		t.Error("expected non-empty filename")
 	}
@@ -780,14 +842,12 @@ func TestDownload_TypedErr_ValidationInvalidArgument(t *testing.T) {
 	}
 }
 
-// TestDownload_TypedErr_NetworkTransport_HttpError verifies that a non-2xx
-// download response from downloadMediaFile returns a *errs.NetworkError with
-// SubtypeNetworkTransport.
+// TestDownload_TypedErr_NetworkServer_HttpError verifies server error typing.
 //
 // In the end-to-end single-token Execute path the typed error is now passed
 // through directly via r.err (single-mode passthrough).  We call downloadMediaFile
 // directly via a probe shortcut to assert the typed shape at the source.
-func TestDownload_TypedErr_NetworkTransport_HttpError(t *testing.T) {
+func TestDownload_TypedErr_NetworkServer_HttpError(t *testing.T) {
 	chdir(t, t.TempDir())
 
 	var capturedErr error
@@ -808,11 +868,13 @@ func TestDownload_TypedErr_NetworkTransport_HttpError(t *testing.T) {
 	}
 
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
-	reg.Register(&httpmock.Stub{
-		URL:     "example.com/presigned/download",
-		Status:  503,
-		RawBody: []byte("Service Unavailable"),
-	})
+	for range download.DefaultPartRetries + 1 {
+		reg.Register(&httpmock.Stub{
+			URL:     "example.com/presigned/download",
+			Status:  503,
+			RawBody: []byte("Service Unavailable"),
+		})
+	}
 
 	if err := mountAndRun(t, probe, []string{"+probe-dl", "--as", "bot"}, f, nil); err != nil {
 		t.Fatalf("probe shortcut should not error: %v", err)
@@ -824,8 +886,11 @@ func TestDownload_TypedErr_NetworkTransport_HttpError(t *testing.T) {
 	if !errors.As(capturedErr, &ne) {
 		t.Fatalf("expected *errs.NetworkError, got %T: %v", capturedErr, capturedErr)
 	}
-	if ne.Subtype != errs.SubtypeNetworkTransport {
-		t.Errorf("Subtype = %q, want %q", ne.Subtype, errs.SubtypeNetworkTransport)
+	if ne.Subtype != errs.SubtypeNetworkServer {
+		t.Errorf("Subtype = %q, want %q", ne.Subtype, errs.SubtypeNetworkServer)
+	}
+	if !errs.IsRetryable(capturedErr) {
+		t.Errorf("503 error should remain retryable: %v", capturedErr)
 	}
 	if !strings.Contains(ne.Error(), "503") {
 		t.Errorf("error message should contain status code 503, got: %v", ne)


### PR DESCRIPTION
## Summary

Replaces the single unvalidated `GET` behind `minutes +download` with the shared `internal/download` sequential range reader introduced in #2223, so large recording media survives gateway timeouts and mid-transfer interruptions. Command behavior is unchanged: same flags, filename resolution, batch layout, overwrite protection, and JSON output.

This also tightens one thing in the shared framework itself. Minutes is its second consumer, and wiring it up surfaced a header that misdescribed multipart streams; the fix is included here rather than deferred because Minutes is the first caller that reads those headers to derive a filename.

## Changes

**Minutes**

- Route media downloads through `download.URL` → `download.ImmutableSource` → `download.Open` instead of a bare `client.Do` with ad-hoc status handling.
- Declare Minutes media as an immutable representation. A minute token addresses finalized recording bytes, so parts can be combined without a validator. The media endpoint returns no `ETag`, so declaring it mutable would silently fall back to a single full response and lose ranged recovery.
- Use a 128 MiB part size for this domain. Recording media is substantially larger than IM or app files, and smaller parts would multiply requests without benefit. This is a Minutes-level choice and does not change the framework default.
- Drop the fixed per-request deadline in favor of the framework's 60-second progress-based idle timeout, so slow-but-advancing transfers are no longer cut off while dead connections still fail fast.
- Remove the local HTTP status and error-body mapping now owned by the download layer.
- Consume the returned stream directly instead of repacking it into a synthetic `http.Response`; `resolveFilenameFromResponse` now takes the `http.Header` it actually reads.

**Shared download framework**

- A multipart stream now reports its own framing: `Content-Length` is the whole object and the first part's `Content-Range` is dropped. Previously `Stream.Header` was a verbatim clone of the opening `206`, so a caller reading `Content-Length` off the header saw the first part's size while `Stream.ContentLength` held the total. No current caller reads that header field, so this fixes a latent inconsistency rather than a live defect, and it makes the header agree with what the single-response path already produced.

Not included: cross-process checkpointing or resumable downloads. Recovery happens within a single command invocation only.

## Test Plan

- [x] Unit tests pass (`make unit-test`, race enabled, across `cmd`, `internal`, `shortcuts`, and `extension`)
- [x] `go vet ./...`, `go build ./...`, and diff-scoped `golangci-lint` are clean
- [x] Manual local verification confirms the `lark-cli minutes +download` flow works as expected

New coverage:

- `TestOpenReportsAssembledStreamHeaders` pins the assembled-stream header contract: reverting the change fails it with the first part's length.

Verified against live recording media using a temporary, uncommitted transport observer to capture the exact request sequence:

| Media size | Part size | Requests | Result |
| --- | --- | --- | --- |
| 55 MiB | 128 MiB | 1 | single `206`, media decodes cleanly |
| 203 MiB | 128 MiB | 2 | contiguous ranges, no gaps or overlaps |
| 203 MiB | 64 MiB | 4 | contiguous ranges, no gaps or overlaps |
| 203 MiB | 8 MiB | 26 | contiguous ranges, no gaps or overlaps |

- Every response was `206` with an exact `Content-Range`, and no fallback full re-fetch occurred.
- All four runs produced byte-identical output, matching an independent range-by-range reconstruction of the same object.
- Downloading the same token twice produced identical checksums, and the resulting media decodes without errors.
- With `--output` omitted, the filename is derived from the assembled stream's headers; verified on both a single-part and a two-part download, confirming `Content-Type` and `Content-Disposition` survive the header fix.
- Peak RSS stayed near 48 MiB while transferring 203 MiB under a 128 MiB part size, confirming parts are streamed rather than buffered.
- Writing to an existing path without `--overwrite` returns a typed validation error and leaves the original file untouched.
- Interrupting a transfer exits without publishing a final file. The partial temporary file is still left behind, which matches current `main` and is unchanged by this PR.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media downloads for large files through more reliable streaming and segmented transfers.
  * Added validation to reject truncated or unexpectedly encoded download responses, preventing incomplete output.
  * Improved handling and classification of temporary server errors during downloads.
  * Corrected download metadata for assembled streams so file sizes and content types are reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->