### PR TITLE
feat: support bot identity

### DIFF
--- a/shortcuts/minutes/bot_identity_test.go
+++ b/shortcuts/minutes/bot_identity_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// Tests pinning bot-identity support for `minutes +detail` (minute metadata,
+// artifacts, and transcript all flow under a tenant access token).
+
+package minutes
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+func TestMinutesDetailSupportsUserAndBotIdentity(t *testing.T) {
+	want := []string{"user", "bot"}
+	if !reflect.DeepEqual(MinutesDetail.AuthTypes, want) {
+		t.Fatalf("MinutesDetail.AuthTypes = %v, want %v", MinutesDetail.AuthTypes, want)
+	}
+}
+
+func TestDetail_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := detailMountAndRun(t, MinutesDetail, []string{"+detail", "--minute-tokens", "tok001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "/open-apis/minutes/v1/minutes/") {
+		t.Errorf("dry-run should show minutes API path, got: %s", stdout.String())
+	}
+}
+
+func TestDetail_DryRun_BotIdentity_Transcript(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := detailMountAndRun(t, MinutesDetail, []string{"+detail", "--minute-tokens", "tok001", "--transcript", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "artifacts") {
+		t.Errorf("dry-run should show artifacts API path when --transcript is set, got: %s", stdout.String())
+	}
+}
+
+func TestMinutesApplyPermissionSupportsUserAndBotIdentity(t *testing.T) {
+	want := []string{"user", "bot"}
+	if !reflect.DeepEqual(MinutesApplyPermission.AuthTypes, want) {
+		t.Fatalf("MinutesApplyPermission.AuthTypes = %v, want %v", MinutesApplyPermission.AuthTypes, want)
+	}
+}
+
+func TestApplyPermission_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, MinutesApplyPermission, []string{
+		"+apply-permission", "--minute-token", "obcnexampleminute", "--perm", "view", "--dry-run", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/minutes/v1/minutes/obcnexampleminute/permissions/apply") {
+		t.Errorf("dry-run should show apply-permission API path, got: %s", out)
+	}
+	if !strings.Contains(out, `"perm": "view"`) && !strings.Contains(out, `"perm":"view"`) {
+		t.Errorf("dry-run should show perm body, got: %s", out)
+	}
+}

--- a/shortcuts/minutes/minutes_apply_permission.go
+++ b/shortcuts/minutes/minutes_apply_permission.go
@@ -21,7 +21,7 @@ var MinutesApplyPermission = common.Shortcut{
 	Description: "Apply for view or edit permission on a minute",
 	Risk:        "write",
 	Scopes:      []string{"minutes:permission:apply"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "minute-token", Desc: "minute token", Required: true},
 		{Name: "perm", Desc: "permission to apply for", Required: true, Enum: []string{"view", "edit"}},

--- a/shortcuts/minutes/minutes_detail.go
+++ b/shortcuts/minutes/minutes_detail.go
@@ -285,7 +285,7 @@ var MinutesDetail = common.Shortcut{
 	Description: "Query minute details with selective artifact flags (summary, todo, chapter, transcript, keyword)",
 	Risk:        "read",
 	Scopes:      []string{"minutes:minutes.basic:read", "minutes:minutes.artifacts:read"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "minute-tokens", Desc: "minute tokens, comma-separated for batch", Required: true},

--- a/shortcuts/note/note_detail.go
+++ b/shortcuts/note/note_detail.go
@@ -23,7 +23,7 @@ var NoteDetail = common.Shortcut{
 	Description: "Get note detail (display type, document tokens) by note_id",
 	Risk:        "read",
 	Scopes:      []string{"vc:note:read"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "note-id", Desc: "note ID", Required: true},
 	},

--- a/shortcuts/note/note_test.go
+++ b/shortcuts/note/note_test.go
@@ -273,6 +273,70 @@ func TestShortcuts(t *testing.T) {
 	}
 }
 
+func TestNoteDetailAuthTypesIncludeBot(t *testing.T) {
+	got := NoteDetail.AuthTypes
+	if len(got) != 2 || got[0] != "user" || got[1] != "bot" {
+		t.Fatalf("NoteDetail.AuthTypes = %#v, want [user bot]", got)
+	}
+	if len(NoteTranscript.AuthTypes) != 1 || NoteTranscript.AuthTypes[0] != "user" {
+		t.Fatalf("NoteTranscript.AuthTypes = %#v, want [user] only", NoteTranscript.AuthTypes)
+	}
+}
+
+func TestNoteDetailSupportsBotIdentity(t *testing.T) {
+	factory, stdout, _, reg := noteShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/vc/v1/notes/note_bot_ok",
+		Body: map[string]any{
+			"code": 0,
+			"data": map[string]any{
+				"note": map[string]any{
+					"note_display_type": float64(1),
+					"creator_id":        "ou_bot",
+					"create_time":       "1710000000",
+					"artifacts": []any{
+						map[string]any{"artifact_type": float64(1), "doc_token": "doc_main"},
+					},
+				},
+			},
+		},
+	})
+
+	err := runNoteShortcut(t, NoteDetail, []string{"+detail", "--note-id", "note_bot_ok", "--as", "bot"}, factory, stdout)
+	if err != nil {
+		t.Fatalf("note +detail --as bot failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s", err, stdout.String())
+	}
+	if resp["identity"] != "bot" {
+		t.Fatalf("identity = %v, want bot", resp["identity"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	note, _ := data["note"].(map[string]any)
+	if note["note_id"] != "note_bot_ok" || note["note_doc_token"] != "doc_main" {
+		t.Fatalf("note payload = %#v, want note_id/note_doc_token filled", note)
+	}
+}
+
+func TestNoteTranscriptRejectsBotIdentity(t *testing.T) {
+	factory, stdout, _, _ := noteShortcutTestFactory(t)
+	err := runNoteShortcut(t, NoteTranscript, []string{"+transcript", "--note-id", "note_x", "--as", "bot"}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected note +transcript --as bot to fail")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation {
+		t.Fatalf("error = %v (%T), want typed validation error", err, err)
+	}
+	if !strings.Contains(err.Error(), "bot") {
+		t.Fatalf("error = %q, want mention of bot", err.Error())
+	}
+}
+
 func valuesEqual(a, b any) bool {
 	ab, _ := json.Marshal(a)
 	bb, _ := json.Marshal(b)

--- a/shortcuts/vc/bot_identity_test.go
+++ b/shortcuts/vc/bot_identity_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// Tests pinning bot-identity support for the vc read shortcuts
+// (+detail / +notes / +recording).
+
+package vc
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
+)
+
+// ---------------------------------------------------------------------------
+// AuthTypes contracts
+// ---------------------------------------------------------------------------
+
+func TestVCReadShortcutsSupportUserAndBotIdentity(t *testing.T) {
+	want := []string{"user", "bot"}
+	cases := map[string][]string{
+		"+detail":    VCDetail.AuthTypes,
+		"+notes":     VCNotes.AuthTypes,
+		"+recording": VCRecording.AuthTypes,
+	}
+	for cmd, got := range cases {
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s AuthTypes = %v, want %v", cmd, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bot dry-run: the meeting/recording paths flow under bot identity
+// ---------------------------------------------------------------------------
+
+func TestDetail_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCDetail, []string{"+detail", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/vc/v1/meetings/{meeting_id}") {
+		t.Errorf("dry-run should show meeting.get API, got: %s", out)
+	}
+	if !strings.Contains(out, "recording") {
+		t.Errorf("dry-run should show recording API, got: %s", out)
+	}
+}
+
+func TestRecording_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "recording") {
+		t.Errorf("dry-run should show recording API, got: %s", out)
+	}
+}
+
+func TestNotes_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCNotes, []string{"+notes", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/vc/v1/notes/{note_id}") {
+		t.Errorf("dry-run should show note.get API, got: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// calendar-event-ids also flows under bot: a bot has a primary calendar, so the
+// primary-calendar -> meeting_id -> recording/notes chain is expected to work.
+// ---------------------------------------------------------------------------
+
+func TestRecording_DryRun_BotIdentity_CalendarEventIDs(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--calendar-event-ids", "evt001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "mget_instance_relation_info") {
+		t.Errorf("dry-run should show the primary-calendar resolution step, got: %s", out)
+	}
+	if !strings.Contains(out, "recording") {
+		t.Errorf("dry-run should show recording API, got: %s", out)
+	}
+}
+
+func TestNotes_DryRun_BotIdentity_CalendarEventIDs(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCNotes, []string{"+notes", "--calendar-event-ids", "evt001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "mget_instance_relation_info") {
+		t.Errorf("dry-run should show the primary-calendar resolution step, got: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Identity-aware preflight: bot resolves TAT (empty local scopes in this stub),
+// so an under-scoped UAT must not make --as bot fail. Reverting to
+// auth.GetStoredToken(user) would break this.
+// ---------------------------------------------------------------------------
+
+func TestRecording_BotIdentityAwareScopePreflight(t *testing.T) {
+	cfg := defaultConfig()
+	f, stdout, _, _ := cmdutil.TestFactory(t, cfg)
+	f.Credential = credential.NewCredentialProvider(nil, nil, &recordingIdentityTokenResolver{
+		uatScopes: "calendar:calendar:read", // deliberately missing vc:record:readonly
+		tatScopes: "",                       // bot/tenant: no local scope metadata
+	}, nil)
+
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("bot preflight must resolve tenant token, not the under-scoped user token; got error: %v", err)
+	}
+}
+
+// recordingIdentityTokenResolver returns different scopes for UAT vs TAT so
+// bot identity-aware preflight can be pinned separately from user preflight.
+type recordingIdentityTokenResolver struct {
+	uatScopes string
+	tatScopes string
+}
+
+func (r *recordingIdentityTokenResolver) ResolveToken(_ context.Context, req credential.TokenSpec) (*credential.TokenResult, error) {
+	scopes := r.uatScopes
+	if req.Type == credential.TokenTypeTAT {
+		scopes = r.tatScopes
+	}
+	return &credential.TokenResult{Token: "test-token", Scopes: scopes}, nil
+}

--- a/shortcuts/vc/vc_detail.go
+++ b/shortcuts/vc/vc_detail.go
@@ -164,7 +164,7 @@ var VCDetail = common.Shortcut{
 	Description: "Get meeting details including note_id and minute_token by meeting IDs",
 	Risk:        "read",
 	Scopes:      []string{"vc:meeting.meetingevent:read", "vc:record:readonly"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "meeting-ids", Desc: "meeting IDs, comma-separated for batch", Required: true},

--- a/shortcuts/vc/vc_notes.go
+++ b/shortcuts/vc/vc_notes.go
@@ -550,7 +550,7 @@ var VCNotes = common.Shortcut{
 	Description: "Query meeting notes (via meeting-ids, minute-tokens, or calendar-event-ids)",
 	Risk:        "read",
 	Scopes:      []string{"vc:note:read"}, // minimum scope; additional per-flag scopes checked in Validate
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	Hidden:      true, // hidden from --help; prefer vc +detail, minutes +detail, or note +detail
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/vc/vc_recording.go
+++ b/shortcuts/vc/vc_recording.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -91,13 +92,13 @@ var VCRecording = common.Shortcut{
 	Description: "Query minute_token from meeting-ids or calendar-event-ids",
 	Risk:        "read",
 	Scopes:      []string{"vc:record:readonly"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "meeting-ids", Desc: "meeting IDs, comma-separated for batch"},
 		{Name: "calendar-event-ids", Desc: "calendar event instance IDs, comma-separated for batch"},
 	},
-	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := common.ExactlyOneTyped(runtime, "meeting-ids", "calendar-event-ids"); err != nil {
 			return err
 		}
@@ -116,17 +117,13 @@ var VCRecording = common.Shortcut{
 		case runtime.Str("calendar-event-ids") != "":
 			required = scopesRecordingCalendarEventIDs
 		}
-		appID := runtime.Config.AppID
-		userOpenID := runtime.UserOpenId()
-		if appID != "" && userOpenID != "" {
-			stored := auth.GetStoredToken(appID, userOpenID)
-			if stored != nil {
-				if missing := auth.MissingScopes(stored.Scope, required); len(missing) > 0 {
-					return errs.NewPermissionError(errs.SubtypeMissingScope,
-						"missing required scope(s): %s", strings.Join(missing, ", ")).
-						WithMissingScopes(missing...).
-						WithIdentity(string(runtime.As()))
-				}
+		result, err := runtime.Factory.Credential.ResolveToken(ctx, credential.NewTokenSpec(runtime.As(), runtime.Config.AppID))
+		if err == nil && result != nil && result.Scopes != "" {
+			if missing := auth.MissingScopes(result.Scopes, required); len(missing) > 0 {
+				return errs.NewPermissionError(errs.SubtypeMissingScope,
+					"missing required scope(s): %s", strings.Join(missing, ", ")).
+					WithMissingScopes(missing...).
+					WithIdentity(string(runtime.As()))
 			}
 		}
 		return nil

--- a/shortcuts/vc/vc_recording_test.go
+++ b/shortcuts/vc/vc_recording_test.go
@@ -10,14 +10,12 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
-	keyring "github.com/zalando/go-keyring"
 
 	"github.com/larksuite/cli/errs"
-	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -141,27 +139,15 @@ func TestRecording_BatchLimit_CalendarEventIDs(t *testing.T) {
 }
 
 func TestRecording_Validate_MissingScope(t *testing.T) {
-	keyring.MockInit() // use in-memory keyring to avoid macOS keychain popups
-	t.Setenv("HOME", t.TempDir())
-
 	cfg := defaultConfig()
-	// Store a token that intentionally lacks the vc:record:readonly scope.
-	token := &auth.StoredUAToken{
-		UserOpenId:       cfg.UserOpenId,
-		AppId:            cfg.AppID,
-		AccessToken:      "test-user-access-token",
-		RefreshToken:     "test-refresh-token",
-		ExpiresAt:        time.Now().Add(1 * time.Hour).UnixMilli(),
-		RefreshExpiresAt: time.Now().Add(24 * time.Hour).UnixMilli(),
-		Scope:            "calendar:calendar:read",
-		GrantedAt:        time.Now().Add(-1 * time.Hour).UnixMilli(),
-	}
-	if err := auth.SetStoredToken(token); err != nil {
-		t.Fatalf("SetStoredToken() error = %v", err)
-	}
-	t.Cleanup(func() { _ = auth.RemoveStoredToken(cfg.AppID, cfg.UserOpenId) })
-
 	f, _, _, _ := cmdutil.TestFactory(t, cfg)
+	// TestFactory's default token resolver returns empty Scopes, which skips
+	// identity-aware preflight. Inject a resolver that returns an under-scoped
+	// user token so the MissingScopes path is exercised.
+	f.Credential = credential.NewCredentialProvider(nil, nil, &recordingScopedTokenResolver{
+		scopes: "calendar:calendar:read",
+	}, nil)
+
 	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--as", "user"}, f, nil)
 	if err == nil {
 		t.Fatal("expected missing_scope error, got nil")
@@ -187,6 +173,16 @@ func TestRecording_Validate_MissingScope(t *testing.T) {
 	if !found {
 		t.Errorf("expected MissingScopes to contain 'vc:record:readonly', got %v", pe.MissingScopes)
 	}
+}
+
+// recordingScopedTokenResolver returns a token with caller-controlled scopes
+// so tests can deterministically exercise the identity-aware scope preflight.
+type recordingScopedTokenResolver struct {
+	scopes string
+}
+
+func (r *recordingScopedTokenResolver) ResolveToken(_ context.Context, _ credential.TokenSpec) (*credential.TokenResult, error) {
+	return &credential.TokenResult{Token: "test-token", Scopes: r.scopes}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/lark-minutes/SKILL.md
+++ b/skills/lark-minutes/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 ## 身份
 
-所有 minutes 命令默认使用 `--as user`。
+所有 minutes 命令默认使用 `--as user`。`+detail` 和 `+download` 也支持 `--as bot`（bot 只能访问 bot 有权限的妙记）。
 
 ## Shortcuts
 

--- a/skills/lark-note/SKILL.md
+++ b/skills/lark-note/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 # note (v1)
 
-身份：仅使用 `--as user`。使用前阅读 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)。
+身份：`+detail` 支持 `--as user` / `--as bot`。使用前阅读 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)。
 
 **CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-vc/references/vc-domain-boundaries.md`](../lark-vc/references/vc-domain-boundaries.md)**，不读将导致命令使用、会议产物决策、领域边界职责判断错误：
 > 1. 了解日历 & VC、会议产物 & 文档的关联关系和职责划分

--- a/skills/lark-note/references/lark-note-detail.md
+++ b/skills/lark-note/references/lark-note-detail.md
@@ -1,11 +1,12 @@
 # note +detail
 
-通过 `note_id` 查询会议纪要详情，获取下挂文档 Token（AI 智能纪要、逐字稿、会中共享文档）。只读，仅支持 `--as user`。
+通过 `note_id` 查询会议纪要详情，获取下挂文档 Token（AI 智能纪要、逐字稿、会中共享文档）。只读，支持 `--as user` / `--as bot`。bot 身份下能否读到数据取决于应用对纪要主文档是否有 view 权限。
 
 ## 命令
 
 ```bash
 lark-cli note +detail --note-id <note_id>
+lark-cli note +detail --note-id <note_id> --as bot
 ```
 
 ## `note_id` 来源

--- a/skills/lark-vc/SKILL.md
+++ b/skills/lark-vc/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 ## 身份
 
-本 skill 默认使用 `--as user`。`meeting get`、`+meeting-list-active`、`+meeting-events` 和 `+meeting-message-send` 也支持 `--as bot`；`+meeting-events` 和 `+meeting-message-send` 必须沿用 `meeting_id` 的来源身份。`+search` 仅支持 `--as user`。
+本 skill 默认使用 `--as user`。+search`、`meeting get`、`+meeting-list-active`、`+meeting-events` 和 `+meeting-message-send` 也支持 `--as bot`；`+meeting-events` 和 `+meeting-message-send` 必须沿用 `meeting_id` 的来源身份。
 
 ```bash
 # BAD — 查昨天的会议用 calendar，会漏掉即时会议

--- a/skills/lark-vc/references/lark-vc-recording.md
+++ b/skills/lark-vc/references/lark-vc-recording.md
@@ -40,9 +40,9 @@ lark-cli vc +recording --meeting-ids 69xxxxxxxxxxxxx28 --dry-run
 
 每次只能指定一种输入方式。同时传入会报错。
 
-### 2. 仅支持 user 身份
+### 2. 身份支持
 
-该命令仅支持 `user` 身份，使用前需完成 `lark-cli auth login`。user token 只能查自己有权限的录制。
+`--meeting-ids` 和 `--calendar-event-ids` 两种模式都支持 `--as user` 和 `--as bot`。user token 只能查自己有权限的录制；bot 使用 tenant_access_token，只能查 bot 有权限的录制。
 
 ### 3. 批量上限
 

--- a/tests/cli_e2e/minutes/minutes_apply_permission_test.go
+++ b/tests/cli_e2e/minutes/minutes_apply_permission_test.go
@@ -37,6 +37,29 @@ func TestMinutesApplyPermission_DryRun(t *testing.T) {
 	assert.True(t, strings.Contains(output, `"perm": "view"`) || strings.Contains(output, `"perm":"view"`), "dry-run should contain perm body, got: %s", output)
 }
 
+func TestMinutesApplyPermission_DryRun_BotIdentity(t *testing.T) {
+	setDryRunConfigEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"minutes", "+apply-permission",
+			"--minute-token", "obcnexampleminute",
+			"--perm", "view",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	output := result.Stdout
+	assert.True(t, strings.Contains(output, "POST"), "dry-run should contain POST method, got: %s", output)
+	assert.True(t, strings.Contains(output, "/open-apis/minutes/v1/minutes/obcnexampleminute/permissions/apply"), "dry-run should contain API path, got: %s", output)
+	assert.True(t, strings.Contains(output, `"perm": "view"`) || strings.Contains(output, `"perm":"view"`), "dry-run should contain perm body, got: %s", output)
+}
+
 func TestMinutesApplyPermission_InvalidPerm(t *testing.T) {
 	setDryRunConfigEnv(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/tests/cli_e2e/minutes/minutes_detail_dryrun_test.go
+++ b/tests/cli_e2e/minutes/minutes_detail_dryrun_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package minutes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMinutesDetailDryRun_BotIdentity pins that `minutes +detail` accepts
+// --as bot for both the metadata (GetMinuteArtifacts) and transcript
+// (GetMinuteTranscript) paths, which accept a tenant access token.
+func TestMinutesDetailDryRun_BotIdentity(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	setDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"minutes", "+detail",
+			"--minute-tokens", "obcnexampleminute",
+			"--transcript",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	require.Contains(t, result.Args, "--as")
+	require.Contains(t, result.Args, "bot")
+
+	out := result.Stdout
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/minutes/v1/minutes/{minute_token}", clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/minutes/v1/minutes/{minute_token}/artifacts", clie2e.DryRunGet(out, "api.1.url").String(), "stdout:\n%s", out)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"minutes", "+detail", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+}

--- a/tests/cli_e2e/note/coverage.md
+++ b/tests/cli_e2e/note/coverage.md
@@ -11,6 +11,7 @@ Live E2E is intentionally not counted yet because both commands require meeting-
 
 ## Summary
 - TestNoteDetailDryRun: dry-run coverage for `note +detail`; asserts the detail request method and `/open-apis/vc/v1/notes/{note_id}` URL without calling live APIs.
+- TestNoteDetailDryRunAsBot: dry-run coverage for `note +detail --as bot`; pins bot identity acceptance and the same detail endpoint.
 - TestNoteTranscriptDryRun: dry-run coverage for `note +transcript`; asserts the two-step request shape (`note detail` precheck, then `unified_note_transcript`), transcript query parameters, and that `--transcript-format` coexists with the global `--format` output flag.
 
 ## Command Table
@@ -18,4 +19,5 @@ Live E2E is intentionally not counted yet because both commands require meeting-
 | Status | Cmd | Type | Testcase | Key parameter shapes | Notes / uncovered reason |
 | --- | --- | --- | --- | --- | --- |
 | dry-run ✓ / live ✕ | note +detail | shortcut | note_dryrun_test.go::TestNoteDetailDryRun | `--note-id`; user identity | live note fixtures depend on meeting-generated artifacts |
+| dry-run ✓ / live ✕ | note +detail | shortcut | note_dryrun_test.go::TestNoteDetailDryRunAsBot | `--note-id`; `--as bot` | live note fixtures depend on meeting-generated artifacts |
 | dry-run ✓ / live ✕ | note +transcript | shortcut | note_dryrun_test.go::TestNoteTranscriptDryRun | `--note-id`; `--transcript-format`; `--format json`; transcript API `format/page_size/locale` params | live unified-note fixtures depend on generated VC note artifacts |

--- a/tests/cli_e2e/note/note_dryrun_test.go
+++ b/tests/cli_e2e/note/note_dryrun_test.go
@@ -10,6 +10,7 @@ import (
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestNoteDetailDryRun(t *testing.T) {
@@ -34,6 +35,32 @@ func TestNoteDetailDryRun(t *testing.T) {
 		t.Fatalf("method=%q, want GET\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/vc/v1/notes/note_dryrun" {
+		t.Fatalf("url=%q, want note detail endpoint\nstdout:\n%s", got, out)
+	}
+}
+
+func TestNoteDetailDryRunAsBot(t *testing.T) {
+	setNoteDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"note", "+detail",
+			"--note-id", "note_dryrun_bot",
+			"--as", "bot",
+			"--dry-run",
+		},
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := gjson.Get(out, "identity").String(); got != "bot" {
+		t.Fatalf("identity=%q, want bot\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/vc/v1/notes/note_dryrun_bot" {
 		t.Fatalf("url=%q, want note detail endpoint\nstdout:\n%s", got, out)
 	}
 }

--- a/tests/cli_e2e/vc/vc_detail_dryrun_test.go
+++ b/tests/cli_e2e/vc/vc_detail_dryrun_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVCDetailDryRun_BotIdentity pins that `vc +detail` accepts --as bot and
+// previews the meeting.get + recording API round-trip (GetMeetingByID /
+// GetRecordingByMeetingID both accept a tenant access token).
+func TestVCDetailDryRun_BotIdentity(t *testing.T) {
+	setVCDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+detail",
+			"--meeting-ids", "7628568141510692381",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	require.Contains(t, result.Args, "--as")
+	require.Contains(t, result.Args, "bot")
+
+	out := result.Stdout
+	require.Equal(t, int64(2), clie2e.DryRunGet(out, "api.#").Int(), "stdout:\n%s", out)
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/vc/v1/meetings/{meeting_id}", clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/vc/v1/meetings/{meeting_id}/recording", clie2e.DryRunGet(out, "api.1.url").String(), "stdout:\n%s", out)
+	require.Equal(t, "7628568141510692381", clie2e.DryRunGet(out, "meeting_ids.0").String(), "stdout:\n%s", out)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"vc", "+detail", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+}

--- a/tests/cli_e2e/vc/vc_recording_dryrun_test.go
+++ b/tests/cli_e2e/vc/vc_recording_dryrun_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVCRecordingDryRun_BotIdentity pins that `vc +recording --meeting-ids`
+// accepts --as bot (GetRecordingByMeetingID accepts a tenant access token).
+func TestVCRecordingDryRun_BotIdentity(t *testing.T) {
+	setVCDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+recording",
+			"--meeting-ids", "7628568141510692381",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/vc/v1/meetings/{meeting_id}/recording", clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"vc", "+recording", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+}
+
+// TestVCRecordingDryRun_BotIdentity_CalendarEventIDs pins that the
+// calendar-event-ids path also flows under --as bot: a bot has a primary
+// calendar, so the primary -> mget_instance_relation_info -> recording chain
+// is previewed without a validation error.
+func TestVCRecordingDryRun_BotIdentity_CalendarEventIDs(t *testing.T) {
+	setVCDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+recording",
+			"--calendar-event-ids", "evt_001",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Contains(t, out, "mget_instance_relation_info", "stdout:\n%s", out)
+	require.Contains(t, out, "recording", "stdout:\n%s", out)
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bot identity support for meeting minutes details and permission requests.
  - Added bot identity support for note details.
  - Added bot identity support for video conference details, notes, and recordings, including calendar event lookups.
  - Bot access remains limited to content available to the configured bot.

- **Documentation**
  - Updated command guidance and examples to describe supported bot authentication options and access requirements.

- **Tests**
  - Added comprehensive end-to-end and validation coverage for bot-authenticated commands and dry runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->