### PR TITLE
docs(calendar): clarify identity selection for scheduling

### DIFF
--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -21,6 +21,8 @@ metadata:
 - 查看/管理登录用户本人的日程 → `--as user`（默认，绝大多数场景）。
 - 查看/管理 bot 自己创建/拥有的日程 → `--as bot` 
 
+**对话人称映射**：「我」= 登录用户，「你」= 应用（bot）；作为字段取值的人称（参会人、会议 owner 等）不参与身份判定，如「你创建日程，邀请我、会议 owner 为我」→ `--as bot` 创建，登录用户仅作参会人与会议 owner。
+
 ```bash
 # 用户本人日程 → user
 lark-cli calendar +agenda --as user

--- a/skills/lark-calendar/references/lark-calendar-create.md
+++ b/skills/lark-calendar/references/lark-calendar-create.md
@@ -61,6 +61,7 @@ lark-cli calendar event.attendees create \
   --data '{"attendees": [{"type": "resource", "room_id": "omm_xxx", "approval_reason": "申请原因"}]}'
 
 完整 API 命令的关键差异：
+- `+create` 在传入 `--attendee-ids`（即需要邀请其他参会人）时，会自动把当前身份一并加进参会人，但 `calendar events create` / `calendar event.attendees create` 等完整 API **不会**自动加。需自行把调用身份的 open_id 以 `type:user` 写入 attendees，与邀请的其他参会人合并去重后添加。open_id 用 `lark-cli auth status --json --verify` 获取：bot 取 `identities.bot.openId`（`--verify` 才会填充），user 取 `identities.user.openId`。
 - 时间参数是 **Unix 秒字符串**（非 ISO 8601）。换算时**禁止依赖容器默认时区**（常为 UTC，会导致 8 小时偏移），必须显式指定目标时区。
 - 全天日程的开始日期和结束日期必须分别是日程开始的第一天和结束的最后一天；单日全天日程两者相同。
 - 手动拆成“创建日程 + 添加参会人”两步时，若第二步失败，建议删除刚创建的空日程，避免遗留无参会人的日程。


### PR DESCRIPTION
## Summary

Agents misread colloquial pronouns when creating calendar events, picking the wrong `--as` identity and dropping fields. This clarifies the calendar skill so identity selection is robust, and documents a gap when using the raw API.

Two concrete problems this fixes:
- "你创建日程…指定会议 owner 为我" was misread as *the logged-in user creates the event* (used `--as user`), because the pronoun "我" appearing as a field value (meeting owner) leaked into identity selection. The meeting owner was also silently dropped.
- Callers falling back to the raw `calendar events` / `event.attendees` API did not add the calling identity as an attendee, unlike `+create` which does this automatically.

## Changes
- `skills/lark-calendar/SKILL.md`: pronouns that are only **field values** (attendees, meeting owner, …) do not participate in `--as` identity selection. Keep the mapping "我" = logged-in user, "你" = application (bot); e.g. "你创建日程，邀请我、会议 owner 为我" → create with `--as bot`, logged-in user is only an attendee / meeting owner.
- `skills/lark-calendar/references/lark-calendar-create.md`: note that the raw `calendar events create` / `calendar event.attendees create` API does **not** auto-add the calling identity the way `+create` does. Guide callers to add the caller's `open_id` as a `type:user` attendee (bot via `lark-cli api GET /open-apis/bot/v3/info --as bot` → `bot.open_id`; user via `lark-cli auth status --json --verify` → `identities.user.openId`).

## Test Plan
- [x] `node scripts/skill-format-check/index.js` passes
- [x] Docs-only change; no Go code affected

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified conversational pronouns in calendar interactions: “我” refers to the logged-in user, while “你” refers to the bot.
  * Clarified that attendees or owners listed in event fields do not determine which identity performs an action.
  * Added guidance that the caller’s ID must be explicitly included when adding them as an attendee.
  * Documented how to retrieve bot and user IDs and avoid duplicate attendees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->