### PR TITLE
docs(calendar): clarify +create-first strategy for advanced fields

### DIFF
--- a/skills/lark-calendar/references/lark-calendar-create.md
+++ b/skills/lark-calendar/references/lark-calendar-create.md
@@ -50,7 +50,8 @@ lark-cli calendar +create --summary "..." --start "..." --end "..." \
 
 ## 高级用法（完整 API 命令）
 
-如需配置 `location`（地理位置，不含会议室位置）、`visibility`（日程公开范围）、自定义 `reminders`（提醒设置）、自定义 `attendee_ability`（参与人权限）、自定义 `free_busy_status`（日程忙闲状态）、参与人可选参加状态或全天日程等高级参数，请使用完整的 API 命令：
+> 优先策略：创建日程优先走 `+create`。遇到 `+create` 不支持的高级参数（如 `location`（地理位置，不含会议室位置）、`visibility`（日程公开范围）、自定义 `reminders`（提醒设置）、自定义 `attendee_ability`（参与人权限）、自定义 `free_busy_status`（日程忙闲状态）、参与人可选参加状态或全天日程等），**优先先用 `+create` 创建成功，再用完整 API update 对这些字段做编辑补齐**，而非整体改用完整 API 从零创建。
+
 **注意**：
 - 全天日程的开始日期和结束日期必须分别是日程开始的第一天和结束的最后一天。如果只有一天的话，开始日期和结束日期是相同。
 
@@ -61,9 +62,7 @@ lark-cli calendar event.attendees create \
   --params '{"calendar_id":"<CALENDAR_ID>","event_id":"<EVENT_ID>"}' \
   --data '{"attendees": [{"type": "resource", "room_id": "omm_xxx", "approval_reason": "申请原因"}]}'
 
-完整 API 命令的关键差异：
-- `+create` 会自动补 `attendee_ability: can_modify_event`、`free_busy_status: busy`、`vchat: {"vc_type": "vc"}`（含飞书视频会议）、`reminders: [{"minutes": 5}]`；完整 API（`calendar events create`）**不会**自动补这些，如需同等体验须在 `--data` 里显式写入对应字段。
-- `+create` 在传入 `--attendee-ids`（即需要邀请其他参会人）时，会自动把当前身份一并加进参会人，但 `calendar events create` / `calendar event.attendees create` 等完整 API **不会**自动加。需自行把调用身份的 open_id 以 `type:user` 写入 attendees，与邀请的其他参会人合并去重后添加。open_id 用 `lark-cli auth status --json --verify` 获取：bot 取 `identities.bot.openId`（`--verify` 才会填充），user 取 `identities.user.openId`。
+完整 API 命令的关键差异和处理策略：
 - 时间参数是 **Unix 秒字符串**（非 ISO 8601）。换算时**禁止依赖容器默认时区**（常为 UTC，会导致 8 小时偏移），必须显式指定目标时区。
 - 全天日程的开始日期和结束日期必须分别是日程开始的第一天和结束的最后一天；单日全天日程两者相同。
 - 手动拆成“创建日程 + 添加参会人”两步时，若第二步失败，建议删除刚创建的空日程，避免遗留无参会人的日程。


### PR DESCRIPTION
## Summary

- Reframe the "advanced usage" section of the `calendar +create` reference around a **`+create`-first strategy**: prefer `+create`, then patch unsupported advanced fields via the raw API `update` — rather than hand-building the whole event from scratch with the raw create API.
- Fold the advanced-field list (`location`, `visibility`, custom `reminders` / `attendee_ability` / `free_busy_status`, optional attendance, all-day) into that single guidance line, removing the earlier duplicate lead sentence.
- Drop the two "raw create differences" notes about auto-filled defaults (`attendee_ability` / `free_busy_status` / `vchat.vc_type` / `reminders`) and self-attendee injection, since the `+create`-first strategy makes hand-building create payloads a non-goal.

## Rationale

Those advanced fields are also **not** settable via the `+update` shortcut, so the guidance now points to the raw API `update` (not `+update`) for backfilling them. This keeps the reference consistent with the shortcut's actual flag surface and avoids steering agents into rebuilding events from scratch.

## Test plan

- [x] Docs-only change; no code affected.
- [x] Markdown renders correctly (blockquote guidance separated from the following section).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated advanced calendar-creation guidance to recommend creating events with `+create` first, then using the full API for unsupported advanced options.
  * Clarified differences between the two approaches, including default field behavior, how the caller is handled as an attendee, and how to obtain the required `open_id`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->