### PR TITLE
feat(calendar): support setting VC meeting owner in +create

### DIFF
--- a/shortcuts/calendar/calendar_create.go
+++ b/shortcuts/calendar/calendar_create.go
@@ -18,13 +18,17 @@ import (
 )
 
 func buildEventData(runtime *common.RuntimeContext, startTs, endTs string) map[string]interface{} {
+	vchat := map[string]interface{}{"vc_type": "vc"}
+	if ownerId := strings.TrimSpace(runtime.Str("meeting-owner-id")); ownerId != "" {
+		vchat["meeting_settings"] = map[string]interface{}{"owner_id": ownerId}
+	}
 	eventData := map[string]interface{}{
 		"summary":          runtime.Str("summary"),
 		"start_time":       map[string]string{"timestamp": startTs},
 		"end_time":         map[string]string{"timestamp": endTs},
 		"attendee_ability": "can_modify_event",
 		"free_busy_status": "busy",
-		"vchat":            map[string]string{"vc_type": "vc"},
+		"vchat":            vchat,
 		"reminders": []map[string]int{
 			{"minutes": 5},
 		},
@@ -124,6 +128,7 @@ var CalendarCreate = common.Shortcut{
 		{Name: "attendee-ids", Desc: "attendee IDs, comma-separated (supports user ou_, chat oc_, room omm_)"},
 		{Name: "calendar-id", Desc: "calendar ID (default: primary)"},
 		{Name: "rrule", Desc: "recurrence rule (rfc5545)"},
+		{Name: "meeting-owner-id", Desc: "VC meeting owner open_id (ou_). Only effective as a bot on the app calendar; owner must be an in-tenant user"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := rejectCalendarAutoBotFallback(runtime); err != nil {
@@ -146,6 +151,18 @@ var CalendarCreate = common.Shortcut{
 				if !strings.HasPrefix(id, "ou_") && !strings.HasPrefix(id, "oc_") && !strings.HasPrefix(id, "omm_") {
 					return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid attendee id format %q: should start with 'ou_', 'oc_', or 'omm_'", id).WithParam("--attendee-ids")
 				}
+			}
+		}
+
+		if ownerId := strings.TrimSpace(runtime.Str("meeting-owner-id")); ownerId != "" {
+			if err := common.RejectDangerousCharsTyped("--meeting-owner-id", ownerId); err != nil {
+				return err
+			}
+			if !strings.HasPrefix(ownerId, "ou_") || ownerId == "ou_" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --meeting-owner-id %q: meeting owner must be a user open_id starting with 'ou_'", ownerId).WithParam("--meeting-owner-id")
+			}
+			if !runtime.IsBot() {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--meeting-owner-id only takes effect when running as a bot on the app calendar; re-run with --as bot").WithParam("--meeting-owner-id")
 			}
 		}
 

--- a/shortcuts/calendar/calendar_test.go
+++ b/shortcuts/calendar/calendar_test.go
@@ -196,12 +196,112 @@ func TestBuildEventData_DefaultVChat(t *testing.T) {
 	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
 	eventData := buildEventData(runtime, "1742515200", "1742518800")
 
-	vchat, ok := eventData["vchat"].(map[string]string)
+	vchat, ok := eventData["vchat"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("vchat = %T, want map[string]string", eventData["vchat"])
+		t.Fatalf("vchat = %T, want map[string]interface{}", eventData["vchat"])
 	}
 	if got := vchat["vc_type"]; got != "vc" {
 		t.Fatalf("vchat.vc_type = %q, want %q", got, "vc")
+	}
+	if _, exists := vchat["meeting_settings"]; exists {
+		t.Fatalf("vchat.meeting_settings should be absent without --meeting-owner-id, got %v", vchat["meeting_settings"])
+	}
+}
+
+func TestBuildEventData_MeetingOwner(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("summary", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("rrule", "", "")
+	cmd.Flags().String("meeting-owner-id", "", "")
+	cmd.Flags().Set("summary", "Team Sync")
+	cmd.Flags().Set("meeting-owner-id", "ou_owner123")
+
+	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
+	eventData := buildEventData(runtime, "1742515200", "1742518800")
+
+	vchat, ok := eventData["vchat"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("vchat = %T, want map[string]interface{}", eventData["vchat"])
+	}
+	if got := vchat["vc_type"]; got != "vc" {
+		t.Fatalf("vchat.vc_type = %q, want %q", got, "vc")
+	}
+	settings, ok := vchat["meeting_settings"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("vchat.meeting_settings = %T, want map[string]interface{}", vchat["meeting_settings"])
+	}
+	if got := settings["owner_id"]; got != "ou_owner123" {
+		t.Fatalf("vchat.meeting_settings.owner_id = %q, want %q", got, "ou_owner123")
+	}
+}
+
+func TestCreate_MeetingOwner_DryRun_IncludesOwnerID(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+
+	err := mountAndRun(t, CalendarCreate, []string{
+		"+create",
+		"--summary", "x",
+		"--start", "2025-03-21T10:00:00+08:00",
+		"--end", "2025-03-21T11:00:00+08:00",
+		"--calendar-id", "cal_test123",
+		"--meeting-owner-id", "ou_owner123",
+		"--dry-run",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"owner_id": "ou_owner123"`) {
+		t.Errorf("dry-run should include vchat.meeting_settings.owner_id, got: %s", stdout.String())
+	}
+}
+
+func TestCreate_MeetingOwner_BareOuPrefix_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarCreate, []string{"+create", "--summary", "x", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--calendar-id", "cal_test123", "--meeting-owner-id", "ou_", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--meeting-owner-id" {
+		t.Errorf("param=%q, want --meeting-owner-id", ve.Param)
+	}
+}
+
+func TestCreate_MeetingOwner_NonOuPrefix_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarCreate, []string{"+create", "--summary", "x", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--calendar-id", "cal_test123", "--meeting-owner-id", "oc_notuser", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--meeting-owner-id" {
+		t.Errorf("param=%q, want --meeting-owner-id", ve.Param)
+	}
+}
+
+func TestCreate_MeetingOwner_NonBot_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarCreate, []string{"+create", "--summary", "x", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--calendar-id", "cal_test123", "--meeting-owner-id", "ou_owner123", "--as", "user"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--meeting-owner-id" {
+		t.Errorf("param=%q, want --meeting-owner-id", ve.Param)
 	}
 }
 

--- a/skills/lark-calendar/references/lark-calendar-create.md
+++ b/skills/lark-calendar/references/lark-calendar-create.md
@@ -36,6 +36,7 @@ lark-cli calendar +create --summary "..." --start "..." --end "..." \
 | `--attendee-ids <id_list>` | 否 | 参与人 ID 列表（逗号分隔）。支持用户（`ou_`）、群组（`oc_`）和会议室（`omm_`）。AI 提取时请务必保留对应前缀。bot 可作为合法参会人，无需剔除 |
 | `--calendar-id <id>` | 否 | 日历 ID（省略则使用主日历） |
 | `--rrule <rrule>` | 否 | 重复日程的重复性规则，规则设置方式参考rfc5545。示例值："FREQ=DAILY;INTERVAL=1;UNTIL=<具体日期>" |
+| `--meeting-owner-id <ou_>` | 否 | 设置 VC 会议 owner。仅以应用（bot）身份在应用日历上操作时生效（需 `--as bot`）；owner 必须为本租户用户身份的 open_id（`ou_`） |
 | `--dry-run` | 否 | 预览 API 调用，不执行 |
 
 > 当用户表达'每周 X'、'每周重复'、'连续 N 周'时，必须使用 rrule 创建重复性日程，而非创建多个独立日程
@@ -61,11 +62,11 @@ lark-cli calendar event.attendees create \
   --data '{"attendees": [{"type": "resource", "room_id": "omm_xxx", "approval_reason": "申请原因"}]}'
 
 完整 API 命令的关键差异：
+- `+create` 会自动补 `attendee_ability: can_modify_event`、`free_busy_status: busy`、`vchat: {"vc_type": "vc"}`（含飞书视频会议）、`reminders: [{"minutes": 5}]`；完整 API（`calendar events create`）**不会**自动补这些，如需同等体验须在 `--data` 里显式写入对应字段。
 - `+create` 在传入 `--attendee-ids`（即需要邀请其他参会人）时，会自动把当前身份一并加进参会人，但 `calendar events create` / `calendar event.attendees create` 等完整 API **不会**自动加。需自行把调用身份的 open_id 以 `type:user` 写入 attendees，与邀请的其他参会人合并去重后添加。open_id 用 `lark-cli auth status --json --verify` 获取：bot 取 `identities.bot.openId`（`--verify` 才会填充），user 取 `identities.user.openId`。
 - 时间参数是 **Unix 秒字符串**（非 ISO 8601）。换算时**禁止依赖容器默认时区**（常为 UTC，会导致 8 小时偏移），必须显式指定目标时区。
 - 全天日程的开始日期和结束日期必须分别是日程开始的第一天和结束的最后一天；单日全天日程两者相同。
 - 手动拆成“创建日程 + 添加参会人”两步时，若第二步失败，建议删除刚创建的空日程，避免遗留无参会人的日程。
-- 设置会议 owner：`+create` 不支持，需用完整 API 命令在 `vchat.meeting_settings.owner_id` 中设置，且必须同时设置 `vchat.vc_type` 为 `vc`（代表该日程为 VC 视频会议）。仅当以应用（bot）身份在应用日历上操作时生效；owner 必须为用户身份（`ou_` open_id），不能为非用户或外部租户用户。
 
 ## 参会人类型
 


### PR DESCRIPTION
## Summary

- Add `--meeting-owner-id` to the `calendar +create` shortcut so bot (tenant-access-token) callers can set the VC meeting owner via `vchat.meeting_settings.owner_id` without dropping down to the raw API.
- Validate the flag: reject dangerous chars, require an `ou_` user open_id, and enforce that it only applies when running `--as bot` (typed `errs` validation errors, not plain errors).
- Update the `lark-calendar-create.md` reference: document the new flag, note the raw-API default-value gap (`attendee_ability` / `free_busy_status` / `vchat.vc_type` / `reminders` are auto-filled only by `+create`), and remove the now-obsolete "owner not supported" guidance.

## Details

`buildEventData` now builds `vchat` as a nested map, keeping the default `vc_type: vc` and injecting `meeting_settings.owner_id` only when `--meeting-owner-id` is provided. Dry-run reuses `buildEventData`, so the owner is reflected there automatically.

## Test plan

- [x] `go test ./shortcuts/calendar/` passes
- [x] `TestBuildEventData_DefaultVChat` updated: asserts nested `vchat` type and that `meeting_settings` is absent by default
- [x] `TestBuildEventData_MeetingOwner` added: asserts `vchat.meeting_settings.owner_id` is set from the flag
- [ ] `make quality-gate` (help/schema surface) to run in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--meeting-owner-id` option for assigning a video meeting owner when creating calendar events in bot mode.
  * Meeting settings are included only when a valid owner ID is provided.

* **Bug Fixes**
  * Improved validation to reject invalid characters, non-user IDs, and unsupported usage contexts.

* **Documentation**
  * Updated calendar creation guidance with meeting-owner requirements, video-conferencing constraints, and usage differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->