### PR TITLE
fix(apps): friendly-ize "Container not exists" for observability commands

### DIFF
--- a/internal/errclass/codemeta_spark.go
+++ b/internal/errclass/codemeta_spark.go
@@ -26,6 +26,7 @@ var sparkCodeMeta = map[int]CodeMeta{
 
 	400002465: {Category: errs.CategoryValidation, Subtype: errs.SubtypeFailedPrecondition}, // app has no database yet
 	500002759: {Category: errs.CategoryValidation, Subtype: errs.SubtypeFailedPrecondition}, // app has no database yet, pre-4xx renumber
+	400002655: {Category: errs.CategoryValidation, Subtype: errs.SubtypeFailedPrecondition}, // app has no running container yet (online observability)
 	400002469: {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                  // table does not exist
 
 	400002477: {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters},         // db sync mapping is invalid

--- a/internal/errclass/codemeta_spark_test.go
+++ b/internal/errclass/codemeta_spark_test.go
@@ -33,6 +33,7 @@ func TestLookupCodeMetaSparkRoleCodes(t *testing.T) {
 		{3344041, errs.CategoryAPI, errs.SubtypeInvalidParameters},
 		{400002465, errs.CategoryValidation, errs.SubtypeFailedPrecondition},
 		{500002759, errs.CategoryValidation, errs.SubtypeFailedPrecondition},
+		{400002655, errs.CategoryValidation, errs.SubtypeFailedPrecondition},
 		{400002469, errs.CategoryAPI, errs.SubtypeNotFound},
 	}
 

--- a/shortcuts/apps/apps_analytics.go
+++ b/shortcuts/apps/apps_analytics.go
@@ -63,7 +63,7 @@ var AppsAnalyticsList = common.Shortcut{
 		}
 		data, err := rctx.CallAPITyped("POST", analyticsListPath(appID), nil, body)
 		if err != nil {
-			return withAppsHint(err, appIDListHint)
+			return withObservabilityHint(err)
 		}
 		out := observabilitySeriesOutput{
 			Items:   normalizeAnalyticsSeries(data, types, labels),

--- a/shortcuts/apps/apps_metrics.go
+++ b/shortcuts/apps/apps_metrics.go
@@ -68,7 +68,7 @@ var AppsMetricList = common.Shortcut{
 		}
 		data, err := rctx.CallAPITyped("POST", metricListPath(appID), nil, body)
 		if err != nil {
-			return withAppsHint(err, appIDListHint)
+			return withObservabilityHint(err)
 		}
 		out := observabilitySeriesOutput{
 			Items:   normalizeMetricSeries(data, names, labels, fillZero),

--- a/shortcuts/apps/apps_observability_execute_test.go
+++ b/shortcuts/apps/apps_observability_execute_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package apps
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+// The two observability commands must route their API failures through
+// withObservabilityHint, not the generic withAppsHint. common_test.go proves the
+// helper in isolation, but that stays green if a call site reverts to
+// withAppsHint — so these command-level tests drive the real Execute path with a
+// mocked "Container not exists" (400002655) envelope and assert the
+// container-specific rewrite. A revert to withAppsHint would leave the raw
+// message and swap in the app-id hint, failing both assertions.
+
+func TestAppsMetricList_NoContainerRewriteThroughExecute(t *testing.T) {
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    metricListPath("app_x"),
+		Body:   map[string]interface{}{"code": appNoContainerCode, "msg": "Container not exists"},
+	})
+
+	err := runAppsShortcut(t, AppsMetricList, []string{
+		"+metric-list", "--app-id", "app_x", "--metric", "requests", "--as", "user",
+	}, factory, stdout)
+
+	p := requireAppsAPIProblem(t, err)
+	if p.Code != appNoContainerCode {
+		t.Errorf("Code = %d, want %d", p.Code, appNoContainerCode)
+	}
+	if p.Message != appNoContainerMessage {
+		t.Errorf("Message = %q, want container rewrite %q (call site may have reverted to withAppsHint)", p.Message, appNoContainerMessage)
+	}
+	if p.Hint != appNoContainerHint {
+		t.Errorf("Hint = %q, want deploy hint %q (call site may have reverted to withAppsHint)", p.Hint, appNoContainerHint)
+	}
+}
+
+func TestAppsAnalyticsList_NoContainerRewriteThroughExecute(t *testing.T) {
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    analyticsListPath("app_x"),
+		Body:   map[string]interface{}{"code": appNoContainerCode, "msg": "Container not exists"},
+	})
+
+	err := runAppsShortcut(t, AppsAnalyticsList, []string{
+		"+analytics-list", "--app-id", "app_x", "--analytics", "users", "--as", "user",
+	}, factory, stdout)
+
+	p := requireAppsAPIProblem(t, err)
+	if p.Code != appNoContainerCode {
+		t.Errorf("Code = %d, want %d", p.Code, appNoContainerCode)
+	}
+	if p.Message != appNoContainerMessage {
+		t.Errorf("Message = %q, want container rewrite %q (call site may have reverted to withAppsHint)", p.Message, appNoContainerMessage)
+	}
+	if p.Hint != appNoContainerHint {
+		t.Errorf("Hint = %q, want deploy hint %q (call site may have reverted to withAppsHint)", p.Hint, appNoContainerHint)
+	}
+}

--- a/shortcuts/apps/apps_observability_execute_test.go
+++ b/shortcuts/apps/apps_observability_execute_test.go
@@ -29,7 +29,7 @@ func TestAppsMetricList_NoContainerRewriteThroughExecute(t *testing.T) {
 		"+metric-list", "--app-id", "app_x", "--metric", "requests", "--as", "user",
 	}, factory, stdout)
 
-	p := requireAppsAPIProblem(t, err)
+	p := requireAppsValidationProblem(t, err)
 	if p.Code != appNoContainerCode {
 		t.Errorf("Code = %d, want %d", p.Code, appNoContainerCode)
 	}
@@ -53,7 +53,7 @@ func TestAppsAnalyticsList_NoContainerRewriteThroughExecute(t *testing.T) {
 		"+analytics-list", "--app-id", "app_x", "--analytics", "users", "--as", "user",
 	}, factory, stdout)
 
-	p := requireAppsAPIProblem(t, err)
+	p := requireAppsValidationProblem(t, err)
 	if p.Code != appNoContainerCode {
 		t.Errorf("Code = %d, want %d", p.Code, appNoContainerCode)
 	}

--- a/shortcuts/apps/common.go
+++ b/shortcuts/apps/common.go
@@ -65,10 +65,15 @@ const appNoContainerCode = 400002655
 // It replaces the infra-sounding "Container not exists" with the actual cause.
 const appNoContainerMessage = "this app has no running container; online metrics and analytics are only produced after the app is deployed and serving traffic"
 
-// appNoContainerHint guides deploying the app so observability data starts
-// flowing. It uses an existing command with a stable placeholder arg so a
-// harness can act on it without parsing natural-language error text.
-const appNoContainerHint = "confirm the app is deployed and running in the online environment (a newly created or undeployed app produces no metrics yet); deploy it with `lark-cli apps +release-create --app-id <app_id>`, then retry once it is serving traffic"
+// appNoContainerHint guides diagnosing and (only with user authorization)
+// deploying the app so observability data starts flowing. Deploying via
+// +release-create is a "write" that takes the whole app live and can affect
+// existing production traffic, so — like appNoDatabaseHint — the hint gates
+// that go-live behind an explicit user confirmation and leads with a read-only
+// status check; a failed metrics read alone does not authorize a release. It
+// names existing commands with a stable placeholder arg so a harness can act on
+// it without parsing natural-language error text.
+const appNoContainerHint = "check the app's deployment status with `lark-cli apps +release-list --app-id <app_id> --status finished` (a newly created or undeployed app has no finished release, so it produces no metrics yet); if it is not deployed, ask the user whether to deploy — deploying takes the whole app live and can affect existing production traffic — and only if confirmed run `lark-cli apps +release-create --app-id <app_id>`, then retry once it is serving traffic"
 
 // appNoContainerMessageMarkers are lowercase substrings of the raw "Container
 // not exists" server message, used as a fallback when the business code is not

--- a/shortcuts/apps/common.go
+++ b/shortcuts/apps/common.go
@@ -50,6 +50,80 @@ const appNoDatabaseMessage = "this app does not have a database yet"
 // user before starting a +chat.
 const appNoDatabaseHint = "ask the user whether to add a database through Miaoda cloud development; if confirmed, run `lark-cli apps +session-list --app-id <app_id>` and reuse an active session, or run `lark-cli apps +session-create --app-id <app_id>`; send the database requirement with `lark-cli apps +chat --app-id <app_id> --session-id <session_id> --message \"<database requirement>\"`, poll `lark-cli apps +session-get --app-id <app_id> --session-id <session_id>` until `latest_turn.status=completed`, then retry the original db command"
 
+// appNoContainerCode is the Spark business code returned by the online
+// observability endpoints (query_metrics_data / query_analytics_data) when the
+// target app has no running container/deployment. It is an expected business
+// state, not a system fault: an app that is not deployed and serving traffic
+// produces no client_api_request metrics or analytics to query. The raw upstream
+// message is "Container not exists", which reads like an infrastructure failure
+// and misleads callers (including AI agents) into retrying a non-retryable,
+// expected state — so the observability commands rewrite it into a user-facing
+// explanation with a deploy-then-retry next step (see withObservabilityHint).
+const appNoContainerCode = 400002655
+
+// appNoContainerMessage is the user-facing explanation for appNoContainerCode.
+// It replaces the infra-sounding "Container not exists" with the actual cause.
+const appNoContainerMessage = "this app has no running container; online metrics and analytics are only produced after the app is deployed and serving traffic"
+
+// appNoContainerHint guides deploying the app so observability data starts
+// flowing. It uses an existing command with a stable placeholder arg so a
+// harness can act on it without parsing natural-language error text.
+const appNoContainerHint = "confirm the app is deployed and running in the online environment (a newly created or undeployed app produces no metrics yet); deploy it with `lark-cli apps +release-create --app-id <app_id>`, then retry once it is serving traffic"
+
+// appNoContainerMessageMarkers are lowercase substrings of the raw "Container
+// not exists" server message, used as a fallback when the business code is not
+// the one the CLI knows. A bare numeric literal is not a stable signal — the
+// no-database case (see isAppNoDatabaseError) was silently dropped when the
+// server renumbered it, with nothing in CI to catch it — so detection is
+// code-OR-message here too. "not exist" (no trailing s) matches both
+// "Container not exists" and a possible "Container not exist".
+var appNoContainerMessageMarkers = []string{
+	"container not exist",
+}
+
+// isAppNoContainerError reports whether a typed observability failure is "this
+// app has no running container", matching on business code OR raw server
+// message for the same code-vs-message stability trade-off documented on
+// isAppNoDatabaseError. Only consulted from the observability helper
+// (withObservabilityHint), so the message marker is scoped to observability
+// context and cannot hijack unrelated apps failures.
+func isAppNoContainerError(p *errs.Problem) bool {
+	if p == nil {
+		return false
+	}
+	if p.Code == appNoContainerCode {
+		return true
+	}
+	message := strings.ToLower(p.Message)
+	for _, marker := range appNoContainerMessageMarkers {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// withObservabilityHint wraps an online observability (metric/analytics) API
+// failure. It first rewrites the "app has no running container" business state
+// into a user-facing explanation, since the raw "Container not exists" upstream
+// message reads like an infra fault and drives non-retryable retries; any other
+// failure falls through to the shared app-id recovery hint (which still applies
+// its own no-database override). Scoped to the two observability commands rather
+// than the global withAppsHint chokepoint because 400002655 is not known to be
+// observability-exclusive, and the message-marker fallback must not reach
+// unrelated commands. err==nil and untyped errors pass through unchanged.
+func withObservabilityHint(err error) error {
+	if err == nil {
+		return nil
+	}
+	if p, ok := errs.ProblemOf(err); ok && isAppNoContainerError(p) {
+		p.Message = appNoContainerMessage
+		p.Hint = appNoContainerHint
+		return err
+	}
+	return withAppsHint(err, appIDListHint)
+}
+
 // withAppsHint attaches an actionable next-step hint to a typed failure,
 // preserving its original classification (subtype/code/log_id). A hint already
 // present on the error is kept (the upstream wording wins); only an empty hint

--- a/shortcuts/apps/common_test.go
+++ b/shortcuts/apps/common_test.go
@@ -205,3 +205,129 @@ func TestIsAppNoDatabaseError_NilProblem(t *testing.T) {
 		t.Error("isAppNoDatabaseError(nil) = true, want false")
 	}
 }
+
+func TestWithObservabilityHint(t *testing.T) {
+	// assertObservabilityClassificationIntact checks that rewriting Message/Hint
+	// leaves the discriminators the error envelope keys on untouched and hands
+	// back the same error value so the cause chain survives.
+	assertObservabilityClassificationIntact := func(t *testing.T, label string, in, out error, wantSubtype errs.Subtype, wantCode int) {
+		t.Helper()
+		if out != in {
+			t.Fatalf("%s: returned a different error value: got %p, want original %p", label, out, in)
+		}
+		p, ok := errs.ProblemOf(out)
+		if !ok {
+			t.Fatalf("%s: returned error is not typed: %T", label, out)
+		}
+		if p.Category != errs.CategoryAPI {
+			t.Errorf("%s: Category = %q, want %q", label, p.Category, errs.CategoryAPI)
+		}
+		if p.Subtype != wantSubtype {
+			t.Errorf("%s: Subtype = %q, want %q", label, p.Subtype, wantSubtype)
+		}
+		if p.Code != wantCode {
+			t.Errorf("%s: Code = %d, want %d", label, p.Code, wantCode)
+		}
+	}
+
+	t.Run("nil error stays nil", func(t *testing.T) {
+		if got := withObservabilityHint(nil); got != nil {
+			t.Fatalf("withObservabilityHint(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("untyped error returned unchanged, no panic", func(t *testing.T) {
+		in := errors.New("plain")
+		out := withObservabilityHint(in)
+		if out == nil || out.Error() != "plain" {
+			t.Fatalf("withObservabilityHint(plain) = %v, want unchanged plain error", out)
+		}
+	})
+
+	t.Run("no-container code rewrites the infra-sounding message and forces deploy hint", func(t *testing.T) {
+		// Raw upstream: infra-sounding message, no hint. A concrete subtype (not
+		// Unknown) proves the override only rewrites Message/Hint.
+		in := errs.NewAPIError(errs.SubtypeNotFound, "Container not exists").WithCode(appNoContainerCode)
+		out := withObservabilityHint(in)
+		p, _ := errs.ProblemOf(out)
+		if p.Message != appNoContainerMessage {
+			t.Errorf("Message = %q, want rewritten %q", p.Message, appNoContainerMessage)
+		}
+		if p.Hint != appNoContainerHint {
+			t.Errorf("Hint = %q, want deploy hint (not the generic app-id hint)", p.Hint)
+		}
+		assertObservabilityClassificationIntact(t, "no-container code", in, out, errs.SubtypeNotFound, appNoContainerCode)
+	})
+
+	t.Run("no-container detected by server message when code is unknown", func(t *testing.T) {
+		// A future/other code the CLI has not enumerated: only the raw message
+		// identifies the case. Covers case-insensitivity and the "not exist"
+		// (no trailing s) variant.
+		for _, msg := range []string{"Container not exists", "container not exist", "CONTAINER NOT EXISTS"} {
+			in := errs.NewAPIError(errs.SubtypeNotFound, msg).WithCode(999999999)
+			out := withObservabilityHint(in)
+			p, _ := errs.ProblemOf(out)
+			if p.Message != appNoContainerMessage || p.Hint != appNoContainerHint {
+				t.Errorf("message %q not detected: Message=%q Hint=%q", msg, p.Message, p.Hint)
+			}
+			assertObservabilityClassificationIntact(t, "message "+msg, in, out, errs.SubtypeNotFound, 999999999)
+		}
+	})
+
+	t.Run("no-container rewrite preserves the wrapped cause", func(t *testing.T) {
+		cause := errors.New("upstream transport failure")
+		in := errs.NewAPIError(errs.SubtypeNotFound, "Container not exists").
+			WithCode(appNoContainerCode).WithCause(cause)
+		out := withObservabilityHint(in)
+		if !errors.Is(out, cause) {
+			t.Errorf("cause chain lost: errors.Is(out, cause) = false")
+		}
+		p, _ := errs.ProblemOf(out)
+		if p.Message != appNoContainerMessage {
+			t.Errorf("Message = %q, want %q", p.Message, appNoContainerMessage)
+		}
+	})
+
+	t.Run("no-container code overrides even a preexisting upstream hint", func(t *testing.T) {
+		in := errs.NewAPIError(errs.SubtypeUnknown, "Container not exists").
+			WithCode(appNoContainerCode).WithHint("upstream hint")
+		out := withObservabilityHint(in)
+		p, _ := errs.ProblemOf(out)
+		if p.Hint != appNoContainerHint {
+			t.Errorf("Hint = %q, want deploy hint to override upstream hint", p.Hint)
+		}
+	})
+
+	t.Run("unrelated failure falls through to the app-id hint", func(t *testing.T) {
+		// A generic observability failure (wrong/inaccessible app-id) must get the
+		// shared app-id recovery hint, not the container rewrite.
+		in := errs.NewAPIError(errs.SubtypeNotFound, "app not found").WithCode(404)
+		out := withObservabilityHint(in)
+		p, _ := errs.ProblemOf(out)
+		if p.Message != "app not found" {
+			t.Errorf("Message = %q, want unchanged %q", p.Message, "app not found")
+		}
+		if p.Hint != appIDListHint {
+			t.Errorf("Hint = %q, want app-id hint %q", p.Hint, appIDListHint)
+		}
+		assertObservabilityClassificationIntact(t, "unrelated", in, out, errs.SubtypeNotFound, 404)
+	})
+
+	t.Run("no-database override still applies through observability path", func(t *testing.T) {
+		// withObservabilityHint falls through to withAppsHint, which retains its
+		// own no-database override; a db-less app queried via observability still
+		// gets the cloud-dev recovery, not the raw internal message.
+		in := errs.NewAPIError(errs.SubtypeNotFound, "workspace has no db branch").WithCode(appNoDatabaseCode)
+		out := withObservabilityHint(in)
+		p, _ := errs.ProblemOf(out)
+		if p.Message != appNoDatabaseMessage || p.Hint != appNoDatabaseHint {
+			t.Errorf("no-database override not applied: Message=%q Hint=%q", p.Message, p.Hint)
+		}
+	})
+}
+
+func TestIsAppNoContainerError_NilProblem(t *testing.T) {
+	if isAppNoContainerError(nil) {
+		t.Error("isAppNoContainerError(nil) = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
`apps +metric-list` and `+analytics-list` passed the upstream business code 400002655 ("Container not exists") through verbatim. The message reads like an infrastructure fault and misleads callers (including AI agents) into retrying a non-retryable, expected business state: an app with no running container simply has no metrics/analytics to query until it is deployed and serving traffic.

## Changes
- Add a scoped `withObservabilityHint` helper in `shortcuts/apps/common.go` that rewrites the "no running container" business state (code `400002655`, or a `container not exist` message fallback) into a user-facing explanation plus a deploy-then-retry hint, mirroring the existing `isAppNoDatabaseError` override.
- Route the two observability callers (`apps_metrics.go`, `apps_analytics.go`) through it instead of the raw `withAppsHint(err, appIDListHint)`.
- Detection is code-OR-message so a server renumber alone cannot silently drop the rewrite; classification, code, and the wrapped cause are preserved, and unrelated failures still fall through to the shared app-id recovery hint (which retains its own no-database override).
- Scoped to the two observability commands (not the global `withAppsHint` chokepoint) because 400002655 is not known to be observability-exclusive and the message-marker fallback must not reach unrelated commands.

## Test Plan
- [x] Unit tests pass — `go test ./shortcuts/apps/` (full package) and `./internal/errclass/...`
- [x] New `TestWithObservabilityHint` (8 subcases: code hit, message fallback, case-insensitivity, cause preservation, overrides upstream hint, unrelated failure falls through, no-database still applies) + `TestIsAppNoContainerError_NilProblem`
- [x] `go build ./...` and `go vet ./shortcuts/apps/...` clean
- [ ] Live E2E intentionally omitted: reproducing 400002655 needs a permissioned app with no running container and no deterministic, cleanable live flow; substitute evidence is the unit tests that construct the typed 400002655 error directly (classification layer verified to place the code in `Problem.Code`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error guidance for analytics and metrics listing failures.
  * Added clear messaging and deployment guidance when an app has no running container.
  * Improved recovery hints for other observability-related errors.
  * Preserved underlying error details while making failures easier to understand and resolve.
  * Improved classification of app observability errors for more accurate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->