### PR TITLE
docs: improve agent contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ version metadata and the embedded service catalog. It, `make vet`,
 the ignored `internal/registry/meta_data.json` is absent and the first run needs
 access to `open.feishu.cn`; a valid existing file is reused.
 `LARKSUITE_CLI_REMOTE_META=off` does not disable this build-time fetch.
-`make live-skills-test` also needs Node/npm, may use `npx`, and needs network.
+`make live-skills-test` requires working `npx` and network access.
 
 If the fetch fails before Go starts, report the missing Python or network
 prerequisite instead of changing product code or generated metadata. `go build .`
@@ -193,13 +193,15 @@ run the focused source test and verify changed paths/symbols directly.
 `make test` currently leaves root binaries `audit-observer` and `readonly-policy`; do not stage them.
 
 Before a Go PR, run `make unit-test`, `make vet`, and `make fmt-check`;
-`go mod tidy` must leave module files unchanged. Then run the CI checks:
+`go mod tidy` must leave module files unchanged. Set
+`QUALITY_GATE_CHANGED_FROM` to the PR base before diff-scoped checks. Pinned
+`go run module@version` commands need module access unless cached.
 
 ```bash
 go mod tidy
 git diff --exit-code -- go.mod go.sum
-go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main
-go run -C lint . --changed-from origin/main ..
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev="$QUALITY_GATE_CHANGED_FROM"
+go run -C lint . --changed-from "$QUALITY_GATE_CHANGED_FROM" ..
 go test -C lint ./... -count=1
 go run github.com/google/go-licenses/v2@v2.0.1 check ./... --disallowed_types=forbidden,restricted,reciprocal,unknown
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,159 +1,221 @@
 # AGENTS.md
 
-## Goal (pick one per PR)
+## Purpose
 
-- Make CLI better: improve UX, error messages, help text, flags, and output clarity.
-- Improve reliability: fix bugs, edge cases, and regressions with tests.
-- Improve developer velocity: simplify code paths, reduce complexity, keep behavior explicit.
-- Improve quality gates: strengthen tests/lint/checks without adding heavy process.
+`lark-cli` is the official Lark/Feishu CLI for humans and AI agents. Optimize
+for predictable machine-readable behavior without making the human CLI worse.
 
-## Build & Test
+Keep each PR focused on one goal: CLI UX, reliability, simpler explicit code,
+or a useful gate. Done means the correct implementation surface, preserved
+contracts unless a break was requested, and reported checks.
+
+Public behavior, tests, lint, and CI define current contracts. Existing code is
+evidence, but a legacy exception is not precedent; `Proposal` documents are
+direction only. Do not mix unrelated cleanup, hand-edit generated files, weaken
+gates, or broaden allowlists to make CI pass.
+
+## Implementation Discipline
+
+Use this sequence for product behavior or enforcement changes:
+
+1. Establish the current contract and owner before choosing a solution. Trace the
+   flow from the command or shortcut through runtime and internal owners to wire
+   output; inspect affected callers and tests, then choose the surface below.
+2. Apply YAGNI to scope. Implement the behavior required now; do not add
+   speculative modes, configuration, compatibility paths, extension points, or
+   scaffolding.
+3. Reuse the project's existing machinery before creating a parallel path.
+   Prefer the owning generic, runtime, or internal surface, then the Go standard
+   library or an existing dependency, while preserving the contracts below.
+4. Fix the root cause at the narrowest cohesive boundary shared by affected
+   callers. Keep command and domain policy at the caller unless there is a real
+   cross-command invariant for an internal owner to enforce.
+5. Ship the smallest complete change: implementation, a revert-failing regression
+   test for behavior or enforcement, and required contract or guidance updates.
+
+Optimize for minimum owned complexity, not minimum diff or line count. A correct
+root-cause fix may touch the owner, callers, tests, and docs; a one-line workaround
+at the wrong layer is not simpler. Prefer deletion and boring explicit code, and
+avoid one-use abstractions or new dependencies for straightforward behavior.
+
+YAGNI never overrides explicit requirements or output, error, path, security,
+compatibility, and data-safety contracts. If a deliberately limited solution has
+a real ceiling, document the ceiling and the concrete condition for expanding it
+at the decision point.
+
+## Build
+
+Run `make build` for the canonical local build; it writes `./lark-cli` with
+version metadata and the embedded service catalog. It, `make vet`,
+`make unit-test`, `make live-skills-test`, and dependent targets first run
+`python3 scripts/fetch_meta.py`, so Python 3 is required. On a clean checkout,
+the ignored `internal/registry/meta_data.json` is absent and the first run needs
+access to `open.feishu.cn`; a valid existing file is reused.
+`LARKSUITE_CLI_REMOTE_META=off` does not disable this build-time fetch.
+`make live-skills-test` also needs Node/npm, may use `npx`, and needs network.
+
+If the fetch fails before Go starts, report the missing Python or network
+prerequisite instead of changing product code or generated metadata. `go build .`
+may compile against the tracked empty fallback metadata, but that is only a
+degraded compile check without the full service catalog.
+
+## Choose the Correct Surface
+
+| Need | Implement in | Rule |
+|------|--------------|------|
+| Agent/human-friendly workflow, composition, or smart defaults | `shortcuts/<domain>/` via `common.Shortcut` | Must add UX or workflow value beyond exposing one endpoint. |
+| One-to-one supported OpenAPI method | Upstream service metadata + generic `cmd/service/` machinery | Verify it with `schema` after the canonical metadata fetch. `internal/registry/meta_data.json` is generated and ignored; never hand-edit it or add a shortcut merely to expose a missing catalog method. |
+| Arbitrary OpenAPI endpoint | Generic `cmd/api/` machinery | Keep it endpoint-agnostic. |
+| Auth, config, profile, update, or CLI lifecycle | `cmd/<area>/` plus the owning shared/internal package | Keep new Cobra code as wiring when a lower owner exists. |
+| EventKey, payload shape, or domain projection | `events/<domain>/` | Shared event mechanics stay in `internal/event/`; CLI assembly stays in `cmd/event/`. |
+| Command-independent mechanism or cross-command invariant | Owning `internal/<area>/` package | Keep UX/domain policy at the caller; use a cohesive owner, not a generic utils package. Test the owner and affected caller contracts. |
+| Public plugin or host integration | `extension/` | Exported symbols are compatibility commitments; orchestration stays internal. |
+| Per-command decision guidance: when, avoid, prerequisites, tips, or examples | `affordance/<domain>.md` | Enrich `--help` and `schema` without restating command descriptions, flags, or field schemas. |
+| Domain routing, concepts, safety, or cross-command agent workflow | `skills/<name>/SKILL.md` and `references/` | Keep always-needed decisions in `SKILL.md`, conditional HOW in references, and link commands from affordance. |
+
+Do not duplicate one command surface inside another. Register new shortcuts in
+the domain's `Shortcuts()`; declare risk, identities/scopes, flags, and dry-run.
+
+## Hard Contracts
+
+Read the [JSON output contract](README.md#json-output-contract) before changing
+wire output. Read the [source guard guide](lint/README.md) and `.golangci.yml`
+before changing or waiving enforcement.
+
+- Command/flag semantics, help/schema metadata, output placement and shapes,
+  errors, exit codes, risk/identity, and exported APIs are compatibility contracts.
+  When forwarding or echoing accepted input, preserve it verbatim unless its
+  contract defines normalization; never silently substitute another behavior.
+- Success data goes to stdout; typed failure envelopes, progress, warnings, and
+  hints go to stderr. Predicate/self-contained results and partial failures are
+  documented exceptions whose complete result remains on stdout.
+- Keep new or touched Cobra code as wiring. Lark/Feishu API calls in shortcuts go
+  through `*common.RuntimeContext`; direct HTTP is only for non-gateway protocols
+  such as presigned storage and requires a precise `//nolint:forbidigo` reason.
+- Keep user/workspace FileIO invocation-scoped: use `runtime.FileIO()`,
+  `runtime.ValidatePath()`, and `runtime.ResolveSavePath()` so portable commands do
+  not assume a local host or process working directory.
+- Shortcuts do not use `internal/vfs` for user/workspace files. A narrow
+  `//nolint:depguard` waiver is allowed only for CLI-owned state or explicitly
+  CLI-managed host configuration; explain that ownership boundary. Other internal
+  filesystem code uses `internal/vfs` and validates paths.
+- If FileIO lacks a host-local tree operation, prefer an owning `internal/` package
+  or optional capability. Direct `os` calls require a stated local-only boundary,
+  validated and bounded paths, and a precise `//nolint:forbidigo` reason.
+- Do not hardcode resolver-owned hosts. At new API boundaries, or when changed
+  behavior consumes fields from a loose map, project that shape into a typed
+  struct before downstream use. Extend published interfaces through optional
+  interfaces rather than breaking external implementations.
+- Source guards enforce raw HTTP/os/vfs, resolver-host, and migrated-error
+  constructs; other semantics rely on tests and review. Every exemption must be
+  narrow, local, and explain why the safe path does not apply.
+
+## Structured Errors
+
+Before changing a command failure, taxonomy, or error wire field, read the
+[error contract](errs/ERROR_CONTRACT.md); it owns constructor selection, wrapping,
+extension fields, stability, and CI guards.
+
+- Command-facing failures use typed `errs.*` unless the error contract defines
+  an output-control exception. Never return a final plain `fmt.Errorf` /
+  `errors.New` or ad hoc envelope; pass typed errors through and preserve causes.
+- Lark API failures use a domain typed wrapper, `runtime.CallAPITyped`, or
+  `runtime.DoAPIJSONTyped`; raw callers use `runtime.ClassifyAPIResponse` or
+  `errclass.BuildAPIError`.
+- `param` names only failing user input; recovery belongs in `hint`. Populate
+  `missing_scopes`, `log_id`, and similar fields only from known runtime evidence.
+- Error tests assert typed metadata and cause preservation, not message text alone.
+
+## Affordance and Skills
+
+Before editing command guidance, read the [affordance guide](affordance/README.md).
+For plugin distributions, read [Ship skills and command guidance](extension/platform/README.md#ship-skills-and-command-guidance).
+
+- Go metadata/schema owns WHAT; affordance owns command-level WHEN; `SKILL.md`
+  owns domain routing, concepts, safety, and cross-command workflows; `references/`
+  owns detailed or conditional HOW.
+- Do not duplicate canonical descriptions, schemas, or generic error taxonomy.
+  Keep workflow-specific recovery in a skill when it changes agent behavior;
+  affordance examples remain runnable, current, and safe.
+- Skill frontmatter `description` is a concise WHAT/WHEN/NOT routing trigger. Keep
+  always-needed decisions in `SKILL.md`; move conditional detail to `references/`.
+- Skill names and reference paths are public pointers. Every path reachable from
+  shipped docs must ship. Before referencing a new content directory, update
+  `content_embed.go` and add an embedded-FS reachability test; `assets/` and
+  `scripts/` stay source-only unless the distribution contract changes.
+
+## Tests
+
+- Every behavior change needs a nearby test that fails if the implementation is
+  reverted; assert fields, requests, typed errors, or side effects directly.
+- Command/shortcut tests needing a Factory use `cmdutil.TestFactory(t, config)`;
+  isolate config with
+  `t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())`.
+- Tests must not depend on developer profiles, keychains, home directories,
+  execution order, or real credentials unless explicitly live.
+- Live E2E flows are self-contained: create, use, and clean up even after failure.
+
+| Shortcut change | Dry-run E2E | Live E2E |
+|-----------------|:-----------:|:--------:|
+| New shortcut | Required | Required |
+| Flags or request params | Required | Required if behavior changes |
+| Bug fix | Required | Required when risk reaches the API boundary |
+| Internal refactor, no behavior change | Not needed | Not needed |
+
+Dry-run tests use placeholder credentials and assert method, URL, params, and
+body without a real API call. Confirm contracts with `--help` and `schema` first.
+If no deterministic, cleanable live flow exists, do not leak tenant state or add
+a flaky test; document the blocker, fixture conditions, and substitute evidence.
+
+## Validation
+
+Run the narrowest useful check while iterating, then broaden with risk:
+
+| Change | Checks |
+|--------|--------|
+| Go package | `go test ./path/to/package/...`, then the pre-PR Go checks below |
+| Broad/cross-cutting | `make test` |
+| Committed command/help/schema surface | `make quality-gate` |
+| Skills | `node scripts/skill-format-check/index.js`, then `make quality-gate` after committing the change |
+| Affordance | Add/update `internal/affordance/*_source_test.go`; run `go test ./internal/affordance ./cmd/service ./internal/schema` |
+| Make-covered scripts/workflows | `make script-test` |
+| Public plugin SDK | `make examples-build` plus relevant `tests/plugin_e2e` |
+| Auth sidecar | `make sidecar-test` |
+| Skills sync behavior | `make live-skills-test` |
+| Dependencies | `go mod tidy` plus the CI `go-licenses` check |
+
+`make quality-gate` and diff-scoped linters compare the base with `HEAD`; they
+ignore staged, unstaged, and untracked changes, so run them after committing.
+Some skill-quality signals are warnings; frontmatter has the separate hard check
+above. The gate does not validate affordance examples or references in this file:
+run the focused source test and verify changed paths/symbols directly.
+
+`make test` currently leaves root binaries `audit-observer` and `readonly-policy`; do not stage them.
+
+Before a Go PR, run `make unit-test`, `make vet`, and `make fmt-check`;
+`go mod tidy` must leave module files unchanged. Then run the CI checks:
 
 ```bash
-make build             # Build (runs fetch_meta first)
-make unit-test         # Required before PR (runs with -race where supported, e.g. amd64/arm64)
-make live-skills-test  # Opt-in real Skills CLI tests; runs with isolated user directories
-make test              # Full: vet + unit + integration
+go mod tidy
+git diff --exit-code -- go.mod go.sum
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main
+go run -C lint . --changed-from origin/main ..
+go test -C lint ./... -count=1
+go run github.com/google/go-licenses/v2@v2.0.1 check ./... --disallowed_types=forbidden,restricted,reciprocal,unknown
 ```
 
-## Notification Opt-Outs
+CI is authoritative; state exactly which relevant checks were not run.
 
-`lark-cli` emits two notice types into JSON envelope `_notice` to nudge AI agents toward fixes:
+## Maintaining This File
 
-- `_notice.update` — a newer binary is available on npm
-- `_notice.skills` — locally installed skills are out of sync with the running binary
+Add a root rule only when it is repository-specific, non-obvious, actionable,
+and prevents a recurring failure or high-impact contract breach. Prefer code,
+tests, or CI for mechanizable constraints; keep only rationale and safe exceptions
+here. Update named references in the same PR, and delete or move stale, obvious,
+redundant, task-local, or fully enforced rules. Each edit should reduce ambiguity,
+not only add text.
 
-To suppress them in non-CI scripts (CI envs are auto-skipped):
+## Commit and PR
 
-| Env var | Effect |
-|---------|--------|
-| `LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1` | Suppress `_notice.update` |
-| `LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1` | Suppress `_notice.skills` |
-
-Both notices recommend the same fix command: `lark-cli update`. The skills notice's `current` field is `""` when skills have never been synced (cold start) and a version string when synced for an older binary (drift).
-
-## Pre-PR Checks (match CI gates)
-
-1. `make unit-test`
-2. `go vet ./...`
-3. `gofmt -l .` — must produce no output
-4. `go mod tidy` — must not change `go.mod`/`go.sum`
-5. `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
-6. If dependencies changed: `go run github.com/google/go-licenses/v2@v2.0.1 check ./... --disallowed_types=forbidden,restricted,reciprocal,unknown`
-
-## Commit & PR
-
-- Conventional Commits in English: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`
-- PR title in the same format. Fill `.github/pull_request_template.md` completely.
-- Never commit secrets, tokens, or internal sensitive data.
-
-## Source Layout
-
-| Path | What it does |
-|------|-------------|
-| `cmd/root.go` | Entry point, command registration, strict mode pruning |
-| `cmd/profile/` | Multi-profile management (add/list/use/rename/remove) |
-| `cmd/config/` | Config init, show, strict-mode |
-| `cmd/service/` | Auto-registered API commands from embedded metadata |
-| `shortcuts/common/runner.go` | Shortcut execution pipeline, Flag.Input (@file/stdin) resolution |
-| `shortcuts/` | Domain-specific shortcut implementations |
-| `internal/cmdutil/factory.go` | Factory pattern — identity resolution, credential, config |
-| `internal/cmdutil/factory_default.go` | Production factory wiring |
-| `internal/credential/` | Credential provider chain (extension → default) |
-| `extension/credential/` | Plugin-facing credential interfaces and env provider |
-| `internal/client/client.go` | APIClient: DoSDKRequest, DoStream |
-| `internal/core/config.go` | Multi-profile config loading/saving |
-| `internal/vfs/` | Filesystem abstraction (use `vfs.*` instead of `os.*`) |
-| `internal/validate/path.go` | Path safety validation |
-
-## Who Uses This CLI
-
-This CLI's primary consumers include AI agents (Claude Code, Cursor, Gemini CLI). Your code is read by machines — error messages, output format, and flag design all directly affect agent success rates.
-
-The one rule to internalize: **every error message you write will be parsed by an AI to decide its next action.** Make errors structured, actionable, and specific.
-
-## Code Conventions
-
-### Structured errors in commands
-
-Command-facing failures must be typed `errs.*` errors — never the legacy `output.Err*` helpers and never a final bare `fmt.Errorf`. AI agents parse the stderr envelope's `type` / `subtype` / `param` / `hint` fields to decide their next action; the full taxonomy lives in `errs/ERROR_CONTRACT.md`.
-
-Picking a constructor:
-
-| Failure | Constructor |
-|---------|-------------|
-| User flag/arg fails validation | `errs.NewValidationError(errs.SubtypeInvalidArgument, ...).WithParam("--flag")` |
-| Valid request, wrong system state | `errs.NewValidationError(errs.SubtypeFailedPrecondition, ...).WithHint(...)` |
-| Lark API returned `code != 0` | `runtime.CallAPITyped` (shortcuts) / `errclass.BuildAPIError` (raw responses) — never hand-build |
-| Network / transport failure | `errs.NewNetworkError(errs.SubtypeNetworkTransport, ...)` |
-| Local file I/O failure | `errs.NewInternalError(errs.SubtypeFileIO, ...)` — validate the path first (`validate.SafeInputPath` / `SafeOutputPath`) and use `vfs.*` |
-| Unclassified lower-layer error as final | `errs.NewInternalError(errs.SubtypeUnknown, ...).WithCause(err)` |
-| Lower layer already returned a typed error | pass it through unchanged — re-wrapping downgrades its classification |
-
-Signatures that are easy to guess wrong:
-
-- `runtime.CallAPITyped(method, url string, params map[string]interface{}, data interface{}) (map[string]interface{}, error)` — it performs the HTTP request itself and classifies `code != 0` into a typed error; just return the error it gives you.
-- Typed pass-through check: `if _, ok := errs.ProblemOf(err); ok { return err }` — `ProblemOf` returns `(*errs.Problem, bool)`, not a nilable pointer.
-- `.WithParam` exists only on `*errs.ValidationError`. `InternalError` / `NetworkError` have no param field — file or endpoint context goes in the message or `.WithHint(...)`.
-
-`forbidigo` + `lint/errscontract` reject the legacy `output.Err*` helpers, bare final `fmt.Errorf` / `errors.New`, and legacy envelope literals on migrated paths. Beyond what lint catches, three authoring conventions apply:
-
-- Preserve the underlying error with `.WithCause(err)` so `errors.Is` / `errors.Unwrap` keep working.
-- `param` names only the user input that actually failed. Recovery guidance goes in `.WithHint(...)`; machine-readable recovery fields (`missing_scopes`, `log_id`) carry server/system ground truth only — never caller-side guesses.
-- Error-path tests assert typed metadata via `errs.ProblemOf` (`category` / `subtype` / `param`) and cause preservation, not message substrings alone.
-
-### stdout is data, stderr is everything else
-
-Program output (JSON envelopes) goes to stdout. Progress, warnings, hints go to stderr. Mixing them corrupts pipe chains.
-
-### Typed data over loose maps
-
-Parse `map[string]interface{}` into a typed struct at the boundary — one projection function per shape — and let everything downstream consume struct fields, not string keys. A typo'd map key compiles fine and fails at runtime, which an agent then debugs blind.
-
-Use distinct types when two values could be swapped silently: see `internal/meta.Token` — a bare string compiles on either side of a string/string signature, a distinct type does not.
-
-Legacy loose-map code exists in older paths. Match its call sites when touching it, but do not copy the pattern into new code.
-
-### Transcribe faithfully — no silent fallbacks
-
-When code echoes input onward (request previews, transformations, proxies), transcribe verbatim. A `default:` branch that coerces unrecognized input into a plausible value ("unknown HTTP verb → GET") makes the output lie, and an agent reasons from the lie.
-
-The same rule applies to flag combinations and internal wiring: if a requested option cannot be honored, return a typed validation error — never silently substitute another behavior and exit 0. Silent guesses (defaulting a missing identity, discarding writes on a nil writer) are bugs even when every current caller happens to avoid them.
-
-### Use `vfs.*` instead of `os.*`
-
-All filesystem access goes through `internal/vfs`. This enables test mocking.
-
-### Validate paths before reading
-
-CLI arguments are untrusted (they come from AI agents). Call `validate.SafeInputPath` before any file I/O.
-
-### Tests
-
-- Every behavior change needs a test alongside the change.
-- A contract test must fail if the implementation is reverted. If you can undo the code change and the suite stays green, the contract is not pinned — assert the new field/behavior directly, not a happy-path substring.
-- `cmdutil.TestFactory(t, config)` for test factories.
-- `t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())` to isolate config state.
-
-### E2E Testing
-
-**Dry-run E2E (required for every shortcut change)**
-- Validates request structure without calling real APIs
-- Place in `tests/cli_e2e/dryrun/` or the corresponding domain directory
-- Set env vars `LARKSUITE_CLI_APP_ID`/`APP_SECRET`/`BRAND`, use `--dry-run`, assert method/URL/params
-- No secrets needed — runs on fork PRs
-- Explore correct params with `lark-cli <domain> --help` and `lark-cli schema` first
-
-**Live E2E (required for new flows or behavior changes)**
-- Validates real API round-trips
-- Place in `tests/cli_e2e/<domain>/`
-- Must be self-contained: create -> use -> cleanup
-- Needs bot credentials (CI secrets, skipped on fork PRs)
-- Reference: `tests/cli_e2e/task/task_status_workflow_test.go`
-
-| Change | Dry-run E2E | Live E2E |
-|--------|:-----------:|:--------:|
-| New shortcut | Required | Required |
-| Modify shortcut flags/params | Required | If behavior changes |
-| Shortcut bug fix | Required | If regression risk |
-| Internal refactor (no shortcut impact) | Not needed | Not needed |
+Use English Conventional Commits/PR titles, complete the PR template, and never
+commit secrets, tokens, internal endpoints, or sensitive test data.


### PR DESCRIPTION
## Summary

Rework the root `AGENTS.md` into concise, project-specific guidance that helps coding agents choose the correct implementation owner, preserve CLI contracts, and validate changes without mistaking environment failures for product bugs.

## Changes

- Add the project's implementation discipline, including YAGNI, root-cause ownership, and the command/shortcut/internal/extension/affordance/skill routing table.
- Document non-obvious build prerequisites and generated metadata behavior, plus the real FileIO/vfs/os, output, and structured-error boundaries.
- Clarify affordance and skill progressive disclosure, E2E expectations, diff-scoped quality-gate limitations, and maintenance criteria for future root rules.

## Test Plan

- [x] `git diff --check origin/main...HEAD`
- [x] Verified referenced files, Markdown anchors, Make targets, and named Go symbols.
- [x] Scanned the final document for credentials, tokens, private network data, internal domains, local user paths, and sensitive test data; no matches.
- [ ] Unit tests pass — not run because this is a documentation-only change and canonical test targets first fetch remote metadata.
- [ ] Manual local `lark-cli <domain> <command>` verification — not applicable; runtime behavior is unchanged.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reworked project guidance for implementation practices, build prerequisites, testing, validation, and documentation maintenance.
  - Added guidance for API and file handling, structured errors, output behavior, generated metadata, end-to-end coverage, and CI checks.
  - Refined commit quality and isolated testing requirements to support more reliable contributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->