### PR TITLE
Add mail rule reorder shortcut

### DIFF
--- a/shortcuts/mail/mail_rule_reorder.go
+++ b/shortcuts/mail/mail_rule_reorder.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+type mailRuleOrderItem struct {
+	ID       string
+	Sequence *int64
+	Index    int
+}
+
+// MailRuleReorder lets callers provide the rule IDs they want at the front.
+// Execute fetches the current full rule list, appends untouched rules in their
+// current relative order, then submits the full list required by the API.
+var MailRuleReorder = common.Shortcut{
+	Service:     "mail",
+	Command:     "+rule-reorder",
+	Description: "Reorder mail rules by providing the rule IDs to move to the front. The CLI fetches current rules and submits the complete rule ID list.",
+	Risk:        "write",
+	Scopes:      []string{"mail:user_mailbox.rule:read", "mail:user_mailbox.rule:write"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "mailbox", Desc: "Mailbox email address that owns the rules (default: me)."},
+		{Name: "rule-ids", Type: "string_slice", Desc: "Rule IDs to place first; comma-separated or repeat the flag. The CLI appends all other current rules automatically."},
+	},
+	Validate: validateMailRuleReorder,
+	DryRun:   dryRunMailRuleReorder,
+	Execute:  executeMailRuleReorder,
+}
+
+func validateMailRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
+	if err := validateBotMailboxNotMe(rt); err != nil {
+		return err
+	}
+	_, err := normalizeMailRuleReorderInput(rt.StrSlice("rule-ids"))
+	return err
+}
+
+func dryRunMailRuleReorder(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
+	mailboxID := resolveMailboxID(rt)
+	inputIDs, _ := normalizeMailRuleReorderInput(rt.StrSlice("rule-ids"))
+	return common.NewDryRunAPI().
+		GET(mailboxPath(mailboxID, "rules")).
+		Desc("Fetch current mail rules to complete the full rule order").
+		POST(mailboxPath(mailboxID, "rules", "reorder")).
+		Body(map[string]interface{}{"rule_ids": inputIDs}).
+		Desc("Submit the complete rule ID order; dry-run shows only the user-provided front segment")
+}
+
+func executeMailRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
+	mailboxID := resolveMailboxID(rt)
+	inputIDs, err := normalizeMailRuleReorderInput(rt.StrSlice("rule-ids"))
+	if err != nil {
+		return err
+	}
+	currentRules, err := fetchMailRulesForReorder(rt, mailboxID)
+	if err != nil {
+		return err
+	}
+	finalIDs, err := buildMailRuleReorderIDs(inputIDs, currentRules)
+	if err != nil {
+		return err
+	}
+
+	_, err = rt.CallAPITyped("POST", mailboxPath(mailboxID, "rules", "reorder"), nil, map[string]interface{}{
+		"rule_ids": finalIDs,
+	})
+	if err != nil {
+		return mailAppendProblemHint(err, "submitted_rule_ids="+mustJSONList(finalIDs))
+	}
+
+	result := map[string]interface{}{
+		"mailbox":            mailboxID,
+		"input_rule_ids":     inputIDs,
+		"submitted_rule_ids": finalIDs,
+		"total":              len(finalIDs),
+	}
+	rt.OutFormat(result, nil, func(w io.Writer) {
+		fmt.Fprintf(w, "Successfully reordered %d mail rule(s)\n", len(finalIDs))
+		fmt.Fprintln(w, "Submitted order:")
+		for i, id := range finalIDs {
+			fmt.Fprintf(w, "  Position %d: %s\n", i+1, id)
+		}
+	})
+	return nil
+}
+
+func normalizeMailRuleReorderInput(raw []string) ([]string, error) {
+	ids := make([]string, 0, len(raw))
+	seen := make(map[string]bool, len(raw))
+	duplicateIDs := make([]string, 0)
+	emptyPositions := make([]errs.InvalidParam, 0)
+	for i, v := range raw {
+		id := strings.TrimSpace(v)
+		if id == "" {
+			emptyPositions = append(emptyPositions, mailInvalidParam(fmt.Sprintf("--rule-ids[%d]", i), "empty rule ID"))
+			continue
+		}
+		if seen[id] {
+			duplicateIDs = append(duplicateIDs, id)
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	if len(emptyPositions) > 0 {
+		return nil, mailValidationError("--rule-ids contains empty rule ID(s)").WithParam("--rule-ids").WithParams(emptyPositions...)
+	}
+	if len(ids) == 0 {
+		return nil, mailValidationParamError("--rule-ids", "--rule-ids must contain at least one rule ID")
+	}
+	if len(duplicateIDs) > 0 {
+		return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule ID(s): %s", strings.Join(duplicateIDs, ", "))
+	}
+	return ids, nil
+}
+
+func fetchMailRulesForReorder(rt *common.RuntimeContext, mailboxID string) ([]mailRuleOrderItem, error) {
+	data, err := rt.CallAPITyped("GET", mailboxPath(mailboxID, "rules"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	items, _ := data["items"].([]interface{})
+	rules := make([]mailRuleOrderItem, 0, len(items))
+	for i, raw := range items {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, mailInvalidResponseError("rules[%d] is not an object", i)
+		}
+		id := strings.TrimSpace(mailRuleStringValue(item["id"]))
+		if id == "" {
+			return nil, mailInvalidResponseError("rules[%d].id is empty", i)
+		}
+		rules = append(rules, mailRuleOrderItem{
+			ID:       id,
+			Sequence: int64PointerValue(item["sequence"]),
+			Index:    i,
+		})
+	}
+	sortMailRulesBySequenceWhenComplete(rules)
+	return rules, nil
+}
+
+func buildMailRuleReorderIDs(inputIDs []string, currentRules []mailRuleOrderItem) ([]string, error) {
+	currentSet := make(map[string]bool, len(currentRules))
+	for _, rule := range currentRules {
+		if currentSet[rule.ID] {
+			return nil, mailInvalidResponseError("rules list contains duplicate rule ID %q", rule.ID)
+		}
+		currentSet[rule.ID] = true
+	}
+	unknownIDs := make([]string, 0)
+	inputSet := make(map[string]bool, len(inputIDs))
+	for _, id := range inputIDs {
+		if !currentSet[id] {
+			unknownIDs = append(unknownIDs, id)
+			continue
+		}
+		inputSet[id] = true
+	}
+	if len(unknownIDs) > 0 {
+		return nil, mailValidationParamError("--rule-ids", "unknown rule ID(s): %s; run `lark-cli mail user_mailbox.rules list --params '{\"user_mailbox_id\":\"me\"}'` to fetch current IDs", strings.Join(unknownIDs, ", "))
+	}
+
+	finalIDs := append([]string(nil), inputIDs...)
+	for _, rule := range currentRules {
+		if !inputSet[rule.ID] {
+			finalIDs = append(finalIDs, rule.ID)
+		}
+	}
+	return finalIDs, nil
+}
+
+func sortMailRulesBySequenceWhenComplete(rules []mailRuleOrderItem) {
+	if len(rules) < 2 {
+		return
+	}
+	for _, rule := range rules {
+		if rule.Sequence == nil {
+			return
+		}
+	}
+	sort.SliceStable(rules, func(i, j int) bool {
+		if *rules[i].Sequence == *rules[j].Sequence {
+			return rules[i].Index < rules[j].Index
+		}
+		return *rules[i].Sequence < *rules[j].Sequence
+	})
+}
+
+func int64PointerValue(v interface{}) *int64 {
+	switch x := v.(type) {
+	case int:
+		n := int64(x)
+		return &n
+	case int64:
+		n := x
+		return &n
+	case float64:
+		n := int64(x)
+		return &n
+	case json.Number:
+		if n, err := x.Int64(); err == nil {
+			return &n
+		}
+	}
+	return nil
+}
+
+func mailRuleStringValue(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case fmt.Stringer:
+		return x.String()
+	case json.Number:
+		return x.String()
+	default:
+		if v == nil {
+			return ""
+		}
+		return fmt.Sprint(v)
+	}
+}
+
+func mustJSONList(ids []string) string {
+	b, err := json.Marshal(ids)
+	if err != nil {
+		return fmt.Sprintf("%v", ids)
+	}
+	return string(b)
+}

--- a/shortcuts/mail/mail_rule_reorder.go
+++ b/shortcuts/mail/mail_rule_reorder.go
@@ -30,7 +30,7 @@ var MailRuleReorder = common.Shortcut{
 	Description: "Reorder mail rules by providing the rule IDs to move to the front. The CLI fetches current rules and submits the complete rule ID list.",
 	Risk:        "write",
 	Scopes:      []string{"mail:user_mailbox.rule:read", "mail:user_mailbox.rule:write"},
-	AuthTypes:   []string{"user", "bot"},
+	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "mailbox", Desc: "Mailbox email address that owns the rules (default: me)."},
@@ -133,20 +133,39 @@ func fetchMailRulesForReorder(rt *common.RuntimeContext, mailboxID string) ([]ma
 	if err != nil {
 		return nil, err
 	}
-	items, _ := data["items"].([]interface{})
+	rawItems, ok := data["items"]
+	if !ok {
+		return nil, mailInvalidResponseError("rules response missing items")
+	}
+	items, ok := rawItems.([]interface{})
+	if !ok {
+		return nil, mailInvalidResponseError("rules response items is %T, want array", rawItems)
+	}
 	rules := make([]mailRuleOrderItem, 0, len(items))
 	for i, raw := range items {
 		item, ok := raw.(map[string]interface{})
 		if !ok {
 			return nil, mailInvalidResponseError("rules[%d] is not an object", i)
 		}
-		id := strings.TrimSpace(mailRuleStringValue(item["id"]))
+		rawID, ok := item["id"]
+		if !ok {
+			return nil, mailInvalidResponseError("rules[%d].id is missing", i)
+		}
+		id, ok := rawID.(string)
+		if !ok {
+			return nil, mailInvalidResponseError("rules[%d].id is %T, want string", i, rawID)
+		}
+		id = strings.TrimSpace(id)
 		if id == "" {
 			return nil, mailInvalidResponseError("rules[%d].id is empty", i)
 		}
+		sequence, err := mailRuleSequenceValue(item["sequence"])
+		if err != nil {
+			return nil, mailInvalidResponseError("rules[%d].sequence %s", i, err.Error())
+		}
 		rules = append(rules, mailRuleOrderItem{
 			ID:       id,
-			Sequence: int64PointerValue(item["sequence"]),
+			Sequence: sequence,
 			Index:    i,
 		})
 	}
@@ -201,38 +220,31 @@ func sortMailRulesBySequenceWhenComplete(rules []mailRuleOrderItem) {
 	})
 }
 
-func int64PointerValue(v interface{}) *int64 {
+func mailRuleSequenceValue(v interface{}) (*int64, error) {
+	if v == nil {
+		return nil, nil
+	}
 	switch x := v.(type) {
 	case int:
 		n := int64(x)
-		return &n
+		return &n, nil
 	case int64:
 		n := x
-		return &n
+		return &n, nil
+	case json.Number:
+		n, err := x.Int64()
+		if err != nil {
+			return nil, fmt.Errorf("is %q, want integer", x.String())
+		}
+		return &n, nil
 	case float64:
+		if x != float64(int64(x)) {
+			return nil, fmt.Errorf("is %v, want integer", x)
+		}
 		n := int64(x)
-		return &n
-	case json.Number:
-		if n, err := x.Int64(); err == nil {
-			return &n
-		}
-	}
-	return nil
-}
-
-func mailRuleStringValue(v interface{}) string {
-	switch x := v.(type) {
-	case string:
-		return x
-	case fmt.Stringer:
-		return x.String()
-	case json.Number:
-		return x.String()
+		return &n, nil
 	default:
-		if v == nil {
-			return ""
-		}
-		return fmt.Sprint(v)
+		return nil, fmt.Errorf("is %T, want integer", v)
 	}
 }
 

--- a/shortcuts/mail/mail_rule_reorder.go
+++ b/shortcuts/mail/mail_rule_reorder.go
@@ -234,17 +234,17 @@ func mailRuleSequenceValue(v interface{}) (*int64, error) {
 	case json.Number:
 		n, err := x.Int64()
 		if err != nil {
-			return nil, fmt.Errorf("is %q, want integer", x.String())
+			return nil, fmt.Errorf("is %q, want integer", x.String()) //nolint:forbidigo // intermediate parser detail; caller wraps into typed invalid_response.
 		}
 		return &n, nil
 	case float64:
 		if x != float64(int64(x)) {
-			return nil, fmt.Errorf("is %v, want integer", x)
+			return nil, fmt.Errorf("is %v, want integer", x) //nolint:forbidigo // intermediate parser detail; caller wraps into typed invalid_response.
 		}
 		n := int64(x)
 		return &n, nil
 	default:
-		return nil, fmt.Errorf("is %T, want integer", v)
+		return nil, fmt.Errorf("is %T, want integer", v) //nolint:forbidigo // intermediate parser detail; caller wraps into typed invalid_response.
 	}
 }
 

--- a/shortcuts/mail/mail_rule_reorder_test.go
+++ b/shortcuts/mail/mail_rule_reorder_test.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestBuildMailRuleReorderIDs_PartialFrontSegment(t *testing.T) {
+	got, err := buildMailRuleReorderIDs([]string{"rule_a", "rule_c"}, []mailRuleOrderItem{
+		{ID: "rule_a", Index: 0},
+		{ID: "rule_b", Index: 1},
+		{ID: "rule_c", Index: 2},
+		{ID: "rule_d", Index: 3},
+	})
+	if err != nil {
+		t.Fatalf("buildMailRuleReorderIDs() error = %v", err)
+	}
+	want := []string{"rule_a", "rule_c", "rule_b", "rule_d"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("buildMailRuleReorderIDs() = %v, want %v", got, want)
+	}
+}
+
+func TestBuildMailRuleReorderIDs_FullInputCompatible(t *testing.T) {
+	got, err := buildMailRuleReorderIDs([]string{"rule_b", "rule_a", "rule_c"}, []mailRuleOrderItem{
+		{ID: "rule_a", Index: 0},
+		{ID: "rule_b", Index: 1},
+		{ID: "rule_c", Index: 2},
+	})
+	if err != nil {
+		t.Fatalf("buildMailRuleReorderIDs() error = %v", err)
+	}
+	want := []string{"rule_b", "rule_a", "rule_c"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("buildMailRuleReorderIDs() = %v, want %v", got, want)
+	}
+}
+
+func TestSortMailRulesBySequenceWhenComplete(t *testing.T) {
+	seq3, seq1, seq2 := int64(3), int64(1), int64(2)
+	rules := []mailRuleOrderItem{
+		{ID: "rule_c", Sequence: &seq3, Index: 0},
+		{ID: "rule_a", Sequence: &seq1, Index: 1},
+		{ID: "rule_b", Sequence: &seq2, Index: 2},
+	}
+	sortMailRulesBySequenceWhenComplete(rules)
+	got := []string{rules[0].ID, rules[1].ID, rules[2].ID}
+	want := []string{"rule_a", "rule_b", "rule_c"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("sorted IDs = %v, want %v", got, want)
+	}
+}
+
+func TestMailRuleReorderExecute_SubmitsCompleteRuleIDs(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubMailRuleList(reg, []map[string]interface{}{
+		{"id": "rule_a"},
+		{"id": "rule_b"},
+		{"id": "rule_c"},
+		{"id": "rule_d"},
+	})
+	reorderStub := stubMailRuleReorder(reg, func(body []byte) bool {
+		return bodyHasRuleIDs(t, body, []string{"rule_a", "rule_c", "rule_b", "rule_d"})
+	}, map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "rule_a,rule_c",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(reorderStub.CapturedBody) == 0 {
+		t.Fatal("expected reorder API to be called")
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+	got := interfaceSliceToStrings(data["submitted_rule_ids"].([]interface{}))
+	want := []string{"rule_a", "rule_c", "rule_b", "rule_d"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("submitted_rule_ids = %v, want %v", got, want)
+	}
+}
+
+func TestMailRuleReorderExecute_UnknownIDDoesNotCallReorder(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubMailRuleList(reg, []map[string]interface{}{
+		{"id": "rule_a"},
+		{"id": "rule_b"},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "rule_x",
+	}, f, stdout)
+	requireMailRuleValidation(t, err, "--rule-ids", "unknown rule ID")
+	reg.Verify(t)
+}
+
+func TestMailRuleReorderExecute_ValidationErrorsDoNotCallAPIs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "empty", args: []string{"+rule-reorder"}, want: "at least one rule ID"},
+		{name: "duplicate", args: []string{"+rule-reorder", "--rule-ids", "rule_a,rule_a"}, want: "duplicate"},
+		{name: "blank element", args: []string{"+rule-reorder", "--rule-ids", "rule_a, "}, want: "empty rule ID"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, MailRuleReorder, tt.args, f, stdout)
+			requireMailRuleValidation(t, err, "--rule-ids", tt.want)
+		})
+	}
+}
+
+func TestMailRuleReorderExecute_ListFailureDoesNotCallReorder(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code":   190001,
+			"msg":    "list failed",
+			"log_id": "log-list",
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "rule_a",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected list failure")
+	}
+	if !strings.Contains(err.Error(), "list failed") {
+		t.Fatalf("error = %v, want list failure", err)
+	}
+	reg.Verify(t)
+}
+
+func TestMailRuleReorderExecute_ReorderFailureAddsSubmittedIDsHint(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubMailRuleList(reg, []map[string]interface{}{
+		{"id": "rule_a"},
+		{"id": "rule_b"},
+		{"id": "rule_c"},
+	})
+	stubMailRuleReorder(reg, func(body []byte) bool {
+		return bodyHasRuleIDs(t, body, []string{"rule_b", "rule_a", "rule_c"})
+	}, map[string]interface{}{
+		"code":   190002,
+		"msg":    "rule set changed",
+		"log_id": "log-reorder",
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "rule_b",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected reorder failure")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T", err)
+	}
+	if !strings.Contains(problem.Hint, `submitted_rule_ids=["rule_b","rule_a","rule_c"]`) {
+		t.Fatalf("hint = %q, want submitted_rule_ids context", problem.Hint)
+	}
+}
+
+func stubMailRuleList(reg *httpmock.Registry, rules []map[string]interface{}) *httpmock.Stub {
+	items := make([]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		items = append(items, rule)
+	}
+	stub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{"items": items},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func stubMailRuleReorder(reg *httpmock.Registry, filter func([]byte) bool, body map[string]interface{}) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method:     "POST",
+		URL:        "/user_mailboxes/me/rules/reorder",
+		Body:       body,
+		BodyFilter: filter,
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func bodyHasRuleIDs(t *testing.T, body []byte, want []string) bool {
+	t.Helper()
+	var gotBody map[string]interface{}
+	if err := json.Unmarshal(body, &gotBody); err != nil {
+		t.Fatalf("request body is not JSON: %v; body=%s", err, string(body))
+	}
+	rawIDs, ok := gotBody["rule_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("request body rule_ids = %#v, want array", gotBody["rule_ids"])
+	}
+	got := interfaceSliceToStrings(rawIDs)
+	return equalStringSlices(got, want)
+}
+
+func interfaceSliceToStrings(raw []interface{}) []string {
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		out = append(out, item.(string))
+	}
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func requireMailRuleValidation(t *testing.T, err error, param, contains string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected validation error containing %q, got nil", contains)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if validationErr.Param != param {
+		t.Fatalf("validation Param = %q, want %q", validationErr.Param, param)
+	}
+	if !strings.Contains(err.Error(), contains) {
+		t.Fatalf("validation error = %v, want substring %q", err, contains)
+	}
+}

--- a/shortcuts/mail/mail_rule_reorder_test.go
+++ b/shortcuts/mail/mail_rule_reorder_test.go
@@ -148,6 +148,47 @@ func TestMailRuleReorderExecute_ListFailureDoesNotCallReorder(t *testing.T) {
 	reg.Verify(t)
 }
 
+func TestMailRuleReorderExecute_RejectsMalformedRuleList(t *testing.T) {
+	tests := []struct {
+		name  string
+		items interface{}
+		want  string
+	}{
+		{name: "missing items", items: nil, want: "missing items"},
+		{name: "non-array items", items: "bad", want: "want array"},
+		{name: "non-object rule", items: []interface{}{"bad"}, want: "not an object"},
+		{name: "missing id", items: []interface{}{map[string]interface{}{"sequence": float64(1)}}, want: "id is missing"},
+		{name: "non-string id", items: []interface{}{map[string]interface{}{"id": float64(123)}}, want: "id is json.Number, want string"},
+		{name: "fractional sequence", items: []interface{}{map[string]interface{}{"id": "rule_a", "sequence": float64(1.5)}}, want: `sequence is "1.5", want integer`},
+		{name: "non-numeric sequence", items: []interface{}{map[string]interface{}{"id": "rule_a", "sequence": "1"}}, want: "sequence is string, want integer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, reg := mailShortcutTestFactory(t)
+			data := map[string]interface{}{}
+			if tt.items != nil {
+				data["items"] = tt.items
+			}
+			reg.Register(&httpmock.Stub{
+				Method: "GET",
+				URL:    "/user_mailboxes/me/rules",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "ok",
+					"data": data,
+				},
+			})
+
+			err := runMountedMailShortcut(t, MailRuleReorder, []string{
+				"+rule-reorder",
+				"--rule-ids", "rule_a",
+			}, f, stdout)
+			requireMailRuleInternal(t, err, tt.want)
+			reg.Verify(t)
+		})
+	}
+}
+
 func TestMailRuleReorderExecute_ReorderFailureAddsSubmittedIDsHint(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	stubMailRuleList(reg, []map[string]interface{}{
@@ -247,6 +288,16 @@ func requireMailRuleValidation(t *testing.T, err error, param, contains string) 
 	if err == nil {
 		t.Fatalf("expected validation error containing %q, got nil", contains)
 	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T: %v", err, err)
+	}
+	if problem.Category != errs.CategoryValidation {
+		t.Fatalf("problem Category = %q, want %q", problem.Category, errs.CategoryValidation)
+	}
+	if problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem Subtype = %q, want %q", problem.Subtype, errs.SubtypeInvalidArgument)
+	}
 	var validationErr *errs.ValidationError
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
@@ -256,5 +307,25 @@ func requireMailRuleValidation(t *testing.T, err error, param, contains string) 
 	}
 	if !strings.Contains(err.Error(), contains) {
 		t.Fatalf("validation error = %v, want substring %q", err, contains)
+	}
+}
+
+func requireMailRuleInternal(t *testing.T, err error, contains string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected internal error containing %q, got nil", contains)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T: %v", err, err)
+	}
+	if problem.Category != errs.CategoryInternal {
+		t.Fatalf("problem Category = %q, want %q", problem.Category, errs.CategoryInternal)
+	}
+	if problem.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("problem Subtype = %q, want %q", problem.Subtype, errs.SubtypeInvalidResponse)
+	}
+	if !strings.Contains(err.Error(), contains) {
+		t.Fatalf("internal error = %v, want substring %q", err, contains)
 	}
 }

--- a/shortcuts/mail/shortcuts.go
+++ b/shortcuts/mail/shortcuts.go
@@ -25,6 +25,7 @@ func Shortcuts() []common.Shortcut {
 		MailSendReceipt,
 		MailDeclineReceipt,
 		MailSignature,
+		MailRuleReorder,
 		MailShareToChat,
 		MailTemplateCreate,
 		MailTemplateUpdate,

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -50,7 +50,7 @@
 | 不可逆删除 | `*.delete`、`drafts.delete` | ✅ 必须 |
 | 软删除 | `*.trash`、`*.batch_trash` | ✅ 必须 |
 | 取消定时 | `*.cancel_scheduled_send` | ✅ 必须 |
-| 修改收信规则 | `rules.create` / `update` / `delete` | ✅ 必须 |
+| 修改收信规则 | `rules.create` / `update` / `delete` / `+rule-reorder` | ✅ 必须 |
 | 标签变更 | `*.add_label`、`*.remove_label` | ❌ 可逆，免确认 |
 | 已读状态 | `*.mark_read` / `mark_unread` | ❌ 可逆，免确认 |
 | 移动文件夹 | `*.move` | ❌ 可逆，免确认 |

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -64,7 +64,7 @@ metadata:
 | 不可逆删除 | `*.delete`、`drafts.delete` | ✅ 必须 |
 | 软删除 | `*.trash`、`*.batch_trash` | ✅ 必须 |
 | 取消定时 | `*.cancel_scheduled_send` | ✅ 必须 |
-| 修改收信规则 | `rules.create` / `update` / `delete` | ✅ 必须 |
+| 修改收信规则 | `rules.create` / `update` / `delete` / `+rule-reorder` | ✅ 必须 |
 | 标签变更 | `*.add_label`、`*.remove_label` | ❌ 可逆，免确认 |
 | 已读状态 | `*.mark_read` / `mark_unread` | ❌ 可逆，免确认 |
 | 移动文件夹 | `*.move` | ❌ 可逆，免确认 |
@@ -284,6 +284,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli mail +<verb> [flags]`）�
 | [`+send-receipt`](references/lark-mail-send-receipt.md) | Send a read-receipt reply for an incoming message that requested one (i.e. carries the READ_RECEIPT_REQUEST label). Body is auto-generated (subject / recipient / send time / read time) to match the Lark client's receipt format — callers cannot customize it, matching the industry norm that read-receipt bodies are system-generated templates, not free-form replies. Intended for agent use after the user confirms. |
 | [`+decline-receipt`](references/lark-mail-decline-receipt.md) | Dismiss the read-receipt request banner on an incoming mail by clearing its READ_RECEIPT_REQUEST label, without sending a receipt. Use when the user wants to silence the prompt but refuse to confirm they have read it. Idempotent — safe to re-run. |
 | [`+signature`](references/lark-mail-signature.md) | List or view email signatures with default usage info. |
+| [`+rule-reorder`](references/lark-mail-rules.md) | Reorder mail rules from a partial front segment. The CLI fetches the current full rule list, appends omitted rules in their existing relative order, and submits complete `rule_ids`. |
 | [`+share-to-chat`](references/lark-mail-share-to-chat.md) | Share an email or thread as a card to a Lark IM chat. |
 | [`+template-create`](references/lark-mail-template-create.md) | Create a personal mail template. Scans HTML <img src> local paths (reusing draft inline-image detection), uploads inline images and non-inline attachments to Drive, rewrites HTML to cid: references, and POSTs a Template payload to mail.user_mailbox.templates.create. |
 | [`+template-update`](references/lark-mail-template-update.md) | Update an existing mail template. Supports --inspect (read-only projection), --print-patch-template (prints a JSON skeleton for --patch-file), and flat flags (--set-subject / --set-name / etc). Internally it GETs the template, applies the patch, rewrites <img> local paths to cid: refs, and PUTs a full-replace update (no optimistic locking: last-write-wins). |

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -21,6 +21,23 @@ lark-cli mail user_mailbox.rules delete --as user \
 
 Quick codes above: condition `type=6` = subject, `operator=1` = contains, action `type=3` = mark as read.
 
+## 调整规则顺序
+
+优先使用 `mail +rule-reorder`，它允许只传入要排到最前的一段 `rule_id`，CLI 会先读取当前全部规则，再按“输入顺序 + 未输入规则原顺序”补齐完整 `rule_ids` 后调用 reorder。不要直接把部分 ID 传给原生 `user_mailbox.rules reorder`。
+
+```bash
+# 将 rule_b、rule_a 排到最前，其余规则保持当前相对顺序
+lark-cli mail +rule-reorder --as user \
+  --rule-ids rule_b,rule_a
+```
+
+如果需要确认当前规则 ID，先运行：
+
+```bash
+lark-cli mail user_mailbox.rules list --as user \
+  --params '{"user_mailbox_id":"me"}'
+```
+
 ## 原生 API
 
 收信规则走 `user_mailbox.rules` 资源。参数不确定时先运行：


### PR DESCRIPTION
Adds a mail rule reorder shortcut that accepts a partial ordered list of rule IDs and expands it to the complete mailbox rule order before submitting the reorder request.

Changes include:
- fetch the current mailbox rules before reordering
- validate empty, duplicate, and unknown rule IDs before calling reorder
- preserve the relative order of rules omitted by the user
- surface reorder failures with the submitted full ID list for diagnostics
- add focused tests for validation, request shape, list failure, reorder failure, and full-list compatibility
- document that partial rule ID input is supported by the shortcut


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a mail rule reordering command that moves selected rules to the front while preserving all remaining rules in their existing order.
  - Supports input validation, dry-run previews, structured and human-readable output, and actionable error hints.
  - Requires confirmation before applying changes.

- **Documentation**
  - Added guidance for identifying rule IDs and avoiding incomplete reorder requests.

- **Tests**
  - Added coverage for successful reordering, validation errors, unknown rules, API failures, and partial ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->