### PR TITLE
docs(lark-im): correct images.create identity label and add files.create entry

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -40,6 +40,7 @@ Chat (oc_xxx)
 - `--as user` means **user identity** and uses `user_access_token`. Calls run as the authorized end user, so permissions depend on both the app scopes and that user's own access to the target chat/message/resource.
 - `--as bot` means **bot identity** and uses `tenant_access_token`. Calls run as the app bot, so behavior depends on the bot's membership, app visibility, availability range, and bot-specific scopes.
 - If an IM API says it supports both `user` and `bot`, the token type changes who the operator is. The same API can succeed with one identity and fail with the other because owner/admin status, chat membership, tenant boundary, or app availability are checked against the current caller.
+- Media upload (`images.create`, `files.create`) follows the caller's identity: UAT when `--as user` (requires `im:resource` on the UAT), TAT when `--as bot`. The `+messages-send` / `+messages-reply` shortcuts upload and send in a single identity — do not split the steps across identities.
 
 ### Sender Name Resolution
 
@@ -190,7 +191,11 @@ lark-cli im <resource> <method> [flags] # 调用 API
 
 ### images
 
-  - `create` — 上传图片。Identity: `bot` only (`tenant_access_token`).
+  - `create` — 上传图片。Identity: supports `user` and `bot`; user identity requires `im:resource` scope on the UAT.
+
+### files
+
+  - `create` — 上传文件。Identity: supports `user` and `bot`; user identity requires `im:resource` scope on the UAT.
 
 ### pins
 
@@ -238,6 +243,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `reactions.list` | `im:message.reactions:read` |
 | `threads.forward` | `im:message` |
 | `images.create` | `im:resource` |
+| `files.create` | `im:resource` |
 | `pins.create` | `im:message.pins:write_only` |
 | `pins.delete` | `im:message.pins:write_only` |
 | `pins.list` | `im:message.pins:read` |


### PR DESCRIPTION
﻿## Summary
The `lark-im` SKILL.md API table marked `images.create` as bot-only (`tenant_access_token`), but user identity with the `im:resource` scope can upload and send media. This PR corrects the identity annotation and fills in the missing `files.create` entry.

## Changes
- `images.create` identity changed from `bot only` to `supports user and bot`, noting the `im:resource` scope requirement on the UAT.
- Added `files.create` entry under a new `### files` section with the same identity annotation.
- Added a media-upload identity note to the Identity and Token Mapping section: upload follows the caller's identity, and `+messages-send` / `+messages-reply` upload and send in a single identity.
- Added `files.create` (`im:resource`) to the scope table.

## Test Plan
- [x] `node scripts/skill-format-check/index.js` passes
- [x] Verified the corrected annotations are consistent with `references/lark-im-messages-send.md` and `references/lark-im-messages-reply.md`, which already state both upload and send steps use the same identity
- [ ] Manual local verification: `lark-cli im +messages-send --chat-id oc_xxx --as user --image ./test.png` uploads and sends as user

## Related Issues
- Fixes #2173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media uploads now support both user and bot identities.
  * File uploads are now documented alongside image uploads.
  * Combined message send/reply shortcuts preserve the caller’s identity.

* **Documentation**
  * Added guidance on required permissions for user media uploads and file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->