### PR TITLE
docs(slides): use built-in --jq in cli examples and fix workflow link labels

### DIFF
--- a/skills/lark-slides/references/cli/lark-slides-media-upload.md
+++ b/skills/lark-slides/references/cli/lark-slides-media-upload.md
@@ -1,4 +1,3 @@
-
 # slides +media-upload（上传本地图片到飞书幻灯片）
 
 把本地图片上传到指定演示文稿的 drive 媒体库，返回 `file_token`。**返回的 token 作为 `<img src="...">` 的值塞进 slide XML 即可显示图片。**
@@ -65,7 +64,7 @@ SID=yyy       # 要加图的那一页
 
 # 1) 上传图片拿 file_token
 TOKEN=$(lark-cli slides +media-upload --as user \
-  --file ./pic.png --presentation $PRES_ID | jq -r '.data.file_token')
+  --file ./pic.png --presentation $PRES_ID --jq '.data.file_token')
 
 # 2) block_insert 到页末（或用 insert_before_block_id 指定插入位置）
 lark-cli slides +replace-slide --as user \

--- a/skills/lark-slides/references/cli/lark-slides-replace-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-replace-slide.md
@@ -185,7 +185,7 @@ SID=yyy
 
 # 1) 上传图片
 TOKEN=$(lark-cli slides +media-upload --as user \
-  --file ./pic.png --presentation "$PID" | jq -r '.data.file_token')
+  --file ./pic.png --presentation "$PID" --jq '.data.file_token')
 
 # 2) block_insert 到页末
 lark-cli slides +replace-slide --as user \
@@ -256,4 +256,4 @@ lark-cli slides +replace-slide --as user \
 - [xml_presentation.slide get](lark-slides-xml-presentation-slide-get.md) — 读原页拿 `block_id` / `revision_id`
 - [xml_presentation.slide replace](lark-slides-xml-presentation-slide-replace.md) — 底层 replace API 参考
 - [+media-upload](lark-slides-media-upload.md) — 上传图片拿 `file_token`
-- [lark-slides-edit-workflows.md](../workflow/slides_editing.md) — 读-改-写闭环 + 决策树
+- [slides_editing.md](../workflow/slides_editing.md) — 读-改-写闭环 + 决策树

--- a/skills/lark-slides/references/cli/lark-slides-replace-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-replace-slide.md
@@ -226,7 +226,7 @@ lark-cli slides +replace-slide --as user \
 # 读时记录 revision_id
 REV=$(lark-cli slides xml_presentation.slide get --as user \
   --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}" \
-  | jq '.data.revision_id')
+  --jq '.data.revision_id')
 
 # 写时传 --revision-id；传不存在的版本号（超过当前 revision）返回 3350002
 lark-cli slides +replace-slide --as user \

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
@@ -107,4 +107,4 @@ lark-cli slides xml_presentation.slide get --as user --params '{
 - [slides +replace-slide](lark-slides-replace-slide.md) — 块级替换 shortcut（推荐）
 - [xml_presentation.slide replace](lark-slides-xml-presentation-slide-replace.md) — 底层 replace API 参考
 - [slides +xml-get](lark-slides-xml-presentations-get.md) — 读整个 PPT 并保存到本地文件
-- [lark-slides-edit-workflows.md](../workflow/slides_editing.md) — 读-改-写闭环
+- [slides_editing.md](../workflow/slides_editing.md) — 读-改-写闭环

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
@@ -48,7 +48,7 @@ lark-cli slides xml_presentation.slide get --as user --params '{
 ```bash
 lark-cli slides xml_presentation.slide get --as user \
   --params '{"xml_presentation_id":"slides_example_presentation_id","slide_id":"slide_example_id"}' \
-  | jq -r '.data.slide.content'
+  --jq '.data.slide.content'
 ```
 
 ### 读指定历史版本
@@ -99,7 +99,7 @@ lark-cli slides xml_presentation.slide get --as user --params '{
    ```bash
    lark-cli slides xml_presentation.slide get --as user \
      --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}" \
-     | jq -r '.data.slide.content' | grep -oE 'id="[^"]+"' | sed 's/id="//;s/"//'
+     --jq '.data.slide.content' | grep -oE 'id="[^"]+"' | sed 's/id="//;s/"//'
    ```
 
 ## 相关命令

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-replace.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-replace.md
@@ -95,7 +95,7 @@ lark-cli slides xml_presentation.slide replace --as user --params '{
 
 ```bash
 # 先拿 file_token
-TOKEN=$(lark-cli slides +media-upload --file ./pic.png --presentation "$PID" --as user | jq -r '.data.file_token')
+TOKEN=$(lark-cli slides +media-upload --file ./pic.png --presentation "$PID" --as user --jq '.data.file_token')
 
 lark-cli slides xml_presentation.slide replace --as user --params "{
   \"xml_presentation_id\": \"$PID\",
@@ -185,4 +185,4 @@ lark-cli slides xml_presentation.slide replace --as user --params '{
 - [slides +replace-slide](lark-slides-replace-slide.md) — 块级替换 shortcut（推荐，自动注入 id）
 - [xml_presentation.slide get](lark-slides-xml-presentation-slide-get.md) — 读原页拿 block short ID
 - [slides +media-upload](lark-slides-media-upload.md) — 上传图片拿 file_token
-- [lark-slides-edit-workflows.md](../workflow/slides_editing.md) — 读-改-写闭环 + 决策树
+- [slides_editing.md](../workflow/slides_editing.md) — 读-改-写闭环 + 决策树

--- a/skills/lark-slides/references/workflow/slides_editing.md
+++ b/skills/lark-slides/references/workflow/slides_editing.md
@@ -43,7 +43,7 @@ lark-cli slides +replace-slide --as user \
 # 读时拿当前 revision_id
 REV=$(lark-cli slides xml_presentation.slide get --as user \
   --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}" \
-  | jq '.data.revision_id')
+  --jq '.data.revision_id')
 
 # 写时传该版本号，服务端以此为 base
 lark-cli slides +replace-slide --as user \


### PR DESCRIPTION
Small docs-only fixes to the lark-slides `references/cli/` command references. No code changed.

## Summary
Update 4 CLI command docs: replace the external `| jq -r` pipe in examples with lark-cli's built-in `--jq` flag, and fix stale workflow link labels. Applied from local edits in the internal mirror.

## Changes
- `lark-slides-media-upload.md` — `| jq -r '.data.file_token'` → `--jq '.data.file_token'`; drop a stray leading blank line.
- `lark-slides-replace-slide.md` — same `--jq` swap; link label `lark-slides-edit-workflows.md` → `slides_editing.md`.
- `lark-slides-xml-presentation-slide-get.md` — link label → `slides_editing.md`.
- `lark-slides-xml-presentation-slide-replace.md` — `--jq` swap; link label → `slides_editing.md`.

Why `--jq`: it's a built-in lark-cli flag (`-q/--jq`, added in #211) that filters JSON output in-process, so examples no longer depend on an external `jq` binary being installed and avoid stderr progress lines polluting `$(...)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated slide media, image upload, XML extraction, and revision lookup examples to use the built-in `--jq` option, eliminating the need for external JSON-processing commands.
  - Corrected workflow reference labels and standardized links to the slide editing workflow across related guides.
  - Improved command examples for more consistent, streamlined copying and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->