### PR TITLE
feat: propagate credential metadata

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -47,24 +47,24 @@ type APIClient struct {
 	Credential *credential.CredentialProvider
 }
 
-func (c *APIClient) resolveAccessToken(ctx context.Context, as core.Identity) (string, error) {
+func (c *APIClient) resolveAccessToken(ctx context.Context, as core.Identity) (*credential.TokenResult, error) {
 	result, err := c.Credential.ResolveToken(ctx, credential.NewTokenSpec(as, c.Config.AppID))
 	if err != nil {
 		var unavailableErr *credential.TokenUnavailableError
 		if errors.As(err, &unavailableErr) {
-			return "", newTokenMissingError(as, unavailableErr)
+			return nil, newTokenMissingError(as, unavailableErr)
 		}
 		// The credential chain already emits a typed *errs.AuthenticationError
 		// for the missing-UAT case (e.g. UAT refresh returned
 		// need_user_authorization), so it flows through unchanged: the
 		// outer-typed gate in cmd/root.go and the idempotent WrapDoAPIError
 		// both preserve its authentication category and exit 3.
-		return "", err
+		return nil, err
 	}
 	if result.Token == "" {
-		return "", newTokenMissingError(as, nil)
+		return nil, newTokenMissingError(as, nil)
 	}
-	return result.Token, nil
+	return result, nil
 }
 
 // newTokenMissingError builds the typed *errs.AuthenticationError that
@@ -138,14 +138,15 @@ func (c *APIClient) DoSDKRequest(ctx context.Context, req *larkcore.ApiReq, as c
 	}
 	if as.IsBot() {
 		req.SupportedAccessTokenTypes = []larkcore.AccessTokenType{larkcore.AccessTokenTypeTenant}
-		opts = append(opts, larkcore.WithTenantAccessToken(token))
+		opts = append(opts, larkcore.WithTenantAccessToken(token.Token))
 	} else {
 		req.SupportedAccessTokenTypes = []larkcore.AccessTokenType{larkcore.AccessTokenTypeUser}
-		opts = append(opts, larkcore.WithUserAccessToken(token))
+		opts = append(opts, larkcore.WithUserAccessToken(token.Token))
 	}
 
 	opts = append(opts, extraOpts...)
-	resp, err := c.SDK.Do(ctx, req, opts...)
+	requestCtx := core.WithCredentialSource(ctx, token.Source)
+	resp, err := c.SDK.Do(requestCtx, req, opts...)
 	if err != nil {
 		return nil, WrapDoAPIError(err)
 	}
@@ -188,10 +189,10 @@ func (c *APIClient) DoStream(ctx context.Context, req *larkcore.ApiReq, as core.
 	httpClient := *c.HTTP
 	httpClient.Timeout = 0
 	cancel := func() {}
-	requestCtx := ctx
+	requestCtx := core.WithCredentialSource(ctx, token.Source)
 	if cfg.timeout > 0 {
-		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-			requestCtx, cancel = context.WithTimeout(ctx, cfg.timeout)
+		if _, hasDeadline := requestCtx.Deadline(); !hasDeadline {
+			requestCtx, cancel = context.WithTimeout(requestCtx, cfg.timeout)
 		}
 	}
 
@@ -212,7 +213,7 @@ func (c *APIClient) DoStream(ctx context.Context, req *larkcore.ApiReq, as core.
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Authorization", "Bearer "+token.Token)
 
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -4,11 +4,55 @@
 package core
 
 import (
+	"context"
 	"net/url"
 	"strings"
 
 	"github.com/larksuite/cli/internal/envvars"
 )
+
+// CredentialSource is the bounded category of the credential used by one
+// outbound request. It excludes provider-specific detail and credential values.
+type CredentialSource string
+
+const (
+	CredentialSourceLocal     CredentialSource = "local"
+	CredentialSourceEnv       CredentialSource = "env"
+	CredentialSourceSidecar   CredentialSource = "sidecar"
+	CredentialSourceExtension CredentialSource = "extension"
+)
+
+func (s CredentialSource) valid() bool {
+	switch s {
+	case CredentialSourceLocal, CredentialSourceEnv, CredentialSourceSidecar, CredentialSourceExtension:
+		return true
+	default:
+		return false
+	}
+}
+
+type credentialSourceContextKey struct{}
+
+// WithCredentialSource binds a resolved token's source to its request flow.
+// Invalid values deliberately shadow inherited metadata.
+func WithCredentialSource(ctx context.Context, source CredentialSource) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, credentialSourceContextKey{}, source)
+}
+
+// CredentialSourceFromContext returns the validated source for this request.
+func CredentialSourceFromContext(ctx context.Context) (CredentialSource, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	source, ok := ctx.Value(credentialSourceContextKey{}).(CredentialSource)
+	if !ok || !source.valid() {
+		return "", false
+	}
+	return source, true
+}
 
 // LarkBrand represents the Lark platform brand.
 // "feishu" targets China-mainland, "lark" targets international.

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -4,10 +4,23 @@
 package core
 
 import (
+	"context"
 	"net/url"
 	"reflect"
 	"testing"
 )
+
+func TestCredentialSourceContext(t *testing.T) {
+	ctx := WithCredentialSource(context.Background(), CredentialSourceEnv)
+	if source, ok := CredentialSourceFromContext(ctx); !ok || source != CredentialSourceEnv {
+		t.Fatalf("CredentialSourceFromContext() = %q, %t; want env, true", source, ok)
+	}
+
+	ctx = WithCredentialSource(ctx, CredentialSource("vault:prod"))
+	if source, ok := CredentialSourceFromContext(ctx); ok || source != "" {
+		t.Fatalf("CredentialSourceFromContext() = %q, %t; want empty, false", source, ok)
+	}
+}
 
 func TestResolveEndpoints_Feishu(t *testing.T) {
 	ep := ResolveEndpoints(BrandFeishu)

--- a/internal/credential/credential_provider.go
+++ b/internal/credential/credential_provider.go
@@ -113,8 +113,9 @@ func (s defaultTokenSource) TryResolveToken(ctx context.Context, req TokenSpec) 
 	if result.Token == "" {
 		return nil, false, &MalformedTokenResultError{Source: s.Name(), Type: req.Type, Reason: "empty token"}
 	}
-	result.Source = core.CredentialSource(s.CredentialSource())
-	return result, true, nil
+	resultCopy := *result
+	resultCopy.Source = core.CredentialSource(s.CredentialSource())
+	return &resultCopy, true, nil
 }
 
 func (s defaultTokenSource) ResolveIdentityHint(ctx context.Context, acct *Account) (*IdentityHint, error) {

--- a/internal/credential/credential_provider.go
+++ b/internal/credential/credential_provider.go
@@ -33,6 +33,7 @@ var (
 
 type credentialSource interface {
 	Name() string
+	CredentialSource() string
 	TryResolveToken(ctx context.Context, req TokenSpec) (*TokenResult, bool, error)
 	ResolveIdentityHint(ctx context.Context, acct *Account) (*IdentityHint, error)
 }
@@ -42,6 +43,15 @@ type extensionTokenSource struct {
 }
 
 func (s extensionTokenSource) Name() string { return s.provider.Name() }
+
+func (s extensionTokenSource) CredentialSource() string {
+	switch s.Name() {
+	case "env", "sidecar":
+		return s.Name()
+	default:
+		return "extension"
+	}
+}
 
 func (s extensionTokenSource) TryResolveToken(ctx context.Context, req TokenSpec) (*TokenResult, bool, error) {
 	tok, err := s.provider.ResolveToken(ctx, extcred.TokenSpec{
@@ -57,7 +67,7 @@ func (s extensionTokenSource) TryResolveToken(ctx context.Context, req TokenSpec
 	if tok.Value == "" {
 		return nil, false, &MalformedTokenResultError{Source: s.Name(), Type: req.Type, Reason: "empty token"}
 	}
-	return &TokenResult{Token: tok.Value, Scopes: tok.Scopes}, true, nil
+	return &TokenResult{Token: tok.Value, Scopes: tok.Scopes, Source: core.CredentialSource(s.CredentialSource())}, true, nil
 }
 
 func (s extensionTokenSource) ResolveIdentityHint(ctx context.Context, acct *Account) (*IdentityHint, error) {
@@ -86,7 +96,8 @@ type defaultTokenSource struct {
 	resolver DefaultTokenResolver
 }
 
-func (s defaultTokenSource) Name() string { return "default" }
+func (s defaultTokenSource) Name() string             { return "default" }
+func (s defaultTokenSource) CredentialSource() string { return "local" }
 
 func (s defaultTokenSource) TryResolveToken(ctx context.Context, req TokenSpec) (*TokenResult, bool, error) {
 	if s.resolver == nil {
@@ -102,6 +113,7 @@ func (s defaultTokenSource) TryResolveToken(ctx context.Context, req TokenSpec) 
 	if result.Token == "" {
 		return nil, false, &MalformedTokenResultError{Source: s.Name(), Type: req.Type, Reason: "empty token"}
 	}
+	result.Source = core.CredentialSource(s.CredentialSource())
 	return result, true, nil
 }
 
@@ -229,7 +241,8 @@ func (p *CredentialProvider) enrichUserInfo(ctx context.Context, acct *Account, 
 	if err != nil {
 		return fmt.Errorf("failed to get HTTP client for user_info: %w", err)
 	}
-	info, err := fetchUserInfo(ctx, hc, acct.Brand, tok.Token)
+	requestCtx := core.WithCredentialSource(ctx, tok.Source)
+	info, err := fetchUserInfo(requestCtx, hc, acct.Brand, tok.Token)
 	if err != nil {
 		return fmt.Errorf("failed to verify user identity: %w", err)
 	}
@@ -254,7 +267,7 @@ func (p *CredentialProvider) selectedCredentialSource(ctx context.Context) (cred
 	return p.selectedSource, nil
 }
 
-func resolveTokenFromSource(ctx context.Context, source credentialSource, req TokenSpec) (*TokenResult, error) {
+func (p *CredentialProvider) resolveTokenFromSource(ctx context.Context, source credentialSource, req TokenSpec) (*TokenResult, error) {
 	result, found, err := source.TryResolveToken(ctx, req)
 	if err != nil {
 		return nil, err
@@ -307,7 +320,7 @@ func (p *CredentialProvider) ResolveToken(ctx context.Context, req TokenSpec) (*
 		return nil, err
 	}
 	if source != nil {
-		return resolveTokenFromSource(ctx, source, req)
+		return p.resolveTokenFromSource(ctx, source, req)
 	}
 
 	for _, prov := range p.providers {

--- a/internal/credential/credential_provider_test.go
+++ b/internal/credential/credential_provider_test.go
@@ -137,12 +137,13 @@ func TestCredentialProvider_TokenFromExtension(t *testing.T) {
 }
 
 func TestCredentialProvider_TokenFallsToDefault(t *testing.T) {
+	defaultResult := &TokenResult{
+		Token:  "default_tok",
+		Source: core.CredentialSourceExtension,
+	}
 	cp := NewCredentialProvider(
 		[]extcred.Provider{&mockExtProvider{name: "skip"}},
-		&mockDefaultAcct{}, &mockDefaultToken{result: &TokenResult{
-			Token:  "default_tok",
-			Source: core.CredentialSourceExtension,
-		}}, nil,
+		&mockDefaultAcct{}, &mockDefaultToken{result: defaultResult}, nil,
 	)
 	result, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeUAT})
 	if err != nil {
@@ -153,6 +154,9 @@ func TestCredentialProvider_TokenFallsToDefault(t *testing.T) {
 	}
 	if result.Source != core.CredentialSourceLocal {
 		t.Errorf("TokenResult.Source = %q, want local", result.Source)
+	}
+	if defaultResult.Source != core.CredentialSourceExtension {
+		t.Errorf("default resolver result Source = %q, want unchanged extension", defaultResult.Source)
 	}
 }
 

--- a/internal/credential/credential_provider_test.go
+++ b/internal/credential/credential_provider_test.go
@@ -131,12 +131,18 @@ func TestCredentialProvider_TokenFromExtension(t *testing.T) {
 	if result.Token != "ext_tok" {
 		t.Errorf("expected ext_tok, got %s", result.Token)
 	}
+	if result.Source != core.CredentialSourceEnv {
+		t.Errorf("TokenResult.Source = %q, want env", result.Source)
+	}
 }
 
 func TestCredentialProvider_TokenFallsToDefault(t *testing.T) {
 	cp := NewCredentialProvider(
 		[]extcred.Provider{&mockExtProvider{name: "skip"}},
-		&mockDefaultAcct{}, &mockDefaultToken{result: &TokenResult{Token: "default_tok"}}, nil,
+		&mockDefaultAcct{}, &mockDefaultToken{result: &TokenResult{
+			Token:  "default_tok",
+			Source: core.CredentialSourceExtension,
+		}}, nil,
 	)
 	result, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeUAT})
 	if err != nil {
@@ -144,6 +150,21 @@ func TestCredentialProvider_TokenFallsToDefault(t *testing.T) {
 	}
 	if result.Token != "default_tok" {
 		t.Errorf("expected default_tok, got %s", result.Token)
+	}
+	if result.Source != core.CredentialSourceLocal {
+		t.Errorf("TokenResult.Source = %q, want local", result.Source)
+	}
+}
+
+func TestExtensionCredentialSource(t *testing.T) {
+	for _, test := range []struct{ provider, want string }{
+		{provider: "sidecar", want: "sidecar"},
+		{provider: "custom", want: "extension"},
+	} {
+		source := extensionTokenSource{provider: &mockExtProvider{name: test.provider}}
+		if got := source.CredentialSource(); got != test.want {
+			t.Errorf("provider %q source = %q, want %q", test.provider, got, test.want)
+		}
 	}
 }
 

--- a/internal/credential/integration_test.go
+++ b/internal/credential/integration_test.go
@@ -50,6 +50,9 @@ func TestFullChain_EnvWins(t *testing.T) {
 	if result.Token != "env_uat" {
 		t.Errorf("expected env_uat, got %s", result.Token)
 	}
+	if result.Source != core.CredentialSourceEnv {
+		t.Errorf("source = %q, want env", result.Source)
+	}
 }
 
 func TestFullChain_Fallthrough(t *testing.T) {
@@ -69,6 +72,9 @@ func TestFullChain_Fallthrough(t *testing.T) {
 	}
 	if result.Token != "mock_tok" || result.Scopes != "drive:read" {
 		t.Errorf("unexpected: %+v", result)
+	}
+	if result.Source != core.CredentialSourceLocal {
+		t.Errorf("source = %q, want local", result.Source)
 	}
 }
 

--- a/internal/credential/types.go
+++ b/internal/credential/types.go
@@ -129,7 +129,8 @@ type TokenSpec struct {
 // TokenResult is the output of TokenProvider.ResolveToken.
 type TokenResult struct {
 	Token  string
-	Scopes string // optional, space-separated; empty = skip scope pre-check
+	Scopes string                // optional, space-separated; empty = skip scope pre-check
+	Source core.CredentialSource // whewe the token came from
 }
 
 // IdentityHint is credential-layer guidance for resolving the effective identity.

--- a/internal/identitydiag/diagnostics.go
+++ b/internal/identitydiag/diagnostics.go
@@ -347,6 +347,7 @@ func diagnoseUser(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, 
 	}
 	verifyCtx, cancel := context.WithTimeout(ctx, verifyTimeout)
 	defer cancel()
+	verifyCtx = core.WithCredentialSource(verifyCtx, core.CredentialSourceLocal)
 	if err := larkauth.VerifyUserToken(verifyCtx, sdk, token); err != nil {
 		return markVerifyFailed("server rejected token: "+err.Error(), "run: lark-cli auth login --help", recovery.TargetAuthLogin)
 	}
@@ -360,18 +361,18 @@ func diagnoseUser(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, 
 	return id
 }
 
-func resolveBotToken(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig) (string, error) {
+func resolveBotToken(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig) (*credential.TokenResult, error) {
 	if f == nil || f.Credential == nil {
-		return "", &credential.TokenUnavailableError{Type: credential.TokenTypeTAT}
+		return nil, &credential.TokenUnavailableError{Type: credential.TokenTypeTAT}
 	}
 	result, err := f.Credential.ResolveToken(ctx, credential.NewTokenSpec(core.AsBot, cfg.AppID))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if result == nil || result.Token == "" {
-		return "", &credential.TokenUnavailableError{Type: credential.TokenTypeTAT}
+		return nil, &credential.TokenUnavailableError{Type: credential.TokenTypeTAT}
 	}
-	return result.Token, nil
+	return result, nil
 }
 
 type botInfo struct {
@@ -379,11 +380,12 @@ type botInfo struct {
 	AppName string
 }
 
-func fetchBotInfo(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, token string) (*botInfo, error) {
+func fetchBotInfo(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, token *credential.TokenResult) (*botInfo, error) {
 	httpClient, err := f.HttpClient()
 	if err != nil {
 		return nil, fmt.Errorf("create HTTP client: %w", err)
 	}
+	ctx = core.WithCredentialSource(ctx, token.Source)
 	ctx, cancel := context.WithTimeout(ctx, verifyTimeout)
 	defer cancel()
 	url := strings.TrimRight(core.ResolveEndpoints(cfg.Brand).Open, "/") + "/open-apis/bot/v3/info"
@@ -391,7 +393,7 @@ func fetchBotInfo(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, 
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+token.Token)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/riskcontrol/transport.go
+++ b/internal/riskcontrol/transport.go
@@ -15,23 +15,26 @@ import (
 var _ internaltransport.RoundTripperDecorator = (*Transport)(nil)
 
 const (
-	HeaderProductModel = "X-Agent-Device-Type"
-	HeaderOSType       = "X-Agent-Os-Type"
+	HeaderProductModel     = "X-Agent-Device-Type"
+	HeaderOSType           = "X-Agent-Os-Type"
+	HeaderCredentialSource = "X-Agent-Credential-Source"
 )
 
-var restrictedHeaders = [...]string{HeaderProductModel, HeaderOSType}
+var restrictedHeaders = [...]string{HeaderProductModel, HeaderOSType, HeaderCredentialSource}
 
 // Transport is the feature's final outbound boundary. It removes caller- or
-// extension-supplied signal headers first and writes trusted values only after
-// authorizing an official SDK origin and authentication state.
+// extension-supplied signal headers first and writes trusted values only when
+// workspace policy enables risk control and the request targets an official
+// SDK origin.
 type Transport struct {
 	next   http.RoundTripper
 	source Source
 }
 
 // NewTransport creates the final SDK outbound policy boundary. A nil source
-// disables collection and injection while preserving restricted-header
-// stripping for opt-out and extension-credential requests.
+// means workspace policy disabled risk control, so all signal injection,
+// including credential source, is disabled. Restricted headers are still
+// stripped from caller- and extension-supplied requests.
 func NewTransport(next http.RoundTripper, source Source) *Transport {
 	if next == nil {
 		next = internaltransport.Fallback()
@@ -72,7 +75,12 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	stripRestrictedHeaders(req.Header)
 
+	// A nil source is the caller's disabled/unavailable policy marker. Treat it
+	// as the master gate for the complete signal set, not only device collection.
 	if t.source != nil && t.routeAllowsSignals(req) {
+		if source, ok := core.CredentialSourceFromContext(req.Context()); ok {
+			req.Header.Set(HeaderCredentialSource, string(source))
+		}
 		snapshot := t.source.Snapshot()
 		if isSupportedOSType(snapshot.OSType) {
 			req.Header.Set(HeaderOSType, string(snapshot.OSType))
@@ -111,10 +119,12 @@ type origin struct {
 }
 
 var officialFeishuOrigins = [...]origin{
-	apiOrigin(core.BrandFeishu, core.ResolveEndpoints(core.BrandFeishu).Open),
-	apiOrigin(core.BrandLark, core.ResolveEndpoints(core.BrandLark).Open),
-	apiOrigin(core.BrandFeishu, core.ResolveEndpoints(core.BrandFeishu).Accounts),
-	apiOrigin(core.BrandLark, core.ResolveEndpoints(core.BrandLark).Accounts),
+	apiOrigin(core.ResolveEndpoints(core.BrandFeishu).Open),
+	apiOrigin(core.ResolveEndpoints(core.BrandLark).Open),
+	apiOrigin(core.ResolveEndpoints(core.BrandFeishu).Accounts),
+	apiOrigin(core.ResolveEndpoints(core.BrandLark).Accounts),
+	apiOrigin(core.ResolveEndpoints(core.BrandFeishu).MCP),
+	apiOrigin(core.ResolveEndpoints(core.BrandLark).MCP),
 }
 
 func (t *Transport) routeAllowsSignals(req *http.Request) bool {
@@ -141,7 +151,7 @@ func originOf(value *url.URL) origin {
 	return origin{scheme: scheme, host: strings.ToLower(value.Hostname()), port: port}
 }
 
-func apiOrigin(brand core.LarkBrand, endpointURL string) origin {
+func apiOrigin(endpointURL string) origin {
 	endpoint, err := url.Parse(endpointURL)
 	if err != nil {
 		return origin{}

--- a/internal/riskcontrol/transport_test.go
+++ b/internal/riskcontrol/transport_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/larksuite/cli/internal/core"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -41,6 +43,8 @@ func TestTransportAuthorizesBeforeCollecting(t *testing.T) {
 		{name: "official explicit HTTPS port", requestURL: "https://OPEN.FEISHU.CN:443/open-apis/test", authorization: "Bearer token", wantSignals: true},
 		{name: "unauthenticated", requestURL: "https://open.feishu.cn/open-apis/test", wantSignals: true},
 		{name: "official non-OpenAPI origin", requestURL: "https://accounts.feishu.cn/open-apis/test", authorization: "Bearer token", wantSignals: true},
+		{name: "Feishu MCP", requestURL: "https://mcp.feishu.cn/mcp", wantSignals: true},
+		{name: "Lark MCP", requestURL: "https://mcp.larksuite.com/mcp", wantSignals: true},
 		{name: "off domain", requestURL: "https://example.com/test", authorization: "Bearer token", wantSignals: false},
 		{name: "lookalike", requestURL: "https://open.feishu.cn.evil.example/test", authorization: "Bearer token", wantSignals: false},
 		{name: "plain HTTP", requestURL: "http://open.feishu.cn/test", authorization: "Bearer token", wantSignals: false},
@@ -62,7 +66,9 @@ func TestTransportAuthorizesBeforeCollecting(t *testing.T) {
 			req.Header.Set("Authorization", test.authorization)
 			req.Header.Set(HeaderOSType, "caller-value")
 			req.Header.Set(HeaderProductModel, "caller-value")
+			req.Header.Set(HeaderCredentialSource, "caller-value")
 			req.Header["x-agent-device-type"] = []string{"non-canonical-caller-value"}
+			req = req.WithContext(core.WithCredentialSource(req.Context(), core.CredentialSourceLocal))
 
 			resp, err := NewTransport(base, source).RoundTrip(req)
 			if err != nil {
@@ -81,6 +87,9 @@ func TestTransportAuthorizesBeforeCollecting(t *testing.T) {
 			if got := source.calls.Load(); got != wantCalls {
 				t.Fatalf("Snapshot calls = %d, want %d", got, wantCalls)
 			}
+			if got := received.Get(HeaderCredentialSource); test.wantSignals && got != "local" {
+				t.Fatalf("credential source = %q, want local", got)
+			}
 			if got := req.Header.Get(HeaderOSType); got != "caller-value" {
 				t.Fatalf("caller request OS header = %q, want unchanged", got)
 			}
@@ -89,10 +98,75 @@ func TestTransportAuthorizesBeforeCollecting(t *testing.T) {
 			}
 			if !test.wantSignals {
 				for name := range received {
-					if strings.EqualFold(name, HeaderProductModel) || strings.EqualFold(name, HeaderOSType) {
+					if strings.EqualFold(name, HeaderProductModel) || strings.EqualFold(name, HeaderOSType) || strings.EqualFold(name, HeaderCredentialSource) {
 						t.Fatalf("restricted header leaked as %q", name)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestTransportRiskControlDisabledSuppressesAllSignals(t *testing.T) {
+	var received http.Header
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		received = req.Header.Clone()
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+	req, err := http.NewRequest(http.MethodGet, "https://open.feishu.cn/open-apis/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Restricted values must not survive from either the caller or the trusted
+	// credential provider after the workspace opts out of risk control.
+	req.Header.Set(HeaderOSType, "caller-value")
+	req.Header.Set(HeaderProductModel, "caller-value")
+	req.Header.Set(HeaderCredentialSource, "caller-value")
+	req = req.WithContext(core.WithCredentialSource(req.Context(), core.CredentialSourceLocal))
+
+	resp, err := NewTransport(base, nil).RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	for _, name := range restrictedHeaders {
+		if got := received.Get(name); got != "" {
+			t.Fatalf("risk-control opt-out sent %s=%q", name, got)
+		}
+	}
+}
+
+func TestTransportCredentialSourceIsRequestScoped(t *testing.T) {
+	var received http.Header
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		received = req.Header.Clone()
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+	transport := NewTransport(base, staticSource{OSType: OSTypeMacOS})
+
+	for _, test := range []struct {
+		name   string
+		source core.CredentialSource
+		want   string
+	}{
+		{name: "local request", source: core.CredentialSourceLocal, want: "local"},
+		{name: "environment request", source: core.CredentialSourceEnv, want: "env"},
+		{name: "request without resolved credential"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "https://open.feishu.cn/open-apis/test", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req = req.WithContext(core.WithCredentialSource(req.Context(), test.source))
+			resp, err := transport.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+			if got := received.Get(HeaderCredentialSource); got != test.want {
+				t.Fatalf("%s = %q, want %q", HeaderCredentialSource, got, test.want)
 			}
 		})
 	}

--- a/shortcuts/common/mcp_client.go
+++ b/shortcuts/common/mcp_client.go
@@ -29,7 +29,7 @@ func MCPEndpoint(brand core.LarkBrand) string {
 
 // CallMCPTool calls an MCP tool via JSON-RPC 2.0 and returns the parsed result.
 func CallMCPTool(runtime *RuntimeContext, toolName string, args map[string]interface{}) (map[string]interface{}, error) {
-	accessToken, err := runtime.AccessToken()
+	token, err := runtime.resolveAccessToken()
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,8 @@ func CallMCPTool(runtime *RuntimeContext, toolName string, args map[string]inter
 		return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "failed to get HTTP client: %v", err).WithCause(err)
 	}
 
-	raw, err := DoMCPCall(runtime.Ctx(), httpClient, toolName, args, accessToken, MCPEndpoint(runtime.Config.Brand), runtime.IsBot())
+	requestCtx := core.WithCredentialSource(runtime.Ctx(), token.Source)
+	raw, err := DoMCPCall(requestCtx, httpClient, toolName, args, token.Token, MCPEndpoint(runtime.Config.Brand), runtime.IsBot())
 	if err != nil {
 		return nil, err
 	}

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -205,19 +205,30 @@ func (ctx *RuntimeContext) getAPIClient() (*client.APIClient, error) {
 // For user: returns user access token (with auto-refresh).
 // For bot: returns tenant access token.
 func (ctx *RuntimeContext) AccessToken() (string, error) {
+	result, err := ctx.resolveAccessToken()
+	if err != nil {
+		return "", err
+	}
+	return result.Token, nil
+}
+
+// resolveAccessToken retains the request-scoped origin metadata needed by
+// direct HTTP paths such as MCP. Callers that only need the token value should
+// use AccessToken.
+func (ctx *RuntimeContext) resolveAccessToken() (*credential.TokenResult, error) {
 	result, err := ctx.Factory.Credential.ResolveToken(ctx.ctx, credential.NewTokenSpec(ctx.As(), ctx.Config.AppID))
 	if err != nil {
 		// ResolveToken classifies its own failures (config/api); pass those
 		// through so a typed lower-layer error is not flattened to token_invalid.
 		if _, ok := errs.ProblemOf(err); ok {
-			return "", err
+			return nil, err
 		}
-		return "", errs.NewAuthenticationError(errs.SubtypeTokenInvalid, "failed to get access token: %s", err).WithCause(err)
+		return nil, errs.NewAuthenticationError(errs.SubtypeTokenInvalid, "failed to get access token: %s", err).WithCause(err)
 	}
 	if result == nil || result.Token == "" {
-		return "", errs.NewAuthenticationError(errs.SubtypeTokenMissing, "no access token available for %s", ctx.As())
+		return nil, errs.NewAuthenticationError(errs.SubtypeTokenMissing, "no access token available for %s", ctx.As())
 	}
-	return result.Token, nil
+	return result, nil
 }
 
 // LarkSDK returns the eagerly-initialized Lark SDK client.


### PR DESCRIPTION
## Summary
Propagate request-scoped credential metadata through shared request paths.

## Changes
- Preserve credential metadata alongside resolved access tokens.
- Propagate it through supported request paths.

## Test Plan
- [ x ] Unit tests pass

## Related Issues
- None