### PR TITLE
fix(apps): reject non-HTML apps in +html-publish with actionable error

### DIFF
--- a/shortcuts/apps/apps_html_publish.go
+++ b/shortcuts/apps/apps_html_publish.go
@@ -260,10 +260,66 @@ func prepareHTMLPublishTarball(fio fileio.FileIO, path string) (*htmlPublishTarb
 	return tarball, nil
 }
 
+// htmlPublishableAppTypes is the whitelist of app types the +html-publish path
+// (pre_release → TOS upload → release-create --tos-path) can actually deploy.
+// frontend / full_stack apps build and ship through a different chain; the
+// backend rejects them from this path with an opaque business code
+// (400000059). queryAppType normalizes to lowercase, so keys are lowercase.
+var htmlPublishableAppTypes = map[string]bool{
+	"html":        true,
+	"modern_html": true,
+}
+
+// appTypeReleaseErrorCode is the backend business code returned when
+// release-create runs against an app whose type does not support the HTML
+// publish path. The precheck should catch this earlier via app_type; this
+// constant backs a defense-in-depth translation for the rare case the precheck
+// cannot see (e.g. the app_type changed between the precheck and release).
+const appTypeReleaseErrorCode = 400000059
+
+// ensureHTMLPublishable rejects a +html-publish request whose target app is not
+// an HTML-flavored app, before any packing or upload work happens. A failure to
+// resolve the app_type (e.g. a wrong/inaccessible --app-id, backend code
+// 400002577) is annotated with the shared +list recovery hint so the user gets
+// an actionable message instead of a raw business code.
+func ensureHTMLPublishable(ctx context.Context, rctx *common.RuntimeContext, appID string) error {
+	appType, err := queryAppType(ctx, rctx, appID)
+	if err != nil {
+		return withAppsHint(err, appIDListHint)
+	}
+	if htmlPublishableAppTypes[appType] {
+		return nil
+	}
+	return appsFailedPreconditionParamError("--app-id",
+		"app %s has app_type %q, which +html-publish cannot deploy (only html and modern_html apps are supported)",
+		appID, appType).
+		WithHint(fmt.Sprintf(
+			"a %s app ships through its own build/deploy chain; publish it with `lark-cli apps +release-create --app-id %s` instead",
+			appType, appID))
+}
+
+// isAppTypeReleaseError reports whether a release-create failure is the backend
+// "app_type not supported" rejection, matched on the business code or (as a
+// fallback channel) the message. Mirrors shouldRetryRoleMemberListWithoutFilter.
+func isAppTypeReleaseError(err error) bool {
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		return false
+	}
+	if problem.Code == appTypeReleaseErrorCode {
+		return true
+	}
+	return strings.Contains(strings.ToLower(problem.Message), "app_type")
+}
+
 // runHTMLPublishTOS handles the publish path: validate → tar.gz →
 // call pre_release to get TOS upload URL → upload tar.gz to TOS → return
 // tos_path for +release-create --tos-path.
 func runHTMLPublishTOS(ctx context.Context, rctx *common.RuntimeContext, spec appsHTMLPublishSpec) (map[string]interface{}, error) {
+	if err := ensureHTMLPublishable(ctx, rctx, spec.AppID); err != nil {
+		return nil, err
+	}
+
 	tarball, err := prepareHTMLPublishTarball(rctx.FileIO(), spec.Path)
 	if err != nil {
 		return nil, err
@@ -323,6 +379,14 @@ func runHTMLPublishTOS(ctx context.Context, rctx *common.RuntimeContext, spec ap
 		"tos_path": tosPath,
 	})
 	if err != nil {
+		// Defense in depth: the app_type precheck should have caught this, but
+		// if the type changed mid-flight the backend still rejects with an
+		// opaque code — translate it into the actionable +release-create hint.
+		if isAppTypeReleaseError(err) {
+			return nil, withAppsHint(err, fmt.Sprintf(
+				"this app_type cannot be published via +html-publish; use `lark-cli apps +release-create --app-id %s` instead",
+				spec.AppID))
+		}
 		return nil, err
 	}
 

--- a/shortcuts/apps/apps_html_publish_test.go
+++ b/shortcuts/apps/apps_html_publish_test.go
@@ -687,6 +687,53 @@ func TestRunHTMLPublishTOS_AppNotExist(t *testing.T) {
 	}
 }
 
+// TestRunHTMLPublishTOS_ReleaseAppTypeErrorTranslated pins the defense-in-depth
+// layer: the app_type precheck passes (HTML), pre_release and TOS upload
+// succeed, but release-create still returns the app_type business code
+// (400000059) — e.g. the type changed mid-flight. The opaque code must be
+// translated into the actionable +release-create hint rather than bubbling raw.
+func TestRunHTMLPublishTOS_ReleaseAppTypeErrorTranslated(t *testing.T) {
+	site := writeAppsSampleSite(t)
+	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "HTML")
+
+	tosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer tosServer.Close()
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/spark/v1/apps/app_tos/pre_release",
+		Body: map[string]interface{}{
+			"code": float64(0),
+			"data": map[string]interface{}{
+				"kvs": []interface{}{
+					map[string]interface{}{"key": "upload_url", "value": tosServer.URL},
+					map[string]interface{}{"key": "tos_path", "value": "tos://bucket/key"},
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/spark/v1/apps/app_tos/releases",
+		Body:   map[string]interface{}{"code": float64(400000059), "msg": "app_type invalid"},
+	})
+
+	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: site})
+	if err == nil {
+		t.Fatalf("expected error from release-create app_type rejection")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T: %v", err, err)
+	}
+	if !strings.Contains(problem.Hint, "+release-create") {
+		t.Fatalf("release-create app_type rejection should be translated to a +release-create hint, got %q", problem.Hint)
+	}
+}
+
 func TestRunHTMLPublishTOS_Success(t *testing.T) {
 	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)

--- a/shortcuts/apps/apps_html_publish_test.go
+++ b/shortcuts/apps/apps_html_publish_test.go
@@ -541,9 +541,156 @@ func newTOSTestRuntime(t *testing.T) (*common.RuntimeContext, *httpmock.Registry
 	return rt, reg
 }
 
+// registerAppTypeStub registers the GET /apps/{id} stub that the app_type
+// precheck at the top of runHTMLPublishTOS issues via queryAppType. appType is
+// the uppercase server value ("HTML", "FULL_STACK", ...); queryAppType
+// normalizes it to lowercase. The bare /apps/{id} URL is not a substring of the
+// downstream /apps/{id}/pre_release or /apps/{id}/releases stubs, so httpmock
+// resolution stays order-independent.
+func registerAppTypeStub(reg *httpmock.Registry, appID, appType string) {
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/spark/v1/apps/" + appID,
+		Body: map[string]interface{}{
+			"code": float64(0),
+			"data": map[string]interface{}{
+				"app": map[string]interface{}{
+					"app_id":   appID,
+					"app_type": appType,
+				},
+			},
+		},
+	})
+}
+
+// failIfCalled returns an OnMatch hook that fails the test if a stub is hit,
+// proving the app_type precheck short-circuited before that downstream step.
+func failIfCalled(t *testing.T, step string) func(*http.Request) {
+	t.Helper()
+	return func(*http.Request) { t.Errorf("precheck should have rejected before %s", step) }
+}
+
+func TestRunHTMLPublishTOS_RejectsFullStack(t *testing.T) {
+	site := writeAppsSampleSite(t)
+	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "FULL_STACK")
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/apps/app_tos/pre_release",
+		Optional: true,
+		OnMatch:  failIfCalled(t, "pre_release"),
+		Body:     map[string]interface{}{"code": float64(0)},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/apps/app_tos/releases",
+		Optional: true,
+		OnMatch:  failIfCalled(t, "release-create"),
+		Body:     map[string]interface{}{"code": float64(0)},
+	})
+
+	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: site})
+	problem := requireAppsProblem(t, err, errs.CategoryValidation)
+	if problem.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("subtype=%q, want %q", problem.Subtype, errs.SubtypeFailedPrecondition)
+	}
+	if !strings.Contains(problem.Message, "full_stack") {
+		t.Fatalf("message should name the rejected app_type, got %q", problem.Message)
+	}
+	if !strings.Contains(problem.Hint, "+release-create") {
+		t.Fatalf("hint should redirect to +release-create, got %q", problem.Hint)
+	}
+}
+
+func TestRunHTMLPublishTOS_RejectsFrontend(t *testing.T) {
+	site := writeAppsSampleSite(t)
+	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "FRONTEND")
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/apps/app_tos/pre_release",
+		Optional: true,
+		OnMatch:  failIfCalled(t, "pre_release"),
+		Body:     map[string]interface{}{"code": float64(0)},
+	})
+
+	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: site})
+	problem := requireAppsProblem(t, err, errs.CategoryValidation)
+	if problem.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("subtype=%q, want %q", problem.Subtype, errs.SubtypeFailedPrecondition)
+	}
+	if !strings.Contains(problem.Message, "frontend") {
+		t.Fatalf("message should name the rejected app_type, got %q", problem.Message)
+	}
+}
+
+func TestRunHTMLPublishTOS_AllowsModernHTML(t *testing.T) {
+	site := writeAppsSampleSite(t)
+	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "MODERN_HTML")
+
+	tosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer tosServer.Close()
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/spark/v1/apps/app_tos/pre_release",
+		Body: map[string]interface{}{
+			"code": float64(0),
+			"data": map[string]interface{}{
+				"kvs": []interface{}{
+					map[string]interface{}{"key": "upload_url", "value": tosServer.URL},
+					map[string]interface{}{"key": "tos_path", "value": "tos://bucket/key"},
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/spark/v1/apps/app_tos/releases",
+		Body: map[string]interface{}{
+			"code": float64(0),
+			"data": map[string]interface{}{"release_id": "rel_mh", "status": "publishing"},
+		},
+	})
+
+	out, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: site})
+	if err != nil {
+		t.Fatalf("modern_html should be publishable, got err=%v", err)
+	}
+	if out["release_id"] != "rel_mh" {
+		t.Fatalf("release_id=%v, want rel_mh", out["release_id"])
+	}
+}
+
+func TestRunHTMLPublishTOS_AppNotExist(t *testing.T) {
+	site := writeAppsSampleSite(t)
+	rt, reg := newTOSTestRuntime(t)
+	// queryAppType resolves the app first; a non-existent app surfaces the
+	// backend "app not exist" business code (400002577). The precheck must
+	// translate it into the actionable +list hint (#8), not leak the raw code.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/spark/v1/apps/app_tos",
+		Body:   map[string]interface{}{"code": float64(400002577), "msg": "app not exist"},
+	})
+
+	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: site})
+	if err == nil {
+		t.Fatalf("expected error for non-existent app")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T: %v", err, err)
+	}
+	if !strings.Contains(problem.Hint, "+list") {
+		t.Fatalf("hint should point to +list to find the right app_id, got %q", problem.Hint)
+	}
+}
+
 func TestRunHTMLPublishTOS_Success(t *testing.T) {
 	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "HTML")
 
 	// Start httptest server to accept the TOS upload.
 	tosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -604,7 +751,8 @@ func TestRunHTMLPublishTOS_MissingIndexHTML(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	rt, _ := newTOSTestRuntime(t)
+	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "HTML")
 	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{
 		AppID: "app_tos",
 		Path:  dir,
@@ -620,6 +768,7 @@ func TestRunHTMLPublishTOS_MissingIndexHTML(t *testing.T) {
 func TestRunHTMLPublishTOS_PreReleaseError(t *testing.T) {
 	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "HTML")
 
 	// Register pre_release API stub that returns an error code.
 	reg.Register(&httpmock.Stub{
@@ -643,6 +792,7 @@ func TestRunHTMLPublishTOS_PreReleaseError(t *testing.T) {
 func TestRunHTMLPublishTOS_MissingParams(t *testing.T) {
 	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "HTML")
 
 	// Register pre_release API stub that returns empty kvs list.
 	reg.Register(&httpmock.Stub{
@@ -672,6 +822,7 @@ func TestRunHTMLPublishTOS_MissingParams(t *testing.T) {
 func TestRunHTMLPublishTOS_MissingParamsObject(t *testing.T) {
 	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "HTML")
 
 	// Register pre_release API stub that returns no kvs key at all.
 	reg.Register(&httpmock.Stub{
@@ -699,6 +850,7 @@ func TestRunHTMLPublishTOS_MissingParamsObject(t *testing.T) {
 func TestRunHTMLPublishTOS_UploadFails(t *testing.T) {
 	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)
+	registerAppTypeStub(reg, "app_tos", "HTML")
 
 	// Start httptest server that returns 500.
 	tosServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/shortcuts/apps/apps_html_publish_test.go
+++ b/shortcuts/apps/apps_html_publish_test.go
@@ -571,7 +571,6 @@ func failIfCalled(t *testing.T, step string) func(*http.Request) {
 }
 
 func TestRunHTMLPublishTOS_RejectsFullStack(t *testing.T) {
-	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)
 	registerAppTypeStub(reg, "app_tos", "FULL_STACK")
 	reg.Register(&httpmock.Stub{
@@ -587,7 +586,12 @@ func TestRunHTMLPublishTOS_RejectsFullStack(t *testing.T) {
 		Body:     map[string]interface{}{"code": float64(0)},
 	})
 
-	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: site})
+	// A nonexistent --path proves the precheck short-circuits before any
+	// packaging: if the precheck ever moved below prepareHTMLPublishTarball,
+	// walkHTMLPublishCandidates would fail first with a different (non
+	// FailedPrecondition) error and this test would break.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: missing})
 	problem := requireAppsProblem(t, err, errs.CategoryValidation)
 	if problem.Subtype != errs.SubtypeFailedPrecondition {
 		t.Fatalf("subtype=%q, want %q", problem.Subtype, errs.SubtypeFailedPrecondition)
@@ -601,7 +605,6 @@ func TestRunHTMLPublishTOS_RejectsFullStack(t *testing.T) {
 }
 
 func TestRunHTMLPublishTOS_RejectsFrontend(t *testing.T) {
-	site := writeAppsSampleSite(t)
 	rt, reg := newTOSTestRuntime(t)
 	registerAppTypeStub(reg, "app_tos", "FRONTEND")
 	reg.Register(&httpmock.Stub{
@@ -611,7 +614,9 @@ func TestRunHTMLPublishTOS_RejectsFrontend(t *testing.T) {
 		Body:     map[string]interface{}{"code": float64(0)},
 	})
 
-	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: site})
+	// Nonexistent --path: see the rationale in TestRunHTMLPublishTOS_RejectsFullStack.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := runHTMLPublishTOS(context.Background(), rt, appsHTMLPublishSpec{AppID: "app_tos", Path: missing})
 	problem := requireAppsProblem(t, err, errs.CategoryValidation)
 	if problem.Subtype != errs.SubtypeFailedPrecondition {
 		t.Fatalf("subtype=%q, want %q", problem.Subtype, errs.SubtypeFailedPrecondition)

--- a/shortcuts/apps/apps_html_publish_test.go
+++ b/shortcuts/apps/apps_html_publish_test.go
@@ -544,9 +544,11 @@ func newTOSTestRuntime(t *testing.T) (*common.RuntimeContext, *httpmock.Registry
 // registerAppTypeStub registers the GET /apps/{id} stub that the app_type
 // precheck at the top of runHTMLPublishTOS issues via queryAppType. appType is
 // the uppercase server value ("HTML", "FULL_STACK", ...); queryAppType
-// normalizes it to lowercase. The bare /apps/{id} URL is not a substring of the
-// downstream /apps/{id}/pre_release or /apps/{id}/releases stubs, so httpmock
-// resolution stays order-independent.
+// normalizes it to lowercase. httpmock matches a stub when the request URL
+// contains stub.URL (strings.Contains). queryAppType requests the bare
+// /apps/{id} path, which cannot contain a longer /apps/{id}/pre_release or
+// /apps/{id}/releases stub URL, so it only ever matches this app_type stub —
+// resolution stays unambiguous regardless of registration order.
 func registerAppTypeStub(reg *httpmock.Registry, appID, appType string) {
 	reg.Register(&httpmock.Stub{
 		Method: "GET",


### PR DESCRIPTION
## Summary
`apps +html-publish` only supports html/modern_html apps, but non-HTML apps (frontend/full_stack) and non-existent apps used to fail partway through with opaque backend business codes (`400000059` app_type invalid, `400002577` app not exist). This adds a client-side app_type precheck that rejects unsupported apps up front with a readable message and an actionable recovery hint.

## Changes
- Add an app_type whitelist precheck at the top of `runHTMLPublishTOS` (Execute path): resolve type via `queryAppType`, allow only `html`/`modern_html`, reject others with `FailedPrecondition` naming the type and redirecting to `+release-create`.
- Translate a failed app lookup (wrong/inaccessible `--app-id`, code `400002577`) into the shared `+list` recovery hint instead of bubbling the raw code — no new error-code constant.
- Defense in depth: if `release-create` still returns `400000059` (type changed mid-flight), translate it via a code-OR-message dual channel into a `+release-create` hint.
- No new bypass flag, no Validate change, no Scopes change (html-publish already declares `spark:app:read`).

## Test Plan
- [x] Unit tests pass — `go test ./shortcuts/apps/` (full package green; new tests: RejectsFullStack/RejectsFrontend/AllowsModernHTML/AppNotExist/ReleaseAppTypeErrorTranslated + patched existing runHTMLPublishTOS network tests)
- [x] `go vet ./shortcuts/apps/` clean, `gofmt -l` empty
- [x] Manual local verification: built binary, `apps +html-publish --help` registration + flags unchanged, `--dry-run` regression prints plan and exits 0

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTML publishing now validates the app type before packaging or uploading.
  * Publishing is limited to supported HTML app types; unsupported types receive actionable guidance.
  * Improved error messages for missing apps and release failures caused by incompatible app types.
  * Prevents publishing workflows from making downstream requests when validation fails.

* **Tests**
  * Added coverage for supported, unsupported, nonexistent, and release-time app type scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->