### PR TITLE
feat: support bot identity

### DIFF
--- a/shortcuts/minutes/bot_identity_test.go
+++ b/shortcuts/minutes/bot_identity_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// Tests pinning bot-identity support for `minutes +detail` (minute metadata,
+// artifacts, and transcript all flow under a tenant access token).
+
+package minutes
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+func TestMinutesDetailSupportsUserAndBotIdentity(t *testing.T) {
+	want := []string{"user", "bot"}
+	if !reflect.DeepEqual(MinutesDetail.AuthTypes, want) {
+		t.Fatalf("MinutesDetail.AuthTypes = %v, want %v", MinutesDetail.AuthTypes, want)
+	}
+}
+
+func TestDetail_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := detailMountAndRun(t, MinutesDetail, []string{"+detail", "--minute-tokens", "tok001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "/open-apis/minutes/v1/minutes/") {
+		t.Errorf("dry-run should show minutes API path, got: %s", stdout.String())
+	}
+}
+
+func TestDetail_DryRun_BotIdentity_Transcript(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := detailMountAndRun(t, MinutesDetail, []string{"+detail", "--minute-tokens", "tok001", "--transcript", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "artifacts") {
+		t.Errorf("dry-run should show artifacts API path when --transcript is set, got: %s", stdout.String())
+	}
+}
+
+func TestMinutesApplyPermissionSupportsUserAndBotIdentity(t *testing.T) {
+	want := []string{"user", "bot"}
+	if !reflect.DeepEqual(MinutesApplyPermission.AuthTypes, want) {
+		t.Fatalf("MinutesApplyPermission.AuthTypes = %v, want %v", MinutesApplyPermission.AuthTypes, want)
+	}
+}
+
+func TestApplyPermission_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, MinutesApplyPermission, []string{
+		"+apply-permission", "--minute-token", "obcnexampleminute", "--perm", "view", "--dry-run", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/minutes/v1/minutes/obcnexampleminute/permissions/apply") {
+		t.Errorf("dry-run should show apply-permission API path, got: %s", out)
+	}
+	if !strings.Contains(out, `"perm": "view"`) && !strings.Contains(out, `"perm":"view"`) {
+		t.Errorf("dry-run should show perm body, got: %s", out)
+	}
+}

--- a/shortcuts/minutes/minutes_apply_permission.go
+++ b/shortcuts/minutes/minutes_apply_permission.go
@@ -21,7 +21,7 @@ var MinutesApplyPermission = common.Shortcut{
 	Description: "Apply for view or edit permission on a minute",
 	Risk:        "write",
 	Scopes:      []string{"minutes:permission:apply"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "minute-token", Desc: "minute token", Required: true},
 		{Name: "perm", Desc: "permission to apply for", Required: true, Enum: []string{"view", "edit"}},

--- a/shortcuts/minutes/minutes_detail.go
+++ b/shortcuts/minutes/minutes_detail.go
@@ -285,7 +285,7 @@ var MinutesDetail = common.Shortcut{
 	Description: "Query minute details with selective artifact flags (summary, todo, chapter, transcript, keyword)",
 	Risk:        "read",
 	Scopes:      []string{"minutes:minutes.basic:read", "minutes:minutes.artifacts:read"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "minute-tokens", Desc: "minute tokens, comma-separated for batch", Required: true},

--- a/shortcuts/minutes/skill_docs_test.go
+++ b/shortcuts/minutes/skill_docs_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// Capability source test: pins the identity (user/bot) claims made in
+// skills/lark-minutes against the AuthTypes actually declared on the
+// shortcuts, and pins that the write shortcut this PR opened to bot
+// (`+apply-permission`) ships with a reference doc — PR #2278's review found
+// it had none, which made the main SKILL.md's own "read the reference before
+// using a shortcut" contract unsatisfiable.
+
+package minutes
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func hasAuthType(authTypes []string, want string) bool {
+	for _, a := range authTypes {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readSkillDoc(t *testing.T, relPath string) string {
+	t.Helper()
+	data, err := os.ReadFile("../../" + relPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", relPath, err)
+	}
+	return string(data)
+}
+
+// TestMinutesBotShortcutsIdentityDocsMatchAuthTypes pins that every minutes
+// shortcut declared bot-capable in code is documented as such in the main
+// SKILL.md identity line, so the two sources can't silently diverge again.
+func TestMinutesBotShortcutsIdentityDocsMatchAuthTypes(t *testing.T) {
+	skill := readSkillDoc(t, "skills/lark-minutes/SKILL.md")
+
+	for _, cmd := range []struct {
+		name      string
+		authTypes []string
+	}{
+		{"+search", MinutesSearch.AuthTypes},
+		{"+detail", MinutesDetail.AuthTypes},
+		{"+download", MinutesDownload.AuthTypes},
+		{"+apply-permission", MinutesApplyPermission.AuthTypes},
+	} {
+		if !hasAuthType(cmd.authTypes, "bot") {
+			t.Errorf("%s AuthTypes = %v, want bot included", cmd.name, cmd.authTypes)
+			continue
+		}
+		token := "`" + cmd.name + "`"
+		if !strings.Contains(skill, token) {
+			t.Errorf("skills/lark-minutes/SKILL.md identity section must mention %s alongside its bot support", token)
+		}
+	}
+	if !strings.Contains(skill, "也支持 `--as bot`") {
+		t.Error("skills/lark-minutes/SKILL.md identity section must state which commands also support --as bot")
+	}
+}
+
+// TestMinutesApplyPermissionHasReference pins that `+apply-permission` (this
+// PR's new write-capable-by-bot shortcut) has a dedicated reference doc that
+// the Shortcuts table links to, satisfying the SKILL.md-wide
+// "read the reference before using any shortcut" contract.
+func TestMinutesApplyPermissionHasReference(t *testing.T) {
+	if !hasAuthType(MinutesApplyPermission.AuthTypes, "bot") {
+		t.Fatalf("MinutesApplyPermission.AuthTypes = %v, want bot included (this PR's contract)", MinutesApplyPermission.AuthTypes)
+	}
+
+	reference := readSkillDoc(t, "skills/lark-minutes/references/lark-minutes-apply-permission.md")
+	for _, must := range []string{"--as bot", "--as user", "身份", "missing scope"} {
+		if !strings.Contains(reference, must) {
+			t.Errorf("lark-minutes-apply-permission.md must cover %q (user/bot identity + scope-vs-ACL guidance)", must)
+		}
+	}
+
+	skill := readSkillDoc(t, "skills/lark-minutes/SKILL.md")
+	if !strings.Contains(skill, "[`+apply-permission`](references/lark-minutes-apply-permission.md)") {
+		t.Error("skills/lark-minutes/SKILL.md Shortcuts table must link +apply-permission to its reference doc")
+	}
+}

--- a/shortcuts/note/note_detail.go
+++ b/shortcuts/note/note_detail.go
@@ -23,7 +23,7 @@ var NoteDetail = common.Shortcut{
 	Description: "Get note detail (display type, document tokens) by note_id",
 	Risk:        "read",
 	Scopes:      []string{"vc:note:read"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "note-id", Desc: "note ID", Required: true},
 	},

--- a/shortcuts/note/note_test.go
+++ b/shortcuts/note/note_test.go
@@ -273,6 +273,70 @@ func TestShortcuts(t *testing.T) {
 	}
 }
 
+func TestNoteDetailAuthTypesIncludeBot(t *testing.T) {
+	got := NoteDetail.AuthTypes
+	if len(got) != 2 || got[0] != "user" || got[1] != "bot" {
+		t.Fatalf("NoteDetail.AuthTypes = %#v, want [user bot]", got)
+	}
+	if len(NoteTranscript.AuthTypes) != 1 || NoteTranscript.AuthTypes[0] != "user" {
+		t.Fatalf("NoteTranscript.AuthTypes = %#v, want [user] only", NoteTranscript.AuthTypes)
+	}
+}
+
+func TestNoteDetailSupportsBotIdentity(t *testing.T) {
+	factory, stdout, _, reg := noteShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/vc/v1/notes/note_bot_ok",
+		Body: map[string]any{
+			"code": 0,
+			"data": map[string]any{
+				"note": map[string]any{
+					"note_display_type": float64(1),
+					"creator_id":        "ou_bot",
+					"create_time":       "1710000000",
+					"artifacts": []any{
+						map[string]any{"artifact_type": float64(1), "doc_token": "doc_main"},
+					},
+				},
+			},
+		},
+	})
+
+	err := runNoteShortcut(t, NoteDetail, []string{"+detail", "--note-id", "note_bot_ok", "--as", "bot"}, factory, stdout)
+	if err != nil {
+		t.Fatalf("note +detail --as bot failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s", err, stdout.String())
+	}
+	if resp["identity"] != "bot" {
+		t.Fatalf("identity = %v, want bot", resp["identity"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	note, _ := data["note"].(map[string]any)
+	if note["note_id"] != "note_bot_ok" || note["note_doc_token"] != "doc_main" {
+		t.Fatalf("note payload = %#v, want note_id/note_doc_token filled", note)
+	}
+}
+
+func TestNoteTranscriptRejectsBotIdentity(t *testing.T) {
+	factory, stdout, _, _ := noteShortcutTestFactory(t)
+	err := runNoteShortcut(t, NoteTranscript, []string{"+transcript", "--note-id", "note_x", "--as", "bot"}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected note +transcript --as bot to fail")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryValidation {
+		t.Fatalf("error = %v (%T), want typed validation error", err, err)
+	}
+	if !strings.Contains(err.Error(), "bot") {
+		t.Fatalf("error = %q, want mention of bot", err.Error())
+	}
+}
+
 func valuesEqual(a, b any) bool {
 	ab, _ := json.Marshal(a)
 	bb, _ := json.Marshal(b)

--- a/shortcuts/note/skill_docs_test.go
+++ b/shortcuts/note/skill_docs_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// Capability source test: pins the identity (user/bot) claims made in
+// skills/lark-note against the AuthTypes actually declared on the
+// shortcuts, and pins the bot+unified stop-path guidance PR #2278's review
+// found missing: NoteTranscript stays user-only, so any doc reachable from a
+// `+detail --as bot` -> unified routing decision must say so explicitly
+// instead of silently falling back to --as user.
+
+package note
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func hasAuthType(authTypes []string, want string) bool {
+	for _, a := range authTypes {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readSkillDoc(t *testing.T, relPath string) string {
+	t.Helper()
+	data, err := os.ReadFile("../../" + relPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", relPath, err)
+	}
+	return string(data)
+}
+
+func TestNoteIdentityDocsMatchAuthTypes(t *testing.T) {
+	if !hasAuthType(NoteDetail.AuthTypes, "bot") {
+		t.Fatalf("NoteDetail.AuthTypes = %v, want bot included (this PR's contract)", NoteDetail.AuthTypes)
+	}
+	if hasAuthType(NoteTranscript.AuthTypes, "bot") {
+		t.Fatalf("NoteTranscript.AuthTypes = %v now includes bot; update the bot+unified stop-path guidance below (and this test) instead of leaving it stale", NoteTranscript.AuthTypes)
+	}
+
+	skill := readSkillDoc(t, "skills/lark-note/SKILL.md")
+	if !strings.Contains(skill, "`+detail` 支持 `--as user` / `--as bot`") {
+		t.Error("skills/lark-note/SKILL.md must state that +detail supports both user and bot")
+	}
+	if !strings.Contains(skill, "`+transcript` 仅支持 `--as user`") {
+		t.Error("skills/lark-note/SKILL.md must state that +transcript is user-only (matches NoteTranscript.AuthTypes)")
+	}
+}
+
+// TestNoteUnifiedBotStopPathIsDocumented pins that every doc reachable from a
+// `note +detail` -> `note_display_type=unified` routing decision explicitly
+// calls out that `+transcript` can't continue under --as bot, rather than
+// letting an agent silently drop --as and switch identity.
+func TestNoteUnifiedBotStopPathIsDocumented(t *testing.T) {
+	for _, path := range []string{
+		"skills/lark-note/SKILL.md",
+		"skills/lark-note/references/lark-note-detail.md",
+		"skills/lark-note/references/lark-note-transcript.md",
+	} {
+		content := readSkillDoc(t, path)
+		if !strings.Contains(content, "bot") || !strings.Contains(content, "user") {
+			t.Errorf("%s must document the bot+unified boundary for note +transcript (mention both user and bot)", path)
+		}
+	}
+}

--- a/shortcuts/vc/bot_identity_test.go
+++ b/shortcuts/vc/bot_identity_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// Tests pinning bot-identity support for the vc read shortcuts
+// (+detail / +notes / +recording).
+
+package vc
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
+)
+
+// ---------------------------------------------------------------------------
+// AuthTypes contracts
+// ---------------------------------------------------------------------------
+
+func TestVCReadShortcutsSupportUserAndBotIdentity(t *testing.T) {
+	want := []string{"user", "bot"}
+	cases := map[string][]string{
+		"+detail":    VCDetail.AuthTypes,
+		"+notes":     VCNotes.AuthTypes,
+		"+recording": VCRecording.AuthTypes,
+	}
+	for cmd, got := range cases {
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s AuthTypes = %v, want %v", cmd, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bot dry-run: the meeting/recording paths flow under bot identity
+// ---------------------------------------------------------------------------
+
+func TestDetail_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCDetail, []string{"+detail", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/vc/v1/meetings/{meeting_id}") {
+		t.Errorf("dry-run should show meeting.get API, got: %s", out)
+	}
+	if !strings.Contains(out, "recording") {
+		t.Errorf("dry-run should show recording API, got: %s", out)
+	}
+}
+
+func TestRecording_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "recording") {
+		t.Errorf("dry-run should show recording API, got: %s", out)
+	}
+}
+
+func TestNotes_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCNotes, []string{"+notes", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/vc/v1/notes/{note_id}") {
+		t.Errorf("dry-run should show note.get API, got: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// calendar-event-ids also flows under bot: a bot has a primary calendar, so the
+// primary-calendar -> meeting_id -> recording/notes chain is expected to work.
+// ---------------------------------------------------------------------------
+
+func TestRecording_DryRun_BotIdentity_CalendarEventIDs(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--calendar-event-ids", "evt001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "mget_instance_relation_info") {
+		t.Errorf("dry-run should show the primary-calendar resolution step, got: %s", out)
+	}
+	if !strings.Contains(out, "recording") {
+		t.Errorf("dry-run should show recording API, got: %s", out)
+	}
+}
+
+func TestNotes_DryRun_BotIdentity_CalendarEventIDs(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, VCNotes, []string{"+notes", "--calendar-event-ids", "evt001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "mget_instance_relation_info") {
+		t.Errorf("dry-run should show the primary-calendar resolution step, got: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Identity-aware preflight: bot resolves TAT (empty local scopes in this stub),
+// so an under-scoped UAT must not make --as bot fail. The req.Type assertions
+// below pin that the credential layer is asked for a tenant token (not a user
+// token) when --as bot is used — this holds regardless of which layer issues
+// the request (the shared per-shortcut scope preflight or vc_recording.go's
+// own calendar-event-ids check), so it does not by itself catch a revert of
+// vc_recording.go's Validate. TestRecording_CalendarEventIDs_MissingExtraScope
+// below is the test that actually fails if that shortcut-local check regresses.
+// ---------------------------------------------------------------------------
+
+func TestRecording_BotIdentityAwareScopePreflight(t *testing.T) {
+	cfg := defaultConfig()
+	f, stdout, _, _ := cmdutil.TestFactory(t, cfg)
+	resolver := &recordingIdentityTokenResolver{
+		uatScopes: "calendar:calendar:read", // deliberately missing vc:record:readonly
+		tatScopes: "",                       // bot/tenant: no local scope metadata
+	}
+	f.Credential = credential.NewCredentialProvider(nil, nil, resolver, nil)
+
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--dry-run", "--as", "bot"}, f, stdout)
+	if err != nil {
+		t.Fatalf("bot preflight must resolve tenant token, not the under-scoped user token; got error: %v", err)
+	}
+
+	reqs := resolver.requestsOfType(credential.TokenTypeTAT)
+	if len(reqs) == 0 {
+		t.Fatalf("expected ResolveToken to be called with TokenTypeTAT for --as bot, got requests: %v", resolver.requests)
+	}
+	for _, req := range reqs {
+		if req.AppID != cfg.AppID {
+			t.Errorf("TAT request AppID = %q, want %q", req.AppID, cfg.AppID)
+		}
+	}
+	if uatReqs := resolver.requestsOfType(credential.TokenTypeUAT); len(uatReqs) != 0 {
+		t.Errorf("--as bot must not resolve a UAT, got: %v", uatReqs)
+	}
+}
+
+// TestRecording_UserIdentityScopePreflight is the user-identity counterpart:
+// --as user must resolve a UAT, never a TAT.
+func TestRecording_UserIdentityScopePreflight(t *testing.T) {
+	cfg := defaultConfig()
+	f, stdout, _, _ := cmdutil.TestFactory(t, cfg)
+	resolver := &recordingIdentityTokenResolver{
+		uatScopes: "vc:record:readonly",
+		tatScopes: "",
+	}
+	f.Credential = credential.NewCredentialProvider(nil, nil, resolver, nil)
+
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--dry-run", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as user: %v", err)
+	}
+
+	if reqs := resolver.requestsOfType(credential.TokenTypeUAT); len(reqs) == 0 {
+		t.Fatalf("expected ResolveToken to be called with TokenTypeUAT for --as user, got requests: %v", resolver.requests)
+	}
+	if reqs := resolver.requestsOfType(credential.TokenTypeTAT); len(reqs) != 0 {
+		t.Errorf("--as user must not resolve a TAT, got: %v", reqs)
+	}
+}
+
+// TestRecording_CalendarEventIDs_MissingExtraScope pins the
+// calendar-event-ids-only scope preflight in vc_recording.go's Validate: the
+// generic per-shortcut scope check only knows about the statically declared
+// vc:record:readonly, so the calendar read scopes required for the
+// calendar-event-ids resolution path are only caught by this shortcut-local
+// check. Reverting it to the old auth.GetStoredToken(user)-only lookup, or
+// dropping the calendar-event-ids branch, would let this under-scoped
+// request reach the API undetected.
+func TestRecording_CalendarEventIDs_MissingExtraScope(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	f.Credential = credential.NewCredentialProvider(nil, nil, &recordingScopedTokenResolver{
+		scopes: "vc:record:readonly", // satisfies the shortcut's static Scopes, but not the calendar ones
+	}, nil)
+
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--calendar-event-ids", "evt001", "--as", "user"}, f, nil)
+	if err == nil {
+		t.Fatal("expected missing_scope error for calendar-event-ids path, got nil")
+	}
+	var pe *errs.PermissionError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *errs.PermissionError, got %T: %v", err, err)
+	}
+	if pe.Subtype != errs.SubtypeMissingScope {
+		t.Errorf("Subtype = %q, want %q", pe.Subtype, errs.SubtypeMissingScope)
+	}
+	for _, want := range []string{"calendar:calendar:read", "calendar:calendar.event:read"} {
+		found := false
+		for _, s := range pe.MissingScopes {
+			if s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("MissingScopes = %v, want to contain %q", pe.MissingScopes, want)
+		}
+	}
+}
+
+// TestRecording_ScopePreflight_ResolveTokenError pins the fail-open behavior
+// when the credential layer cannot resolve a token at all: the shortcut-local
+// preflight must not block the request (the API call itself remains the
+// authoritative check), so dry-run still succeeds.
+func TestRecording_ScopePreflight_ResolveTokenError(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	f.Credential = credential.NewCredentialProvider(nil, nil, &erroringTokenResolver{}, nil)
+
+	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--dry-run", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("a token-resolution error must not block the request, got: %v", err)
+	}
+}
+
+// recordingIdentityTokenResolver returns different scopes for UAT vs TAT so
+// bot identity-aware preflight can be pinned separately from user preflight,
+// and records every request it receives so tests can assert on TokenSpec.Type.
+type recordingIdentityTokenResolver struct {
+	uatScopes string
+	tatScopes string
+	requests  []credential.TokenSpec
+}
+
+func (r *recordingIdentityTokenResolver) ResolveToken(_ context.Context, req credential.TokenSpec) (*credential.TokenResult, error) {
+	r.requests = append(r.requests, req)
+	scopes := r.uatScopes
+	if req.Type == credential.TokenTypeTAT {
+		scopes = r.tatScopes
+	}
+	return &credential.TokenResult{Token: "test-token", Scopes: scopes}, nil
+}
+
+func (r *recordingIdentityTokenResolver) requestsOfType(t credential.TokenType) []credential.TokenSpec {
+	var out []credential.TokenSpec
+	for _, req := range r.requests {
+		if req.Type == t {
+			out = append(out, req)
+		}
+	}
+	return out
+}
+
+// erroringTokenResolver simulates a credential layer that cannot resolve any
+// token (e.g. network failure resolving app credentials).
+type erroringTokenResolver struct{}
+
+func (r *erroringTokenResolver) ResolveToken(_ context.Context, _ credential.TokenSpec) (*credential.TokenResult, error) {
+	return nil, errors.New("simulated credential resolution failure")
+}

--- a/shortcuts/vc/skill_docs_test.go
+++ b/shortcuts/vc/skill_docs_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// Capability source test: pins the identity (user/bot) claims made in
+// skills/lark-vc against the AuthTypes actually declared on the shortcuts.
+// PR #2278's review found the docs had already drifted from the code once
+// (SKILL.md claimed `+search` supported bot while vc_search.go stayed
+// user-only) — this test fails loudly the next time that happens instead of
+// relying on a human re-reading both sides on every AuthTypes change.
+
+package vc
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func hasAuthType(authTypes []string, want string) bool {
+	for _, a := range authTypes {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readSkillDoc(t *testing.T, relPath string) string {
+	t.Helper()
+	data, err := os.ReadFile("../../" + relPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", relPath, err)
+	}
+	return string(data)
+}
+
+// TestVCSearchIdentityDocsMatchAuthTypes pins that `+search` stays user-only
+// in both code and docs. If AuthTypes ever gains "bot", this test forces a
+// deliberate update to the SKILL.md/reference wording below instead of
+// letting the docs silently fall out of sync.
+func TestVCSearchIdentityDocsMatchAuthTypes(t *testing.T) {
+	skill := readSkillDoc(t, "skills/lark-vc/SKILL.md")
+	reference := readSkillDoc(t, "skills/lark-vc/references/lark-vc-search.md")
+
+	if hasAuthType(VCSearch.AuthTypes, "bot") {
+		t.Fatalf("VCSearch.AuthTypes = %v now includes bot; update skills/lark-vc/SKILL.md and lark-vc-search.md wording (and this test) to reflect the new support instead of leaving the user-only claims below", VCSearch.AuthTypes)
+	}
+	if !strings.Contains(skill, "`+search` 仅支持 `--as user`") {
+		t.Error("skills/lark-vc/SKILL.md must state that `+search` only supports --as user (matches VCSearch.AuthTypes)")
+	}
+	if !strings.Contains(reference, "仅支持 `user` 身份") && !strings.Contains(reference, "仅 `--as user`") {
+		t.Error("lark-vc-search.md must state that +search only supports user identity (matches VCSearch.AuthTypes)")
+	}
+}
+
+// TestVCBotShortcutsIdentityDocsMatchAuthTypes pins that the VC shortcuts this
+// PR opened to bot (`+detail`, `+recording`) are both declared bot-capable in
+// code and documented as such in the main SKILL.md identity line.
+func TestVCBotShortcutsIdentityDocsMatchAuthTypes(t *testing.T) {
+	skill := readSkillDoc(t, "skills/lark-vc/SKILL.md")
+
+	for _, cmd := range []struct {
+		name      string
+		authTypes []string
+	}{
+		{"+detail", VCDetail.AuthTypes},
+		{"+recording", VCRecording.AuthTypes},
+	} {
+		if !hasAuthType(cmd.authTypes, "bot") {
+			t.Errorf("%s AuthTypes = %v, want bot included (this PR's contract)", cmd.name, cmd.authTypes)
+			continue
+		}
+		token := "`" + cmd.name + "`"
+		if !strings.Contains(skill, token) {
+			t.Errorf("skills/lark-vc/SKILL.md identity section must mention %s alongside its bot support", token)
+		}
+	}
+	if !strings.Contains(skill, "也支持 `--as bot`") {
+		t.Error("skills/lark-vc/SKILL.md identity section must state which commands also support --as bot")
+	}
+}

--- a/shortcuts/vc/vc_detail.go
+++ b/shortcuts/vc/vc_detail.go
@@ -164,7 +164,7 @@ var VCDetail = common.Shortcut{
 	Description: "Get meeting details including note_id and minute_token by meeting IDs",
 	Risk:        "read",
 	Scopes:      []string{"vc:meeting.meetingevent:read", "vc:record:readonly"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "meeting-ids", Desc: "meeting IDs, comma-separated for batch", Required: true},

--- a/shortcuts/vc/vc_notes.go
+++ b/shortcuts/vc/vc_notes.go
@@ -550,7 +550,7 @@ var VCNotes = common.Shortcut{
 	Description: "Query meeting notes (via meeting-ids, minute-tokens, or calendar-event-ids)",
 	Risk:        "read",
 	Scopes:      []string{"vc:note:read"}, // minimum scope; additional per-flag scopes checked in Validate
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	Hidden:      true, // hidden from --help; prefer vc +detail, minutes +detail, or note +detail
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/vc/vc_recording.go
+++ b/shortcuts/vc/vc_recording.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -91,13 +92,13 @@ var VCRecording = common.Shortcut{
 	Description: "Query minute_token from meeting-ids or calendar-event-ids",
 	Risk:        "read",
 	Scopes:      []string{"vc:record:readonly"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "meeting-ids", Desc: "meeting IDs, comma-separated for batch"},
 		{Name: "calendar-event-ids", Desc: "calendar event instance IDs, comma-separated for batch"},
 	},
-	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := common.ExactlyOneTyped(runtime, "meeting-ids", "calendar-event-ids"); err != nil {
 			return err
 		}
@@ -116,17 +117,13 @@ var VCRecording = common.Shortcut{
 		case runtime.Str("calendar-event-ids") != "":
 			required = scopesRecordingCalendarEventIDs
 		}
-		appID := runtime.Config.AppID
-		userOpenID := runtime.UserOpenId()
-		if appID != "" && userOpenID != "" {
-			stored := auth.GetStoredToken(appID, userOpenID)
-			if stored != nil {
-				if missing := auth.MissingScopes(stored.Scope, required); len(missing) > 0 {
-					return errs.NewPermissionError(errs.SubtypeMissingScope,
-						"missing required scope(s): %s", strings.Join(missing, ", ")).
-						WithMissingScopes(missing...).
-						WithIdentity(string(runtime.As()))
-				}
+		result, err := runtime.Factory.Credential.ResolveToken(ctx, credential.NewTokenSpec(runtime.As(), runtime.Config.AppID))
+		if err == nil && result != nil && result.Scopes != "" {
+			if missing := auth.MissingScopes(result.Scopes, required); len(missing) > 0 {
+				return errs.NewPermissionError(errs.SubtypeMissingScope,
+					"missing required scope(s): %s", strings.Join(missing, ", ")).
+					WithMissingScopes(missing...).
+					WithIdentity(string(runtime.As()))
 			}
 		}
 		return nil

--- a/shortcuts/vc/vc_recording_test.go
+++ b/shortcuts/vc/vc_recording_test.go
@@ -10,14 +10,12 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
-	keyring "github.com/zalando/go-keyring"
 
 	"github.com/larksuite/cli/errs"
-	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -141,27 +139,15 @@ func TestRecording_BatchLimit_CalendarEventIDs(t *testing.T) {
 }
 
 func TestRecording_Validate_MissingScope(t *testing.T) {
-	keyring.MockInit() // use in-memory keyring to avoid macOS keychain popups
-	t.Setenv("HOME", t.TempDir())
-
 	cfg := defaultConfig()
-	// Store a token that intentionally lacks the vc:record:readonly scope.
-	token := &auth.StoredUAToken{
-		UserOpenId:       cfg.UserOpenId,
-		AppId:            cfg.AppID,
-		AccessToken:      "test-user-access-token",
-		RefreshToken:     "test-refresh-token",
-		ExpiresAt:        time.Now().Add(1 * time.Hour).UnixMilli(),
-		RefreshExpiresAt: time.Now().Add(24 * time.Hour).UnixMilli(),
-		Scope:            "calendar:calendar:read",
-		GrantedAt:        time.Now().Add(-1 * time.Hour).UnixMilli(),
-	}
-	if err := auth.SetStoredToken(token); err != nil {
-		t.Fatalf("SetStoredToken() error = %v", err)
-	}
-	t.Cleanup(func() { _ = auth.RemoveStoredToken(cfg.AppID, cfg.UserOpenId) })
-
 	f, _, _, _ := cmdutil.TestFactory(t, cfg)
+	// TestFactory's default token resolver returns empty Scopes, which skips
+	// identity-aware preflight. Inject a resolver that returns an under-scoped
+	// user token so the MissingScopes path is exercised.
+	f.Credential = credential.NewCredentialProvider(nil, nil, &recordingScopedTokenResolver{
+		scopes: "calendar:calendar:read",
+	}, nil)
+
 	err := mountAndRun(t, VCRecording, []string{"+recording", "--meeting-ids", "m001", "--as", "user"}, f, nil)
 	if err == nil {
 		t.Fatal("expected missing_scope error, got nil")
@@ -187,6 +173,16 @@ func TestRecording_Validate_MissingScope(t *testing.T) {
 	if !found {
 		t.Errorf("expected MissingScopes to contain 'vc:record:readonly', got %v", pe.MissingScopes)
 	}
+}
+
+// recordingScopedTokenResolver returns a token with caller-controlled scopes
+// so tests can deterministically exercise the identity-aware scope preflight.
+type recordingScopedTokenResolver struct {
+	scopes string
+}
+
+func (r *recordingScopedTokenResolver) ResolveToken(_ context.Context, _ credential.TokenSpec) (*credential.TokenResult, error) {
+	return &credential.TokenResult{Token: "test-token", Scopes: r.scopes}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 **CRITICAL：先判断场景，再读取该场景的参考文件；不要在任务开始时一次性读取全部参考文件。每个文件只在首次进入对应阶段时读取一次。**
 
-**身份：文档操作推荐显式指定 `--as user`。**
+**身份：文档操作推荐显式指定 `--as user`。例外：如果 `doc_token` / `note_doc_token` 等是从 bot 链路（如 `vc +detail --as bot` → `note +detail --as bot`）取得的，应继续显式使用 `--as bot`，不要无条件切回 user——身份延续规则见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)。**
 
 **所有表示本地文件的 `@path` 均使用 `@./xxx` 形式的相对路径，并以运行 `lark-cli` 时的当前工作目录（CWD）为基准。**
 

--- a/skills/lark-minutes/SKILL.md
+++ b/skills/lark-minutes/SKILL.md
@@ -20,7 +20,9 @@ metadata:
 
 ## 身份
 
-所有 minutes 命令默认使用 `--as user`。
+身份是跨命令工作流的状态：一旦某个 `minute_token` / `note_id` 由某个身份取得，后续消费它的命令必须显式沿用相同 `--as`，不要依赖 profile 默认身份。完整规则见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) 的「身份延续」。
+
+所有 minutes 命令默认使用 `--as user`。`+search`、`minutes get`、`+detail`、`+download` 和 `+apply-permission` 也支持 `--as bot`（bot 只能访问 / 操作 bot 有权限的妙记）。精确身份支持以 `<command> --help` 为准。
 
 ## Shortcuts
 
@@ -31,7 +33,7 @@ metadata:
 | [`+download`](references/lark-minutes-download.md) | 下载妙记音视频媒体文件 |
 | [`+upload`](references/lark-minutes-upload.md) | 上传 file_token 生成妙记 |
 | [`+update`](references/lark-minutes-update.md) | 更新妙记标题 |
-| `+apply-permission` | 申请妙记查看或编辑权限 |
+| [`+apply-permission`](references/lark-minutes-apply-permission.md) | 申请妙记查看或编辑权限 |
 | [`+speaker-replace`](references/lark-minutes-speaker-replace.md) | 替换妙记逐字稿中的说话人（须先 `lark-cli api GET .../speakerlist` 取 `speaker_id`） |
 | `+word-replace` | 批量替换逐字稿关键词（详见 `lark-cli minutes +word-replace --help`） |
 | [`+summary`](references/lark-minutes-summary.md) | 替换妙记 AI 总结全文 |
@@ -79,17 +81,21 @@ metadata:
 
 ### 3. 申请妙记权限
 
-遇到妙记没有查看或编辑权限时，引导用户申请对应权限；只有用户明确要申请时，才调用 `minutes +apply-permission`。
+遇到妙记没有查看或编辑权限时，引导用户申请对应权限；只有用户明确要申请时，才调用 `minutes +apply-permission`。使用前必读 [`+apply-permission` reference](references/lark-minutes-apply-permission.md)（write 操作，含 user/bot 身份与权限语义）。
 
 只有当用户明确要求"申请查看权限"、"申请编辑权限"、"帮我申请这条妙记权限"时，才调用：
 
 ```bash
-lark-cli minutes +apply-permission --minute-token <token> --perm view|edit
+lark-cli minutes +apply-permission --minute-token <token> --perm view|edit --as user
+lark-cli minutes +apply-permission --minute-token <token> --perm view|edit --as bot
 ```
 
 这是向妙记所有者发起权限申请，不代表立即获得权限。
 
-**安全约束**：遇到无权限错误时，不要自动调用 `+apply-permission`；先把无权限事实告知用户，只有用户明确要求申请权限时才发起申请。
+**安全约束**：
+- 遇到无权限错误时，不要自动调用 `+apply-permission`；先把无权限事实告知用户，只有用户明确要求申请权限时才发起申请。
+- **必须沿用触发无权限错误时的来源身份**：例如 `--as bot` 读取妙记时遇到无权限，申请也要用 `--as bot`，不要切到 user 身份申请。
+- **禁止**用切换身份的方式绕过资源权限（例如 bot 无权限时改用 user 身份重新读取）。
 
 ### 4. 上传音视频文件生成妙记（并可继续获取纪要 / 逐字稿）
 

--- a/skills/lark-minutes/references/lark-minutes-apply-permission.md
+++ b/skills/lark-minutes/references/lark-minutes-apply-permission.md
@@ -1,0 +1,95 @@
+# minutes +apply-permission
+
+向妙记所有者发起查看或编辑权限申请。**写操作**，只在用户明确要求申请权限时才调用；调用后不代表立即获得权限，只是提交了一条申请。
+
+本 skill 对应 shortcut：`lark-cli minutes +apply-permission`（调用 `POST /open-apis/minutes/v1/minutes/{minute_token}/permissions/apply`）。支持 `--as user` / `--as bot`。
+
+## 命令
+
+```bash
+# 以 user 身份申请查看权限
+lark-cli minutes +apply-permission --minute-token obcnxxxxxxxxxxxxxxxxxxxx --perm view --as user
+
+# 以 bot 身份申请编辑权限
+lark-cli minutes +apply-permission --minute-token obcnxxxxxxxxxxxxxxxxxxxx --perm edit --as bot
+
+# 预览 API 调用
+lark-cli minutes +apply-permission --minute-token obcnxxxxxxxxxxxxxxxxxxxx --perm view --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--minute-token <token>` | 是 | 妙记 Token |
+| `--perm <view\|edit>` | 是 | 申请的权限：`view`（查看）或 `edit`（编辑） |
+| `--dry-run` | 否 | 预览 API 调用，不执行 |
+
+## user / bot 身份与权限语义
+
+- **user**：以当前登录用户身份向妙记所有者申请。所有者在飞书客户端收到申请通知，同意后该用户获得对应权限。
+- **bot**：以应用身份向妙记所有者申请，代表"这个应用"而不是某个用户。同意后应用（bot）获得对应权限，不会让触发申请的用户本人获得权限。
+- 两种身份的申请互不代表：user 身份申请通过后 bot 仍然无权限，反之亦然。
+
+## 核心约束
+
+### 1. 必须继承触发无权限错误的来源身份
+
+`+apply-permission` 不是通用的"求权限"按钮：它申请的是**当前 `--as` 对应身份**的权限。如果是 `--as bot` 读取妙记时遇到无权限，就要用 `--as bot` 申请；如果是 `--as user` 遇到无权限，就用 `--as user` 申请。不要在申请时切换成另一个身份——那申请的是另一个主体的权限，解决不了原来那次调用的问题。
+
+### 2. missing scope 与资源 ACL 是两类不同问题
+
+- **missing scope**（当前身份完全没有 `minutes:permission:apply` / `minutes:minutes.basic:read` 等 scope）：这不是"没有这条妙记的权限"，`+apply-permission` 解决不了。`--as user` 用 `auth login --scope` 补权限；`--as bot` 去开发者后台开通，**禁止**对 bot 执行 `auth login`。完整规则见 [lark-shared](../../lark-shared/SKILL.md)。
+- **资源 ACL**（scope 都有，但对**这一条具体妙记**没有查看/编辑权限）：这才是 `+apply-permission` 要解决的场景。
+
+先看错误的 `error.subtype` 是 `missing_scope` 还是资源级别的权限拒绝，再决定要不要调用本命令。
+
+### 3. 只有用户明确要求才发起申请
+
+遇到无权限错误时，先把"当前身份对这条妙记没有权限"的事实告知用户；只有用户明确说"帮我申请查看/编辑权限"时才调用本命令。不要在检测到无权限后自动发起申请。
+
+### 4. 禁止通过切换身份绕过资源权限
+
+如果 `--as bot` 对某条妙记没有权限，不要改用 `--as user` 重新读取来"绕过"这个限制（除非用户明确同意切换身份继续任务）。申请权限和切换身份是两件不同的事：前者是解决 bot 自身权限不足，后者是换一个完全不同的主体去访问资源。
+
+## 所需权限
+
+| 身份 | 所需权限 |
+|------|---------|
+| user / bot | `minutes:permission:apply` |
+
+## 输出结果
+
+```json
+{
+  "minute_token": "obcnxxxxxxxxxxxxxxxxxxxx",
+  "perm": "view"
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `minute_token` | 妙记 Token |
+| `perm` | 申请的权限（`view` / `edit`） |
+
+## 如何获取 minute_token
+
+| 来源 | 获取方式 |
+|------|---------|
+| 妙记 URL | 从 URL 末尾提取，如 `https://sample.feishu.cn/minutes/obcnxxxxxxxxxxxxxxxxxxxx` |
+| 妙记搜索 | `lark-cli minutes +search --query "关键词"` |
+| 会议产物查询 | `lark-cli vc +recording --meeting-ids <id>`，拿到 `minute_token`（沿用同一 `--as`） |
+
+## 常见错误与排查
+
+| 错误现象 | 根本原因 | 解决方案 |
+|---------|---------|---------|
+| `--perm` 不是 `view`/`edit` | 参数值不合法 | 只能传 `view` 或 `edit` |
+| `missing required scope(s)` | 当前身份缺少 `minutes:permission:apply` | 见上方「missing scope 与资源 ACL」 |
+| 申请后仍无权限 | 所有者尚未同意 | 这是异步申请，需等待所有者处理；不代表命令执行失败 |
+
+## 参考
+
+- [lark-minutes](../SKILL.md) — 妙记全部命令
+- [minutes +detail](lark-minutes-detail.md) — 妙记内容与产物查询
+- [lark-shared](../../lark-shared/SKILL.md) — 身份延续与权限恢复规则

--- a/skills/lark-minutes/references/lark-minutes-detail.md
+++ b/skills/lark-minutes/references/lark-minutes-detail.md
@@ -1,7 +1,7 @@
 
 # minutes +detail
 
-通过 `minute_token` 查询妙记详情，按需获取 AI 产物（总结/待办/章节/逐字稿/关键词）。只读。
+通过 `minute_token` 查询妙记详情，按需获取 AI 产物（总结/待办/章节/逐字稿/关键词）。只读，支持 `--as user` / `--as bot`。
 
 > `--summary` / `--todo` / `--chapter` / `--keyword` / `--transcript` 至少一个；不传任何产物 flag 时只返回基础信息（如 `title`），AI 产物字段都不会出现。一次性获取所有产物：`--summary --todo --chapter --keyword --transcript`。
 
@@ -46,17 +46,18 @@ lark-cli minutes +detail --minute-tokens obcxxx --transcript --overwrite --outpu
 
 ## 典型链路：从 minute_token 拿纪要文档 token
 
-只持有 `minute_token`（如妙记 URL 入口），又想拿 AI 智能纪要 / 逐字稿文档时：
+只持有 `minute_token`（如妙记 URL 入口），又想拿 AI 智能纪要 / 逐字稿文档时；每一步都要沿用同一个 `--as`（完整规则见 [lark-shared](../../lark-shared/SKILL.md) 的「身份延续」）：
 
 ```bash
 # 1. 取妙记关联的 note_id，没有关联会议纪要则为空
-lark-cli minutes +detail --minute-tokens <minute_token>
+lark-cli minutes +detail --minute-tokens obcnxxxxxxxxxxxxxxxxxxxx --as bot
 
 # 2. 用 note_id 拿 note_doc_token / verbatim_doc_token / shared_doc_tokens
-lark-cli note +detail --note-id <note_id>
+#    沿用第 1 步的身份，不要省略 --as
+lark-cli note +detail --note-id <note_id> --as bot
 
-# 3. 读纪要 / 逐字稿正文
-lark-cli docs +fetch --api-version v2 --doc <note_doc_token> --doc-format markdown
+# 3. 读纪要 / 逐字稿正文（同样沿用第 1 步的身份）
+lark-cli docs +fetch --api-version v2 --doc <note_doc_token> --doc-format markdown --as bot
 ```
 
 > `minute_token` 不要直接传给 `note +detail`：必须先用本命令拿到 `note_id` 再调用 `note +detail`。

--- a/skills/lark-minutes/references/lark-minutes-download.md
+++ b/skills/lark-minutes/references/lark-minutes-download.md
@@ -2,9 +2,11 @@
 # minutes +download
 
 
-下载妙记的音视频媒体文件到本地，或获取有效期 1 天的下载链接。只读操作。
+下载妙记的音视频媒体文件到本地，或获取有效期 1 天的下载链接。只读操作，支持 `--as user` / `--as bot`。
 
 本 skill 对应 shortcut：`lark-cli minutes +download`。
+
+`minute_token` 是在某个身份下解析出来的（如 `vc +recording --as bot`）：调用本命令时必须显式沿用同一个 `--as`，不要省略让身份被默认值悄悄换掉（完整规则见 [lark-shared](../../lark-shared/SKILL.md) 的「身份延续」）。
 
 ## 命令
 
@@ -119,7 +121,7 @@ API 限流 5 次/秒，批量下载时需注意控制频率。
 | 妙记尚未准备好 | 2091003 | 转写未完成 | 等待转写完成后重试 |
 | 资源已删除 | 2091004 | 妙记已被删除 | 确认妙记文件仍然存在 |
 | 权限不足 | 2091005 | 无阅读权限 | 检查是否有该妙记的访问权限 |
-| `missing required scope(s)` | — | 应用缺少权限 | 运行 `auth login --scope "minutes:minutes.media:export"` |
+| `missing required scope(s)` | — | 当前身份缺少 scope | `--as user`：运行 `auth login --scope "minutes:minutes.media:export"`；`--as bot`：使用错误中的 `console_url` 去开发者后台开通，**禁止**对 bot 执行 `auth login`（见 [lark-shared](../../lark-shared/SKILL.md) 的权限恢复表） |
 
 ## 提示
 

--- a/skills/lark-note/SKILL.md
+++ b/skills/lark-note/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 # note (v1)
 
-身份：仅使用 `--as user`。使用前阅读 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)。
+身份：`+detail` 支持 `--as user` / `--as bot`；`+transcript` 仅支持 `--as user`。`note_id` 若由某个身份取得（例如 `vc +detail --as bot`），`+detail` 必须显式沿用同一个 `--as`——不要依赖 profile 默认身份。完整身份延续规则见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，使用前必读。
 
 **CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-vc/references/vc-domain-boundaries.md`](../lark-vc/references/vc-domain-boundaries.md)**，不读将导致命令使用、会议产物决策、领域边界职责判断错误：
 > 1. 了解日历 & VC、会议产物 & 文档的关联关系和职责划分
@@ -36,12 +36,14 @@ Note 域只接受显式 `note_id`：用户直接提供，或 `docs +fetch` 返�
 
 | `note +detail` 结果 | 用户要逐字稿 / 原始记录时 |
 |------|---------------|
-| `normal` + `verbatim_doc_token` 非空 | `docs +fetch --doc <verbatim_doc_token>` |
+| `normal` + `verbatim_doc_token` 非空 | `docs +fetch --doc <verbatim_doc_token>`（沿用 `+detail` 用的身份） |
 | `unknown` + `verbatim_doc_token` 非空 | 先按独立文档处理；不要猜成 unified |
 | `unknown` + 无逐字稿 token | 停止重试并说明无法确定逐字稿入口 |
-| `unified` | `note +transcript --note-id <note_id>` |
+| `unified` | `note +transcript --note-id <note_id>`（仅支持 `--as user`） |
 
 判别键是 `note_display_type`，不是 `verbatim_doc_token` 是否为空：unified 纪要也可能返回非空 `verbatim_doc_token`。
+
+> **bot + unified 的边界**：`+transcript` 目前仅支持 `--as user`。如果 `+detail --as bot` 返回 `unified`，不要静默切到 `--as user` 继续——先停下来向用户说明"该纪要逐字稿只能以 user 身份读取"，只有用户明确同意才切换身份重试。
 
 ## 关键字段
 
@@ -83,12 +85,12 @@ Note 域只接受显式 `note_id`：用户直接提供，或 `docs +fetch` 返�
 3. 获取到文档 Token 后，可使用 `docs +fetch` 读取文档内容，或使用 `drive metas batch_query` 获取文档元信息。
 
 ```bash
-# 1. 从会议获取 note_id
-lark-cli vc +detail --meeting-ids <meeting_id>
+# 1. 从会议获取 note_id（这里以 bot 身份为例）
+lark-cli vc +detail --meeting-ids <meeting_id> --as bot
 
-# 2. 用 note_id 拿文档 Token
-lark-cli note +detail --note-id <note_id>
+# 2. 用 note_id 拿文档 Token；沿用第 1 步的身份，不要省略 --as
+lark-cli note +detail --note-id <note_id> --as bot
 
-# 3. 读取纪要文档内容
-lark-cli docs +fetch --doc <note_doc_token> --doc-format markdown
+# 3. 读取纪要文档内容；同样沿用第 1 步的身份
+lark-cli docs +fetch --doc <note_doc_token> --doc-format markdown --as bot
 ```

--- a/skills/lark-note/references/lark-note-detail.md
+++ b/skills/lark-note/references/lark-note-detail.md
@@ -1,11 +1,12 @@
 # note +detail
 
-通过 `note_id` 查询会议纪要详情，获取下挂文档 Token（AI 智能纪要、逐字稿、会中共享文档）。只读，仅支持 `--as user`。
+通过 `note_id` 查询会议纪要详情，获取下挂文档 Token（AI 智能纪要、逐字稿、会中共享文档）。只读，支持 `--as user` / `--as bot`。bot 身份下能否读到数据取决于应用对纪要主文档是否有 view 权限。
 
 ## 命令
 
 ```bash
 lark-cli note +detail --note-id <note_id>
+lark-cli note +detail --note-id <note_id> --as bot
 ```
 
 ## `note_id` 来源
@@ -21,6 +22,8 @@ lark-cli note +detail --note-id <note_id>
 | `note_doc_token` | 读纪要正文 / 总结 / 待办 / 章节：`docs +fetch --doc <note_doc_token>` |
 | `note_display_type=normal` + `verbatim_doc_token` | 读逐字稿：`docs +fetch --doc <verbatim_doc_token>` |
 | `note_display_type=unknown` + `verbatim_doc_token` | 先按普通独立逐字稿文档读取；不要猜成 unified |
-| `note_display_type=unified` | 读逐字稿 / 原始记录：转 [`note +transcript`](lark-note-transcript.md) |
+| `note_display_type=unified` | 读逐字稿 / 原始记录：转 [`note +transcript`](lark-note-transcript.md)（仅支持 `--as user`） |
 
 判别键是 `note_display_type`。即使 unified 纪要返回了非空 `verbatim_doc_token`，逐字稿仍按 unified 路由。
+
+> **bot + unified 的边界**：如果本命令用 `--as bot` 拿到 `note_display_type=unified`，`note +transcript` 只支持 `--as user`，不能直接沿用 bot 身份。停下来向用户说明这个边界，只有用户明确同意才切到 `--as user` 继续，不要静默切换身份。

--- a/skills/lark-note/references/lark-note-transcript.md
+++ b/skills/lark-note/references/lark-note-transcript.md
@@ -2,6 +2,8 @@
 
 只在 `note +detail` 已确认 `note_display_type=unified` 时使用。普通纪要逐字稿是独立 Docx 文档，应回到 [lark-doc](../../lark-doc/SKILL.md) 读取 `verbatim_doc_token`。
 
+只支持 `--as user`，不支持 `--as bot`。如果 `note +detail --as bot` 返回 `unified`，不要在这里静默省略 `--as` 或改用 user 身份继续——先停下来向用户说明"该纪要逐字稿只能以 user 身份读取"，只有用户明确同意才切换身份重试。
+
 ```bash
 lark-cli note +transcript --note-id NOTE_ID
 ```

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -64,6 +64,32 @@ LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1 LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1 lark-cli a
 - **User 权限**：后台开通 scope + 用户通过 `auth login` 授权，两层都要满足
 
 
+### 身份延续（跨命令工作流）
+
+身份是**整个工作流的状态**，不是单条命令的局部参数。CLI 不会在进程之间继承"上一步用的身份"——省略 `--as` 不代表"保持当前身份"，而是把身份选择交回下面这条优先级链：
+
+```text
+显式 --as > profile default-as > credential auto-detect
+```
+
+因此，只要用户显式选择了身份，或某个 ID / Token 是通过某个身份取得的（例如 `vc +detail --as bot` 返回的 `note_id`），**后续每一条消费该 ID/Token 的命令都必须显式带上相同的 `--as`**，跨 skill 传递也不例外：
+
+- 禁止依赖 profile 默认身份让后续命令"自动"沿用同一身份。
+- 禁止仅仅因为遇到权限错误就切换身份去绕过它——先如实报告，只有用户明确同意才切换。
+- 下游命令根本不支持来源身份时（如 `--as bot` 拿到的 `note_id` 指向 `note_display_type=unified`，而 `note +transcript` 仅支持 `--as user`），停止并向用户说明这个边界，不要静默省略 `--as` 把身份交给默认值。
+- 命令支持的精确身份以 `<command> --help` / `schema` 为准；各 skill 的身份小节只标注会影响路由决策的例外，不重复维护完整矩阵。
+
+```bash
+# GOOD — note_id 来自 bot 链路，下一步显式沿用 bot
+lark-cli vc +detail --meeting-ids <meeting_id> --as bot
+lark-cli note +detail --note-id <note_id> --as bot
+lark-cli docs +fetch --doc <note_doc_token> --as bot
+
+# BAD — 省略 --as，身份可能被 profile 默认值悄悄换成 user
+lark-cli vc +detail --meeting-ids <meeting_id> --as bot
+lark-cli note +detail --note-id <note_id>
+```
+
 ### 权限不足处理
 
 遇到权限相关错误时，**根据当前身份类型采取不同解决方案**。
@@ -72,6 +98,16 @@ LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1 LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1 lark-cli a
 - `missing_scopes`：列出缺失的 scope (N选1)
 - `console_url`：飞书开发者后台的权限配置链接
 - `hint`：建议的修复命令
+
+**missing_scope 与资源 ACL（无权访问某具体资源）是两类不同问题**，恢复方式也不同：
+
+| 失败类型 | user | bot |
+|---------|---------|---------|
+| missing scope（应用/用户完全没有这个权限） | `auth login --scope ...` | 使用错误中的 `console_url` 去开发者后台开通，**禁止** `auth login` |
+| 资源 ACL（有 scope，但对这一条具体资源没有访问权限） | 请求资源所有者给当前用户授权 | 请求资源所有者给当前应用/bot 授权 |
+| 资源在当前身份下不可见 | 保持当前身份，如实报告不可见，不要切换身份重试 | 保持当前身份，如实报告不可见，不要切换身份重试 |
+
+任何权限恢复完成后，都必须用**触发错误时的原身份**重试，不要在恢复过程中换成另一个身份。
 
 #### Bot 身份（`--as bot`）
 

--- a/skills/lark-vc/SKILL.md
+++ b/skills/lark-vc/SKILL.md
@@ -20,7 +20,9 @@ metadata:
 
 ## 身份
 
-本 skill 默认使用 `--as user`。`meeting get`、`+meeting-list-active`、`+meeting-events` 和 `+meeting-message-send` 也支持 `--as bot`；`+meeting-events` 和 `+meeting-message-send` 必须沿用 `meeting_id` 的来源身份。`+search` 仅支持 `--as user`。
+身份是跨命令工作流的状态，不是单条命令的局部参数：一旦某个 ID（如 `note_id`、`minute_token`）由某个身份取得，后续消费它的命令（包括跨到 lark-minutes / lark-note / lark-doc）必须显式沿用相同 `--as`；不要依赖 profile 默认身份，也不要为绕过权限错误切换身份。完整规则见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) 的「身份延续」。
+
+本 skill 默认使用 `--as user`。`+detail`、`+recording`、`meeting get`、`+meeting-list-active`、`+meeting-events` 和 `+meeting-message-send` 也支持 `--as bot`；`+meeting-events` 和 `+meeting-message-send` 必须沿用 `meeting_id` 的来源身份。`+search` 仅支持 `--as user`。
 
 ```bash
 # BAD — 查昨天的会议用 calendar，会漏掉即时会议
@@ -178,6 +180,7 @@ Meeting (视频会议)
 > - 已有 `doc_token` 且目标是读正文 → [lark-doc](../lark-doc/SKILL.md)。
 > - 只有自然语言纪要标题 → 文档搜索 / Docx 正文读取；有显式 `vc-node-id` 才进入 [lark-note](../lark-note/SKILL.md)。
 > - 从日程出发（只有 `event_id`）→ 先走 [`calendar +meeting`](../lark-calendar/references/lark-calendar-meeting.md) 拿到 `meeting_id` 或 `meeting_note`，再按上述路径继续。
+> - **跨到 lark-minutes / lark-note / lark-doc 时必须沿用来源身份**：例如 `vc +detail --as bot` 拿到的 `note_id`，下一步 `note +detail --note-id <note_id>` 也要显式加 `--as bot`；不要省略 `--as` 让身份被 profile 默认值悄悄换成 user（或反过来）。`note +transcript` 目前仅支持 `--as user`——如果 `note +detail --as bot` 返回 `note_display_type=unified`，停在这一步向用户说明"该纪要的逐字稿只能以 user 身份读取"，只有用户明确同意才切到 `--as user`，不要静默切换。
 
 ## API Resources
 

--- a/skills/lark-vc/references/lark-vc-detail.md
+++ b/skills/lark-vc/references/lark-vc-detail.md
@@ -1,13 +1,16 @@
 
 # vc +detail
 
-通过会议 ID 获取会议详情，包括基本信息、关联的纪要 ID（`note_id`）和妙记 Token（`minute_token`）。只读。
+通过会议 ID 获取会议详情，包括基本信息、关联的纪要 ID（`note_id`）和妙记 Token（`minute_token`）。只读，支持 `--as user` / `--as bot`。
 
 ## 命令
 
 ```bash
 # 单个 / 批量（逗号分隔，最多 50 个）
 lark-cli vc +detail --meeting-ids <meeting_id1>,<meeting_id2>
+
+# bot 身份（只能查 bot 有权限的会议）
+lark-cli vc +detail --meeting-ids <meeting_id1>,<meeting_id2> --as bot
 ```
 
 ## 输出字段
@@ -26,19 +29,21 @@ lark-cli vc +detail --meeting-ids <meeting_id1>,<meeting_id2>
 
 ### 场景 1：获取会议的纪要和妙记关联
 
-`vc +detail` 只能拿到 `note_id` 和 `minute_token`，不直接返回纪要文档 token 与妙记产物内容。要获取实际产物，需根据用户诉求继续调用 `note +detail` 或 `minutes +detail`：
+`vc +detail` 只能拿到 `note_id` 和 `minute_token`，不直接返回纪要文档 token 与妙记产物内容。要获取实际产物，需根据用户诉求继续调用 `note +detail` 或 `minutes +detail`，**并沿用第 1 步同一个 `--as`**（完整规则见 [lark-shared](../../lark-shared/SKILL.md) 的「身份延续」）：
 
 ```bash
 # 1. 获取会议详情，拿到 note_id 和 minute_token
-lark-cli vc +detail --meeting-ids <meeting_id>
+lark-cli vc +detail --meeting-ids <meeting_id> --as bot
 
 # 2. 用 note_id 获取纪要文档 Token（note_doc_token / verbatim_doc_token / shared_doc_tokens）
-lark-cli note +detail --note-id <note_id>
+#    显式沿用第 1 步的身份，不要省略 --as
+lark-cli note +detail --note-id <note_id> --as bot
 
-# 3. 用 minute_token 获取妙记产物
+# 3. 用 minute_token 获取妙记产物（同样沿用第 1 步的身份）
 # ⚠️ 必须显式指定 --summary / --todo / --chapter / --keyword / --transcript 中至少一个 flag，
 # 不传任何 flag 则不会返回任何产物内容。
-lark-cli minutes +detail --minute-tokens <minute_token> --todo --transcript
+lark-cli minutes +detail --minute-tokens obcnxxxxxxxxxxxxxxxxxxxx --todo --transcript --as bot
 ```
 
 > **路由建议**：当用户未明确指定使用妙记时，**优先**走 `note +detail` 链路（纪要文档信息更完整、含逐字稿原文），仅在 `note_id` 为空或用户要求妙记产物时才走 `minutes +detail`。
+> **身份边界**：`note +transcript` 目前仅支持 `--as user`。若上面第 2 步用 `--as bot` 拿到 `note_display_type=unified`，停下来向用户说明该纪要逐字稿只能以 user 身份读取，只有用户明确同意才切换身份重试。

--- a/skills/lark-vc/references/lark-vc-recording.md
+++ b/skills/lark-vc/references/lark-vc-recording.md
@@ -40,9 +40,11 @@ lark-cli vc +recording --meeting-ids 69xxxxxxxxxxxxx28 --dry-run
 
 每次只能指定一种输入方式。同时传入会报错。
 
-### 2. 仅支持 user 身份
+### 2. 身份支持
 
-该命令仅支持 `user` 身份，使用前需完成 `lark-cli auth login`。user token 只能查自己有权限的录制。
+`--meeting-ids` 和 `--calendar-event-ids` 两种模式都支持 `--as user` 和 `--as bot`。user token 只能查自己有权限的录制；bot 使用 tenant_access_token，只能查 bot 有权限的录制。
+
+拿到的 `minute_token` 是在某个身份下解析出来的：下一步传给 `minutes minutes get` / `minutes +detail` / `minutes +download` 时必须显式沿用同一个 `--as`，不要省略让身份被 profile 默认值悄悄换掉（完整规则见 [lark-shared](../../lark-shared/SKILL.md) 的「身份延续」）。
 
 ### 3. 批量上限
 
@@ -78,10 +80,10 @@ lark-cli vc +recording --meeting-ids 69xxxxxxxxxxxxx28 --dry-run
 
 ```bash
 # 第 1 步：通过 meeting_id 查询录制，拿到 minute_token
-lark-cli vc +recording --meeting-ids xxx
+lark-cli vc +recording --meeting-ids xxx --as bot
 
-# 第 2 步：使用上一步返回的 minute_token 下载妙记文件
-lark-cli minutes +download --minute-tokens <minute_token>
+# 第 2 步：使用上一步返回的 minute_token 下载妙记文件，沿用第 1 步的身份
+lark-cli minutes +download --minute-tokens obcnxxxxxxxxxxxxxxxxxxxx --as bot
 ```
 
 ### 场景 2：知道 meeting_id，想查询妙记基础信息
@@ -136,7 +138,7 @@ lark-cli minutes +download --minute-tokens <minute_token>
 | `no recording available` | 该会议无录制或录制未完成 | 确认会议已结束且开启了录制 |
 | `121005 no permission` | 无权查看该会议录制 | 确认是会议参与者或有录制权限 |
 | `124002 recording generating` | 录制文件仍在生成中 | 等待录制完成后重试 |
-| `missing required scope(s)` | 权限不足 | 按提示运行 `auth login --scope` |
+| `missing required scope(s)` | 权限不足 | `--as user`：按提示运行 `auth login --scope`；`--as bot`：使用错误中的 `console_url` 去开发者后台开通，**禁止**对 bot 执行 `auth login`（见 [lark-shared](../../lark-shared/SKILL.md) 的权限恢复表） |
 
 ## 提示
 

--- a/skills/lark-vc/references/vc-domain-boundaries.md
+++ b/skills/lark-vc/references/vc-domain-boundaries.md
@@ -99,6 +99,8 @@ lark-cli vc +search --start "<YYYY-MM-DD>" --end "<YYYY-MM-DD>" --format json
 
 #### Step 2: 根据 meeting_id 查询产物
 
+> **身份延续**：`vc +detail` 支持 `--as user` / `--as bot`。用哪个身份取到 `note_id` / `minute_token`，Step 2、Step 3 后续每一条命令（`note +detail`、`minutes +detail`、`docs +fetch`）都要显式带上**同一个** `--as`；不要省略让身份被 profile 默认值悄悄换掉。完整规则见 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 的「身份延续」。
+
 ##### 获取会议产物
 
 当用户提供 `meeting_id` 并需要会议产物时，先用 `vc +detail` 拿到 `note_id` 和 `minute_token`：
@@ -111,7 +113,7 @@ lark-cli vc +detail --meeting-ids '<meeting_id1>,<meeting_id2>'
 
 **优先路径：通过 `note_id` 获取纪要产物**
 
-如果用户未明确要求使用妙记，且返回了 `note_id`，**优先**使用 `note +detail` 获取纪要文档的 token 信息：
+如果用户未明确要求使用妙记，且返回了 `note_id`，**优先**使用 `note +detail` 获取纪要文档的 token 信息（沿用上一步的 `--as`）：
 
 ```bash
 lark-cli note +detail --note-id <note_id>
@@ -149,6 +151,9 @@ lark-cli docs +fetch --doc <note_doc_token> --doc-format markdown
 lark-cli docs +fetch --doc <verbatim_doc_token> --doc-format markdown
 
 # note_display_type=unified：逐字稿不是独立文档，按 note_id 拉取
+# ⚠️ note +transcript 目前仅支持 --as user；如果上面的 note_id 是通过 --as bot
+#    拿到的，在这一步停下来向用户说明"该纪要逐字稿只能以 user 身份读取"，
+#    只有用户明确同意才切到 --as user，不要静默切换身份重试
 lark-cli note +transcript --note-id <note_id>
 ```
 

--- a/tests/cli_e2e/minutes/minutes_apply_permission_test.go
+++ b/tests/cli_e2e/minutes/minutes_apply_permission_test.go
@@ -37,6 +37,29 @@ func TestMinutesApplyPermission_DryRun(t *testing.T) {
 	assert.True(t, strings.Contains(output, `"perm": "view"`) || strings.Contains(output, `"perm":"view"`), "dry-run should contain perm body, got: %s", output)
 }
 
+func TestMinutesApplyPermission_DryRun_BotIdentity(t *testing.T) {
+	setDryRunConfigEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"minutes", "+apply-permission",
+			"--minute-token", "obcnexampleminute",
+			"--perm", "view",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	output := result.Stdout
+	assert.True(t, strings.Contains(output, "POST"), "dry-run should contain POST method, got: %s", output)
+	assert.True(t, strings.Contains(output, "/open-apis/minutes/v1/minutes/obcnexampleminute/permissions/apply"), "dry-run should contain API path, got: %s", output)
+	assert.True(t, strings.Contains(output, `"perm": "view"`) || strings.Contains(output, `"perm":"view"`), "dry-run should contain perm body, got: %s", output)
+}
+
 func TestMinutesApplyPermission_InvalidPerm(t *testing.T) {
 	setDryRunConfigEnv(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/tests/cli_e2e/minutes/minutes_detail_dryrun_test.go
+++ b/tests/cli_e2e/minutes/minutes_detail_dryrun_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package minutes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMinutesDetailDryRun_BotIdentity pins that `minutes +detail` accepts
+// --as bot for both the metadata (GetMinuteArtifacts) and transcript
+// (GetMinuteTranscript) paths, which accept a tenant access token.
+func TestMinutesDetailDryRun_BotIdentity(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	setDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"minutes", "+detail",
+			"--minute-tokens", "obcnexampleminute",
+			"--transcript",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	require.Contains(t, result.Args, "--as")
+	require.Contains(t, result.Args, "bot")
+
+	out := result.Stdout
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/minutes/v1/minutes/{minute_token}", clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/minutes/v1/minutes/{minute_token}/artifacts", clie2e.DryRunGet(out, "api.1.url").String(), "stdout:\n%s", out)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"minutes", "+detail", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+}

--- a/tests/cli_e2e/note/coverage.md
+++ b/tests/cli_e2e/note/coverage.md
@@ -11,6 +11,7 @@ Live E2E is intentionally not counted yet because both commands require meeting-
 
 ## Summary
 - TestNoteDetailDryRun: dry-run coverage for `note +detail`; asserts the detail request method and `/open-apis/vc/v1/notes/{note_id}` URL without calling live APIs.
+- TestNoteDetailDryRunAsBot: dry-run coverage for `note +detail --as bot`; pins bot identity acceptance and the same detail endpoint.
 - TestNoteTranscriptDryRun: dry-run coverage for `note +transcript`; asserts the two-step request shape (`note detail` precheck, then `unified_note_transcript`), transcript query parameters, and that `--transcript-format` coexists with the global `--format` output flag.
 
 ## Command Table
@@ -18,4 +19,5 @@ Live E2E is intentionally not counted yet because both commands require meeting-
 | Status | Cmd | Type | Testcase | Key parameter shapes | Notes / uncovered reason |
 | --- | --- | --- | --- | --- | --- |
 | dry-run ✓ / live ✕ | note +detail | shortcut | note_dryrun_test.go::TestNoteDetailDryRun | `--note-id`; user identity | live note fixtures depend on meeting-generated artifacts |
+| dry-run ✓ / live ✕ | note +detail | shortcut | note_dryrun_test.go::TestNoteDetailDryRunAsBot | `--note-id`; `--as bot` | live note fixtures depend on meeting-generated artifacts |
 | dry-run ✓ / live ✕ | note +transcript | shortcut | note_dryrun_test.go::TestNoteTranscriptDryRun | `--note-id`; `--transcript-format`; `--format json`; transcript API `format/page_size/locale` params | live unified-note fixtures depend on generated VC note artifacts |

--- a/tests/cli_e2e/note/note_dryrun_test.go
+++ b/tests/cli_e2e/note/note_dryrun_test.go
@@ -10,6 +10,7 @@ import (
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestNoteDetailDryRun(t *testing.T) {
@@ -34,6 +35,32 @@ func TestNoteDetailDryRun(t *testing.T) {
 		t.Fatalf("method=%q, want GET\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/vc/v1/notes/note_dryrun" {
+		t.Fatalf("url=%q, want note detail endpoint\nstdout:\n%s", got, out)
+	}
+}
+
+func TestNoteDetailDryRunAsBot(t *testing.T) {
+	setNoteDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"note", "+detail",
+			"--note-id", "note_dryrun_bot",
+			"--as", "bot",
+			"--dry-run",
+		},
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := gjson.Get(out, "identity").String(); got != "bot" {
+		t.Fatalf("identity=%q, want bot\nstdout:\n%s", got, out)
+	}
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/vc/v1/notes/note_dryrun_bot" {
 		t.Fatalf("url=%q, want note detail endpoint\nstdout:\n%s", got, out)
 	}
 }

--- a/tests/cli_e2e/vc/vc_detail_dryrun_test.go
+++ b/tests/cli_e2e/vc/vc_detail_dryrun_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVCDetailDryRun_BotIdentity pins that `vc +detail` accepts --as bot and
+// previews the meeting.get + recording API round-trip (GetMeetingByID /
+// GetRecordingByMeetingID both accept a tenant access token).
+func TestVCDetailDryRun_BotIdentity(t *testing.T) {
+	setVCDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+detail",
+			"--meeting-ids", "7628568141510692381",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	require.Contains(t, result.Args, "--as")
+	require.Contains(t, result.Args, "bot")
+
+	out := result.Stdout
+	require.Equal(t, int64(2), clie2e.DryRunGet(out, "api.#").Int(), "stdout:\n%s", out)
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/vc/v1/meetings/{meeting_id}", clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/vc/v1/meetings/{meeting_id}/recording", clie2e.DryRunGet(out, "api.1.url").String(), "stdout:\n%s", out)
+	require.Equal(t, "7628568141510692381", clie2e.DryRunGet(out, "meeting_ids.0").String(), "stdout:\n%s", out)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"vc", "+detail", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+}

--- a/tests/cli_e2e/vc/vc_recording_dryrun_test.go
+++ b/tests/cli_e2e/vc/vc_recording_dryrun_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVCRecordingDryRun_BotIdentity pins that `vc +recording --meeting-ids`
+// accepts --as bot (GetRecordingByMeetingID accepts a tenant access token).
+func TestVCRecordingDryRun_BotIdentity(t *testing.T) {
+	setVCDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+recording",
+			"--meeting-ids", "7628568141510692381",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+	require.Equal(t, "/open-apis/vc/v1/meetings/{meeting_id}/recording", clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"vc", "+recording", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+}
+
+// TestVCRecordingDryRun_BotIdentity_CalendarEventIDs pins that the
+// calendar-event-ids path also flows under --as bot: a bot has a primary
+// calendar, so the primary -> mget_instance_relation_info -> recording chain
+// is previewed without a validation error.
+func TestVCRecordingDryRun_BotIdentity_CalendarEventIDs(t *testing.T) {
+	setVCDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+recording",
+			"--calendar-event-ids", "evt_001",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Contains(t, out, "mget_instance_relation_info", "stdout:\n%s", out)
+	require.Contains(t, out, "recording", "stdout:\n%s", out)
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bot identity support for VC details, notes, and recordings; Minutes details and permission requests; and Note details.
  * Added bot-compatible dry-run workflows for previewing requests, artifacts, permissions, and calendar-based recording lookups.

* **Documentation**
  * Clarified identity continuity across related commands and workflows.
  * Added guidance for bot permissions, scope errors, and explicit consent before switching identities.
  * Documented that Note transcripts remain user-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->