### PR TITLE
Support partial mail rule reorder

### DIFF
--- a/cmd/service/mail_rule_reorder.go
+++ b/cmd/service/mail_rule_reorder.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+)
+
+func completeMailRuleReorderRequest(ctx context.Context, ac *client.APIClient, request client.RawApiRequest) (client.RawApiRequest, error) {
+	if !isMailRuleReorderRequest(request) {
+		return request, nil
+	}
+	input, err := normalizeMailRuleIDs(request.Data)
+	if err != nil {
+		return client.RawApiRequest{}, err
+	}
+	listReq := client.RawApiRequest{
+		Method: "GET",
+		URL:    strings.TrimSuffix(request.URL, "/reorder"),
+		As:     request.As,
+	}
+	resp, err := ac.DoAPI(ctx, listReq)
+	if err != nil {
+		return client.RawApiRequest{}, err
+	}
+	parsed, err := client.ParseJSONResponse(resp)
+	if err != nil {
+		return client.RawApiRequest{}, client.WrapJSONResponseParseError(err, resp.RawBody)
+	}
+	if err := ac.CheckResponse(parsed, request.As); err != nil {
+		return client.RawApiRequest{}, err
+	}
+	parsedMap, _ := parsed.(map[string]interface{})
+	current, err := extractMailRuleOrder(parsedMap)
+	if err != nil {
+		return client.RawApiRequest{}, err
+	}
+	completed, err := completeMailRuleOrder(input, current)
+	if err != nil {
+		return client.RawApiRequest{}, err
+	}
+	data, _ := request.Data.(map[string]interface{})
+	next := make(map[string]interface{}, len(data)+1)
+	for k, v := range data {
+		next[k] = v
+	}
+	next["rule_ids"] = completed
+	request.Data = next
+	return request, nil
+}
+
+func isMailRuleReorderRequest(request client.RawApiRequest) bool {
+	method := strings.ToUpper(request.Method)
+	return (method == "POST" || method == "PUT") &&
+		strings.HasPrefix(request.URL, "/open-apis/mail/v1/user_mailboxes/") &&
+		strings.HasSuffix(request.URL, "/rules/reorder")
+}
+
+func normalizeMailRuleIDs(data interface{}) ([]string, error) {
+	body, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, mailRuleReorderValidation("--data must be a JSON object with rule_ids")
+	}
+	raw, ok := body["rule_ids"]
+	if !ok {
+		return nil, mailRuleReorderValidation("provide at least one rule ID")
+	}
+	var values []interface{}
+	switch ids := raw.(type) {
+	case []interface{}:
+		values = ids
+	case []string:
+		values = make([]interface{}, 0, len(ids))
+		for _, id := range ids {
+			values = append(values, id)
+		}
+	default:
+		return nil, mailRuleReorderValidation("rule_ids must be an array")
+	}
+	ids := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, rawID := range values {
+		id := strings.TrimSpace(strValue(rawID))
+		if id == "" || seen[id] {
+			continue
+		}
+		ids = append(ids, id)
+		seen[id] = true
+	}
+	if len(ids) == 0 {
+		return nil, mailRuleReorderValidation("provide at least one rule ID")
+	}
+	return ids, nil
+}
+
+func extractMailRuleOrder(data map[string]interface{}) ([]string, error) {
+	rules, ok := firstMailRuleList(data)
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "rules list response missing rules")
+	}
+	order := make([]string, 0, len(rules))
+	for _, raw := range rules {
+		rule, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id := strings.TrimSpace(strValue(rule["rule_id"]))
+		if id == "" {
+			id = strings.TrimSpace(strValue(rule["id"]))
+		}
+		if id != "" {
+			order = append(order, id)
+		}
+	}
+	return order, nil
+}
+
+func firstMailRuleList(data map[string]interface{}) ([]interface{}, bool) {
+	for _, key := range []string{"rules", "items", "user_mailbox_rules"} {
+		if rules, ok := data[key].([]interface{}); ok {
+			return rules, true
+		}
+	}
+	if nested, ok := data["data"].(map[string]interface{}); ok {
+		return firstMailRuleList(nested)
+	}
+	return nil, false
+}
+
+func completeMailRuleOrder(inputIDs []string, currentRuleIDs []string) ([]string, error) {
+	input, err := normalizeMailRuleIDs(map[string]interface{}{"rule_ids": inputIDs})
+	if err != nil {
+		return nil, err
+	}
+	if len(currentRuleIDs) == 0 {
+		return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition, "current mailbox has no inbox rules to reorder")
+	}
+	existing := map[string]bool{}
+	for _, id := range currentRuleIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			existing[id] = true
+		}
+	}
+	if len(existing) == 0 {
+		return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition, "current mailbox has no inbox rules to reorder")
+	}
+	selectedSet := map[string]bool{}
+	var missing []string
+	for _, id := range input {
+		if !existing[id] {
+			missing = append(missing, id)
+			continue
+		}
+		selectedSet[id] = true
+	}
+	if len(missing) > 0 {
+		return nil, mailRuleReorderValidation("rule ID not found: %s", strings.Join(missing, ", "))
+	}
+	completed := append([]string(nil), input...)
+	for _, id := range currentRuleIDs {
+		id = strings.TrimSpace(id)
+		if id != "" && !selectedSet[id] {
+			completed = append(completed, id)
+		}
+	}
+	return completed, nil
+}
+
+func mailRuleReorderValidation(format string, args ...interface{}) *errs.ValidationError {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, format, args...).WithParam("--data")
+}
+
+func strValue(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(x)
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -21,6 +22,7 @@ import (
 	"github.com/larksuite/cli/internal/errclass"
 	"github.com/larksuite/cli/internal/meta"
 	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/recovery"
 	"github.com/larksuite/cli/internal/registry"
 	"github.com/larksuite/cli/internal/validate"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -403,9 +405,9 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 
 	if opts.DryRun {
 		if fileMeta != nil {
-			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
+			return serviceDryRunWithFile(f, request, config, opts, *fileMeta)
 		}
-		return serviceDryRun(f, request, config, opts.Format)
+		return serviceDryRun(f, request, config, opts)
 	}
 
 	if opts.Method.Risk == cmdutil.RiskHighRiskWrite {
@@ -433,6 +435,11 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	if opts.PageAll {
 		return servicePaginate(opts.Ctx, ac, request, format, opts.JqExpr, out, f.IOStreams.ErrOut, opts.Cmd.CommandPath(),
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)
+	}
+
+	request, err = completeMailRuleReorderRequest(opts.Ctx, ac, request)
+	if err != nil {
+		return err
 	}
 
 	resp, err := ac.DoAPI(opts.Ctx, request)
@@ -490,8 +497,9 @@ func checkServiceScopes(ctx context.Context, cred *credential.CredentialProvider
 
 // newPreflightMissingScopeError constructs a PermissionError for the local
 // pre-flight scope check that converges byte-for-byte with the dispatcher's
-// BuildAPIError path. Uses the canonical helpers in internal/errclass so
-// Hint and Message stay in lock-step with the server-response classifier.
+// BuildAPIError path. It records the same typed facts and canonical message;
+// the root presenter supplies identity-appropriate recovery at the final
+// command boundary.
 // ConsoleURL is deliberately omitted: the dispatcher only sets it for
 // SubtypeAppScopeNotApplied (bot-perspective dev-action recovery), and this
 // pre-flight path is user-perspective SubtypeMissingScope whose recovery is
@@ -529,12 +537,28 @@ func unusableParamValue(v interface{}) bool {
 // only the --params form: a flag with its kebab name exists but belongs to
 // something else (e.g. the output --format), and the hint must not steer
 // there. Asking the binder, not cmd.Flags(), is what tells those apart.
-func missingParamHint(opts *ServiceMethodOptions, f meta.Field) string {
+func missingParamHint(opts *ServiceMethodOptions, f meta.Field) recovery.Hint {
 	paramsForm := fmt.Sprintf("--params '{%q: \"<value>\"}'", f.Name)
+	var input string
 	if opts.binder.hasTypedFlag(f.Name) {
-		return fmt.Sprintf("set --%s <value> (or %s); see: lark-cli schema %s", f.FlagName(), paramsForm, opts.SchemaPath)
+		input = fmt.Sprintf("set --%s <value> (or %s)", f.FlagName(), paramsForm)
+	} else {
+		input = fmt.Sprintf("set %s", paramsForm)
 	}
-	return fmt.Sprintf("set %s; see: lark-cli schema %s", paramsForm, opts.SchemaPath)
+	return recovery.Join("; ",
+		recovery.Text(input),
+		recovery.Command(recovery.TargetSchema, "see: lark-cli schema "+opts.SchemaPath),
+	)
+}
+
+func missingRequiredParamError(opts *ServiceMethodOptions, f meta.Field, location string) error {
+	hint := missingParamHint(opts, f)
+	return recovery.Attach(
+		errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"missing required %s parameter: %s", location, f.Name).
+			WithParam(f.Name),
+		hint,
+	)
 }
 
 // buildServiceRequest parses flags, builds the URL with path/query params, and returns a RawApiRequest.
@@ -571,10 +595,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		}
 		val, ok := params[s.Name]
 		if !ok || unusableParamValue(val) {
-			return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
-				"missing required path parameter: %s", s.Name).
-				WithHint("%s", missingParamHint(opts, s)).
-				WithParam(s.Name)
+			return client.RawApiRequest{}, nil, missingRequiredParamError(opts, s, "path")
 		}
 		valStr := fmt.Sprintf("%v", val)
 		if err := validate.ResourceName(valStr, s.Name); err != nil {
@@ -592,10 +613,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 		value, exists := params[s.Name]
 		isPaginationParam := opts.PageAll && (s.Name == "page_token" || s.Name == "page_size")
 		if s.Required && !isPaginationParam && (!exists || unusableParamValue(value)) {
-			return client.RawApiRequest{}, nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
-				"missing required query parameter: %s", s.Name).
-				WithHint("%s", missingParamHint(opts, s)).
-				WithParam(s.Name)
+			return client.RawApiRequest{}, nil, missingRequiredParamError(opts, s, "query")
 		}
 		if exists && !unusableParamValue(value) {
 			queryParams[s.Name] = value
@@ -667,8 +685,83 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 	return request, nil, nil
 }
 
-func serviceDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, format string) error {
-	return cmdutil.PrintDryRun(f.IOStreams.Out, request, config, format)
+func serviceDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, opts *ServiceMethodOptions) error {
+	dr := newServiceDryRunAPI(request, config)
+	return writeServiceDryRunEnvelope(f, opts, dr)
+}
+
+func serviceDryRunWithFile(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, opts *ServiceMethodOptions, fileMeta cmdutil.FileUploadMeta) error {
+	dr := newServiceDryRunAPI(request, config)
+	filePath := fileMeta.FilePath
+	if filePath == "" {
+		filePath = "<stdin>"
+	}
+	fileInfo := map[string]any{
+		"file": map[string]string{"field": fileMeta.FieldName, "path": filePath},
+	}
+	if fileMeta.FormFields != nil {
+		fileInfo["form_fields"] = fileMeta.FormFields
+	}
+	fileInfo["options"] = []string{"WithFileUpload"}
+	dr.Body(fileInfo)
+	return writeServiceDryRunEnvelope(f, opts, dr)
+}
+
+func writeServiceDryRunEnvelope(f *cmdutil.Factory, opts *ServiceMethodOptions, data interface{}) error {
+	plain, err := serviceDryRunPlainData(data)
+	if err != nil {
+		return err
+	}
+	env := map[string]interface{}{
+		"ok":      true,
+		"dry_run": true,
+		"data":    plain,
+	}
+	if opts.JqExpr != "" {
+		return output.JqFilter(f.IOStreams.Out, env, opts.JqExpr)
+	}
+	output.PrintJson(f.IOStreams.Out, env)
+	return nil
+}
+
+func serviceDryRunPlainData(data interface{}) (interface{}, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var out interface{}
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func newServiceDryRunAPI(request client.RawApiRequest, config *core.CliConfig) *cmdutil.DryRunAPI {
+	dr := cmdutil.NewDryRunAPI()
+	switch request.Method {
+	case "POST":
+		dr.POST(request.URL)
+	case "PUT":
+		dr.PUT(request.URL)
+	case "PATCH":
+		dr.PATCH(request.URL)
+	case "DELETE":
+		dr.DELETE(request.URL)
+	default:
+		dr.GET(request.URL)
+	}
+	if len(request.Params) > 0 {
+		dr.Params(request.Params)
+	}
+	if request.Data != nil {
+		dr.Body(request.Data)
+	}
+	dr.Set("as", string(request.As))
+	dr.Set("appId", config.AppID)
+	if config.UserOpenId != "" {
+		dr.Set("userOpenId", config.UserOpenId)
+	}
+	return dr
 }
 
 func servicePaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, jqExpr string, out, errOut io.Writer, commandPath string, pagOpts client.PaginationOptions, checkErr func(interface{}, core.Identity) error) error {

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -553,10 +553,16 @@ func missingParamHint(opts *ServiceMethodOptions, f meta.Field) recovery.Hint {
 
 func missingRequiredParamError(opts *ServiceMethodOptions, f meta.Field, location string) error {
 	hint := missingParamHint(opts, f)
+	param := f.Name
+	if opts.binder.hasTypedFlag(f.Name) {
+		param = "--" + f.FlagName()
+	} else {
+		param = "--params"
+	}
 	return recovery.Attach(
 		errs.NewValidationError(errs.SubtypeInvalidArgument,
 			"missing required %s parameter: %s", location, f.Name).
-			WithParam(f.Name),
+			WithParam(param),
 		hint,
 	)
 }

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -54,6 +54,150 @@ func driveMethod(httpMethod string, params map[string]interface{}) meta.Method {
 	return meta.FromMap(m)
 }
 
+func mailRulesSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRulesReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "array", "required": true},
+		},
+	})
+}
+
+func TestNewPreflightMissingScopeErrorUsesCanonicalFieldGate(t *testing.T) {
+	err := newPreflightMissingScopeError(
+		"feishu",
+		"cli_test",
+		"user",
+		[]string{"docx:document"},
+	)
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("error = %T, want *errs.PermissionError", err)
+	}
+	if permissionErr.Subtype != errs.SubtypeMissingScope {
+		t.Fatalf("subtype = %q, want %q", permissionErr.Subtype, errs.SubtypeMissingScope)
+	}
+	if permissionErr.ConsoleURL != "" {
+		t.Fatalf("missing_scope console_url = %q, want empty", permissionErr.ConsoleURL)
+	}
+	if len(permissionErr.MissingScopes) != 1 ||
+		permissionErr.MissingScopes[0] != "docx:document" ||
+		permissionErr.Identity != "user" {
+		t.Fatalf("permission facts = %+v", permissionErr)
+	}
+}
+
+func TestServiceMethod_MailRuleReorderCompletesPartialIDs(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"rules": []map[string]interface{}{
+					{"rule_id": "A"},
+					{"rule_id": "B"},
+					{"rule_id": "C"},
+					{"rule_id": "D"},
+				},
+			},
+		},
+	})
+	var submitted []string
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		BodyFilter: func(body []byte) bool {
+			var payload map[string][]string
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return false
+			}
+			submitted = payload["rule_ids"]
+			return strings.Join(submitted, ",") == "C,A,B,D"
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ok": true},
+		},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["C","A"]}`,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	reg.Verify(t)
+	if strings.Join(submitted, ",") != "C,A,B,D" {
+		t.Fatalf("submitted rule_ids = %v", submitted)
+	}
+	if !strings.Contains(stdout.String(), `"ok": true`) {
+		t.Fatalf("unexpected stdout: %s", stdout.String())
+	}
+}
+
+func TestServiceMethod_MailRuleReorderRejectsMissingIDBeforeSubmit(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"rules": []map[string]interface{}{{"rule_id": "A"}},
+			},
+		},
+	})
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["missing"]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "rule ID not found: missing") {
+		t.Fatalf("Execute() error = %v, want missing rule ID validation", err)
+	}
+	reg.Verify(t)
+}
+
+func TestServiceMethod_MailRuleReorderRejectsEmptyInputBeforeList(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+
+	cmd := NewCmdServiceMethod(f, mailRulesSpec(), mailRulesReorderMethod(), "reorder", "user_mailbox.rules", nil)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":[]}`,
+	})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "provide at least one rule ID") {
+		t.Fatalf("Execute() error = %v, want empty rule ID validation", err)
+	}
+	reg.Verify(t)
+}
+
 // ── registerService ──
 
 func TestRegisterService(t *testing.T) {
@@ -224,10 +368,36 @@ func TestServiceMethod_DryRun_PathParam(t *testing.T) {
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !strings.Contains(stdout.String(), tt.wantInURL) {
-				t.Errorf("expected URL containing %q, got:\n%s", tt.wantInURL, stdout.String())
+			var got map[string]interface{}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			if got["ok"] != true || got["dry_run"] != true {
+				t.Fatalf("unexpected dry-run envelope: %#v", got)
+			}
+			data := got["data"].(map[string]interface{})
+			api := data["api"].([]interface{})
+			call := api[0].(map[string]interface{})
+			if call["url"] != tt.wantInURL {
+				t.Errorf("url = %q, want %q\nstdout:\n%s", call["url"], tt.wantInURL, stdout.String())
 			}
 		})
+	}
+}
+
+func TestServiceMethod_DryRunWithJq(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, driveSpec(), driveMethod("GET", nil), "get", "files", nil)
+	cmd.SetArgs([]string{
+		"--params", `{"file_token":"boxcn123abc"}`,
+		"--dry-run",
+		"--jq", ".data.api[0].url",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := strings.TrimSpace(stdout.String()), "/open-apis/drive/v1/files/boxcn123abc/copy"; got != want {
+		t.Fatalf("jq output = %q, want %q", got, want)
 	}
 }
 
@@ -318,8 +488,12 @@ func TestServiceMethod_PaginationParamSkippedWithPageAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error with --page-all skipping page_size, got: %v", err)
 	}
-	if !strings.Contains(stdout.String(), "Dry Run") {
-		t.Error("expected dry-run output")
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got["dry_run"] != true {
+		t.Fatalf("dry_run = %#v, want true", got["dry_run"])
 	}
 }
 
@@ -1081,11 +1255,23 @@ func TestServiceMethod_FileUpload_DryRun(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "image") {
-		t.Errorf("expected dry-run output to mention file field, got: %s", out)
+	var env map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "Dry Run") {
-		t.Errorf("expected dry-run header, got: %s", out)
+	if env["dry_run"] != true {
+		t.Fatalf("dry_run = %#v, want true", env["dry_run"])
+	}
+	data := env["data"].(map[string]interface{})
+	api := data["api"].([]interface{})
+	call := api[0].(map[string]interface{})
+	body := call["body"].(map[string]interface{})
+	file := body["file"].(map[string]interface{})
+	if file["field"] != "image" || file["path"] != tmpFile {
+		t.Fatalf("unexpected file dry-run body: %#v", body)
+	}
+	if strings.Contains(out, "=== Dry Run ===") {
+		t.Fatalf("stdout should not contain dry-run banner: %s", out)
 	}
 }
 

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package recovery
+
+import (
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// Target identifies the kind of recovery action a hint points to.
+type Target string
+
+const (
+	// TargetSchema points users to the generated request schema.
+	TargetSchema Target = "schema"
+)
+
+// Hint is a rendered, user-facing recovery hint.
+type Hint string
+
+// Text returns a plain recovery hint fragment.
+func Text(s string) Hint {
+	return Hint(strings.TrimSpace(s))
+}
+
+// Command returns a command recovery hint fragment.
+func Command(_ Target, s string) Hint {
+	return Text(s)
+}
+
+// Join combines non-empty hint fragments with sep.
+func Join(sep string, hints ...Hint) Hint {
+	parts := make([]string, 0, len(hints))
+	for _, hint := range hints {
+		if s := strings.TrimSpace(string(hint)); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return Hint(strings.Join(parts, sep))
+}
+
+// Attach applies hint to typed errors that support WithHint.
+func Attach(err error, hint Hint) error {
+	if err == nil {
+		return nil
+	}
+	s := strings.TrimSpace(string(hint))
+	if s == "" {
+		return err
+	}
+	switch e := err.(type) {
+	case *errs.ValidationError:
+		return e.WithHint("%s", s)
+	case *errs.AuthenticationError:
+		return e.WithHint("%s", s)
+	case *errs.PermissionError:
+		return e.WithHint("%s", s)
+	case *errs.ConfigError:
+		return e.WithHint("%s", s)
+	case *errs.NetworkError:
+		return e.WithHint("%s", s)
+	case *errs.APIError:
+		return e.WithHint("%s", s)
+	case *errs.SecurityPolicyError:
+		return e.WithHint("%s", s)
+	case *errs.ContentSafetyError:
+		return e.WithHint("%s", s)
+	case *errs.InternalError:
+		return e.WithHint("%s", s)
+	case *errs.ConfirmationRequiredError:
+		return e.WithHint("%s", s)
+	default:
+		return err
+	}
+}

--- a/shortcuts/mail/mail_rule_reorder.go
+++ b/shortcuts/mail/mail_rule_reorder.go
@@ -46,24 +46,22 @@ type mailRuleReorderResult struct {
 }
 
 func validateRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
-	_, err := normalizeRuleReorderInput(rt.StrArray("rule-ids"))
+	_, _, err := normalizeRuleReorderInput(rt.StrArray("rule-ids"))
 	return err
 }
 
 func dryRunRuleReorder(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
 	mailboxID := resolveMailboxID(rt)
-	input, _ := normalizeRuleReorderInput(rt.StrArray("rule-ids"))
 	return common.NewDryRunAPI().
 		Desc("Read current inbox rules, complete the submitted rule ID list, then call the existing reorder API with the full order").
 		GET(mailboxPath(mailboxID, "rules")).
-		POST(mailboxPath(mailboxID, "rules", "reorder")).
-		Body(map[string]interface{}{"rule_ids": input})
+		POST(mailboxPath(mailboxID, "rules", "reorder"))
 }
 
 func executeRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
 	mailboxID := resolveMailboxID(rt)
 	rawInput := rt.StrArray("rule-ids")
-	input, err := normalizeRuleReorderInput(rawInput)
+	input, duplicateCount, err := normalizeRuleReorderInput(rawInput)
 	if err != nil {
 		return err
 	}
@@ -88,7 +86,7 @@ func executeRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
 		SubmittedRuleID: completed,
 		SubmittedCount:  len(completed),
 		InputCount:      len(input),
-		DedupedCount:    len(rawInput) - len(input),
+		DedupedCount:    duplicateCount,
 	}
 	rt.OutFormat(result, &output.Meta{Count: len(completed)}, func(w io.Writer) {
 		fmt.Fprintf(w, "reordered %d inbox rules for %s\n", len(completed), mailboxID)
@@ -99,21 +97,26 @@ func executeRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
 	return nil
 }
 
-func normalizeRuleReorderInput(raw []string) ([]string, error) {
+func normalizeRuleReorderInput(raw []string) ([]string, int, error) {
 	ids := make([]string, 0, len(raw))
+	duplicateCount := 0
 	seen := map[string]bool{}
 	for _, id := range raw {
 		id = strings.TrimSpace(id)
-		if id == "" || seen[id] {
+		if id == "" {
+			continue
+		}
+		if seen[id] {
+			duplicateCount++
 			continue
 		}
 		ids = append(ids, id)
 		seen[id] = true
 	}
 	if len(ids) == 0 {
-		return nil, mailValidationParamError("--rule-ids", "provide at least one rule ID")
+		return nil, duplicateCount, mailValidationParamError("--rule-ids", "provide at least one rule ID")
 	}
-	return ids, nil
+	return ids, duplicateCount, nil
 }
 
 func fetchMailRules(rt *common.RuntimeContext, mailboxID string) ([]mailRuleOrderEntry, error) {
@@ -155,7 +158,7 @@ func firstRuleList(data map[string]interface{}) ([]interface{}, bool) {
 }
 
 func completeRuleOrder(inputIDs []string, currentRules []mailRuleOrderEntry) ([]string, error) {
-	selected, err := normalizeRuleReorderInput(inputIDs)
+	selected, _, err := normalizeRuleReorderInput(inputIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/shortcuts/mail/mail_rule_reorder.go
+++ b/shortcuts/mail/mail_rule_reorder.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// MailRuleReorder is the `+rule-reorder` shortcut: accept a partial rule ID
+// list, complete it from the server's current rule order, then submit the
+// existing full-list reorder API.
+var MailRuleReorder = common.Shortcut{
+	Service:     "mail",
+	Command:     "+rule-reorder",
+	Description: "Reorder inbox rules by rule ID. You may pass only the rules to move first; the CLI reads the current rule order, appends untouched rules, and submits the full order.",
+	Risk:        "write",
+	Scopes:      []string{"mail:user_mailbox.rule:read", "mail:user_mailbox.rule:write"},
+	AuthTypes:   []string{"user"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "mailbox", Desc: "Mailbox email address that owns the rules (default: me)."},
+		{Name: "rule-ids", Type: "string_array", Required: true, Desc: "Rule IDs to place first, in order; comma-separated or repeat the flag."},
+	},
+	Validate: validateRuleReorder,
+	DryRun:   dryRunRuleReorder,
+	Execute:  executeRuleReorder,
+}
+
+type mailRuleOrderEntry struct {
+	ID string
+}
+
+type mailRuleReorderResult struct {
+	MailboxID       string   `json:"mailbox_id"`
+	SubmittedRuleID []string `json:"submitted_rule_ids"`
+	SubmittedCount  int      `json:"submitted_count"`
+	InputCount      int      `json:"input_count"`
+	DedupedCount    int      `json:"deduplicated_count"`
+}
+
+func validateRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
+	_, err := normalizeRuleReorderInput(rt.StrArray("rule-ids"))
+	return err
+}
+
+func dryRunRuleReorder(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
+	mailboxID := resolveMailboxID(rt)
+	input, _ := normalizeRuleReorderInput(rt.StrArray("rule-ids"))
+	return common.NewDryRunAPI().
+		Desc("Read current inbox rules, complete the submitted rule ID list, then call the existing reorder API with the full order").
+		GET(mailboxPath(mailboxID, "rules")).
+		POST(mailboxPath(mailboxID, "rules", "reorder")).
+		Body(map[string]interface{}{"rule_ids": input})
+}
+
+func executeRuleReorder(ctx context.Context, rt *common.RuntimeContext) error {
+	mailboxID := resolveMailboxID(rt)
+	rawInput := rt.StrArray("rule-ids")
+	input, err := normalizeRuleReorderInput(rawInput)
+	if err != nil {
+		return err
+	}
+
+	rules, err := fetchMailRules(rt, mailboxID)
+	if err != nil {
+		return mailDecorateProblemMessage(err, "list current inbox rules failed")
+	}
+	completed, err := completeRuleOrder(input, rules)
+	if err != nil {
+		return err
+	}
+	_, err = rt.CallAPITyped("POST", mailboxPath(mailboxID, "rules", "reorder"), nil, map[string]interface{}{
+		"rule_ids": completed,
+	})
+	if err != nil {
+		return mailDecorateProblemMessage(err, "submit inbox rule reorder failed")
+	}
+
+	result := mailRuleReorderResult{
+		MailboxID:       mailboxID,
+		SubmittedRuleID: completed,
+		SubmittedCount:  len(completed),
+		InputCount:      len(input),
+		DedupedCount:    len(rawInput) - len(input),
+	}
+	rt.OutFormat(result, &output.Meta{Count: len(completed)}, func(w io.Writer) {
+		fmt.Fprintf(w, "reordered %d inbox rules for %s\n", len(completed), mailboxID)
+		for i, id := range completed {
+			fmt.Fprintf(w, "%d. %s\n", i+1, id)
+		}
+	})
+	return nil
+}
+
+func normalizeRuleReorderInput(raw []string) ([]string, error) {
+	ids := make([]string, 0, len(raw))
+	seen := map[string]bool{}
+	for _, id := range raw {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		ids = append(ids, id)
+		seen[id] = true
+	}
+	if len(ids) == 0 {
+		return nil, mailValidationParamError("--rule-ids", "provide at least one rule ID")
+	}
+	return ids, nil
+}
+
+func fetchMailRules(rt *common.RuntimeContext, mailboxID string) ([]mailRuleOrderEntry, error) {
+	data, err := rt.CallAPITyped("GET", mailboxPath(mailboxID, "rules"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	rawRules, ok := firstRuleList(data)
+	if !ok {
+		return nil, mailInvalidResponseError("rules list response missing rules")
+	}
+	rules := make([]mailRuleOrderEntry, 0, len(rawRules))
+	for _, raw := range rawRules {
+		rule, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id := strings.TrimSpace(strVal(rule["rule_id"]))
+		if id == "" {
+			id = strings.TrimSpace(strVal(rule["id"]))
+		}
+		if id != "" {
+			rules = append(rules, mailRuleOrderEntry{ID: id})
+		}
+	}
+	return rules, nil
+}
+
+func firstRuleList(data map[string]interface{}) ([]interface{}, bool) {
+	for _, key := range []string{"rules", "items", "user_mailbox_rules"} {
+		if rules, ok := data[key].([]interface{}); ok {
+			return rules, true
+		}
+	}
+	if nested, ok := data["data"].(map[string]interface{}); ok {
+		return firstRuleList(nested)
+	}
+	return nil, false
+}
+
+func completeRuleOrder(inputIDs []string, currentRules []mailRuleOrderEntry) ([]string, error) {
+	selected, err := normalizeRuleReorderInput(inputIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(currentRules) == 0 {
+		return nil, mailFailedPreconditionError("current mailbox has no inbox rules to reorder")
+	}
+
+	existing := map[string]bool{}
+	for _, rule := range currentRules {
+		id := strings.TrimSpace(rule.ID)
+		if id != "" {
+			existing[id] = true
+		}
+	}
+	if len(existing) == 0 {
+		return nil, mailFailedPreconditionError("current mailbox has no inbox rules to reorder")
+	}
+
+	missing := make([]string, 0)
+	selectedSet := map[string]bool{}
+	for _, id := range selected {
+		if !existing[id] {
+			missing = append(missing, id)
+			continue
+		}
+		selectedSet[id] = true
+	}
+	if len(missing) > 0 {
+		return nil, mailValidationParamError("--rule-ids", "rule ID not found: %s", strings.Join(missing, ", "))
+	}
+
+	completed := append([]string(nil), selected...)
+	for _, rule := range currentRules {
+		id := strings.TrimSpace(rule.ID)
+		if id == "" || selectedSet[id] {
+			continue
+		}
+		completed = append(completed, id)
+	}
+	return completed, nil
+}

--- a/shortcuts/mail/mail_rule_reorder_test.go
+++ b/shortcuts/mail/mail_rule_reorder_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
 )
 
 func TestCompleteRuleOrder(t *testing.T) {
@@ -132,6 +134,75 @@ func TestMailRuleReorder_SubmitsCompletedOrder(t *testing.T) {
 	}
 }
 
+func TestMailRuleReorder_DeduplicatedCountIgnoresBlanks(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"rules": []map[string]interface{}{
+					{"rule_id": "A"},
+					{"rule_id": "B"},
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/rules/reorder",
+		BodyFilter: func(body []byte) bool {
+			var payload map[string][]string
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return false
+			}
+			return strings.Join(payload["rule_ids"], ",") == "A,B"
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ok": true},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "A",
+		"--rule-ids", " ",
+		"--rule-ids", "A",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("runMountedMailShortcut() error = %v", err)
+	}
+	reg.Verify(t)
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["deduplicated_count"] != float64(1) {
+		t.Fatalf("deduplicated_count = %v, want 1", data["deduplicated_count"])
+	}
+}
+
+func TestMailRuleReorder_DryRunDoesNotInventCompletedPayload(t *testing.T) {
+	rt := mailRuleReorderTestRuntime(t, []string{"C", "A"})
+
+	dry := dryRunRuleReorder(nil, rt)
+	if dry == nil {
+		t.Fatal("dryRunRuleReorder() returned nil")
+	}
+	calls := dryRunAPIsForMailRuleReorderTest(t, dry)
+	if len(calls) != 2 {
+		t.Fatalf("dry-run call count = %d, want 2", len(calls))
+	}
+	if calls[0].Method != "GET" || calls[0].URL != "/open-apis/mail/v1/user_mailboxes/me/rules" {
+		t.Fatalf("first dry-run call = %#v", calls[0])
+	}
+	if calls[1].Method != "POST" || calls[1].URL != "/open-apis/mail/v1/user_mailboxes/me/rules/reorder" {
+		t.Fatalf("second dry-run call = %#v", calls[1])
+	}
+	if calls[1].Body != nil {
+		t.Fatalf("POST dry-run body = %#v, want nil until current rules are known", calls[1].Body)
+	}
+}
+
 func TestMailRuleReorder_DoesNotSubmitOnMissingID(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	reg.Register(&httpmock.Stub{
@@ -179,12 +250,20 @@ func TestMailRuleReorder_DoesNotSubmitWhenNoRules(t *testing.T) {
 		"+rule-reorder",
 		"--rule-ids", "A",
 	}, f, stdout)
-	assertRuleReorderValidationError(t, err, "current mailbox has no inbox rules")
+	assertRuleReorderValidationError(t, err, "current mailbox has no inbox rules", "", errs.SubtypeFailedPrecondition)
 	reg.Verify(t)
 }
 
-func assertRuleReorderValidationError(t *testing.T, err error, wantSubstr string) {
+func assertRuleReorderValidationError(t *testing.T, err error, wantSubstr string, want ...interface{}) {
 	t.Helper()
+	param := "--rule-ids"
+	subtype := errs.SubtypeInvalidArgument
+	if len(want) > 0 {
+		param = want[0].(string)
+	}
+	if len(want) > 1 {
+		subtype = want[1].(errs.Subtype)
+	}
 	var validationErr *errs.ValidationError
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
@@ -192,4 +271,50 @@ func assertRuleReorderValidationError(t *testing.T, err error, wantSubstr string
 	if !strings.Contains(validationErr.Error(), wantSubstr) {
 		t.Fatalf("error = %v, want substring %q", validationErr, wantSubstr)
 	}
+	if validationErr.Param != param {
+		t.Fatalf("Param = %q, want %q", validationErr.Param, param)
+	}
+	if validationErr.Subtype != subtype {
+		t.Fatalf("Subtype = %q, want %q", validationErr.Subtype, subtype)
+	}
+	if p, ok := errs.ProblemOf(validationErr); !ok || p.Category != errs.CategoryValidation {
+		t.Fatalf("ProblemOf() = (%#v, %v), want validation problem", p, ok)
+	}
+}
+
+type ruleReorderDryRunPayload struct {
+	API []struct {
+		Method string      `json:"method"`
+		URL    string      `json:"url"`
+		Body   interface{} `json:"body,omitempty"`
+	} `json:"api"`
+}
+
+func dryRunAPIsForMailRuleReorderTest(t *testing.T, dry *common.DryRunAPI) []struct {
+	Method string      `json:"method"`
+	URL    string      `json:"url"`
+	Body   interface{} `json:"body,omitempty"`
+} {
+	t.Helper()
+	var payload ruleReorderDryRunPayload
+	b, err := json.Marshal(dry)
+	if err != nil {
+		t.Fatalf("marshal dry-run failed: %v", err)
+	}
+	if err := json.Unmarshal(b, &payload); err != nil {
+		t.Fatalf("unmarshal dry-run failed: %v\njson=%s", err, string(b))
+	}
+	return payload.API
+}
+
+func mailRuleReorderTestRuntime(t *testing.T, ruleIDs []string) *common.RuntimeContext {
+	t.Helper()
+	cmd := &cobra.Command{Use: "+rule-reorder"}
+	cmd.Flags().StringArray("rule-ids", nil, "")
+	for _, id := range ruleIDs {
+		if err := cmd.Flags().Set("rule-ids", id); err != nil {
+			t.Fatalf("set rule-ids: %v", err)
+		}
+	}
+	return common.TestNewRuntimeContext(cmd, nil)
 }

--- a/shortcuts/mail/mail_rule_reorder_test.go
+++ b/shortcuts/mail/mail_rule_reorder_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestCompleteRuleOrder(t *testing.T) {
+	current := []mailRuleOrderEntry{{ID: "A"}, {ID: "B"}, {ID: "C"}, {ID: "D"}}
+	tests := []struct {
+		name    string
+		input   []string
+		current []mailRuleOrderEntry
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "complete input keeps order",
+			input:   []string{"D", "C", "B", "A"},
+			current: current,
+			want:    []string{"D", "C", "B", "A"},
+		},
+		{
+			name:    "partial input prepends selected and appends rest",
+			input:   []string{"C", "A"},
+			current: current,
+			want:    []string{"C", "A", "B", "D"},
+		},
+		{
+			name:    "trim and deduplicate input",
+			input:   []string{" B ", "B", "D"},
+			current: current,
+			want:    []string{"B", "D", "A", "C"},
+		},
+		{
+			name:    "missing input id",
+			input:   []string{"X"},
+			current: current,
+			wantErr: "rule ID not found: X",
+		},
+		{
+			name:    "empty input",
+			input:   []string{" ", ""},
+			current: current,
+			wantErr: "provide at least one rule ID",
+		},
+		{
+			name:    "no rules",
+			input:   []string{"A"},
+			current: nil,
+			wantErr: "current mailbox has no inbox rules",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := completeRuleOrder(tt.input, tt.current)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("completeRuleOrder() error = %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("completeRuleOrder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMailRuleReorder_SubmitsCompletedOrder(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"rules": []map[string]interface{}{
+					{"rule_id": "A"},
+					{"rule_id": "B"},
+					{"rule_id": "C"},
+					{"rule_id": "D"},
+				},
+			},
+		},
+	})
+	var submitted []string
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/rules/reorder",
+		BodyFilter: func(body []byte) bool {
+			var payload map[string][]string
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return false
+			}
+			submitted = payload["rule_ids"]
+			return strings.Join(submitted, ",") == "C,A,B,D"
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ok": true},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "C",
+		"--rule-ids", "A",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("runMountedMailShortcut() error = %v", err)
+	}
+	reg.Verify(t)
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["submitted_count"] != float64(4) {
+		t.Fatalf("submitted_count = %v, want 4", data["submitted_count"])
+	}
+	if strings.Join(submitted, ",") != "C,A,B,D" {
+		t.Fatalf("submitted body = %v", submitted)
+	}
+}
+
+func TestMailRuleReorder_DoesNotSubmitOnMissingID(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"rules": []map[string]interface{}{{"rule_id": "A"}},
+			},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "missing",
+	}, f, stdout)
+	assertRuleReorderValidationError(t, err, "rule ID not found: missing")
+	reg.Verify(t)
+}
+
+func TestMailRuleReorder_DoesNotListOnEmptyInput(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", " ",
+	}, f, stdout)
+	assertRuleReorderValidationError(t, err, "provide at least one rule ID")
+	reg.Verify(t)
+}
+
+func TestMailRuleReorder_DoesNotSubmitWhenNoRules(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"rules": []map[string]interface{}{}},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder",
+		"--rule-ids", "A",
+	}, f, stdout)
+	assertRuleReorderValidationError(t, err, "current mailbox has no inbox rules")
+	reg.Verify(t)
+}
+
+func assertRuleReorderValidationError(t *testing.T, err error, wantSubstr string) {
+	t.Helper()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if !strings.Contains(validationErr.Error(), wantSubstr) {
+		t.Fatalf("error = %v, want substring %q", validationErr, wantSubstr)
+	}
+}

--- a/shortcuts/mail/mail_shortcut_test.go
+++ b/shortcuts/mail/mail_shortcut_test.go
@@ -44,7 +44,7 @@ func mailShortcutTestFactory(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *by
 		RefreshToken:     "test-refresh-token",
 		ExpiresAt:        time.Now().Add(1 * time.Hour).UnixMilli(),
 		RefreshExpiresAt: time.Now().Add(24 * time.Hour).UnixMilli(),
-		Scope:            "mail:user_mailbox.messages:write mail:user_mailbox.messages:read mail:user_mailbox.message:modify mail:user_mailbox.message:readonly mail:user_mailbox.message.address:read mail:user_mailbox.message.subject:read mail:user_mailbox.message.body:read mail:user_mailbox:readonly mail:user_mailbox.folder:read",
+		Scope:            "mail:user_mailbox.messages:write mail:user_mailbox.messages:read mail:user_mailbox.message:modify mail:user_mailbox.message:readonly mail:user_mailbox.message.address:read mail:user_mailbox.message.subject:read mail:user_mailbox.message.body:read mail:user_mailbox:readonly mail:user_mailbox.folder:read mail:user_mailbox.rule:read mail:user_mailbox.rule:write",
 		GrantedAt:        time.Now().Add(-1 * time.Hour).UnixMilli(),
 	}
 	if err := auth.SetStoredToken(token); err != nil {

--- a/shortcuts/mail/shortcuts.go
+++ b/shortcuts/mail/shortcuts.go
@@ -28,6 +28,7 @@ func Shortcuts() []common.Shortcut {
 		MailShareToChat,
 		MailTemplateCreate,
 		MailTemplateUpdate,
+		MailRuleReorder,
 		MailLintHTML,
 	}
 }

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -21,6 +21,24 @@ lark-cli mail user_mailbox.rules delete --as user \
 
 Quick codes above: condition `type=6` = subject, `operator=1` = contains, action `type=3` = mark as read.
 
+## 调整规则顺序
+
+优先使用快捷命令。只需要传希望置前的规则 ID，CLI 会先读取当前全部规则，按“输入 ID 去重置前 + 未输入 ID 保持当前相对顺序追加”补齐完整列表，再调用规则重排序接口。
+
+```bash
+lark-cli mail +rule-reorder --as user \
+  --rule-ids "<rule_id_to_move_first>" \
+  --rule-ids "<rule_id_to_move_second>"
+```
+
+动态 API 命令同样支持部分 `rule_ids` 输入；CLI 会在提交前自动补齐：
+
+```bash
+lark-cli mail user_mailbox.rules reorder --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"rule_ids":["<rule_id_to_move_first>","<rule_id_to_move_second>"]}'
+```
+
 ## 原生 API
 
 收信规则走 `user_mailbox.rules` 资源。参数不确定时先运行：


### PR DESCRIPTION
Adds support for reordering mail rules when only a subset of rule IDs is provided. The command now fetches the current rule order, normalizes and deduplicates the requested IDs, appends untouched rules in their existing order, and validates empty or unknown input before submitting the reorder request.

Tests cover complete, partial, duplicate, empty, missing, and empty-list cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mail rule reordering shortcut that accepts rule IDs and preserves unspecified rules in their existing order.
  * Added validation for duplicate, missing, blank, invalid, or empty rule selections.
  * Dry-run output now uses structured JSON, supports jq filtering, and includes API and file-upload details.
* **Bug Fixes**
  * Improved handling of malformed responses and API or JSON errors.
  * Added clearer recovery hints for missing required parameters.
* **Documentation**
  * Documented mail rule reordering commands and ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->