### PR TITLE
fix(slides): move add-slide and delete-slide reference docs to cli/ directory

### DIFF
--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -79,12 +79,12 @@ metadata:
 
 | 用户需求 | 优先动作 | 关键文档 / 命令 |
 |----------|----------|-----------------|
-| 新建 PPT | 先规划 `slide_plan.json`，再按页数选择一步或两步创建 | `planning-layer.md`、`visual-planning.md`、`asset-planning.md`、`cli/lark-slides-create.md`、`slides +create`、`slides +add-slide`、`xml/lark-slides-add-slide.md`（两步创建逐页添加） |
+| 新建 PPT | 先规划 `slide_plan.json`，再按页数选择一步或两步创建 | `planning-layer.md`、`visual-planning.md`、`asset-planning.md`、`cli/lark-slides-create.md`、`slides +create`、`slides +add-slide`、`cli/lark-slides-add-slide.md`（两步创建逐页添加） |
 | 用户要求使用模板，或提供 PPTX 文件要求修改、美化 | 将模板导入为 Slides 再编辑 | `workflow/template-editing.md` |
 | 编辑单个标题、文本块、图片或局部元素 | 块级替换/插入，**只动点名的 block，同页其他元素不受影响**；不改页序 | `slides +replace-slide`、`cli/lark-slides-replace-slide.md` |
 | 一页改动很多（批量字体/配色）、要改页面背景、要删掉若干元素 | 整页覆盖，`slide_id` 和页序不变；带原 `id` 写回的元素保留 id，不带 `id` 的会作为新元素插入并拿到新 id；**代价是没写进 `--content` 的元素会被删除，所以改个别元素不要用它** | `slides +update-slide`、`lark-slides-update-slide.md` |
-| 给已有 PPT 追加或插入页面 | 一次一页，`--slide` 支持 `@file` 绕开 shell 转义 | `slides +add-slide`、`xml/lark-slides-add-slide.md` |
-| 删除页面 | 按 `slide_id` 单页删除，删前先回读确认 | `slides +delete-slide`、`xml/lark-slides-delete-slide.md` |
+| 给已有 PPT 追加或插入页面 | 一次一页，`--slide` 支持 `@file` 绕开 shell 转义 | `slides +add-slide`、`cli/lark-slides-add-slide.md` |
+| 删除页面 | 按 `slide_id` 单页删除，删前先回读确认 | `slides +delete-slide`、`cli/lark-slides-delete-slide.md` |
 | 读取或分析已有 PPT | 解析 slides/wiki token，用 shortcut 回读全文 XML 或读取单页 XML，保存 `xml_presentation_id`、`slide_id`、`revision_id` | `slides +xml-get`、`xml_presentation.slide.get`、`cli/lark-slides-xml-presentations-get.md` |
 | 查看或回滚历史版本 | 先用 `+history-list` 找 `history_version_id`，再 `+history-revert`，必要时 `+history-revert-status` 轮询 | [`cli/lark-slides-history.md`](references/cli/lark-slides-history.md) |
 | 获取幻灯片页面截图 | 按页码用 `--slide-number`，按 ID 用 `--slide-id`；单张用 `--output`，批量或全量用 `--output-dir`，每批最多 10 页串行执行；截图目录复用同一任务的 deck/task 标识，后续读取返回的实际路径 | `slides +screenshot`、`cli/lark-slides-screenshot.md` |
@@ -148,8 +148,8 @@ lark-cli auth login --domain slides
 
 调用相关命令前必须读取相关的文档以了解命令的使用方式：
 
-- 创建：[`cli/lark-slides-create.md`](references/cli/lark-slides-create.md)、[`xml/lark-slides-add-slide.md`](references/xml/lark-slides-add-slide.md)（逐页添加 / 给已有 PPT 追加页面）
-- 删除页面：[`xml/lark-slides-delete-slide.md`](references/xml/lark-slides-delete-slide.md)
+- 创建：[`cli/lark-slides-create.md`](references/cli/lark-slides-create.md)、[`cli/lark-slides-add-slide.md`](references/cli/lark-slides-add-slide.md)（逐页添加 / 给已有 PPT 追加页面）
+- 删除页面：[`cli/lark-slides-delete-slide.md`](references/cli/lark-slides-delete-slide.md)
 - 阅读：[`cli/lark-slides-xml-presentations-get.md`](references/cli/lark-slides-xml-presentations-get.md)
 - 编辑：[`workflow/slides_editing.md`](references/workflow/slides_editing.md)、[`cli/lark-slides-replace-slide.md`](references/cli/lark-slides-replace-slide.md)、[`lark-slides-update-slide.md`](references/lark-slides-update-slide.md)
 - 历史版本：[`cli/lark-slides-history.md`](references/cli/lark-slides-history.md)
@@ -212,7 +212,7 @@ Step 2: 生成大纲 → 写入 slide_plan.json
 Step 3: 按 slide_plan.json 生成 XML → 创建
   - 逐页消费 plan：key_message 定主结论，layout_type 定几何，visual_focus 定主视觉，text_density 定文本量
   - 缺少真实素材时必须用 `fallback_if_missing` 生成替代图片，不要留空
-  - 读 cli/lark-slides-create.md 定一步创建还是两步创建，并据此构造 `slides +create`；两步创建再读 xml/lark-slides-add-slide.md 用 `+add-slide` 逐页添加
+  - 读 cli/lark-slides-create.md 定一步创建还是两步创建，并据此构造 `slides +create`；两步创建再读 cli/lark-slides-add-slide.md 用 `+add-slide` 逐页添加
   - 图片按 cli/lark-slides-media-upload.md 处理；复杂 XML、转义和 3350001 排查按 workflow/error-handling.md 执行
 
 Step 4: 审查 & 交付
@@ -284,8 +284,8 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 | Shortcut | 说明 |
 |----------|------|
 | [`+create`](references/cli/lark-slides-create.md) | 创建 PPT，可选一步添加页面 |
-| [`+add-slide`](references/xml/lark-slides-add-slide.md) | 向已有演示文稿追加或插入**一页**（`--before-slide-id` 控制位置），XML 支持 `@file` / stdin，`<img src="@./path">` 占位符自动上传 |
-| [`+delete-slide`](references/xml/lark-slides-delete-slide.md) | 按 `slide_id` 删除**一页** |
+| [`+add-slide`](references/cli/lark-slides-add-slide.md) | 向已有演示文稿追加或插入**一页**（`--before-slide-id` 控制位置），XML 支持 `@file` / stdin，`<img src="@./path">` 占位符自动上传 |
+| [`+delete-slide`](references/cli/lark-slides-delete-slide.md) | 按 `slide_id` 删除**一页** |
 | [`+xml-get`](references/cli/lark-slides-xml-presentations-get.md) | 读取全文 XML，用 `--presentation` 指定演示文稿的 `xml_presentation_id`，用 `--output` 把 XML 存到本地文件（必须是 CWD 内的相对路径，如 `.lark-slides/plan/<deck>/readback.xml`） |
 | [`+screenshot`](references/cli/lark-slides-screenshot.md) | 把幻灯片页面截图保存为本地图片；用 `--slide-number` 指定页码（从 1 开始，多页重复传入）或用 `--slide-id` 指定页面；单张用 `--output .lark-slides/screenshots/<deck-or-task-id>/page-01`，批量用 `--output-dir .lark-slides/screenshots/<deck-or-task-id>`（一次最多 10 页）；后续必须读取返回的 `output` / `screenshots[].path` |
 | [`+media-upload`](references/cli/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |

--- a/skills/lark-slides/references/cli/lark-slides-add-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-add-slide.md
@@ -62,7 +62,7 @@ lark-cli slides +add-slide --as user \
 ```
 
 - 文件不存在、不是普通文件、超过 20 MB，都在**调用任何接口之前**报错，不会留下半成品。
-- 去重只在**单次调用内**生效：多页共用同一张图时，逐页循环会把它每页重传一次。这种图先用 [`+media-upload`](../cli/lark-slides-media-upload.md) 传一次，把 `file_token` 写进各页的 `src`。
+- 去重只在**单次调用内**生效：多页共用同一张图时，逐页循环会把它每页重传一次。这种图先用 [`+media-upload`](lark-slides-media-upload.md) 传一次，把 `file_token` 写进各页的 `src`。
 
 ## 成功输出
 

--- a/skills/lark-slides/references/cli/lark-slides-create.md
+++ b/skills/lark-slides/references/cli/lark-slides-create.md
@@ -12,8 +12,8 @@
 | 场景 | 推荐方式 |
 |------|----------|
 | 不超过 10 页 | 每页存一个 XML 文件，`slides +create --slide @page-01.xml --slide @page-02.xml ...` 一步创建 |
-| 超过 10 页 | **两步创建**：先 `slides +create` 创建空白 PPT，再用 [`+add-slide`](../xml/lark-slides-add-slide.md) 逐页添加 |
-| 已有 PPT 继续追加或插入页面 | 使用 [`+add-slide`](../xml/lark-slides-add-slide.md)，必要时配合 `--before-slide-id` |
+| 超过 10 页 | **两步创建**：先 `slides +create` 创建空白 PPT，再用 [`+add-slide`](lark-slides-add-slide.md) 逐页添加 |
+| 已有 PPT 继续追加或插入页面 | 使用 [`+add-slide`](lark-slides-add-slide.md)，必要时配合 `--before-slide-id` |
 
 > [!IMPORTANT]
 > `slides +create` 带页面时底层会逐页创建，不是原子操作。中途失败时先记录 `xml_presentation_id`，回读确认当前状态，再继续修复或追加。
@@ -56,7 +56,7 @@ lark-cli slides +create --title "项目汇报" --slide @./slide-01.xml --dry-run
 - **`permission_grant`**（object，可选）：仅 `--as bot` 时返回，说明是否已自动为当前 CLI 用户授予可管理权限
 
 > [!IMPORTANT]
-> 不带页面参数时，`slides +create` 只创建空白演示文稿。创建后用 [`+add-slide`](../xml/lark-slides-add-slide.md) 逐页添加 slide 内容。
+> 不带页面参数时，`slides +create` 只创建空白演示文稿。创建后用 [`+add-slide`](lark-slides-add-slide.md) 逐页添加 slide 内容。
 >
 > 带了页面时，CLI 先创建空白演示文稿，再逐页调用 slide 创建接口添加页面。如果某一页添加失败，CLI 会停止并报错，已创建的演示文稿和已添加的页面会保留。
 >
@@ -77,7 +77,7 @@ lark-cli slides +create --title "项目汇报" --slide @./slide-01.xml --dry-run
 | `--slide` | 否 | 一页 `<slide>` XML，或 `@路径`；可重复，最多 10 次。格式见[页面输入形式](#页面输入形式) |
 | `--slides` | 否 | 页面 XML 的 JSON 字符串数组，最多 10 个；支持 `@文件` 和 `-`（stdin）。格式见[页面输入形式](#页面输入形式) |
 
-10 页是 CLI 的上限，服务端每次只接收一页。超过 10 页时先用 `+create` 创建空白 PPT，再用 [`+add-slide`](../xml/lark-slides-add-slide.md) 逐页添加。
+10 页是 CLI 的上限，服务端每次只接收一页。超过 10 页时先用 `+create` 创建空白 PPT，再用 [`+add-slide`](lark-slides-add-slide.md) 逐页添加。
 
 两种形式的每一页都会在发请求前校验成「单个完整的 `<slide>` 文档」。不合格的页在创建演示文稿之前报错并指出页序号，不会留下空壳演示文稿。
 
@@ -172,5 +172,5 @@ lark-cli slides +add-slide --as user \
 
 ## 相关命令
 
-- [slides +add-slide](../xml/lark-slides-add-slide.md) — 追加/插入单页（两步创建的第二步）
+- [slides +add-slide](lark-slides-add-slide.md) — 追加/插入单页（两步创建的第二步）
 - [slides +xml-get](lark-slides-xml-presentations-get.md) — 读取 PPT 内容并保存到本地文件

--- a/skills/lark-slides/references/cli/lark-slides-delete-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-delete-slide.md
@@ -1,6 +1,6 @@
 # slides +delete-slide（按 slide_id 删除单页）
 
-从演示文稿删除**一页**，按 `slide_id` 指定。只改一页里的局部内容用 [`+replace-slide`](../cli/lark-slides-replace-slide.md)，不要删了重建。
+从演示文稿删除**一页**，按 `slide_id` 指定。只改一页里的局部内容用 [`+replace-slide`](lark-slides-replace-slide.md)，不要删了重建。
 
 `--presentation` 接受 token / `/slides/` URL / `/wiki/` URL，ID 是普通 flag 而不是 `--params` JSON 串。
 
@@ -54,7 +54,7 @@ lark-cli slides +delete-slide --presentation "$PID" --slide-id "$SID" --dry-run
 
 ## 删错了怎么办
 
-删除在原地不可撤销，但可以走历史版本回滚：`+history-list` 找 `history_version_id` → `+history-revert`（只接受 `history_version_id`，不能传 `revision_id`）→ `+history-revert-status` 轮询。命令用法见 [lark-slides-history.md](../cli/lark-slides-history.md)。
+删除在原地不可撤销，但可以走历史版本回滚：`+history-list` 找 `history_version_id` → `+history-revert`（只接受 `history_version_id`，不能传 `revision_id`）→ `+history-revert-status` 轮询。命令用法见 [lark-slides-history.md](lark-slides-history.md)。
 
 ## 常见错误
 

--- a/skills/lark-slides/references/cli/lark-slides-media-upload.md
+++ b/skills/lark-slides/references/cli/lark-slides-media-upload.md
@@ -52,7 +52,7 @@ lark-cli slides +media-upload --file ./pic.png --presentation $PRES_ID --dry-run
 
 ## 使用流程
 
-> 新建 PPT（[`+create --slides`](lark-slides-create.md)）或给已有 PPT 加新页（[`+add-slide`](../xml/lark-slides-add-slide.md)）都不需要单独上传：XML 里把 `<img src>` 写成 `@<本地路径>`，CLI 会自动上传并替换成 `file_token`。
+> 新建 PPT（[`+create --slides`](lark-slides-create.md)）或给已有 PPT 加新页（[`+add-slide`](lark-slides-add-slide.md)）都不需要单独上传：XML 里把 `<img src>` 写成 `@<本地路径>`，CLI 会自动上传并替换成 `file_token`。
 > 本命令用于往**已有页**里加图，或需要自己拿着 `file_token` 拼 XML 的场景。
 
 ### 给已有 PPT 的已有页加图
@@ -101,4 +101,4 @@ lark-cli slides +replace-slide --as user \
 
 - [+create](lark-slides-create.md) — 新建 PPT（支持 `@` 占位符自动上传图片）
 - [+replace-slide](lark-slides-replace-slide.md) — 给已有页加图 / 换图（`block_insert` / `block_replace`）
-- [+add-slide](../xml/lark-slides-add-slide.md) — 追加/插入单页（同样支持 `@` 占位符自动上传）
+- [+add-slide](lark-slides-add-slide.md) — 追加/插入单页（同样支持 `@` 占位符自动上传）

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentations-get.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentations-get.md
@@ -153,5 +153,5 @@ lark-cli slides xml_presentations get --as user --params '<json_params>'
 ## 相关命令
 
 - [slides +create](lark-slides-create.md) - 创建空白 PPT
-- [slides +add-slide](../xml/lark-slides-add-slide.md) - 添加幻灯片页面
-- [slides +delete-slide](../xml/lark-slides-delete-slide.md) - 删除幻灯片页面
+- [slides +add-slide](lark-slides-add-slide.md) - 添加幻灯片页面
+- [slides +delete-slide](lark-slides-delete-slide.md) - 删除幻灯片页面

--- a/skills/lark-slides/references/lark-slides-add-slide.md
+++ b/skills/lark-slides/references/lark-slides-add-slide.md
@@ -1,5 +1,5 @@
 # slides +add-slide（兼容入口）
 
-本文档已迁移至 [`xml/lark-slides-add-slide.md`](xml/lark-slides-add-slide.md)。
+本文档已迁移至 [`cli/lark-slides-add-slide.md`](cli/lark-slides-add-slide.md)。
 
 此文件仅保留旧路径兼容性；后续引用请使用新路径。

--- a/skills/lark-slides/references/lark-slides-delete-slide.md
+++ b/skills/lark-slides/references/lark-slides-delete-slide.md
@@ -1,5 +1,5 @@
 # slides +delete-slide（兼容入口）
 
-本文档已迁移至 [`xml/lark-slides-delete-slide.md`](xml/lark-slides-delete-slide.md)。
+本文档已迁移至 [`cli/lark-slides-delete-slide.md`](cli/lark-slides-delete-slide.md)。
 
 此文件仅保留旧路径兼容性；后续引用请使用新路径。

--- a/skills/lark-slides/references/workflow/error-handling.md
+++ b/skills/lark-slides/references/workflow/error-handling.md
@@ -59,4 +59,4 @@
 
 - 图片上传、`@path` 占位符、`file_token`：见 [lark-slides-media-upload.md](../cli/lark-slides-media-upload.md) 和 [lark-slides-create.md](../cli/lark-slides-create.md)。
 - 块级替换、`block_id`、3350001 replace 细节：见 [lark-slides-replace-slide.md](../cli/lark-slides-replace-slide.md)。
-- 追加/插入单页、`--before-slide-id` 和 `--slide @file` 绕开转义：见 [lark-slides-add-slide.md](../xml/lark-slides-add-slide.md)。
+- 追加/插入单页、`--before-slide-id` 和 `--slide @file` 绕开转义：见 [lark-slides-add-slide.md](../cli/lark-slides-add-slide.md)。


### PR DESCRIPTION
## Summary

`lark-slides-add-slide.md` and `lark-slides-delete-slide.md` are CLI command references, not XML schema references. They belong in `references/cli/`, not `references/xml/`.

## Changes

- Move the two files from `references/xml/` to `references/cli/` via `git mv`
- Update all cross-file links in `SKILL.md`, `cli/*.md`, `workflow/*.md`, and the `references/` compatibility stubs

## Verification

- `grep` for `xml/lark-slides-add-slide` and `xml/lark-slides-delete-slide` — zero stale references
- `content_embed.go` uses `skills/*/references` recursively, unaffected by intra-directory moves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated slide creation, deletion, and media-upload references to point to the current command-line documentation.
  * Corrected links across quick references, workflows, command guides, API tables, and related documentation.
  * Refreshed migration guidance while preserving compatibility notices for legacy documentation.
  * Improved navigation between slide-management commands and supporting resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->