### PR TITLE
fix(wiki): clarify resource permission recovery

### DIFF
--- a/shortcuts/wiki/wiki_helpers.go
+++ b/shortcuts/wiki/wiki_helpers.go
@@ -41,3 +41,11 @@ func appendWikiProblemHint(err error, hint string) error {
 	}
 	return err
 }
+
+// wikiPermissionDeniedHint provides stable recovery for wiki's 131006. The
+// service uses one public code for both node and space ACL failures, while the
+// upstream message is informational and normalized by the shared classifier.
+// Keep the command hint accurate without branching on that unstable text.
+func wikiPermissionDeniedHint() string {
+	return "The current user or app/bot identity lacks access to the target wiki space or node. This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error; ask the resource owner or wiki administrator to grant read access, or use an accessible resource."
+}

--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -271,13 +271,46 @@ func TestWikiNodeListProblemAddsActionableHint(t *testing.T) {
 	t.Parallel()
 
 	err := errs.NewAPIError(errs.SubtypeInvalidParameters, "param err: invalid page_token").WithCode(131002)
-	got := wikiNodeListProblem(err, nil)
+	got := wikiNodeListProblem(err)
 	p, ok := errs.ProblemOf(got)
 	if !ok {
 		t.Fatalf("ProblemOf() ok=false")
 	}
 	if !strings.Contains(p.Hint, "page token is invalid or stale") {
 		t.Fatalf("hint = %q, want invalid page token guidance", p.Hint)
+	}
+}
+
+func TestWikiNodeListProblemExplainsResourcePermissionDenied(t *testing.T) {
+	tests := []string{
+		"permission denied: wiki space permission denied, user needs read permission.",
+		"permission denied: node permission denied, tenant needs read permission.",
+	}
+
+	for _, message := range tests {
+		t.Run(message, func(t *testing.T) {
+			cause := errors.New("upstream permission failure")
+			err := errs.NewPermissionError(errs.SubtypePermissionDenied, message).
+				WithCode(131006).
+				WithCause(cause)
+			got := wikiNodeListProblem(err)
+			p, ok := errs.ProblemOf(got)
+			if !ok {
+				t.Fatalf("ProblemOf() ok=false")
+			}
+			if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied || p.Code != 131006 {
+				t.Fatalf("problem = %#v, want authorization/permission_denied/131006", p)
+			}
+			if p.Retryable {
+				t.Fatalf("problem retryable = true, want false: %#v", p)
+			}
+			if !errors.Is(got, cause) {
+				t.Fatalf("errors.Is(got, cause) = false, want preserved cause")
+			}
+			if !strings.Contains(p.Hint, "resource access, not app scope authorization") || !strings.Contains(p.Hint, "Do not retry the same request") {
+				t.Fatalf("hint = %q, want non-retryable resource-access guidance", p.Hint)
+			}
+		})
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -143,6 +143,9 @@ func wikiNodeGetProblem(err error) error {
 	}
 
 	switch p.Code {
+	case 131006:
+		p.Retryable = false
+		appendWikiProblemHint(err, wikiPermissionDeniedHint())
 	case 131012:
 		p.Subtype = errs.SubtypeNotFound
 		p.Retryable = false

--- a/shortcuts/wiki/wiki_node_get_test.go
+++ b/shortcuts/wiki/wiki_node_get_test.go
@@ -487,6 +487,74 @@ func TestWikiNodeGetMountedClassifiesTerminalBusinessErrors(t *testing.T) {
 	}
 }
 
+func TestWikiNodeGetMountedExplainsResourcePermissionDenied(t *testing.T) {
+	for _, identity := range []string{"user", "bot"} {
+		t.Run(identity, func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+			factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+			reg.Register(&httpmock.Stub{
+				Method: "GET",
+				URL:    "/open-apis/wiki/v2/spaces/get_node",
+				Body: map[string]interface{}{
+					"code":   131006,
+					"msg":    "permission denied: node permission denied, user needs read permission.",
+					"log_id": "log-node-get-permission",
+				},
+			})
+
+			err := mountAndRunWiki(t, WikiNodeGet, []string{
+				"+node-get",
+				"--node-token", testWikiNodeToken,
+				"--as", identity,
+			}, factory, stdout)
+			if err == nil {
+				t.Fatal("expected permission error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed error, got %T: %v", err, err)
+			}
+			if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied || p.Code != 131006 {
+				t.Fatalf("problem = %#v, want authorization/permission_denied/131006", p)
+			}
+			if p.Retryable {
+				t.Fatalf("problem retryable = true, want false: %#v", p)
+			}
+			if !strings.Contains(p.Hint, "resource access, not app scope authorization") || !strings.Contains(p.Hint, "Do not retry the same request") {
+				t.Fatalf("hint = %q, want non-retryable resource-access guidance", p.Hint)
+			}
+		})
+	}
+}
+
+func TestWikiNodeGetProblemPreservesPermissionErrorContract(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("opaque upstream cause")
+	err := errs.NewPermissionError(errs.SubtypePermissionDenied, "opaque upstream message").
+		WithCode(131006).
+		WithCause(cause)
+
+	got := wikiNodeGetProblem(err)
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false")
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied || p.Code != 131006 {
+		t.Fatalf("problem = %#v, want authorization/permission_denied/131006", p)
+	}
+	if p.Retryable {
+		t.Fatalf("problem retryable = true, want false: %#v", p)
+	}
+	if !errors.Is(got, cause) {
+		t.Fatalf("errors.Is(got, cause) = false, want preserved cause")
+	}
+	if p.Hint != wikiPermissionDeniedHint() {
+		t.Fatalf("hint = %q, want %q", p.Hint, wikiPermissionDeniedHint())
+	}
+}
+
 func TestWikiNodeGetMountedAcceptsNodeTokenFlag(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 

--- a/shortcuts/wiki/wiki_node_list.go
+++ b/shortcuts/wiki/wiki_node_list.go
@@ -238,7 +238,7 @@ func fetchWikiNodes(runtime *common.RuntimeContext, spaceID, parentNodeToken str
 		}
 		data, err := runtime.CallAPITyped("GET", apiPath, params, nil)
 		if err != nil {
-			return nil, false, "", wikiNodeListProblem(err, runtime)
+			return nil, false, "", wikiNodeListProblem(err)
 		}
 		items, _ := data["items"].([]interface{})
 		for _, item := range items {
@@ -262,7 +262,7 @@ func fetchWikiNodes(runtime *common.RuntimeContext, spaceID, parentNodeToken str
 	return nodes, lastHasMore, lastPageToken, nil
 }
 
-func wikiNodeListProblem(err error, runtime *common.RuntimeContext) error {
+func wikiNodeListProblem(err error) error {
 	p, ok := errs.ProblemOf(err)
 	if !ok {
 		return err
@@ -281,11 +281,8 @@ func wikiNodeListProblem(err error, runtime *common.RuntimeContext) error {
 	case 131005:
 		appendWikiProblemHint(err, "The target wiki space or parent node was not found. Re-discover the space with `wiki +space-list` and the parent with `wiki +node-list`/`wiki +node-get`; do not retry the same stale token.")
 	case 131006:
-		if runtime != nil && runtime.As().IsBot() {
-			appendWikiProblemHint(err, "The bot/app identity cannot read this wiki space or node. Grant the app the required wiki scope and ensure the app or bot has access to the target knowledge space.")
-		} else {
-			appendWikiProblemHint(err, "The current user cannot read this wiki space or node. Switch to a user with access or ask the space owner to grant read permission.")
-		}
+		p.Retryable = false
+		appendWikiProblemHint(err, wikiPermissionDeniedHint())
 	case 99991400:
 		appendWikiProblemHint(err, "Rate limited by the wiki API. Stop immediate retries and retry later with exponential backoff or a smaller --page-limit.")
 	}

--- a/skills/lark-wiki/references/lark-wiki-node-get.md
+++ b/skills/lark-wiki/references/lark-wiki-node-get.md
@@ -58,6 +58,7 @@ These HTTP 200 responses carry a non-zero business code and are not retryable wi
 
 | Code | Meaning | Required action |
 |------|---------|-----------------|
+| `131006` | The current user or app/bot identity lacks access to the Wiki node or space | This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error; ask the node owner or wiki administrator to grant read access, or use an accessible resource |
 | `131012` | The Wiki node has been deleted | Do not retry the same node token; rediscover the node or ask for a current Wiki link |
 | `131013` | The resource token is invalid | Do not switch identity or reauthorize; correct the URL/token |
 | `131014` | The document is not mounted in Wiki | Stop Wiki resolution; use the corresponding docs/sheets/base/drive command, or provide a Wiki URL/node_token |

--- a/skills/lark-wiki/references/lark-wiki-node-list.md
+++ b/skills/lark-wiki/references/lark-wiki-node-list.md
@@ -87,7 +87,7 @@ lark-cli wiki +node-list --space-id 6946843325487912356 --parent-node-token wikc
 - `--space-id my_library` is a per-user alias and only valid with `--as user`. The shortcut will refuse `--as bot` with `my_library` upfront.
 - `--space-id` is a numeric wiki `space_id`. Do not pass a wiki URL, wiki node token, document token, or title. Use `lark-cli wiki +space-list --as user` to discover it.
 - `--parent-node-token` must resolve to a wiki node token. If you have a docx/sheet/base/file URL, first run `lark-cli wiki +node-get --node-token <url>` and use the returned `node_token`.
-- Treat `invalid_parameters` (`space_id is not int`, `invalid page_token`), `not_found` (`node not found by parent node token`), and `permission_denied` as terminal for the current arguments. Fix the argument or permission before retrying.
+- Treat `invalid_parameters` (`space_id is not int`, `invalid page_token`), `not_found` (`node not found by parent node token`), and `permission_denied` as terminal for the current arguments. For `131006 permission_denied`, the user or app/bot identity lacks access to the target space or parent node; this is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error. Ask the resource owner or wiki administrator to grant read access, or use an accessible resource.
 - For `rate_limit`, stop immediate retries and retry later with exponential backoff or a smaller `--page-limit`.
 
 ## Required Scope


### PR DESCRIPTION
## Summary
Clarify recovery guidance for Wiki `131006` failures so agents treat them as resource-access errors instead of app-scope authorization failures. The change keeps the existing non-retryable classification and avoids branching on normalized upstream message text.

## Changes
- Add shared resource-permission recovery guidance for `wiki +node-get` and `wiki +node-list`.
- Remove misleading app-scope advice and explicitly discourage same-request retries, reauthorization, and identity trial-and-error.
- Document `131006` behavior in the command references and add regression coverage.

## Test Plan
- [x] `go test ./shortcuts/wiki/...`
- [x] `node scripts/skill-format-check/index.js`
- [x] `git diff --check`

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Wiki permission-error handling for node retrieval and listing.
  - Permission-denied errors are clearly identified as non-retryable.
  - Recovery guidance directs users to request access to the relevant Wiki space or node.

- **Documentation**
  - Clarified the difference between resource access issues and app authorization problems.
  - Added guidance not to retry, reauthorize, or switch identities for these errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->