### PR TITLE
fix(drive): guide wiki permission recovery

### DIFF
--- a/shortcuts/drive/drive_import_common_test.go
+++ b/shortcuts/drive/drive_import_common_test.go
@@ -5,15 +5,20 @@ package drive
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
 )
 
 func TestValidateDriveImportSpec(t *testing.T) {
@@ -480,6 +485,29 @@ func TestDriveImportContinuesWhenFolderTokenDoesNotResolveAsWiki(t *testing.T) {
 	point, _ := body["point"].(map[string]interface{})
 	if got := point["mount_key"]; got != "fldcnImportTarget" {
 		t.Fatalf("import mount_key = %#v, want fldcnImportTarget", got)
+	}
+}
+
+func TestDriveImportWikiProbePermissionFailureRemainsNonBlocking(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 131006,
+			"msg":  "permission denied: node permission denied, user needs read permission.",
+		},
+	})
+	runtime := common.TestNewRuntimeContextForAPI(
+		context.Background(),
+		&cobra.Command{Use: "drive +import"},
+		driveTestConfig(),
+		f,
+		core.AsUser,
+	)
+
+	if err := rejectDriveImportWikiFolderToken(runtime, "fldcnImportTarget"); err != nil {
+		t.Fatalf("wiki probe permission failure must not block a valid Drive folder token: %v", err)
 	}
 }
 

--- a/shortcuts/drive/drive_inspect.go
+++ b/shortcuts/drive/drive_inspect.go
@@ -108,7 +108,7 @@ var DriveInspect = common.Shortcut{
 				},
 			)
 			if err != nil {
-				return driveInspectAnnotateError("resolve_wiki", err)
+				return driveInspectAnnotateWikiResolveError(err)
 			}
 
 			node := common.GetMap(data, "node")
@@ -257,6 +257,20 @@ func driveInspectWait(ctx context.Context, d time.Duration) error {
 	case <-driveInspectAfter(d):
 		return nil
 	}
+}
+
+const (
+	driveInspectWikiPermissionDeniedCode = 131006
+	driveInspectWikiPermissionDeniedHint = "The current user or app/bot identity lacks access to the target wiki space or node. This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error; ask the resource owner or wiki administrator to grant read access, or use an accessible resource."
+)
+
+func driveInspectAnnotateWikiResolveError(err error) error {
+	err = driveInspectAnnotateError("resolve_wiki", err)
+	problem, ok := errs.ProblemOf(err)
+	if ok && problem != nil && problem.Code == driveInspectWikiPermissionDeniedCode {
+		problem.Hint = driveInspectWikiPermissionDeniedHint
+	}
+	return err
 }
 
 func driveInspectAnnotateError(stage string, err error) error {

--- a/shortcuts/drive/drive_inspect_test.go
+++ b/shortcuts/drive/drive_inspect_test.go
@@ -486,6 +486,43 @@ func TestDriveInspectExecute_WikiURL(t *testing.T) {
 	}
 }
 
+func TestDriveInspectExecute_WikiPermissionDeniedUsesTerminalGuidance(t *testing.T) {
+	cfg := driveTestConfig()
+	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code":   131006,
+			"msg":    "permission denied: node permission denied, user needs read permission.",
+			"log_id": "log-drive-inspect-wiki-permission",
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveInspect, []string{
+		"+inspect",
+		"--url", "https://xxx.feishu.cn/wiki/wikcnABC",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied || p.Code != 131006 {
+		t.Fatalf("problem = %#v, want authorization/permission_denied/131006", p)
+	}
+	if p.Retryable {
+		t.Fatalf("problem retryable = true, want false: %#v", p)
+	}
+	if p.Hint != driveInspectWikiPermissionDeniedHint {
+		t.Fatalf("hint = %q, want %q", p.Hint, driveInspectWikiPermissionDeniedHint)
+	}
+}
+
 func TestDriveInspectExecute_WikiGetNodeIncompleteData(t *testing.T) {
 	cfg := driveTestConfig()
 	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)


### PR DESCRIPTION
## Summary

When `drive +inspect` unwraps a Wiki URL and the Wiki API returns code `131006`, return terminal resource-access guidance instead of suggesting repeated authorization or identity changes. The fix stays local to the Drive shortcut; shared `internal` error classification and existing Wiki shortcut behavior are unchanged.

## Changes

- Handle Wiki `131006` only at the `drive +inspect` Wiki-resolution boundary.
- Preserve the typed authorization error, code, log ID, and non-retryable semantics while replacing only its recovery hint.
- Keep the Drive import Wiki probe non-blocking.
- Add regression coverage for both behaviors.

## Test Plan

- [x] `go test ./shortcuts/drive -count=1`
- [x] `go vet ./shortcuts/drive`
- [x] `gofmt` and `git diff --check`
- [ ] `make unit-test` — affected packages pass; the full repository run still has unrelated metadata-baseline failures in `cmd/schema`, `internal/affordance`, and `internal/schema` (schema count/high-risk metadata/IM image token metadata).

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Drive wiki resolution errors by clearly identifying permission-denied access issues.
  - Added guidance explaining that these errors are not resolved by retrying or switching accounts.
  - Permission failures during folder checks no longer block valid Drive folder imports.
  - Improved error classification and terminal guidance for authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->