### PR TITLE
chore: add Base skill code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /skills/lark-approval/
 /skills/lark-apps/
 /skills/lark-attendance/
-/skills/lark-base/
+/skills/lark-base/ @zgz2048
 /skills/lark-calendar/
 /skills/lark-contact/
 /skills/lark-doc/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /skills/lark-approval/
 /skills/lark-apps/
 /skills/lark-attendance/
-/skills/lark-base/ @zgz2048
+/skills/lark-base/ @zgz2048 @kongenpei
 /skills/lark-calendar/
 /skills/lark-contact/
 /skills/lark-doc/


### PR DESCRIPTION
## Summary

Assign `@zgz2048` and `@kongenpei` as CODEOWNERS for the `lark-base` skill so future changes request the appropriate reviews.

## Changes

- Replace the existing ownerless exemption for `/skills/lark-base/` with `@zgz2048` and `@kongenpei`.
- Leave ownership rules for all other skills unchanged.

## Test Plan

- [x] `git diff --check`
- [x] Confirmed the commits change only `.github/CODEOWNERS`.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership settings for the Lark Base skill area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->