### PR TITLE
fix(drive): harden export and push failure recovery

### DIFF
--- a/internal/errclass/codemeta_drive.go
+++ b/internal/errclass/codemeta_drive.go
@@ -17,6 +17,7 @@ var driveCodeMeta = map[int]CodeMeta{
 	1061007:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // file has been deleted
 	1061043:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},                // file size beyond limit
 	1061044:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // parent folder does not exist (upload)
+	1061061:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},                // user quota exceeded
 	1061101:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},                // file quota exceeded
 	1062507:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},                // parent folder child count limit exceeded
 	1062009:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // actual size inconsistent with declared size

--- a/internal/errclass/codemeta_drive.go
+++ b/internal/errclass/codemeta_drive.go
@@ -10,6 +10,7 @@ import "github.com/larksuite/cli/errs"
 // ambiguous codes fall back to CategoryAPI via BuildAPIError.
 // BuildAPIError consumes this map via mergeCodeMeta + LookupCodeMeta.
 var driveCodeMeta = map[int]CodeMeta{
+	1663:      {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive multipart upload internal error
 	1061001:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeServerError, Retryable: true}, // Drive "unknown error"
 	1061002:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // params error
 	1061004:   {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // forbidden

--- a/internal/errclass/codemeta_drive.go
+++ b/internal/errclass/codemeta_drive.go
@@ -22,6 +22,10 @@ var driveCodeMeta = map[int]CodeMeta{
 	1063001:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // secure label invalid parameter
 	1063002:   {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // secure label permission denied
 	1063013:   {Category: errs.CategoryValidation, Subtype: errs.SubtypeFailedPrecondition},    // secure label downgrade requires approval
+	1069902:   {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied},   // export task caller cannot export the source document
+	1069906:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // export source document was deleted
+	1069914:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                     // export file token is invalid or mismatched with type
+	1069918:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // export file extension does not match source type
 	1069302:   {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // comment endpoint "Invalid or missing parameters"
 	99992402:  {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // platform field validation failed
 	9499:      {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},            // invalid parameter type in JSON field

--- a/internal/errclass/codemeta_drive_test.go
+++ b/internal/errclass/codemeta_drive_test.go
@@ -32,6 +32,11 @@ func TestLookupCodeMeta_DriveCodes(t *testing.T) {
 		{1063001, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 		{1063002, errs.CategoryAuthorization, errs.SubtypePermissionDenied, false},
 		{1063013, errs.CategoryValidation, errs.SubtypeFailedPrecondition, false},
+		// Export task errors observed from the Drive export API.
+		{1069902, errs.CategoryAuthorization, errs.SubtypePermissionDenied, false},
+		{1069906, errs.CategoryAPI, errs.SubtypeNotFound, false},
+		{1069914, errs.CategoryAPI, errs.SubtypeNotFound, false},
+		{1069918, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 		{99992402, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 		{9499, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 	}

--- a/internal/errclass/codemeta_test.go
+++ b/internal/errclass/codemeta_test.go
@@ -115,6 +115,7 @@ func TestLookupCodeMeta_DrivePushCodes(t *testing.T) {
 		{1061004, errs.CategoryAuthorization, errs.SubtypePermissionDenied, false},
 		{1061007, errs.CategoryAPI, errs.SubtypeNotFound, false},
 		{1061043, errs.CategoryAPI, errs.SubtypeQuotaExceeded, false},
+		{1061061, errs.CategoryAPI, errs.SubtypeQuotaExceeded, false},
 		{1061101, errs.CategoryAPI, errs.SubtypeQuotaExceeded, false},
 		{1062009, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 		{2200, errs.CategoryAPI, errs.SubtypeServerError, true},

--- a/internal/errclass/codemeta_test.go
+++ b/internal/errclass/codemeta_test.go
@@ -109,6 +109,7 @@ func TestLookupCodeMeta_DrivePushCodes(t *testing.T) {
 		wantSubtype errs.Subtype
 		wantRetry   bool
 	}{
+		{1663, errs.CategoryAPI, errs.SubtypeServerError, true},
 		{1061001, errs.CategoryAPI, errs.SubtypeServerError, true},
 		{1061002, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
 		{1061004, errs.CategoryAuthorization, errs.SubtypePermissionDenied, false},

--- a/shortcuts/drive/drive_errors.go
+++ b/shortcuts/drive/drive_errors.go
@@ -200,7 +200,7 @@ func withDriveExportCreateRateLimitRecovery(err error) error {
 		return err
 	}
 
-	const hint = "export task creation was rate limited before a ticket was issued; stop and wait at least 1 minute, then rerun the same `lark-cli drive +export` command\nif rate limiting continues, use exponential backoff starting at 1 minute instead of retrying immediately; do not run `lark-cli drive +task_result` because no export ticket exists yet"
+	const hint = "export task creation was rate limited before a ticket was issued; stop and wait at least 1 minute, then rerun the original command with the same arguments\nif rate limiting continues, use exponential backoff starting at 1 minute instead of retrying immediately; do not run `lark-cli drive +task_result` because no export ticket exists yet"
 	return appendDriveExportRecoveryHint(err, hint)
 }
 

--- a/shortcuts/drive/drive_errors.go
+++ b/shortcuts/drive/drive_errors.go
@@ -146,7 +146,31 @@ func driveExportIsRateLimit(err error) bool {
 	if !ok || problem == nil {
 		return false
 	}
-	return problem.Subtype == errs.SubtypeRateLimit || problem.Code == 99991400
+	return problem.Subtype == errs.SubtypeRateLimit ||
+		problem.Code == 99991400 ||
+		(problem.Code == 9499 && driveExportTooManyRequestsMessage(problem.Message))
+}
+
+// normalizeDriveExportRateLimit scopes the overloaded 9499 interpretation to
+// Drive export task creation/status calls. The shared classifier intentionally
+// keeps the code's general meaning (invalid_parameters) for every other API.
+func normalizeDriveExportRateLimit(err error) error {
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem == nil || problem.Code != 9499 || !driveExportTooManyRequestsMessage(problem.Message) {
+		return err
+	}
+	problem.Category = errs.CategoryAPI
+	problem.Subtype = errs.SubtypeRateLimit
+	problem.Retryable = true
+	// BuildAPIError attached invalid-parameter recovery before the export
+	// boundary could disambiguate 9499. Drop it before adding rate-limit recovery.
+	problem.Hint = ""
+	return err
+}
+
+func driveExportTooManyRequestsMessage(message string) bool {
+	normalized := strings.Trim(strings.ToLower(strings.TrimSpace(message)), " .")
+	return normalized == "too many request" || normalized == "too many requests"
 }
 
 // withDriveExportRateLimitRecovery preserves the upstream typed rate-limit
@@ -154,6 +178,7 @@ func driveExportIsRateLimit(err error) bool {
 // task already exists at this point, so callers must reuse its ticket instead
 // of creating a duplicate task with drive +export.
 func withDriveExportRateLimitRecovery(err error, ticket, fileToken string) error {
+	err = normalizeDriveExportRateLimit(err)
 	if !driveExportIsRateLimit(err) {
 		return err
 	}
@@ -170,10 +195,37 @@ func withDriveExportRateLimitRecovery(err error, ticket, fileToken string) error
 // task exists. There is no ticket to resume, so callers must retry the original
 // export command after backing off instead of invoking drive +task_result.
 func withDriveExportCreateRateLimitRecovery(err error) error {
+	err = normalizeDriveExportRateLimit(err)
 	if !driveExportIsRateLimit(err) {
 		return err
 	}
 
 	const hint = "export task creation was rate limited before a ticket was issued; stop and wait at least 1 minute, then rerun the same `lark-cli drive +export` command\nif rate limiting continues, use exponential backoff starting at 1 minute instead of retrying immediately; do not run `lark-cli drive +task_result` because no export ticket exists yet"
+	return appendDriveExportRecoveryHint(err, hint)
+}
+
+// withDriveExportCreateRecovery adds command-specific recovery to permanent
+// export-task failures while preserving the typed category, subtype, code, and
+// log ID decided by the shared response classifier.
+func withDriveExportCreateRecovery(err error) error {
+	err = withDriveExportCreateRateLimitRecovery(err)
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem == nil {
+		return err
+	}
+
+	var hint string
+	switch problem.Code {
+	case 1069902:
+		hint = "verify the current --as identity can view and export the source document and that sharing, security-label, DLP, and tenant policies allow downloading; ask the document owner or tenant admin to grant access before retrying"
+	case 1069906:
+		hint = "the source document was deleted; stop retrying and export an existing document, or restore the document first"
+	case 1069914:
+		hint = "prefer --url with the original document link so the CLI can infer its type; for a bare Wiki node token, use --doc-type wiki; otherwise verify the token still exists and --doc-type matches the source"
+	case 1069918, 99992402:
+		hint = "check that --file-extension is supported by the source type and that sheet/bitable CSV exports include the correct --sub-id"
+	default:
+		return err
+	}
 	return appendDriveExportRecoveryHint(err, hint)
 }

--- a/shortcuts/drive/drive_export_common.go
+++ b/shortcuts/drive/drive_export_common.go
@@ -422,7 +422,7 @@ func buildDriveExportTaskBody(spec driveExportSpec) map[string]interface{} {
 func createDriveExportTask(runtime *common.RuntimeContext, spec driveExportSpec) (string, error) {
 	data, err := runtime.CallAPITyped("POST", "/open-apis/drive/v1/export_tasks", nil, buildDriveExportTaskBody(spec))
 	if err != nil {
-		return "", withDriveExportCreateRateLimitRecovery(err)
+		return "", withDriveExportCreateRecovery(err)
 	}
 
 	ticket := common.GetString(data, "ticket")

--- a/shortcuts/drive/drive_export_test.go
+++ b/shortcuts/drive/drive_export_test.go
@@ -1494,6 +1494,225 @@ func TestDriveExportCreateRateLimitSuggestsRetryingOriginalCommand(t *testing.T)
 	}
 }
 
+func TestDriveExportCreateCode9499TooManyRequestsUsesRateLimitRecovery(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	createStub := &httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Status: http.StatusBadRequest,
+		Body: map[string]interface{}{
+			"code": 9499,
+			"msg":  "too many request",
+		},
+	}
+	reg.Register(createStub)
+
+	err := mountAndRunDrive(t, DriveExport, []string{
+		"+export",
+		"--token", "docx123",
+		"--doc-type", "docx",
+		"--file-extension", "pdf",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected rate-limit error, got nil")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed rate-limit error, got %T (%v)", err, err)
+	}
+	if problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeRateLimit || problem.Code != 9499 || !problem.Retryable {
+		t.Fatalf("problem = %+v, want api/rate_limit code 9499 retryable", problem)
+	}
+	for _, want := range []string{
+		"before a ticket was issued",
+		"wait at least 1 minute",
+		"rerun the same `lark-cli drive +export` command",
+	} {
+		if !strings.Contains(problem.Hint, want) {
+			t.Fatalf("hint missing %q: %q", want, problem.Hint)
+		}
+	}
+}
+
+func TestDriveExportCreateCode9499NonRateLimitRemainsInvalidParameters(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Status: http.StatusBadRequest,
+		Body: map[string]interface{}{
+			"code": 9499,
+			"msg":  "Invalid parameter type in json: id",
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveExport, []string{
+		"+export",
+		"--token", "docx123",
+		"--doc-type", "docx",
+		"--file-extension", "pdf",
+		"--as", "bot",
+	}, f, stdout)
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed invalid-parameters error, got %T (%v)", err, err)
+	}
+	if problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeInvalidParameters || problem.Code != 9499 || problem.Retryable {
+		t.Fatalf("problem = %+v, want api/invalid_parameters code 9499 non-retryable", problem)
+	}
+	if strings.Contains(problem.Hint, "wait at least 1 minute") {
+		t.Fatalf("non-rate-limit 9499 received export throttling recovery: %q", problem.Hint)
+	}
+}
+
+func TestDriveExportPollCode9499TooManyRequestsStopsImmediately(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ticket": "tk_9499_rate_limited"},
+		},
+	})
+	pollStub := &httpmock.Stub{
+		Method:   http.MethodGet,
+		URL:      "/open-apis/drive/v1/export_tasks/tk_9499_rate_limited",
+		Status:   http.StatusBadRequest,
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 9499,
+			"msg":  "too many request",
+		},
+	}
+	reg.Register(pollStub)
+
+	prevAttempts, prevInterval := driveExportPollAttempts, driveExportPollInterval
+	driveExportPollAttempts, driveExportPollInterval = 3, 0
+	t.Cleanup(func() {
+		driveExportPollAttempts, driveExportPollInterval = prevAttempts, prevInterval
+	})
+
+	err := mountAndRunDrive(t, DriveExport, []string{
+		"+export",
+		"--token", "docx123",
+		"--doc-type", "docx",
+		"--file-extension", "pdf",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected rate-limit error, got nil")
+	}
+	if got := len(pollStub.CapturedBodies); got != 1 {
+		t.Fatalf("export status poll count = %d, want 1 after code 9499 rate limit", got)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Subtype != errs.SubtypeRateLimit || problem.Code != 9499 || !problem.Retryable {
+		t.Fatalf("problem = %+v, ok=%v, want rate_limit code 9499 retryable", problem, ok)
+	}
+	for _, want := range []string{
+		"ticket=tk_9499_rate_limited",
+		"lark-cli drive +task_result --scenario export --ticket tk_9499_rate_limited --file-token docx123",
+		"do not run `lark-cli drive +export` again",
+	} {
+		if !strings.Contains(problem.Hint, want) {
+			t.Fatalf("hint missing %q: %q", want, problem.Hint)
+		}
+	}
+}
+
+func TestDriveExportCreatePermanentFailuresHaveActionableRecovery(t *testing.T) {
+	cases := []struct {
+		name        string
+		code        int
+		message     string
+		wantCat     errs.Category
+		wantSubtype errs.Subtype
+		wantHints   []string
+	}{
+		{
+			name:        "resource permission denied",
+			code:        1069902,
+			message:     "no permission",
+			wantCat:     errs.CategoryAuthorization,
+			wantSubtype: errs.SubtypePermissionDenied,
+			wantHints:   []string{"current --as identity", "DLP", "document owner"},
+		},
+		{
+			name:        "source document deleted",
+			code:        1069906,
+			message:     "docs deleted",
+			wantCat:     errs.CategoryAPI,
+			wantSubtype: errs.SubtypeNotFound,
+			wantHints:   []string{"source document was deleted", "stop retrying"},
+		},
+		{
+			name:        "source token invalid",
+			code:        1069914,
+			message:     "file token invalid",
+			wantCat:     errs.CategoryAPI,
+			wantSubtype: errs.SubtypeNotFound,
+			wantHints:   []string{"prefer --url", "--doc-type wiki", "token still exists"},
+		},
+		{
+			name:        "extension mismatch",
+			code:        1069918,
+			message:     "file extension mismatch",
+			wantCat:     errs.CategoryAPI,
+			wantSubtype: errs.SubtypeInvalidParameters,
+			wantHints:   []string{"--file-extension", "--sub-id"},
+		},
+		{
+			name:        "field validation failure",
+			code:        99992402,
+			message:     "field validation failed",
+			wantCat:     errs.CategoryAPI,
+			wantSubtype: errs.SubtypeInvalidParameters,
+			wantHints:   []string{"--file-extension", "--sub-id"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+			reg.Register(&httpmock.Stub{
+				Method: http.MethodPost,
+				URL:    "/open-apis/drive/v1/export_tasks",
+				Status: http.StatusBadRequest,
+				Body: map[string]interface{}{
+					"code":   tc.code,
+					"msg":    tc.message,
+					"log_id": "log_export_recovery",
+				},
+			})
+
+			err := mountAndRunDrive(t, DriveExport, []string{
+				"+export",
+				"--token", "docx123",
+				"--doc-type", "docx",
+				"--file-extension", "pdf",
+				"--as", "bot",
+			}, f, stdout)
+			problem, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed error, got %T (%v)", err, err)
+			}
+			if problem.Category != tc.wantCat || problem.Subtype != tc.wantSubtype || problem.Code != tc.code || problem.Retryable {
+				t.Fatalf("problem = %+v, want %s/%s code %d non-retryable", problem, tc.wantCat, tc.wantSubtype, tc.code)
+			}
+			if problem.LogID != "log_export_recovery" {
+				t.Fatalf("log ID = %q, want preserved log_export_recovery", problem.LogID)
+			}
+			for _, want := range tc.wantHints {
+				if !strings.Contains(problem.Hint, want) {
+					t.Errorf("hint missing %q: %q", want, problem.Hint)
+				}
+			}
+		})
+	}
+}
+
 func TestDriveExportRateLimitAfterObservedStatusReturnsError(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{

--- a/shortcuts/drive/drive_export_test.go
+++ b/shortcuts/drive/drive_export_test.go
@@ -1481,7 +1481,7 @@ func TestDriveExportCreateRateLimitSuggestsRetryingOriginalCommand(t *testing.T)
 	for _, want := range []string{
 		"before a ticket was issued",
 		"wait at least 1 minute",
-		"rerun the same `lark-cli drive +export` command",
+		"rerun the original command with the same arguments",
 		"exponential backoff starting at 1 minute",
 		"do not run `lark-cli drive +task_result`",
 	} {
@@ -1527,7 +1527,7 @@ func TestDriveExportCreateCode9499TooManyRequestsUsesRateLimitRecovery(t *testin
 	for _, want := range []string{
 		"before a ticket was issued",
 		"wait at least 1 minute",
-		"rerun the same `lark-cli drive +export` command",
+		"rerun the original command with the same arguments",
 	} {
 		if !strings.Contains(problem.Hint, want) {
 			t.Fatalf("hint missing %q: %q", want, problem.Hint)

--- a/shortcuts/drive/drive_pull_test.go
+++ b/shortcuts/drive/drive_pull_test.go
@@ -1149,6 +1149,10 @@ func TestDrivePullContinuesAfterDownloadNotFound(t *testing.T) {
 	if len(items) != 2 || items[0]["rel_path"] != "a.txt" || items[1]["rel_path"] != "b.txt" || items[1]["action"] != "downloaded" {
 		t.Fatalf("item-local 404 must not block b.txt: %#v", items)
 	}
+	failedItem := items[0]
+	if failedItem["action"] != "failed" || failedItem["phase"] != "download" || failedItem["code"] != float64(http.StatusNotFound) || failedItem["retryable"] != false {
+		t.Fatalf("unexpected failed-download metadata: %#v", failedItem)
+	}
 	mustReadFile(t, filepath.Join("local", "b.txt"), "BBB")
 }
 

--- a/shortcuts/drive/drive_pull_test.go
+++ b/shortcuts/drive/drive_pull_test.go
@@ -1092,6 +1092,66 @@ func TestDrivePullAbortsAfterDownloadForbidden(t *testing.T) {
 	}
 }
 
+func TestDrivePullContinuesAfterDownloadNotFound(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"files": []interface{}{
+					map[string]interface{}{"token": "tok_a", "name": "a.txt", "type": "file"},
+					map[string]interface{}{"token": "tok_b", "name": "b.txt", "type": "file"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "/open-apis/drive/v1/files/tok_a/download",
+		Status:  http.StatusNotFound,
+		RawBody: []byte("not found"),
+	})
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "/open-apis/drive/v1/files/tok_b/download",
+		Status:  http.StatusOK,
+		RawBody: []byte("BBB"),
+	})
+
+	err := mountAndRunDrive(t, DrivePull, []string{
+		"+pull",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	assertDrivePullPartialFailure(t, err)
+
+	summary, items := splitDrivePullStdout(t, stdout.Bytes())
+	if got := summary["aborted"]; got != false {
+		t.Fatalf("summary.aborted = %v, want false", got)
+	}
+	if got := summary["failed"]; got != float64(1) {
+		t.Fatalf("summary.failed = %v, want 1", got)
+	}
+	if got := summary["downloaded"]; got != float64(1) {
+		t.Fatalf("summary.downloaded = %v, want 1", got)
+	}
+	if len(items) != 2 || items[0]["rel_path"] != "a.txt" || items[1]["rel_path"] != "b.txt" || items[1]["action"] != "downloaded" {
+		t.Fatalf("item-local 404 must not block b.txt: %#v", items)
+	}
+	mustReadFile(t, filepath.Join("local", "b.txt"), "BBB")
+}
+
 // TestDrivePullDeleteLocalDoesNotEscapeViaSymlinkParentRef is the
 // regression for the "link/.." escape applied to --delete-local — the
 // most dangerous variant, since the bug would otherwise let the kernel

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -603,7 +603,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Code = problem.Code
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
-	decision.Hint = problem.Hint
 
 	switch {
 	case problem.Category == errs.CategoryAuthorization && problem.Code == 99991672:

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -5,7 +5,6 @@ package drive
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -30,23 +29,19 @@ const (
 )
 
 type drivePushItem struct {
-	RelPath           string   `json:"rel_path"`
-	FileToken         string   `json:"file_token,omitempty"`
-	Action            string   `json:"action"`
-	Version           string   `json:"version,omitempty"`
-	SizeBytes         int64    `json:"size_bytes,omitempty"`
-	Error             string   `json:"error,omitempty"`
-	Hint              string   `json:"hint,omitempty"`
-	Phase             string   `json:"phase,omitempty"`
-	ErrorClass        string   `json:"error_class,omitempty"`
-	Code              int      `json:"code,omitempty"`
-	Subtype           string   `json:"subtype,omitempty"`
-	Retryable         *bool    `json:"retryable,omitempty"`
-	RetryAfterSeconds int      `json:"retry_after_seconds,omitempty"`
-	LogID             string   `json:"log_id,omitempty"`
-	Troubleshooter    string   `json:"troubleshooter,omitempty"`
-	MissingScopes     []string `json:"missing_scopes,omitempty"`
-	ConsoleURL        string   `json:"console_url,omitempty"`
+	RelPath           string `json:"rel_path"`
+	FileToken         string `json:"file_token,omitempty"`
+	Action            string `json:"action"`
+	Version           string `json:"version,omitempty"`
+	SizeBytes         int64  `json:"size_bytes,omitempty"`
+	Error             string `json:"error,omitempty"`
+	Hint              string `json:"hint,omitempty"`
+	Phase             string `json:"phase,omitempty"`
+	ErrorClass        string `json:"error_class,omitempty"`
+	Code              int    `json:"code,omitempty"`
+	Subtype           string `json:"subtype,omitempty"`
+	Retryable         *bool  `json:"retryable,omitempty"`
+	RetryAfterSeconds int    `json:"retry_after_seconds,omitempty"`
 }
 
 type driveBatchFailureDecision struct {
@@ -57,10 +52,6 @@ type driveBatchFailureDecision struct {
 	RetryAfterSeconds int
 	Terminal          bool
 	Hint              string
-	LogID             string
-	Troubleshooter    string
-	MissingScopes     []string
-	ConsoleURL        string
 }
 
 // DrivePush is a one-way, file-level mirror from a local directory onto a
@@ -598,10 +589,6 @@ func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int
 		Subtype:           decision.Subtype,
 		Retryable:         driveBoolPtr(decision.Retryable),
 		RetryAfterSeconds: decision.RetryAfterSeconds,
-		LogID:             decision.LogID,
-		Troubleshooter:    decision.Troubleshooter,
-		MissingScopes:     decision.MissingScopes,
-		ConsoleURL:        decision.ConsoleURL,
 	}
 	return item, decision.Terminal
 }
@@ -620,15 +607,8 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
 	decision.Hint = problem.Hint
-	decision.LogID = problem.LogID
-	decision.Troubleshooter = problem.Troubleshooter
 	if retryAfter, ok := errs.RetryAfter(err); ok {
 		decision.RetryAfterSeconds = int(retryAfter / time.Second)
-	}
-	var permissionErr *errs.PermissionError
-	if errors.As(err, &permissionErr) && permissionErr != nil {
-		decision.MissingScopes = append([]string(nil), permissionErr.MissingScopes...)
-		decision.ConsoleURL = permissionErr.ConsoleURL
 	}
 
 	switch {
@@ -694,7 +674,7 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 		decision.Class = "server_error"
 		decision.Terminal = true
 		if decision.Hint == "" {
-			decision.Hint = "Stop the current push and retry later with bounded exponential backoff; keep log_id for server-side diagnosis."
+			decision.Hint = "Stop the current push and retry later with bounded exponential backoff."
 		}
 	case problem.Subtype == errs.SubtypeFailedPrecondition:
 		decision.Class = "local_file_changed"

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -5,6 +5,7 @@ package drive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -29,27 +30,37 @@ const (
 )
 
 type drivePushItem struct {
-	RelPath    string `json:"rel_path"`
-	FileToken  string `json:"file_token,omitempty"`
-	Action     string `json:"action"`
-	Version    string `json:"version,omitempty"`
-	SizeBytes  int64  `json:"size_bytes,omitempty"`
-	Error      string `json:"error,omitempty"`
-	Hint       string `json:"hint,omitempty"`
-	Phase      string `json:"phase,omitempty"`
-	ErrorClass string `json:"error_class,omitempty"`
-	Code       int    `json:"code,omitempty"`
-	Subtype    string `json:"subtype,omitempty"`
-	Retryable  *bool  `json:"retryable,omitempty"`
+	RelPath           string   `json:"rel_path"`
+	FileToken         string   `json:"file_token,omitempty"`
+	Action            string   `json:"action"`
+	Version           string   `json:"version,omitempty"`
+	SizeBytes         int64    `json:"size_bytes,omitempty"`
+	Error             string   `json:"error,omitempty"`
+	Hint              string   `json:"hint,omitempty"`
+	Phase             string   `json:"phase,omitempty"`
+	ErrorClass        string   `json:"error_class,omitempty"`
+	Code              int      `json:"code,omitempty"`
+	Subtype           string   `json:"subtype,omitempty"`
+	Retryable         *bool    `json:"retryable,omitempty"`
+	RetryAfterSeconds int      `json:"retry_after_seconds,omitempty"`
+	LogID             string   `json:"log_id,omitempty"`
+	Troubleshooter    string   `json:"troubleshooter,omitempty"`
+	MissingScopes     []string `json:"missing_scopes,omitempty"`
+	ConsoleURL        string   `json:"console_url,omitempty"`
 }
 
 type driveBatchFailureDecision struct {
-	Class     string
-	Code      int
-	Subtype   string
-	Retryable bool
-	Terminal  bool
-	Hint      string
+	Class             string
+	Code              int
+	Subtype           string
+	Retryable         bool
+	RetryAfterSeconds int
+	Terminal          bool
+	Hint              string
+	LogID             string
+	Troubleshooter    string
+	MissingScopes     []string
+	ConsoleURL        string
 }
 
 // DrivePush is a one-way, file-level mirror from a local directory onto a
@@ -575,17 +586,22 @@ func drivePushShouldSkipSmart(localFile drivePushLocalFile, remoteFile driveRemo
 func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int64, err error) (drivePushItem, bool) {
 	decision := driveClassifyBatchFailure(err)
 	item := drivePushItem{
-		RelPath:    relPath,
-		FileToken:  fileToken,
-		Action:     action,
-		SizeBytes:  sizeBytes,
-		Error:      err.Error(),
-		Hint:       decision.Hint,
-		Phase:      phase,
-		ErrorClass: decision.Class,
-		Code:       decision.Code,
-		Subtype:    decision.Subtype,
-		Retryable:  driveBoolPtr(decision.Retryable),
+		RelPath:           relPath,
+		FileToken:         fileToken,
+		Action:            action,
+		SizeBytes:         sizeBytes,
+		Error:             err.Error(),
+		Hint:              decision.Hint,
+		Phase:             phase,
+		ErrorClass:        decision.Class,
+		Code:              decision.Code,
+		Subtype:           decision.Subtype,
+		Retryable:         driveBoolPtr(decision.Retryable),
+		RetryAfterSeconds: decision.RetryAfterSeconds,
+		LogID:             decision.LogID,
+		Troubleshooter:    decision.Troubleshooter,
+		MissingScopes:     decision.MissingScopes,
+		ConsoleURL:        decision.ConsoleURL,
 	}
 	return item, decision.Terminal
 }
@@ -603,6 +619,17 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Code = problem.Code
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
+	decision.Hint = problem.Hint
+	decision.LogID = problem.LogID
+	decision.Troubleshooter = problem.Troubleshooter
+	if retryAfter, ok := errs.RetryAfter(err); ok {
+		decision.RetryAfterSeconds = int(retryAfter / time.Second)
+	}
+	var permissionErr *errs.PermissionError
+	if errors.As(err, &permissionErr) && permissionErr != nil {
+		decision.MissingScopes = append([]string(nil), permissionErr.MissingScopes...)
+		decision.ConsoleURL = permissionErr.ConsoleURL
+	}
 
 	switch {
 	case problem.Category == errs.CategoryAuthorization && problem.Code == 99991672:
@@ -617,31 +644,63 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	case problem.Category == errs.CategoryNetwork && problem.Code == http.StatusForbidden:
 		decision.Class = "permission_denied"
 		decision.Terminal = true
+	case problem.Code == 1062009:
+		decision.Class = "upload_size_mismatch"
+		decision.Hint = "Rescan the local file before retrying; its contents or size may have changed during upload."
 	case problem.Subtype == errs.SubtypeInvalidParameters || problem.Code == 1061002:
 		decision.Class = "invalid_api_parameters"
 		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Check --folder-token, overwrite mode, file_token, file name, and upload parameters before retrying; do not repeat the same parameter set."
+		}
 	case problem.Subtype == errs.SubtypeRateLimit || problem.Code == 99991400:
 		decision.Class = "rate_limited"
 		decision.Terminal = true
+		if decision.RetryAfterSeconds > 0 {
+			decision.Hint = fmt.Sprintf("Stop immediate retries and wait at least %d second(s) before retrying this push.", decision.RetryAfterSeconds)
+		} else {
+			decision.Hint = "Stop immediate retries and retry later with exponential backoff and jitter."
+		}
+	case problem.Code == 1061045:
+		decision.Class = "conflict"
+		decision.Terminal = true
+		decision.Hint = "Stop this push and retry later with backoff; avoid concurrent folder creation or push operations against the same destination."
 	case problem.Code == 1062507:
 		decision.Class = "parent_sibling_limit"
 		decision.Terminal = true
 		decision.Hint = "The destination parent folder has reached its child-count limit. Clean up that folder, choose another --folder-token, or split the upload across subfolders before retrying."
-	case problem.Subtype == errs.SubtypeQuotaExceeded || problem.Code == 1061043:
+	case problem.Code == 1061043:
 		decision.Class = "file_size_limit"
-	case problem.Code == 1062009:
-		decision.Class = "upload_size_mismatch"
+		decision.Hint = "Do not retry the same file unchanged; split it into smaller files or use another storage method."
+	case problem.Subtype == errs.SubtypeQuotaExceeded:
+		decision.Class = "quota_exceeded"
+		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Free the relevant Drive quota or choose another destination before retrying."
+		}
 	case problem.Code == 1061044:
 		decision.Class = "parent_node_missing"
 		decision.Terminal = true
 		decision.Hint = "The destination parent folder no longer exists or is not visible. Verify --folder-token, folder permissions, and whether a parent directory was deleted during push before retrying."
 	case problem.Subtype == errs.SubtypeNotFound || problem.Code == 1061007:
 		decision.Class = "remote_not_found"
+	case problem.Category == errs.CategoryNetwork:
+		decision.Class = string(problem.Subtype)
+		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Stop the current push; check connectivity and retry later with bounded exponential backoff."
+		}
 	case problem.Subtype == errs.SubtypeServerError || problem.Code == 1061001 || problem.Code == 2200:
 		decision.Class = "server_error"
 		decision.Terminal = true
+		if decision.Hint == "" {
+			decision.Hint = "Stop the current push and retry later with bounded exponential backoff; keep log_id for server-side diagnosis."
+		}
 	case problem.Subtype == errs.SubtypeFailedPrecondition:
 		decision.Class = "local_file_changed"
+		if decision.Hint == "" {
+			decision.Hint = "Rescan the local file before retrying this item."
+		}
 	default:
 		decision.Class = string(problem.Subtype)
 	}

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -573,7 +573,7 @@ func drivePushShouldSkipSmart(localFile drivePushLocalFile, remoteFile driveRemo
 }
 
 func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int64, err error) (drivePushItem, bool) {
-	decision := driveClassifyBatchFailure(err)
+	decision := driveClassifyPushFailure(err)
 	item := drivePushItem{
 		RelPath:    relPath,
 		FileToken:  fileToken,
@@ -588,6 +588,22 @@ func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int
 		Retryable:  driveBoolPtr(decision.Retryable),
 	}
 	return item, decision.Terminal
+}
+
+// driveClassifyPushFailure applies +push's batch-wide stop policy without
+// changing the item-level behavior shared by +pull and +sync. In particular,
+// streaming HTTP errors are represented as network errors; responses such as a
+// stale file's 404 can be item-specific and must not make those commands abort.
+func driveClassifyPushFailure(err error) driveBatchFailureDecision {
+	decision := driveClassifyBatchFailure(err)
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem == nil {
+		return decision
+	}
+	if decision.Class == "conflict" || decision.Class == "quota_exceeded" || problem.Category == errs.CategoryNetwork {
+		decision.Terminal = true
+	}
+	return decision
 }
 
 func driveBoolPtr(v bool) *bool {
@@ -632,7 +648,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 		decision.Hint = "Stop immediate retries and retry later with exponential backoff and jitter."
 	case problem.Code == 1061045:
 		decision.Class = "conflict"
-		decision.Terminal = true
 		decision.Hint = "Stop this push and retry later with backoff; avoid concurrent folder creation or push operations against the same destination."
 	case problem.Code == 1062507:
 		decision.Class = "parent_sibling_limit"
@@ -643,7 +658,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 		decision.Hint = "Do not retry the same file unchanged; split it into smaller files or use another storage method."
 	case problem.Subtype == errs.SubtypeQuotaExceeded:
 		decision.Class = "quota_exceeded"
-		decision.Terminal = true
 		if decision.Hint == "" {
 			decision.Hint = "Free the relevant Drive quota or choose another destination before retrying."
 		}
@@ -655,7 +669,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 		decision.Class = "remote_not_found"
 	case problem.Category == errs.CategoryNetwork:
 		decision.Class = string(problem.Subtype)
-		decision.Terminal = true
 		if decision.Hint == "" {
 			decision.Hint = "Stop the current push; check connectivity and retry later with bounded exponential backoff."
 		}

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -29,29 +29,27 @@ const (
 )
 
 type drivePushItem struct {
-	RelPath           string `json:"rel_path"`
-	FileToken         string `json:"file_token,omitempty"`
-	Action            string `json:"action"`
-	Version           string `json:"version,omitempty"`
-	SizeBytes         int64  `json:"size_bytes,omitempty"`
-	Error             string `json:"error,omitempty"`
-	Hint              string `json:"hint,omitempty"`
-	Phase             string `json:"phase,omitempty"`
-	ErrorClass        string `json:"error_class,omitempty"`
-	Code              int    `json:"code,omitempty"`
-	Subtype           string `json:"subtype,omitempty"`
-	Retryable         *bool  `json:"retryable,omitempty"`
-	RetryAfterSeconds int    `json:"retry_after_seconds,omitempty"`
+	RelPath    string `json:"rel_path"`
+	FileToken  string `json:"file_token,omitempty"`
+	Action     string `json:"action"`
+	Version    string `json:"version,omitempty"`
+	SizeBytes  int64  `json:"size_bytes,omitempty"`
+	Error      string `json:"error,omitempty"`
+	Hint       string `json:"hint,omitempty"`
+	Phase      string `json:"phase,omitempty"`
+	ErrorClass string `json:"error_class,omitempty"`
+	Code       int    `json:"code,omitempty"`
+	Subtype    string `json:"subtype,omitempty"`
+	Retryable  *bool  `json:"retryable,omitempty"`
 }
 
 type driveBatchFailureDecision struct {
-	Class             string
-	Code              int
-	Subtype           string
-	Retryable         bool
-	RetryAfterSeconds int
-	Terminal          bool
-	Hint              string
+	Class     string
+	Code      int
+	Subtype   string
+	Retryable bool
+	Terminal  bool
+	Hint      string
 }
 
 // DrivePush is a one-way, file-level mirror from a local directory onto a
@@ -577,18 +575,17 @@ func drivePushShouldSkipSmart(localFile drivePushLocalFile, remoteFile driveRemo
 func drivePushFailedItem(relPath, fileToken, action, phase string, sizeBytes int64, err error) (drivePushItem, bool) {
 	decision := driveClassifyBatchFailure(err)
 	item := drivePushItem{
-		RelPath:           relPath,
-		FileToken:         fileToken,
-		Action:            action,
-		SizeBytes:         sizeBytes,
-		Error:             err.Error(),
-		Hint:              decision.Hint,
-		Phase:             phase,
-		ErrorClass:        decision.Class,
-		Code:              decision.Code,
-		Subtype:           decision.Subtype,
-		Retryable:         driveBoolPtr(decision.Retryable),
-		RetryAfterSeconds: decision.RetryAfterSeconds,
+		RelPath:    relPath,
+		FileToken:  fileToken,
+		Action:     action,
+		SizeBytes:  sizeBytes,
+		Error:      err.Error(),
+		Hint:       decision.Hint,
+		Phase:      phase,
+		ErrorClass: decision.Class,
+		Code:       decision.Code,
+		Subtype:    decision.Subtype,
+		Retryable:  driveBoolPtr(decision.Retryable),
 	}
 	return item, decision.Terminal
 }
@@ -607,9 +604,6 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	decision.Subtype = string(problem.Subtype)
 	decision.Retryable = problem.Retryable
 	decision.Hint = problem.Hint
-	if retryAfter, ok := errs.RetryAfter(err); ok {
-		decision.RetryAfterSeconds = int(retryAfter / time.Second)
-	}
 
 	switch {
 	case problem.Category == errs.CategoryAuthorization && problem.Code == 99991672:
@@ -636,11 +630,7 @@ func driveClassifyBatchFailure(err error) driveBatchFailureDecision {
 	case problem.Subtype == errs.SubtypeRateLimit || problem.Code == 99991400:
 		decision.Class = "rate_limited"
 		decision.Terminal = true
-		if decision.RetryAfterSeconds > 0 {
-			decision.Hint = fmt.Sprintf("Stop immediate retries and wait at least %d second(s) before retrying this push.", decision.RetryAfterSeconds)
-		} else {
-			decision.Hint = "Stop immediate retries and retry later with exponential backoff and jitter."
-		}
+		decision.Hint = "Stop immediate retries and retry later with exponential backoff and jitter."
 	case problem.Code == 1061045:
 		decision.Class = "conflict"
 		decision.Terminal = true

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1611,23 +1611,6 @@ func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
 	}
 }
 
-func TestDrivePushFailedItemPreservesRetryAfter(t *testing.T) {
-	rateErr := errs.NewAPIError(errs.SubtypeRateLimit, "rate limited").
-		WithCode(99991400).
-		WithRetryable().
-		WithRetryAfterSeconds(7)
-	rateItem, terminal := drivePushFailedItem("b.txt", "", "failed", "upload", 1, rateErr)
-	if !terminal {
-		t.Fatal("rate limit must be terminal")
-	}
-	if rateItem.RetryAfterSeconds != 7 || rateItem.Retryable == nil || !*rateItem.Retryable {
-		t.Fatalf("retry metadata was not preserved: %#v", rateItem)
-	}
-	if !strings.Contains(rateItem.Hint, "wait at least 7 second") {
-		t.Fatalf("rate-limit hint must honor retry_after_seconds: %#v", rateItem)
-	}
-}
-
 func TestDrivePushDetectsLocalFileChangedBeforeUpload(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1611,9 +1611,9 @@ func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
 	}
 }
 
-func TestDriveClassifyBatchFailureStopsOnDriveQuotaExceeded(t *testing.T) {
+func TestDriveClassifyPushFailureStopsOnDriveQuotaExceeded(t *testing.T) {
 	err := errs.NewAPIError(errs.SubtypeQuotaExceeded, "file quota exceeded").WithCode(1061101)
-	decision := driveClassifyBatchFailure(err)
+	decision := driveClassifyPushFailure(err)
 
 	if decision.Class != "quota_exceeded" || !decision.Terminal || decision.Retryable {
 		t.Fatalf("decision = %#v, want terminal non-retryable quota_exceeded", decision)

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1611,6 +1611,18 @@ func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
 	}
 }
 
+func TestDriveClassifyBatchFailureStopsOnDriveQuotaExceeded(t *testing.T) {
+	err := errs.NewAPIError(errs.SubtypeQuotaExceeded, "file quota exceeded").WithCode(1061101)
+	decision := driveClassifyBatchFailure(err)
+
+	if decision.Class != "quota_exceeded" || !decision.Terminal || decision.Retryable {
+		t.Fatalf("decision = %#v, want terminal non-retryable quota_exceeded", decision)
+	}
+	if !strings.Contains(decision.Hint, "Free the relevant Drive quota") {
+		t.Fatalf("decision.Hint = %q, want quota recovery guidance", decision.Hint)
+	}
+}
+
 func TestDrivePushDetectsLocalFileChangedBeforeUpload(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1196,6 +1196,156 @@ func TestDrivePushAbortsAfterUploadParamsError(t *testing.T) {
 	}
 }
 
+func TestDrivePushContinuesAfterUploadSizeMismatch(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "a.txt"), []byte("A"), 0o644); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "b.txt"), []byte("B"), 0o644); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:     "POST",
+		URL:        "/open-apis/drive/v1/files/upload_all",
+		BodyFilter: func(body []byte) bool { return strings.Contains(string(body), "a.txt") },
+		Body: map[string]interface{}{
+			"code": 1062009,
+			"msg":  "The actual size is inconsistent with the declared size.",
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:     "POST",
+		URL:        "/open-apis/drive/v1/files/upload_all",
+		BodyFilter: func(body []byte) bool { return strings.Contains(string(body), "b.txt") },
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{"file_token": "tok_b"},
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["failed"]; got != float64(1) {
+		t.Fatalf("summary.failed = %v, want 1", got)
+	}
+	if got := summary["uploaded"]; got != float64(1) {
+		t.Fatalf("summary.uploaded = %v, want 1", got)
+	}
+	if got := summary["aborted"]; got != false {
+		t.Fatalf("summary.aborted = %v, want false", got)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items len = %d, want 2; items=%#v", len(items), items)
+	}
+	failedItem := items[0]
+	if failedItem["rel_path"] != "a.txt" || failedItem["error_class"] != "upload_size_mismatch" {
+		t.Fatalf("unexpected failed item: %#v", failedItem)
+	}
+	if failedItem["code"] != float64(1062009) || failedItem["retryable"] != false {
+		t.Fatalf("unexpected failure metadata: %#v", failedItem)
+	}
+	if got, _ := failedItem["hint"].(string); !strings.Contains(got, "Rescan") || !strings.Contains(got, "changed") {
+		t.Fatalf("hint should tell callers to rescan the changed file, got item=%#v", failedItem)
+	}
+	if items[1]["rel_path"] != "b.txt" || items[1]["action"] != "uploaded" {
+		t.Fatalf("size mismatch must not block independent files, got items=%#v", items)
+	}
+}
+
+func TestDrivePushAbortsAfterUploadBadGateway(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "a.txt"), []byte("A"), 0o644); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "b.txt"), []byte("B"), 0o644); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:  "POST",
+		URL:     "/open-apis/drive/v1/files/upload_all",
+		Status:  http.StatusBadGateway,
+		RawBody: []byte("bad gateway"),
+		Headers: http.Header{
+			"Content-Type": []string{"text/plain"},
+			"X-Tt-Logid":   []string{"push-log-502"},
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["aborted"]; got != true {
+		t.Fatalf("summary.aborted = %v, want true", got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1; a terminal gateway failure must stop before b.txt: %#v", len(items), items)
+	}
+	item := items[0]
+	if item["rel_path"] != "a.txt" || item["error_class"] != "server_error" {
+		t.Fatalf("unexpected failed item: %#v", item)
+	}
+	if item["code"] != float64(http.StatusBadGateway) || item["retryable"] != true || item["log_id"] != "push-log-502" {
+		t.Fatalf("unexpected gateway failure metadata: %#v", item)
+	}
+	if got, _ := item["hint"].(string); !strings.Contains(got, "Stop the current push") || !strings.Contains(got, "backoff") {
+		t.Fatalf("gateway hint should prevent immediate batch retries, got item=%#v", item)
+	}
+}
+
 func TestDrivePushAbortsAfterUploadParentNodeMissing(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 
@@ -1400,6 +1550,106 @@ func TestDrivePushAbortsAfterCreateFolderParentSiblingLimit(t *testing.T) {
 		if item["rel_path"] == "b" {
 			t.Fatalf("parent sibling limit must abort before b, got items=%#v", items)
 		}
+	}
+}
+
+func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll(filepath.Join("local", "a"), 0o755); err != nil {
+		t.Fatalf("MkdirAll a: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join("local", "b"), 0o755); err != nil {
+		t.Fatalf("MkdirAll b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/create_folder",
+		Body: map[string]interface{}{
+			"code": 1061045,
+			"msg":  "resource contention, please retry.",
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["aborted"]; got != true {
+		t.Fatalf("summary.aborted = %v, want true", got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1; conflict must stop before b: %#v", len(items), items)
+	}
+	item := items[0]
+	if item["rel_path"] != "a" || item["phase"] != "create_folder" || item["error_class"] != "conflict" {
+		t.Fatalf("unexpected failed item: %#v", item)
+	}
+	if item["code"] != float64(1061045) || item["retryable"] != true {
+		t.Fatalf("unexpected conflict metadata: %#v", item)
+	}
+	if got, _ := item["hint"].(string); !strings.Contains(got, "Stop this push") || !strings.Contains(got, "concurrent") {
+		t.Fatalf("conflict hint should prevent immediate retries, got item=%#v", item)
+	}
+}
+
+func TestDrivePushFailedItemPreservesTypedDiagnostics(t *testing.T) {
+	permissionErr := errs.NewPermissionError(errs.SubtypeAppScopeNotApplied, "scope missing").
+		WithCode(99991672).
+		WithHint("open the developer console").
+		WithLogID("push-log-permission").
+		WithMissingScopes("drive:file:upload").
+		WithConsoleURL("https://open.feishu.cn/app/cli_test/permission")
+	permissionErr.Troubleshooter = "https://open.feishu.cn/document/troubleshoot/push"
+
+	item, terminal := drivePushFailedItem("a.txt", "", "failed", "upload", 1, permissionErr)
+	if !terminal {
+		t.Fatal("app scope failure must be terminal")
+	}
+	if item.Hint != "open the developer console" || item.LogID != "push-log-permission" {
+		t.Fatalf("typed hint/log_id were not preserved: %#v", item)
+	}
+	if item.Troubleshooter != permissionErr.Troubleshooter || item.ConsoleURL != permissionErr.ConsoleURL {
+		t.Fatalf("typed diagnostic URLs were not preserved: %#v", item)
+	}
+	if len(item.MissingScopes) != 1 || item.MissingScopes[0] != "drive:file:upload" {
+		t.Fatalf("missing_scopes were not preserved: %#v", item)
+	}
+
+	rateErr := errs.NewAPIError(errs.SubtypeRateLimit, "rate limited").
+		WithCode(99991400).
+		WithRetryable().
+		WithRetryAfterSeconds(7)
+	rateItem, terminal := drivePushFailedItem("b.txt", "", "failed", "upload", 1, rateErr)
+	if !terminal {
+		t.Fatal("rate limit must be terminal")
+	}
+	if rateItem.RetryAfterSeconds != 7 || rateItem.Retryable == nil || !*rateItem.Retryable {
+		t.Fatalf("retry metadata was not preserved: %#v", rateItem)
+	}
+	if !strings.Contains(rateItem.Hint, "wait at least 7 second") {
+		t.Fatalf("rate-limit hint must honor retry_after_seconds: %#v", rateItem)
 	}
 }
 

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1304,14 +1304,11 @@ func TestDrivePushAbortsAfterUploadBadGateway(t *testing.T) {
 		},
 	})
 	reg.Register(&httpmock.Stub{
-		Method:  "POST",
-		URL:     "/open-apis/drive/v1/files/upload_all",
-		Status:  http.StatusBadGateway,
-		RawBody: []byte("bad gateway"),
-		Headers: http.Header{
-			"Content-Type": []string{"text/plain"},
-			"X-Tt-Logid":   []string{"push-log-502"},
-		},
+		Method:      "POST",
+		URL:         "/open-apis/drive/v1/files/upload_all",
+		Status:      http.StatusBadGateway,
+		RawBody:     []byte("bad gateway"),
+		ContentType: "text/plain",
 	})
 
 	err := mountAndRunDrive(t, DrivePush, []string{
@@ -1338,7 +1335,7 @@ func TestDrivePushAbortsAfterUploadBadGateway(t *testing.T) {
 	if item["rel_path"] != "a.txt" || item["error_class"] != "server_error" {
 		t.Fatalf("unexpected failed item: %#v", item)
 	}
-	if item["code"] != float64(http.StatusBadGateway) || item["retryable"] != true || item["log_id"] != "push-log-502" {
+	if item["code"] != float64(http.StatusBadGateway) || item["retryable"] != true {
 		t.Fatalf("unexpected gateway failure metadata: %#v", item)
 	}
 	if got, _ := item["hint"].(string); !strings.Contains(got, "Stop the current push") || !strings.Contains(got, "backoff") {
@@ -1614,29 +1611,7 @@ func TestDrivePushAbortsAfterCreateFolderConflict(t *testing.T) {
 	}
 }
 
-func TestDrivePushFailedItemPreservesTypedDiagnostics(t *testing.T) {
-	permissionErr := errs.NewPermissionError(errs.SubtypeAppScopeNotApplied, "scope missing").
-		WithCode(99991672).
-		WithHint("open the developer console").
-		WithLogID("push-log-permission").
-		WithMissingScopes("drive:file:upload").
-		WithConsoleURL("https://open.feishu.cn/app/cli_test/permission")
-	permissionErr.Troubleshooter = "https://open.feishu.cn/document/troubleshoot/push"
-
-	item, terminal := drivePushFailedItem("a.txt", "", "failed", "upload", 1, permissionErr)
-	if !terminal {
-		t.Fatal("app scope failure must be terminal")
-	}
-	if item.Hint != "open the developer console" || item.LogID != "push-log-permission" {
-		t.Fatalf("typed hint/log_id were not preserved: %#v", item)
-	}
-	if item.Troubleshooter != permissionErr.Troubleshooter || item.ConsoleURL != permissionErr.ConsoleURL {
-		t.Fatalf("typed diagnostic URLs were not preserved: %#v", item)
-	}
-	if len(item.MissingScopes) != 1 || item.MissingScopes[0] != "drive:file:upload" {
-		t.Fatalf("missing_scopes were not preserved: %#v", item)
-	}
-
+func TestDrivePushFailedItemPreservesRetryAfter(t *testing.T) {
 	rateErr := errs.NewAPIError(errs.SubtypeRateLimit, "rate limited").
 		WithCode(99991400).
 		WithRetryable().

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -1280,6 +1280,67 @@ func TestDrivePushContinuesAfterUploadSizeMismatch(t *testing.T) {
 	}
 }
 
+func TestDrivePushAbortsAfterUserQuotaExceeded(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "a.txt"), []byte("A"), 0o644); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("local", "b.txt"), []byte("B"), 0o644); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/upload_all",
+		Body: map[string]interface{}{
+			"code": 1061061,
+			"msg":  "user quota exceeded.",
+		},
+	})
+
+	err := mountAndRunDrive(t, DrivePush, []string{
+		"+push",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatalf("expected partial failure, got nil\nstdout: %s", stdout.String())
+	}
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	summary, items := splitDrivePushStdout(t, stdout.Bytes())
+	if got := summary["aborted"]; got != true {
+		t.Fatalf("summary.aborted = %v, want true", got)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1; user quota exhaustion must stop before b.txt: %#v", len(items), items)
+	}
+	item := items[0]
+	if item["rel_path"] != "a.txt" || item["phase"] != "upload" || item["error_class"] != "quota_exceeded" {
+		t.Fatalf("unexpected failed item: %#v", item)
+	}
+	if item["code"] != float64(1061061) || item["subtype"] != "quota_exceeded" || item["retryable"] != false {
+		t.Fatalf("unexpected user quota metadata: %#v", item)
+	}
+}
+
 func TestDrivePushAbortsAfterUploadBadGateway(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 

--- a/shortcuts/drive/drive_sync_test.go
+++ b/shortcuts/drive/drive_sync_test.go
@@ -438,6 +438,10 @@ func TestDriveSyncContinuesAfterNewRemoteDownloadNotFound(t *testing.T) {
 	if len(items) != 2 || items[0].RelPath != "a.txt" || items[1].RelPath != "b.txt" || items[1].Action != "downloaded" {
 		t.Fatalf("item-local 404 must not block b.txt: %#v", items)
 	}
+	failedItem := items[0]
+	if failedItem.Action != "failed" || failedItem.Phase != "download" || failedItem.Code != http.StatusNotFound || failedItem.Retryable == nil || *failedItem.Retryable {
+		t.Fatalf("unexpected failed-download metadata: %#v", failedItem)
+	}
 	mustReadFile(t, filepath.Join("local", "b.txt"), "BBB")
 }
 

--- a/shortcuts/drive/drive_sync_test.go
+++ b/shortcuts/drive/drive_sync_test.go
@@ -376,6 +376,71 @@ func TestDriveSyncAbortsAfterNewRemoteDownloadForbidden(t *testing.T) {
 	}
 }
 
+func TestDriveSyncContinuesAfterNewRemoteDownloadNotFound(t *testing.T) {
+	syncTestConfig := &core.CliConfig{
+		AppID: "drive-sync-not-found", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	}
+	f, stdout, _, reg := cmdutil.TestFactory(t, syncTestConfig)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.MkdirAll("local", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"files": []interface{}{
+					map[string]interface{}{"token": "tok_a", "name": "a.txt", "type": "file", "modified_time": "100"},
+					map[string]interface{}{"token": "tok_b", "name": "b.txt", "type": "file", "modified_time": "100"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "/open-apis/drive/v1/files/tok_a/download",
+		Status:  http.StatusNotFound,
+		RawBody: []byte("not found"),
+	})
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "/open-apis/drive/v1/files/tok_b/download",
+		Status:  http.StatusOK,
+		RawBody: []byte("BBB"),
+	})
+
+	err := mountAndRunDrive(t, DriveSync, []string{
+		"+sync",
+		"--local-dir", "local",
+		"--folder-token", "folder_root",
+		"--quick",
+		"--as", "bot",
+	}, f, stdout)
+	assertDriveSyncPartialFailure(t, err)
+
+	summary := driveSyncStdoutSummary(t, stdout.Bytes())
+	if got := summary["aborted"]; got != false {
+		t.Fatalf("summary.aborted = %v, want false", got)
+	}
+	if got := summary["failed"]; got != float64(1) {
+		t.Fatalf("summary.failed = %v, want 1", got)
+	}
+	if got := summary["pulled"]; got != float64(1) {
+		t.Fatalf("summary.pulled = %v, want 1", got)
+	}
+	items := driveSyncStdoutItems(t, stdout.Bytes())
+	if len(items) != 2 || items[0].RelPath != "a.txt" || items[1].RelPath != "b.txt" || items[1].Action != "downloaded" {
+		t.Fatalf("item-local 404 must not block b.txt: %#v", items)
+	}
+	mustReadFile(t, filepath.Join("local", "b.txt"), "BBB")
+}
+
 // TestDriveSyncLocalWinsPushesOverRemote verifies that --on-conflict=local-wins
 // pushes the local version over the remote file.
 func TestDriveSyncLocalWinsPushesOverRemote(t *testing.T) {

--- a/shortcuts/sheets/lark_sheet_workbook_export_test.go
+++ b/shortcuts/sheets/lark_sheet_workbook_export_test.go
@@ -5,9 +5,11 @@ package sheets
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/vfs/localfileio"
 	"github.com/larksuite/cli/shortcuts/drive"
@@ -97,5 +99,36 @@ func TestWorkbookExport_ExecuteExportOnly(t *testing.T) {
 	}
 	if env.Data["doc_type"] != "sheet" {
 		t.Errorf("doc_type = %v, want sheet", env.Data["doc_type"])
+	}
+}
+
+func TestWorkbookExport_CreateRateLimitKeepsCallerRecovery(t *testing.T) {
+	stubs := []*httpmock.Stub{
+		{
+			Method: "POST",
+			URL:    "/open-apis/drive/v1/export_tasks",
+			Status: http.StatusBadRequest,
+			Body: map[string]interface{}{
+				"code": 9499,
+				"msg":  "too many request",
+			},
+		},
+	}
+
+	_, err := runShortcutWithStubs(t, WorkbookExport, []string{
+		"--url", testURL, "--file-extension", "xlsx", "--as", "user",
+	}, stubs...)
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed rate-limit error, got %T: %v", err, err)
+	}
+	if problem.Subtype != errs.SubtypeRateLimit || problem.Code != 9499 || !problem.Retryable {
+		t.Fatalf("problem = %+v, want retryable rate_limit code 9499", problem)
+	}
+	if !strings.Contains(problem.Hint, "rerun the original command with the same arguments") {
+		t.Fatalf("hint should preserve the workbook-export caller: %q", problem.Hint)
+	}
+	if strings.Contains(problem.Hint, "drive +export") {
+		t.Fatalf("workbook-export hint must not redirect users to drive +export: %q", problem.Hint)
 	}
 }

--- a/shortcuts/sheets/lark_sheet_workbook_export_test.go
+++ b/shortcuts/sheets/lark_sheet_workbook_export_test.go
@@ -5,6 +5,7 @@ package sheets
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -122,8 +123,12 @@ func TestWorkbookExport_CreateRateLimitKeepsCallerRecovery(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected typed rate-limit error, got %T: %v", err, err)
 	}
-	if problem.Subtype != errs.SubtypeRateLimit || problem.Code != 9499 || !problem.Retryable {
-		t.Fatalf("problem = %+v, want retryable rate_limit code 9499", problem)
+	if problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeRateLimit || problem.Code != 9499 || !problem.Retryable {
+		t.Fatalf("problem = %+v, want api/rate_limit code 9499 retryable", problem)
+	}
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T, want *errs.APIError", err)
 	}
 	if !strings.Contains(problem.Hint, "rerun the original command with the same arguments") {
 		t.Fatalf("hint should preserve the workbook-export caller: %q", problem.Hint)

--- a/skills/lark-drive/references/lark-drive-export.md
+++ b/skills/lark-drive/references/lark-drive-export.md
@@ -147,6 +147,7 @@ lark-cli drive +export \
 | `1069914` | token 非法或 token/type 不匹配；常见原因是把 Wiki node token 当作底层 `docx` / `sheet` / `bitable` token 使用，没有传 `--doc-type wiki` | 优先改用 `--url <Wiki URL>`；只有裸 Wiki token 时，用 `--token <WIKI_NODE_TOKEN> --doc-type wiki`。不确定 token 类型时，先用 `lark-cli drive +inspect --url <TOKEN> --type wiki` 检查是否能解包为 Wiki node；如果不是 Wiki token，再检查 token 来源、`--doc-type` 是否与实际资源类型一致 |
 | `1069902` | 没有当前导出任务所需权限 | 不要直接重试同一命令；先确认当前 `--as` 身份是否能访问该文档、是否有下载/导出权限，以及文档是否受分享、密级或租户策略限制。需要补权限时，让文档 owner 或管理员授权后再执行 |
 | `99991400` / `rate_limit` | OpenAPI 请求频率受限 | 立即停止并按错误 `hint` 处理：没有 `ticket` 时，至少等待 1 分钟后重跑原 `drive +export`；已有 `ticket` 时，只执行 `drive +task_result --scenario export` 续查，不要重复创建任务。持续限频时从 1 分钟开始指数退避 |
+| `9499` + `too many request(s)` | 导出任务接口的另一种限频响应；同一个 `9499` 在其它 Drive 接口也可能表示参数类型错误，CLI 会结合服务端消息区分 | 按 `rate_limit` 处理：立即停止，等待至少 1 分钟并指数退避；已有 `ticket` 时只续查该任务，不要重新创建 |
 | `99991679` | 缺少 OpenAPI scope | 按错误 envelope 中的 `missing_scopes` / `required_scope` / `hint` 补齐授权；常见方式是重新执行 `lark-cli auth login --scope "<缺失 scope>"`。补 scope 前不要反复重试导出命令 |
 
 ## 推荐续跑方式

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -120,7 +120,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     {"rel_path": "...", "file_token": "...", "action": "uploaded",       "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "overwritten",    "version": "...", "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "skipped",        "size_bytes": 0},
-    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0},
+    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
     {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
     {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "...", "hint": "...", "phase": "delete", "error_class": "...", "code": 0, "subtype": "...", "retryable": false}
@@ -134,7 +134,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
-失败项会保留上游 typed error 已提供的 `hint` 和 `retry_after_seconds`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
+失败项会保留上游 typed error 已提供的 `hint`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；重试时采用有上限的指数退避和抖动。
 
 常见终止性错误：
 

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -146,7 +146,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 | `invalid_api_parameters` | `1061002` | API 参数被服务端拒绝 | 停止重试，检查 `--folder-token`、覆盖模式、`file_token`、文件名和上传参数；不要对同一参数组合批量重试 |
 | `parent_node_missing` | `1061044` | 上传 / 建目录使用的父文件夹不存在或当前身份不可见 | 停止重试，检查 `--folder-token` 是否仍存在、是否有权限、父目录是否在 push 过程中被删除；不要继续上传同一目录树 |
 | `parent_sibling_limit` | `1062507` | 目标父文件夹单层子节点数量超过上限 | 停止重试，清理目标目录、换一个 `--folder-token`，或把上传内容拆到多个子目录 |
-| `quota_exceeded` | `1061101` | Drive 文件容量配额已满 | 停止重试，释放容量、调整目标位置或扩容后再执行 push |
+| `quota_exceeded` | `1061101` / `1061061` | 租户或当前用户的 Drive 容量配额已满 | 停止重试，释放容量、调整目标位置或扩容后再执行 push |
 | `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
 | `conflict` | `1061045` | 同一目标发生资源竞争 | 停止当前批次，避免并发操作同一目标；退避后有限重试 |
 | `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试 |

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -120,7 +120,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     {"rel_path": "...", "file_token": "...", "action": "uploaded",       "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "overwritten",    "version": "...", "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "skipped",        "size_bytes": 0},
-    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0, "log_id": "...", "troubleshooter": "...", "missing_scopes": ["..."], "console_url": "..."},
+    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
     {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
     {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "...", "hint": "...", "phase": "delete", "error_class": "...", "code": 0, "subtype": "...", "retryable": false}
@@ -134,7 +134,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
-失败项会保留上游 typed error 已提供的 `hint`、`log_id`、`troubleshooter`、`retry_after_seconds`，以及权限错误的 `missing_scopes` / `console_url`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
+失败项会保留上游 typed error 已提供的 `hint` 和 `retry_after_seconds`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
 
 常见终止性错误：
 
@@ -148,7 +148,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 | `parent_sibling_limit` | `1062507` | 目标父文件夹单层子节点数量超过上限 | 停止重试，清理目标目录、换一个 `--folder-token`，或把上传内容拆到多个子目录 |
 | `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
 | `conflict` | `1061045` | 同一目标发生资源竞争 | 停止当前批次，避免并发操作同一目标；退避后有限重试 |
-| `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试；保留 `log_id` 便于排查 |
+| `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试 |
 
 非终止但需要解释的状态：
 

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -134,7 +134,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
-失败项会保留上游 typed error 已提供的 `hint`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；重试时采用有上限的指数退避和抖动。
+`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；重试时采用有上限的指数退避和抖动。
 
 常见终止性错误：
 
@@ -146,6 +146,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 | `invalid_api_parameters` | `1061002` | API 参数被服务端拒绝 | 停止重试，检查 `--folder-token`、覆盖模式、`file_token`、文件名和上传参数；不要对同一参数组合批量重试 |
 | `parent_node_missing` | `1061044` | 上传 / 建目录使用的父文件夹不存在或当前身份不可见 | 停止重试，检查 `--folder-token` 是否仍存在、是否有权限、父目录是否在 push 过程中被删除；不要继续上传同一目录树 |
 | `parent_sibling_limit` | `1062507` | 目标父文件夹单层子节点数量超过上限 | 停止重试，清理目标目录、换一个 `--folder-token`，或把上传内容拆到多个子目录 |
+| `quota_exceeded` | `1061101` | Drive 文件容量配额已满 | 停止重试，释放容量、调整目标位置或扩容后再执行 push |
 | `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
 | `conflict` | `1061045` | 同一目标发生资源竞争 | 停止当前批次，避免并发操作同一目标；退避后有限重试 |
 | `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试 |

--- a/skills/lark-drive/references/lark-drive-push.md
+++ b/skills/lark-drive/references/lark-drive-push.md
@@ -120,7 +120,7 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
     {"rel_path": "...", "file_token": "...", "action": "uploaded",       "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "overwritten",    "version": "...", "size_bytes": 0},
     {"rel_path": "...", "file_token": "...", "action": "skipped",        "size_bytes": 0},
-    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false},
+    {"rel_path": "...",                       "action": "failed",        "size_bytes": 0, "error": "...", "hint": "...", "phase": "upload", "error_class": "...", "code": 0, "subtype": "...", "retryable": false, "retry_after_seconds": 0, "log_id": "...", "troubleshooter": "...", "missing_scopes": ["..."], "console_url": "..."},
     {"rel_path": "...", "file_token": "...", "action": "deleted_remote"},
     {"rel_path": "...", "file_token": "...", "action": "already_deleted"},
     {"rel_path": "...", "file_token": "...", "action": "delete_failed",  "error": "...", "hint": "...", "phase": "delete", "error_class": "...", "code": 0, "subtype": "...", "retryable": false}
@@ -134,6 +134,8 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 
 `+push` 的失败项带结构化字段，agent 必须优先读 `items[].error_class` / `phase` / `code`，不要只看自然语言 `error` 文本。`summary.aborted=true` 表示命令已经遇到终止性错误并停止后续批处理；这时**不要原样重试**，先修复根因。
 
+失败项会保留上游 typed error 已提供的 `hint`、`log_id`、`troubleshooter`、`retry_after_seconds`，以及权限错误的 `missing_scopes` / `console_url`。`retryable=true` 只表示修复根因或等待后可以再次尝试，不表示应该立即、无限重放整个 push；有 `retry_after_seconds` 时至少等待该时长，否则采用有上限的指数退避和抖动。
+
 常见终止性错误：
 
 | `error_class` | 常见 `code` | 含义 | Agent 应对 |
@@ -145,7 +147,8 @@ lark-cli drive +push --local-dir ./repo --folder-token fldcnxxxxxxxxx \
 | `parent_node_missing` | `1061044` | 上传 / 建目录使用的父文件夹不存在或当前身份不可见 | 停止重试，检查 `--folder-token` 是否仍存在、是否有权限、父目录是否在 push 过程中被删除；不要继续上传同一目录树 |
 | `parent_sibling_limit` | `1062507` | 目标父文件夹单层子节点数量超过上限 | 停止重试，清理目标目录、换一个 `--folder-token`，或把上传内容拆到多个子目录 |
 | `rate_limited` | `99991400` | 触发频控 | 停止当前批次，退避后再重试 |
-| `server_error` | `1061001` / `2200` | Drive 服务端异常 | 停止当前批次，稍后重试；保留 `log_id` 便于排查 |
+| `conflict` | `1061045` | 同一目标发生资源竞争 | 停止当前批次，避免并发操作同一目标；退避后有限重试 |
+| `server_error` | `1663` / `1061001` / `2200` / HTTP 5xx | Drive 服务端或网关异常 | 停止当前批次，稍后有限重试；保留 `log_id` 便于排查 |
 
 非终止但需要解释的状态：
 


### PR DESCRIPTION
## Summary

Harden Drive export and push failure recovery for the error patterns observed in production.

## Changes

### Export recovery

- Disambiguate code `9499` only at the Drive export task boundary using its exact throttling message, leaving the shared classifier unchanged and preserving `invalid_parameters` everywhere else.
- Add typed mappings for export codes `1069902`, `1069906`, `1069914`, and `1069918`.
- Stop export polling immediately on the `9499` rate-limit variant and return ticket-aware resume guidance instead of amplifying throttling.
- Add actionable recovery hints for permission, deleted document, invalid token/type, and extension/sub-ID failures.

### Push failure handling

- Keep upload size mismatch (`1062009`) file-local so independent files continue, while stopping the batch on shared failures such as resource contention, quota exhaustion, multipart internal errors, and HTTP/network failures.
- Add bounded-backoff guidance for retryable push failures without inventing a retry delay that the upstream response did not provide.
- Register Drive multipart error `1663` as a retryable server error.
- Document finite retry behavior and the expanded push failure contract.

### Tests and docs

- Add command-level regression coverage for export task creation/polling and permanent export failures.
- Add push coverage for size mismatch, HTTP 502, resource contention, quota exhaustion, and Drive code `1663`.
- Update the Drive export and push skill references.

## Test Plan

- [x] `go test -race -count=1 ./internal/errclass ./shortcuts/drive`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `node scripts/skill-format-check/index.js`
- [x] `go test -C lint ./... -count=1`
- [x] `go run -C lint . --changed-from origin/main ..`
- [x] `make quality-gate`
- [x] Command-level HTTP stubs verify export and push API/error boundaries.

`make unit-test` passed all changed and Drive-related packages under `-race`. The aggregate run encountered the repository's unrelated macOS `TempDir RemoveAll` flake in `internal/qualitygate/rules` (`.git: directory not empty`); the failing package passed when rerun in isolation. Live rate-limit and destructive push E2E cases were not forced because they would be unsafe or nondeterministic; deterministic command-level HTTP stubs cover the changed behavior.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Drive export error handling and recovery guidance for permissions, deleted files, invalid references, and unsupported formats.
  * Correctly distinguishes rate limits from other errors and applies safer retry behavior.
  * Drive push operations now provide clearer failure classifications, quota handling, and retry guidance.
  * Pull and sync operations continue processing remaining files when an individual download is unavailable.

* **Documentation**
  * Updated Drive export and push guidance with backoff, retry timing, and failure-handling instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->