### PR TITLE
fix(drive): harden push failure handling

### DIFF
--- a/internal/errclass/codemeta_drive.go
+++ b/internal/errclass/codemeta_drive.go
@@ -10,6 +10,7 @@ import "github.com/larksuite/cli/errs"
 // ambiguous codes fall back to CategoryAPI via BuildAPIError.
 // BuildAPIError consumes this map via mergeCodeMeta + LookupCodeMeta.
 var driveCodeMeta = map[int]CodeMeta{
+	1663:      {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive multipart upload internal error
 	1061001:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive "unknown error"
 	1061002:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // params error
 	1061004:   {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // forbidden

--- a/internal/errclass/codemeta_test.go
+++ b/internal/errclass/codemeta_test.go
@@ -109,6 +109,7 @@ func TestLookupCodeMeta_DrivePushCodes(t *testing.T) {
 		wantSubtype errs.Subtype
 		wantRetry   bool
 	}{
+		{1663, errs.CategoryAPI, errs.SubtypeServerError, true},
 		{1061001, errs.CategoryAPI, errs.SubtypeServerError, true},
 		{1061002, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 		{1061004, errs.CategoryAuthorization, errs.SubtypePermissionDenied, false},

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -603,7 +603,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Code = problem.Code
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
-	decision.Hint = problem.Hint
 
 	switch {
 	case problem.Category == errs.CategoryAuthorization && problem.Code == 99991672:

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -5,7 +5,6 @@ package drive
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -30,23 +29,19 @@ const (
 )
 
 type drivePushItem struct {
-	RelPath           string   `json:"rel_path"`
-	FileToken         string   `json:"file_token,omitempty"`
-	Action            string   `json:"action"`
-	Version           string   `json:"version,omitempty"`
-	SizeBytes         int64    `json:"size_bytes,omitempty"`
-	Error             string   `json:"error,omitempty"`
-	Hint              string   `json:"hint,omitempty"`
-	Phase             string   `json:"phase,omitempty"`
-	ErrorClass        string   `json:"error_class,omitempty"`
-	Code              int      `json:"code,omitempty"`
-	Subtype           string   `json:"subtype,omitempty"`
-	Retryable         *bool    `json:"retryable,omitempty"`
-	RetryAfterSeconds int      `json:"retry_after_seconds,omitempty"`
-	LogID             string   `json:"log_id,omitempty"`
-	Troubleshooter    string   `json:"troubleshooter,omitempty"`
-	MissingScopes     []string `json:"missing_scopes,omitempty"`
-	ConsoleURL        string   `json:"console_url,omitempty"`
+	RelPath           string `json:"rel_path"`
+	FileToken         string `json:"file_token,omitempty"`
+	Action            string `json:"action"`
+	Version           string `json:"version,omitempty"`
+	SizeBytes         int64  `json:"size_bytes,omitempty"`
+	Error             string `json:"error,omitempty"`
+	Hint              string `json:"hint,omitempty"`
+	Phase             string `json:"phase,omitempty"`
+	ErrorClass        string `json:"error_class,omitempty"`
+	Code              int    `json:"code,omitempty"`
+	Subtype           string `json:"subtype,omitempty"`
+	Retryable         *bool  `json:"retryable,omitempty"`
+	RetryAfterSeconds int    `json:"retry_after_seconds,omitempty"`
 }
 
 type driveBatchFailureDecision struct {
@@ -57,10 +52,6 @@ type driveBatchFailureDecision struct {
 	RetryAfterSeconds int
 	Terminal          bool
 	Hint              string
-	LogID             string
-	Troubleshooter    string
-	MissingScopes     []string
-	ConsoleURL        string
 }
 
 // DrivePush is a one-way, file-level mirror from a local directory onto a
@@ -598,10 +589,6 @@ func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int
 		Subtype:           decision.Subtype,
 		Retryable:         driveBoolPtr(decision.Retryable),
 		RetryAfterSeconds: decision.RetryAfterSeconds,
-		LogID:             decision.LogID,
-		Troubleshooter:    decision.Troubleshooter,
-		MissingScopes:     decision.MissingScopes,
-		ConsoleURL:        decision.ConsoleURL,
 	}
 	return item, decision.Terminal
 }
@@ -620,15 +607,8 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
 	decision.Hint = problem.Hint
-	decision.LogID = problem.LogID
-	decision.Troubleshooter = problem.Troubleshooter
 	if retryAfter, ok := errs.RetryAfter(err); ok {
 		decision.RetryAfterSeconds = int(retryAfter / time.Second)
-	}
-	var permissionErr *errs.PermissionError
-	if errors.As(err, &permissionErr) && permissionErr != nil {
-		decision.MissingScopes = append([]string(nil), permissionErr.MissingScopes...)
-		decision.ConsoleURL = permissionErr.ConsoleURL
 	}
 
 	switch {
@@ -694,7 +674,7 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 		decision.Class = "server_error"
 		decision.Terminal = true
 		if decision.Hint == "" {
-			decision.Hint = "Stop the current push and retry later with bounded exponential backoff; keep log_id for server-side diagnosis."
+			decision.Hint = "Stop the current push and retry later with bounded exponential backoff."
 		}
 	case problem.Subtype == errs.SubtypeFailedPrecondition:
 		decision.Class = "local_file_changed"

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -5,6 +5,7 @@ package drive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -29,27 +30,37 @@ const (
 )
 
 type drivePushItem struct {
-	RelPath    string `json:"rel_path"`
-	FileToken  string `json:"file_token,omitempty"`
-	Action     string `json:"action"`
-	Version    string `json:"version,omitempty"`
-	SizeBytes  int64  `json:"size_bytes,omitempty"`
-	Error      string `json:"error,omitempty"`
-	Hint       string `json:"hint,omitempty"`
-	Phase      string `json:"phase,omitempty"`
-	ErrorClass string `json:"error_class,omitempty"`
-	Code       int    `json:"code,omitempty"`
-	Subtype    string `json:"subtype,omitempty"`
-	Retryable  *bool  `json:"retryable,omitempty"`
+	RelPath           string   `json:"rel_path"`
+	FileToken         string   `json:"file_token,omitempty"`
+	Action            string   `json:"action"`
+	Version           string   `json:"version,omitempty"`
+	SizeBytes         int64    `json:"size_bytes,omitempty"`
+	Error             string   `json:"error,omitempty"`
+	Hint              string   `json:"hint,omitempty"`
+	Phase             string   `json:"phase,omitempty"`
+	ErrorClass        string   `json:"error_class,omitempty"`
+	Code              int      `json:"code,omitempty"`
+	Subtype           string   `json:"subtype,omitempty"`
+	Retryable         *bool    `json:"retryable,omitempty"`
+	RetryAfterSeconds int      `json:"retry_after_seconds,omitempty"`
+	LogID             string   `json:"log_id,omitempty"`
+	Troubleshooter    string   `json:"troubleshooter,omitempty"`
+	MissingScopes     []string `json:"missing_scopes,omitempty"`
+	ConsoleURL        string   `json:"console_url,omitempty"`
 }
 
 type driveBatchFailureDecision struct {
-	Class     string
-	Code      int
-	Subtype   string
-	Retryable bool
-	Terminal  bool
-	Hint      string
+	Class             string
+	Code              int
+	Subtype           string
+	Retryable         bool
+	RetryAfterSeconds int
+	Terminal          bool
+	Hint              string
+	LogID             string
+	Troubleshooter    string
+	MissingScopes     []string
+	ConsoleURL        string
 }
 
 // DrivePush is a one-way, file-level mirror from a local directory onto a
@@ -575,17 +586,22 @@ func drivePushShouldSkipSmart(localFile drivePushLocalFile, remoteFile driveRemo
 func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int64, err error) (drivePushItem, bool) {
 	decision := driveClassifyBatchFailure(err)
 	item := drivePushItem{
-		RelPath:    relPath,
-		FileToken:  fileToken,
-		Action:     action,
-		SizeBytes:  sizeBytes,
-		Error:      err.Error(),
-		Hint:       decision.Hint,
-		Phase:      phase,
-		ErrorClass: decision.Class,
-		Code:       decision.Code,
-		Subtype:    decision.Subtype,
-		Retryable:  driveBoolPtr(decision.Retryable),
+		RelPath:           relPath,
+		FileToken:         fileToken,
+		Action:            action,
+		SizeBytes:         sizeBytes,
+		Error:             err.Error(),
+		Hint:              decision.Hint,
+		Phase:             phase,
+		ErrorClass:        decision.Class,
+		Code:              decision.Code,
+		Subtype:           decision.Subtype,
+		Retryable:         driveBoolPtr(decision.Retryable),
+		RetryAfterSeconds: decision.RetryAfterSeconds,
+		LogID:             decision.LogID,
+		Troubleshooter:    decision.Troubleshooter,
+		MissingScopes:     decision.MissingScopes,
+		ConsoleURL:        decision.ConsoleURL,
 	}
 	return item, decision.Terminal
 }
@@ -603,6 +619,17 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Code = problem.Code
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
+	decision.Hint = problem.Hint
+	decision.LogID = problem.LogID
+	decision.Troubleshooter = problem.Troubleshooter
+	if retryAfter, ok := errs.RetryAfter(err); ok {
+		decision.RetryAfterSeconds = int(retryAfter / time.Second)
+	}
+	var permissionErr *errs.PermissionError
+	if errors.As(err, &permissionErr) && permissionErr != nil {
+		decision.MissingScopes = append([]string(nil), permissionErr.MissingScopes...)
+		decision.ConsoleURL = permissionErr.ConsoleURL
+	}
 
 	switch {
 	case problem.Category == errs.CategoryAuthorization && problem.Code == 99991672:
@@ -617,31 +644,63 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	case problem.Category == errs.CategoryNetwork && problem.Code == http.StatusForbidden:
 		decision.Class = "permission_denied"
 		decision.Terminal = true
+	case problem.Code == 1062009:
+		decision.Class = "upload_size_mismatch"
+		decision.Hint = "Rescan the local file before retrying; its contents or size may have changed during upload."
 	case problem.Subtype == errs.SubtypeInvalidParameters || problem.Code == 1061002:
 		decision.Class = "invalid_api_parameters"
 		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Check --folder-token, overwrite mode, file_token, file name, and upload parameters before retrying; do not repeat the same parameter set."
+		}
 	case problem.Subtype == errs.SubtypeRateLimit || problem.Code == 99991400:
 		decision.Class = "rate_limited"
 		decision.Terminal = true
+		if decision.RetryAfterSeconds > 0 {
+			decision.Hint = fmt.Sprintf("Stop immediate retries and wait at least %d second(s) before retrying this push.", decision.RetryAfterSeconds)
+		} else {
+			decision.Hint = "Stop immediate retries and retry later with exponential backoff and jitter."
+		}
+	case problem.Code == 1061045:
+		decision.Class = "conflict"
+		decision.Terminal = true
+		decision.Hint = "Stop this push and retry later with backoff; avoid concurrent folder creation or push operations against the same destination."
 	case problem.Code == 1062507:
 		decision.Class = "parent_sibling_limit"
 		decision.Terminal = true
 		decision.Hint = "The destination parent folder has reached its child-count limit. Clean up that folder, choose another --folder-token, or split the upload across subfolders before retrying."
-	case problem.Subtype == errs.SubtypeQuotaExceeded || problem.Code == 1061043:
+	case problem.Code == 1061043:
 		decision.Class = "file_size_limit"
-	case problem.Code == 1062009:
-		decision.Class = "upload_size_mismatch"
+		decision.Hint = "Do not retry the same file unchanged; split it into smaller files or use another storage method."
+	case problem.Subtype == errs.SubtypeQuotaExceeded:
+		decision.Class = "quota_exceeded"
+		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Free the relevant Drive quota or choose another destination before retrying."
+		}
 	case problem.Code == 1061044:
 		decision.Class = "parent_node_missing"
 		decision.Terminal = true
 		decision.Hint = "The destination parent folder no longer exists or is not visible. Verify --folder-token, folder permissions, and whether a parent directory was deleted during push before retrying."
 	case problem.Subtype == errs.SubtypeNotFound || problem.Code == 1061007:
 		decision.Class = "remote_not_found"
+	case problem.Category == errs.CategoryNetwork:
+		decision.Class = string(problem.Subtype)
+		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Stop the current push; check connectivity and retry later with bounded exponential backoff."
+		}
 	case problem.Subtype == errs.SubtypeServerError || problem.Code == 1061001 || problem.Code == 2200:
 		decision.Class = "server_error"
 		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Stop the current push and retry later with bounded exponential backoff; keep log_id for server-side diagnosis."
+		}
 	case problem.Subtype == errs.SubtypeFailedPrecondition:
 		decision.Class = "local_file_changed"
+		if decision.Hint == "" {
+			decision.Hint = "Rescan the local file before retrying this item."
+		}
 	default:
 		decision.Class = string(problem.Subtype)
 	}

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -29,29 +29,27 @@ const (
 )
 
 type drivePushItem struct {
-	RelPath           string `json:"rel_path"`
-	FileToken         string `json:"file_token,omitempty"`
-	Action            string `json:"action"`
-	Version           string `json:"version,omitempty"`
-	SizeBytes         int64  `json:"size_bytes,omitempty"`
-	Error             string `json:"error,omitempty"`
-	Hint              string `json:"hint,omitempty"`
-	Phase             string `json:"phase,omitempty"`
-	ErrorClass        string `json:"error_class,omitempty"`
-	Code              int    `json:"code,omitempty"`
-	Subtype           string `json:"subtype,omitempty"`
-	Retryable         *bool  `json:"retryable,omitempty"`
-	RetryAfterSeconds int    `json:"retry_after_seconds,omitempty"`
+	RelPath    string `json:"rel_path"`
+	FileToken  string `json:"file_token,omitempty"`
+	Action     string `json:"action"`
+	Version    string `json:"version,omitempty"`
+	SizeBytes  int64  `json:"size_bytes,omitempty"`
+	Error      string `json:"error,omitempty"`
+	Hint       string `json:"hint,omitempty"`
+	Phase      string `json:"phase,omitempty"`
+	ErrorClass string `json:"error_class,omitempty"`
+	Code       int    `json:"code,omitempty"`
+	Subtype    string `json:"subtype,omitempty"`
+	Retryable  *bool  `json:"retryable,omitempty"`
 }
 
 type driveBatchFailureDecision struct {
-	Class             string
-	Code              int
-	Subtype           string
-	Retryable         bool
-	RetryAfterSeconds int
-	Terminal          bool
-	Hint              string
+	Class     string
+	Code      int
+	Subtype   string
+	Retryable bool
+	Terminal  bool
+	Hint      string
 }
 
 // DrivePush is a one-way, file-level mirror from a local directory onto a
@@ -577,18 +575,17 @@ func drivePushShouldSkipSmart(localFile drivePushLocalFile, remoteFile driveRemo
 func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int64, err error) (drivePushItem, bool) {
 	decision := driveClassifyBatchFailure(err)
 	item := drivePushItem{
-		RelPath:           relPath,
-		FileToken:         fileToken,
-		Action:            action,
-		SizeBytes:         sizeBytes,
-		Error:             err.Error(),
-		Hint:              decision.Hint,
-		Phase:             phase,
-		ErrorClass:        decision.Class,
-		Code:              decision.Code,
-		Subtype:           decision.Subtype,
-		Retryable:         driveBoolPtr(decision.Retryable),
-		RetryAfterSeconds: decision.RetryAfterSeconds,
+		RelPath:    relPath,
+		FileToken:  fileToken,
+		Action:     action,
+		SizeBytes:  sizeBytes,
+		Error:      err.Error(),
+		Hint:       decision.Hint,
+		Phase:      phase,
+		ErrorClass: decision.Class,
+		Code:       decision.Code,
+		Subtype:    decision.Subtype,
+		Retryable:  driveBoolPtr(decision.Retryable),
 	}
 	return item, decision.Terminal
 }
@@ -607,9 +604,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
 	decision.Hint = problem.Hint
-	if retryAfter, ok := errs.RetryAfter(err); ok {
-		decision.RetryAfterSeconds = int(retryAfter / time.Second)
-	}
 
 	switch {
 	case problem.Category == errs.CategoryAuthorization && problem.Code == 99991672:
@@ -636,11 +630,7 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	case problem.Subtype == errs.SubtypeRateLimit || problem.Code == 99991400:
 		decision.Class = "rate_limited"
 		decision.Terminal = true
-		if decision.RetryAfterSeconds > 0 {
-			decision.Hint = fmt.Sprintf("Stop immediate retries and wait at least %d second(s) before retrying this push.", decision.RetryAfterSeconds)
-		} else {
-			decision.Hint = "Stop immediate retries and retry later with exponential backoff and jitter."
-		}
+		decision.Hint = "Stop immediate retries and retry later with exponential backoff and jitter."
 	case problem.Code == 1061045:
 		decision.Class = "conflict"
 		decision.Terminal = true

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1611,23 +1611,6 @@ func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
 	}
 }
 
-func TestDrivePushFailedItemPreservesRetryAfter(t *testing.T) {
-	rateErr := errs.NewAPIError(errs.SubtypeRateLimit, "rate limited").
-		WithCode(99991400).
-		WithRetryable().
-		WithRetryAfterSeconds(7)
-	rateItem, terminal := drivePushFailedItem("b.txt", "", "failed", "upload", 1, rateErr)
-	if !terminal {
-		t.Fatal("rate limit must be terminal")
-	}
-	if rateItem.RetryAfterSeconds != 7 || rateItem.Retryable == nil || !*rateItem.Retryable {
-		t.Fatalf("retry metadata was not preserved: %#v", rateItem)
-	}
-	if !strings.Contains(rateItem.Hint, "wait at least 7 second") {
-		t.Fatalf("rate-limit hint must honor retry_after_seconds: %#v", rateItem)
-	}
-}
-
 func TestDrivePushDetectsLocalFileChangedBeforeUpload(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1611,6 +1611,18 @@ func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
 	}
 }
 
+func TestDriveClassifyBatchFailureStopsOnDriveQuotaExceeded(t *testing.T) {
+	err := errs.NewAPIError(errs.SubtypeQuotaExceeded, "file quota exceeded").WithCode(1061101)
+	decision := driveClassifyBatchFailure(err)
+
+	if decision.Class != "quota_exceeded" || !decision.Terminal || decision.Retryable {
+		t.Fatalf("decision = %#v, want terminal non-retryable quota_exceeded", decision)
+	}
+	if !strings.Contains(decision.Hint, "Free the relevant Drive quota") {
+		t.Fatalf("decision.Hint = %q, want quota recovery guidance", decision.Hint)
+	}
+}
+
 func TestDrivePushDetectsLocalFileChangedBeforeUpload(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1196,6 +1196,156 @@ func TestDrivePushAbortsAfterUploadParamsError(t *testing.T) {
 	}
 }
 
+func TestDrivePushContinuesAfterUploadSizeMismatch(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "a.txt"), []byte("A"), 0o644); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "b.txt"), []byte("B"), 0o644); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:     "POST",
+		URL:        "/open-apis/drive/v1/files/upload_all",
+		BodyFilter: func(body []byte) bool { return strings.Contains(string(body), "a.txt") },
+		Body: map[string]interface{}{
+			"code": 1062009,
+			"msg":  "The actual size is inconsistent with the declared size.",
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:     "POST",
+		URL:        "/open-apis/drive/v1/files/upload_all",
+		BodyFilter: func(body []byte) bool { return strings.Contains(string(body), "b.txt") },
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{"file_token": "tok_b"},
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["failed"]; got != float64(1) {
+		t.Fatalf("summary.failed = %v, want 1", got)
+	}
+	if got := summary["uploaded"]; got != float64(1) {
+		t.Fatalf("summary.uploaded = %v, want 1", got)
+	}
+	if got := summary["aborted"]; got != false {
+		t.Fatalf("summary.aborted = %v, want false", got)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items len = %d, want 2; items=%#v", len(items), items)
+	}
+	failedItem := items[0]
+	if failedItem["rel_path"] != "a.txt" || failedItem["error_class"] != "upload_size_mismatch" {
+		t.Fatalf("unexpected failed item: %#v", failedItem)
+	}
+	if failedItem["code"] != float64(1062009) || failedItem["retryable"] != false {
+		t.Fatalf("unexpected failure metadata: %#v", failedItem)
+	}
+	if got, _ := failedItem["hint"].(string); !strings.Contains(got, "Rescan") || !strings.Contains(got, "changed") {
+		t.Fatalf("hint should tell callers to rescan the changed file, got item=%#v", failedItem)
+	}
+	if items[1]["rel_path"] != "b.txt" || items[1]["action"] != "uploaded" {
+		t.Fatalf("size mismatch must not block independent files, got items=%#v", items)
+	}
+}
+
+func TestDrivePushAbortsAfterUploadBadGateway(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "a.txt"), []byte("A"), 0o644); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "b.txt"), []byte("B"), 0o644); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:  "POST",
+		URL:     "/open-apis/drive/v1/files/upload_all",
+		Status:  http.StatusBadGateway,
+		RawBody: []byte("bad gateway"),
+		Headers: http.Header{
+			"Content-Type": []string{"text/plain"},
+			"X-Tt-Logid":   []string{"push-log-502"},
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["aborted"]; got != true {
+		t.Fatalf("summary.aborted = %v, want true", got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1; a terminal gateway failure must stop before b.txt: %#v", len(items), items)
+	}
+	item := items[0]
+	if item["rel_path"] != "a.txt" || item["error_class"] != "server_error" {
+		t.Fatalf("unexpected failed item: %#v", item)
+	}
+	if item["code"] != float64(http.StatusBadGateway) || item["retryable"] != true || item["log_id"] != "push-log-502" {
+		t.Fatalf("unexpected gateway failure metadata: %#v", item)
+	}
+	if got, _ := item["hint"].(string); !strings.Contains(got, "Stop the current push") || !strings.Contains(got, "backoff") {
+		t.Fatalf("gateway hint should prevent immediate batch retries, got item=%#v", item)
+	}
+}
+
 func TestDrivePushAbortsAfterUploadParentNodeMissing(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 
@@ -1400,6 +1550,106 @@ func TestDrivePushAbortsAfterCreateFolderParentSiblingLimit(t *testing.T) {
 		if item["rel_path"] == "b" {
 			t.Fatalf("parent sibling limit must abort before b, got items=%#v", items)
 		}
+	}
+}
+
+func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll(filepath.Join("local", "a"), 0o755); err != nil {
+		t.Fatalf("MkdirAll a: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join("local", "b"), 0o755); err != nil {
+		t.Fatalf("MkdirAll b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/create_folder",
+		Body: map[string]interface{}{
+			"code": 1061045,
+			"msg":  "resource contention, please retry.",
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["aborted"]; got != true {
+		t.Fatalf("summary.aborted = %v, want true", got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1; conflict must stop before b: %#v", len(items), items)
+	}
+	item := items[0]
+	if item["rel_path"] != "a" || item["phase"] != "create_folder" || item["error_class"] != "conflict" {
+		t.Fatalf("unexpected failed item: %#v", item)
+	}
+	if item["code"] != float64(1061045) || item["retryable"] != true {
+		t.Fatalf("unexpected conflict metadata: %#v", item)
+	}
+	if got, _ := item["hint"].(string); !strings.Contains(got, "Stop this push") || !strings.Contains(got, "concurrent") {
+		t.Fatalf("conflict hint should prevent immediate retries, got item=%#v", item)
+	}
+}
+
+func TestDrivePushFailedItemPreservesTypedDiagnostics(t *testing.T) {
+	permissionErr := errs.NewPermissionError(errs.SubtypeAppScopeNotApplied, "scope missing").
+		WithCode(99991672).
+		WithHint("open the developer console").
+		WithLogID("push-log-permission").
+		WithMissingScopes("drive:file:upload").
+		WithConsoleURL("https://open.feishu.cn/app/cli_test/permission")
+	permissionErr.Troubleshooter = "https://open.feishu.cn/document/troubleshoot/push"
+
+	item, terminal := drivePushFailedItem("a.txt", "", "failed", "upload", 1, permissionErr)
+	if !terminal {
+		t.Fatal("app scope failure must be terminal")
+	}
+	if item.Hint != "open the developer console" || item.LogID != "push-log-permission" {
+		t.Fatalf("typed hint/log_id were not preserved: %#v", item)
+	}
+	if item.Troubleshooter != permissionErr.Troubleshooter || item.ConsoleURL != permissionErr.ConsoleURL {
+		t.Fatalf("typed diagnostic URLs were not preserved: %#v", item)
+	}
+	if len(item.MissingScopes) != 1 || item.MissingScopes[0] != "drive:file:upload" {
+		t.Fatalf("missing_scopes were not preserved: %#v", item)
+	}
+
+	rateErr := errs.NewAPIError(errs.SubtypeRateLimit, "rate limited").
+		WithCode(99991400).
+		WithRetryable().
+		WithRetryAfterSeconds(7)
+	rateItem, terminal := drivePushFailedItem("b.txt", "", "failed", "upload", 1, rateErr)
+	if !terminal {
+		t.Fatal("rate limit must be terminal")
+	}
+	if rateItem.RetryAfterSeconds != 7 || rateItem.Retryable == nil || !*rateItem.Retryable {
+		t.Fatalf("retry metadata was not preserved: %#v", rateItem)
+	}
+	if !strings.Contains(rateItem.Hint, "wait at least 7 second") {
+		t.Fatalf("rate-limit hint must honor retry_after_seconds: %#v", rateItem)
 	}
 }
 

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1304,14 +1304,11 @@ func TestDrivePushAbortsAfterUploadBadGateway(t *testing.T) {
 		},
 	})
 	reg.Register(&httpmock.Stub{
-		Method:  "POST",
-		URL:     "/open-apis/drive/v1/files/upload_all",
-		Status:  http.StatusBadGateway,
-		RawBody: []byte("bad gateway"),
-		Headers: http.Header{
-			"Content-Type": []string{"text/plain"},
-			"X-Tt-Logid":   []string{"push-log-502"},
-		},
+		Method:      "POST",
+		URL:         "/open-apis/drive/v1/files/upload_all",
+		Status:      http.StatusBadGateway,
+		RawBody:     []byte("bad gateway"),
+		ContentType: "text/plain",
 	})
 
 	err := mountAndRunDrive(t, DrivePush, []string{
@@ -1338,7 +1335,7 @@ func TestDrivePushAbortsAfterUploadBadGateway(t *testing.T) {
 	if item["rel_path"] != "a.txt" || item["error_class"] != "server_error" {
 		t.Fatalf("unexpected failed item: %#v", item)
 	}
-	if item["code"] != float64(http.StatusBadGateway) || item["retryable"] != true || item["log_id"] != "push-log-502" {
+	if item["code"] != float64(http.StatusBadGateway) || item["retryable"] != true {
 		t.Fatalf("unexpected gateway failure metadata: %#v", item)
 	}
 	if got, _ := item["hint"].(string); !strings.Contains(got, "Stop the current push") || !strings.Contains(got, "backoff") {
@@ -1614,29 +1611,7 @@ func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
 	}
 }
 
-func TestDrivePushFailedItemPreservesTypedDiagnostics(t *testing.T) {
-	permissionErr := errs.NewPermissionError(errs.SubtypeAppScopeNotApplied, "scope missing").
-		WithCode(99991672).
-		WithHint("open the developer console").
-		WithLogID("push-log-permission").
-		WithMissingScopes("drive:file:upload").
-		WithConsoleURL("https://open.feishu.cn/app/cli_test/permission")
-	permissionErr.Troubleshooter = "https://open.feishu.cn/document/troubleshoot/push"
-
-	item, terminal := drivePushFailedItem("a.txt", "", "failed", "upload", 1, permissionErr)
-	if !terminal {
-		t.Fatal("app scope failure must be terminal")
-	}
-	if item.Hint != "open the developer console" || item.LogID != "push-log-permission" {
-		t.Fatalf("typed hint/log_id were not preserved: %#v", item)
-	}
-	if item.Troubleshooter != permissionErr.Troubleshooter || item.ConsoleURL != permissionErr.ConsoleURL {
-		t.Fatalf("typed diagnostic URLs were not preserved: %#v", item)
-	}
-	if len(item.MissingScopes) != 1 || item.MissingScopes[0] != "drive:file:upload" {
-		t.Fatalf("missing_scopes were not preserved: %#v", item)
-	}
-
+func TestDrivePushFailedItemPreservesRetryAfter(t *testing.T) {
 	rateErr := errs.NewAPIError(errs.SubtypeRateLimit, "rate limited").
 		WithCode(99991400).
 		WithRetryable().

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -120,7 +120,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     {"rel_path": "...", "file_token": "...", "action": "uploaded",       "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "overwritten",    "version": "...", "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "skipped",        "size_bytes": 0},
-    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0},
+    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
     {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
     {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "...", "hint": "...", "phase": "delete", "error_class": "...", "code": 0, "subtype": "...", "retryable": false}
@@ -134,7 +134,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
-失败项会保留上游 typed error 已提供的 `hint` 和 `retry_after_seconds`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
+失败项会保留上游 typed error 已提供的 `hint`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；重试时采用有上限的指数退避和抖动。
 
 常见终止性错误：
 

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -120,7 +120,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     {"rel_path": "...", "file_token": "...", "action": "uploaded",       "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "overwritten",    "version": "...", "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "skipped",        "size_bytes": 0},
-    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0, "log_id": "...", "troubleshooter": "...", "missing_scopes": ["..."], "console_url": "..."},
+    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
     {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
     {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "...", "hint": "...", "phase": "delete", "error_class": "...", "code": 0, "subtype": "...", "retryable": false}
@@ -134,7 +134,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
-失败项会保留上游 typed error 已提供的 `hint`、`log_id`、`troubleshooter`、`retry_after_seconds`，以及权限错误的 `missing_scopes` / `console_url`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
+失败项会保留上游 typed error 已提供的 `hint` 和 `retry_after_seconds`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
 
 常见终止性错误：
 
@@ -148,7 +148,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 | `parent_sibling_limit` | `1062507` | 目标父文件夹单层子节点数量超过上限 | 停止重试，清理目标目录、换一个 `--folder-token`，或把上传内容拆到多个子目录 |
 | `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
 | `conflict` | `1061045` | 同一目标发生资源竞争 | 停止当前批次，避免并发操作同一目标；退避后有限重试 |
-| `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试；保留 `log_id` 便于排查 |
+| `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试 |
 
 非终止但需要解释的状态：
 

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -134,7 +134,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
-失败项会保留上游 typed error 已提供的 `hint`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；重试时采用有上限的指数退避和抖动。
+`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；重试时采用有上限的指数退避和抖动。
 
 常见终止性错误：
 
@@ -146,6 +146,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 | `invalid_api_parameters` | `1061002` | API 参数被服务端拒绝 | 停止重试，检查 `--folder-token`、覆盖模式、`file_token`、文件名和上传参数；不要对同一参数组合批量重试 |
 | `parent_node_missing` | `1061044` | 上传 / 建目录使用的父文件夹不存在或当前身份不可见 | 停止重试，检查 `--folder-token` 是否仍存在、是否有权限、父目录是否在 push 过程中被删除；不要继续上传同一目录树 |
 | `parent_sibling_limit` | `1062507` | 目标父文件夹单层子节点数量超过上限 | 停止重试，清理目标目录、换一个 `--folder-token`，或把上传内容拆到多个子目录 |
+| `quota_exceeded` | `1061101` | Drive 文件容量配额已满 | 停止重试，释放容量、调整目标位置或扩容后再执行 push |
 | `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
 | `conflict` | `1061045` | 同一目标发生资源竞争 | 停止当前批次，避免并发操作同一目标；退避后有限重试 |
 | `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试 |

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -120,7 +120,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     {"rel_path": "...", "file_token": "...", "action": "uploaded",       "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "overwritten",    "version": "...", "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "skipped",        "size_bytes": 0},
-    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false},
+    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0, "log_id": "...", "troubleshooter": "...", "missing_scopes": ["..."], "console_url": "..."},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
     {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
     {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "...", "hint": "...", "phase": "delete", "error_class": "...", "code": 0, "subtype": "...", "retryable": false}
@@ -134,6 +134,8 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
+失败项会保留上游 typed error 已提供的 `hint`、`log_id`、`troubleshooter`、`retry_after_seconds`，以及权限错误的 `missing_scopes` / `console_url`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
+
 常见终止性错误：
 
 | `error_class` | 常见 `code` | 含义 | Agent 应对 |
@@ -145,7 +147,8 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 | `parent_node_missing` | `1061044` | 上传 / 建目录使用的父文件夹不存在或当前身份不可见 | 停止重试，检查 `--folder-token` 是否仍存在、是否有权限、父目录是否在 push 过程中被删除；不要继续上传同一目录树 |
 | `parent_sibling_limit` | `1062507` | 目标父文件夹单层子节点数量超过上限 | 停止重试，清理目标目录、换一个 `--folder-token`，或把上传内容拆到多个子目录 |
 | `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
-| `server_error` | `1061001` / `2200` | Drive 服务端异常 | 停止当前批次，稍后重试；保留 `log_id` 便于排查 |
+| `conflict` | `1061045` | 同一目标发生资源竞争 | 停止当前批次，避免并发操作同一目标；退避后有限重试 |
+| `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试；保留 `log_id` 便于排查 |
 
 非终止但需要解释的状态：
 


### PR DESCRIPTION
## Summary

Harden `drive +push` batch control so deterministic or shared failures do not fan out across the remaining batch, using only error signals available on the command's real response path.

## Changes

- classify `1062009` as the file-local `upload_size_mismatch` before the generic invalid-parameters branch, allowing independent files to continue
- stop the batch on Drive resource contention, global storage quota, multipart internal errors, and HTTP/network failures
- use command-owned bounded-backoff guidance instead of forwarding arbitrary upstream hints or encouraging immediate replay
- document the retry contract and add regression coverage for size mismatch, HTTP 502, resource contention, quota exhaustion, and Drive code `1663`

## Test Plan

- [x] `go test ./shortcuts/drive ./internal/errclass -count=1`
- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `node scripts/skill-format-check/index.js`
- [x] `make quality-gate`
- [ ] Live tenant verification was not run; deterministic HTTP stubs cover the changed API behavior without writing Drive data

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Drive upload failure handling with clearer diagnostics and troubleshooting guidance.
  * Upload size mismatches now allow independent files to continue processing.
  * Improved handling for server errors, conflicts, rate limits, quotas, and network failures.
  * Retryable failures now include retry timing and relevant console or log links.
  * Multipart upload internal failures are now classified for automatic retry.
  * Quota exhaustion is correctly identified as non-retryable.

* **Documentation**
  * Expanded Drive push error classifications and bounded retry recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->