### PR TITLE
docs(slides): harden update file input guidance

### DIFF
--- a/affordance/slides.md
+++ b/affordance/slides.md
@@ -1,0 +1,14 @@
+# slides
+
+## +update-slide
+
+### Tips
+
+- Read the page first with `slides +xml-get --slide-id <id>`, edit that XML, and hand it back whole.
+- Anything left out of `--content` is removed from the page; pass the full page, not a fragment.
+- Editing one element is cheaper with `slides +replace-slide`.
+- In shell loops, assign the computed path to a variable, reject empty or missing files before invoking the command, and prefer `--content - < "$file"` over constructing an `@file` argument inline.
+
+### Skills
+
+- lark-slides/references/lark-slides-update-slide.md

--- a/internal/affordance/slides_source_test.go
+++ b/internal/affordance/slides_source_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package affordance
+
+import (
+	"os"
+	"testing"
+
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func TestSlidesUpdateAffordancePreservesSafetyAndShellGuidance(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	raw, ok := For("slides", "+update-slide")
+	if !ok {
+		t.Fatal("For(slides, +update-slide) ok=false")
+	}
+	a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+	if !ok {
+		t.Fatal("slides +update-slide affordance did not parse")
+	}
+
+	for _, want := range []string{
+		"Read the page first",
+		"Anything left out",
+		"Editing one element",
+		`--content - < "$file"`,
+	} {
+		if !containsItem(a.Tips, want) {
+			t.Errorf("tips must contain %q: %v", want, a.Tips)
+		}
+	}
+}

--- a/shortcuts/slides/slides_update_slide.go
+++ b/shortcuts/slides/slides_update_slide.go
@@ -46,15 +46,10 @@ var SlidesUpdateSlide = common.Shortcut{
 	// wiki:node:read is required only when --presentation is a wiki URL.
 	ConditionalScopes: []string{"wiki:node:read"},
 	AuthTypes:         []string{"user", "bot"},
-	Tips: []string{
-		"Read the page first with `slides +xml-get --slide-id <id>`, edit that XML, hand it back whole",
-		"Anything left out of --content is removed from the page — pass the full page, not a fragment",
-		"Editing one element is cheaper with `slides +replace-slide`",
-	},
-	Flags:    updateSlideFlags,
-	Validate: updateSlideValidate,
-	DryRun:   updateSlideDryRun,
-	Execute:  updateSlideExecute,
+	Flags:             updateSlideFlags,
+	Validate:          updateSlideValidate,
+	DryRun:            updateSlideDryRun,
+	Execute:           updateSlideExecute,
 }
 
 // SlidesUpdate registers `slides +update` as a hidden alias.

--- a/skills/lark-slides/references/lark-slides-update-slide.md
+++ b/skills/lark-slides/references/lark-slides-update-slide.md
@@ -12,8 +12,8 @@ lark-cli slides +update-slide --as user \
   --content @page.xml
 
 # XML 从 stdin 读
-cat page.xml | lark-cli slides +update-slide --as user \
-  --presentation "$PRES" --slide-id "$SLIDE" --content -
+lark-cli slides +update-slide --as user \
+  --presentation "$PRES" --slide-id "$SLIDE" --content - < page.xml
 
 # wiki 链接直接传（CLI 自动解析并校验 obj_type=slides）
 lark-cli slides +update-slide --as user \
@@ -23,6 +23,25 @@ lark-cli slides +update-slide --as user \
 # 预览请求，不实际写入
 lark-cli slides +update-slide --as user \
   --presentation "$PRES" --slide-id "$SLIDE" --content @page.xml --dry-run
+```
+
+循环中通过变量生成文件名时，先构造并校验路径，再优先从 stdin 读取。`${xml:?xml is empty}` 会在变量未设置或为空时立即终止；仅把 `$xml` 改成 `${xml}` 不能解决空变量问题。
+
+```bash
+set -Eeuo pipefail
+
+for slide_xml in "slide-id-1:page-01" "slide-id-2:page-02"; do
+  slide="${slide_xml%%:*}"
+  xml="${slide_xml#*:}"
+  file="${xml:?xml is empty}.xml"
+  [[ -f "$file" ]] || {
+    printf 'missing XML file: %q\n' "$file" >&2
+    exit 1
+  }
+
+  lark-cli slides +update-slide --as user \
+    --presentation "$PRES" --slide-id "$slide" --content - < "$file"
+done
 ```
 
 ## 参数

--- a/skills/lark-slides/references/workflow/error-handling.md
+++ b/skills/lark-slides/references/workflow/error-handling.md
@@ -54,6 +54,7 @@
 | 3350001 | XML 非 well-formed、XML 结构不符合服务端要求，或 replace 片段问题 | 优先检查未转义字符；replace 场景再看 `block_id` 和 `<content/>` |
 | 3350002 | `revision_id` 大于当前版本 | 用 `-1` 取当前版本，或重新用 `slides +xml-get` 取最新 `revision_id` |
 | validation: unsafe file path | `--file` 给了绝对路径或上层路径 | `--file` 必须是 CWD 内相对路径；先 `cd` 到素材目录再执行 |
+| `cannot read file ".xml"` | CLI 收到的 `@file` 路径已经是 `.xml`，通常是 shell 变量为空或被外层 shell 提前展开 | 用 `file="${xml:?xml is empty}.xml"` 检查变量、用 `[[ -f "$file" ]]` 检查文件，再传 `--content - < "$file"`；仅把 `$xml` 改成 `${xml}` 不能解决空变量问题 |
 
 ## Command-Specific References
 


### PR DESCRIPTION
## Summary
Improve `slides +update-slide` guidance for shell loops where a computed `@file` path can collapse to `.xml` when a variable is empty or expanded too early. This keeps the command fail-closed and changes guidance only; file parsing and Slides write behavior are unchanged.

## Changes
- Move the existing `+update-slide` tips to the affordance surface and add safe shell-loop guidance.
- Update the skill reference to validate computed paths and prefer stdin for loop-generated filenames.
- Document the `cannot read file ".xml"` signal and clarify that braces alone do not fix an empty variable.

## Test Plan
- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] `node scripts/skill-format-check/index.js`
- [x] Manual `go run . slides +update-slide --help` verification

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for updating presentation slides, including full-slide edits, partial replacements, and batch updates.
  - Clarified safe shell usage, file validation, and troubleshooting for invalid XML file paths.
  - Updated examples to use shell redirection for submitting slide content.

- **Tests**
  - Added coverage to verify that slide update guidance retains required safety and shell-usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->