### PR TITLE
feat(sheets): support bubble waterfall and pareto charts

### DIFF
--- a/shortcuts/sheets/chart_examples.go
+++ b/shortcuts/sheets/chart_examples.go
@@ -33,6 +33,73 @@ var chartExampleTemplates = map[string]string{
 	"line":   chartSimpleExample("line"),
 	"area":   chartSimpleExample("area"),
 	"radar":  chartSimpleExample("radar"),
+	"bubble": `{
+  "position": {"row": 1, "col": "G"},
+  "size": {"width": 600, "height": 400},
+  "snapshot": {
+    "title": {"text": "气泡图标题"},
+    "plotArea": {"plot": {
+      "type": "bubble",
+      "extra": {"bubble": {
+        "aggregate": false,
+        "showNegativeSize": false,
+        "opacityGradientStyle": "linear",
+        "idLabel": {"visible": true}
+      }}
+    }},
+    "data": {
+      "refs": [{"value": "'Sheet1'!A1:E20"}],
+      "dim1": {"serie": {"index": 1}},
+      "dim2": {"series": [
+        {"index": 2, "role": "x"},
+        {"index": 3, "role": "y"},
+        {"index": 4, "role": "group"},
+        {"index": 5, "role": "size"}
+      ]}
+    }
+  }
+}`,
+	"waterfall": `{
+  "position": {"row": 1, "col": "F"},
+  "size": {"width": 600, "height": 400},
+  "snapshot": {
+    "title": {"text": "瀑布图标题"},
+    "plotArea": {"plot": {
+      "type": "waterfall",
+      "extra": {"waterfall": {
+        "firstValueAsTotal": true,
+        "lastValueAsSubtotal": true,
+        "connectorLine": {"style": "solid", "width": 1},
+        "totalLabels": {"template": "{{value}}"}
+      }}
+    }},
+    "data": {
+      "refs": [{"value": "'Sheet1'!A1:B10"}],
+      "dim1": {"serie": {"index": 1}},
+      "dim2": {"series": [{"index": 2}]}
+    }
+  }
+}`,
+	"pareto": `{
+  "position": {"row": 1, "col": "F"},
+  "size": {"width": 600, "height": 400},
+  "snapshot": {
+    "title": {"text": "排列图标题"},
+    "plotArea": {"plot": {
+      "type": "pareto",
+      "extra": {"pareto": {"aggregateType": "sum", "categoryNumber": 5}},
+      "series": [
+        {"index": 1, "bars": {"gap": 0.25}, "labels": {"value": true}},
+        {"index": 2, "line": {"width": 2}, "points": {"shape": "circle", "size": 6}, "labels": {"percentage": true, "format": "0%"}}
+      ]
+    }},
+    "data": {
+      "refs": [{"value": "'Sheet1'!A1:B20"}],
+      "dim1": {"serie": {"index": 1, "aggregate": true}},
+      "dim2": {"series": [{"index": 2, "aggregateType": "sum"}]}
+    }
+  }
+}`,
 	"scatter": `{
   "position": {"row": 1, "col": "F"},
   "size": {"width": 600, "height": 400},

--- a/shortcuts/sheets/chart_examples_test.go
+++ b/shortcuts/sheets/chart_examples_test.go
@@ -65,6 +65,26 @@ func TestChartExampleTemplates_ValidateAgainstSchema(t *testing.T) {
 	}
 }
 
+func TestChartExampleTemplates_SpecialChartContracts(t *testing.T) {
+	t.Parallel()
+	tests := map[string][]string{
+		"bubble":    {`"role": "x"`, `"role": "y"`, `"role": "group"`, `"role": "size"`},
+		"waterfall": {`"firstValueAsTotal"`, `"lastValueAsSubtotal"`, `"connectorLine"`},
+		"pareto":    {`"aggregateType": "sum"`, `"index": 1`, `"index": 2`, `"percentage": true`},
+	}
+	for typ, markers := range tests {
+		tmpl, ok := chartExampleTemplates[typ]
+		if !ok {
+			t.Fatalf("missing %s template", typ)
+		}
+		for _, marker := range markers {
+			if !strings.Contains(tmpl, marker) {
+				t.Errorf("%s template missing %s", typ, marker)
+			}
+		}
+	}
+}
+
 // TestNormalizeChartHexColors_Arrays pins color normalization inside arrays:
 // the chart schema uses colorTheme / colorScale / highlight_colors, whose
 // values are LISTS of bare hex strings. Recursing without the key context

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -3376,7 +3376,7 @@
         "kind": "own",
         "type": "string",
         "required": "optional",
-        "desc": "Print a minimal ready-to-edit --properties template for a chart type (area|bar|column|combo|line|pie|radar|scatter) and exit. Purely local: no locator flags, no network; an unknown type lists the available ones"
+        "desc": "Print a minimal ready-to-edit --properties template for a chart type (area|bar|bubble|column|combo|line|pareto|pie|radar|scatter|waterfall) and exit. Purely local: no locator flags, no network; an unknown type lists the available ones"
       },
       {
         "name": "dry-run",

--- a/shortcuts/sheets/data/flag-schemas.json
+++ b/shortcuts/sheets/data/flag-schemas.json
@@ -1119,7 +1119,10 @@
                           "combo",
                           "pie",
                           "radar",
-                          "scatter"
+                          "scatter",
+                          "bubble",
+                          "waterfall",
+                          "pareto"
                         ]
                       },
                       "comboType": {
@@ -1176,6 +1179,297 @@
                               "area": {
                                 "type": "boolean",
                                 "description": "是否填充区域"
+                              }
+                            }
+                          },
+                          "bubble": {
+                            "type": "object",
+                            "description": "气泡图配置。气泡图的 x、y、group、size 数据角色在 data.dim2 中指定。",
+                            "properties": {
+                              "aggregate": {
+                                "type": "boolean",
+                                "description": "是否对相同分组与坐标的数据进行汇总"
+                              },
+                              "showNegativeSize": {
+                                "type": "boolean",
+                                "description": "是否显示气泡大小为负值的数据点"
+                              },
+                              "opacityGradientStyle": {
+                                "type": "string",
+                                "description": "气泡透明度渐变样式",
+                                "enum": [
+                                  "linear",
+                                  "radial"
+                                ]
+                              },
+                              "idLabel": {
+                                "description": "气泡标识标签配置；false 表示隐藏标识标签",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "visible": {
+                                        "type": "boolean",
+                                        "description": "是否显示标识标签"
+                                      },
+                                      "fontSize": {
+                                        "type": "number",
+                                        "description": "标签字号"
+                                      },
+                                      "bold": {
+                                        "type": "boolean",
+                                        "description": "是否加粗"
+                                      },
+                                      "italic": {
+                                        "type": "boolean",
+                                        "description": "是否斜体"
+                                      },
+                                      "underline": {
+                                        "type": "boolean",
+                                        "description": "是否下划线"
+                                      },
+                                      "strikethrough": {
+                                        "type": "boolean",
+                                        "description": "是否删除线"
+                                      },
+                                      "color": {
+                                        "type": "string",
+                                        "description": "标签字体颜色"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "boolean",
+                                    "enum": [
+                                      false
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "waterfall": {
+                            "type": "object",
+                            "description": "瀑布图全局配置。单个系列可通过 plot.series[].waterfall 覆盖数值解释和正负值样式。",
+                            "properties": {
+                              "firstValueAsTotal": {
+                                "type": "boolean",
+                                "description": "是否将第一个值视为总计"
+                              },
+                              "lastValueAsSubtotal": {
+                                "type": "boolean",
+                                "description": "是否将最后一个值视为小计"
+                              },
+                              "positiveStyle": {
+                                "type": "object",
+                                "description": "正值柱样式",
+                                "properties": {
+                                  "color": {
+                                    "type": "string",
+                                    "description": "填充颜色"
+                                  },
+                                  "opacity": {
+                                    "type": "number",
+                                    "description": "透明度，取值 0-1"
+                                  },
+                                  "borderColor": {
+                                    "type": "string",
+                                    "description": "边框颜色"
+                                  },
+                                  "borderWidth": {
+                                    "type": "number",
+                                    "description": "边框宽度"
+                                  },
+                                  "borderStyle": {
+                                    "type": "string",
+                                    "description": "边框样式",
+                                    "enum": [
+                                      "solid",
+                                      "dashed",
+                                      "dotted"
+                                    ]
+                                  }
+                                }
+                              },
+                              "negativeStyle": {
+                                "type": "object",
+                                "description": "负值柱样式",
+                                "properties": {
+                                  "color": {
+                                    "type": "string",
+                                    "description": "填充颜色"
+                                  },
+                                  "opacity": {
+                                    "type": "number",
+                                    "description": "透明度，取值 0-1"
+                                  },
+                                  "borderColor": {
+                                    "type": "string",
+                                    "description": "边框颜色"
+                                  },
+                                  "borderWidth": {
+                                    "type": "number",
+                                    "description": "边框宽度"
+                                  },
+                                  "borderStyle": {
+                                    "type": "string",
+                                    "description": "边框样式",
+                                    "enum": [
+                                      "solid",
+                                      "dashed",
+                                      "dotted"
+                                    ]
+                                  }
+                                }
+                              },
+                              "totalStyle": {
+                                "type": "object",
+                                "description": "总计与小计柱样式",
+                                "properties": {
+                                  "color": {
+                                    "type": "string",
+                                    "description": "填充颜色"
+                                  },
+                                  "opacity": {
+                                    "type": "number",
+                                    "description": "透明度，取值 0-1"
+                                  },
+                                  "borderColor": {
+                                    "type": "string",
+                                    "description": "边框颜色"
+                                  },
+                                  "borderWidth": {
+                                    "type": "number",
+                                    "description": "边框宽度"
+                                  },
+                                  "borderStyle": {
+                                    "type": "string",
+                                    "description": "边框样式",
+                                    "enum": [
+                                      "solid",
+                                      "dashed",
+                                      "dotted"
+                                    ]
+                                  }
+                                }
+                              },
+                              "cornerRadius": {
+                                "type": "string",
+                                "description": "柱子圆角大小",
+                                "enum": [
+                                  "default",
+                                  "small",
+                                  "large"
+                                ]
+                              },
+                              "gradient": {
+                                "type": "boolean",
+                                "description": "是否使用渐变填充"
+                              },
+                              "connectorLine": {
+                                "description": "瀑布柱之间的连接线配置；false 表示隐藏连接线",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "color": {
+                                        "type": "string",
+                                        "description": "连接线颜色"
+                                      },
+                                      "width": {
+                                        "type": "number",
+                                        "description": "连接线宽度"
+                                      },
+                                      "style": {
+                                        "type": "string",
+                                        "description": "连接线样式",
+                                        "enum": [
+                                          "solid",
+                                          "dashed",
+                                          "dotted"
+                                        ]
+                                      },
+                                      "opacity": {
+                                        "type": "number",
+                                        "description": "连接线透明度，取值 0-1"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "boolean",
+                                    "enum": [
+                                      false
+                                    ]
+                                  }
+                                ]
+                              },
+                              "totalLabels": {
+                                "description": "总计与小计标签配置；false 表示隐藏该类标签",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "template": {
+                                        "type": "string",
+                                        "description": "标签文本模板"
+                                      },
+                                      "fontSize": {
+                                        "type": "number",
+                                        "description": "标签字号"
+                                      },
+                                      "bold": {
+                                        "type": "boolean",
+                                        "description": "是否加粗"
+                                      },
+                                      "italic": {
+                                        "type": "boolean",
+                                        "description": "是否斜体"
+                                      },
+                                      "underline": {
+                                        "type": "boolean",
+                                        "description": "是否下划线"
+                                      },
+                                      "strikethrough": {
+                                        "type": "boolean",
+                                        "description": "是否删除线"
+                                      },
+                                      "color": {
+                                        "type": "string",
+                                        "description": "标签字体颜色"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "boolean",
+                                    "enum": [
+                                      false
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "pareto": {
+                            "type": "object",
+                            "description": "排列图配置。柱子、累计曲线、数据点和标签复用现有 bars、line、points、labels 配置。",
+                            "properties": {
+                              "aggregateType": {
+                                "type": "string",
+                                "description": "排列图的数据汇总方式",
+                                "enum": [
+                                  "sum",
+                                  "average",
+                                  "count",
+                                  "counta",
+                                  "min",
+                                  "max",
+                                  "median"
+                                ]
+                              },
+                              "categoryNumber": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "参与排列的类别数量，必须为正整数"
                               }
                             }
                           }
@@ -2031,6 +2325,113 @@
                               "type": "object",
                               "description": "数据标签配置（覆盖单系列，配置项同 plotArea.plot.labels）。不覆盖该系列数据标签时省略整个 labels 字段；一旦传入 labels（即便显示开关全部置为 false），该系列仍会显示数据标签。"
                             },
+                            "waterfall": {
+                              "type": "object",
+                              "description": "瀑布图的单系列配置，覆盖 plot.extra.waterfall 中对应的数值解释和样式。",
+                              "properties": {
+                                "firstValueAsTotal": {
+                                  "type": "boolean",
+                                  "description": "是否将该系列第一个值视为总计"
+                                },
+                                "lastValueAsSubtotal": {
+                                  "type": "boolean",
+                                  "description": "是否将该系列最后一个值视为小计"
+                                },
+                                "positiveStyle": {
+                                  "type": "object",
+                                  "description": "该系列的正值柱样式",
+                                  "properties": {
+                                    "color": {
+                                      "type": "string",
+                                      "description": "填充颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "description": "透明度，取值 0-1"
+                                    },
+                                    "borderColor": {
+                                      "type": "string",
+                                      "description": "边框颜色"
+                                    },
+                                    "borderWidth": {
+                                      "type": "number",
+                                      "description": "边框宽度"
+                                    },
+                                    "borderStyle": {
+                                      "type": "string",
+                                      "description": "边框样式",
+                                      "enum": [
+                                        "solid",
+                                        "dashed",
+                                        "dotted"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "negativeStyle": {
+                                  "type": "object",
+                                  "description": "该系列的负值柱样式",
+                                  "properties": {
+                                    "color": {
+                                      "type": "string",
+                                      "description": "填充颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "description": "透明度，取值 0-1"
+                                    },
+                                    "borderColor": {
+                                      "type": "string",
+                                      "description": "边框颜色"
+                                    },
+                                    "borderWidth": {
+                                      "type": "number",
+                                      "description": "边框宽度"
+                                    },
+                                    "borderStyle": {
+                                      "type": "string",
+                                      "description": "边框样式",
+                                      "enum": [
+                                        "solid",
+                                        "dashed",
+                                        "dotted"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "totalStyle": {
+                                  "type": "object",
+                                  "description": "该系列的总计与小计柱样式",
+                                  "properties": {
+                                    "color": {
+                                      "type": "string",
+                                      "description": "填充颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "description": "透明度，取值 0-1"
+                                    },
+                                    "borderColor": {
+                                      "type": "string",
+                                      "description": "边框颜色"
+                                    },
+                                    "borderWidth": {
+                                      "type": "number",
+                                      "description": "边框宽度"
+                                    },
+                                    "borderStyle": {
+                                      "type": "string",
+                                      "description": "边框样式",
+                                      "enum": [
+                                        "solid",
+                                        "dashed",
+                                        "dotted"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "sectors": {
                               "type": "object",
                               "description": "扇区配置（饼图）",
@@ -2512,6 +2913,16 @@
                             "nameRef": {
                               "type": "string",
                               "description": "可选。系列名称的单元格引用（A1 表示法，如 'Sheet1!C1'）。当系列名称不直接来自 refs 首行/首列时，可通过此字段把系列名显式指向目标表头单元格，图表会以该单元格当前值作为系列名（图例/tooltip）展示。"
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "气泡图中该数据系列的角色：x 为横轴、y 为纵轴、group 为分组、size 为气泡大小。气泡图必须各有一个 x 和 y，group 和 size 可选。",
+                              "enum": [
+                                "x",
+                                "y",
+                                "group",
+                                "size"
+                              ]
                             }
                           },
                           "required": [
@@ -2527,10 +2938,25 @@
                           "properties": {
                             "valueType": {
                               "type": "string",
-                              "description": "值类型",
+                              "description": "值类型。x、y、size 角色使用 number；group 角色可使用 string 或 number。",
                               "enum": [
-                                "number"
+                                "number",
+                                "string"
                               ]
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "气泡图中该静态字段的角色：x 为横轴、y 为纵轴、group 为分组、size 为气泡大小。气泡图必须各有一个 x 和 y，group 和 size 可选。",
+                              "enum": [
+                                "x",
+                                "y",
+                                "group",
+                                "size"
+                              ]
+                            },
+                            "format": {
+                              "type": "string",
+                              "description": "字段数值格式"
                             },
                             "name": {
                               "type": "string",
@@ -2875,7 +3301,10 @@
                           "combo",
                           "pie",
                           "radar",
-                          "scatter"
+                          "scatter",
+                          "bubble",
+                          "waterfall",
+                          "pareto"
                         ]
                       },
                       "comboType": {
@@ -2932,6 +3361,297 @@
                               "area": {
                                 "type": "boolean",
                                 "description": "是否填充区域"
+                              }
+                            }
+                          },
+                          "bubble": {
+                            "type": "object",
+                            "description": "气泡图配置。气泡图的 x、y、group、size 数据角色在 data.dim2 中指定。",
+                            "properties": {
+                              "aggregate": {
+                                "type": "boolean",
+                                "description": "是否对相同分组与坐标的数据进行汇总"
+                              },
+                              "showNegativeSize": {
+                                "type": "boolean",
+                                "description": "是否显示气泡大小为负值的数据点"
+                              },
+                              "opacityGradientStyle": {
+                                "type": "string",
+                                "description": "气泡透明度渐变样式",
+                                "enum": [
+                                  "linear",
+                                  "radial"
+                                ]
+                              },
+                              "idLabel": {
+                                "description": "气泡标识标签配置；false 表示隐藏标识标签",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "visible": {
+                                        "type": "boolean",
+                                        "description": "是否显示标识标签"
+                                      },
+                                      "fontSize": {
+                                        "type": "number",
+                                        "description": "标签字号"
+                                      },
+                                      "bold": {
+                                        "type": "boolean",
+                                        "description": "是否加粗"
+                                      },
+                                      "italic": {
+                                        "type": "boolean",
+                                        "description": "是否斜体"
+                                      },
+                                      "underline": {
+                                        "type": "boolean",
+                                        "description": "是否下划线"
+                                      },
+                                      "strikethrough": {
+                                        "type": "boolean",
+                                        "description": "是否删除线"
+                                      },
+                                      "color": {
+                                        "type": "string",
+                                        "description": "标签字体颜色"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "boolean",
+                                    "enum": [
+                                      false
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "waterfall": {
+                            "type": "object",
+                            "description": "瀑布图全局配置。单个系列可通过 plot.series[].waterfall 覆盖数值解释和正负值样式。",
+                            "properties": {
+                              "firstValueAsTotal": {
+                                "type": "boolean",
+                                "description": "是否将第一个值视为总计"
+                              },
+                              "lastValueAsSubtotal": {
+                                "type": "boolean",
+                                "description": "是否将最后一个值视为小计"
+                              },
+                              "positiveStyle": {
+                                "type": "object",
+                                "description": "正值柱样式",
+                                "properties": {
+                                  "color": {
+                                    "type": "string",
+                                    "description": "填充颜色"
+                                  },
+                                  "opacity": {
+                                    "type": "number",
+                                    "description": "透明度，取值 0-1"
+                                  },
+                                  "borderColor": {
+                                    "type": "string",
+                                    "description": "边框颜色"
+                                  },
+                                  "borderWidth": {
+                                    "type": "number",
+                                    "description": "边框宽度"
+                                  },
+                                  "borderStyle": {
+                                    "type": "string",
+                                    "description": "边框样式",
+                                    "enum": [
+                                      "solid",
+                                      "dashed",
+                                      "dotted"
+                                    ]
+                                  }
+                                }
+                              },
+                              "negativeStyle": {
+                                "type": "object",
+                                "description": "负值柱样式",
+                                "properties": {
+                                  "color": {
+                                    "type": "string",
+                                    "description": "填充颜色"
+                                  },
+                                  "opacity": {
+                                    "type": "number",
+                                    "description": "透明度，取值 0-1"
+                                  },
+                                  "borderColor": {
+                                    "type": "string",
+                                    "description": "边框颜色"
+                                  },
+                                  "borderWidth": {
+                                    "type": "number",
+                                    "description": "边框宽度"
+                                  },
+                                  "borderStyle": {
+                                    "type": "string",
+                                    "description": "边框样式",
+                                    "enum": [
+                                      "solid",
+                                      "dashed",
+                                      "dotted"
+                                    ]
+                                  }
+                                }
+                              },
+                              "totalStyle": {
+                                "type": "object",
+                                "description": "总计与小计柱样式",
+                                "properties": {
+                                  "color": {
+                                    "type": "string",
+                                    "description": "填充颜色"
+                                  },
+                                  "opacity": {
+                                    "type": "number",
+                                    "description": "透明度，取值 0-1"
+                                  },
+                                  "borderColor": {
+                                    "type": "string",
+                                    "description": "边框颜色"
+                                  },
+                                  "borderWidth": {
+                                    "type": "number",
+                                    "description": "边框宽度"
+                                  },
+                                  "borderStyle": {
+                                    "type": "string",
+                                    "description": "边框样式",
+                                    "enum": [
+                                      "solid",
+                                      "dashed",
+                                      "dotted"
+                                    ]
+                                  }
+                                }
+                              },
+                              "cornerRadius": {
+                                "type": "string",
+                                "description": "柱子圆角大小",
+                                "enum": [
+                                  "default",
+                                  "small",
+                                  "large"
+                                ]
+                              },
+                              "gradient": {
+                                "type": "boolean",
+                                "description": "是否使用渐变填充"
+                              },
+                              "connectorLine": {
+                                "description": "瀑布柱之间的连接线配置；false 表示隐藏连接线",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "color": {
+                                        "type": "string",
+                                        "description": "连接线颜色"
+                                      },
+                                      "width": {
+                                        "type": "number",
+                                        "description": "连接线宽度"
+                                      },
+                                      "style": {
+                                        "type": "string",
+                                        "description": "连接线样式",
+                                        "enum": [
+                                          "solid",
+                                          "dashed",
+                                          "dotted"
+                                        ]
+                                      },
+                                      "opacity": {
+                                        "type": "number",
+                                        "description": "连接线透明度，取值 0-1"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "boolean",
+                                    "enum": [
+                                      false
+                                    ]
+                                  }
+                                ]
+                              },
+                              "totalLabels": {
+                                "description": "总计与小计标签配置；false 表示隐藏该类标签",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "template": {
+                                        "type": "string",
+                                        "description": "标签文本模板"
+                                      },
+                                      "fontSize": {
+                                        "type": "number",
+                                        "description": "标签字号"
+                                      },
+                                      "bold": {
+                                        "type": "boolean",
+                                        "description": "是否加粗"
+                                      },
+                                      "italic": {
+                                        "type": "boolean",
+                                        "description": "是否斜体"
+                                      },
+                                      "underline": {
+                                        "type": "boolean",
+                                        "description": "是否下划线"
+                                      },
+                                      "strikethrough": {
+                                        "type": "boolean",
+                                        "description": "是否删除线"
+                                      },
+                                      "color": {
+                                        "type": "string",
+                                        "description": "标签字体颜色"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "boolean",
+                                    "enum": [
+                                      false
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "pareto": {
+                            "type": "object",
+                            "description": "排列图配置。柱子、累计曲线、数据点和标签复用现有 bars、line、points、labels 配置。",
+                            "properties": {
+                              "aggregateType": {
+                                "type": "string",
+                                "description": "排列图的数据汇总方式",
+                                "enum": [
+                                  "sum",
+                                  "average",
+                                  "count",
+                                  "counta",
+                                  "min",
+                                  "max",
+                                  "median"
+                                ]
+                              },
+                              "categoryNumber": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "参与排列的类别数量，必须为正整数"
                               }
                             }
                           }
@@ -3787,6 +4507,113 @@
                               "type": "object",
                               "description": "数据标签配置（覆盖单系列，配置项同 plotArea.plot.labels）。不覆盖该系列数据标签时省略整个 labels 字段；一旦传入 labels（即便显示开关全部置为 false），该系列仍会显示数据标签。"
                             },
+                            "waterfall": {
+                              "type": "object",
+                              "description": "瀑布图的单系列配置，覆盖 plot.extra.waterfall 中对应的数值解释和样式。",
+                              "properties": {
+                                "firstValueAsTotal": {
+                                  "type": "boolean",
+                                  "description": "是否将该系列第一个值视为总计"
+                                },
+                                "lastValueAsSubtotal": {
+                                  "type": "boolean",
+                                  "description": "是否将该系列最后一个值视为小计"
+                                },
+                                "positiveStyle": {
+                                  "type": "object",
+                                  "description": "该系列的正值柱样式",
+                                  "properties": {
+                                    "color": {
+                                      "type": "string",
+                                      "description": "填充颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "description": "透明度，取值 0-1"
+                                    },
+                                    "borderColor": {
+                                      "type": "string",
+                                      "description": "边框颜色"
+                                    },
+                                    "borderWidth": {
+                                      "type": "number",
+                                      "description": "边框宽度"
+                                    },
+                                    "borderStyle": {
+                                      "type": "string",
+                                      "description": "边框样式",
+                                      "enum": [
+                                        "solid",
+                                        "dashed",
+                                        "dotted"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "negativeStyle": {
+                                  "type": "object",
+                                  "description": "该系列的负值柱样式",
+                                  "properties": {
+                                    "color": {
+                                      "type": "string",
+                                      "description": "填充颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "description": "透明度，取值 0-1"
+                                    },
+                                    "borderColor": {
+                                      "type": "string",
+                                      "description": "边框颜色"
+                                    },
+                                    "borderWidth": {
+                                      "type": "number",
+                                      "description": "边框宽度"
+                                    },
+                                    "borderStyle": {
+                                      "type": "string",
+                                      "description": "边框样式",
+                                      "enum": [
+                                        "solid",
+                                        "dashed",
+                                        "dotted"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "totalStyle": {
+                                  "type": "object",
+                                  "description": "该系列的总计与小计柱样式",
+                                  "properties": {
+                                    "color": {
+                                      "type": "string",
+                                      "description": "填充颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "description": "透明度，取值 0-1"
+                                    },
+                                    "borderColor": {
+                                      "type": "string",
+                                      "description": "边框颜色"
+                                    },
+                                    "borderWidth": {
+                                      "type": "number",
+                                      "description": "边框宽度"
+                                    },
+                                    "borderStyle": {
+                                      "type": "string",
+                                      "description": "边框样式",
+                                      "enum": [
+                                        "solid",
+                                        "dashed",
+                                        "dotted"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "sectors": {
                               "type": "object",
                               "description": "扇区配置（饼图）",
@@ -4268,6 +5095,16 @@
                             "nameRef": {
                               "type": "string",
                               "description": "可选。系列名称的单元格引用（A1 表示法，如 'Sheet1!C1'）。当系列名称不直接来自 refs 首行/首列时，可通过此字段把系列名显式指向目标表头单元格，图表会以该单元格当前值作为系列名（图例/tooltip）展示。"
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "气泡图中该数据系列的角色：x 为横轴、y 为纵轴、group 为分组、size 为气泡大小。气泡图必须各有一个 x 和 y，group 和 size 可选。",
+                              "enum": [
+                                "x",
+                                "y",
+                                "group",
+                                "size"
+                              ]
                             }
                           },
                           "required": [
@@ -4283,10 +5120,25 @@
                           "properties": {
                             "valueType": {
                               "type": "string",
-                              "description": "值类型",
+                              "description": "值类型。x、y、size 角色使用 number；group 角色可使用 string 或 number。",
                               "enum": [
-                                "number"
+                                "number",
+                                "string"
                               ]
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "气泡图中该静态字段的角色：x 为横轴、y 为纵轴、group 为分组、size 为气泡大小。气泡图必须各有一个 x 和 y，group 和 size 可选。",
+                              "enum": [
+                                "x",
+                                "y",
+                                "group",
+                                "size"
+                              ]
+                            },
+                            "format": {
+                              "type": "string",
+                              "description": "字段数值格式"
                             },
                             "name": {
                               "type": "string",

--- a/shortcuts/sheets/data/flag-schemas.json
+++ b/shortcuts/sheets/data/flag-schemas.json
@@ -1158,6 +1158,10 @@
                             "type": "object",
                             "description": "堆叠配置",
                             "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "是否启用堆叠"
+                              },
                               "percentage": {
                                 "type": "boolean",
                                 "description": "是否百分比堆叠"
@@ -1203,54 +1207,40 @@
                                 ]
                               },
                               "idLabel": {
-                                "description": "气泡标识标签配置；false 表示隐藏标识标签",
-                                "oneOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "visible": {
-                                        "type": "boolean",
-                                        "description": "是否显示标识标签"
-                                      },
-                                      "fontSize": {
-                                        "type": "number",
-                                        "description": "标签字号"
-                                      },
-                                      "bold": {
-                                        "type": "boolean",
-                                        "description": "是否加粗"
-                                      },
-                                      "italic": {
-                                        "type": "boolean",
-                                        "description": "是否斜体"
-                                      },
-                                      "underline": {
-                                        "type": "boolean",
-                                        "description": "是否下划线"
-                                      },
-                                      "strikethrough": {
-                                        "type": "boolean",
-                                        "description": "是否删除线"
-                                      },
-                                      "color": {
-                                        "type": "string",
-                                        "description": "标签字体颜色"
-                                      }
-                                    }
+                                "type": "object",
+                                "description": "气泡标识标签样式配置",
+                                "properties": {
+                                  "fontSize": {
+                                    "type": "number",
+                                    "description": "标签字号"
                                   },
-                                  {
+                                  "bold": {
                                     "type": "boolean",
-                                    "enum": [
-                                      false
-                                    ]
+                                    "description": "是否加粗"
+                                  },
+                                  "italic": {
+                                    "type": "boolean",
+                                    "description": "是否斜体"
+                                  },
+                                  "underline": {
+                                    "type": "boolean",
+                                    "description": "是否下划线"
+                                  },
+                                  "strikethrough": {
+                                    "type": "boolean",
+                                    "description": "是否删除线"
+                                  },
+                                  "color": {
+                                    "type": "string",
+                                    "description": "标签字体颜色"
                                   }
-                                ]
+                                }
                               }
                             }
                           },
                           "waterfall": {
                             "type": "object",
-                            "description": "瀑布图全局配置。单个系列可通过 plot.series[].waterfall 覆盖数值解释和正负值样式。",
+                            "description": "瀑布图全局配置。正值柱样式复用 plot.bars；单个系列可通过 plot.series[].bars 和 plot.series[].waterfall 覆盖样式与数值解释。",
                             "properties": {
                               "firstValueAsTotal": {
                                 "type": "boolean",
@@ -1259,37 +1249,6 @@
                               "lastValueAsSubtotal": {
                                 "type": "boolean",
                                 "description": "是否将最后一个值视为小计"
-                              },
-                              "positiveStyle": {
-                                "type": "object",
-                                "description": "正值柱样式",
-                                "properties": {
-                                  "color": {
-                                    "type": "string",
-                                    "description": "填充颜色"
-                                  },
-                                  "opacity": {
-                                    "type": "number",
-                                    "description": "透明度，取值 0-1"
-                                  },
-                                  "borderColor": {
-                                    "type": "string",
-                                    "description": "边框颜色"
-                                  },
-                                  "borderWidth": {
-                                    "type": "number",
-                                    "description": "边框宽度"
-                                  },
-                                  "borderStyle": {
-                                    "type": "string",
-                                    "description": "边框样式",
-                                    "enum": [
-                                      "solid",
-                                      "dashed",
-                                      "dotted"
-                                    ]
-                                  }
-                                }
                               },
                               "negativeStyle": {
                                 "type": "object",
@@ -1353,6 +1312,54 @@
                                   }
                                 }
                               },
+                              "titleText": {
+                                "type": "object",
+                                "description": "瀑布图正值、负值和小计的标题文本",
+                                "properties": {
+                                  "positive": {
+                                    "type": "string",
+                                    "description": "正值标题"
+                                  },
+                                  "negative": {
+                                    "type": "string",
+                                    "description": "负值标题"
+                                  },
+                                  "subtotal": {
+                                    "type": "string",
+                                    "description": "小计标题"
+                                  }
+                                }
+                              },
+                              "subtotals": {
+                                "type": "array",
+                                "description": "小计节点配置数组",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "index": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "小计节点索引，从 0 开始"
+                                    },
+                                    "mode": {
+                                      "type": "integer",
+                                      "enum": [
+                                        0,
+                                        1
+                                      ],
+                                      "description": "小计计算模式"
+                                    },
+                                    "alias": {
+                                      "type": "string",
+                                      "description": "小计别名"
+                                    }
+                                  },
+                                  "required": [
+                                    "index",
+                                    "mode"
+                                  ]
+                                }
+                              },
                               "cornerRadius": {
                                 "type": "string",
                                 "description": "柱子圆角大小",
@@ -1412,6 +1419,24 @@
                                       "template": {
                                         "type": "string",
                                         "description": "标签文本模板"
+                                      },
+                                      "position": {
+                                        "type": "string",
+                                        "description": "标签位置",
+                                        "enum": [
+                                          "default",
+                                          "top",
+                                          "middle",
+                                          "bottom"
+                                        ]
+                                      },
+                                      "category": {
+                                        "type": "boolean",
+                                        "description": "是否显示类别名"
+                                      },
+                                      "value": {
+                                        "type": "boolean",
+                                        "description": "是否显示数值"
                                       },
                                       "fontSize": {
                                         "type": "number",
@@ -2327,7 +2352,7 @@
                             },
                             "waterfall": {
                               "type": "object",
-                              "description": "瀑布图的单系列配置，覆盖 plot.extra.waterfall 中对应的数值解释和样式。",
+                              "description": "瀑布图的单系列配置，覆盖 plot.extra.waterfall 中对应的数值解释、负值和总计样式；正值柱样式复用同级 bars。",
                               "properties": {
                                 "firstValueAsTotal": {
                                   "type": "boolean",
@@ -2336,37 +2361,6 @@
                                 "lastValueAsSubtotal": {
                                   "type": "boolean",
                                   "description": "是否将该系列最后一个值视为小计"
-                                },
-                                "positiveStyle": {
-                                  "type": "object",
-                                  "description": "该系列的正值柱样式",
-                                  "properties": {
-                                    "color": {
-                                      "type": "string",
-                                      "description": "填充颜色"
-                                    },
-                                    "opacity": {
-                                      "type": "number",
-                                      "description": "透明度，取值 0-1"
-                                    },
-                                    "borderColor": {
-                                      "type": "string",
-                                      "description": "边框颜色"
-                                    },
-                                    "borderWidth": {
-                                      "type": "number",
-                                      "description": "边框宽度"
-                                    },
-                                    "borderStyle": {
-                                      "type": "string",
-                                      "description": "边框样式",
-                                      "enum": [
-                                        "solid",
-                                        "dashed",
-                                        "dotted"
-                                      ]
-                                    }
-                                  }
                                 },
                                 "negativeStyle": {
                                   "type": "object",
@@ -2428,6 +2422,54 @@
                                         "dotted"
                                       ]
                                     }
+                                  }
+                                },
+                                "titleText": {
+                                  "type": "object",
+                                  "description": "该系列正值、负值和小计的标题文本",
+                                  "properties": {
+                                    "positive": {
+                                      "type": "string",
+                                      "description": "正值标题"
+                                    },
+                                    "negative": {
+                                      "type": "string",
+                                      "description": "负值标题"
+                                    },
+                                    "subtotal": {
+                                      "type": "string",
+                                      "description": "小计标题"
+                                    }
+                                  }
+                                },
+                                "subtotals": {
+                                  "type": "array",
+                                  "description": "该系列的小计节点配置数组",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "index": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "小计节点索引，从 0 开始"
+                                      },
+                                      "mode": {
+                                        "type": "integer",
+                                        "enum": [
+                                          0,
+                                          1
+                                        ],
+                                        "description": "小计计算模式"
+                                      },
+                                      "alias": {
+                                        "type": "string",
+                                        "description": "小计别名"
+                                      }
+                                    },
+                                    "required": [
+                                      "index",
+                                      "mode"
+                                    ]
                                   }
                                 }
                               }
@@ -3340,6 +3382,10 @@
                             "type": "object",
                             "description": "堆叠配置",
                             "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "是否启用堆叠"
+                              },
                               "percentage": {
                                 "type": "boolean",
                                 "description": "是否百分比堆叠"
@@ -3385,54 +3431,40 @@
                                 ]
                               },
                               "idLabel": {
-                                "description": "气泡标识标签配置；false 表示隐藏标识标签",
-                                "oneOf": [
-                                  {
-                                    "type": "object",
-                                    "properties": {
-                                      "visible": {
-                                        "type": "boolean",
-                                        "description": "是否显示标识标签"
-                                      },
-                                      "fontSize": {
-                                        "type": "number",
-                                        "description": "标签字号"
-                                      },
-                                      "bold": {
-                                        "type": "boolean",
-                                        "description": "是否加粗"
-                                      },
-                                      "italic": {
-                                        "type": "boolean",
-                                        "description": "是否斜体"
-                                      },
-                                      "underline": {
-                                        "type": "boolean",
-                                        "description": "是否下划线"
-                                      },
-                                      "strikethrough": {
-                                        "type": "boolean",
-                                        "description": "是否删除线"
-                                      },
-                                      "color": {
-                                        "type": "string",
-                                        "description": "标签字体颜色"
-                                      }
-                                    }
+                                "type": "object",
+                                "description": "气泡标识标签样式配置",
+                                "properties": {
+                                  "fontSize": {
+                                    "type": "number",
+                                    "description": "标签字号"
                                   },
-                                  {
+                                  "bold": {
                                     "type": "boolean",
-                                    "enum": [
-                                      false
-                                    ]
+                                    "description": "是否加粗"
+                                  },
+                                  "italic": {
+                                    "type": "boolean",
+                                    "description": "是否斜体"
+                                  },
+                                  "underline": {
+                                    "type": "boolean",
+                                    "description": "是否下划线"
+                                  },
+                                  "strikethrough": {
+                                    "type": "boolean",
+                                    "description": "是否删除线"
+                                  },
+                                  "color": {
+                                    "type": "string",
+                                    "description": "标签字体颜色"
                                   }
-                                ]
+                                }
                               }
                             }
                           },
                           "waterfall": {
                             "type": "object",
-                            "description": "瀑布图全局配置。单个系列可通过 plot.series[].waterfall 覆盖数值解释和正负值样式。",
+                            "description": "瀑布图全局配置。正值柱样式复用 plot.bars；单个系列可通过 plot.series[].bars 和 plot.series[].waterfall 覆盖样式与数值解释。",
                             "properties": {
                               "firstValueAsTotal": {
                                 "type": "boolean",
@@ -3441,37 +3473,6 @@
                               "lastValueAsSubtotal": {
                                 "type": "boolean",
                                 "description": "是否将最后一个值视为小计"
-                              },
-                              "positiveStyle": {
-                                "type": "object",
-                                "description": "正值柱样式",
-                                "properties": {
-                                  "color": {
-                                    "type": "string",
-                                    "description": "填充颜色"
-                                  },
-                                  "opacity": {
-                                    "type": "number",
-                                    "description": "透明度，取值 0-1"
-                                  },
-                                  "borderColor": {
-                                    "type": "string",
-                                    "description": "边框颜色"
-                                  },
-                                  "borderWidth": {
-                                    "type": "number",
-                                    "description": "边框宽度"
-                                  },
-                                  "borderStyle": {
-                                    "type": "string",
-                                    "description": "边框样式",
-                                    "enum": [
-                                      "solid",
-                                      "dashed",
-                                      "dotted"
-                                    ]
-                                  }
-                                }
                               },
                               "negativeStyle": {
                                 "type": "object",
@@ -3535,6 +3536,54 @@
                                   }
                                 }
                               },
+                              "titleText": {
+                                "type": "object",
+                                "description": "瀑布图正值、负值和小计的标题文本",
+                                "properties": {
+                                  "positive": {
+                                    "type": "string",
+                                    "description": "正值标题"
+                                  },
+                                  "negative": {
+                                    "type": "string",
+                                    "description": "负值标题"
+                                  },
+                                  "subtotal": {
+                                    "type": "string",
+                                    "description": "小计标题"
+                                  }
+                                }
+                              },
+                              "subtotals": {
+                                "type": "array",
+                                "description": "小计节点配置数组",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "index": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "小计节点索引，从 0 开始"
+                                    },
+                                    "mode": {
+                                      "type": "integer",
+                                      "enum": [
+                                        0,
+                                        1
+                                      ],
+                                      "description": "小计计算模式"
+                                    },
+                                    "alias": {
+                                      "type": "string",
+                                      "description": "小计别名"
+                                    }
+                                  },
+                                  "required": [
+                                    "index",
+                                    "mode"
+                                  ]
+                                }
+                              },
                               "cornerRadius": {
                                 "type": "string",
                                 "description": "柱子圆角大小",
@@ -3594,6 +3643,24 @@
                                       "template": {
                                         "type": "string",
                                         "description": "标签文本模板"
+                                      },
+                                      "position": {
+                                        "type": "string",
+                                        "description": "标签位置",
+                                        "enum": [
+                                          "default",
+                                          "top",
+                                          "middle",
+                                          "bottom"
+                                        ]
+                                      },
+                                      "category": {
+                                        "type": "boolean",
+                                        "description": "是否显示类别名"
+                                      },
+                                      "value": {
+                                        "type": "boolean",
+                                        "description": "是否显示数值"
                                       },
                                       "fontSize": {
                                         "type": "number",
@@ -4509,7 +4576,7 @@
                             },
                             "waterfall": {
                               "type": "object",
-                              "description": "瀑布图的单系列配置，覆盖 plot.extra.waterfall 中对应的数值解释和样式。",
+                              "description": "瀑布图的单系列配置，覆盖 plot.extra.waterfall 中对应的数值解释、负值和总计样式；正值柱样式复用同级 bars。",
                               "properties": {
                                 "firstValueAsTotal": {
                                   "type": "boolean",
@@ -4518,37 +4585,6 @@
                                 "lastValueAsSubtotal": {
                                   "type": "boolean",
                                   "description": "是否将该系列最后一个值视为小计"
-                                },
-                                "positiveStyle": {
-                                  "type": "object",
-                                  "description": "该系列的正值柱样式",
-                                  "properties": {
-                                    "color": {
-                                      "type": "string",
-                                      "description": "填充颜色"
-                                    },
-                                    "opacity": {
-                                      "type": "number",
-                                      "description": "透明度，取值 0-1"
-                                    },
-                                    "borderColor": {
-                                      "type": "string",
-                                      "description": "边框颜色"
-                                    },
-                                    "borderWidth": {
-                                      "type": "number",
-                                      "description": "边框宽度"
-                                    },
-                                    "borderStyle": {
-                                      "type": "string",
-                                      "description": "边框样式",
-                                      "enum": [
-                                        "solid",
-                                        "dashed",
-                                        "dotted"
-                                      ]
-                                    }
-                                  }
                                 },
                                 "negativeStyle": {
                                   "type": "object",
@@ -4610,6 +4646,54 @@
                                         "dotted"
                                       ]
                                     }
+                                  }
+                                },
+                                "titleText": {
+                                  "type": "object",
+                                  "description": "该系列正值、负值和小计的标题文本",
+                                  "properties": {
+                                    "positive": {
+                                      "type": "string",
+                                      "description": "正值标题"
+                                    },
+                                    "negative": {
+                                      "type": "string",
+                                      "description": "负值标题"
+                                    },
+                                    "subtotal": {
+                                      "type": "string",
+                                      "description": "小计标题"
+                                    }
+                                  }
+                                },
+                                "subtotals": {
+                                  "type": "array",
+                                  "description": "该系列的小计节点配置数组",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "index": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "小计节点索引，从 0 开始"
+                                      },
+                                      "mode": {
+                                        "type": "integer",
+                                        "enum": [
+                                          0,
+                                          1
+                                        ],
+                                        "description": "小计计算模式"
+                                      },
+                                      "alias": {
+                                        "type": "string",
+                                        "description": "小计别名"
+                                      }
+                                    },
+                                    "required": [
+                                      "index",
+                                      "mode"
+                                    ]
                                   }
                                 }
                               }

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -209,7 +209,7 @@ var flagDefs = map[string]commandDef{
 			{Name: "sheet-id", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet reference_id — required: pass this or `--sheet-name` (exactly one of the two)"},
 			{Name: "sheet-name", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet name — required: pass this or `--sheet-id` (exactly one of the two)"},
 			{Name: "properties", Kind: "own", Type: "string", Required: "required", Desc: "Full chart config JSON. Top-level keys: `position` / `offset` / `size` / `snapshot` (no top-level `data`, no extra nested `properties`); chart data config lives under `snapshot.data` (`refs` / `headerMode` / `dim1` / `dim2`); must include at least one of `snapshot.data.dim1.serie.index` or `dim2.series[].index`, otherwise the server rejects it. Deeply nested — run `--print-schema --flag-name properties` for the full structure.", Input: []string{"file", "stdin"}},
-			{Name: "print-example", Kind: "own", Type: "string", Required: "optional", Desc: "Print a minimal ready-to-edit --properties template for a chart type (area|bar|column|combo|line|pie|radar|scatter) and exit. Purely local: no locator flags, no network; an unknown type lists the available ones"},
+			{Name: "print-example", Kind: "own", Type: "string", Required: "optional", Desc: "Print a minimal ready-to-edit --properties template for a chart type (area|bar|bubble|column|combo|line|pareto|pie|radar|scatter|waterfall) and exit. Purely local: no locator flags, no network; an unknown type lists the available ones"},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional", Desc: "Print the request template; no side effects"},
 		},
 	},

--- a/skills/lark-sheets/references/lark-sheets-chart.md
+++ b/skills/lark-sheets/references/lark-sheets-chart.md
@@ -24,10 +24,13 @@
 | "趋势"、"变化"、"走势" | 折线图（line） | 时间序列首选 |
 | "堆积"、"组成构成" | 堆积柱形图（column + stack） | 多系列累加 |
 | "分布"、"相关性" | 散点图（scatter） | 两变量关系 |
+| "气泡大小"、"三变量关系"、"分组散点" | 气泡图（bubble） | x/y 决定位置，size 决定气泡大小，group 决定分组 |
+| "逐项增减"、"变动贡献"、"从期初到期末" | 瀑布图（waterfall） | 展示正负变化及总计/小计 |
+| "主要原因"、"累计占比"、"80/20" | 排列图（pareto） | 降序柱形 + 累计百分比曲线 |
 
 **多图表需求**：当用户同时提到多种分析（如"统计占比 + 对比数量"），必须创建多个图表，每个对应一种类型，不要只做一个。
 
-**`--properties` 结构锚点（构造前必读）**：`--properties` 顶层只有 `position` / `offset` / `size` / `snapshot` 四个字段，**没有**顶层 `data`，也没有再嵌一层 `properties`。图表数据配置全部挂在 `snapshot.data` 下——下文及示例里出现的 `refs` / `headerMode` / `dim1` / `dim2` / `nameRef` 一律指 `snapshot.data.refs` / `snapshot.data.headerMode` / `snapshot.data.dim1` / `snapshot.data.dim2`（及其下的 `serie.nameRef` / `series[].nameRef`）；样式 / 堆叠 / 数据标签等在 `snapshot.plotArea` 下。**构造起点优先用 `lark-cli sheets +chart-create --print-example <column|bar|line|area|pie|scatter|radar|combo>` 拿最小可用模板改参**（本地即时返回）；查深层字段用点分路径切片 `--print-schema --flag-name properties.snapshot.plotArea.axes`，别整篇 dump 翻页。完整结构以 `--print-schema --flag-name properties` 为准。
+**`--properties` 结构锚点（构造前必读）**：`--properties` 顶层只有 `position` / `offset` / `size` / `snapshot` 四个字段，**没有**顶层 `data`，也没有再嵌一层 `properties`。图表数据配置全部挂在 `snapshot.data` 下——下文及示例里出现的 `refs` / `headerMode` / `dim1` / `dim2` / `nameRef` 一律指 `snapshot.data.refs` / `snapshot.data.headerMode` / `snapshot.data.dim1` / `snapshot.data.dim2`（及其下的 `serie.nameRef` / `series[].nameRef`）；样式 / 堆叠 / 数据标签等在 `snapshot.plotArea` 下。**构造起点优先用 `lark-cli sheets +chart-create --print-example <area|bar|bubble|column|combo|line|pareto|pie|radar|scatter|waterfall>` 拿最小可用模板改参**（本地即时返回）；查深层字段用点分路径切片 `--print-schema --flag-name properties.snapshot.plotArea.axes`，别整篇 dump 翻页。完整结构以 `--print-schema --flag-name properties` 为准。
 
 **常见配置错误（必须注意）**：
 - **图表类型选择错误**：用户说"堆积柱形图/百分比堆积"时，应在 `properties.snapshot.plotArea.plot.extra.stack` 中配置堆叠；百分比堆叠需在该 stack 下设置 `percentage: true`。用户说"占比/比例"时，优先考虑饼图或百分比堆积图。注意区分 `column`（柱形图，纵向）与 `bar`（条形图，横向）是两个不同的 type 取值，"对比/各 XX" 类纵向柱默认用 `column`
@@ -41,6 +44,30 @@
 - **axes[].label 不接受 `format` / `number_format` 字段**：想给坐标轴数值加千分位、百分号等格式化时，不要在 `axes[i].label` 里传 `format` 或 `number_format`（schema 未定义，会报 `unexpected property "format" is not defined in schema`）。数值格式化统一在源数据单元格的 `cell_styles.number_format` 里设置（写 `+cells-set` 时），图表会沿用单元格格式。**日期轴同理**：横轴显示成 `45297` 这类 Excel 序列号，是因为源日期列没设日期格式——给源列设 `number_format="yyyy-mm-dd"` 后横轴才会显示成日期（反例：折线图横轴日期显示为序列号）。大数值轴显示科学计数法同理，给源列设整数 / 千分位格式（反例：透视表数值轴显示科学计数法）。
 - **轴口径要对齐用户要的指标**：用户要"占比 / 比例"时，**纵轴应是百分比**——用饼图，或柱 / 条形图设 `stack.percentage: true` 让纵轴变 %，并把数据源指向占比列 / 让数据标签显示百分比；不要交付纵轴仍是原始计数的图（反例：要求看各类占比，却用普通堆积柱、纵轴是 0–350 的人数而非百分比）。
 - **创建后必须验证**：图表创建后必须调用 `+chart-list` 验证配置是否正确
+
+## 气泡图、瀑布图、排列图专属结构
+
+先打印可运行模板，再替换数据范围、索引、标题和样式：
+
+```bash
+lark-cli sheets +chart-create --print-example bubble
+lark-cli sheets +chart-create --print-example waterfall
+lark-cli sheets +chart-create --print-example pareto
+```
+
+| 图表 | 配置路径 | 含义与约束 |
+|---|---|---|
+| 气泡图 | `snapshot.data.dim1.serie` | `Primary` 维度：标识每个气泡，通常也是 `idLabel` 的文字来源；它不替代 x/y/group/size 角色。 |
+| 气泡图 | `snapshot.data.dim2.series[].role` | `x`、`y`、`group`、`size` 四种角色；`x` 和 `y` 各一个且必需，`group`、`size` 可选。x/y/size 对应数值列，group 可对应文本或数值列。 |
+| 气泡图 | `snapshot.plotArea.plot.extra.bubble` | `aggregate` 控制同组同坐标汇总；`showNegativeSize` 控制是否显示负 size；`opacityGradientStyle` 为 `linear` / `radial`；`idLabel` 配置标识标签，传 `false` 隐藏。 |
+| 气泡图 | `snapshot.plotArea.plot.points` | 复用现有点样式，可配置 `shape` / `size` / `color` 等。 |
+| 瀑布图 | `snapshot.plotArea.plot.extra.waterfall` | 全局配置：`firstValueAsTotal`、`lastValueAsSubtotal`、正/负/总计柱样式、圆角、渐变、连接线及总计标签。 |
+| 瀑布图 | `snapshot.plotArea.plot.series[].waterfall` | 单系列覆盖项，可覆盖首值/末值解释和 `positiveStyle` / `negativeStyle` / `totalStyle`；未传字段继续使用全局配置。 |
+| 排列图 | `snapshot.plotArea.plot.extra.pareto` | `aggregateType` 为 `sum` / `average` / `count` / `counta` / `min` / `max` / `median`；`categoryNumber` 是参与排列的正整数类别数。 |
+| 排列图 | `snapshot.plotArea.plot.series[index=1]` | 排列柱系列，样式复用现有 `bars` 和 `labels`。这里的 `index=1` 表示排列图输出的柱系列角色，不是源数据列号。 |
+| 排列图 | `snapshot.plotArea.plot.series[index=2]` | 累计百分比曲线系列，样式复用现有 `line`、`points` 和 `labels`。这里的 `index=2` 表示累计线角色，不是源数据列号。 |
+
+排列图的源数据列仍由 `snapshot.data.dim1.serie.index`（类别列）和 `snapshot.data.dim2.series[].index`（数值列）指定。不要把 `plot.series[].index` 与源数据列索引混为一谈。
 
 > **⚠️ 硬性规则：当用户通过列标题名称（而非列索引）指定横轴/纵轴系列时，必须先读取表格首行（表头）来确定列名与列索引的对应关系，再设置 `dim1`/`dim2` 的 `index`。**
 > 例如用户说"横轴为车型系列，纵轴为Q1-Q4的销量"，你不能猜测列索引，必须先通过读取表格数据源范围的首行内容（使用 `lark-sheets-read-data` 的 `+cells-get` 或其他读取单元格的工具），确认"车型系列"是第几列、"Q1"~"Q4"分别是第几列，然后再将正确的列索引填入 `dim1.serie.index` 和 `dim2.series[].index`。
@@ -125,7 +152,7 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--properties` | string + File + Stdin（复合 JSON） | required | 图表完整配置 JSON。顶层字段为 `position` / `offset` / `size` / `snapshot`（无顶层 `data`，也无再嵌一层 `properties`）；图表数据配置在 `snapshot.data` 下（含 `refs` / `headerMode` / `dim1` / `dim2`）；必须至少含 `snapshot.data.dim1.serie.index` 或 `dim2.series[].index` 之一，否则 server 拒。结构嵌套深，完整结构跑 `--print-schema --flag-name properties` |
-| `--print-example` | string | optional | 打印指定图表类型的最小可用 `--properties` 模板后直接退出（`area` / `bar` / `column` / `combo` / `line` / `pie` / `radar` / `scatter`）。纯本地执行，不需要 locator flag、不发网络请求；传入未知类型时列出全部可用类型 |
+| `--print-example` | string | optional | 打印指定图表类型的最小可用 `--properties` 模板后直接退出（`area` / `bar` / `bubble` / `column` / `combo` / `line` / `pareto` / `pie` / `radar` / `scatter` / `waterfall`）。纯本地执行，不需要 locator flag、不发网络请求；传入未知类型时列出全部可用类型 |
 
 ### `+chart-update`
 


### PR DESCRIPTION
## Problem

The Sheets chart CLI schema and local examples did not expose bubble, waterfall, or pareto chart configurations, so callers could not discover or construct these chart types reliably.

## Changes

- Sync the chart property schema and chart skill reference from sheet-skill-spec MR https://code.byted.org/ee/sheet-skill-spec/merge_requests/87
- Add ready-to-edit examples for bubble, waterfall, and pareto
- Preserve bubble data roles, waterfall global options, and pareto bar/cumulative-line series roles
- Add contract coverage for the three templates

The runtime chart support is tracked in https://code.byted.org/ee/byted-sheet/merge_requests/4112.

## Verification

- go test -count=1 ./shortcuts/sheets/...
- go vet ./shortcuts/sheets/...
- ./build.sh
- Local --print-example and deep --print-schema checks for all three chart types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ready-to-edit examples for bubble, waterfall, and pareto charts.
  * Added support for creating and updating scatter, bubble, waterfall, and pareto charts.
  * Added chart-specific configuration for data mappings, labels, formatting, and series settings.
* **Documentation**
  * Updated chart command guidance and examples to include the newly supported chart types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->