### PR TITLE
Complete mail rule reorder IDs

### DIFF
--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -29,7 +28,7 @@ func serviceDryRunMailRulesReorder(f *cmdutil.Factory, request client.RawApiRequ
 	body := map[string]interface{}{"rule_ids": []string{"<user_rule_id_1>", "<user_rule_id_2>", "<remaining_rule_ids_in_current_order>"}}
 	if bodyMap, ok := request.Data.(map[string]interface{}); ok {
 		body = cloneMap(bodyMap)
-		body["rule_ids"] = []string{"<user_rule_id_1>", "<user_rule_id_2>", "<remaining_rule_ids_in_current_order>"}
+		body["rule_ids"] = dryRunCompleteRuleIDs(bodyMap["rule_ids"])
 	}
 	dr := cmdutil.NewDryRunAPI().
 		GET(listRequest.URL).
@@ -79,8 +78,7 @@ func userRuleIDsFromReorderBody(data interface{}) ([]string, map[string]interfac
 	}
 	ruleIDs, err := stringList(raw)
 	if err != nil {
-		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
-			"--data.rule_ids must be an array of strings").WithParam("rule_ids").WithCause(err)
+		return nil, nil, err
 	}
 	if len(ruleIDs) == 0 {
 		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
@@ -98,21 +96,33 @@ func stringList(raw interface{}) ([]string, error) {
 				items[i] = v
 			}
 		} else {
-			return nil, fmt.Errorf("got %T", raw)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--data.rule_ids must be an array of strings; got %T", raw).WithParam("rule_ids")
 		}
 	}
 	out := make([]string, 0, len(items))
-	for _, item := range items {
+	for i, item := range items {
 		s, ok := item.(string)
 		if !ok {
-			return nil, fmt.Errorf("got item %T", item)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--data.rule_ids[%d] must be a string; got %T", i, item).WithParam("rule_ids")
 		}
-		s = strings.TrimSpace(s)
-		if s != "" {
-			out = append(out, s)
+		trimmed := strings.TrimSpace(s)
+		if trimmed == "" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--data.rule_ids[%d] must not be blank", i).WithParam("rule_ids")
 		}
+		out = append(out, trimmed)
 	}
 	return out, nil
+}
+
+func dryRunCompleteRuleIDs(raw interface{}) []string {
+	ruleIDs, err := stringList(raw)
+	if err != nil || len(ruleIDs) == 0 {
+		return []string{"<user_rule_id_1>", "<user_rule_id_2>", "<remaining_rule_ids_in_current_order>"}
+	}
+	return append(ruleIDs, "<remaining_rule_ids_in_current_order>")
 }
 
 func completeRuleIDs(userRuleIDs, currentRuleIDs []string) ([]string, error) {
@@ -155,6 +165,7 @@ func completeRuleIDs(userRuleIDs, currentRuleIDs []string) ([]string, error) {
 func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest client.RawApiRequest, checkErr func(interface{}, core.Identity) error) ([]string, error) {
 	var all []string
 	var pageToken string
+	seenPageTokens := map[string]bool{}
 	for {
 		result, err := ac.CallAPI(ctx, mailRulesListRequest(reorderRequest, pageToken))
 		if err != nil {
@@ -188,6 +199,11 @@ func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderReque
 			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
 				"mail rules list response has_more=true but no page token")
 		}
+		if seenPageTokens[pageToken] {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
+				"mail rules list response repeated page token %q", pageToken)
+		}
+		seenPageTokens[pageToken] = true
 	}
 	return all, nil
 }

--- a/cmd/service/mail_rules_reorder.go
+++ b/cmd/service/mail_rules_reorder.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+)
+
+const (
+	mailRulesReorderSchemaPath = "mail.user_mailbox.rules.reorder"
+	mailRulesListPathSuffix    = "/rules"
+	mailRulesReorderPathSuffix = "/rules/reorder"
+)
+
+func isMailRulesReorder(opts *ServiceMethodOptions) bool {
+	return opts != nil && opts.SchemaPath == mailRulesReorderSchemaPath
+}
+
+func serviceDryRunMailRulesReorder(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, opts *ServiceMethodOptions) error {
+	listRequest := mailRulesListRequest(request, "")
+	body := map[string]interface{}{"rule_ids": []string{"<user_rule_id_1>", "<user_rule_id_2>", "<remaining_rule_ids_in_current_order>"}}
+	if bodyMap, ok := request.Data.(map[string]interface{}); ok {
+		body = cloneMap(bodyMap)
+		body["rule_ids"] = []string{"<user_rule_id_1>", "<user_rule_id_2>", "<remaining_rule_ids_in_current_order>"}
+	}
+	dr := cmdutil.NewDryRunAPI().
+		GET(listRequest.URL).
+		Params(listRequest.Params).
+		Desc("fetch current mailbox rules before reordering").
+		POST(request.URL).
+		Params(request.Params).
+		Body(body).
+		Desc("submit reorder with a complete rule_ids list")
+	return cmdutil.WriteDryRun(dr, serviceDryRunOutputOptions(f, opts))
+}
+
+func completeMailRulesReorderRequest(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, checkErr func(interface{}, core.Identity) error) (client.RawApiRequest, error) {
+	userRuleIDs, body, err := userRuleIDsFromReorderBody(request.Data)
+	if err != nil {
+		return request, err
+	}
+	if duplicates := duplicateStrings(userRuleIDs); len(duplicates) > 0 {
+		return request, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"duplicate rule_ids in reorder request: %s", strings.Join(duplicates, ", ")).
+			WithParam("rule_ids")
+	}
+
+	currentRuleIDs, err := fetchAllMailRuleIDs(ctx, ac, request, checkErr)
+	if err != nil {
+		return request, err
+	}
+	completedRuleIDs, err := completeRuleIDs(userRuleIDs, currentRuleIDs)
+	if err != nil {
+		return request, err
+	}
+	body["rule_ids"] = completedRuleIDs
+	request.Data = body
+	return request, nil
+}
+
+func userRuleIDsFromReorderBody(data interface{}) ([]string, map[string]interface{}, error) {
+	body, ok := data.(map[string]interface{})
+	if !ok || body == nil {
+		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--data must be a JSON object with non-empty rule_ids").WithParam("--data")
+	}
+	raw, ok := body["rule_ids"]
+	if !ok {
+		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--data.rule_ids is required").WithParam("rule_ids")
+	}
+	ruleIDs, err := stringList(raw)
+	if err != nil {
+		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--data.rule_ids must be an array of strings").WithParam("rule_ids").WithCause(err)
+	}
+	if len(ruleIDs) == 0 {
+		return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--data.rule_ids must not be empty").WithParam("rule_ids")
+	}
+	return ruleIDs, cloneMap(body), nil
+}
+
+func stringList(raw interface{}) ([]string, error) {
+	items, ok := raw.([]interface{})
+	if !ok {
+		if typed, ok := raw.([]string); ok {
+			items = make([]interface{}, len(typed))
+			for i, v := range typed {
+				items[i] = v
+			}
+		} else {
+			return nil, fmt.Errorf("got %T", raw)
+		}
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("got item %T", item)
+		}
+		s = strings.TrimSpace(s)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+func completeRuleIDs(userRuleIDs, currentRuleIDs []string) ([]string, error) {
+	currentSet := make(map[string]bool, len(currentRuleIDs))
+	for _, id := range currentRuleIDs {
+		currentSet[id] = true
+	}
+	var unknown []string
+	for _, id := range userRuleIDs {
+		if !currentSet[id] {
+			unknown = append(unknown, id)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"unknown rule_ids in reorder request: %s", strings.Join(unknown, ", ")).
+			WithParam("rule_ids")
+	}
+	seen := make(map[string]bool, len(userRuleIDs))
+	completed := make([]string, 0, len(currentRuleIDs))
+	for _, id := range userRuleIDs {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		completed = append(completed, id)
+	}
+	for _, id := range currentRuleIDs {
+		if !seen[id] {
+			completed = append(completed, id)
+		}
+	}
+	if len(completed) == 0 {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"completed rule_ids must not be empty").WithParam("rule_ids")
+	}
+	return completed, nil
+}
+
+func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest client.RawApiRequest, checkErr func(interface{}, core.Identity) error) ([]string, error) {
+	var all []string
+	var pageToken string
+	for {
+		result, err := ac.CallAPI(ctx, mailRulesListRequest(reorderRequest, pageToken))
+		if err != nil {
+			return nil, err
+		}
+		if checkErr != nil {
+			if apiErr := checkErr(result, reorderRequest.As); apiErr != nil {
+				return nil, apiErr
+			}
+		}
+		resultMap, ok := result.(map[string]interface{})
+		if !ok {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
+				"mail rules list response is not a JSON object")
+		}
+		data, _ := resultMap["data"].(map[string]interface{})
+		items := mailRuleItems(data)
+		for _, item := range items {
+			ruleID, ok := mailRuleID(item)
+			if !ok {
+				return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
+					"mail rules list response item missing rule_id")
+			}
+			all = append(all, ruleID)
+		}
+		if !mailRulesHasMore(data) {
+			break
+		}
+		pageToken = mailRulesNextPageToken(data)
+		if pageToken == "" {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
+				"mail rules list response has_more=true but no page token")
+		}
+	}
+	return all, nil
+}
+
+func mailRulesListRequest(reorderRequest client.RawApiRequest, pageToken string) client.RawApiRequest {
+	params := cloneMap(reorderRequest.Params)
+	if pageToken != "" {
+		params["page_token"] = pageToken
+	}
+	return client.RawApiRequest{
+		Method:    "GET",
+		URL:       strings.TrimSuffix(reorderRequest.URL, mailRulesReorderPathSuffix) + mailRulesListPathSuffix,
+		Params:    params,
+		As:        reorderRequest.As,
+		ExtraOpts: reorderRequest.ExtraOpts,
+	}
+}
+
+func mailRuleItems(data map[string]interface{}) []interface{} {
+	if data == nil {
+		return nil
+	}
+	for _, key := range []string{"items", "rules"} {
+		if items, ok := data[key].([]interface{}); ok {
+			return items
+		}
+	}
+	return nil
+}
+
+func mailRuleID(item interface{}) (string, bool) {
+	m, ok := item.(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	for _, key := range []string{"rule_id", "id"} {
+		if id, ok := m[key].(string); ok && strings.TrimSpace(id) != "" {
+			return strings.TrimSpace(id), true
+		}
+	}
+	return "", false
+}
+
+func mailRulesHasMore(data map[string]interface{}) bool {
+	if data == nil {
+		return false
+	}
+	hasMore, _ := data["has_more"].(bool)
+	return hasMore
+}
+
+func mailRulesNextPageToken(data map[string]interface{}) string {
+	if data == nil {
+		return ""
+	}
+	for _, key := range []string{"page_token", "next_page_token"} {
+		if token, ok := data[key].(string); ok && token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+func duplicateStrings(values []string) []string {
+	seen := map[string]bool{}
+	reported := map[string]bool{}
+	var duplicates []string
+	for _, value := range values {
+		if seen[value] && !reported[value] {
+			duplicates = append(duplicates, value)
+			reported[value] = true
+		}
+		seen[value] = true
+	}
+	return duplicates
+}
+
+func cloneMap(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -118,14 +118,16 @@ func TestCompleteRuleIDs(t *testing.T) {
 
 func TestUserRuleIDsFromReorderBodyValidation(t *testing.T) {
 	tests := []struct {
-		name    string
-		body    interface{}
-		wantErr string
+		name      string
+		body      interface{}
+		wantErr   string
+		wantParam string
 	}{
-		{name: "missing body", body: nil, wantErr: "--data must be a JSON object"},
-		{name: "missing rule ids", body: map[string]interface{}{}, wantErr: "--data.rule_ids is required"},
-		{name: "empty rule ids", body: map[string]interface{}{"rule_ids": []interface{}{}}, wantErr: "must not be empty"},
-		{name: "non string rule id", body: map[string]interface{}{"rule_ids": []interface{}{1}}, wantErr: "array of strings"},
+		{name: "missing body", body: nil, wantErr: "--data must be a JSON object", wantParam: "--data"},
+		{name: "missing rule ids", body: map[string]interface{}{}, wantErr: "--data.rule_ids is required", wantParam: "rule_ids"},
+		{name: "empty rule ids", body: map[string]interface{}{"rule_ids": []interface{}{}}, wantErr: "must not be empty", wantParam: "rule_ids"},
+		{name: "non string rule id", body: map[string]interface{}{"rule_ids": []interface{}{1}}, wantErr: "must be a string", wantParam: "rule_ids"},
+		{name: "blank rule id", body: map[string]interface{}{"rule_ids": []interface{}{"rule_a", " "}}, wantErr: "must not be blank", wantParam: "rule_ids"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -133,6 +135,7 @@ func TestUserRuleIDsFromReorderBodyValidation(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %v, want contains %q", err, tt.wantErr)
 			}
+			assertValidationProblem(t, err, tt.wantParam)
 		})
 	}
 }
@@ -172,8 +175,14 @@ func TestServiceMethod_MailRulesReorderDryRunShowsListThenReorder(t *testing.T) 
 	}
 	body := second["body"].(map[string]interface{})
 	ruleIDs := body["rule_ids"].([]interface{})
-	if len(ruleIDs) != 3 || ruleIDs[2] != "<remaining_rule_ids_in_current_order>" {
-		t.Fatalf("dry-run rule_ids = %#v", ruleIDs)
+	want := []string{"rule_c", "rule_a", "<remaining_rule_ids_in_current_order>"}
+	if len(ruleIDs) != len(want) {
+		t.Fatalf("dry-run rule_ids len = %d, want %d: %#v", len(ruleIDs), len(want), ruleIDs)
+	}
+	for i, wantID := range want {
+		if ruleIDs[i] != wantID {
+			t.Fatalf("dry-run rule_ids[%d] = %v, want %s; all=%#v", i, ruleIDs[i], wantID, ruleIDs)
+		}
 	}
 }
 
@@ -381,6 +390,11 @@ func TestServiceMethod_MailRulesReorderValidationFailuresDoNotPost(t *testing.T)
 			if !errors.As(err, &validationErr) {
 				t.Fatalf("error = %T, want *errs.ValidationError", err)
 			}
+			if validationErr.Category != errs.CategoryValidation || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "rule_ids" {
+				t.Fatalf("validation metadata = (%s, %s, %q), want (%s, %s, %q)",
+					validationErr.Category, validationErr.Subtype, validationErr.Param,
+					errs.CategoryValidation, errs.SubtypeInvalidArgument, "rule_ids")
+			}
 		})
 	}
 }
@@ -472,5 +486,58 @@ func TestFetchAllMailRuleIDsRejectsMalformedPagination(t *testing.T) {
 	}, ac.CheckResponse)
 	if err == nil || !strings.Contains(err.Error(), "has_more=true") {
 		t.Fatalf("error = %v, want malformed pagination error", err)
+	}
+	requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, 0)
+}
+
+func TestFetchAllMailRuleIDsRejectsRepeatedPageToken(t *testing.T) {
+	ac, _, _, reg := newServicePaginateTestHarness(t)
+	ac.ErrOut = io.Discard
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"rule_id": "rule_a"}},
+				"has_more":   true,
+				"page_token": "next",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "page_token=next",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"rule_id": "rule_b"}},
+				"has_more":   true,
+				"page_token": "next",
+			},
+		},
+	})
+
+	_, err := fetchAllMailRuleIDs(context.Background(), ac, client.RawApiRequest{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		As:     core.AsBot,
+	}, ac.CheckResponse)
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("error = %v, want repeated page token error", err)
+	}
+	requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, 0)
+}
+
+func assertValidationProblem(t *testing.T, err error, wantParam string) {
+	t.Helper()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T, want *errs.ValidationError", err)
+	}
+	if validationErr.Category != errs.CategoryValidation || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != wantParam {
+		t.Fatalf("validation metadata = (%s, %s, %q), want (%s, %s, %q)",
+			validationErr.Category, validationErr.Subtype, validationErr.Param,
+			errs.CategoryValidation, errs.SubtypeInvalidArgument, wantParam)
 	}
 }

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -1,0 +1,476 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func mailRulesSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{"type": "string", "location": "path", "required": true},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "array", "required": true},
+		},
+		"accessTokens": []interface{}{"user"},
+	})
+}
+
+func mailRulesReorderCommand(f *cmdutil.Factory) *cobraCommandWrapper {
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	return &cobraCommandWrapper{cmd: cmd}
+}
+
+type cobraCommandWrapper struct {
+	cmd interface {
+		SetArgs([]string)
+		Execute() error
+	}
+}
+
+func (w *cobraCommandWrapper) run(args ...string) error {
+	w.cmd.SetArgs(args)
+	return w.cmd.Execute()
+}
+
+func TestCompleteRuleIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		user    []string
+		current []string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "partial input prepends user order and appends remaining",
+			user:    []string{"C", "A"},
+			current: []string{"A", "B", "C", "D"},
+			want:    []string{"C", "A", "B", "D"},
+		},
+		{
+			name:    "complete input keeps original behavior",
+			user:    []string{"A", "B", "C"},
+			current: []string{"A", "B", "C"},
+			want:    []string{"A", "B", "C"},
+		},
+		{
+			name:    "remaining rules keep server relative order",
+			user:    []string{"D"},
+			current: []string{"A", "B", "C", "D", "E"},
+			want:    []string{"D", "A", "B", "C", "E"},
+		},
+		{
+			name:    "unknown rule id fails",
+			user:    []string{"A", "X"},
+			current: []string{"A", "B", "C"},
+			wantErr: "unknown rule_ids",
+		},
+		{
+			name:    "empty completed list fails",
+			user:    []string{},
+			current: []string{},
+			wantErr: "completed rule_ids must not be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := completeRuleIDs(tt.user, tt.current)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want contains %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("completeRuleIDs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserRuleIDsFromReorderBodyValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    interface{}
+		wantErr string
+	}{
+		{name: "missing body", body: nil, wantErr: "--data must be a JSON object"},
+		{name: "missing rule ids", body: map[string]interface{}{}, wantErr: "--data.rule_ids is required"},
+		{name: "empty rule ids", body: map[string]interface{}{"rule_ids": []interface{}{}}, wantErr: "must not be empty"},
+		{name: "non string rule id", body: map[string]interface{}{"rule_ids": []interface{}{1}}, wantErr: "array of strings"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := userRuleIDsFromReorderBody(tt.body)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want contains %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceMethod_MailRulesReorderDryRunShowsListThenReorder(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := mailRulesReorderCommand(f)
+
+	err := cmd.run(
+		"--as", "user",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_c","rule_a"]}`,
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got["dry_run"] != true {
+		t.Fatalf("dry_run = %#v, want true", got["dry_run"])
+	}
+	data := got["data"].(map[string]interface{})
+	apis := data["api"].([]interface{})
+	if len(apis) != 2 {
+		t.Fatalf("api calls = %d, want 2: %#v", len(apis), apis)
+	}
+	first := apis[0].(map[string]interface{})
+	second := apis[1].(map[string]interface{})
+	if first["method"] != "GET" || first["url"] != "/open-apis/mail/v1/user_mailboxes/me/rules" {
+		t.Fatalf("first call = %#v", first)
+	}
+	if second["method"] != "POST" || second["url"] != "/open-apis/mail/v1/user_mailboxes/me/rules/reorder" {
+		t.Fatalf("second call = %#v", second)
+	}
+	body := second["body"].(map[string]interface{})
+	ruleIDs := body["rule_ids"].([]interface{})
+	if len(ruleIDs) != 3 || ruleIDs[2] != "<remaining_rule_ids_in_current_order>" {
+		t.Fatalf("dry-run rule_ids = %#v", ruleIDs)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderCompletesRuleIDsBeforePost(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, testConfig)
+	order := []string{}
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		OnMatch: func(*http.Request) {
+			order = append(order, "GET")
+		},
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "rule_a"},
+					map[string]interface{}{"rule_id": "rule_b"},
+					map[string]interface{}{"rule_id": "rule_c"},
+					map[string]interface{}{"rule_id": "rule_d"},
+				},
+			},
+		},
+	})
+	postStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		OnMatch: func(*http.Request) {
+			order = append(order, "POST")
+		},
+		Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"ok": true}},
+	}
+	reg.Register(postStub)
+	cmd := mailRulesReorderCommand(f)
+
+	err := cmd.run(
+		"--as", "user",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_c","rule_a"]}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Join(order, ",") != "GET,POST" {
+		t.Fatalf("call order = %v, want GET,POST", order)
+	}
+	var captured map[string]interface{}
+	if err := json.Unmarshal(postStub.CapturedBody, &captured); err != nil {
+		t.Fatalf("POST body invalid JSON: %v\n%s", err, string(postStub.CapturedBody))
+	}
+	got := captured["rule_ids"].([]interface{})
+	want := []string{"rule_c", "rule_a", "rule_b", "rule_d"}
+	if len(got) != len(want) {
+		t.Fatalf("rule_ids len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i, wantID := range want {
+		if got[i] != wantID {
+			t.Fatalf("rule_ids[%d] = %v, want %s; all=%#v", i, got[i], wantID, got)
+		}
+	}
+	if !strings.Contains(stdout.String(), `"ok":true`) && !strings.Contains(stdout.String(), `"ok": true`) {
+		t.Fatalf("expected success output, got: %s", stdout.String())
+	}
+}
+
+func TestServiceMethod_MailRulesReorderPaginatesBeforePost(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"rule_id": "rule_a"}},
+				"has_more":   true,
+				"page_token": "next",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "page_token=next",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{map[string]interface{}{"rule_id": "rule_b"}},
+			},
+		},
+	})
+	postStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	}
+	reg.Register(postStub)
+	cmd := mailRulesReorderCommand(f)
+
+	err := cmd.run(
+		"--as", "user",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_b"]}`,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var captured map[string]interface{}
+	if err := json.Unmarshal(postStub.CapturedBody, &captured); err != nil {
+		t.Fatalf("POST body invalid JSON: %v", err)
+	}
+	got := captured["rule_ids"].([]interface{})
+	if strings.Join([]string{got[0].(string), got[1].(string)}, ",") != "rule_b,rule_a" {
+		t.Fatalf("rule_ids = %#v, want [rule_b rule_a]", got)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderPageAllDoesNotBypassCompletion(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"rule_id": "rule_a"},
+					map[string]interface{}{"rule_id": "rule_b"},
+				},
+			},
+		},
+	})
+	postStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	}
+	reg.Register(postStub)
+	cmd := mailRulesReorderCommand(f)
+
+	err := cmd.run(
+		"--as", "user",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_b"]}`,
+		"--page-all",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var captured map[string]interface{}
+	if err := json.Unmarshal(postStub.CapturedBody, &captured); err != nil {
+		t.Fatalf("POST body invalid JSON: %v", err)
+	}
+	got := captured["rule_ids"].([]interface{})
+	if strings.Join([]string{got[0].(string), got[1].(string)}, ",") != "rule_b,rule_a" {
+		t.Fatalf("rule_ids = %#v, want [rule_b rule_a]", got)
+	}
+}
+
+func TestServiceMethod_MailRulesReorderValidationFailuresDoNotPost(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		stubGet bool
+		wantErr string
+	}{
+		{name: "empty input", data: `{"rule_ids":[]}`, wantErr: "must not be empty"},
+		{name: "duplicate input", data: `{"rule_ids":["rule_a","rule_a"]}`, wantErr: "duplicate rule_ids"},
+		{name: "unknown input", data: `{"rule_ids":["rule_x"]}`, stubGet: true, wantErr: "unknown rule_ids"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+			if tt.stubGet {
+				reg.Register(&httpmock.Stub{
+					Method: "GET",
+					URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+					Body: map[string]interface{}{
+						"code": 0, "msg": "ok",
+						"data": map[string]interface{}{
+							"items": []interface{}{map[string]interface{}{"rule_id": "rule_a"}},
+						},
+					},
+				})
+			}
+			postStub := &httpmock.Stub{
+				Method:   "POST",
+				URL:      "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+				Optional: true,
+				OnMatch: func(*http.Request) {
+					t.Fatal("reorder POST must not be called on validation failure")
+				},
+				Body: map[string]interface{}{"code": 0, "msg": "ok"},
+			}
+			reg.Register(postStub)
+			cmd := mailRulesReorderCommand(f)
+
+			err := cmd.run(
+				"--as", "user",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", tt.data,
+			)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want contains %q", err, tt.wantErr)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %T, want *errs.ValidationError", err)
+			}
+		})
+	}
+}
+
+func TestServiceMethod_MailRulesReorderListFailureDoesNotPost(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 230027,
+			"msg":  "user not authorized",
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:   "POST",
+		URL:      "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Optional: true,
+		OnMatch: func(*http.Request) {
+			t.Fatal("reorder POST must not be called when list fails")
+		},
+		Body: map[string]interface{}{"code": 0, "msg": "ok"},
+	})
+	cmd := mailRulesReorderCommand(f)
+
+	err := cmd.run(
+		"--as", "user",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_a"]}`,
+	)
+	if err == nil {
+		t.Fatal("expected list API error")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+}
+
+func TestServiceMethod_MailRulesReorderDryRunDoesNotCallAPI(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Optional: true,
+		OnMatch: func(*http.Request) {
+			t.Fatal("dry-run must not call list API")
+		},
+		Body: map[string]interface{}{"code": 0},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:   "POST",
+		URL:      "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Optional: true,
+		OnMatch: func(*http.Request) {
+			t.Fatal("dry-run must not call reorder API")
+		},
+		Body: map[string]interface{}{"code": 0},
+	})
+	cmd := mailRulesReorderCommand(f)
+
+	err := cmd.run(
+		"--as", "user",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["rule_a"]}`,
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchAllMailRuleIDsRejectsMalformedPagination(t *testing.T) {
+	ac, _, _, reg := newServicePaginateTestHarness(t)
+	ac.ErrOut = io.Discard
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":    []interface{}{map[string]interface{}{"rule_id": "rule_a"}},
+				"has_more": true,
+			},
+		},
+	})
+
+	_, err := fetchAllMailRuleIDs(context.Background(), ac, client.RawApiRequest{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		As:     core.AsBot,
+	}, ac.CheckResponse)
+	if err == nil || !strings.Contains(err.Error(), "has_more=true") {
+		t.Fatalf("error = %v, want malformed pagination error", err)
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -403,6 +403,9 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	}
 
 	if opts.DryRun {
+		if isMailRulesReorder(opts) {
+			return serviceDryRunMailRulesReorder(f, request, config, opts)
+		}
 		if fileMeta != nil {
 			return cmdutil.PrintDryRunWithFile(request, config, serviceDryRunOutputOptions(f, opts), *fileMeta)
 		}
@@ -431,7 +434,13 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	// with MissingScopes / Identity / ConsoleURL populated from the response.
 	checkErr := ac.CheckResponse
 
-	if opts.PageAll {
+	if isMailRulesReorder(opts) {
+		var err error
+		request, err = completeMailRulesReorderRequest(opts.Ctx, ac, request, checkErr)
+		if err != nil {
+			return err
+		}
+	} else if opts.PageAll {
 		return servicePaginate(opts.Ctx, ac, request, format, opts.JqExpr, out, f.IOStreams.ErrOut, opts.Cmd.CommandPath(),
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)
 	}


### PR DESCRIPTION
## Summary
- fetch mailbox rules before reorder requests and complete partial rule_ids with the current server order
- validate empty, duplicate, and unknown rule IDs locally before calling reorder
- add dry-run planning output and focused service tests

## Tests
- go test ./cmd/service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reordering mail rules.
  * Automatically completes partial rule lists by appending omitted rules in their existing order.
  * Supports dry-run previews before applying changes.
  * Handles paginated rule lists and validates duplicate, unknown, or malformed rule IDs.

* **Bug Fixes**
  * Prevents changes from being submitted when validation or rule-list retrieval fails.
  * Improves handling of pagination errors during reorder operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->