### PR TITLE
docs: document supported image formats in lark-slides media-upload

### DIFF
--- a/skills/lark-slides/references/cli/lark-slides-media-upload.md
+++ b/skills/lark-slides/references/cli/lark-slides-media-upload.md
@@ -44,7 +44,7 @@ lark-cli slides +media-upload --file ./pic.png --presentation $PRES_ID --dry-run
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--file` | 是 | 本地图片路径，**必须是 CWD 内的相对路径**（如 `./pic.png`）。**最大 20 MB**（slides upload API 不支持分片上传） |
+| `--file` | 是 | 本地图片路径，**必须是 CWD 内的相对路径**（如 `./pic.png`）。**最大 20 MB**（slides upload API 不支持分片上传）。**仅支持 png / jpeg / gif / bmp / tiff / webp** |
 | `--presentation` | 是 | `xml_presentation_id`、`/slides/<token>` URL，或 `/wiki/<token>` URL |
 
 > [!IMPORTANT]


### PR DESCRIPTION
## 变更说明

在 `lark-slides` skill 的 `+media-upload` 文档中补充支持的图片格式：**png / jpeg / gif / bmp / tiff / webp**。

## 背景

使用错误格式的图片上传时，服务端会报错。

## 改动

- `skills/lark-slides/references/cli/lark-slides-media-upload.md` — `--file` 参数说明中补充受支持格式列表

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that media uploads support PNG, JPEG, GIF, BMP, TIFF, and WebP image formats.
  - Retained existing requirements for relative file paths and the 20 MB size limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->