### PR TITLE
fix(service): advertise only supported identities in --as help

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -97,7 +97,7 @@ Examples:
 
 	cmd.Flags().StringVar(&opts.Params, "params", "", "query parameters JSON (supports - for stdin, @file for file input)")
 	cmd.Flags().StringVar(&opts.Data, "data", "", "request body JSON (supports - for stdin, @file for file input)")
-	cmdutil.AddAPIIdentityFlag(ctx, cmd, f, &asStr)
+	cmdutil.AddAPIIdentityFlag(ctx, cmd, f, &asStr, nil)
 	cmd.Flags().StringVarP(&opts.Output, "output", "o", "", "output file path for binary responses")
 	cmd.Flags().BoolVar(&opts.PageAll, "page-all", false, "automatically paginate through all pages")
 	cmd.Flags().IntVar(&opts.PageSize, "page-size", 0, "page size (0 = use API default)")

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -287,7 +287,14 @@ func buildMethodCommand(ctx context.Context, f *cmdutil.Factory, spec methodComm
 		}
 		cmd.Flags().StringVar(&opts.Data, "data", "", dataUsage)
 	}
-	cmdutil.AddAPIIdentityFlag(ctx, cmd, f, &asStr)
+	// Advertise only the identities the method's metadata permits; unrestricted
+	// methods keep the default user | bot shape. This keeps --help in sync with
+	// CheckIdentity below (see larksuite/cli#2206).
+	identities := []string(nil)
+	if spec.restricts {
+		identities = spec.identities
+	}
+	cmdutil.AddAPIIdentityFlag(ctx, cmd, f, &asStr, identities)
 	cmd.Flags().StringVarP(&opts.Output, "output", "o", "", "output file path for binary responses")
 	cmd.Flags().BoolVar(&opts.PageAll, "page-all", false, "automatically paginate through all pages")
 	cmd.Flags().IntVar(&opts.PageLimit, "page-limit", 10, "max pages to fetch with --page-all (0 = unlimited)")

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -172,6 +172,49 @@ func TestNewCmdServiceMethod_StrictModeHidesAsFlag(t *testing.T) {
 	}
 }
 
+// Regression for larksuite/cli#2206: a method restricted to a single identity
+// must advertise exactly that identity in --as help, so --help stops promising
+// --as bot on commands that CheckIdentity will refuse at run time.
+func TestNewCmdServiceMethod_RestrictedIdentityAdvertisedInHelp(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	m := meta.FromMap(map[string]interface{}{
+		"description":  "create draft",
+		"httpMethod":   "POST",
+		"accessTokens": []string{"user"},
+	})
+	cmd := NewCmdServiceMethod(f, driveSpec(), m, "create", "user_mailbox.drafts", nil)
+
+	flag := cmd.Flags().Lookup("as")
+	if flag == nil {
+		t.Fatal("expected --as flag to be registered")
+	}
+	wantUsage := "identity type: user"
+	if flag.Usage != wantUsage {
+		t.Errorf("Usage = %q, want %q", flag.Usage, wantUsage)
+	}
+	if strings.Contains(flag.Usage, "bot") {
+		t.Errorf("Usage should not advertise bot for user-only method, got %q", flag.Usage)
+	}
+}
+
+func TestNewCmdServiceMethod_UnrestrictedIdentityAdvertisesBoth(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	m := meta.FromMap(map[string]interface{}{
+		"description": "list",
+		"httpMethod":  "GET",
+	})
+	cmd := NewCmdServiceMethod(f, driveSpec(), m, "list", "files", nil)
+
+	flag := cmd.Flags().Lookup("as")
+	if flag == nil {
+		t.Fatal("expected --as flag to be registered")
+	}
+	wantUsage := "identity type: user | bot"
+	if flag.Usage != wantUsage {
+		t.Errorf("Usage = %q, want %q", flag.Usage, wantUsage)
+	}
+}
+
 // ── NewCmdServiceMethod flags ──
 
 func TestNewCmdServiceMethod_GETHasNoDataFlag(t *testing.T) {

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -74,7 +74,7 @@ func newCmdWhoami(f *cmdutil.Factory, projector *recovery.Projector) *cobra.Comm
 		},
 	}
 	cmdutil.DisableAuthCheck(cmd)
-	cmdutil.AddAPIIdentityFlag(context.Background(), cmd, f, &opts.As)
+	cmdutil.AddAPIIdentityFlag(context.Background(), cmd, f, &opts.As, nil)
 	// Output is always JSON. Accept (and ignore) --json so existing
 	// `whoami --json` callers don't break; hide it to avoid implying a non-JSON
 	// mode exists.

--- a/internal/cmdutil/identity_flag.go
+++ b/internal/cmdutil/identity_flag.go
@@ -12,11 +12,19 @@ import (
 )
 
 // AddAPIIdentityFlag registers the standard --as flag shape used by api/service commands.
-func AddAPIIdentityFlag(ctx context.Context, cmd *cobra.Command, f *Factory, target *string) {
+// supported lists the identities the command permits, rendered in both help and
+// shell completion. A nil slice keeps the unrestricted default shape ("identity
+// type: user | bot"); a non-nil slice (including an empty one) is rendered
+// verbatim so restricted methods stop advertising identities that CheckIdentity
+// will reject (see larksuite/cli#2206).
+func AddAPIIdentityFlag(ctx context.Context, cmd *cobra.Command, f *Factory, target *string, supported []string) {
+	if supported == nil {
+		supported = []string{"user", "bot"}
+	}
 	addIdentityFlag(ctx, cmd, f, target, identityFlagConfig{
 		defaultValue:     "",
-		usage:            "identity type: user | bot",
-		completionValues: []string{"user", "bot"},
+		usage:            "identity type: " + strings.Join(supported, " | "),
+		completionValues: supported,
 	})
 }
 

--- a/internal/cmdutil/identity_flag_test.go
+++ b/internal/cmdutil/identity_flag_test.go
@@ -5,6 +5,7 @@ package cmdutil
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -98,6 +99,44 @@ func TestAddAPIIdentityFlag_BotOnly(t *testing.T) {
 	wantUsage := "identity type: bot"
 	if flag.Usage != wantUsage {
 		t.Errorf("Usage = %q, want %q", flag.Usage, wantUsage)
+	}
+}
+
+// TestAddAPIIdentityFlag_CompletionValues pins the shell completion values to
+// the supported-identity list, including the distinction between nil
+// (unrestricted, user | bot) and a non-nil empty list (no supported identity).
+func TestAddAPIIdentityFlag_CompletionValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		supported []string
+		want      []string
+	}{
+		{name: "unrestricted", supported: nil, want: []string{"user", "bot"}},
+		{name: "user only", supported: []string{"user"}, want: []string{"user"}},
+		{name: "bot only", supported: []string{"bot"}, want: []string{"bot"}},
+		{name: "empty restriction", supported: []string{}, want: []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetFlagCompletionsEnabled(true)
+			t.Cleanup(func() { SetFlagCompletionsEnabled(false) })
+			f, _, _, _ := TestFactory(t, &core.CliConfig{AppID: "a", AppSecret: "s"})
+			cmd := &cobra.Command{Use: "test"}
+
+			AddAPIIdentityFlag(context.Background(), cmd, f, nil, tt.supported)
+
+			fn, ok := cmd.GetFlagCompletionFunc("as")
+			if !ok {
+				t.Fatal("expected --as completion func to be registered")
+			}
+			got, directive := fn(cmd, nil, "")
+			if directive != cobra.ShellCompDirectiveNoFileComp {
+				t.Errorf("directive = %v, want %v", directive, cobra.ShellCompDirectiveNoFileComp)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("completion values = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cmdutil/identity_flag_test.go
+++ b/internal/cmdutil/identity_flag_test.go
@@ -16,7 +16,7 @@ func TestAddAPIIdentityFlag_NonStrictMode(t *testing.T) {
 	f, _, _, _ := TestFactory(t, &core.CliConfig{AppID: "a", AppSecret: "s"})
 	cmd := &cobra.Command{Use: "test"}
 
-	AddAPIIdentityFlag(context.Background(), cmd, f, nil)
+	AddAPIIdentityFlag(context.Background(), cmd, f, nil, nil)
 
 	flag := cmd.Flags().Lookup("as")
 	if flag == nil {
@@ -28,6 +28,10 @@ func TestAddAPIIdentityFlag_NonStrictMode(t *testing.T) {
 	if got := flag.DefValue; got != "" {
 		t.Fatalf("default value = %q, want empty string", got)
 	}
+	wantUsage := "identity type: user | bot"
+	if flag.Usage != wantUsage {
+		t.Errorf("Usage = %q, want %q", flag.Usage, wantUsage)
+	}
 }
 
 func TestAddAPIIdentityFlag_StrictModeHidesFlagAndLocksDefault(t *testing.T) {
@@ -36,7 +40,7 @@ func TestAddAPIIdentityFlag_StrictModeHidesFlagAndLocksDefault(t *testing.T) {
 	})
 	cmd := &cobra.Command{Use: "test"}
 
-	AddAPIIdentityFlag(context.Background(), cmd, f, nil)
+	AddAPIIdentityFlag(context.Background(), cmd, f, nil, nil)
 
 	flag := cmd.Flags().Lookup("as")
 	if flag == nil {
@@ -47,6 +51,53 @@ func TestAddAPIIdentityFlag_StrictModeHidesFlagAndLocksDefault(t *testing.T) {
 	}
 	if got := flag.DefValue; got != "bot" {
 		t.Fatalf("default value = %q, want %q", got, "bot")
+	}
+}
+
+func TestAddAPIIdentityFlag_UserOnly(t *testing.T) {
+	f, _, _, _ := TestFactory(t, &core.CliConfig{AppID: "a", AppSecret: "s"})
+	cmd := &cobra.Command{Use: "test"}
+
+	AddAPIIdentityFlag(context.Background(), cmd, f, nil, []string{"user"})
+
+	flag := cmd.Flags().Lookup("as")
+	if flag == nil {
+		t.Fatal("expected --as flag to be registered")
+	}
+	if flag.Hidden {
+		t.Fatal("expected --as flag to be visible")
+	}
+	if got := flag.DefValue; got != "" {
+		t.Fatalf("default value = %q, want empty string", got)
+	}
+	wantUsage := "identity type: user"
+	if flag.Usage != wantUsage {
+		t.Errorf("Usage = %q, want %q", flag.Usage, wantUsage)
+	}
+	if strings.Contains(flag.Usage, "bot") {
+		t.Errorf("Usage should not advertise bot for user-only command, got %q", flag.Usage)
+	}
+}
+
+func TestAddAPIIdentityFlag_BotOnly(t *testing.T) {
+	f, _, _, _ := TestFactory(t, &core.CliConfig{AppID: "a", AppSecret: "s"})
+	cmd := &cobra.Command{Use: "test"}
+
+	AddAPIIdentityFlag(context.Background(), cmd, f, nil, []string{"bot"})
+
+	flag := cmd.Flags().Lookup("as")
+	if flag == nil {
+		t.Fatal("expected --as flag to be registered")
+	}
+	if flag.Hidden {
+		t.Fatal("expected --as flag to be visible")
+	}
+	if got := flag.DefValue; got != "" {
+		t.Fatalf("default value = %q, want empty string", got)
+	}
+	wantUsage := "identity type: bot"
+	if flag.Usage != wantUsage {
+		t.Errorf("Usage = %q, want %q", flag.Usage, wantUsage)
 	}
 }
 


### PR DESCRIPTION
﻿## Summary
API method commands registered the `--as` flag with a hardcoded "identity type: user | bot" help string even when the method metadata restricts identity (e.g. `mail user_mailbox.drafts create` only supports user). The `--as` help and shell completion are now derived from the method's declared identities, keeping `--help` in sync with the runtime `CheckIdentity` validation.

## Changes
- `internal/cmdutil`: `AddAPIIdentityFlag` accepts a supported-identity list; nil keeps the unrestricted default (`user | bot`), a non-nil slice is rendered verbatim in help and completion.
- `cmd/service`: restricted API method commands pass their declared identities when registering `--as`; unrestricted methods keep the default.
- `cmd/api`, `cmd/whoami`: explicitly keep the unrestricted `user | bot` shape.
- Tests: API identity flag renders user-only/bot-only/default shapes; service-method regression tests cover restricted (user-only) and unrestricted commands.

## Test Plan
- [x] Unit tests pass: `go test ./internal/cmdutil ./cmd/service ./cmd/api ./cmd/whoami`
- [x] `go vet` passes on the affected packages
- [x] `gofmt` clean
- [x] `golangci-lint run --new-from-rev=origin/main` reports 0 issues
- [ ] Manual local verification confirms the `lark-cli mail user_mailbox.drafts create --help` flow shows `identity type: user` only

## Related Issues
- Fixes #2206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Identity selection now reflects the identities supported by each service method.
  * Command help and shell completion display only permitted identity options.

* **Bug Fixes**
  * Prevented unsupported identity types from appearing for restricted methods.
  * Preserved user and bot options for unrestricted commands.

* **Tests**
  * Added coverage for user-only, bot-only, and unrestricted identity configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->