### PR TITLE
feat(base): print dashboard block examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,10 @@ For plugin distributions, read [Ship skills and command guidance](extension/plat
   shipped docs must ship. Before referencing a new content directory, update
   `content_embed.go` and add an embedded-FS reachability test; `assets/` and
   `scripts/` stay source-only unless the distribution contract changes.
+- When adding or changing a Base dashboard block type, update the command type
+  description, `dashboardBlockExampleTemplates`, its exact-type coverage and
+  validation test, and the `lark-base` dashboard references in the same change.
+  Every supported canonical type must have a locally valid example template.
 
 ## Tests
 

--- a/docs/superpowers/specs/2026-08-13-dashboard-block-print-example-design.md
+++ b/docs/superpowers/specs/2026-08-13-dashboard-block-print-example-design.md
@@ -1,0 +1,70 @@
+# Base 仪表盘组件模板输出设计
+
+## 目标
+
+为 `lark-cli base +dashboard-block-create` 增加纯本地的
+`--print-example <type>` 模式，让 AI 在创建仪表盘组件前按目标类型获取一份最小、可编辑、可直接传给 `--data-config` 的 JSON 模板。
+
+该能力只提供配置示例，不查询 Base、不访问网络，也不创建组件。
+
+## 接口
+
+```bash
+lark-cli base +dashboard-block-create --print-example column
+```
+
+模板模式不要求 `--base-token`、`--dashboard-id`、`--name`、`--type` 或
+`--data-config`。成功时 stdout 只输出目标类型的 `data_config` JSON，并以
+状态码 0 结束。
+
+未知类型返回 typed validation error，错误参数为 `--print-example`，并列出
+全部可用的 canonical 类型。类型严格匹配，不自动纠错或转换别名。
+
+第一版不支持 `all`，避免把所有模板加载进 AI 上下文。
+
+## 实现边界
+
+实现沿用 Sheets `+chart-create --print-example <type>` 的现有模式：
+
+1. 在 Base shortcut 包内维护按 block type 索引的最小 JSON 模板。
+2. 为 `+dashboard-block-create` 增加 `--print-example` flag。
+3. 命中模板模式时，在认证、必填参数检查和 API 调用前打印模板并结束。
+4. 正常创建路径保持不变。
+
+本次不修改现有 `--type` 创建校验、不增加后端接口、不新增独立 Shortcut，
+也不改变其他 Dashboard 命令。
+
+## 模板范围
+
+模板覆盖当前文档列出的组件类型：
+
+```text
+area, bar, column, combo, funnel, line, pie, radar, ring,
+scatter, statistics, text, wordCloud
+```
+
+模板使用占位表名和字段名，保持最小合法结构。复杂业务说明（筛选规则、
+漏斗累计口径等）继续由 `dashboard-block-data-config.md` 承担，模板输出不复制
+长篇指导。
+
+## 错误处理
+
+若请求不存在的模板，例如 `--print-example colum`：
+
+- 返回 `validation / invalid_argument`；
+- `param` 为 `--print-example`；
+- 消息包含输入值和排序后的可用类型；
+- 不认证、不访问网络、不进入真实创建路径。
+
+## 验证
+
+新增邻近测试固定以下契约：
+
+1. 合法类型无需定位参数即可输出模板并跳过 API。
+2. 未知类型返回带 `--print-example` 参数的 typed validation error。
+3. 每份模板都是合法 JSON。
+4. 每份模板都通过现有 `normalizeDataConfig` 和
+   `validateBlockDataConfig` 校验，防止模板与当前 CLI 创建契约漂移。
+5. 正常 `+dashboard-block-create` 行为保持不变。
+
+按仓库要求执行技能格式检查和相关质量门；不扩大到无关功能或历史校验问题。

--- a/shortcuts/base/dashboard_block_create.go
+++ b/shortcuts/base/dashboard_block_create.go
@@ -26,13 +26,16 @@ var BaseDashboardBlockCreate = common.Shortcut{
 		{Name: "name", Desc: "block name", Required: true},
 		{Name: "type", Desc: "block type: column(柱状图)|bar(条形图)|line(折线图)|pie(饼图)|ring(环形图)|area(面积图)|combo(组合图)|scatter(散点图)|funnel(漏斗图)|wordCloud(词云)|radar(雷达图)|statistics(指标卡)|text(文本). Read dashboard-block-data-config.md before creating.", Required: true},
 		{Name: "data-config", Desc: "data_config JSON object; read dashboard-block-data-config.md for the SSOT"},
+		{Name: "print-example", Desc: "Print a minimal ready-to-edit data_config template for a dashboard block type and exit. Purely local: no Base locator flags, authentication, or network request."},
 		{Name: "user-id-type", Desc: "user ID type for user fields in filters: open_id / union_id / user_id"},
 		{Name: "no-validate", Type: "bool", Desc: "skip local data_config validation and normalization; send data_config as-is"},
 	},
 	Tips: []string{
+		`lark-cli base +dashboard-block-create --print-example column`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Dashboard Note" --type text --data-config '{"text":"# Sales Dashboard"}'`,
 		"Before creating data-backed blocks, use +table-list and +field-list to confirm real table and field names.",
+		"Use --print-example <type> to print one minimal data_config template locally before filling in real table and field names.",
 		"data_config uses table and field names, not table_id or field_id.",
 		"Read dashboard-block-data-config.md as the SSOT for chart templates, filters, metric rules, and type-specific fields; do not invent data_config from natural language.",
 		"For funnel/stage charts backed by ordered helper data, set the intended group_by.sort in the initial create request; do not create first and then issue a second update just to fix sorting.",
@@ -93,4 +96,5 @@ var BaseDashboardBlockCreate = common.Shortcut{
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return executeDashboardBlockCreate(runtime)
 	},
+	PostMount: withDashboardBlockPrintExample(nil),
 }

--- a/shortcuts/base/dashboard_block_examples.go
+++ b/shortcuts/base/dashboard_block_examples.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Templates mirror the minimal shapes documented in the lark-base dashboard
+// data_config reference. The validator drift test keeps this local fast path
+// aligned with the existing create contract.
+var dashboardBlockExampleTemplates = map[string]string{
+	"area":       dashboardBlockSeriesExample,
+	"bar":        dashboardBlockSeriesExample,
+	"column":     dashboardBlockSeriesExample,
+	"funnel":     dashboardBlockCountByGroupExample,
+	"line":       dashboardBlockSeriesExample,
+	"pie":        dashboardBlockCountByGroupExample,
+	"ring":       dashboardBlockCountByGroupExample,
+	"scatter":    dashboardBlockSeriesExample,
+	"wordCloud":  dashboardBlockCountByGroupExample,
+	"statistics": dashboardBlockStatisticsExample,
+	"text": `{
+  "text": "# 仪表盘说明\n在这里填写说明文字"
+}`,
+	"combo": `{
+  "table_name": "表名",
+  "series": [
+    {"field_name": "指标1", "rollup": "SUM"},
+    {"field_name": "指标2", "rollup": "SUM"}
+  ],
+  "group_by": [{"field_name": "分组字段", "mode": "integrated"}]
+}`,
+	"radar": `{
+  "table_name": "表名",
+  "series": [
+    {"field_name": "维度1", "rollup": "SUM"},
+    {"field_name": "维度2", "rollup": "SUM"},
+    {"field_name": "维度3", "rollup": "SUM"}
+  ],
+  "group_by": [{"field_name": "分类字段", "mode": "integrated"}]
+}`,
+}
+
+const dashboardBlockSeriesExample = `{
+  "table_name": "表名",
+  "series": [{"field_name": "数值字段", "rollup": "SUM"}],
+  "group_by": [{"field_name": "分组字段", "mode": "integrated"}]
+}`
+
+const dashboardBlockCountByGroupExample = `{
+  "table_name": "表名",
+  "count_all": true,
+  "group_by": [{"field_name": "分类字段", "mode": "integrated"}]
+}`
+
+const dashboardBlockStatisticsExample = `{
+  "table_name": "表名",
+  "series": [{"field_name": "数值字段", "rollup": "SUM"}]
+}`
+
+func dashboardBlockExampleTypes() []string {
+	types := make([]string, 0, len(dashboardBlockExampleTemplates))
+	for typ := range dashboardBlockExampleTemplates {
+		types = append(types, typ)
+	}
+	sort.Strings(types)
+	return types
+}
+
+func withDashboardBlockPrintExample(prev func(cmd *cobra.Command)) func(cmd *cobra.Command) {
+	return func(cmd *cobra.Command) {
+		if prev != nil {
+			prev(cmd)
+		}
+
+		prevPreRunE := cmd.PreRunE
+		cmd.PreRunE = func(c *cobra.Command, args []string) error {
+			if typ, _ := c.Flags().GetString("print-example"); typ != "" {
+				c.Flags().VisitAll(func(flag *pflag.Flag) {
+					delete(flag.Annotations, cobra.BashCompOneRequiredFlag)
+				})
+			}
+			if prevPreRunE != nil {
+				return prevPreRunE(c, args)
+			}
+			return nil
+		}
+
+		prevRunE := cmd.RunE
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			typ, _ := c.Flags().GetString("print-example")
+			if typ == "" {
+				return prevRunE(c, args)
+			}
+			template, ok := dashboardBlockExampleTemplates[typ]
+			if !ok {
+				return common.ValidationErrorf("no example for dashboard block type %q; available: %s", typ, strings.Join(dashboardBlockExampleTypes(), ", ")).WithParam("--print-example")
+			}
+			fmt.Fprintln(c.OutOrStdout(), template)
+			return nil
+		}
+	}
+}

--- a/shortcuts/base/dashboard_block_examples_test.go
+++ b/shortcuts/base/dashboard_block_examples_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/spf13/cobra"
+)
+
+func runDashboardBlockPrintExample(t *testing.T, typ string) (string, error) {
+	t.Helper()
+	factory, _, _ := newExecuteFactory(t)
+	shortcut := BaseDashboardBlockCreate
+	shortcut.AuthTypes = []string{"bot"}
+	parent := &cobra.Command{Use: "base"}
+	shortcut.Mount(parent, factory)
+
+	var stdout bytes.Buffer
+	parent.SetOut(&stdout)
+	parent.SetArgs([]string{"+dashboard-block-create", "--print-example", typ})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	err := parent.ExecuteContext(context.Background())
+	return stdout.String(), err
+}
+
+func TestDashboardBlockPrintExample_PrintsColumnWithoutCreateFlags(t *testing.T) {
+	got, err := runDashboardBlockPrintExample(t, "column")
+	if err != nil {
+		t.Fatalf("print example: %v", err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal([]byte(got), &cfg); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, got)
+	}
+	if cfg["table_name"] != "表名" {
+		t.Fatalf("table_name=%#v, want placeholder", cfg["table_name"])
+	}
+	if _, ok := cfg["series"].([]interface{}); !ok {
+		t.Fatalf("series=%#v, want array", cfg["series"])
+	}
+	if _, ok := cfg["group_by"].([]interface{}); !ok {
+		t.Fatalf("group_by=%#v, want array", cfg["group_by"])
+	}
+}
+
+func TestDashboardBlockPrintExample_RejectsUnknownType(t *testing.T) {
+	_, err := runDashboardBlockPrintExample(t, "colum")
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error=%T %v, want ValidationError", err, err)
+	}
+	if validationErr.Param != "--print-example" {
+		t.Fatalf("param=%q, want --print-example", validationErr.Param)
+	}
+	if !strings.Contains(validationErr.Message, `"colum"`) || !strings.Contains(validationErr.Message, "column") {
+		t.Fatalf("message=%q, want input and available type", validationErr.Message)
+	}
+}
+
+func TestDashboardBlockPrintExample_TemplatesCoverAndValidateSupportedTypes(t *testing.T) {
+	wantTypes := []string{
+		"area", "bar", "column", "combo", "funnel", "line", "pie",
+		"radar", "ring", "scatter", "statistics", "text", "wordCloud",
+	}
+	if got := dashboardBlockExampleTypes(); !reflect.DeepEqual(got, wantTypes) {
+		t.Fatalf("types=%v, want %v", got, wantTypes)
+	}
+
+	for _, typ := range wantTypes {
+		t.Run(typ, func(t *testing.T) {
+			var cfg map[string]interface{}
+			if err := json.Unmarshal([]byte(dashboardBlockExampleTemplates[typ]), &cfg); err != nil {
+				t.Fatalf("template is not valid JSON: %v", err)
+			}
+			if problems := validateBlockDataConfig(typ, normalizeDataConfig(cfg)); len(problems) > 0 {
+				t.Fatalf("template fails data_config validation: %v", problems)
+			}
+		})
+	}
+}

--- a/skills/lark-base/references/dashboard-block-data-config.md
+++ b/skills/lark-base/references/dashboard-block-data-config.md
@@ -2,6 +2,14 @@
 
 Block 的 `data_config` 字段因 `type` 不同而变化。本文档是 dashboard block `data_config` 的单一事实来源（SSOT），包含组件类型、字段结构、筛选格式、约束和可复制模板。
 
+只需要某一类型的最小可编辑模板时，优先运行下面的纯本地命令，避免把本页全部模板加载进上下文：
+
+```bash
+lark-cli base +dashboard-block-create --print-example <type>
+```
+
+该模式无需 Base 参数、认证或网络请求，也不会创建组件。获取模板后，用 `+table-list` / `+field-list` 返回的真实表名和字段名替换占位符；需要筛选、排序或业务口径说明时再继续阅读本页。
+
 ## 支持的组件类型（`type` 枚举）
 
 | type 值 | 说明 |

--- a/skills/lark-base/references/lark-base-dashboard.md
+++ b/skills/lark-base/references/lark-base-dashboard.md
@@ -16,6 +16,7 @@ Dashboard 是 Base 中的数据可视化看板，可以把表格数据变成**�
 |------|-----------|---------|
 | 创建/删除/改名称 | `+dashboard-create/delete/update` | 本页下方「仪表盘管理」 |
 | 在仪表盘里添加组件 | `+dashboard-block-create` | 先定位 dashboard、表和字段，再读 [dashboard-block-data-config.md](dashboard-block-data-config.md) 构造 `data_config` |
+| 获取某类组件的最小配置模板 | `+dashboard-block-create --print-example <type>` | 纯本地输出；无需 Base 参数、认证或网络请求，不会创建组件 |
 | 修改组件 | `+dashboard-block-update` | 先读 block 现状，再读 [dashboard-block-data-config.md](dashboard-block-data-config.md) 决定替换哪些顶层 key |
 | 查看仪表盘有哪些组件 | `+dashboard-get` 或 `+dashboard-block-list` | 本页下方「查看仪表盘」 |
 | 读取图表计算结果 | `+dashboard-block-get-data` | 返回图表最终数据协议；需要 block 元数据先用 `+dashboard-block-get` |
@@ -46,9 +47,12 @@ lark-cli base +field-list --base-token xxx --table-id <table_id>
 # 第 3 步：规划应该创建哪些组件（根据用户需求确定组件类型和数量）
 # 例如：总销售额（指标卡）、月度趋势（折线图）、品类占比（饼图）
 
-# 第 4 步：顺序创建每个组件（必须串行执行，不能并发）
-# 重要：创建组件前，先确定 dashboard_id、组件 name/type 和真实表字段
-# 再阅读 dashboard-block-data-config.md 了解 data_config 结构、组件类型和 filter 规则
+# 第 4 步：先按 type 获取一个最小 data_config 模板，再顺序创建组件
+# print-example 纯本地运行，不需要 base-token/dashboard-id/name，也不会创建组件
+lark-cli base +dashboard-block-create --print-example statistics
+
+# 用真实表名和字段名替换模板占位符；复杂筛选和类型约束再读 dashboard-block-data-config.md
+# 同一 dashboard 的组件必须串行创建，不能并发
 
 # 第 1 个组件
 lark-cli base +dashboard-block-create \
@@ -91,9 +95,10 @@ lark-cli base +dashboard-get --base-token xxx --dashboard-id blk_xxx
 lark-cli base +table-list --base-token xxx
 lark-cli base +field-list --base-token xxx --table-id <table_id>
 
-# 第 4 步：顺序创建每个新组件（必须串行执行，不能并发）
-# 重要：先确定 dashboard_id、组件 name/type 和真实表字段
-# 再阅读 dashboard-block-data-config.md 了解 data_config 结构
+# 第 4 步：按选定 type 获取最小模板，再替换成真实表名和字段名
+lark-cli base +dashboard-block-create --print-example column
+
+# 顺序创建每个新组件（必须串行执行，不能并发）
 lark-cli base +dashboard-block-create \
   --base-token xxx \
   --dashboard-id blk_xxx \
@@ -216,7 +221,8 @@ lark-cli base +dashboard-block-get-data --base-token xxx --block-id chtxxxxxxxx
 **Q: 创建组件的命令和 data_config 怎么写？**
 A:
 1. 先确定 `dashboard_id`、组件 `name`、组件 `type` 和真实表字段
-2. 再读 [dashboard-block-data-config.md](dashboard-block-data-config.md) 了解：
+2. 运行 `lark-cli base +dashboard-block-create --print-example <type>` 获取该类型的最小 `data_config` JSON
+3. 复杂配置再读 [dashboard-block-data-config.md](dashboard-block-data-config.md) 了解：
    - 全部组件类型的可复制模板
    - filter 筛选条件格式
    - 字段类型与操作符对应表


### PR DESCRIPTION
## Summary

Add a pure-local way for agents and humans to print one minimal Base dashboard block `data_config` template by type, without Base locator flags, authentication, or API calls.

## Changes

- Add `base +dashboard-block-create --print-example <type>` for all 13 supported dashboard block types.
- Return a typed validation error for unknown example types and list canonical values.
- Validate every embedded template against the existing Base `data_config` validator.
- Update lark-base dashboard guidance to use the one-template local workflow while keeping the detailed reference as the SSOT.
- Keep the real create path, backend API, and existing `--type` behavior unchanged.

## Test Plan

- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `QUALITY_GATE_CHANGED_FROM=upstream/main make quality-gate`
- [x] `node scripts/skill-format-check/index.js`
- [x] Manual smoke test from an empty CLI config directory

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--print-example <type>` to generate editable dashboard block configuration templates locally.
  * Supports 13 dashboard block types with minimal, valid JSON output.
  * Templates require no authentication or network access and do not create dashboard components.
  * Invalid types return clear validation errors showing the provided and supported values.

* **Documentation**
  * Added usage guidance and updated dashboard creation workflows and FAQs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->