### PR TITLE
Complete mail rule reorder IDs

### DIFF
--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -45,6 +45,7 @@ func mailRulesReorderMethod() meta.Method {
 
 func newMailRulesReorderCommand(t *testing.T) (*cmdutil.Factory, *httpmock.Registry, *cobraCommandShim) {
 	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
 		AppID: "test-app-mail-rules", AppSecret: "test-secret-mail-rules", Brand: core.BrandFeishu,
 	})
@@ -70,6 +71,7 @@ func TestCompleteMailRuleReorderIDs(t *testing.T) {
 		requested []string
 		want      []string
 		wantErr   string
+		wantParam string
 	}{
 		{
 			name:      "complete input unchanged",
@@ -94,12 +96,14 @@ func TestCompleteMailRuleReorderIDs(t *testing.T) {
 			current:   []string{"A", "B", "C"},
 			requested: []string{"B", "B"},
 			wantErr:   "duplicate rule ID",
+			wantParam: "rule_ids",
 		},
 		{
 			name:      "unknown requested ID",
 			current:   []string{"A", "B", "C"},
 			requested: []string{"C", "X"},
 			wantErr:   "does not exist",
+			wantParam: "rule_ids",
 		},
 		{
 			name:      "empty current list",
@@ -121,6 +125,9 @@ func TestCompleteMailRuleReorderIDs(t *testing.T) {
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+				}
+				if tt.wantParam != "" {
+					requireValidationParam(t, err, tt.wantParam)
 				}
 				return
 			}
@@ -239,7 +246,7 @@ func TestMailRulesReorderFetchesAllListPages(t *testing.T) {
 
 	shim.cmd.SetArgs([]string{
 		"--as", "bot",
-		"--params", `{"user_mailbox_id":"me"}`,
+		"--params", `{"user_mailbox_id":"me","page_token":"stale"}`,
 		"--data", `{"rule_ids":["B"]}`,
 	})
 	if err := shim.cmd.Execute(); err != nil {
@@ -251,6 +258,47 @@ func TestMailRulesReorderFetchesAllListPages(t *testing.T) {
 	if got, want := stringifyInterfaceSlice(reorderBody["rule_ids"]), []string{"B", "A", "C"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("reorder rule_ids = %#v, want %#v", got, want)
 	}
+}
+
+func TestMailRulesReorderRejectsRepeatedPageToken(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "A"}},
+				"has_more":   true,
+				"page_token": "next-1",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "B"}},
+				"has_more":   true,
+				"page_token": "next-1",
+			},
+		},
+	})
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["A"]}`,
+	})
+	err := shim.cmd.Execute()
+	if err == nil {
+		t.Fatal("expected repeated page token error")
+	}
+	requireMailRulesProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse)
 }
 
 func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {
@@ -302,9 +350,37 @@ func TestMailRulesReorderValidationFailureDoesNotCallReorder(t *testing.T) {
 	if strings.Contains(err.Error(), "no stub") {
 		t.Fatalf("reorder was called after validation failure: %v", err)
 	}
-	var validationErr *errs.ValidationError
-	if !errors.As(err, &validationErr) {
-		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
+	requireValidationParam(t, err, "rule_ids")
+}
+
+func TestMailRulesReorderLocalBodyValidationDoesNotCallListOrReorder(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{name: "missing rule_ids", data: `{}`},
+		{name: "empty rule_ids", data: `{"rule_ids":[]}`},
+		{name: "empty ID", data: `{"rule_ids":[""]}`},
+		{name: "non-string ID", data: `{"rule_ids":[123]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, shim := newMailRulesReorderCommand(t)
+			shim.cmd.SetArgs([]string{
+				"--as", "bot",
+				"--params", `{"user_mailbox_id":"me"}`,
+				"--data", tt.data,
+			})
+			err := shim.cmd.Execute()
+			if err == nil {
+				t.Fatal("expected local validation error")
+			}
+			if strings.Contains(err.Error(), "no stub") {
+				t.Fatalf("list or reorder was called after local validation failure: %v", err)
+			}
+			requireValidationParam(t, err, "rule_ids")
+		})
 	}
 }
 
@@ -348,4 +424,31 @@ func stringifyInterfaceSlice(value interface{}) []string {
 		out = append(out, item.(string))
 	}
 	return out
+}
+
+func requireValidationParam(t *testing.T, err error, wantParam string) {
+	t.Helper()
+	requireMailRulesProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
+	}
+	if validationErr.Param != wantParam {
+		t.Fatalf("validation param = %q, want %q", validationErr.Param, wantParam)
+	}
+}
+
+func requireMailRulesProblem(t *testing.T, err error, wantCategory errs.Category, wantSubtype errs.Subtype) *errs.Problem {
+	t.Helper()
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("ProblemOf(%T) ok = false; err = %v", err, err)
+	}
+	if problem.Category != wantCategory {
+		t.Fatalf("problem category = %q, want %q", problem.Category, wantCategory)
+	}
+	if problem.Subtype != wantSubtype {
+		t.Fatalf("problem subtype = %q, want %q", problem.Subtype, wantSubtype)
+	}
+	return problem
 }

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -109,7 +110,8 @@ func TestCompleteMailRuleReorderIDs(t *testing.T) {
 			name:      "empty current list",
 			current:   nil,
 			requested: []string{"A"},
-			wantErr:   "returned no rule IDs",
+			wantErr:   "do not exist",
+			wantParam: "rule_ids",
 		},
 		{
 			name:      "duplicate current list",
@@ -299,6 +301,73 @@ func TestMailRulesReorderRejectsRepeatedPageToken(t *testing.T) {
 		t.Fatal("expected repeated page token error")
 	}
 	requireMailRulesProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse)
+}
+
+func TestMailRulesReorderRejectsTooManyListPages(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	var calls int
+	for i := 0; i < maxMailRuleReorderListPages; i++ {
+		nextToken := "next"
+		if i+1 < maxMailRuleReorderListPages {
+			nextToken = fmt.Sprintf("next-%d", i+1)
+		}
+		reg.Register(&httpmock.Stub{
+			Method: http.MethodGet,
+			URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+			OnMatch: func(req *http.Request) {
+				calls++
+			},
+			Body: map[string]interface{}{
+				"code": 0,
+				"msg":  "ok",
+				"data": map[string]interface{}{
+					"items":      []interface{}{map[string]interface{}{"id": "A"}},
+					"has_more":   true,
+					"page_token": nextToken,
+				},
+			},
+		})
+	}
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["A"]}`,
+	})
+	err := shim.cmd.Execute()
+	if err == nil {
+		t.Fatal("expected too many pages error")
+	}
+	requireMailRulesProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse)
+	if calls != maxMailRuleReorderListPages {
+		t.Fatalf("list calls = %d, want %d", calls, maxMailRuleReorderListPages)
+	}
+}
+
+func TestMailRulesReorderEmptyListReturnsRuleIDValidation(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{},
+			},
+		},
+	})
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["deleted-rule"]}`,
+	})
+	err := shim.cmd.Execute()
+	if err == nil {
+		t.Fatal("expected rule_ids validation error")
+	}
+	requireValidationParam(t, err, "rule_ids")
 }
 
 func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {

--- a/cmd/service/mail_rules_reorder_test.go
+++ b/cmd/service/mail_rules_reorder_test.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func mailRulesSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"risk":       cmdutil.RiskWrite,
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type":     "string",
+				"location": "path",
+				"required": true,
+			},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "array", "required": true},
+		},
+	})
+}
+
+func newMailRulesReorderCommand(t *testing.T) (*cmdutil.Factory, *httpmock.Registry, *cobraCommandShim) {
+	t.Helper()
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-mail-rules", AppSecret: "test-secret-mail-rules", Brand: core.BrandFeishu,
+	})
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	return f, reg, &cobraCommandShim{cmd: cmd, stdout: stdout}
+}
+
+type cobraCommandShim struct {
+	cmd interface {
+		SetArgs([]string)
+		Execute() error
+	}
+	stdout interface {
+		Bytes() []byte
+		String() string
+	}
+}
+
+func TestCompleteMailRuleReorderIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   []string
+		requested []string
+		want      []string
+		wantErr   string
+	}{
+		{
+			name:      "complete input unchanged",
+			current:   []string{"A", "B", "C"},
+			requested: []string{"C", "A", "B"},
+			want:      []string{"C", "A", "B"},
+		},
+		{
+			name:      "single partial input is prepended",
+			current:   []string{"A", "B", "C", "D"},
+			requested: []string{"C"},
+			want:      []string{"C", "A", "B", "D"},
+		},
+		{
+			name:      "multiple partial input keeps requested order",
+			current:   []string{"A", "B", "C", "D"},
+			requested: []string{"C", "A"},
+			want:      []string{"C", "A", "B", "D"},
+		},
+		{
+			name:      "duplicate requested ID",
+			current:   []string{"A", "B", "C"},
+			requested: []string{"B", "B"},
+			wantErr:   "duplicate rule ID",
+		},
+		{
+			name:      "unknown requested ID",
+			current:   []string{"A", "B", "C"},
+			requested: []string{"C", "X"},
+			wantErr:   "does not exist",
+		},
+		{
+			name:      "empty current list",
+			current:   nil,
+			requested: []string{"A"},
+			wantErr:   "returned no rule IDs",
+		},
+		{
+			name:      "duplicate current list",
+			current:   []string{"A", "A"},
+			requested: []string{"A"},
+			wantErr:   "duplicate rule ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := completeMailRuleReorderIDs(tt.current, tt.requested)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("completed IDs = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMailRulesReorderFetchesListAndSubmitsCompletedIDs(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	var calls []string
+	var reorderBody map[string]interface{}
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		OnMatch: func(*http.Request) {
+			calls = append(calls, "list")
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"id": "A"},
+					map[string]interface{}{"id": "B"},
+					map[string]interface{}{"id": "C"},
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		OnMatch: func(req *http.Request) {
+			calls = append(calls, "reorder")
+			if err := json.NewDecoder(req.Body).Decode(&reorderBody); err != nil {
+				t.Fatalf("decode reorder body: %v", err)
+			}
+		},
+		Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	})
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["C"]}`,
+	})
+	if err := shim.cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !reflect.DeepEqual(calls, []string{"list", "reorder"}) {
+		t.Fatalf("calls = %#v, want list then reorder", calls)
+	}
+	got := stringifyInterfaceSlice(reorderBody["rule_ids"])
+	if want := []string{"C", "A", "B"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("reorder rule_ids = %#v, want %#v", got, want)
+	}
+	if !strings.Contains(shim.stdout.String(), `"ok": true`) {
+		t.Fatalf("stdout missing success envelope: %s", shim.stdout.String())
+	}
+}
+
+func TestMailRulesReorderFetchesAllListPages(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	var listTokens []string
+	var reorderBody map[string]interface{}
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		OnMatch: func(req *http.Request) {
+			listTokens = append(listTokens, req.URL.Query().Get("page_token"))
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "A"}},
+				"has_more":   true,
+				"page_token": "next-1",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		OnMatch: func(req *http.Request) {
+			listTokens = append(listTokens, req.URL.Query().Get("page_token"))
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"id": "B"},
+					map[string]interface{}{"id": "C"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		OnMatch: func(req *http.Request) {
+			if err := json.NewDecoder(req.Body).Decode(&reorderBody); err != nil {
+				t.Fatalf("decode reorder body: %v", err)
+			}
+		},
+		Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	})
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["B"]}`,
+	})
+	if err := shim.cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if want := []string{"", "next-1"}; !reflect.DeepEqual(listTokens, want) {
+		t.Fatalf("list page tokens = %#v, want %#v", listTokens, want)
+	}
+	if got, want := stringifyInterfaceSlice(reorderBody["rule_ids"]), []string{"B", "A", "C"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("reorder rule_ids = %#v, want %#v", got, want)
+	}
+}
+
+func TestMailRulesReorderListFailureDoesNotCallReorder(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body:   map[string]interface{}{"code": 999, "msg": "list failed"},
+	})
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["A"]}`,
+	})
+	if err := shim.cmd.Execute(); err == nil {
+		t.Fatal("expected list failure")
+	} else if strings.Contains(err.Error(), "no stub") {
+		t.Fatalf("reorder was called after list failure: %v", err)
+	}
+}
+
+func TestMailRulesReorderValidationFailureDoesNotCallReorder(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"id": "A"},
+					map[string]interface{}{"id": "B"},
+				},
+			},
+		},
+	})
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["A","A"]}`,
+	})
+	err := shim.cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if strings.Contains(err.Error(), "no stub") {
+		t.Fatalf("reorder was called after validation failure: %v", err)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
+	}
+}
+
+func TestMailRulesReorderBackendFailureIncludesRetryHint(t *testing.T) {
+	_, reg, shim := newMailRulesReorderCommand(t)
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{map[string]interface{}{"id": "A"}},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]interface{}{"code": 999, "msg": "rule set changed"},
+	})
+
+	shim.cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["A"]}`,
+	})
+	err := shim.cmd.Execute()
+	if err == nil {
+		t.Fatal("expected reorder API error")
+	}
+	if problem, ok := errs.ProblemOf(err); !ok || !strings.Contains(problem.Hint, "rules list") {
+		t.Fatalf("error hint = %#v, want rules list retry hint", problem)
+	}
+}
+
+func stringifyInterfaceSlice(value interface{}) []string {
+	items, _ := value.([]interface{})
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.(string))
+	}
+	return out
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -419,6 +419,10 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		return err
 	}
 
+	if err := prepareMailRuleReorder(opts.Ctx, ac, opts, &request); err != nil {
+		return err
+	}
+
 	out := f.IOStreams.Out
 	format, formatOK := output.ParseFormat(opts.Format)
 	if !formatOK {
@@ -439,7 +443,7 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	if err != nil {
 		return err
 	}
-	return client.HandleResponse(resp, client.ResponseOptions{
+	err = client.HandleResponse(resp, client.ResponseOptions{
 		OutputPath:  opts.Output,
 		Format:      format,
 		JqExpr:      opts.JqExpr,
@@ -450,6 +454,188 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		Identity:    opts.As,
 		CheckError:  checkErr,
 	})
+	if err != nil && opts.SchemaPath == mailRulesReorderSchemaPath {
+		return withMailRuleReorderHint(err)
+	}
+	return err
+}
+
+const mailRulesReorderSchemaPath = "mail.user_mailbox.rules.reorder"
+
+func prepareMailRuleReorder(ctx context.Context, ac *client.APIClient, opts *ServiceMethodOptions, request *client.RawApiRequest) error {
+	if opts.SchemaPath != mailRulesReorderSchemaPath {
+		return nil
+	}
+	body, ok := request.Data.(map[string]interface{})
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--data must be a JSON object").WithParam("--data")
+	}
+	requestedIDs, err := serviceStringSlice(body["rule_ids"], "rule_ids")
+	if err != nil {
+		return err
+	}
+	if len(requestedIDs) == 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "rule_ids must contain at least one rule ID").WithParam("rule_ids")
+	}
+	currentIDs, err := fetchAllMailRuleIDs(ctx, ac, *request)
+	if err != nil {
+		return err
+	}
+	completedIDs, err := completeMailRuleReorderIDs(currentIDs, requestedIDs)
+	if err != nil {
+		return err
+	}
+	body["rule_ids"] = completedIDs
+	request.Data = body
+	return nil
+}
+
+func serviceStringSlice(value interface{}, field string) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return append([]string(nil), v...), nil
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok || s == "" {
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s[%d] must be a non-empty string", field, i).WithParam(field)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s must be an array of strings", field).WithParam(field)
+	}
+}
+
+func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderRequest client.RawApiRequest) ([]string, error) {
+	listURL, ok := strings.CutSuffix(reorderRequest.URL, "/reorder")
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeUnknown, "mail rules reorder URL %q does not end with /reorder", reorderRequest.URL)
+	}
+	params := map[string]interface{}{}
+	for k, v := range reorderRequest.Params {
+		params[k] = v
+	}
+
+	var ids []string
+	for {
+		result, err := ac.CallAPI(ctx, client.RawApiRequest{
+			Method:    "GET",
+			URL:       listURL,
+			Params:    params,
+			As:        reorderRequest.As,
+			ExtraOpts: reorderRequest.ExtraOpts,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := ac.CheckResponse(result, reorderRequest.As); err != nil {
+			return nil, err
+		}
+		data, ok := resultDataMap(result)
+		if !ok {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing data object")
+		}
+		items, ok := data["items"].([]interface{})
+		if !ok {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response missing items array")
+		}
+		for i, item := range items {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d is not an object", i)
+			}
+			id, ok := itemMap["id"].(string)
+			if !ok || id == "" {
+				return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d missing id", i)
+			}
+			ids = append(ids, id)
+		}
+
+		hasMore, nextToken := nextPageToken(data)
+		if !hasMore {
+			break
+		}
+		if nextToken == "" {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response has more pages but no page token")
+		}
+		params["page_token"] = nextToken
+	}
+	return ids, nil
+}
+
+func resultDataMap(result interface{}) (map[string]interface{}, bool) {
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	data, ok := resultMap["data"].(map[string]interface{})
+	return data, ok
+}
+
+func nextPageToken(data map[string]interface{}) (bool, string) {
+	hasMore, _ := data["has_more"].(bool)
+	if !hasMore {
+		return false, ""
+	}
+	for _, key := range []string{"page_token", "next_page_token"} {
+		if token, ok := data[key].(string); ok && token != "" {
+			return true, token
+		}
+	}
+	return true, ""
+}
+
+func completeMailRuleReorderIDs(currentIDs, requestedIDs []string) ([]string, error) {
+	if len(currentIDs) == 0 {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list returned no rule IDs")
+	}
+	currentSet := make(map[string]bool, len(currentIDs))
+	for i, id := range currentIDs {
+		if id == "" {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list item %d missing id", i)
+		}
+		if currentSet[id] {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list returned duplicate rule ID %q", id)
+		}
+		currentSet[id] = true
+	}
+
+	completed := make([]string, 0, len(currentIDs))
+	requestedSet := make(map[string]bool, len(requestedIDs))
+	for _, id := range requestedIDs {
+		if requestedSet[id] {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "duplicate rule ID %q in rule_ids", id).WithParam("rule_ids")
+		}
+		if !currentSet[id] {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule ID %q does not exist in current mailbox rules", id).WithParam("rule_ids")
+		}
+		requestedSet[id] = true
+		completed = append(completed, id)
+	}
+	for _, id := range currentIDs {
+		if !requestedSet[id] {
+			completed = append(completed, id)
+		}
+	}
+	if len(completed) != len(currentIDs) {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "completed rule ID count %d does not match current rule count %d", len(completed), len(currentIDs))
+	}
+	return completed, nil
+}
+
+func withMailRuleReorderHint(err error) error {
+	if problem, ok := errs.ProblemOf(err); ok {
+		hint := "Rules may have changed since they were listed; run `lark-cli mail user_mailbox.rules list` again and retry reorder."
+		if problem.Hint == "" {
+			problem.Hint = hint
+		} else if !strings.Contains(problem.Hint, hint) {
+			problem.Hint += "\n" + hint
+		}
+	}
+	return err
 }
 
 // checkServiceScopes pre-checks user scopes before making the API call.

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -518,8 +518,10 @@ func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderReque
 	for k, v := range reorderRequest.Params {
 		params[k] = v
 	}
+	delete(params, "page_token")
 
 	var ids []string
+	seenPageTokens := map[string]bool{}
 	for {
 		result, err := ac.CallAPI(ctx, client.RawApiRequest{
 			Method:    "GET",
@@ -561,6 +563,10 @@ func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderReque
 		if nextToken == "" {
 			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response has more pages but no page token")
 		}
+		if seenPageTokens[nextToken] {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list response repeated page token %q", nextToken)
+		}
+		seenPageTokens[nextToken] = true
 		params["page_token"] = nextToken
 	}
 	return ids, nil

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const maxMailRuleReorderListPages = 100
+
 // RegisterServiceCommands registers all service commands from from_meta specs.
 func RegisterServiceCommands(parent *cobra.Command, f *cmdutil.Factory) {
 	RegisterServiceCommandsWithContext(context.Background(), parent, f)
@@ -522,7 +524,10 @@ func fetchAllMailRuleIDs(ctx context.Context, ac *client.APIClient, reorderReque
 
 	var ids []string
 	seenPageTokens := map[string]bool{}
-	for {
+	for page := 0; ; page++ {
+		if page >= maxMailRuleReorderListPages {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list exceeded %d pages while completing reorder rule IDs", maxMailRuleReorderListPages)
+		}
 		result, err := ac.CallAPI(ctx, client.RawApiRequest{
 			Method:    "GET",
 			URL:       listURL,
@@ -596,7 +601,7 @@ func nextPageToken(data map[string]interface{}) (bool, string) {
 
 func completeMailRuleReorderIDs(currentIDs, requestedIDs []string) ([]string, error) {
 	if len(currentIDs) == 0 {
-		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "mail rules list returned no rule IDs")
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "rule IDs do not exist in current mailbox rules").WithParam("rule_ids")
 	}
 	currentSet := make(map[string]bool, len(currentIDs))
 	for i, id := range currentIDs {

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -14,12 +14,21 @@ lark-cli mail user_mailbox.rules create --as user \
 lark-cli mail user_mailbox.rules list --as user \
   --params '{"user_mailbox_id":"me"}'
 
-# 3. 删除规则
+# 3. 将指定规则排到前面。可以只输入部分 rule_id；CLI 会自动补齐剩余规则。
+lark-cli mail user_mailbox.rules reorder --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"rule_ids":["<rule_id_to_move_first>"]}'
+
+# 4. 删除规则
 lark-cli mail user_mailbox.rules delete --as user \
   --params '{"user_mailbox_id":"me","rule_id":"<rule_id>"}'
 ```
 
 Quick codes above: condition `type=6` = subject, `operator=1` = contains, action `type=3` = mark as read.
+
+## 排序规则
+
+`rules.reorder` 可以输入部分合法 `rule_id`。CLI 会先读取当前全部收信规则 ID，再把输入的 ID 按给定顺序排到前面，未输入规则保持当前列表中的原相对顺序并自动追加后再提交。输入重复 ID 或未知 ID 时，CLI 会返回参数错误且不会调用 reorder。
 
 ## 原生 API
 


### PR DESCRIPTION
Complete mail rule reorder IDs

Fetch the current mailbox rule list before running the generated reorder command, complete partial rule_id input locally, and reject invalid inputs before making the write call.

Co-authored-by: TRAE CLI <noreply@bytedance.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail rules can now be reordered by specifying rule IDs; remaining rules are completed automatically.
  * Supports rule lists spanning multiple pages, with safeguards against excessive or repeated pagination.
  * Invalid, empty, duplicate, unknown, or incomplete rule IDs are rejected before submission.
  * Failed reorder requests now include a retry hint.

* **Documentation**
  * Added examples and guidance for reordering mail rules, including partial rule ID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->