### PR TITLE
feat: fix doc skill about identity coutinue

### DIFF
--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 **CRITICAL：先判断场景，再读取该场景的参考文件；不要在任务开始时一次性读取全部参考文件。每个文件只在首次进入对应阶段时读取一次。**
 
-**身份：文档操作推荐显式指定 `--as user`。例外：如果 `doc_token` / `note_doc_token` 等是从 bot 链路（如 `vc +detail --as bot` → `note +detail --as bot`）取得的，应继续显式使用 `--as bot`，不要无条件切回 user——身份延续规则见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)。**
+**身份：文档操作推荐显式指定 `--as user`。**
 
 **所有表示本地文件的 `@path` 均使用 `@./xxx` 形式的相对路径，并以运行 `lark-cli` 时的当前工作目录（CWD）为基准。**
 

--- a/skills/lark-note/SKILL.md
+++ b/skills/lark-note/SKILL.md
@@ -12,6 +12,8 @@ metadata:
 
 身份：`+detail` 支持 `--as user` / `--as bot`；`+transcript` 仅支持 `--as user`。`note_id` 若由某个身份取得（例如 `vc +detail --as bot`），`+detail` 必须显式沿用同一个 `--as`——不要依赖 profile 默认身份。完整身份延续规则见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，使用前必读。
 
+`+detail` 返回的 `note_doc_token` / `verbatim_doc_token` / `shared_doc_tokens` 交给 [lark-doc](../lark-doc/SKILL.md) 读正文时，仍要显式带上同一个 `--as`。lark-doc 对普通文档推荐 `--as user`，**不覆盖这些纪要文档 token 的来源身份**。
+
 **CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-vc/references/vc-domain-boundaries.md`](../lark-vc/references/vc-domain-boundaries.md)**，不读将导致命令使用、会议产物决策、领域边界职责判断错误：
 > 1. 了解日历 & VC、会议产物 & 文档的关联关系和职责划分
 > 2. 了解会议产物（妙记和纪要）之间的关联关系，例如：**妙记和纪要产生条件相互独立**

--- a/skills/lark-vc/SKILL.md
+++ b/skills/lark-vc/SKILL.md
@@ -22,6 +22,8 @@ metadata:
 
 身份是跨命令工作流的状态，不是单条命令的局部参数：一旦某个 ID（如 `note_id`、`minute_token`）由某个身份取得，后续消费它的命令（包括跨到 lark-minutes / lark-note / lark-doc）必须显式沿用相同 `--as`；不要依赖 profile 默认身份，也不要为绕过权限错误切换身份。完整规则见 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) 的「身份延续」。
 
+**本链路的身份策略覆盖到最后一跳读正文**：`vc +detail` → `note +detail` → `docs +fetch --doc <note_doc_token> / <verbatim_doc_token>` 全程用同一个 `--as`。[lark-doc](../lark-doc/SKILL.md) 对普通文档推荐 `--as user`，**不覆盖本链路取得的纪要文档 token**；读正文时不要因此切回 user。
+
 本 skill 默认使用 `--as user`。`+detail`、`+recording`、`meeting get`、`+meeting-list-active`、`+meeting-events` 和 `+meeting-message-send` 也支持 `--as bot`；`+meeting-events` 和 `+meeting-message-send` 必须沿用 `meeting_id` 的来源身份。`+search` 仅支持 `--as user`。
 
 ```bash

--- a/skills/lark-vc/references/vc-domain-boundaries.md
+++ b/skills/lark-vc/references/vc-domain-boundaries.md
@@ -143,6 +143,8 @@ lark-cli minutes +detail --minute-tokens '<minute_token1>,<minute_token2>' \
 
 智能纪要（`note_doc_token`）是飞书文档，使用 `docs +fetch` 读取正文内容；**逐字稿的读取方式由 `note_display_type` 决定**：
 
+读正文是本链路的最后一跳，身份仍由本链路决定：`--as <user|bot>` 一律填 Step 2 取得 token 时用的那个身份。[lark-doc](../../lark-doc/SKILL.md) 对普通文档推荐 `--as user`，那是用户自有文档的默认建议，**不适用于这里的纪要文档 token**，不要因此切回 user。
+
 ```bash
 # 纪要正文（两种展示类型都适用）
 lark-cli docs +fetch --doc <note_doc_token> --doc-format markdown


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified identity handling when retrieving document content from notes and meeting details.
  * Added guidance to consistently use the same explicit identity throughout multi-step document retrieval.
  * Removed guidance that could allow switching identities during bot-derived document workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->