### PR TITLE
feat(affordance): support domain skill lists

### DIFF
--- a/affordance/README.md
+++ b/affordance/README.md
@@ -10,6 +10,8 @@ step. Maintain these files alongside `skills/` and `shortcuts/`.
 A small, fixed markdown subset; each file describes one domain:
 
     # <domain>            optional `> skill: <name>` applies to every command below
+    ## Skills             optional bullets shown on the business-domain help;
+                          merged after `> skill:` and not inherited by commands
     ## <command>          the command as typed, minus `lark-cli <domain>`; a
                           +-prefixed heading (## +create) targets that shortcut
     <lead paragraph>      when to use this command
@@ -36,6 +38,13 @@ nothing. Point a command at its own reference (e.g. `+search-user` →
 domain skill, which the `> skill:` default already covers. When a shortcut also
 sets a hand-authored `Tips` list in Go, the overlay's `### Tips` win — they
 replace the Go tips (not merged), so keep tips in one place.
+
+The reserved domain-level `## Skills` section controls the skill pointers on
+`lark-cli <domain> --help`. Its entries use the same name or name/relpath format
+and existence gating as command-level `### Skills`. The canonical `> skill:` is
+shown first automatically; additional domain entries are display-only and do
+not become defaults for every command. If `## Skills` is absent, the existing
+single domain guide behavior is unchanged.
 
 ## Example
 

--- a/cmd/service/affordance.go
+++ b/cmd/service/affordance.go
@@ -18,10 +18,10 @@ import (
 )
 
 // PrepareDomainHelp appends navigational guidance (routing line, risk legend,
-// skill pointer) to a top-level Lark domain's description, returning false for
-// anything that is not such a domain. Built lazily at help time because
+// skill pointers) to a top-level Lark domain's description, returning false
+// for anything that is not such a domain. Built lazily at help time because
 // shortcuts attach after service registration. skillFS (nil-safe) gates the
-// skill pointer.
+// skill pointers.
 //
 // A hand-authored Long is preserved as the base (e.g. event's "Use 'event
 // consume <EventKey>'…"); service domains carry only a Short at this point, so
@@ -68,13 +68,11 @@ func PrepareDomainHelpWithReferences(cmd *cobra.Command, skillFS fs.FS, referenc
 		b.WriteString("\n\nPrefer a +-prefixed shortcut when one matches your task; otherwise use the raw API resource below.")
 	}
 	b.WriteString("\n\nRisk levels (read | write | high-risk-write) appear in each command's --help; high-risk-write requires --yes, only after the user confirms.")
-	canonicalSkill := "lark-" + cmd.Name()
-	if declared, ok := affordance.DomainSkill(cmdmeta.Domain(cmd)); ok {
-		canonicalSkill = declared
+	canonicalSkills := []string{"lark-" + cmd.Name()}
+	if declared, ok := affordance.DomainSkills(cmdmeta.Domain(cmd)); ok {
+		canonicalSkills = declared
 	}
-	if skill, ok := resolveSkillReference(canonicalSkill, skillFS, references); ok {
-		fmt.Fprintf(&b, "\n\nDomain guide (concepts, command choice, conventions): lark-cli skills read %s", skill)
-	}
+	writeDomainSkills(&b, canonicalSkills, skillFS, references)
 	cmd.Long = b.String()
 	return true
 }
@@ -279,15 +277,7 @@ func writeRisk(b *strings.Builder, cmd *cobra.Command) {
 // exist in skillFS. Nothing is written when skillFS is nil or no entry resolves,
 // so help never prints a `skills read` pointer that cannot be opened.
 func writeRelatedSkills(b *strings.Builder, skills []string, skillFS fs.FS, references *skillref.Resolver) {
-	if skillFS == nil || len(skills) == 0 {
-		return
-	}
-	var avail []string
-	for _, s := range skills {
-		if resolved, ok := resolveSkillReference(s, skillFS, references); ok {
-			avail = append(avail, resolved)
-		}
-	}
+	avail := availableSkillReferences(skills, skillFS, references)
 	if len(avail) == 0 {
 		return
 	}
@@ -295,6 +285,39 @@ func writeRelatedSkills(b *strings.Builder, skills []string, skillFS fs.FS, refe
 	for _, s := range avail {
 		fmt.Fprintf(b, "\n  lark-cli skills read %s", s)
 	}
+}
+
+// writeDomainSkills appends the domain-level skill navigation configured by
+// affordance. Preserve the established single-guide sentence for existing
+// domains; only domains that opt into multiple entries get the list form.
+func writeDomainSkills(b *strings.Builder, skills []string, skillFS fs.FS, references *skillref.Resolver) {
+	avail := availableSkillReferences(skills, skillFS, references)
+	switch len(avail) {
+	case 0:
+		return
+	case 1:
+		fmt.Fprintf(b, "\n\nDomain guide (concepts, command choice, conventions): lark-cli skills read %s", avail[0])
+	default:
+		b.WriteString("\n\nDomain skills (concepts, command choice, conventions):")
+		for _, skill := range avail {
+			fmt.Fprintf(b, "\n  lark-cli skills read %s", skill)
+		}
+	}
+}
+
+func availableSkillReferences(skills []string, skillFS fs.FS, references *skillref.Resolver) []string {
+	if skillFS == nil || len(skills) == 0 {
+		return nil
+	}
+	var avail []string
+	for _, skill := range skills {
+		resolved, ok := resolveSkillReference(skill, skillFS, references)
+		if !ok {
+			continue
+		}
+		avail = append(avail, resolved)
+	}
+	return avail
 }
 
 func resolveSkillReference(canonical string, skillFS fs.FS, references *skillref.Resolver) (string, bool) {

--- a/cmd/service/affordance_test.go
+++ b/cmd/service/affordance_test.go
@@ -323,6 +323,71 @@ func TestDomainSkillReferenceUsesDeclaredAffordanceName(t *testing.T) {
 	}
 }
 
+func TestPrepareDomainHelpDisplaysConfiguredSkills(t *testing.T) {
+	affordance.SetSource(fstest.MapFS{
+		"docs.md": {Data: []byte("# docs\n> skill: lark-doc\n\n## Skills\n- lark-drive\n- lark-doc\n- lark-missing\n")},
+	})
+	t.Cleanup(func() { affordance.SetSource(nil) })
+	content := fstest.MapFS{
+		"lark-doc/SKILL.md":   {Data: []byte("# docs")},
+		"lark-drive/SKILL.md": {Data: []byte("# drive")},
+	}
+
+	root := &cobra.Command{Use: "lark-cli"}
+	domain := &cobra.Command{Use: "docs", Short: "Docs"}
+	cmdmeta.SetSource(domain, cmdmeta.SourceService, false)
+	cmdmeta.SetDomain(domain, "docs")
+	domain.AddCommand(&cobra.Command{Use: "documents", Run: func(*cobra.Command, []string) {}})
+	root.AddCommand(domain)
+
+	if !PrepareDomainHelp(domain, content) {
+		t.Fatal("PrepareDomainHelp returned false")
+	}
+	if !strings.Contains(domain.Long, "Domain skills (concepts, command choice, conventions):") {
+		t.Fatalf("multiple configured skills did not use the domain list form:\n%s", domain.Long)
+	}
+	docAt := strings.Index(domain.Long, "skills read lark-doc")
+	driveAt := strings.Index(domain.Long, "skills read lark-drive")
+	if docAt < 0 || driveAt < 0 || docAt >= driveAt {
+		t.Fatalf("configured domain skills are missing or out of order (doc=%d drive=%d):\n%s", docAt, driveAt, domain.Long)
+	}
+	if strings.Contains(domain.Long, "lark-missing") {
+		t.Fatalf("unresolvable domain skill must be omitted:\n%s", domain.Long)
+	}
+
+	remappedContent := fstest.MapFS{
+		"acme-docx/SKILL.md":  {Data: []byte("# docs")},
+		"acme-drive/SKILL.md": {Data: []byte("# drive")},
+	}
+	resolver, err := skillref.New(remappedContent, []skillref.Mapping{
+		{From: skillref.Ref{Skill: "lark-doc"}, To: skillref.Ref{Skill: "acme-docx"}},
+		{From: skillref.Ref{Skill: "lark-drive"}, To: skillref.Ref{Skill: "acme-drive"}},
+	})
+	if err != nil {
+		t.Fatalf("skillref.New(): %v", err)
+	}
+	remapped := &cobra.Command{Use: "docs", Short: "Docs"}
+	cmdmeta.SetSource(remapped, cmdmeta.SourceService, false)
+	cmdmeta.SetDomain(remapped, "docs")
+	remapped.AddCommand(&cobra.Command{Use: "documents", Run: func(*cobra.Command, []string) {}})
+	remappedRoot := &cobra.Command{Use: "lark-cli"}
+	remappedRoot.AddCommand(remapped)
+
+	if !PrepareDomainHelpWithReferences(remapped, remappedContent, resolver) {
+		t.Fatal("PrepareDomainHelpWithReferences returned false")
+	}
+	for _, want := range []string{"skills read acme-docx", "skills read acme-drive"} {
+		if !strings.Contains(remapped.Long, want) {
+			t.Errorf("remapped domain help missing %q:\n%s", want, remapped.Long)
+		}
+	}
+	for _, canonical := range []string{"skills read lark-doc", "skills read lark-drive"} {
+		if strings.Contains(remapped.Long, canonical) {
+			t.Errorf("remapped domain help leaked canonical pointer %q:\n%s", canonical, remapped.Long)
+		}
+	}
+}
+
 // A shortcut that sets a hand-authored Long keeps it as the lead: the
 // affordance block is appended below, not clobbered, and re-rendering does not
 // double-append.
@@ -394,8 +459,11 @@ func TestPrepareDomainHelp_GatesGuidePointerOnFS(t *testing.T) {
 	if !PrepareDomainHelp(present, fstest.MapFS{"lark-event/SKILL.md": &fstest.MapFile{Data: []byte("x")}}) {
 		t.Fatal("PrepareDomainHelp returned false for a domain-tagged command")
 	}
-	if !strings.Contains(present.Long, "lark-cli skills read lark-event") {
-		t.Errorf("skill present should emit the domain-guide pointer; got:\n%s", present.Long)
+	const want = "Consume and manage real-time events\n\n" +
+		"Risk levels (read | write | high-risk-write) appear in each command's --help; high-risk-write requires --yes, only after the user confirms.\n\n" +
+		"Domain guide (concepts, command choice, conventions): lark-cli skills read lark-event"
+	if present.Long != want {
+		t.Errorf("single-skill domain help changed\n got: %q\nwant: %q", present.Long, want)
 	}
 
 	removed := domainCmd("Consume and manage real-time events", "")

--- a/internal/affordance/affordance.go
+++ b/internal/affordance/affordance.go
@@ -27,8 +27,9 @@ var (
 )
 
 type serviceAffordance struct {
-	skill   string
-	methods map[string]json.RawMessage
+	skill        string
+	domainSkills []string
+	methods      map[string]json.RawMessage
 }
 
 // SetSource installs the markdown guidance tree (the top-level affordance/
@@ -70,6 +71,24 @@ func DomainSkill(service string) (string, bool) {
 	return skill, skill != ""
 }
 
+// DomainSkills returns the skill references configured for service-level help.
+// The canonical `> skill:` entry is first when present, followed by entries in
+// the domain's `## Skills` section. The returned slice is a copy so callers
+// cannot mutate the lazy parse cache.
+func DomainSkills(service string) ([]string, bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	if !tried[service] {
+		tried[service] = true
+		byService[service] = loadService(service)
+	}
+	skills := byService[service].domainSkills
+	if len(skills) == 0 {
+		return nil, false
+	}
+	return append([]string(nil), skills...), true
+}
+
 // loadService parses a service's markdown guidance into its domain metadata
 // and per-method overlays, marshalling each method to JSON so downstream
 // callers keep the same wire shape.
@@ -88,7 +107,11 @@ func loadService(service string) serviceAffordance {
 			m[id] = b
 		}
 	}
-	return serviceAffordance{skill: parsed.skill, methods: m}
+	return serviceAffordance{
+		skill:        parsed.skill,
+		domainSkills: parsed.domainSkills,
+		methods:      m,
+	}
 }
 
 // commandFormResolver maps a method's command-form heading ("user_mailbox.messages

--- a/internal/affordance/affordance_test.go
+++ b/internal/affordance/affordance_test.go
@@ -5,6 +5,7 @@ package affordance
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 	"testing/fstest"
 
@@ -71,8 +72,19 @@ func TestFor(t *testing.T) {
 	if skill, ok := DomainSkill("approval"); !ok || skill != "lark-approval" {
 		t.Errorf("DomainSkill(approval) = %q, %v; want lark-approval, true", skill, ok)
 	}
+	if skills, ok := DomainSkills("approval"); !ok || !slices.Equal(skills, []string{"lark-approval"}) {
+		t.Errorf("DomainSkills(approval) = %v, %v; want [lark-approval], true", skills, ok)
+	} else {
+		skills[0] = "mutated"
+		if cached, _ := DomainSkills("approval"); !slices.Equal(cached, []string{"lark-approval"}) {
+			t.Errorf("DomainSkills returned mutable cache storage: %v", cached)
+		}
+	}
 	if skill, ok := DomainSkill("no_such_service"); ok || skill != "" {
 		t.Errorf("DomainSkill(no_such_service) = %q, %v; want empty, false", skill, ok)
+	}
+	if skills, ok := DomainSkills("no_such_service"); ok || skills != nil {
+		t.Errorf("DomainSkills(no_such_service) = %v, %v; want nil, false", skills, ok)
 	}
 }
 
@@ -110,6 +122,23 @@ func TestParseDomainMD_SkillsMerge(t *testing.T) {
 	}
 	if a := got.methods["bar"]; len(a.Skills) != 1 || a.Skills[0] != "lark-d" {
 		t.Errorf("bar skills = %v, want [lark-d] (domain default inherited)", a.Skills)
+	}
+}
+
+// The reserved domain-level ## Skills section controls domain-help navigation
+// only. The canonical > skill: remains first and is still the sole default
+// inherited by commands.
+func TestParseDomainMD_DomainSkills(t *testing.T) {
+	md := "# d\n> skill: lark-d\n\n" +
+		"## Skills  \n- lark-workflow\n- `lark-d`\n- lark-shared\n\n" +
+		"## foo\ndoes foo.\n\n### Skills\n- lark-command\n"
+	got := parseDomainMD([]byte(md), nil)
+
+	if want := []string{"lark-d", "lark-workflow", "lark-shared"}; !slices.Equal(got.domainSkills, want) {
+		t.Errorf("domain skills = %v, want %v", got.domainSkills, want)
+	}
+	if want := []string{"lark-d", "lark-command"}; !slices.Equal(got.methods["foo"].Skills, want) {
+		t.Errorf("foo skills = %v, want %v; domain-only skills must not leak into commands", got.methods["foo"].Skills, want)
 	}
 }
 

--- a/internal/affordance/mdparse.go
+++ b/internal/affordance/mdparse.go
@@ -13,6 +13,7 @@ import (
 // The affordance source is a narrow, fixed markdown subset (see src/*.md):
 //
 //	# domain            optional `> skill: <name>` applied to every method
+//	## Skills           optional skills shown on domain help (not inherited)
 //	## command          e.g. `instances get`
 //	<lead paragraph>    -> use_when (when this command is right)
 //	### Avoid when      -> avoid_when (links become prefer/alternative edges)
@@ -38,10 +39,10 @@ var standardSection = map[string]string{
 	"Skills":        "skills",
 }
 
-// mergeSkills returns the domain-default skill followed by a command's own skill
-// entries, de-duplicated in author order and empties dropped. Backticks (left by
-// the shared bullet parse) are stripped so each entry is a bare skill name.
-func mergeSkills(domain string, extra []string) []string {
+// mergeSkills returns the primary skill followed by additional entries,
+// de-duplicated in author order and with empties dropped. Backticks (left by
+// the shared bullet parse) are stripped so each entry is a bare reference.
+func mergeSkills(primary string, extra []string) []string {
 	var out []string
 	seen := map[string]bool{}
 	add := func(s string) {
@@ -52,7 +53,7 @@ func mergeSkills(domain string, extra []string) []string {
 		seen[s] = true
 		out = append(out, s)
 	}
-	add(domain)
+	add(primary)
 	for _, s := range extra {
 		add(s)
 	}
@@ -61,13 +62,14 @@ func mergeSkills(domain string, extra []string) []string {
 
 func linkToBacktick(s string) string { return mdLink.ReplaceAllString(s, "`$1`") }
 
-// SkillStatPath maps a `### Skills` entry to the path (relative to the skill
-// tree) whose existence gates it: a bare skill name resolves to its SKILL.md,
-// while an entry containing a slash is a name/relative-path reference (e.g.
+// SkillStatPath maps a domain- or command-level Skills entry to the path
+// (relative to the skill tree) whose existence gates it: a bare skill name
+// resolves to its SKILL.md, while an entry containing a slash is a
+// name/relative-path reference (e.g.
 // "lark-contact/references/lark-contact-search-user.md") and resolves to that
 // path directly. Both render as `lark-cli skills read <entry>` — the slash form
-// skills read already accepts — so a per-command entry can point at that
-// command's own reference file, not just re-point the domain skill.
+// skills read already accepts — so an entry can point at a command's own
+// reference file, not just re-point the domain skill.
 func SkillStatPath(entry string) string {
 	if strings.Contains(entry, "/") {
 		return entry
@@ -94,8 +96,9 @@ type mdSection struct {
 }
 
 type parsedDomain struct {
-	skill   string
-	methods map[string]meta.Affordance
+	skill        string
+	domainSkills []string
+	methods      map[string]meta.Affordance
 }
 
 // parseDomainMD parses one domain's markdown into per-method Affordance values,
@@ -109,6 +112,8 @@ func parseDomainMD(src []byte, resolve func(string) string) parsedDomain {
 	out := map[string]meta.Affordance{}
 
 	var skill, curKey string
+	var domainSkills []string
+	inDomainSkills := false
 	var useWhen, para []string // lead paragraphs -> use_when entries (blank line separates)
 	var secs []*mdSection
 	var sec *mdSection
@@ -167,11 +172,19 @@ func parseDomainMD(src []byte, resolve func(string) string) parsedDomain {
 		line := strings.TrimRight(raw, "\r")
 		t := strings.TrimSpace(line)
 		switch {
+		case strings.HasPrefix(line, "## ") && strings.TrimSpace(line[3:]) == "Skills":
+			flushPending()
+			assemble()
+			curKey = ""
+			reset()
+			inDomainSkills = true
+			continue
 		case strings.HasPrefix(line, "## "):
 			flushPending()
 			assemble()
 			curKey = resolve(line[3:])
 			reset()
+			inDomainSkills = false
 			continue
 		case strings.HasPrefix(line, "# "):
 			continue
@@ -183,6 +196,12 @@ func parseDomainMD(src []byte, resolve func(string) string) parsedDomain {
 			sec = &mdSection{label: strings.TrimSpace(line[4:])}
 			secs = append(secs, sec)
 			pending, fence, inFence = "", nil, false
+			continue
+		}
+		if inDomainSkills {
+			if strings.HasPrefix(t, "-") {
+				domainSkills = append(domainSkills, strings.TrimSpace(t[1:]))
+			}
 			continue
 		}
 		if curKey == "" {
@@ -225,5 +244,9 @@ func parseDomainMD(src []byte, resolve func(string) string) parsedDomain {
 	}
 	flushPending()
 	assemble()
-	return parsedDomain{skill: skill, methods: out}
+	return parsedDomain{
+		skill:        skill,
+		domainSkills: mergeSkills(skill, domainSkills),
+		methods:      out,
+	}
 }

--- a/tests/plugin_e2e/harness.go
+++ b/tests/plugin_e2e/harness.go
@@ -108,6 +108,14 @@ func buildFork(t *testing.T, name, pluginSrc string) string {
 	return buildForkWithMain(t, name, pluginSrc, customerMain)
 }
 
+// buildForkWithAffordance is buildFork with distribution-specific command
+// guidance. It exercises the public SetEmbeddedAffordanceContent boundary
+// without changing the shared fixture used by unrelated plugin scenarios.
+func buildForkWithAffordance(t *testing.T, name, pluginSrc, affordanceSrc string) string {
+	t.Helper()
+	return buildForkWithMainAndAffordance(t, name, pluginSrc, customerMain, affordanceSrc)
+}
+
 // buildConcealedFork uses the same real external-module path as buildFork, but
 // opts the wrapper host into distribution concealment. Keeping this choice in
 // main (rather than the Restrict plugin) is the compatibility boundary under
@@ -119,7 +127,12 @@ func buildConcealedFork(t *testing.T, name, pluginSrc string) string {
 
 func buildForkWithMain(t *testing.T, name, pluginSrc, mainSrc string) string {
 	t.Helper()
-	sum := sha256.Sum256([]byte(name + "\x00" + pluginSrc + "\x00" + mainSrc + "\x00" + customerAffordanceDocs))
+	return buildForkWithMainAndAffordance(t, name, pluginSrc, mainSrc, customerAffordanceDocs)
+}
+
+func buildForkWithMainAndAffordance(t *testing.T, name, pluginSrc, mainSrc, affordanceSrc string) string {
+	t.Helper()
+	sum := sha256.Sum256([]byte(name + "\x00" + pluginSrc + "\x00" + mainSrc + "\x00" + affordanceSrc))
 	cacheKey := fmt.Sprintf("%s-%x", name, sum[:8])
 	builtForksMu.Lock()
 	defer builtForksMu.Unlock()
@@ -157,7 +170,7 @@ func buildForkWithMain(t *testing.T, name, pluginSrc, mainSrc string) string {
 	if err := os.MkdirAll(filepath.Join(mod, "affordance"), 0o755); err != nil {
 		t.Fatalf("mkdir customer affordance: %v", err)
 	}
-	writeFile(t, filepath.Join(mod, "affordance", "docs.md"), customerAffordanceDocs)
+	writeFile(t, filepath.Join(mod, "affordance", "docs.md"), affordanceSrc)
 
 	// go.mod: reuse cli's require graph, rename the module, replace cli with the
 	// local archived tree. This avoids `go mod tidy` (no network at test time).

--- a/tests/plugin_e2e/skills_test.go
+++ b/tests/plugin_e2e/skills_test.go
@@ -198,7 +198,9 @@ func TestForkMainWiresEmbeddedSkillsWithoutOverlay(t *testing.T) {
 
 	docsHelp := run(t, cli, "docs", "--help")
 	if docsHelp.exit != 0 ||
-		!strings.Contains(docsHelp.stdout, "lark-cli skills read lark-doc") {
+		!strings.Contains(docsHelp.stdout,
+			"Domain guide (concepts, command choice, conventions): lark-cli skills read lark-doc") ||
+		strings.Contains(docsHelp.stdout, "Domain skills (concepts, command choice, conventions):") {
 		t.Fatalf("docs help canonical skill pointer missing: exit=%d stdout=%s stderr=%s",
 			docsHelp.exit, docsHelp.stdout, docsHelp.stderr)
 	}
@@ -241,6 +243,48 @@ func TestForkMainWiresEmbeddedSkillsWithoutOverlay(t *testing.T) {
 					tc.shortcut, pointer, rules.exit, rules.stdout, rules.stderr)
 			}
 		}
+	}
+}
+
+func TestForkDomainHelpDisplaysConfiguredSkills(t *testing.T) {
+	affordanceSrc := strings.Replace(
+		customerAffordanceDocs,
+		"> skill: lark-doc\n",
+		"> skill: lark-doc\n\n## Skills\n- lark-a\n- lark-missing\n",
+		1,
+	)
+	bin := buildForkWithAffordance(t, "domain-skills", noopPlugin, affordanceSrc)
+
+	help := run(t, bin, "docs", "--help")
+	if help.exit != 0 {
+		t.Fatalf("docs help: exit=%d stdout=%s stderr=%s", help.exit, help.stdout, help.stderr)
+	}
+	if !strings.Contains(help.stdout, "Domain skills (concepts, command choice, conventions):") {
+		t.Fatalf("configured domain skills did not render as a list:\n%s", help.stdout)
+	}
+	docAt := strings.Index(help.stdout, "lark-cli skills read lark-doc")
+	aAt := strings.Index(help.stdout, "lark-cli skills read lark-a")
+	if docAt < 0 || aAt < 0 || docAt >= aAt {
+		t.Fatalf("domain skill pointers missing or out of order (doc=%d a=%d):\n%s", docAt, aAt, help.stdout)
+	}
+	if strings.Contains(help.stdout, "lark-missing") {
+		t.Fatalf("unreadable domain skill pointer was not filtered:\n%s", help.stdout)
+	}
+	for _, skill := range []string{"lark-doc", "lark-a"} {
+		read := run(t, bin, "skills", "read", skill)
+		if read.exit != 0 || !strings.Contains(read.stdout, "name: "+skill) {
+			t.Errorf("rendered domain skill %q is not readable: exit=%d stdout=%s stderr=%s",
+				skill, read.exit, read.stdout, read.stderr)
+		}
+	}
+
+	commandHelp := run(t, bin, "docs", "+create", "--help")
+	if commandHelp.exit != 0 {
+		t.Fatalf("docs +create help: exit=%d stdout=%s stderr=%s",
+			commandHelp.exit, commandHelp.stdout, commandHelp.stderr)
+	}
+	if strings.Contains(commandHelp.stdout, "lark-cli skills read lark-a") {
+		t.Fatalf("domain-only skill leaked into command help:\n%s", commandHelp.stdout)
 	}
 }
 


### PR DESCRIPTION
## Summary

Extend affordance Markdown so a business domain can declare the skills shown on `lark-cli <domain> --help` independently from command-level skill inheritance. Existing single-skill domain help remains byte-compatible unless a domain opts into the new list.

## Changes

- Add a reserved domain-level `## Skills` section while preserving `> skill:` as the canonical command default and `### Skills` as command-specific guidance.
- Resolve, remap, order, and availability-gate domain skill references through the existing composed skill tree.
- Preserve the established singular `Domain guide` output and render a list only when multiple configured skills remain available.
- Add parser, cache-copy, help compatibility, filtering, remap, and external customer-wrapper E2E coverage.
- Document the new affordance authoring contract.

## Test Plan

- [x] Unit tests pass (`make unit-test`, including race detection).
- [x] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected.
- [x] Full external plugin/customer-wrapper E2E suite passes (`go test -count=1 -timeout=15m ./tests/plugin_e2e/...`).
- [x] `make build`, `make vet`, `make fmt-check`, `go mod tidy`, and `make quality-gate` pass.
- [x] Diff-scoped golangci-lint and source-contract lint report no issues; license policy check passes.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domain help now displays multiple configured skills in a consistent order.
  * Skill references are resolved to their available guides, while unavailable entries are omitted.
  * Domain-level skills can guide navigation without being inherited by individual commands.
  * Help output clearly identifies the canonical domain guide.

* **Documentation**
  * Added guidance for configuring domain-level and command-level Skills sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->