### PR TITLE
fix(wiki): reuse 131006 terminal guidance on copy and move

### DIFF
--- a/shortcuts/wiki/wiki_helpers.go
+++ b/shortcuts/wiki/wiki_helpers.go
@@ -42,10 +42,83 @@ func appendWikiProblemHint(err error, hint string) error {
 	return err
 }
 
-// wikiPermissionDeniedHint provides stable recovery for wiki's 131006. The
-// service uses one public code for both node and space ACL failures, while the
-// upstream message is informational and normalized by the shared classifier.
-// Keep the command hint accurate without branching on that unstable text.
+// wikiPermissionDeniedHint provides stable recovery for read-path 131006
+// (node-get / node-list). The service uses one public code for both node and
+// space ACL failures, while the upstream message is informational and
+// normalized by the shared classifier. Keep the command hint accurate without
+// branching on that unstable text.
 func wikiPermissionDeniedHint() string {
 	return "The current user or app/bot identity lacks access to the target wiki space or node. This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error; ask the resource owner or wiki administrator to grant read access, or use an accessible resource."
+}
+
+// wikiCopyPermissionDeniedHint recovers copy-path 131006. Official copy
+// requires container edit on the source or destination parent; a space-root
+// target can also require wiki space membership or administrator permission.
+func wikiCopyPermissionDeniedHint() string {
+	return "The current user or app/bot identity lacks Wiki container permission for this copy. This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error; ask the resource owner or wiki administrator to grant container edit permission on the relevant source or destination parent node. Copying to a space root can also require wiki space membership or administrator permission. Use an accessible resource if that access cannot be granted."
+}
+
+// wikiNodeMovePermissionDeniedHint recovers node-move 131006. Official move
+// requires edit permission on the node plus container edit on the source and
+// destination parents; a space-root target can also require wiki space
+// membership or administrator permission.
+func wikiNodeMovePermissionDeniedHint() string {
+	return "The current user or app/bot identity lacks permission to move this Wiki node. Official node move requires edit permission on the node plus container edit permission on the source and destination parent nodes. Moving to a space root can also require wiki space membership or administrator permission. This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error. Use an accessible resource if that access cannot be granted."
+}
+
+// wikiDocsToWikiPermissionDeniedHint recovers docs-to-wiki write 131006.
+// Official guidance can mean the source Drive document lacks manage
+// permission or its parent folder lacks edit permission; the destination
+// Wiki parent still needs container edit, and a space-root target can
+// require wiki space membership or administrator permission.
+func wikiDocsToWikiPermissionDeniedHint() string {
+	return "The current user or app/bot identity lacks permission to move this Drive document into Wiki. Official docs-to-wiki 131006 can mean the source document lacks manage permission or its parent folder lacks edit permission; the destination Wiki parent needs container edit permission, and a space-root target can require wiki space membership or administrator permission. This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error."
+}
+
+// wikiTaskPermissionDeniedHint recovers task-get 131006. Official lookup
+// can mean only the task creator can query status, the destination Wiki
+// space or node is inaccessible, or the source Drive document lacks manage
+// permission and its parent folder lacks edit permission.
+func wikiTaskPermissionDeniedHint() string {
+	return "The current user or app/bot identity cannot read this Wiki move task. Official task lookup 131006 can mean only the task creator can query status, the destination Wiki space or node is inaccessible, or the source Drive document lacks manage permission and its parent folder lacks edit permission. This is resource access, not app scope authorization. Do not retry the same status lookup, reauthorize, or switch identity as trial and error."
+}
+
+func annotateWikiPermissionDenied(err error) error {
+	return annotateWikiPermissionDeniedWith(err, wikiPermissionDeniedHint())
+}
+
+func annotateWikiCopyPermissionDenied(err error) error {
+	return annotateWikiPermissionDeniedWith(err, wikiCopyPermissionDeniedHint())
+}
+
+func annotateWikiNodeMovePermissionDenied(err error) error {
+	return annotateWikiPermissionDeniedWith(err, wikiNodeMovePermissionDeniedHint())
+}
+
+func annotateWikiDocsToWikiPermissionDenied(err error) error {
+	return annotateWikiPermissionDeniedWith(err, wikiDocsToWikiPermissionDeniedHint())
+}
+
+func annotateWikiTaskPermissionDenied(err error) error {
+	return annotateWikiPermissionDeniedWith(err, wikiTaskPermissionDeniedHint())
+}
+
+func isWikiPermissionDenied(err error) bool {
+	p, ok := errs.ProblemOf(err)
+	return ok && p != nil && p.Code == 131006
+}
+
+// annotateWikiPermissionDeniedWith marks wiki 131006 as a terminal
+// resource-access failure and attaches the given recovery hint. Other errors
+// pass through.
+func annotateWikiPermissionDeniedWith(err error, hint string) error {
+	p, ok := errs.ProblemOf(err)
+	if !ok || p == nil || p.Code != 131006 {
+		return err
+	}
+	p.Retryable = false
+	if strings.TrimSpace(hint) == "" || strings.Contains(p.Hint, hint) {
+		return err
+	}
+	return appendWikiProblemHint(err, hint)
 }

--- a/shortcuts/wiki/wiki_helpers_test.go
+++ b/shortcuts/wiki/wiki_helpers_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func TestAnnotateWikiPermissionDeniedMarks131006Terminal(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("opaque upstream cause")
+	err := errs.NewPermissionError(errs.SubtypePermissionDenied, "opaque upstream message").
+		WithCode(131006).
+		WithCause(cause)
+
+	got := annotateWikiPermissionDenied(err)
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false")
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied || p.Code != 131006 {
+		t.Fatalf("problem = %#v, want authorization/permission_denied/131006", p)
+	}
+	if p.Retryable {
+		t.Fatalf("problem retryable = true, want false: %#v", p)
+	}
+	if !errors.Is(got, cause) {
+		t.Fatalf("errors.Is(got, cause) = false, want preserved cause")
+	}
+	if p.Hint != wikiPermissionDeniedHint() {
+		t.Fatalf("hint = %q, want %q", p.Hint, wikiPermissionDeniedHint())
+	}
+}
+
+func TestAnnotateWikiCopyPermissionDeniedUsesContainerEditGuidance(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("opaque upstream cause")
+	err := errs.NewPermissionError(errs.SubtypePermissionDenied, "no destination parent node permission").
+		WithCode(131006).
+		WithCause(cause)
+
+	got := annotateWikiCopyPermissionDenied(err)
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false")
+	}
+	if p.Code != 131006 || p.Retryable {
+		t.Fatalf("problem = %#v, want non-retryable 131006", p)
+	}
+	if !errors.Is(got, cause) {
+		t.Fatalf("errors.Is(got, cause) = false, want preserved cause")
+	}
+	if p.Hint != wikiCopyPermissionDeniedHint() {
+		t.Fatalf("hint = %q, want %q", p.Hint, wikiCopyPermissionDeniedHint())
+	}
+	if strings.Contains(p.Hint, "grant read access") || strings.Contains(p.Hint, "source document lacks manage permission") {
+		t.Fatalf("copy hint = %q, must stay on Wiki container recovery", p.Hint)
+	}
+}
+
+func TestAnnotateWikiNodeMovePermissionDeniedIncludesNodeEdit(t *testing.T) {
+	t.Parallel()
+
+	got := annotateWikiNodeMovePermissionDenied(
+		errs.NewPermissionError(errs.SubtypePermissionDenied, "permission denied").WithCode(131006),
+	)
+	p, ok := errs.ProblemOf(got)
+	if !ok || p.Hint != wikiNodeMovePermissionDeniedHint() {
+		t.Fatalf("hint = %q, want node-move guidance", p.Hint)
+	}
+	if !strings.Contains(p.Hint, "edit permission on the node") || !strings.Contains(p.Hint, "source and destination parent") {
+		t.Fatalf("hint = %q, want moved-node and parent-container requirements", p.Hint)
+	}
+}
+
+func TestAnnotateWikiDocsToWikiPermissionDeniedIncludesDriveSource(t *testing.T) {
+	t.Parallel()
+
+	got := annotateWikiDocsToWikiPermissionDenied(
+		errs.NewPermissionError(errs.SubtypePermissionDenied, "permission denied").WithCode(131006),
+	)
+	p, ok := errs.ProblemOf(got)
+	if !ok || p.Hint != wikiDocsToWikiPermissionDeniedHint() {
+		t.Fatalf("hint = %q, want docs-to-wiki guidance", p.Hint)
+	}
+	if !strings.Contains(p.Hint, "source document lacks manage permission") || !strings.Contains(p.Hint, "parent folder lacks edit permission") {
+		t.Fatalf("hint = %q, want Drive source requirements", p.Hint)
+	}
+	if strings.Contains(p.Hint, "edit permission on the node plus") {
+		t.Fatalf("hint = %q, must not use Wiki node-move recovery", p.Hint)
+	}
+}
+
+func TestAnnotateWikiTaskPermissionDeniedUsesCreatorGuidance(t *testing.T) {
+	t.Parallel()
+
+	got := annotateWikiTaskPermissionDenied(
+		errs.NewPermissionError(errs.SubtypePermissionDenied, "permission denied").WithCode(131006),
+	)
+	p, ok := errs.ProblemOf(got)
+	if !ok || p.Hint != wikiTaskPermissionDeniedHint() || p.Retryable {
+		t.Fatalf("problem = %#v, want non-retryable task guidance", p)
+	}
+	if !strings.Contains(p.Hint, "only the task creator can query status") || strings.Contains(p.Hint, "retry status lookup") {
+		t.Fatalf("hint = %q, want terminal task lookup recovery", p.Hint)
+	}
+}
+
+func TestAnnotateWikiPermissionDeniedWithDoesNotDuplicateHint(t *testing.T) {
+	t.Parallel()
+
+	err := annotateWikiTaskPermissionDenied(
+		errs.NewPermissionError(errs.SubtypePermissionDenied, "permission denied").WithCode(131006),
+	)
+	got := annotateWikiTaskPermissionDenied(err)
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false")
+	}
+	if p.Hint != wikiTaskPermissionDeniedHint() {
+		t.Fatalf("hint = %q, want a single task-guidance copy", p.Hint)
+	}
+}
+
+func TestAnnotateWikiPermissionDeniedLeavesOtherCodesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	err := errs.NewAPIError(errs.SubtypeNotFound, "node not found").WithCode(131005)
+	got := annotateWikiPermissionDenied(err)
+	if got != err {
+		t.Fatalf("annotateWikiPermissionDenied() = %v, want original error", got)
+	}
+	p, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("ProblemOf() ok=false")
+	}
+	if p.Code != 131005 || p.Hint != "" {
+		t.Fatalf("problem = %#v, want unchanged 131005 without permission hint", p)
+	}
+}

--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -1286,6 +1286,49 @@ func TestWikiSpaceListPrettyHintsWhenEmptyButHasMore(t *testing.T) {
 	}
 }
 
+func TestWikiNodeCopyMountedExplainsResourcePermissionDenied(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/wiki/v2/spaces/space_src/nodes/wik_src/copy",
+		Body: map[string]interface{}{
+			"code":   131006,
+			"msg":    "permission denied: node permission denied, user needs read permission.",
+			"log_id": "log-node-copy-permission",
+		},
+	})
+
+	err := mountAndRunWiki(t, WikiNodeCopy, []string{
+		"+node-copy",
+		"--space-id", "space_src",
+		"--node-token", "wik_src",
+		"--target-space-id", "space_dst",
+		"--yes",
+		"--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied || p.Code != 131006 {
+		t.Fatalf("problem = %#v, want authorization/permission_denied/131006", p)
+	}
+	if p.Retryable {
+		t.Fatalf("problem retryable = true, want false: %#v", p)
+	}
+	if !strings.Contains(p.Hint, "container edit permission") || !strings.Contains(p.Hint, "source or destination parent") {
+		t.Fatalf("hint = %q, want copy container-edit guidance", p.Hint)
+	}
+	if strings.Contains(p.Hint, "grant read access") || strings.Contains(p.Hint, "edit permission on the node") {
+		t.Fatalf("hint = %q, must not use read or node-move recovery for copy", p.Hint)
+	}
+}
+
 func TestWikiNodeCopyHasFormatPrettyRendersNode(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 

--- a/shortcuts/wiki/wiki_move.go
+++ b/shortcuts/wiki/wiki_move.go
@@ -236,7 +236,7 @@ func (api wikiMoveAPI) GetNode(ctx context.Context, token string) (*wikiNodeReco
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, annotateWikiPermissionDenied(err)
 	}
 	return parseWikiNodeRecord(common.GetMap(data, "node"))
 }
@@ -253,7 +253,7 @@ func (api wikiMoveAPI) MoveNode(ctx context.Context, sourceSpaceID string, spec 
 		spec.NodeMoveBody(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annotateWikiNodeMovePermissionDenied(err)
 	}
 	return parseWikiNodeRecord(common.GetMap(data, "node"))
 }
@@ -269,7 +269,7 @@ func (api wikiMoveAPI) MoveDocsToWiki(ctx context.Context, targetSpaceID string,
 		spec.DocsToWikiBody(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annotateWikiDocsToWikiPermissionDenied(err)
 	}
 
 	return &wikiMoveDocsResponse{
@@ -287,7 +287,7 @@ func (api wikiMoveAPI) GetMoveTask(ctx context.Context, taskID string) (wikiMove
 		nil,
 	)
 	if err != nil {
-		return wikiMoveTaskStatus{}, err
+		return wikiMoveTaskStatus{}, annotateWikiTaskPermissionDenied(err)
 	}
 	return parseWikiMoveTaskStatus(taskID, common.GetMap(data, "task"))
 }
@@ -579,9 +579,9 @@ func pollWikiMoveTask(ctx context.Context, client wikiMoveClient, runtime *commo
 	var lastErr error
 	hadSuccessfulPoll := false
 
-	// The move request itself already succeeded. Treat poll failures as transient
-	// until every attempt fails, then return a resume hint instead of discarding
-	// the task identifier.
+	// The move request itself already succeeded. Stop on known terminal permission
+	// failures; treat other poll failures as transient until every attempt fails,
+	// then return a resume hint instead of discarding the task identifier.
 	for attempt := 1; attempt <= wikiMovePollAttempts; attempt++ {
 		if attempt > 1 {
 			select {
@@ -593,6 +593,9 @@ func pollWikiMoveTask(ctx context.Context, client wikiMoveClient, runtime *commo
 
 		status, err := client.GetMoveTask(ctx, taskID)
 		if err != nil {
+			if isWikiPermissionDenied(err) {
+				return lastStatus, false, annotateWikiTaskPermissionDenied(err)
+			}
 			lastErr = err
 			fmt.Fprintf(runtime.IO().ErrOut, "Wiki move status attempt %d/%d failed: %v\n", attempt, wikiMovePollAttempts, err)
 			continue

--- a/shortcuts/wiki/wiki_move_test.go
+++ b/shortcuts/wiki/wiki_move_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"reflect"
 	"strings"
 	"sync"
@@ -783,6 +784,125 @@ func TestWikiMoveExecuteNodeShortcut(t *testing.T) {
 	}
 }
 
+func TestWikiMoveMountedExplainsResourcePermissionDenied(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/wiki/v2/spaces/space_src/nodes/wik_node/move",
+		Body: map[string]interface{}{
+			"code":   131006,
+			"msg":    "permission denied: no destination parent node permission",
+			"log_id": "log-node-move-permission",
+		},
+	})
+
+	err := mountAndRunWiki(t, WikiMove, []string{
+		"+move",
+		"--node-token", "wik_node",
+		"--source-space-id", "space_src",
+		"--target-space-id", "space_dst",
+		"--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryAuthorization || p.Subtype != errs.SubtypePermissionDenied || p.Code != 131006 {
+		t.Fatalf("problem = %#v, want authorization/permission_denied/131006", p)
+	}
+	if p.Retryable {
+		t.Fatalf("problem retryable = true, want false: %#v", p)
+	}
+	if !strings.Contains(p.Hint, "edit permission on the node") || !strings.Contains(p.Hint, "source and destination parent") {
+		t.Fatalf("hint = %q, want node-move permission guidance", p.Hint)
+	}
+	if strings.Contains(p.Hint, "grant read access") || strings.Contains(p.Hint, "source document lacks manage permission") {
+		t.Fatalf("hint = %q, must not use read or docs-to-wiki recovery for node move", p.Hint)
+	}
+}
+
+func TestWikiMoveMountedDocsToWikiExplainsResourcePermissionDenied(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/wiki/v2/spaces/space_dst/nodes/move_docs_to_wiki",
+		Body: map[string]interface{}{
+			"code":   131006,
+			"msg":    "permission denied: no move permission for document",
+			"log_id": "log-docs-to-wiki-permission",
+		},
+	})
+
+	err := mountAndRunWiki(t, WikiMove, []string{
+		"+move",
+		"--obj-type", "docx",
+		"--obj-token", "doc_token",
+		"--target-space-id", "space_dst",
+		"--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Code != 131006 || p.Retryable {
+		t.Fatalf("problem = %#v, want non-retryable 131006", p)
+	}
+	if !strings.Contains(p.Hint, "source document lacks manage permission") || !strings.Contains(p.Hint, "parent folder lacks edit permission") {
+		t.Fatalf("hint = %q, want docs-to-wiki Drive source guidance", p.Hint)
+	}
+	if strings.Contains(p.Hint, "grant read access") || strings.Contains(p.Hint, "edit permission on the node plus") {
+		t.Fatalf("hint = %q, must not use read or node-move recovery for docs-to-wiki", p.Hint)
+	}
+}
+
+func TestWikiMoveResolveGetNodeUsesReadPermissionHint(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code":   131006,
+			"msg":    "permission denied: node permission denied, user needs read permission.",
+			"log_id": "log-move-resolve-permission",
+		},
+	})
+
+	err := mountAndRunWiki(t, WikiMove, []string{
+		"+move",
+		"--node-token", "wik_node",
+		"--target-space-id", "space_dst",
+		"--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if p.Code != 131006 || p.Retryable {
+		t.Fatalf("problem = %#v, want non-retryable 131006", p)
+	}
+	if !strings.Contains(p.Hint, "grant read access") {
+		t.Fatalf("hint = %q, want read-access guidance for get_node resolve", p.Hint)
+	}
+	if strings.Contains(p.Hint, "container edit permission") {
+		t.Fatalf("hint = %q, must not use write-container guidance for get_node resolve", p.Hint)
+	}
+}
+
 func TestWikiMoveExecuteDocsToWikiShortcutAsyncSuccess(t *testing.T) {
 	withSingleWikiMovePoll(t)
 
@@ -844,6 +964,110 @@ func TestWikiMoveExecuteDocsToWikiShortcutAsyncSuccess(t *testing.T) {
 	body := decodeWikiCapturedJSONBody(t, docsStub)
 	if body["obj_type"] != "sheet" || body["obj_token"] != "sheet_token" || body["apply"] != true {
 		t.Fatalf("docs-to-wiki body = %#v", body)
+	}
+}
+
+func TestWikiMoveMountedStopsPollingOnTaskPermissionDenied(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	wikiMovePollMu.Lock()
+	prevAttempts, prevInterval := wikiMovePollAttempts, wikiMovePollInterval
+	wikiMovePollAttempts, wikiMovePollInterval = 30, 0
+	t.Cleanup(func() {
+		wikiMovePollAttempts, wikiMovePollInterval = prevAttempts, prevInterval
+		wikiMovePollMu.Unlock()
+	})
+
+	factory, stdout, stderr, reg := cmdutil.TestFactory(t, wikiTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/wiki/v2/spaces/space_dst/nodes/move_docs_to_wiki",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"task_id": "task_123",
+			},
+		},
+	})
+	taskGets := 0
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/wiki/v2/tasks/task_123",
+		Reusable: true,
+		OnMatch: func(*http.Request) {
+			taskGets++
+		},
+		Body: map[string]interface{}{
+			"code":   131006,
+			"msg":    "permission denied: only task creator can query status",
+			"log_id": "log-wiki-task-permission",
+		},
+	})
+
+	err := mountAndRunWiki(t, WikiMove, []string{
+		"+move",
+		"--obj-type", "sheet",
+		"--obj-token", "sheet_token",
+		"--target-space-id", "space_dst",
+		"--apply",
+		"--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	if taskGets != 1 {
+		t.Fatalf("GetMoveTask calls = %d, want 1", taskGets)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Code != 131006 || p.Retryable {
+		t.Fatalf("problem = %#v, want non-retryable 131006", p)
+	}
+	if !strings.Contains(p.Hint, "only the task creator can query status") || strings.Contains(p.Hint, "retry status lookup") {
+		t.Fatalf("hint = %q, want terminal task permission guidance without retry", p.Hint)
+	}
+	if strings.Contains(stderr.String(), "Wiki move status attempt") {
+		t.Fatalf("stderr = %q, want no transient poll logs", stderr.String())
+	}
+}
+
+func TestPollWikiMoveTaskStopsOnPermissionDenied(t *testing.T) {
+	wikiMovePollMu.Lock()
+	prevAttempts, prevInterval := wikiMovePollAttempts, wikiMovePollInterval
+	wikiMovePollAttempts, wikiMovePollInterval = 30, 0
+	t.Cleanup(func() {
+		wikiMovePollAttempts, wikiMovePollInterval = prevAttempts, prevInterval
+		wikiMovePollMu.Unlock()
+	})
+
+	runtime, stderr := newWikiMoveRuntimeWithScopes(t, core.AsUser, "")
+	client := &fakeWikiMoveClient{
+		taskErrs: []error{
+			errs.NewPermissionError(errs.SubtypePermissionDenied, "only task creator can query status").WithCode(131006),
+		},
+	}
+
+	status, ready, err := pollWikiMoveTask(context.Background(), client, runtime, "task_123")
+	if err == nil {
+		t.Fatal("expected pollWikiMoveTask() error, got nil")
+	}
+	if ready {
+		t.Fatal("expected ready=false on permission denied")
+	}
+	if status.TaskID != "task_123" {
+		t.Fatalf("status.TaskID = %q, want %q", status.TaskID, "task_123")
+	}
+	if got := len(client.moveTaskCallArgs); got != 1 {
+		t.Fatalf("GetMoveTask calls = %d, want 1", got)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Code != 131006 || p.Retryable {
+		t.Fatalf("problem = %#v, want non-retryable 131006", p)
+	}
+	if !strings.Contains(p.Hint, "only the task creator can query status") || strings.Contains(p.Hint, "retry status lookup") {
+		t.Fatalf("hint = %q, want terminal task permission guidance without retry", p.Hint)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want no transient poll logs", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_copy.go
+++ b/shortcuts/wiki/wiki_node_copy.go
@@ -96,7 +96,7 @@ var WikiNodeCopy = common.Shortcut{
 			return runtime.CallAPITyped("POST", apiPath, nil, body)
 		})
 		if err != nil {
-			return err
+			return annotateWikiCopyPermissionDenied(err)
 		}
 
 		node, err := parseWikiNodeRecord(common.GetMap(data, "node"))

--- a/skills/lark-wiki/references/lark-wiki-move.md
+++ b/skills/lark-wiki/references/lark-wiki-move.md
@@ -110,6 +110,7 @@ lark-cli wiki +move \
 - **继续查询**：看到 `next_command` 后，改用 `lark-cli drive +task_result --scenario wiki_move --task-id <TASK_ID>` 继续查
 - **任务失败直接报错**：如果轮询期间任务进入失败态，shortcut 会直接返回错误，不会再输出 `ready=false` 结果
 - **轮询请求全部失败时也直接报错**：如果任务已创建，但后续每一次状态查询都失败，shortcut 会返回带 hint 的错误，并给出继续查询命令
+- **`131006` 是资源权限失败，不是 scope 缺失**：停止重复调用，并按命令返回的 hint 补齐对应资源权限；不要通过重新授权或切换身份盲目重试
 
 ## 返回结果
 

--- a/skills/lark-wiki/references/lark-wiki-node-copy.md
+++ b/skills/lark-wiki/references/lark-wiki-node-copy.md
@@ -51,6 +51,7 @@ lark-cli wiki +node-copy \
 - Copying is non-recursive: only the requested node and its content are copied.
 - Descendant nodes must be copied separately.
 - When the Wiki service returns `131009` lock contention, the CLI retries twice with bounded exponential backoff. If contention remains, wait before retrying again and avoid concurrent writes under the same target parent.
+- For `131006 permission_denied`, the user or app/bot identity lacks access for this copy. This is resource access, not app scope authorization. Do not retry the same request, reauthorize, or switch identity as trial and error; follow the command hint, or use an accessible resource.
 - To move an existing Wiki node without keeping the source, use [`wiki +move`](lark-wiki-move.md) instead of copy-then-delete.
 
 ## Required Scope


### PR DESCRIPTION
## Summary

`wiki +node-get` already treats Wiki `131006` as a terminal resource-access error. `wiki +node-copy` and `wiki +move` still returned the generic permission hint, so agents could keep retrying the same copy/move after a node or parent ACL failure.

## Changes

- Extract shared `annotateWikiPermissionDenied` for Wiki `131006`.
- Apply it to `wiki +node-copy` and `wiki +move` (including move-time `get_node` resolve).
- Route `+node-get` / `+node-list` through the same helper so the hint stays in one place.
- Add revert-failing tests and document the recovery rule in the copy/move skill references.

## Test Plan

- [x] `go test ./shortcuts/wiki -count=1`
- [ ] Manual local verification confirms the `lark-cli wiki +node-copy` / `lark-cli wiki +move` 131006 flow works as expected

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wiki copy and move error handling with operation-specific permission guidance.
  * Permission-denied errors now identify the required access and are not retried unnecessarily.
  * Asynchronous move tasks stop polling immediately when resource permissions are insufficient.
  * Preserved existing handling for unrelated errors and prevented duplicate guidance.

* **Documentation**
  * Added guidance for resolving resource permission errors during Wiki moves and copies.
  * Clarified access requirements for node moves, Docs-to-Wiki operations, and task-status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->