### PR TITLE
fix: complete mail rule reorder ids

### DIFF
--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+)
+
+const mailRulesReorderSchemaPath = "mail.user_mailbox.rules.reorder"
+
+func isMailRulesReorder(opts *ServiceMethodOptions) bool {
+	return opts != nil && opts.SchemaPath == mailRulesReorderSchemaPath
+}
+
+func completeMailRulesReorderRequest(ctx context.Context, ac *client.APIClient, opts *ServiceMethodOptions, request *client.RawApiRequest) error {
+	if !isMailRulesReorder(opts) {
+		return nil
+	}
+
+	requestedIDs, key, ok, err := mailRulesRequestedIDs(request.Data)
+	if err != nil {
+		return err
+	}
+	if !ok || len(requestedIDs) == 0 {
+		return nil
+	}
+	if duplicates := duplicateStrings(requestedIDs); len(duplicates) > 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"duplicate mail rule id(s): %s", strings.Join(duplicates, ", ")).
+			WithParam(key)
+	}
+
+	currentIDs, err := fetchCurrentMailRuleIDs(ctx, ac, *request)
+	if err != nil {
+		return err
+	}
+	completedIDs, unknown := completeMailRuleIDs(requestedIDs, currentIDs)
+	if len(unknown) > 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"unknown mail rule id(s): %s", strings.Join(unknown, ", ")).
+			WithParam(key).
+			WithHint("run: lark-cli mail user_mailbox.rules list --params '{\"user_mailbox_id\":\"<mailbox>\"}', then retry reorder with existing rule IDs")
+	}
+
+	body := request.Data.(map[string]interface{})
+	body[key] = completedIDs
+	return nil
+}
+
+func mailRulesRequestedIDs(data interface{}) ([]string, string, bool, error) {
+	body, ok := data.(map[string]interface{})
+	if !ok || body == nil {
+		return nil, "", false, nil
+	}
+	for _, key := range []string{"rule_ids", "ruleIds"} {
+		raw, ok := body[key]
+		if !ok {
+			continue
+		}
+		ids, err := stringList(raw)
+		if err != nil {
+			return nil, key, true, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"%s must be an array of rule ID strings", key).
+				WithParam(key).
+				WithCause(err)
+		}
+		return ids, key, true, nil
+	}
+	return nil, "", false, nil
+}
+
+func stringList(raw interface{}) ([]string, error) {
+	switch v := raw.(type) {
+	case []string:
+		return append([]string(nil), v...), nil
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("item %d is %T", i, item)
+			}
+			out = append(out, strings.TrimSpace(s))
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("value is %T", raw)
+	}
+}
+
+func duplicateStrings(values []string) []string {
+	seen := map[string]bool{}
+	dups := map[string]bool{}
+	var ordered []string
+	for _, value := range values {
+		if seen[value] {
+			if !dups[value] {
+				dups[value] = true
+				ordered = append(ordered, value)
+			}
+			continue
+		}
+		seen[value] = true
+	}
+	return ordered
+}
+
+func fetchCurrentMailRuleIDs(ctx context.Context, ac *client.APIClient, request client.RawApiRequest) ([]string, error) {
+	listURL, ok := strings.CutSuffix(request.URL, "/reorder")
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeUnknown,
+			"mail rules reorder URL does not end with /reorder: %s", request.URL)
+	}
+	params := map[string]interface{}{}
+	for k, v := range request.Params {
+		params[k] = v
+	}
+	if _, ok := params["page_size"]; !ok {
+		params["page_size"] = 100
+	}
+	result, err := ac.PaginateAll(ctx, client.RawApiRequest{
+		Method: "GET",
+		URL:    listURL,
+		Params: params,
+		As:     request.As,
+	}, client.PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: request.As})
+	if err != nil {
+		return nil, withMailRuleListHint(err)
+	}
+	if err := ac.CheckResponse(result, request.As); err != nil {
+		return nil, withMailRuleListHint(err)
+	}
+	return mailRuleIDsFromListResult(result), nil
+}
+
+func mailRuleIDsFromListResult(result interface{}) []string {
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	data, ok := resultMap["data"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	arrayField := output.FindArrayField(data)
+	if arrayField == "" {
+		for _, key := range []string{"rules", "rule_list", "items"} {
+			if _, ok := data[key]; ok {
+				arrayField = key
+				break
+			}
+		}
+	}
+	items, ok := data[arrayField].([]interface{})
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"rule_id", "id", "ruleId"} {
+			if id, ok := m[key].(string); ok && id != "" {
+				ids = append(ids, id)
+				break
+			}
+		}
+	}
+	return ids
+}
+
+func completeMailRuleIDs(requestedIDs, currentIDs []string) ([]string, []string) {
+	current := map[string]bool{}
+	for _, id := range currentIDs {
+		current[id] = true
+	}
+	requested := map[string]bool{}
+	var unknown []string
+	for _, id := range requestedIDs {
+		requested[id] = true
+		if !current[id] {
+			unknown = append(unknown, id)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, unknown
+	}
+	completed := append([]string(nil), requestedIDs...)
+	for _, id := range currentIDs {
+		if !requested[id] {
+			completed = append(completed, id)
+		}
+	}
+	return completed, nil
+}
+
+func withMailRuleListHint(err error) error {
+	return withMailRuleHint(err, "could not fetch the complete mail rule list; reorder was not called")
+}
+
+func withMailRuleReorderHint(err error) error {
+	return withMailRuleHint(err, "mail rules may have changed; run lark-cli mail user_mailbox.rules list again, then retry reorder")
+}
+
+func withMailRuleHint(err error, hint string) error {
+	switch e := err.(type) {
+	case *errs.ValidationError:
+		return e.WithHint(hint)
+	case *errs.AuthenticationError:
+		return e.WithHint(hint)
+	case *errs.PermissionError:
+		return e.WithHint(hint)
+	case *errs.ConfigError:
+		return e.WithHint(hint)
+	case *errs.NetworkError:
+		return e.WithHint(hint)
+	case *errs.APIError:
+		return e.WithHint(hint)
+	case *errs.SecurityPolicyError:
+		return e.WithHint(hint)
+	case *errs.ContentSafetyError:
+		return e.WithHint(hint)
+	case *errs.InternalError:
+		return e.WithHint(hint)
+	case *errs.ConfirmationRequiredError:
+		return e.WithHint(hint)
+	default:
+		return err
+	}
+}
+
+func mailRulesReorderCheckResponse(ac *client.APIClient, result interface{}, identity core.Identity) error {
+	if err := ac.CheckResponse(result, identity); err != nil {
+		return withMailRuleReorderHint(err)
+	}
+	return nil
+}

--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -29,7 +30,7 @@ func completeMailRulesReorderRequest(ctx context.Context, ac *client.APIClient, 
 	if err != nil {
 		return err
 	}
-	if !ok || len(requestedIDs) == 0 {
+	if !ok {
 		return nil
 	}
 	if duplicates := duplicateStrings(requestedIDs); len(duplicates) > 0 {
@@ -42,16 +43,27 @@ func completeMailRulesReorderRequest(ctx context.Context, ac *client.APIClient, 
 	if err != nil {
 		return err
 	}
-	completedIDs, unknown := completeMailRuleIDs(requestedIDs, currentIDs)
-	if len(unknown) > 0 {
+	completion := completeMailRuleIDs(requestedIDs, currentIDs)
+	if len(completion.unknown) > 0 {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument,
-			"unknown mail rule id(s): %s", strings.Join(unknown, ", ")).
+			"unknown mail rule id(s): %s", strings.Join(completion.unknown, ", ")).
 			WithParam(key).
 			WithHint("run: lark-cli mail user_mailbox.rules list --params '{\"user_mailbox_id\":\"<mailbox>\"}', then retry reorder with existing rule IDs")
 	}
+	if len(completion.ambiguous) > 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"ambiguous mail rule id prefix(es): %s", strings.Join(completion.ambiguous, "; ")).
+			WithParam(key).
+			WithHint("use a longer rule ID prefix or the full rule ID")
+	}
+	if duplicates := duplicateStrings(completion.resolved); len(duplicates) > 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"duplicate mail rule id(s): %s", strings.Join(duplicates, ", ")).
+			WithParam(key)
+	}
 
 	body := request.Data.(map[string]interface{})
-	body[key] = completedIDs
+	body[key] = completion.completed
 	return nil
 }
 
@@ -86,13 +98,13 @@ func stringList(raw interface{}) ([]string, error) {
 		for i, item := range v {
 			s, ok := item.(string)
 			if !ok {
-				return nil, fmt.Errorf("item %d is %T", i, item)
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "item %d is %T", i, item)
 			}
-			out = append(out, strings.TrimSpace(s))
+			out = append(out, s)
 		}
 		return out, nil
 	default:
-		return nil, fmt.Errorf("value is %T", raw)
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "value is %T", raw)
 	}
 }
 
@@ -179,29 +191,61 @@ func mailRuleIDsFromListResult(result interface{}) []string {
 	return ids
 }
 
-func completeMailRuleIDs(requestedIDs, currentIDs []string) ([]string, []string) {
-	current := map[string]bool{}
-	for _, id := range currentIDs {
-		current[id] = true
+type mailRuleIDCompletion struct {
+	completed []string
+	resolved  []string
+	unknown   []string
+	ambiguous []string
+}
+
+func completeMailRuleIDs(requestedIDs, currentIDs []string) mailRuleIDCompletion {
+	result := mailRuleIDCompletion{
+		resolved: make([]string, 0, len(requestedIDs)),
 	}
-	requested := map[string]bool{}
-	var unknown []string
 	for _, id := range requestedIDs {
-		requested[id] = true
-		if !current[id] {
-			unknown = append(unknown, id)
+		resolved, matches := resolveMailRuleID(id, currentIDs)
+		switch {
+		case len(matches) == 0:
+			result.unknown = append(result.unknown, id)
+		case len(matches) > 1:
+			result.ambiguous = append(result.ambiguous, fmt.Sprintf("%s (%s)", id, strings.Join(matches, ", ")))
+		default:
+			result.resolved = append(result.resolved, resolved)
 		}
 	}
-	if len(unknown) > 0 {
-		return nil, unknown
+	if len(result.unknown) > 0 || len(result.ambiguous) > 0 {
+		return result
 	}
-	completed := append([]string(nil), requestedIDs...)
+
+	requested := map[string]bool{}
+	for _, id := range result.resolved {
+		requested[id] = true
+	}
+	result.completed = append([]string(nil), result.resolved...)
 	for _, id := range currentIDs {
 		if !requested[id] {
-			completed = append(completed, id)
+			result.completed = append(result.completed, id)
 		}
 	}
-	return completed, nil
+	return result
+}
+
+func resolveMailRuleID(requestedID string, currentIDs []string) (string, []string) {
+	for _, currentID := range currentIDs {
+		if requestedID == currentID {
+			return currentID, []string{currentID}
+		}
+	}
+	var matches []string
+	for _, currentID := range currentIDs {
+		if strings.HasPrefix(currentID, requestedID) {
+			matches = append(matches, currentID)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], matches
+	}
+	return "", matches
 }
 
 func withMailRuleListHint(err error) error {
@@ -213,30 +257,47 @@ func withMailRuleReorderHint(err error) error {
 }
 
 func withMailRuleHint(err error, hint string) error {
-	switch e := err.(type) {
-	case *errs.ValidationError:
-		return e.WithHint(hint)
-	case *errs.AuthenticationError:
-		return e.WithHint(hint)
-	case *errs.PermissionError:
-		return e.WithHint(hint)
-	case *errs.ConfigError:
-		return e.WithHint(hint)
-	case *errs.NetworkError:
-		return e.WithHint(hint)
-	case *errs.APIError:
-		return e.WithHint(hint)
-	case *errs.SecurityPolicyError:
-		return e.WithHint(hint)
-	case *errs.ContentSafetyError:
-		return e.WithHint(hint)
-	case *errs.InternalError:
-		return e.WithHint(hint)
-	case *errs.ConfirmationRequiredError:
-		return e.WithHint(hint)
-	default:
-		return err
+	var validation *errs.ValidationError
+	if errors.As(err, &validation) {
+		return validation.WithHint(hint)
 	}
+	var authentication *errs.AuthenticationError
+	if errors.As(err, &authentication) {
+		return authentication.WithHint(hint)
+	}
+	var permission *errs.PermissionError
+	if errors.As(err, &permission) {
+		return permission.WithHint(hint)
+	}
+	var config *errs.ConfigError
+	if errors.As(err, &config) {
+		return config.WithHint(hint)
+	}
+	var network *errs.NetworkError
+	if errors.As(err, &network) {
+		return network.WithHint(hint)
+	}
+	var api *errs.APIError
+	if errors.As(err, &api) {
+		return api.WithHint(hint)
+	}
+	var securityPolicy *errs.SecurityPolicyError
+	if errors.As(err, &securityPolicy) {
+		return securityPolicy.WithHint(hint)
+	}
+	var contentSafety *errs.ContentSafetyError
+	if errors.As(err, &contentSafety) {
+		return contentSafety.WithHint(hint)
+	}
+	var internal *errs.InternalError
+	if errors.As(err, &internal) {
+		return internal.WithHint(hint)
+	}
+	var confirmation *errs.ConfirmationRequiredError
+	if errors.As(err, &confirmation) {
+		return confirmation.WithHint(hint)
+	}
+	return err
 }
 
 func mailRulesReorderCheckResponse(ac *client.APIClient, result interface{}, identity core.Identity) error {

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -39,7 +39,7 @@ func mailRulesReorderMethod() meta.Method {
 }
 
 func TestMailRulesReorderCompletesPartialRuleIDs(t *testing.T) {
-	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
 		AppID: "test-mail-rules-reorder", AppSecret: "test-secret", Brand: core.BrandFeishu,
 	})
 	reg.Register(mailRulesListStub([]interface{}{
@@ -69,8 +69,67 @@ func TestMailRulesReorderCompletesPartialRuleIDs(t *testing.T) {
 	}
 }
 
+func TestMailRulesReorderCompletesEmptyRuleIDs(t *testing.T) {
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-empty", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(mailRulesListStub([]interface{}{
+		map[string]interface{}{"rule_id": "rule-a"},
+		map[string]interface{}{"rule_id": "rule-b"},
+	}))
+	reorderStub := mailRulesReorderStubBody(map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
+	reg.Register(reorderStub)
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":[]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	reg.Verify(t)
+	got := capturedRuleIDs(t, reorderStub)
+	want := []string{"rule-a", "rule-b"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("rule_ids = %v, want %v", got, want)
+	}
+}
+
+func TestMailRulesReorderCompletesUniquePrefix(t *testing.T) {
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-prefix", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(mailRulesListStub([]interface{}{
+		map[string]interface{}{"rule_id": "rule-alpha"},
+		map[string]interface{}{"rule_id": "rule-beta"},
+		map[string]interface{}{"rule_id": "rule-gamma"},
+	}))
+	reorderStub := mailRulesReorderStubBody(map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
+	reg.Register(reorderStub)
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-g"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	reg.Verify(t)
+	got := capturedRuleIDs(t, reorderStub)
+	want := []string{"rule-gamma", "rule-alpha", "rule-beta"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("rule_ids = %v, want %v", got, want)
+	}
+}
+
 func TestMailRulesReorderKeepsCompleteRuleIDs(t *testing.T) {
-	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
 		AppID: "test-mail-rules-reorder-complete", AppSecret: "test-secret", Brand: core.BrandFeishu,
 	})
 	reg.Register(mailRulesListStub([]interface{}{
@@ -100,7 +159,7 @@ func TestMailRulesReorderKeepsCompleteRuleIDs(t *testing.T) {
 }
 
 func TestMailRulesReorderDuplicateIDsDoesNotCallHTTP(t *testing.T) {
-	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
 		AppID: "test-mail-rules-reorder-duplicate", AppSecret: "test-secret", Brand: core.BrandFeishu,
 	})
 	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
@@ -114,6 +173,7 @@ func TestMailRulesReorderDuplicateIDsDoesNotCallHTTP(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected duplicate ID validation error")
 	}
+	requireMailRulesProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument)
 	var validation *errs.ValidationError
 	if !errors.As(err, &validation) {
 		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
@@ -125,7 +185,7 @@ func TestMailRulesReorderDuplicateIDsDoesNotCallHTTP(t *testing.T) {
 }
 
 func TestMailRulesReorderUnknownIDsDoesNotCallReorder(t *testing.T) {
-	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
 		AppID: "test-mail-rules-reorder-unknown", AppSecret: "test-secret", Brand: core.BrandFeishu,
 	})
 	reg.Register(mailRulesListStub([]interface{}{
@@ -143,6 +203,7 @@ func TestMailRulesReorderUnknownIDsDoesNotCallReorder(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unknown ID validation error")
 	}
+	requireMailRulesProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument)
 	var validation *errs.ValidationError
 	if !errors.As(err, &validation) {
 		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
@@ -153,8 +214,38 @@ func TestMailRulesReorderUnknownIDsDoesNotCallReorder(t *testing.T) {
 	reg.Verify(t)
 }
 
+func TestMailRulesReorderAmbiguousPrefixDoesNotCallReorder(t *testing.T) {
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-ambiguous", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(mailRulesListStub([]interface{}{
+		map[string]interface{}{"rule_id": "rule-alpha"},
+		map[string]interface{}{"rule_id": "rule-archive"},
+	}))
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-a"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected ambiguous prefix validation error")
+	}
+	requireMailRulesProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+	var validation *errs.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
+	}
+	if validation.Param != "rule_ids" || !strings.Contains(validation.Message, "rule-a") {
+		t.Fatalf("validation = %+v, want ambiguous rule-a on rule_ids", validation)
+	}
+	reg.Verify(t)
+}
+
 func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {
-	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
 		AppID: "test-mail-rules-reorder-list-failure", AppSecret: "test-secret", Brand: core.BrandFeishu,
 	})
 	reg.Register(&httpmock.Stub{
@@ -173,10 +264,7 @@ func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected list failure")
 	}
-	p, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected typed error, got %T: %v", err, err)
-	}
+	p := requireMailRulesProblem(t, err, errs.CategoryAPI, errs.SubtypeUnknown)
 	if p.Hint == "" || !strings.Contains(p.Hint, "reorder was not called") {
 		t.Fatalf("hint = %q, want reorder not called guidance", p.Hint)
 	}
@@ -184,7 +272,7 @@ func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {
 }
 
 func TestMailRulesReorderBackendFailureIncludesRetryHint(t *testing.T) {
-	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
 		AppID: "test-mail-rules-reorder-backend-failure", AppSecret: "test-secret", Brand: core.BrandFeishu,
 	})
 	reg.Register(mailRulesListStub([]interface{}{
@@ -204,14 +292,40 @@ func TestMailRulesReorderBackendFailureIncludesRetryHint(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected reorder backend failure")
 	}
-	p, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected typed error, got %T: %v", err, err)
-	}
+	p := requireMailRulesProblem(t, err, errs.CategoryAPI, errs.SubtypeUnknown)
 	if p.Hint == "" || !strings.Contains(p.Hint, "list again") {
 		t.Fatalf("hint = %q, want list-again retry guidance", p.Hint)
 	}
 	reg.Verify(t)
+}
+
+func TestMailRulesReorderPreservesRuleIDWhitespace(t *testing.T) {
+	got, err := stringList([]interface{}{" rule-a "})
+	if err != nil {
+		t.Fatalf("stringList() error = %v", err)
+	}
+	if len(got) != 1 || got[0] != " rule-a " {
+		t.Fatalf("stringList() = %#v, want exact supplied ID", got)
+	}
+}
+
+func mailRulesReorderFactory(t *testing.T, config *core.CliConfig) (*cmdutil.Factory, *httpmock.Registry) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, reg := cmdutil.TestFactory(t, config)
+	return f, reg
+}
+
+func requireMailRulesProblem(t *testing.T, err error, category errs.Category, subtype errs.Subtype) *errs.Problem {
+	t.Helper()
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != category || p.Subtype != subtype {
+		t.Fatalf("problem = %s/%s, want %s/%s", p.Category, p.Subtype, category, subtype)
+	}
+	return p
 }
 
 func mailRulesListStub(items []interface{}) *httpmock.Stub {

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -123,6 +124,39 @@ func TestMailRulesReorderCompletesUniquePrefix(t *testing.T) {
 	reg.Verify(t)
 	got := capturedRuleIDs(t, reorderStub)
 	want := []string{"rule-gamma", "rule-alpha", "rule-beta"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("rule_ids = %v, want %v", got, want)
+	}
+}
+
+func TestMailRulesReorderCompletesRuleIDsFromLaterPage(t *testing.T) {
+	f, reg := mailRulesReorderFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-paginated", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	registerMailRulesListPageStub(t, reg, "", "next-1", []interface{}{
+		map[string]interface{}{"rule_id": "rule-a"},
+		map[string]interface{}{"rule_id": "rule-b"},
+	})
+	registerMailRulesListPageStub(t, reg, "next-1", "", []interface{}{
+		map[string]interface{}{"rule_id": "rule-c"},
+		map[string]interface{}{"rule_id": "rule-d"},
+	})
+	reorderStub := mailRulesReorderStubBody(map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
+	reg.Register(reorderStub)
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-c"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	reg.Verify(t)
+	got := capturedRuleIDs(t, reorderStub)
+	want := []string{"rule-c", "rule-a", "rule-b", "rule-d"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("rule_ids = %v, want %v", got, want)
 	}
@@ -341,6 +375,31 @@ func mailRulesListStub(items []interface{}) *httpmock.Stub {
 			},
 		},
 	}
+}
+
+func registerMailRulesListPageStub(t *testing.T, reg *httpmock.Registry, wantPageToken, nextPageToken string, items []interface{}) {
+	t.Helper()
+	data := map[string]interface{}{
+		"items":    items,
+		"has_more": nextPageToken != "",
+	}
+	if nextPageToken != "" {
+		data["page_token"] = nextPageToken
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		OnMatch: func(req *http.Request) {
+			if got := req.URL.Query().Get("page_token"); got != wantPageToken {
+				t.Errorf("page_token = %q, want %q", got, wantPageToken)
+			}
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": data,
+		},
+	})
 }
 
 func mailRulesReorderStubBody(body map[string]interface{}) *httpmock.Stub {

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func mailSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "array", "required": true},
+		},
+	})
+}
+
+func TestMailRulesReorderCompletesPartialRuleIDs(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(mailRulesListStub([]interface{}{
+		map[string]interface{}{"rule_id": "rule-a"},
+		map[string]interface{}{"rule_id": "rule-b"},
+		map[string]interface{}{"rule_id": "rule-c"},
+		map[string]interface{}{"rule_id": "rule-d"},
+	}))
+	reorderStub := mailRulesReorderStubBody(map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
+	reg.Register(reorderStub)
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-c","rule-a"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	reg.Verify(t)
+	got := capturedRuleIDs(t, reorderStub)
+	want := []string{"rule-c", "rule-a", "rule-b", "rule-d"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("rule_ids = %v, want %v", got, want)
+	}
+}
+
+func TestMailRulesReorderKeepsCompleteRuleIDs(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-complete", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(mailRulesListStub([]interface{}{
+		map[string]interface{}{"rule_id": "rule-a"},
+		map[string]interface{}{"rule_id": "rule-b"},
+		map[string]interface{}{"rule_id": "rule-c"},
+	}))
+	reorderStub := mailRulesReorderStubBody(map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}})
+	reg.Register(reorderStub)
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-a","rule-b","rule-c"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	reg.Verify(t)
+	got := capturedRuleIDs(t, reorderStub)
+	want := []string{"rule-a", "rule-b", "rule-c"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("rule_ids = %v, want %v", got, want)
+	}
+}
+
+func TestMailRulesReorderDuplicateIDsDoesNotCallHTTP(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-duplicate", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-a","rule-a"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected duplicate ID validation error")
+	}
+	var validation *errs.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
+	}
+	if validation.Param != "rule_ids" || !strings.Contains(validation.Message, "rule-a") {
+		t.Fatalf("validation = %+v, want duplicate rule-a on rule_ids", validation)
+	}
+	reg.Verify(t)
+}
+
+func TestMailRulesReorderUnknownIDsDoesNotCallReorder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-unknown", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(mailRulesListStub([]interface{}{
+		map[string]interface{}{"rule_id": "rule-a"},
+		map[string]interface{}{"rule_id": "rule-b"},
+	}))
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-x","rule-a"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected unknown ID validation error")
+	}
+	var validation *errs.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
+	}
+	if validation.Param != "rule_ids" || !strings.Contains(validation.Message, "rule-x") {
+		t.Fatalf("validation = %+v, want unknown rule-x on rule_ids", validation)
+	}
+	reg.Verify(t)
+}
+
+func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-list-failure", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body:   map[string]interface{}{"code": 999999, "msg": "list unavailable"},
+	})
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-a"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected list failure")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Hint == "" || !strings.Contains(p.Hint, "reorder was not called") {
+		t.Fatalf("hint = %q, want reorder not called guidance", p.Hint)
+	}
+	reg.Verify(t)
+}
+
+func TestMailRulesReorderBackendFailureIncludesRetryHint(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-mail-rules-reorder-backend-failure", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	reg.Register(mailRulesListStub([]interface{}{
+		map[string]interface{}{"rule_id": "rule-a"},
+		map[string]interface{}{"rule_id": "rule-b"},
+	}))
+	reg.Register(mailRulesReorderStubBody(map[string]interface{}{"code": 999998, "msg": "rule set changed"}))
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule-b"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected reorder backend failure")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Hint == "" || !strings.Contains(p.Hint, "list again") {
+		t.Fatalf("hint = %q, want list-again retry guidance", p.Hint)
+	}
+	reg.Verify(t)
+}
+
+func mailRulesListStub(items []interface{}) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items":    items,
+				"has_more": false,
+			},
+		},
+	}
+}
+
+func mailRulesReorderStubBody(body map[string]interface{}) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   body,
+	}
+}
+
+func capturedRuleIDs(t *testing.T, stub *httpmock.Stub) []string {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("captured body is not JSON: %v\n%s", err, string(stub.CapturedBody))
+	}
+	raw, ok := body["rule_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("rule_ids = %#v, want array", body["rule_ids"])
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		out = append(out, item.(string))
+	}
+	return out
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -431,6 +431,15 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	// with MissingScopes / Identity / ConsoleURL populated from the response.
 	checkErr := ac.CheckResponse
 
+	if err := completeMailRulesReorderRequest(opts.Ctx, ac, opts, &request); err != nil {
+		return err
+	}
+	if isMailRulesReorder(opts) {
+		checkErr = func(result interface{}, identity core.Identity) error {
+			return mailRulesReorderCheckResponse(ac, result, identity)
+		}
+	}
+
 	if opts.PageAll {
 		return servicePaginate(opts.Ctx, ac, request, format, opts.JqExpr, out, f.IOStreams.ErrOut, opts.Cmd.CommandPath(),
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -18,19 +18,24 @@ import (
 // marker, tagged with the given top-level data version and brand.
 func seedCache(t *testing.T, dir, name, marker, version, brand string) {
 	t.Helper()
-	cDir := filepath.Join(dir, "cache")
-	if err := os.MkdirAll(cDir, 0700); err != nil {
-		t.Fatal(err)
-	}
 	reg := MergedRegistry{
 		Version:  version,
 		Services: []meta.Service{{Name: name, Version: "cache", Title: marker}},
+	}
+	seedCacheService(t, dir, reg, brand)
+}
+
+func seedCacheService(t *testing.T, dir string, reg MergedRegistry, brand string) {
+	t.Helper()
+	cDir := filepath.Join(dir, "cache")
+	if err := os.MkdirAll(cDir, 0700); err != nil {
+		t.Fatal(err)
 	}
 	data, _ := json.Marshal(reg)
 	if err := os.WriteFile(filepath.Join(cDir, "remote_meta.json"), data, 0644); err != nil {
 		t.Fatal(err)
 	}
-	cm := CacheMeta{LastCheckAt: time.Now().Unix(), Version: version, Brand: brand}
+	cm := CacheMeta{LastCheckAt: time.Now().Unix(), Version: reg.Version, Brand: brand}
 	mData, _ := json.Marshal(cm)
 	if err := os.WriteFile(filepath.Join(cDir, "remote_meta.meta.json"), mData, 0644); err != nil {
 		t.Fatal(err)

--- a/internal/registry/remote.go
+++ b/internal/registry/remote.go
@@ -314,12 +314,63 @@ func shouldRefresh(cm CacheMeta) bool {
 }
 
 // overlayMergedServices merges remote services into the in-memory map.
-// Remote entries override embedded entries with the same name.
+// Remote entries override matching embedded fields, but a stale remote cache
+// must not remove methods compiled into the current binary.
 func overlayMergedServices(reg *MergedRegistry) {
 	for _, svc := range reg.Services {
 		if svc.Name == "" {
 			continue
 		}
+		if existing, ok := mergedServices[svc.Name]; ok {
+			mergedServices[svc.Name] = mergeService(existing, svc)
+			continue
+		}
 		mergedServices[svc.Name] = svc
 	}
+}
+
+func mergeService(base, overlay meta.Service) meta.Service {
+	if overlay.Name == "" {
+		overlay.Name = base.Name
+	}
+	overlay.Resources = mergeResources(base.Resources, overlay.Resources)
+	return overlay
+}
+
+func mergeResources(base, overlay map[string]meta.Resource) map[string]meta.Resource {
+	if len(base) == 0 {
+		return overlay
+	}
+	if len(overlay) == 0 {
+		return base
+	}
+	merged := make(map[string]meta.Resource, len(base)+len(overlay))
+	for name, res := range base {
+		merged[name] = res
+	}
+	for name, res := range overlay {
+		if existing, ok := merged[name]; ok {
+			res.Methods = mergeMethods(existing.Methods, res.Methods)
+			res.Resources = mergeResources(existing.Resources, res.Resources)
+		}
+		merged[name] = res
+	}
+	return merged
+}
+
+func mergeMethods(base, overlay map[string]meta.Method) map[string]meta.Method {
+	if len(base) == 0 {
+		return overlay
+	}
+	if len(overlay) == 0 {
+		return base
+	}
+	merged := make(map[string]meta.Method, len(base)+len(overlay))
+	for name, method := range base {
+		merged[name] = method
+	}
+	for name, method := range overlay {
+		merged[name] = method
+	}
+	return merged
 }

--- a/internal/registry/remote_test.go
+++ b/internal/registry/remote_test.go
@@ -331,6 +331,131 @@ func TestOverlayMergedServices(t *testing.T) {
 	}
 }
 
+func TestOverlayMergedServicesPreservesEmbeddedMethods(t *testing.T) {
+	resetInit()
+	mergedServices = map[string]meta.Service{
+		"mail": {
+			Name:        "mail",
+			Version:     "embedded",
+			Title:       "Embedded Mail API",
+			ServicePath: "/open-apis/mail/v1",
+			Resources: map[string]meta.Resource{
+				"user_mailbox.rules": {
+					Methods: map[string]meta.Method{
+						"list": {
+							Path:       "user_mailboxes/{user_mailbox_id}/rules",
+							HTTPMethod: "GET",
+						},
+						"reorder": {
+							Path:       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+							HTTPMethod: "POST",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	overlayMergedServices(&MergedRegistry{
+		Services: []meta.Service{
+			{
+				Name:        "mail",
+				Version:     "cache",
+				Title:       "Cached Mail API",
+				ServicePath: "/open-apis/mail/v1",
+				Resources: map[string]meta.Resource{
+					"user_mailbox.rules": {
+						Methods: map[string]meta.Method{
+							"list": {
+								Path:        "user_mailboxes/{user_mailbox_id}/rules",
+								HTTPMethod:  "GET",
+								Description: "cached list description",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	rules := mergedServices["mail"].Resources["user_mailbox.rules"]
+	if _, ok := rules.Methods["reorder"]; !ok {
+		t.Fatal("embedded reorder method was removed by stale cache overlay")
+	}
+	if got := rules.Methods["list"].Description; got != "cached list description" {
+		t.Fatalf("list method description = %q, want cached overlay value", got)
+	}
+}
+
+func TestRuntimeCatalogPreservesEmbeddedMethodsWithNewerCache(t *testing.T) {
+	embedded, _ := json.Marshal(MergedRegistry{
+		Version: "1.0.0",
+		Services: []meta.Service{
+			{
+				Name:        "mail",
+				Version:     "v1",
+				ServicePath: "/open-apis/mail/v1",
+				Resources: map[string]meta.Resource{
+					"user_mailbox.rules": {
+						Methods: map[string]meta.Method{
+							"list": {
+								Path:       "user_mailboxes/{user_mailbox_id}/rules",
+								HTTPMethod: "GET",
+							},
+							"reorder": {
+								Path:       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+								HTTPMethod: "POST",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	swapEmbeddedMeta(t, embedded)
+
+	tmp := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmp)
+	t.Setenv("LARKSUITE_CLI_REMOTE_META", "on")
+	t.Setenv("LARKSUITE_CLI_META_TTL", "3600")
+	seedCacheService(t, tmp, MergedRegistry{
+		Version: "2.0.0",
+		Services: []meta.Service{
+			{
+				Name:        "mail",
+				Version:     "v1",
+				ServicePath: "/open-apis/mail/v1",
+				Resources: map[string]meta.Resource{
+					"user_mailbox.rules": {
+						Methods: map[string]meta.Method{
+							"list": {
+								Path:        "user_mailboxes/{user_mailbox_id}/rules",
+								HTTPMethod:  "GET",
+								Description: "cached list description",
+							},
+						},
+					},
+				},
+			},
+		},
+	}, "feishu")
+
+	target, err := RuntimeCatalog().Resolve([]string{"mail", "user_mailbox.rules", "reorder"})
+	if err != nil {
+		t.Fatalf("runtime catalog lost embedded reorder method: %v", err)
+	}
+	if target.Method.SchemaPath() != "mail.user_mailbox.rules.reorder" {
+		t.Fatalf("schema path = %q, want mail.user_mailbox.rules.reorder", target.Method.SchemaPath())
+	}
+	list, err := RuntimeCatalog().Resolve([]string{"mail", "user_mailbox.rules", "list"})
+	if err != nil {
+		t.Fatalf("runtime catalog lost cached list method: %v", err)
+	}
+	if got := list.Method.Method.Description; got != "cached list description" {
+		t.Fatalf("list description = %q, want cached overlay value", got)
+	}
+}
+
 func TestOverlayMergedServicesDoesNotPolluteFollowingInit(t *testing.T) {
 	resetInit()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -23,7 +23,7 @@ Quick codes above: condition `type=6` = subject, `operator=1` = contains, action
 
 ## 调整规则顺序
 
-`reorder` 可只传需要提前或调整相对顺序的部分 `rule_id`。CLI 会先读取当前完整规则列表，并把未输入的规则按当前相对顺序追加到请求末尾；如果输入包含重复或不存在的 ID，会在本地报错且不会调用 reorder。
+`reorder` 可只传需要提前或调整相对顺序的部分 `rule_id`。CLI 会先读取当前完整规则列表，并把未输入的规则按当前相对顺序追加到请求末尾；输入可使用唯一的规则 ID 前缀，前缀匹配多个规则或未匹配任何规则时会在本地报错且不会调用 reorder。重复 ID 同样会在本地报错。
 
 ```bash
 lark-cli mail user_mailbox.rules reorder --as user \

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -21,6 +21,16 @@ lark-cli mail user_mailbox.rules delete --as user \
 
 Quick codes above: condition `type=6` = subject, `operator=1` = contains, action `type=3` = mark as read.
 
+## 调整规则顺序
+
+`reorder` 可只传需要提前或调整相对顺序的部分 `rule_id`。CLI 会先读取当前完整规则列表，并把未输入的规则按当前相对顺序追加到请求末尾；如果输入包含重复或不存在的 ID，会在本地报错且不会调用 reorder。
+
+```bash
+lark-cli mail user_mailbox.rules reorder --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"rule_ids":["<rule_id_to_place_first>","<rule_id_to_place_second>"]}'
+```
+
 ## 原生 API
 
 收信规则走 `user_mailbox.rules` 资源。参数不确定时先运行：

--- a/tests/cli_e2e/base/base_role_workflow_test.go
+++ b/tests/cli_e2e/base/base_role_workflow_test.go
@@ -30,8 +30,8 @@ func TestBase_RoleWorkflow(t *testing.T) {
 	result.AssertStdoutStatus(t, true)
 
 	roleName := "Reviewer-" + clie2e.GenerateSuffix()
-	createRole(t, ctx, baseToken, `{"role_name":"`+roleName+`","role_type":"custom_role"}`)
-	roleID := ""
+	roleID := createRole(t, ctx, baseToken, `{"role_name":"`+roleName+`","role_type":"custom_role"}`)
+	require.NotEmpty(t, roleID, "created role ID should be returned")
 
 	parentT.Cleanup(func() {
 		if roleID == "" {
@@ -51,35 +51,48 @@ func TestBase_RoleWorkflow(t *testing.T) {
 	})
 
 	t.Run("list as bot", func(t *testing.T) {
-		result, err := clie2e.RunCmd(ctx, clie2e.Request{
-			Args:      []string{"base", "+role-list", "--base-token", baseToken},
-			DefaultAs: "bot",
+		var lastStdout string
+		pollTimeout := 30 * time.Second
+		pollCtx, pollCancel := context.WithTimeout(ctx, pollTimeout)
+		defer pollCancel()
+
+		err := clie2e.WaitForCondition(pollCtx, clie2e.WaitOptions{
+			Timeout:  pollTimeout,
+			Interval: 3 * time.Second,
+		}, func() (bool, error) {
+			result, err := clie2e.RunCmd(pollCtx, clie2e.Request{
+				Args:      []string{"base", "+role-list", "--base-token", baseToken},
+				DefaultAs: "bot",
+			})
+			if err != nil {
+				return false, err
+			}
+			lastStdout = result.Stdout
+			if result.ExitCode != 0 {
+				return false, result.RunErr
+			}
+			if !gjson.Get(result.Stdout, "ok").Bool() {
+				return false, nil
+			}
+
+			roleListPayload := gjson.Get(result.Stdout, "data.data").String()
+			if roleListPayload == "" || !gjson.Valid(roleListPayload) {
+				return false, nil
+			}
+
+			roleItems := gjson.Get(roleListPayload, "base_roles").Array()
+			for _, item := range roleItems {
+				rolePayload := item.String()
+				if !gjson.Valid(rolePayload) {
+					continue
+				}
+				if gjson.Get(rolePayload, "role_id").String() == roleID && gjson.Get(rolePayload, "role_name").String() == roleName {
+					return true, nil
+				}
+			}
+			return false, nil
 		})
-		require.NoError(t, err)
-		result.AssertExitCode(t, 0)
-		result.AssertStdoutStatus(t, true)
-
-		roleListPayload := gjson.Get(result.Stdout, "data.data").String()
-		require.NotEmpty(t, roleListPayload, "stdout:\n%s", result.Stdout)
-		assert.True(t, gjson.Valid(roleListPayload), "role list payload should be valid JSON: %s", roleListPayload)
-
-		roleItems := gjson.Get(roleListPayload, "base_roles").Array()
-		assert.NotEmpty(t, roleItems, "role list should contain at least one role: %s", roleListPayload)
-
-		found := false
-		for _, item := range roleItems {
-			rolePayload := item.String()
-			if !gjson.Valid(rolePayload) {
-				continue
-			}
-			if gjson.Get(rolePayload, "role_name").String() == roleName {
-				roleID = gjson.Get(rolePayload, "role_id").String()
-				found = true
-				break
-			}
-		}
-		require.True(t, found, "stdout:\n%s", result.Stdout)
-		require.NotEmpty(t, roleID, "stdout:\n%s", result.Stdout)
+		require.NoError(t, err, "role %q should appear in list; last stdout:\n%s", roleName, lastStdout)
 	})
 
 	t.Run("get role as bot", func(t *testing.T) {

--- a/tests/cli_e2e/base/helpers_role_test.go
+++ b/tests/cli_e2e/base/helpers_role_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import "testing"
+
+func TestExtractCreatedRoleID(t *testing.T) {
+	tests := []struct {
+		name   string
+		stdout string
+		want   string
+	}{
+		{
+			name:   "direct payload",
+			stdout: `{"ok":true,"data":{"role_id":"rol_direct"}}`,
+			want:   "rol_direct",
+		},
+		{
+			name:   "nested payload",
+			stdout: `{"ok":true,"data":{"data":{"role_id":"rol_nested"}}}`,
+			want:   "rol_nested",
+		},
+		{
+			name:   "string encoded nested payload",
+			stdout: `{"ok":true,"data":{"data":"{\"role_id\":\"rol_string\"}"}}`,
+			want:   "rol_string",
+		},
+		{
+			name:   "business envelope",
+			stdout: `{"ok":true,"data":{"data":{"data":{"role_id":"rol_business"}}}}`,
+			want:   "rol_business",
+		},
+		{
+			name:   "missing",
+			stdout: `{"ok":true,"data":{"data":{}}}`,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractCreatedRoleID(tt.stdout); got != tt.want {
+				t.Fatalf("extractCreatedRoleID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/cli_e2e/base/helpers_role_test.go
+++ b/tests/cli_e2e/base/helpers_role_test.go
@@ -27,6 +27,11 @@ func TestExtractCreatedRoleID(t *testing.T) {
 			want:   "rol_string",
 		},
 		{
+			name:   "string encoded business envelope",
+			stdout: `{"ok":true,"data":{"data":"{\"data\":{\"role_id\":\"rol_nested_string\"}}"}}`,
+			want:   "rol_nested_string",
+		},
+		{
 			name:   "business envelope",
 			stdout: `{"ok":true,"data":{"data":{"data":{"role_id":"rol_business"}}}}`,
 			want:   "rol_business",

--- a/tests/cli_e2e/base/helpers_test.go
+++ b/tests/cli_e2e/base/helpers_test.go
@@ -186,7 +186,36 @@ func createRole(t *testing.T, ctx context.Context, baseToken string, body string
 	result.AssertExitCode(t, 0)
 	result.AssertStdoutStatus(t, true)
 
-	return gjson.Get(result.Stdout, "data.role_id").String()
+	roleID := extractCreatedRoleID(result.Stdout)
+	require.NotEmpty(t, roleID, "created role ID should be returned; stdout:\n%s", result.Stdout)
+	return roleID
+}
+
+func extractCreatedRoleID(stdout string) string {
+	for _, path := range []string{
+		"data.role_id",
+		"data.data.role_id",
+		"data.data.data.role_id",
+	} {
+		if roleID := gjson.Get(stdout, path).String(); roleID != "" {
+			return roleID
+		}
+	}
+
+	for _, path := range []string{"data.data", "data.data.data"} {
+		raw := gjson.Get(stdout, path).String()
+		if raw == "" || !gjson.Valid(raw) {
+			continue
+		}
+		if roleID := gjson.Get(raw, "role_id").String(); roleID != "" {
+			return roleID
+		}
+		if roleID := gjson.Get(raw, "data.role_id").String(); roleID != "" {
+			return roleID
+		}
+	}
+
+	return ""
 }
 
 func findBaseTableByID(t *testing.T, ctx context.Context, baseToken string, tableID string) gjson.Result {


### PR DESCRIPTION
Adds mail rule reordering support that expands user-provided rule ID prefixes into a complete ordered list before calling the API.

- Fetches the current mailbox rules before reordering.
- Validates duplicate, missing, unknown, and ambiguous rule IDs locally.
- Adds tests for full IDs, partial IDs, and invalid input.
- Documents how partial rule IDs are handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorder mail rules by submitting only the rule IDs to move.
  * Automatically preserves unlisted rules, including when rules are paginated.
  * Validates duplicate, unknown, malformed, and ambiguous IDs before making changes.
  * Provides clearer error details and retry guidance when fetching or applying a reorder fails.

* **Documentation**
  * Added guidance for mail-rule reordering and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->