### PR TITLE
fix: complete mail rule reorder IDs

### DIFF
--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -139,7 +139,7 @@ func ruleIDsFromArray(value interface{}) []string {
 	ids := make([]string, 0, len(items))
 	for _, item := range items {
 		if m, ok := item.(map[string]interface{}); ok {
-			if id, ok := m["rule_id"]; ok {
+			if id, ok := mailRuleID(m); ok {
 				ids = append(ids, fmt.Sprint(id))
 			}
 		}
@@ -156,7 +156,7 @@ func collectRuleIDs(value interface{}) []string {
 		}
 		return ids
 	case map[string]interface{}:
-		if id, ok := typed["rule_id"]; ok {
+		if id, ok := mailRuleID(typed); ok {
 			return []string{fmt.Sprint(id)}
 		}
 		keys := make([]string, 0, len(typed))
@@ -172,6 +172,15 @@ func collectRuleIDs(value interface{}) []string {
 	default:
 		return nil
 	}
+}
+
+func mailRuleID(rule map[string]interface{}) (interface{}, bool) {
+	for _, key := range []string{"id", "rule_id"} {
+		if id, ok := rule[key]; ok {
+			return id, true
+		}
+	}
+	return nil, false
 }
 
 func stringSlice(value interface{}) []string {

--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/core"
+)
+
+func maybeCompleteMailRuleReorderRequest(ctx context.Context, ac *client.APIClient, opts *ServiceMethodOptions, request *client.RawApiRequest, checkErr func(interface{}, core.Identity) error) error {
+	if !isMailRuleReorder(opts, request) {
+		return nil
+	}
+	body, inputRuleIDs, err := mailRuleReorderBody(request.Data)
+	if err != nil {
+		return err
+	}
+
+	listResult, err := ac.CallAPI(ctx, client.RawApiRequest{
+		Method: "GET",
+		URL:    mailRuleListURL(request.URL),
+		As:     request.As,
+	})
+	if err != nil {
+		return err
+	}
+	if err := checkErr(listResult, request.As); err != nil {
+		return err
+	}
+
+	body["rule_ids"] = completeMailRuleIDs(inputRuleIDs, extractMailRuleIDs(listResult))
+	request.Data = body
+	return nil
+}
+
+func isMailRuleReorder(opts *ServiceMethodOptions, request *client.RawApiRequest) bool {
+	if opts == nil {
+		return false
+	}
+	if opts.SchemaPath == "mail.user_mailbox.rules.reorder" || opts.Method.ID == "mail.user_mailbox.rules.reorder" {
+		return true
+	}
+	return strings.HasPrefix(opts.ServicePath, "/open-apis/mail/") &&
+		strings.Contains(request.URL, "/user_mailboxes/") &&
+		strings.HasSuffix(strings.TrimRight(request.URL, "/"), "/rules/reorder")
+}
+
+func mailRuleReorderBody(data interface{}) (map[string]interface{}, []string, error) {
+	body, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, nil, mailRuleIDsValidationError()
+	}
+	ruleIDs, ok := body["rule_ids"]
+	if !ok {
+		return nil, nil, mailRuleIDsValidationError()
+	}
+	ids := stringSlice(ruleIDs)
+	if len(ids) == 0 {
+		return nil, nil, mailRuleIDsValidationError()
+	}
+	return body, ids, nil
+}
+
+func mailRuleIDsValidationError() error {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must contain at least one id").WithParam("rule_ids")
+}
+
+func mailRuleListURL(reorderURL string) string {
+	return strings.TrimSuffix(strings.TrimRight(reorderURL, "/"), "/reorder")
+}
+
+func completeMailRuleIDs(inputRuleIDs, currentRuleIDs []string) []string {
+	userIDs := dedupeStrings(inputRuleIDs)
+	currentIDs := dedupeStrings(currentRuleIDs)
+	currentSet := make(map[string]bool, len(currentIDs))
+	for _, id := range currentIDs {
+		currentSet[id] = true
+	}
+	userSet := make(map[string]bool, len(userIDs))
+	var inCurrent []string
+	var notInCurrent []string
+	for _, id := range userIDs {
+		userSet[id] = true
+		if currentSet[id] {
+			inCurrent = append(inCurrent, id)
+		} else {
+			notInCurrent = append(notInCurrent, id)
+		}
+	}
+
+	out := append([]string{}, inCurrent...)
+	for _, id := range currentIDs {
+		if !userSet[id] {
+			out = append(out, id)
+		}
+	}
+	return append(out, notInCurrent...)
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func extractMailRuleIDs(result interface{}) []string {
+	if root, ok := result.(map[string]interface{}); ok {
+		if data, ok := root["data"].(map[string]interface{}); ok {
+			for _, key := range []string{"items", "rules", "rule_list", "user_mailbox_rules"} {
+				if ids := ruleIDsFromArray(data[key]); len(ids) > 0 {
+					return ids
+				}
+			}
+			return collectRuleIDs(data)
+		}
+	}
+	return collectRuleIDs(result)
+}
+
+func ruleIDsFromArray(value interface{}) []string {
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]interface{}); ok {
+			if id, ok := m["rule_id"]; ok {
+				ids = append(ids, fmt.Sprint(id))
+			}
+		}
+	}
+	return ids
+}
+
+func collectRuleIDs(value interface{}) []string {
+	switch typed := value.(type) {
+	case []interface{}:
+		var ids []string
+		for _, item := range typed {
+			ids = append(ids, collectRuleIDs(item)...)
+		}
+		return ids
+	case map[string]interface{}:
+		if id, ok := typed["rule_id"]; ok {
+			return []string{fmt.Sprint(id)}
+		}
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		var ids []string
+		for _, key := range keys {
+			ids = append(ids, collectRuleIDs(typed[key])...)
+		}
+		return ids
+	default:
+		return nil
+	}
+}
+
+func stringSlice(value interface{}) []string {
+	switch typed := value.(type) {
+	case []string:
+		return append([]string(nil), typed...)
+	case []interface{}:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, fmt.Sprint(item))
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -435,6 +435,10 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)
 	}
 
+	if err := maybeCompleteMailRuleReorderRequest(opts.Ctx, ac, opts, &request, checkErr); err != nil {
+		return err
+	}
+
 	resp, err := ac.DoAPI(opts.Ctx, request)
 	if err != nil {
 		return err

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -54,6 +54,225 @@ func driveMethod(httpMethod string, params map[string]interface{}) meta.Method {
 	return meta.FromMap(m)
 }
 
+func mailSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"id":         "mail.user_mailbox.rules.reorder",
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "list", "required": true},
+		},
+	})
+}
+
+func TestNewPreflightMissingScopeErrorUsesCanonicalFieldGate(t *testing.T) {
+	err := newPreflightMissingScopeError(
+		"feishu",
+		"cli_test",
+		"user",
+		[]string{"docx:document"},
+	)
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("error = %T, want *errs.PermissionError", err)
+	}
+	if permissionErr.Subtype != errs.SubtypeMissingScope {
+		t.Fatalf("subtype = %q, want %q", permissionErr.Subtype, errs.SubtypeMissingScope)
+	}
+	if permissionErr.ConsoleURL != "" {
+		t.Fatalf("missing_scope console_url = %q, want empty", permissionErr.ConsoleURL)
+	}
+	if len(permissionErr.MissingScopes) != 1 ||
+		permissionErr.MissingScopes[0] != "docx:document" ||
+		permissionErr.Identity != "user" {
+		t.Fatalf("permission facts = %+v", permissionErr)
+	}
+}
+
+func TestCompleteMailRuleIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		current []string
+		want    []string
+	}{
+		{
+			name:    "full input keeps user order",
+			input:   []string{"r2", "r1", "r3"},
+			current: []string{"r1", "r2", "r3"},
+			want:    []string{"r2", "r1", "r3"},
+		},
+		{
+			name:    "partial input appends omitted current rules",
+			input:   []string{"r2"},
+			current: []string{"r1", "r2", "r3"},
+			want:    []string{"r2", "r1", "r3"},
+		},
+		{
+			name:    "duplicate user ids keep first occurrence",
+			input:   []string{"r2", "r2", "r1"},
+			current: []string{"r1", "r2", "r3"},
+			want:    []string{"r2", "r1", "r3"},
+		},
+		{
+			name:    "invalid ids are retained at tail",
+			input:   []string{"r2", "foreign", "r1"},
+			current: []string{"r1", "r2", "r3"},
+			want:    []string{"r2", "r1", "r3", "foreign"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := completeMailRuleIDs(tt.input, tt.current)
+			if !slicesEqual(got, tt.want) {
+				t.Fatalf("completeMailRuleIDs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMailRuleReorderBodyRejectsEmptyRuleIDs(t *testing.T) {
+	_, _, err := mailRuleReorderBody(map[string]interface{}{"rule_ids": []interface{}{}})
+	if err == nil {
+		t.Fatal("expected empty rule_ids validation error")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T, want *errs.ValidationError", err)
+	}
+	if validationErr.Param != "rule_ids" {
+		t.Fatalf("param = %q, want rule_ids", validationErr.Param)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderCompletesRuleIDs(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	listStub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "r1"},
+					map[string]interface{}{"rule_id": "r2"},
+					map[string]interface{}{"rule_id": "r3"},
+				},
+			},
+		},
+	}
+	reorderStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	}
+	reg.Register(listStub)
+	reg.Register(reorderStub)
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["r2","r2","foreign","r1"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gotRuleIDs := capturedRuleIDs(t, reorderStub)
+	wantRuleIDs := []string{"r2", "r1", "r3", "foreign"}
+	if !slicesEqual(gotRuleIDs, wantRuleIDs) {
+		t.Fatalf("reorder rule_ids = %v, want %v", gotRuleIDs, wantRuleIDs)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderListFailurePreventsReorder(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body:   map[string]interface{}{"code": 230027, "msg": "list failed"},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["r1"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected list failure")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+}
+
+func TestServiceMethod_MailRulesReorderFailurePropagates(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{map[string]interface{}{"rule_id": "r1"}},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]interface{}{"code": 230027, "msg": "reorder failed"},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["r1"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected reorder failure")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+}
+
+func capturedRuleIDs(t *testing.T, stub *httpmock.Stub) []string {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("invalid captured reorder body: %v\n%s", err, string(stub.CapturedBody))
+	}
+	return stringSlice(body["rule_ids"])
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // ── registerService ──
 
 func TestRegisterService(t *testing.T) {

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -173,9 +173,9 @@ func TestServiceMethod_MailRulesReorderCompletesRuleIDs(t *testing.T) {
 			"code": 0, "msg": "ok",
 			"data": map[string]interface{}{
 				"items": []interface{}{
-					map[string]interface{}{"rule_id": "r1"},
-					map[string]interface{}{"rule_id": "r2"},
-					map[string]interface{}{"rule_id": "r3"},
+					map[string]interface{}{"id": "r1"},
+					map[string]interface{}{"id": "r2"},
+					map[string]interface{}{"id": "r3"},
 				},
 			},
 		},
@@ -202,6 +202,23 @@ func TestServiceMethod_MailRulesReorderCompletesRuleIDs(t *testing.T) {
 	wantRuleIDs := []string{"r2", "r1", "r3", "foreign"}
 	if !slicesEqual(gotRuleIDs, wantRuleIDs) {
 		t.Fatalf("reorder rule_ids = %v, want %v", gotRuleIDs, wantRuleIDs)
+	}
+}
+
+func TestExtractMailRuleIDsKeepsRuleIDFallback(t *testing.T) {
+	result := map[string]interface{}{
+		"data": map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{"rule_id": "legacy-r1"},
+				map[string]interface{}{"rule_id": "legacy-r2"},
+			},
+		},
+	}
+
+	got := extractMailRuleIDs(result)
+	want := []string{"legacy-r1", "legacy-r2"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("extractMailRuleIDs() = %v, want %v", got, want)
 	}
 }
 

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -155,9 +155,16 @@ func TestMailRuleReorderBodyRejectsEmptyRuleIDs(t *testing.T) {
 	if validationErr.Param != "rule_ids" {
 		t.Fatalf("param = %q, want rule_ids", validationErr.Param)
 	}
+	if validationErr.Category != errs.CategoryValidation {
+		t.Fatalf("category = %q, want %q", validationErr.Category, errs.CategoryValidation)
+	}
+	if validationErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("subtype = %q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+	}
 }
 
 func TestServiceMethod_MailRulesReorderCompletesRuleIDs(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
 	listStub := &httpmock.Stub{
 		Method: "GET",
@@ -199,6 +206,7 @@ func TestServiceMethod_MailRulesReorderCompletesRuleIDs(t *testing.T) {
 }
 
 func TestServiceMethod_MailRulesReorderListFailurePreventsReorder(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
@@ -221,6 +229,7 @@ func TestServiceMethod_MailRulesReorderListFailurePreventsReorder(t *testing.T) 
 }
 
 func TestServiceMethod_MailRulesReorderFailurePropagates(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
 	reg.Register(&httpmock.Stub{
 		Method: "GET",


### PR DESCRIPTION
## Summary
- list current mail receiving rules before invoking reorder
- complete partial user rule_ids with omitted current rules while preserving user intent
- keep duplicate handling, invalid IDs at tail, and existing error propagation covered by tests

## Tests
- go test ./cmd/service

Co-authored-by: TRAE CLI <noreply@bytedance.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail-rule reorder requests now complete automatically using the current rule list.
  * Requested existing rules retain their order, omitted rules are appended, and unknown rules are placed last.
  * Reordering supports both standard and legacy rule-order response formats.
* **Bug Fixes**
  * Added validation for empty or malformed rule-order data and removed duplicate rule IDs.
  * Improved error handling when retrieving the current rule list or submitting reordered rules fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->