### PR TITLE
docs(lark-im): support user and bot identities for resource uploads

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -40,7 +40,6 @@ Chat (oc_xxx)
 - `--as user` means **user identity** and uses `user_access_token`. Calls run as the authorized end user, so permissions depend on both the app scopes and that user's own access to the target chat/message/resource.
 - `--as bot` means **bot identity** and uses `tenant_access_token`. Calls run as the app bot, so behavior depends on the bot's membership, app visibility, availability range, and bot-specific scopes.
 - If an IM API says it supports both `user` and `bot`, the token type changes who the operator is. The same API can succeed with one identity and fail with the other because owner/admin status, chat membership, tenant boundary, or app availability are checked against the current caller.
-- Media upload (`images.create`, `files.create`) follows the caller's identity: UAT when `--as user` (requires `im:resource` on the UAT), TAT when `--as bot`. The `+messages-send` / `+messages-reply` shortcuts upload and send in a single identity — do not split the steps across identities.
 
 ### Sender Name Resolution
 

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -40,6 +40,7 @@ Chat (oc_xxx)
 - `--as user` means **user identity** and uses `user_access_token`. Calls run as the authorized end user, so permissions depend on both the app scopes and that user's own access to the target chat/message/resource.
 - `--as bot` means **bot identity** and uses `tenant_access_token`. Calls run as the app bot, so behavior depends on the bot's membership, app visibility, availability range, and bot-specific scopes.
 - If an IM API says it supports both `user` and `bot`, the token type changes who the operator is. The same API can succeed with one identity and fail with the other because owner/admin status, chat membership, tenant boundary, or app availability are checked against the current caller.
+- Media upload (`images.create`, `files.create`) follows the caller's identity: UAT when `--as user` (requires `im:resource` on the UAT), TAT when `--as bot`. The `+messages-send` / `+messages-reply` shortcuts upload and send in a single identity — do not split the steps across identities.
 
 ### Sender Name Resolution
 
@@ -190,7 +191,11 @@ lark-cli im <resource> <method> [flags] # 调用 API
 
 ### images
 
-  - `create` — 上传图片。Identity: `bot` only (`tenant_access_token`).
+  - `create` — 上传图片。Identity: supports `user` and `bot`; user identity requires `im:resource` scope on the UAT.
+
+### files
+
+  - `create` — 上传文件。Identity: supports `user` and `bot`; user identity requires `im:resource` scope on the UAT.
 
 ### pins
 
@@ -238,6 +243,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `reactions.list` | `im:message.reactions:read` |
 | `threads.forward` | `im:message` |
 | `images.create` | `im:resource` |
+| `files.create` | `im:resource` |
 | `pins.create` | `im:message.pins:write_only` |
 | `pins.delete` | `im:message.pins:write_only` |
 | `pins.list` | `im:message.pins:read` |


### PR DESCRIPTION
## Summary

Update the generated `lark-im` Skill documentation to expose the correct identity support for IM resource upload APIs. This change adds `files.create` and documents that both `images.create` and `files.create` support user and bot identities.

## Changes

- Update `images.create` to indicate support for both user and bot identities.
- Add `files.create` to the IM resource list and API permission table.
- Regenerate the `lark-im` Skill content from the latest registry configuration.

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Verified `lark-cli schema im.images.create`
- [x] Verified `lark-cli schema im.files.create`
- [x] Manual local verification confirms the `lark-cli im <resource> <method>` flow works as expected

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image uploads now support both user and bot identities.
  * File uploads now support both user and bot identities.
* **Documentation**
  * Added permission guidance for user image uploads, including the required `im:resource` scope.
  * Documented the `files.create` permission and its required scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->