### PR TITLE
chore: release v1.0.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.86] - 2026-08-11
+
+### Features
+
+- **drive**: add wiki url/token support to +download and +preview (#2220)
+- report upload file events (#2093)
+- **slides**: normalize replace-slide part aliases (#2225)
+- **drive**: add +member-remove shortcut (#1994)
+- support shared vc live references and document context (#2249)
+- **wiki**: improve node creation and terminal errors (#2266)
+- **base**: require --fields on +table-create (#2221)
+- support bot identity (#2288)
+- **affordance**: support domain skill lists (#2291)
+- expose compact task fields (#2109)
+- **drive**: document copy workflow guidance (#2184)
+- add apps database sync shortcuts for Base-to-database import (#2251)
+- **apps**: add +user-id-convert shortcut for Miaoda↔Feishu ID conversion (#2270)
+- **slides**: inline slides reference docs into help output (#2181)
+
+### Bug Fixes
+
+- **wiki**: correct copy semantics and rename routing (#2238)
+- **slides**: move add-slide and delete-slide reference docs to cli/ directory (#2272)
+- **drive**: harden export and push failure recovery (#2279)
+- **wiki**: clarify resource permission recovery (#2281)
+
+### Documentation
+
+- improve agent contribution guidance (#2259)
+- document supported image formats in lark-slides media-upload (#2269)
+- **calendar**: clarify identity selection for scheduling (#2280)
+- **slides**: use built-in --jq in cli examples and fix workflow link labels (#2286)
+
+### Refactoring
+
+- reorganize lark slides skill references (#2207)
+
+### Misc
+
+- prune unsupported iconpark index entries (#2252)
+- verify release Go toolchain (#2256)
+
 ## [v1.0.85] - 2026-08-07
 
 ### Features
@@ -1860,6 +1902,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.86]: https://github.com/larksuite/cli/releases/tag/v1.0.86
 [v1.0.85]: https://github.com/larksuite/cli/releases/tag/v1.0.85
 [v1.0.84]: https://github.com/larksuite/cli/releases/tag/v1.0.84
 [v1.0.83]: https://github.com/larksuite/cli/releases/tag/v1.0.83

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.85",
+  "version": "1.0.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@larksuite/cli",
-      "version": "1.0.85",
+      "version": "1.0.86",
       "cpu": [
         "x64",
         "arm64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.85",
+  "version": "1.0.86",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

| Field | Value |
| --- | --- |
| Current version | `1.0.85` |
| Release version | `1.0.86` |
| Tag | `v1.0.86` |
| Branch | `release/v1.0.86` |
| Date | `2026-08-11` |

## Changes

- fix(wiki): correct copy semantics and rename routing (#2238)
- feat(drive): add wiki url/token support to +download and +preview (#2220)
- refactor: reorganize lark slides skill references (#2207)
- chore: prune unsupported iconpark index entries (#2252)
- feat: report upload file events (#2093)
- feat(slides): normalize replace-slide part aliases (#2225)
- docs: improve agent contribution guidance (#2259)
- docs: document supported image formats in lark-slides media-upload (#2269)
- feat(drive): add +member-remove shortcut (#1994)
- fix(slides): move add-slide and delete-slide reference docs to cli/ directory (#2272)
- feat: support shared vc live references and document context (#2249)
- feat(wiki): improve node creation and terminal errors (#2266)
- feat(base): require --fields on +table-create (#2221)
- fix(drive): harden export and push failure recovery (#2279)
- fix(wiki): clarify resource permission recovery (#2281)
- feat: support bot identity (#2288)
- feat(affordance): support domain skill lists (#2291)
- docs(calendar): clarify identity selection for scheduling (#2280)
- docs(slides): use built-in --jq in cli examples and fix workflow link labels (#2286)
- feat: expose compact task fields (#2109)
- feat(drive): document copy workflow guidance (#2184)
- feat: add apps database sync shortcuts for Base-to-database import (#2251)
- ci: verify release Go toolchain (#2256)
- feat(apps): add +user-id-convert shortcut for Miaoda↔Feishu ID conversion (#2270)
- feat(slides): inline slides reference docs into help output (#2181)

## Files Changed

- `package.json`
- `package-lock.json`
- `CHANGELOG.md`

## Review Checklist

- [ ] Version bump is intentional and package metadata versions match
- [ ] CHANGELOG.md reflects the merged PRs
- [ ] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version **1.0.86**.
  * Added release notes covering the latest features, bug fixes, documentation updates, and refinements.
  * Added a reference link to the corresponding GitHub release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->