### PR TITLE
feat(sheets): answer +sheet-list instead of failing the guess

### DIFF
--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -113,6 +113,32 @@
       }
     ]
   },
+  "+sheet-list": {
+    "risk": "read",
+    "flags": [
+      {
+        "name": "url",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "spreadsheet-token",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "dry-run",
+        "kind": "system",
+        "type": "bool",
+        "required": "optional",
+        "desc": ""
+      }
+    ]
+  },
   "+sheet-create": {
     "risk": "write",
     "flags": [

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -883,6 +883,14 @@ var flagDefs = map[string]commandDef{
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},
+	"+sheet-list": {
+		Risk: "read",
+		Flags: []flagDef{
+			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
+		},
+	},
 	"+sheet-move": {
 		Risk: "write",
 		Flags: []flagDef{

--- a/shortcuts/sheets/lark_sheet_sheet_list.go
+++ b/shortcuts/sheets/lark_sheet_sheet_list.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"context"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// ─── lark_sheet_sheet_list ─────────────────────────────────────────────
+//
+// SheetList is a read-only derivative over get_workbook_structure that projects
+// out only the sub-sheet array. +workbook-info is the documented way to read a
+// workbook's structure; +sheet-list exists because callers reach for that name
+// unprompted — the sheets surface has a whole +sheet-* family (+sheet-create /
+// +sheet-copy / +sheet-delete / +sheet-info / ...), so "list the sheets" spells
+// itself +sheet-list. The miss is not self-correcting either: internal/suggest
+// ranks shared prefixes first, so the "did you mean" hint points at
+// +sheet-create and its siblings, never at +workbook-info.
+//
+// Hidden on both surfaces on purpose: absent from `sheets --help` (the Hidden
+// field below) and from the lark-sheets skill docs (doc_hidden_shortcuts in
+// sheet-skill-spec's canonical-spec/surfaces/bundle.json). Callers who read
+// either surface are never offered a second name for what +workbook-info
+// already does; the command only ever answers someone who typed it anyway.
+var SheetList = common.Shortcut{
+	Service:     "sheets",
+	Command:     "+sheet-list",
+	Description: "List a spreadsheet's sub-sheets with their metadata (sheet_id, title, dimensions, freeze, hidden).",
+	Risk:        "read",
+	Scopes:      []string{"sheets:spreadsheet:read"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Hidden:      true,
+	Flags:       flagsFor("+sheet-list"),
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := resolveSpreadsheetToken(runtime)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		token, _ := resolveSpreadsheetToken(runtime)
+		return invokeToolDryRun(token, ToolKindRead, "get_workbook_structure", map[string]interface{}{
+			"excel_id": token,
+		})
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetTokenExec(runtime)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindRead, "get_workbook_structure", map[string]interface{}{
+			"excel_id": token,
+		})
+		if err != nil {
+			return err
+		}
+		sheets, err := projectSheets(out)
+		if err != nil {
+			return err
+		}
+		runtime.Out(sheets, nil)
+		return nil
+	},
+	Tips: []string{
+		"+workbook-info is the documented command for this: it returns these same sheets alongside the rest of the workbook structure.",
+	},
+}
+
+// projectSheets narrows a get_workbook_structure response to its `sheets`
+// array. Entries pass through exactly as the tool returned them, so the
+// per-sheet shape is the one +workbook-info shows. Every workbook has at least
+// one sub-sheet, so a missing or non-array `sheets` is a malformed response
+// rather than an empty workbook — surface it as an error instead of emitting a
+// silent empty list.
+func projectSheets(out interface{}) (interface{}, error) {
+	obj, ok := out.(map[string]interface{})
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
+			"get_workbook_structure returned non-object output")
+	}
+	sheets, ok := obj["sheets"].([]interface{})
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
+			"get_workbook_structure did not return a sheets array")
+	}
+	return sheets, nil
+}

--- a/shortcuts/sheets/lark_sheet_sheet_list_test.go
+++ b/shortcuts/sheets/lark_sheet_sheet_list_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// workbookStructureOutput is one get_workbook_structure response carrying two
+// sub-sheets plus the sibling fields +sheet-list drops.
+const workbookStructureOutput = `{"revision":60,"sheets":[` +
+	`{"sheet_id":"sh1","title":"Sheet1","row_count":1000,"column_count":26,"index":0,"hidden":false},` +
+	`{"sheet_id":"sh2","title":"Q1","row_count":200,"column_count":8,"index":1,"hidden":true}]}`
+
+func TestSheetListProjectSheets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts the sheets array from a workbook-structure object", func(t *testing.T) {
+		out := map[string]interface{}{
+			"revision": float64(60),
+			"sheets": []interface{}{
+				map[string]interface{}{"sheet_id": "sh1"},
+				map[string]interface{}{"sheet_id": "sh2"},
+			},
+		}
+		got, err := projectSheets(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		sheets, ok := got.([]interface{})
+		if !ok || len(sheets) != 2 {
+			t.Fatalf("sheets = %#v, want a 2-element array", got)
+		}
+	})
+
+	t.Run("errors when sheets is absent", func(t *testing.T) {
+		_, err := projectSheets(map[string]interface{}{"revision": float64(60)})
+		requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, "sheets array")
+	})
+
+	t.Run("errors when sheets is not an array", func(t *testing.T) {
+		_, err := projectSheets(map[string]interface{}{"sheets": "Sheet1"})
+		requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, "sheets array")
+	})
+
+	t.Run("errors on a non-object output", func(t *testing.T) {
+		_, err := projectSheets("not-an-object")
+		requireProblem(t, err, errs.CategoryInternal, errs.SubtypeInvalidResponse, "non-object")
+	})
+}
+
+// TestExecute_SheetList_EmitsSheetsArray locks the output contract that makes
+// +sheet-list worth having next to +workbook-info: envelope data is the bare
+// sheets array, with each entry passed through exactly as the tool returned it.
+func TestExecute_SheetList_EmitsSheetsArray(t *testing.T) {
+	t.Parallel()
+	stub := toolOutputStub(testToken, "read", workbookStructureOutput)
+	out, err := runShortcutWithStubs(t, SheetList, []string{"--url", testURL}, stub)
+	if err != nil {
+		t.Fatalf("execute failed: %v\nout=%s", err, out)
+	}
+
+	var envelope struct {
+		OK   bool          `json:"ok"`
+		Data []interface{} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("failed to decode envelope: %v\nraw=%s", err, out)
+	}
+	if !envelope.OK {
+		t.Fatalf("envelope.ok=false: %s", out)
+	}
+	if len(envelope.Data) != 2 {
+		t.Fatalf("data len = %d, want 2; out=%s", len(envelope.Data), out)
+	}
+	first, _ := envelope.Data[0].(map[string]interface{})
+	if first["sheet_id"] != "sh1" || first["title"] != "Sheet1" ||
+		first["row_count"] != float64(1000) || first["index"] != float64(0) {
+		t.Errorf("first sheet lost fields on the way through: %#v", first)
+	}
+}
+
+// TestSheetList_MatchesWorkbookInfoEntries pins the "same per-sheet shape"
+// promise: the entries +sheet-list emits are the ones +workbook-info nests
+// under `sheets`, not a re-projected subset.
+func TestSheetList_MatchesWorkbookInfoEntries(t *testing.T) {
+	t.Parallel()
+
+	listOut, err := runShortcutWithStubs(t, SheetList, []string{"--url", testURL},
+		toolOutputStub(testToken, "read", workbookStructureOutput))
+	if err != nil {
+		t.Fatalf("+sheet-list failed: %v\nout=%s", err, listOut)
+	}
+	infoOut, err := runShortcutWithStubs(t, WorkbookInfo, []string{"--url", testURL},
+		toolOutputStub(testToken, "read", workbookStructureOutput))
+	if err != nil {
+		t.Fatalf("+workbook-info failed: %v\nout=%s", err, infoOut)
+	}
+
+	var list struct {
+		Data []interface{} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(listOut), &list); err != nil {
+		t.Fatalf("decode +sheet-list envelope: %v\nraw=%s", err, listOut)
+	}
+	info := decodeEnvelopeData(t, infoOut)
+	infoSheets, _ := info["sheets"].([]interface{})
+
+	got, _ := json.Marshal(list.Data)
+	want, _ := json.Marshal(infoSheets)
+	if string(got) != string(want) {
+		t.Errorf("+sheet-list entries = %s, want +workbook-info's sheets = %s", got, want)
+	}
+}
+
+// TestSheetList_DryRunInvokesWorkbookStructure asserts the shortcut reuses the
+// existing read tool rather than reaching for a dedicated backend endpoint.
+func TestSheetList_DryRunInvokesWorkbookStructure(t *testing.T) {
+	t.Parallel()
+	body := parseDryRunBody(t, SheetList, []string{"--url", testURL})
+	input := decodeToolInput(t, body, "get_workbook_structure")
+	if input["excel_id"] != testToken {
+		t.Errorf("excel_id = %v, want %s", input["excel_id"], testToken)
+	}
+}
+
+// TestSheetList_StaysOffTheHelpSurface guards the half of the design Go owns:
+// +sheet-list answers callers who already typed it and is advertised to nobody.
+// (The skill-doc half lives in sheet-skill-spec's doc_hidden_shortcuts.)
+func TestSheetList_StaysOffTheHelpSurface(t *testing.T) {
+	t.Parallel()
+	if !shortcutFromRegistry(t, "+sheet-list").Hidden {
+		t.Error("+sheet-list must stay hidden: it is a fallback for a guessed name, not a second documented way to read workbook structure")
+	}
+}

--- a/shortcuts/sheets/shortcuts.go
+++ b/shortcuts/sheets/shortcuts.go
@@ -59,6 +59,7 @@ func shortcutList() []common.Shortcut {
 		// lark_sheet_workbook
 		WorkbookInfo,
 		RevisionGet,
+		SheetList,
 		SheetCreate,
 		SheetDelete,
 		SheetRename,

--- a/tests/cli_e2e/sheets/sheets_sheet_list_dryrun_test.go
+++ b/tests/cli_e2e/sheets/sheets_sheet_list_dryrun_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestSheets_SheetListDryRun pins the +sheet-list request shape: a single
+// get_workbook_structure invoke_READ carrying just the workbook token. The
+// endpoint half matters as much as the tool name — the gateway 403s a read tool
+// sent to invoke_write, and +sheet-list sits in a file whose siblings are all
+// write shortcuts. +sheet-list is added in this branch, so AGENTS.md requires
+// the dry-run E2E.
+//
+// The command is hidden from `sheets --help`, which is exactly why it needs
+// executable coverage: nothing on the help surface would reveal a regression.
+func TestSheets_SheetListDryRun(t *testing.T) {
+	setSheetsDryRunEnv(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "by token",
+			args: []string{"--spreadsheet-token", "shtDryRun"},
+		},
+		{
+			name: "by url",
+			args: []string{"--url", "https://example.feishu.cn/sheets/shtDryRun"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      append([]string{"sheets", "+sheet-list"}, append(tt.args, "--dry-run")...),
+				DefaultAs: "user",
+			})
+			if result != nil {
+				result.Stdout = clie2e.DryRunData(result.Stdout)
+			}
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+
+			out := result.Stdout
+
+			require.Equal(t, "POST", gjson.Get(out, "api.0.method").String(), "stdout:\n%s", out)
+			require.Equal(t, "/open-apis/sheet_ai/v2/spreadsheets/shtDryRun/tools/invoke_read",
+				gjson.Get(out, "api.0.url").String(), "stdout:\n%s", out)
+			require.Equal(t, "get_workbook_structure",
+				gjson.Get(out, "api.0.body.tool_name").String(), "stdout:\n%s", out)
+			require.Equal(t, `{"excel_id":"shtDryRun"}`,
+				gjson.Get(out, "api.0.body.input").String(), "stdout:\n%s", out)
+		})
+	}
+}

--- a/tests/cli_e2e/sheets/sheets_sheet_list_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_sheet_list_workflow_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestSheets_SheetListWorkflow exercises +sheet-list against a real workbook.
+// It is the only coverage that sees the actual backend response: the package
+// tests stub get_workbook_structure, so they can only prove the projection is
+// consistent with the shape the stub asserts, not with the shape the server
+// sends.
+//
+// The contract under test is the reason +sheet-list exists as its own shortcut
+// rather than an alias: its data is the bare sheets array, entry-for-entry
+// identical to what +workbook-info nests under `sheets`. A projection that
+// re-serialized or filtered per-sheet fields would still pass a "has sheet_id"
+// assertion, so the last subtest compares the two payloads verbatim.
+func TestSheets_SheetListWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	spreadsheetToken := ""
+	createdSheetID := ""
+
+	t.Run("create spreadsheet as bot", func(t *testing.T) {
+		spreadsheetToken = createSpreadsheet(t, parentT, ctx, "lark-cli-e2e-sheet-list-"+suffix, "bot")
+	})
+
+	// A second sub-sheet makes the list non-trivial: a one-entry array would pass
+	// an ordering-blind assertion either way.
+	t.Run("add a second sub-sheet as bot", func(t *testing.T) {
+		require.NotEmpty(t, spreadsheetToken, "spreadsheet token is required")
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"sheets", "+sheet-create",
+				"--spreadsheet-token", spreadsheetToken,
+				"--title", "data-" + suffix,
+				"--index", "1",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+
+		createdSheetID = gjson.Get(result.Stdout, "data.sheet_id").String()
+		require.NotEmpty(t, createdSheetID, "created sheet_id should not be empty, stdout: %s", result.Stdout)
+	})
+
+	t.Run("+sheet-list emits a bare sheets array as bot", func(t *testing.T) {
+		require.NotEmpty(t, spreadsheetToken, "spreadsheet token is required")
+		require.NotEmpty(t, createdSheetID, "created sheet_id is required")
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"sheets", "+sheet-list", "--spreadsheet-token", spreadsheetToken},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+
+		data := gjson.Get(result.Stdout, "data")
+		require.True(t, data.IsArray(), "data must be the sheets array itself, stdout:\n%s", result.Stdout)
+
+		// At least the workbook's default sheet plus the one just created. Not an
+		// exact count: how many sheets +create seeds a new workbook with is that
+		// command's contract, and pinning it here would misattribute its change to
+		// +sheet-list.
+		entries := data.Array()
+		require.GreaterOrEqual(t, len(entries), 2, "stdout:\n%s", result.Stdout)
+
+		ids := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			id := entry.Get("sheet_id").String()
+			require.NotEmpty(t, id, "every entry carries sheet_id, stdout:\n%s", result.Stdout)
+			assert.NotEmpty(t, entry.Get("sheet_name").String(), "stdout:\n%s", result.Stdout)
+			ids = append(ids, id)
+		}
+		assert.Contains(t, ids, createdSheetID, "the sub-sheet just created must be listed, stdout:\n%s", result.Stdout)
+	})
+
+	t.Run("+sheet-list entries match +workbook-info's sheets as bot", func(t *testing.T) {
+		require.NotEmpty(t, spreadsheetToken, "spreadsheet token is required")
+
+		listResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"sheets", "+sheet-list", "--spreadsheet-token", spreadsheetToken},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		listResult.AssertExitCode(t, 0)
+		listResult.AssertStdoutStatus(t, true)
+
+		infoResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args:      []string{"sheets", "+workbook-info", "--spreadsheet-token", spreadsheetToken},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		infoResult.AssertExitCode(t, 0)
+		infoResult.AssertStdoutStatus(t, true)
+
+		assert.JSONEq(t,
+			gjson.Get(infoResult.Stdout, "data.sheets").Raw,
+			gjson.Get(listResult.Stdout, "data").Raw,
+			"+sheet-list must forward +workbook-info's sheets entries verbatim\nlist:\n%s\ninfo:\n%s",
+			listResult.Stdout, infoResult.Stdout)
+	})
+}


### PR DESCRIPTION
## Why

Callers reach for `+sheet-list` on their own. The sheets surface has a whole `+sheet-*` family — `+sheet-create`, `+sheet-copy`, `+sheet-delete`, `+sheet-info` — so "list the sheets" spells itself `+sheet-list`, even though the command that reads workbook structure is `+workbook-info`.

The miss does not self-correct. `internal/suggest.Closest` ranks shared prefixes ahead of edit distance, and `+sheet-list` shares a 7-character prefix with `+sheet-create` but only 1 character with `+workbook-info`. The "did you mean" hint therefore lists unrelated `+sheet-*` commands and never points at the right one.

## What

A read-only projection over `get_workbook_structure` that emits the bare sheets array:

```console
$ lark-cli sheets +sheet-list --spreadsheet-token <token>
{ "ok": true, "identity": "user",
  "data": [ {"sheet_id":"0HSoFo","sheet_name":"Jan","index":0,"row_count":200,
             "column_count":20,"is_hidden":true, ...}, ... ] }
```

Entries are forwarded exactly as the tool returned them, so they are identical to what `+workbook-info` nests under `sheets`. `+workbook-info` keeps one extra top-level field, `revision`, which `+revision-get` already projects on its own.

It reuses the existing read tool rather than adding a backend endpoint — the same shape `+revision-get` already uses for the `revision` field.

## Why hidden

The command exists to answer a name that was guessed, not to offer a second documented way to read workbook structure. Advertising it would leave callers choosing between two commands that do the same thing.

So it is hidden on both surfaces: `Hidden: true` keeps it out of `sheets --help` and completion here, and it is excluded from the lark-sheets skill docs upstream in sheet-skill-spec. `sheets +sheet-list --help` still works and points back at `+workbook-info`.

## Testing

- Package tests: `projectSheets` happy path and the three malformed-response paths; an execute-path test asserting `data` is the bare array with fields intact; a test comparing `+sheet-list`'s output against `+workbook-info`'s `sheets` on the same stubbed response; a dry-run test pinning `get_workbook_structure`; and one asserting the command stays off the help surface.
- Dry-run E2E (`tests/cli_e2e/sheets/sheets_sheet_list_dryrun_test.go`): `--spreadsheet-token` and `--url` both resolve to a single `invoke_read` POST carrying `{"excel_id":"..."}`. The read-vs-write endpoint is asserted deliberately: every sibling shortcut in this area is a write, and a read tool sent to `invoke_write` is rejected by the gateway.
- Live E2E (`tests/cli_e2e/sheets/sheets_sheet_list_workflow_test.go`): creates a workbook and a second sub-sheet, then asserts the payload is an array containing the new sheet, and that it matches `+workbook-info`'s `sheets` verbatim. Self-cleaning via the shared `createSpreadsheet` helper.
- Manually verified against a real 32-sub-sheet workbook: `+sheet-list`'s `data` is byte-identical to `+workbook-info`'s `data.sheets`.

## Notes

`data/flag-defs.json` and `flag_defs_gen.go` carry the new shortcut's flag entry, sourced from the spec repo that owns those artifacts.

Three conventions are intentionally left as-is, matching every other shortcut in this domain rather than making this one command an outlier:

- Output goes through `runtime.Out`, like all 56 sheets shortcuts (none use the format-aware emitter today), so `--format` behaves exactly as it does for `+workbook-info`.
- Scopes declare `sheets:spreadsheet:read` only. The wiki-URL path needs `wiki:node:read`, but no sheets shortcut declares it conditionally today, including `+workbook-info`.
- `projectSheets` reads the response as a loose map, like `projectRevision`. A typed struct would risk dropping fields the verbatim-forwarding contract depends on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hidden, read-only `sheets +sheet-list` shortcut.
  * Supports spreadsheet URLs or tokens to retrieve sheet details.
  * Added optional dry-run support and formatted output.
  * Sheet results align with the entries returned by workbook information commands.

* **Bug Fixes**
  * Added validation for missing or malformed workbook and sheet data.

* **Tests**
  * Added unit, end-to-end, workflow, and dry-run coverage for the new shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->