### PR TITLE
feat(wiki): improve wiki node creation and terminal errors

### DIFF
--- a/shortcuts/wiki/wiki_node_create.go
+++ b/shortcuts/wiki/wiki_node_create.go
@@ -41,6 +41,7 @@ var wikiObjectTypes = []string{
 	"sheet",
 	"mindnote",
 	"bitable",
+	"file",
 	"docx",
 	"slides",
 }
@@ -60,12 +61,13 @@ var WikiNodeCreate = common.Shortcut{
 		{Name: "parent-node-token", Desc: "parent wiki node token; if set, the new node is created under that parent"},
 		{Name: "title", Desc: "node title"},
 		{Name: "node-type", Default: wikiNodeTypeOrigin, Desc: "node type", Enum: []string{wikiNodeTypeOrigin, wikiNodeTypeShortcut}},
-		{Name: "obj-type", Default: "docx", Desc: "target object type", Enum: wikiObjectTypes},
+		{Name: "obj-type", Default: "docx", Desc: "target object type; file is supported only when --node-type=shortcut", Enum: wikiObjectTypes},
 		{Name: "origin-node-token", Desc: "source node token when --node-type=shortcut"},
 	},
 	Tips: []string{
 		"If --space-id and --parent-node-token are both omitted, user identity falls back to my_library.",
 		"Use --node-type shortcut --origin-node-token <token> to create a shortcut node.",
+		"Use --node-type shortcut --obj-type file --origin-node-token <token> to create a shortcut to a file; origin nodes cannot use --obj-type file.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return validateWikiNodeCreateSpec(readWikiNodeCreateSpec(runtime), runtime.As())
@@ -235,6 +237,14 @@ func validateWikiNodeCreateSpec(spec wikiNodeCreateSpec, identity core.Identity)
 	}
 	if spec.NodeType != wikiNodeTypeShortcut && spec.OriginNodeToken != "" {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--origin-node-token can only be used when --node-type=shortcut").WithParam("--origin-node-token")
+	}
+	if spec.NodeType == wikiNodeTypeOrigin && spec.ObjType == "file" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--obj-type file is not supported when --node-type=origin").
+			WithParams(
+				errs.InvalidParam{Name: "--node-type", Reason: "use shortcut when creating a Wiki reference to a file"},
+				errs.InvalidParam{Name: "--obj-type", Reason: "file is supported only for shortcut nodes"},
+			).
+			WithHint("use --node-type shortcut --obj-type file --origin-node-token <TOKEN>")
 	}
 
 	// Bot identity has no meaningful "personal document library" target, so

--- a/shortcuts/wiki/wiki_node_create_test.go
+++ b/shortcuts/wiki/wiki_node_create_test.go
@@ -192,6 +192,57 @@ func TestValidateWikiNodeCreateSpecRejectsOriginTokenForOriginNode(t *testing.T)
 	}
 }
 
+func TestValidateWikiNodeCreateSpecRejectsFileForOriginNode(t *testing.T) {
+	t.Parallel()
+
+	err := validateWikiNodeCreateSpec(wikiNodeCreateSpec{
+		NodeType: wikiNodeTypeOrigin,
+		ObjType:  "file",
+	}, core.AsUser)
+	if err == nil || !strings.Contains(err.Error(), "--obj-type file is not supported when --node-type=origin") {
+		t.Fatalf("expected origin file validation error, got %v", err)
+	}
+	requireWikiValidationParams(t, err, "--node-type", "--obj-type")
+	p, ok := errs.ProblemOf(err)
+	if !ok || !strings.Contains(p.Hint, "--node-type shortcut --obj-type file") {
+		t.Fatalf("expected shortcut recovery hint, got %v", err)
+	}
+}
+
+func TestValidateWikiNodeCreateSpecAllowsFileForShortcutNode(t *testing.T) {
+	t.Parallel()
+
+	spec := wikiNodeCreateSpec{
+		NodeType:        wikiNodeTypeShortcut,
+		ObjType:         "file",
+		OriginNodeToken: "wik_file_origin",
+	}
+	if err := validateWikiNodeCreateSpec(spec, core.AsUser); err != nil {
+		t.Fatalf("validateWikiNodeCreateSpec() error = %v", err)
+	}
+	body := spec.RequestBody()
+	if body["node_type"] != wikiNodeTypeShortcut || body["obj_type"] != "file" || body["origin_node_token"] != "wik_file_origin" {
+		t.Fatalf("RequestBody() = %#v, want shortcut file payload", body)
+	}
+}
+
+func TestWikiNodeCreateObjTypeEnumIncludesFile(t *testing.T) {
+	t.Parallel()
+
+	for _, flag := range WikiNodeCreate.Flags {
+		if flag.Name != "obj-type" {
+			continue
+		}
+		for _, value := range flag.Enum {
+			if value == "file" {
+				return
+			}
+		}
+		t.Fatalf("--obj-type enum = %v, want file", flag.Enum)
+	}
+	t.Fatal("--obj-type flag not found")
+}
+
 func TestValidateWikiNodeCreateSpecRejectsBotWithoutLocation(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -100,7 +100,7 @@ var WikiNodeGet = common.Shortcut{
 
 		data, err := runtime.CallAPITyped("GET", "/open-apis/wiki/v2/spaces/get_node", spec.RequestParams(), nil)
 		if err != nil {
-			return err
+			return wikiNodeGetProblem(err)
 		}
 		raw := common.GetMap(data, "node")
 		node, err := parseWikiNodeRecord(raw)
@@ -129,6 +129,34 @@ var WikiNodeGet = common.Shortcut{
 		})
 		return nil
 	},
+}
+
+// wikiNodeGetProblem adds command-specific classification and recovery for
+// get_node business errors that are intentionally not registered in the
+// process-wide code metadata table. These failures are terminal for the same
+// input: callers must change the resource token or operation instead of
+// retrying the request or switching identities.
+func wikiNodeGetProblem(err error) error {
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		return err
+	}
+
+	switch p.Code {
+	case 131012:
+		p.Subtype = errs.SubtypeNotFound
+		p.Retryable = false
+		appendWikiProblemHint(err, "The Wiki node has been deleted. Do not retry the same node token; rediscover the node or ask for a current Wiki link.")
+	case 131013:
+		p.Subtype = errs.SubtypeInvalidParameters
+		p.Retryable = false
+		appendWikiProblemHint(err, "The resource token is invalid. Do not retry the same token, switch identity, or reauthorize; check the URL/token and provide a valid wiki node_token or typed document URL.")
+	case 131014:
+		p.Subtype = errs.SubtypeFailedPrecondition
+		p.Retryable = false
+		appendWikiProblemHint(err, "The document exists but is not mounted in Wiki. Do not retry wiki +node-get with the same document; use the corresponding docs, sheets, base, or drive command, or provide a Wiki URL/node_token.")
+	}
+	return err
 }
 
 // wikiNodeGetSpec is the normalized input for the shortcut.

--- a/shortcuts/wiki/wiki_node_get_test.go
+++ b/shortcuts/wiki/wiki_node_get_test.go
@@ -409,6 +409,84 @@ func TestWikiNodeGetMountedExecuteParsesURLAndFormatsOutput(t *testing.T) {
 	}
 }
 
+func TestWikiNodeGetMountedClassifiesTerminalBusinessErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     int
+		message  string
+		subtype  errs.Subtype
+		hintText string
+	}{
+		{
+			name:     "deleted node",
+			code:     131012,
+			message:  "node has been deleted",
+			subtype:  errs.SubtypeNotFound,
+			hintText: "Do not retry the same node token",
+		},
+		{
+			name:     "invalid resource token",
+			code:     131013,
+			message:  "token is invalid",
+			subtype:  errs.SubtypeInvalidParameters,
+			hintText: "Do not retry the same token",
+		},
+		{
+			name:     "document not in wiki",
+			code:     131014,
+			message:  "document is not in wiki",
+			subtype:  errs.SubtypeFailedPrecondition,
+			hintText: "Do not retry wiki +node-get with the same document",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+			factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+			reg.Register(&httpmock.Stub{
+				Method: "GET",
+				URL:    "/open-apis/wiki/v2/spaces/get_node",
+				Body: map[string]interface{}{
+					"code":   tt.code,
+					"msg":    tt.message,
+					"log_id": "log-node-get-terminal",
+				},
+			})
+
+			err := mountAndRunWiki(t, WikiNodeGet, []string{
+				"+node-get",
+				"--node-token", testWikiNodeToken,
+				"--as", "bot",
+			}, factory, stdout)
+			if err == nil {
+				t.Fatal("expected a terminal business error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed error, got %T: %v", err, err)
+			}
+			if p.Category != errs.CategoryAPI || p.Code != tt.code || p.Subtype != tt.subtype {
+				t.Fatalf("problem category/code/subtype = %s/%d/%s, want %s/%d/%s",
+					p.Category, p.Code, p.Subtype, errs.CategoryAPI, tt.code, tt.subtype)
+			}
+			if p.Retryable {
+				t.Fatalf("problem retryable = true, want false: %#v", p)
+			}
+			if !strings.Contains(p.Hint, tt.hintText) {
+				t.Fatalf("hint = %q, want %q", p.Hint, tt.hintText)
+			}
+			if p.LogID != "log-node-get-terminal" {
+				t.Fatalf("log_id = %q, want log-node-get-terminal", p.LogID)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want no success envelope", stdout.String())
+			}
+		})
+	}
+}
+
 func TestWikiNodeGetMountedAcceptsNodeTokenFlag(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 

--- a/skills/lark-wiki/references/lark-wiki-node-create.md
+++ b/skills/lark-wiki/references/lark-wiki-node-create.md
@@ -78,7 +78,7 @@ lark-cli wiki +node-create \
 | `--parent-node-token` | 否 | 父知识库节点 token；传入后会在该节点下创建新节点 |
 | `--title` | 否 | 节点标题 |
 | `--node-type` | 否 | 节点类型，默认 `origin`；可选值：`origin`、`shortcut` |
-| `--obj-type` | 否 | 节点对应对象类型，默认 `docx`；可选值：`sheet`、`mindnote`、`bitable`、`docx`、`slides` |
+| `--obj-type` | 否 | 节点对应对象类型，默认 `docx`；可选值：`sheet`、`mindnote`、`bitable`、`file`、`docx`、`slides`。`file` 仅支持 `shortcut` 节点 |
 | `--origin-node-token` | 否 | 当 `--node-type=shortcut` 时必填，表示快捷方式指向的源节点 token |
 
 ## 空间解析规则
@@ -89,11 +89,27 @@ lark-cli wiki +node-create \
 - **个人知识库回退**：`user` 身份下，如果 `--space-id` 和 `--parent-node-token` 都没传，会自动解析 `my_library`
 - **bot 身份限制**：`bot` 身份既没有“个人知识库”回退语义，也不支持显式传 `--space-id my_library`；请改用真实 `space_id` 或 `--parent-node-token`
 
-## shortcut 节点规则
+## 节点类型与对象类型
+
+| `node_type` | 支持的 `obj_type` |
+|-------------|-------------------|
+| `origin` | `sheet`、`mindnote`、`bitable`、`docx`、`slides` |
+| `shortcut` | `sheet`、`mindnote`、`bitable`、`file`、`docx`、`slides` |
 
 - `--node-type=shortcut` 时，必须同时提供 `--origin-node-token`
 - `--node-type=origin` 时，不能传 `--origin-node-token`
+- `--obj-type=file` 仅支持 `--node-type=shortcut`；实体节点不支持创建 `file` 类型
 - `shortcut` 节点只是知识库中的快捷方式入口；真正被引用的节点由 `--origin-node-token` 指定
+- 如果 `+node-create` 因上述组合返回参数校验错误，禁止改用 raw `wiki nodes create` 或直接调用 OpenAPI 绕过校验；应修正 `node_type`、`obj_type` 或 `origin_node_token`
+
+```bash
+# 创建一个指向文件的快捷方式节点
+lark-cli wiki +node-create \
+  --space-id <SPACE_ID> \
+  --node-type shortcut \
+  --obj-type file \
+  --origin-node-token <ORIGIN_NODE_TOKEN>
+```
 
 ## 一致性校验
 

--- a/skills/lark-wiki/references/lark-wiki-node-get.md
+++ b/skills/lark-wiki/references/lark-wiki-node-get.md
@@ -52,6 +52,16 @@ lark-cli wiki +node-get \
 - `creator` falls back to `creator` when `node_creator` is absent. `updated_at` is `obj_edit_time` formatted as RFC3339.
 - No `url` is returned: `get_node` does not provide one and a synthesized `www.feishu.cn/wiki/<node_token>` link is non-canonical/misleading for a read command. Use `node_token` / `obj_token` as the identifiers.
 
+## Terminal business errors
+
+These HTTP 200 responses carry a non-zero business code and are not retryable with the same input:
+
+| Code | Meaning | Required action |
+|------|---------|-----------------|
+| `131012` | The Wiki node has been deleted | Do not retry the same node token; rediscover the node or ask for a current Wiki link |
+| `131013` | The resource token is invalid | Do not switch identity or reauthorize; correct the URL/token |
+| `131014` | The document is not mounted in Wiki | Stop Wiki resolution; use the corresponding docs/sheets/base/drive command, or provide a Wiki URL/node_token |
+
 ## Required Scope
 
 `wiki:node:retrieve`

--- a/tests/cli_e2e/wiki/helpers_test.go
+++ b/tests/cli_e2e/wiki/helpers_test.go
@@ -265,12 +265,7 @@ func deleteWikiNodeAndVerify(ctx context.Context, spaceID, nodeToken, objType st
 		}
 	}
 
-	deleteToken := originalNodeToken
-	if node.Get("node_type").String() == "origin" {
-		if objToken := node.Get("obj_token").String(); objToken != "" {
-			deleteToken = objToken
-		}
-	}
+	deleteToken, objType := wikiDeleteTarget(node, originalNodeToken, objType)
 
 	deleteResult, deleteErr := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
 		Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes/" + deleteToken},
@@ -295,6 +290,58 @@ func deleteWikiNodeAndVerify(ctx context.Context, spaceID, nodeToken, objType st
 		return deleteResult, err
 	}
 	return deleteResult, nil
+}
+
+// wikiDeleteTarget returns the token kind expected by the delete-node API.
+// Origin nodes are addressed by their backing object token and object type;
+// shortcut nodes are addressed by their Wiki node token and obj_type=wiki.
+func wikiDeleteTarget(node gjson.Result, nodeToken, fallbackObjType string) (string, string) {
+	if node.Get("node_type").String() == "shortcut" {
+		return nodeToken, "wiki"
+	}
+	if objToken := node.Get("obj_token").String(); objToken != "" {
+		nodeToken = objToken
+	}
+	if objType := node.Get("obj_type").String(); objType != "" {
+		fallbackObjType = objType
+	}
+	return nodeToken, fallbackObjType
+}
+
+func TestWikiDeleteTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodeJSON    string
+		nodeToken   string
+		objType     string
+		wantToken   string
+		wantObjType string
+	}{
+		{
+			name:        "origin uses backing object",
+			nodeJSON:    `{"node_type":"origin","node_token":"wikcnOrigin","obj_token":"docxOrigin","obj_type":"docx"}`,
+			nodeToken:   "wikcnOrigin",
+			objType:     "docx",
+			wantToken:   "docxOrigin",
+			wantObjType: "docx",
+		},
+		{
+			name:        "shortcut uses wiki node",
+			nodeJSON:    `{"node_type":"shortcut","node_token":"wikcnShortcut","obj_token":"boxcnFile","obj_type":"file"}`,
+			nodeToken:   "wikcnShortcut",
+			objType:     "file",
+			wantToken:   "wikcnShortcut",
+			wantObjType: "wiki",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToken, gotObjType := wikiDeleteTarget(gjson.Parse(tt.nodeJSON), tt.nodeToken, tt.objType)
+			require.Equal(t, tt.wantToken, gotToken)
+			require.Equal(t, tt.wantObjType, gotObjType)
+		})
+	}
 }
 
 func listWikiNodeChildren(ctx context.Context, spaceID, parentNodeToken string) ([]wikiNodeInfo, *clie2e.Result, error) {
@@ -472,16 +519,22 @@ func isWikiNodeDeletedResult(result *clie2e.Result) bool {
 	if result == nil {
 		return false
 	}
-	if code := gjson.Get(result.Stdout, "error.code"); code.Exists() && code.Int() == 131005 {
-		return true
-	}
-	if code := gjson.Get(result.Stdout, "code"); code.Exists() && code.Int() == 131005 {
-		return true
+	for _, payload := range []string{result.Stdout, result.Stderr} {
+		for _, path := range []string{"error.code", "code"} {
+			if code := gjson.Get(payload, path); code.Exists() && isWikiNodeDeletedCode(code.Int()) {
+				return true
+			}
+		}
 	}
 	combined := strings.ToLower(result.Stdout + "\n" + result.Stderr)
 	return strings.Contains(combined, "131005") ||
 		strings.Contains(combined, "node not found") ||
+		strings.Contains(combined, "node has been deleted") ||
 		strings.Contains(combined, "not found")
+}
+
+func isWikiNodeDeletedCode(code int64) bool {
+	return code == 131005 || code == 93012 || code == 131012
 }
 
 func isWikiVerifyTransientResult(result *clie2e.Result) bool {
@@ -558,6 +611,41 @@ func TestWikiVerifyTransientResult(t *testing.T) {
 
 		require.False(t, isWikiVerifyTransientResult(result))
 	})
+}
+
+func TestIsWikiNodeDeletedResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *clie2e.Result
+		want   bool
+	}{
+		{
+			name:   "raw get-node deleted code on stderr",
+			result: &clie2e.Result{ExitCode: 1, Stderr: `{"ok":false,"error":{"type":"api","code":93012,"message":"node has been deleted"}}`},
+			want:   true,
+		},
+		{
+			name:   "CLI terminal deleted code on stderr",
+			result: &clie2e.Result{ExitCode: 1, Stderr: `{"ok":false,"error":{"type":"api","code":131012,"message":"node has been deleted"}}`},
+			want:   true,
+		},
+		{
+			name:   "legacy node not found code on stdout",
+			result: &clie2e.Result{ExitCode: 1, Stdout: `{"code":131005,"msg":"node not found"}`},
+			want:   true,
+		},
+		{
+			name:   "unrelated API error",
+			result: &clie2e.Result{ExitCode: 1, Stderr: `{"ok":false,"error":{"type":"api","code":131004,"message":"permission denied"}}`},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isWikiNodeDeletedResult(tt.result))
+		})
+	}
 }
 
 func findWikiNodeByToken(t *testing.T, ctx context.Context, spaceID string, nodeToken string, parentNodeTokens ...string) gjson.Result {

--- a/tests/cli_e2e/wiki/wiki_node_create_dryrun_test.go
+++ b/tests/cli_e2e/wiki/wiki_node_create_dryrun_test.go
@@ -102,6 +102,60 @@ func TestWikiNodeCreateDryRun(t *testing.T) {
 		assert.Equal(t, "wikcnORIG", clie2e.DryRunGet(result.Stdout, "api.0.body.origin_node_token").String())
 	})
 
+	t.Run("HappyPath_FileShortcut", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--node-type", "shortcut",
+				"--obj-type", "file",
+				"--origin-node-token", "wikcnFILE",
+				"--title", "FileShortcut",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		assert.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+		assert.Equal(t, "/open-apis/wiki/v2/spaces/123456/nodes", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+		assert.Equal(t, "shortcut", clie2e.DryRunGet(result.Stdout, "api.0.body.node_type").String())
+		assert.Equal(t, "file", clie2e.DryRunGet(result.Stdout, "api.0.body.obj_type").String())
+		assert.Equal(t, "wikcnFILE", clie2e.DryRunGet(result.Stdout, "api.0.body.origin_node_token").String())
+		assert.Equal(t, "FileShortcut", clie2e.DryRunGet(result.Stdout, "api.0.body.title").String())
+	})
+
+	t.Run("RejectsFileOrigin", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--node-type", "origin",
+				"--obj-type", "file",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+		assert.Empty(t, result.Stdout, "Validate-stage failures must not write to stdout")
+		assert.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String())
+		assert.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String())
+		assert.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "--obj-type file is not supported")
+		assert.Contains(t, gjson.Get(result.Stderr, "error.hint").String(), "--node-type shortcut --obj-type file")
+		assert.Equal(t, "use shortcut when creating a Wiki reference to a file",
+			gjson.Get(result.Stderr, `error.params.#(name=="--node-type").reason`).String())
+		assert.Equal(t, "file is supported only for shortcut nodes",
+			gjson.Get(result.Stderr, `error.params.#(name=="--obj-type").reason`).String())
+	})
+
 	t.Run("RejectsShortcutWithoutOriginNodeToken", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		t.Cleanup(cancel)

--- a/tests/cli_e2e/wiki/wiki_node_create_file_shortcut_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_node_create_file_shortcut_workflow_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestWiki_NodeCreateFileShortcutWorkflow verifies that +node-create can create
+// a shortcut to a file-backed Wiki node. Every resource is created during the
+// test and registered with the existing cleanup helpers.
+func TestWiki_NodeCreateFileShortcutWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	folderToken := createDriveFolderOrSkipWikiSource(t, parentT, ctx, "lark-cli-e2e-wiki-file-shortcut-"+suffix)
+	fileToken := uploadWikiSourceFixture(t, parentT, ctx, folderToken, "file-shortcut.txt", "wiki file shortcut "+suffix+"\n")
+
+	_, parentNode := createWikiNodeUnderAnyHost(t, parentT, ctx, "lark-cli-e2e-wiki-file-shortcut-parent-"+suffix)
+	spaceID := parentNode.Get("space_id").String()
+	parentNodeToken := parentNode.Get("node_token").String()
+	require.NotEmpty(t, spaceID)
+	require.NotEmpty(t, parentNodeToken)
+
+	fileNodeToken := moveDriveFileIntoWikiOrSkip(t, ctx, spaceID, parentNodeToken, fileToken)
+	require.NotEmpty(t, fileNodeToken)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"wiki", "+node-create",
+			"--space-id", spaceID,
+			"--parent-node-token", parentNodeToken,
+			"--node-type", "shortcut",
+			"--obj-type", "file",
+			"--origin-node-token", fileNodeToken,
+			"--title", "lark-cli-e2e-wiki-file-shortcut-" + suffix,
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+
+	shortcutNodeToken := gjson.Get(result.Stdout, "data.node_token").String()
+	require.NotEmpty(t, shortcutNodeToken, "stdout:\n%s", result.Stdout)
+	parentT.Cleanup(func() {
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+		deleteResult, deleteErr := deleteWikiNodeAndVerify(cleanupCtx, spaceID, shortcutNodeToken, "file")
+		clie2e.ReportCleanupFailure(parentT, "delete wiki file shortcut "+shortcutNodeToken, deleteResult, deleteErr)
+	})
+
+	shortcut := getWikiNode(t, ctx, shortcutNodeToken)
+	require.Equal(t, "shortcut", shortcut.Get("node_type").String(), "node:\n%s", shortcut.Raw)
+	require.Equal(t, "file", shortcut.Get("obj_type").String(), "node:\n%s", shortcut.Raw)
+	require.Equal(t, fileNodeToken, shortcut.Get("origin_node_token").String(), "node:\n%s", shortcut.Raw)
+}


### PR DESCRIPTION
## Summary

- allow `wiki +node-create` to create file shortcuts while rejecting unsupported origin file nodes locally
- classify `wiki +node-get` business errors `131012`, `131013`, and `131014` as terminal, non-retryable failures with actionable hints
- update the Wiki skill guidance and shortcut references

## Testing

- `go test ./shortcuts/wiki -count=1`
- `go test ./internal/qualitygate/skillscan -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating Wiki shortcut nodes that point to files.
  * Added clear validation and usage guidance when file objects are used with unsupported node types.
* **Bug Fixes**
  * Improved handling of Wiki node retrieval errors, including deleted nodes, invalid resources, and documents not mounted in Wiki.
  * Added actionable recovery guidance and preserved request log details.
* **Documentation**
  * Updated Wiki node creation and retrieval documentation with supported combinations, examples, and error-handling guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->