### PR TITLE
feat: add citation framework for read-command envelopes

### DIFF
--- a/internal/citation/citation.go
+++ b/internal/citation/citation.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package citation defines the wire type, process-level gate, and time
+// normalization for command citations. It depends on nothing above the
+// envvars constant table so every layer may import it.
+package citation
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+// Citation is one wire entry of the envelope-level citations array.
+// SourceType, URL and Title carry no omitempty: they are required on the wire
+// (entries without a URL are dropped by Normalize before serialization, and
+// an int omitempty would silently drop a required zero).
+type Citation struct {
+	SourceType  SourceType `json:"source_type"`
+	URL         string     `json:"url"`
+	Title       string     `json:"title"`
+	Snippet     string     `json:"snippet,omitempty"`
+	ResourceID  string     `json:"resource_id,omitempty"`
+	PublishTime string     `json:"publish_time,omitempty"`
+}
+
+// Enabled reports whether citation output is on. Only the exact value "1"
+// enables it; no second boolean grammar is introduced.
+func Enabled() bool {
+	return os.Getenv(envvars.CliCitation) == "1"
+}
+
+// Normalize drops entries without a URL and returns nil for an empty result
+// so the envelope omits the citations key entirely.
+func Normalize(items []Citation) []Citation {
+	var kept []Citation
+	for _, item := range items {
+		if item.URL == "" {
+			continue
+		}
+		kept = append(kept, item)
+	}
+	return kept
+}
+
+// Time accepts unix seconds, unix milliseconds (int, int64, float64, or a
+// digit string), or a preformatted timestamp and returns RFC3339 with an
+// explicit offset. It returns "" when the input cannot be parsed. Digit
+// inputs are classified by decimal length: up to 10 digits are seconds,
+// exactly 13 digits are milliseconds, anything else is unparseable.
+func Time(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case int:
+		return timeFromUnixDigits(strconv.FormatInt(int64(t), 10))
+	case int64:
+		return timeFromUnixDigits(strconv.FormatInt(t, 10))
+	case float64:
+		return timeFromUnixDigits(strconv.FormatInt(int64(t), 10))
+	case string:
+		s := strings.TrimSpace(t)
+		if s == "" {
+			return ""
+		}
+		if isDigits(s) {
+			return timeFromUnixDigits(s)
+		}
+		if parsed, err := time.Parse(time.RFC3339, s); err == nil {
+			return parsed.Format(time.RFC3339)
+		}
+		for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02 15:04"} {
+			if parsed, err := time.ParseInLocation(layout, s, time.Local); err == nil {
+				return parsed.Format(time.RFC3339)
+			}
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+func timeFromUnixDigits(s string) string {
+	if !isDigits(s) { // 负数等非纯数字形态一律不可解析
+		return ""
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n <= 0 {
+		// zero and negative epoch values are not valid publish times
+		return ""
+	}
+	switch {
+	case len(s) <= 10:
+		return time.Unix(n, 0).Format(time.RFC3339)
+	case len(s) == 13:
+		return time.UnixMilli(n).Format(time.RFC3339)
+	default:
+		return ""
+	}
+}

--- a/internal/citation/citation_test.go
+++ b/internal/citation/citation_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package citation
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+func TestEnabledExactMatch(t *testing.T) {
+	cases := map[string]bool{"1": true, "true": false, "on": false, "": false, " 1": false, "01": false}
+	for value, want := range cases {
+		t.Setenv(envvars.CliCitation, value)
+		if got := Enabled(); got != want {
+			t.Errorf("Enabled() with %q = %v, want %v", value, got, want)
+		}
+	}
+}
+
+func TestEnabledUnset(t *testing.T) {
+	// t.Setenv 后手动删除，模拟未设置
+	t.Setenv(envvars.CliCitation, "1")
+	if err := unsetenvForTest(t); err != nil {
+		t.Fatal(err)
+	}
+	if Enabled() {
+		t.Error("Enabled() with unset env = true, want false")
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	in := []Citation{
+		{SourceType: SourceWiki, URL: "https://a.example/1", Title: "keep-1"},
+		{SourceType: SourceWiki, URL: "", Title: "drop-no-url"},
+		{SourceType: SourceWiki, URL: "https://a.example/2", Title: "keep-2"},
+	}
+	got := Normalize(in)
+	if len(got) != 2 || got[0].Title != "keep-1" || got[1].Title != "keep-2" {
+		t.Fatalf("Normalize() = %#v, want 2 kept entries in order", got)
+	}
+	if Normalize(nil) != nil {
+		t.Error("Normalize(nil) != nil")
+	}
+	if Normalize([]Citation{{URL: ""}}) != nil {
+		t.Error("Normalize(all-dropped) != nil")
+	}
+}
+
+func TestTime(t *testing.T) {
+	local := time.Unix(1721996760, 0)
+	wantSec := local.Format(time.RFC3339)
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"unix seconds int64", int64(1721996760), wantSec},
+		{"unix seconds int", int(1721996760), wantSec},
+		{"unix seconds float64", float64(1721996760), wantSec},
+		{"unix seconds string", "1721996760", wantSec},
+		{"unix millis string", "1721996760000", wantSec},
+		{"unix millis int64", int64(1721996760000), wantSec},
+		{"rfc3339 passthrough", "2026-07-27T21:26:00+08:00", "2026-07-27T21:26:00+08:00"},
+		{"11-digit garbage", "17219967600", ""},
+		{"non-time string", "not-a-time", ""},
+		{"nil", nil, ""},
+		{"negative", int64(-5), ""},
+		{"zero int", int(0), ""},
+		{"zero string", "0", ""},
+		{"empty string", "", ""},
+		{"whitespace", "   ", ""},
+	}
+	for _, tc := range cases {
+		if got := Time(tc.in); got != tc.want {
+			t.Errorf("Time(%s: %v) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+	// 本地时间串（无时区偏移）按本地时区补偏移
+	localStr := "2026-07-27 21:26:00"
+	parsed, _ := time.ParseInLocation("2006-01-02 15:04:05", localStr, time.Local)
+	if got := Time(localStr); got != parsed.Format(time.RFC3339) {
+		t.Errorf("Time(local string) = %q, want %q", got, parsed.Format(time.RFC3339))
+	}
+	localMin := "2026-07-27 21:26"
+	parsedMin, _ := time.ParseInLocation("2006-01-02 15:04", localMin, time.Local)
+	if got := Time(localMin); got != parsedMin.Format(time.RFC3339) {
+		t.Errorf("Time(local minute string) = %q, want %q", got, parsedMin.Format(time.RFC3339))
+	}
+}
+
+func TestIsAllocated(t *testing.T) {
+	if IsAllocated(SourceUnset) {
+		t.Error("IsAllocated(SourceUnset) = true")
+	}
+	for _, st := range []SourceType{SourceWiki, SourceDoc, SourceMessage, SourceMinute, SourceBitable, SourceSheet, SourceMeeting, SourceMeetingNote} {
+		if !IsAllocated(st) {
+			t.Errorf("IsAllocated(%d) = false", st)
+		}
+	}
+	if IsAllocated(SourceType(4)) || IsAllocated(SourceType(99)) {
+		t.Error("IsAllocated(unallocated int) = true")
+	}
+}
+
+func unsetenvForTest(t *testing.T) error {
+	t.Helper()
+	return os.Unsetenv(envvars.CliCitation) // t.Setenv 已登记恢复，直接删除是安全的
+}

--- a/internal/citation/literal_guard_test.go
+++ b/internal/citation/literal_guard_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package citation
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// 命令侧构造 Citation 时只准写 citation.SourceXxx 符号常量。字面量 int 绕过
+// 值域追踪：值域变更时 grep 常量表就能找到全部引用，字面量找不到。
+func TestNoSourceTypeIntLiteralsInShortcuts(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "shortcuts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	literal := regexp.MustCompile(`SourceType:\s*[0-9]|SourceType\(\s*[0-9]`)
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(content), "\n") {
+			if literal.MatchString(line) {
+				t.Errorf("%s:%d: SourceType must use citation.SourceXxx constants, not int literals: %s",
+					path, i+1, strings.TrimSpace(line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/citation/sourcetype.go
+++ b/internal/citation/sourcetype.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package citation
+
+// SourceType is the globally defined business-scene enum carried on the wire
+// as an integer. Zero is reserved for "unset" and is never a valid scene.
+// The scene set mirrors the read-command catalog's source hosts; values 2-8
+// follow the downstream consumer's protocol, and the provisional block below
+// uses values outside that protocol's known range until the consumer assigns
+// authoritative ones. Scenes without a catalog host get no constant here.
+type SourceType int
+
+const (
+	SourceUnset SourceType = 0
+
+	// Values assigned by the downstream consumer's protocol.
+	SourceWiki    SourceType = 2 // wiki nodes and spaces
+	SourceDoc     SourceType = 3 // cloud documents
+	SourceMessage SourceType = 6 // IM messages and chats
+	SourceMinute  SourceType = 8 // minutes recordings
+
+	// Provisional values for catalog hosts the consumer's protocol has not
+	// assigned yet. They deliberately sit above the protocol's known range so
+	// a future authoritative assignment cannot collide silently; renumber them
+	// here once the consumer publishes the real values.
+	SourceBitable     SourceType = 13 // bitable (Base) tables and records
+	SourceSheet       SourceType = 14 // spreadsheets
+	SourceMeeting     SourceType = 15 // meetings
+	SourceMeetingNote SourceType = 16 // meeting notes
+)
+
+var allocated = map[SourceType]struct{}{
+	SourceWiki: {}, SourceDoc: {}, SourceMessage: {}, SourceMinute: {},
+	SourceBitable: {}, SourceSheet: {}, SourceMeeting: {}, SourceMeetingNote: {},
+}
+
+// IsAllocated reports whether st is an assigned business scene. SourceUnset
+// and any value outside the assigned table are not valid on the wire.
+func IsAllocated(st SourceType) bool {
+	_, ok := allocated[st]
+	return ok
+}

--- a/internal/envvars/envvars.go
+++ b/internal/envvars/envvars.go
@@ -20,6 +20,9 @@ const (
 	// Content safety scanning mode
 	CliContentSafetyMode = "LARKSUITE_CLI_CONTENT_SAFETY_MODE"
 
+	// Citation output gate. Exactly "1" enables citations in JSON envelopes.
+	CliCitation = "LARKSUITE_CLI_CITATION"
+
 	CliAgentName  = "LARKSUITE_CLI_AGENT_NAME"
 	CliAgentTrace = "LARKSUITE_CLI_AGENT_TRACE"
 

--- a/internal/output/emitter.go
+++ b/internal/output/emitter.go
@@ -10,6 +10,7 @@ import (
 	"io"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/citation"
 )
 
 // NoticeProvider supplies the notice attached to a structured envelope.
@@ -51,6 +52,13 @@ type EmitOptions struct {
 	DryRun          bool
 	Pretty          PrettyRenderer
 	JQSafetyWarning bool
+
+	// Citations lazily builds the envelope citations. emitEnvelope invokes it
+	// only after the format dispatch has committed to an envelope; nil means
+	// this result carries no citations. Laziness matters: only the emitter
+	// knows which branch really produces an envelope (jq precedence, pretty
+	// fallback, unknown-format fallback), so callers must not pre-judge.
+	Citations func() []citation.Citation
 }
 
 // StreamOptions describes one streamed page's wire representation. Streaming
@@ -201,6 +209,9 @@ func (e *Emitter) emitEnvelope(data interface{}, ok bool, opts EmitOptions) erro
 		Data:     data,
 		Meta:     opts.Meta,
 		Notice:   e.notice(),
+	}
+	if opts.Citations != nil {
+		env.Citations = opts.Citations()
 	}
 	if scanResult.Alert != nil {
 		env.ContentSafetyAlert = scanResult.Alert

--- a/internal/output/emitter_citation_test.go
+++ b/internal/output/emitter_citation_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/citation"
+)
+
+func citationTestEmitter(out, errOut *bytes.Buffer) *Emitter {
+	return NewEmitter(EmitterConfig{Out: out, ErrOut: errOut, CommandPath: "lark test +cmd", Identity: "user"})
+}
+
+func sampleCitations() []citation.Citation {
+	return []citation.Citation{{SourceType: citation.SourceWiki, URL: "https://docs.example.com/wiki/tok", Title: "t"}}
+}
+
+func TestEmitEnvelopeInjectsCitations(t *testing.T) {
+	var out, errOut bytes.Buffer
+	e := citationTestEmitter(&out, &errOut)
+	err := e.Success(map[string]any{"k": "v"}, EmitOptions{Citations: func() []citation.Citation { return sampleCitations() }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatal(err)
+	}
+	raw, ok := env["citations"]
+	if !ok {
+		t.Fatalf("citations key missing: %s", out.String())
+	}
+	var items []citation.Citation
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) != 1 || items[0].SourceType != citation.SourceWiki {
+		t.Fatalf("citations = %s", raw)
+	}
+}
+
+func TestEmitEnvelopeNilProviderOmitsKey(t *testing.T) {
+	var out, errOut bytes.Buffer
+	e := citationTestEmitter(&out, &errOut)
+	if err := e.Success(map[string]any{"k": "v"}, EmitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "citations") {
+		t.Fatalf("citations key must be absent: %s", out.String())
+	}
+}
+
+func TestEmitEnvelopeEmptyResultOmitsKey(t *testing.T) {
+	var out, errOut bytes.Buffer
+	e := citationTestEmitter(&out, &errOut)
+	if err := e.Success(map[string]any{"k": "v"}, EmitOptions{Citations: func() []citation.Citation { return nil }}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "citations") {
+		t.Fatalf("citations key must be absent: %s", out.String())
+	}
+}
+
+func TestNonEnvelopeFormatsNeverInvokeProvider(t *testing.T) {
+	probe := func() []citation.Citation { t.Fatal("provider must not be called"); return nil }
+	data := []map[string]any{{"a": "1"}}
+	for _, format := range []string{"table", "csv", "ndjson"} {
+		var out, errOut bytes.Buffer
+		e := citationTestEmitter(&out, &errOut)
+		if err := e.Success(data, EmitOptions{Format: format, Citations: probe}); err != nil {
+			t.Fatalf("format %s: %v", format, err)
+		}
+	}
+	// pretty with renderer 也不构造
+	var out, errOut bytes.Buffer
+	e := citationTestEmitter(&out, &errOut)
+	err := e.Success(data, EmitOptions{Format: "pretty", Citations: probe,
+		Pretty: func(w io.Writer, _ bool) error { _, err := w.Write([]byte("ok\n")); return err }})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStreamPageHasNoCitationPath(t *testing.T) {
+	// StreamOptions 没有 Citations 字段——本测试只固化流式页不经 emitEnvelope
+	var out, errOut bytes.Buffer
+	e := citationTestEmitter(&out, &errOut)
+	if err := e.StreamPage([]map[string]any{{"a": "1"}}, StreamOptions{Format: "ndjson"}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "citations") {
+		t.Fatal("stream page must not carry citations")
+	}
+}
+
+func TestJQCanFilterCitations(t *testing.T) {
+	var out, errOut bytes.Buffer
+	e := citationTestEmitter(&out, &errOut)
+	err := e.Success(map[string]any{"k": "v"}, EmitOptions{JQ: ".citations | length", Citations: func() []citation.Citation { return sampleCitations() }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out.String()) != "1" {
+		t.Fatalf("jq .citations|length = %q, want 1", out.String())
+	}
+}
+
+func TestPartialFailureEnvelopeInjectsCitations(t *testing.T) {
+	var out, errOut bytes.Buffer
+	e := citationTestEmitter(&out, &errOut)
+	err := e.PartialFailure(map[string]any{"k": "v"}, EmitOptions{Citations: func() []citation.Citation { return sampleCitations() }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "\"citations\"") {
+		t.Fatalf("partial failure envelope missing citations: %s", out.String())
+	}
+}

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -3,12 +3,15 @@
 
 package output
 
+import "github.com/larksuite/cli/internal/citation"
+
 // Envelope is the standard success response wrapper.
 type Envelope struct {
 	OK                 bool                   `json:"ok"`
 	Identity           string                 `json:"identity,omitempty"`
 	DryRun             bool                   `json:"dry_run,omitempty"`
 	Data               interface{}            `json:"data,omitempty"`
+	Citations          []citation.Citation    `json:"citations,omitempty"`
 	Meta               *Meta                  `json:"meta,omitempty"`
 	ContentSafetyAlert interface{}            `json:"_content_safety_alert,omitempty"`
 	Notice             map[string]interface{} `json:"_notice,omitempty"`

--- a/shortcuts/common/citation.go
+++ b/shortcuts/common/citation.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/larksuite/cli/internal/citation"
+)
+
+// CitationDefinition declares a read command's citation capability.
+// Legacy shortcuts mount it on Shortcut.Citation with Build set; typed
+// shortcuts mount it on Output.Citation with SourceTypes only (the typed
+// builder lives in Hooks.BuildCitation so it can see *Args and Data).
+//
+// Source constraint: every citation text field (title, snippet, and any
+// future free-text field) must be drawn from material the command already
+// has in hand — the output payload (data), the command's own input
+// parameters, and Brand. A builder must never introduce text that isn't
+// already present in one of those. Content-safety scanning runs on data
+// before the citations closure runs; a builder that respects this
+// constraint can only ever surface text that has already been scanned, so
+// citation text carries the same safety guarantee as the payload it was
+// built from. Pulling in new text from elsewhere (a fresh API call, a
+// hardcoded string, anything outside data/args/Brand) breaks that
+// guarantee and must not be done.
+type CitationDefinition struct {
+	// SourceTypes bounds what the builder may return; entries outside this
+	// set are dropped at runtime with a stderr warning.
+	SourceTypes []citation.SourceType
+	// Build is the legacy builder. It sees the final output payload just
+	// before serialization; it must not call any API.
+	Build func(rt *RuntimeContext, data any) []citation.Citation
+}
+
+// validateCitationDeclaration is the registration-time contract shared by the
+// legacy mount path and the typed compiler: citations are a read-only-command
+// capability with an explicitly bounded scene set.
+func validateCitationDeclaration(def *CitationDefinition, risk string) error {
+	if def == nil {
+		return nil
+	}
+	if risk != string(RiskRead) {
+		return fmt.Errorf("citation requires explicit Risk %q, got %q", RiskRead, risk)
+	}
+	if len(def.SourceTypes) == 0 {
+		return fmt.Errorf("citation requires a non-empty SourceTypes set")
+	}
+	for _, st := range def.SourceTypes {
+		if !citation.IsAllocated(st) {
+			return fmt.Errorf("citation SourceTypes contains unallocated value %d", st)
+		}
+	}
+	return nil
+}
+
+// wrapCitationBuilder is the single runtime chokepoint shared by both command
+// paths: gate short-circuit, then build, then per-entry validation with a
+// stderr warning per dropped entry, then Normalize. A nil return means this
+// invocation carries no citations at all.
+func wrapCitationBuilder(errOut io.Writer, commandPath string,
+	declared []citation.SourceType, build func() []citation.Citation) func() []citation.Citation {
+	if build == nil || !citation.Enabled() {
+		return nil
+	}
+	declaredSet := make(map[citation.SourceType]struct{}, len(declared))
+	for _, st := range declared {
+		declaredSet[st] = struct{}{}
+	}
+	return func() []citation.Citation {
+		items := build()
+		kept := make([]citation.Citation, 0, len(items))
+		for _, item := range items {
+			if reason := invalidCitationReason(declaredSet, item); reason != "" {
+				fmt.Fprintf(errOut, "warning: %s: dropped citation: %s\n", commandPath, reason)
+				continue
+			}
+			kept = append(kept, item)
+		}
+		return citation.Normalize(kept)
+	}
+}
+
+// invalidCitationReason reports why an entry must be dropped, or "" to keep
+// it. An empty URL is not an error here: Normalize drops it silently as the
+// protocol's normal degradation.
+func invalidCitationReason(declared map[citation.SourceType]struct{}, item citation.Citation) string {
+	if item.SourceType == citation.SourceUnset {
+		return "source_type is unset"
+	}
+	if _, ok := declared[item.SourceType]; !ok {
+		return fmt.Sprintf("source_type %d is not declared by this command", item.SourceType)
+	}
+	if item.URL != "" {
+		parsed, err := url.Parse(item.URL)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+			return "url is not an absolute https URL"
+		}
+	}
+	return ""
+}

--- a/shortcuts/common/citation_legacy_test.go
+++ b/shortcuts/common/citation_legacy_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+func citationTestShortcut(builderCalled *bool) *Shortcut {
+	return &Shortcut{
+		Service: "testsvc", Command: "+cite", Description: "test", Risk: "read",
+		Citation: &CitationDefinition{
+			SourceTypes: []citation.SourceType{citation.SourceWiki},
+			Build: func(rt *RuntimeContext, data any) []citation.Citation {
+				*builderCalled = true
+				return []citation.Citation{{SourceType: citation.SourceWiki, URL: "https://x.example/1", Title: "t"}}
+			},
+		},
+		Execute: func(ctx context.Context, rt *RuntimeContext) error {
+			rt.Out(map[string]any{"k": "v"}, nil)
+			return nil
+		},
+	}
+}
+
+// runCitationTestShortcut mounts s on a fresh parent command via a
+// cmdutil.TestFactory, executes it (as user, matching this package's other
+// full-execution helpers such as runBotInfoShortcut in
+// runner_botinfo_test.go), and returns everything written to stdout. config
+// is passed straight through to cmdutil.TestFactory; nil is fine since none
+// of these shortcuts make an API call.
+func runCitationTestShortcut(t *testing.T, s *Shortcut, config *core.CliConfig) string {
+	t.Helper()
+	f, stdout, _, _ := cmdutil.TestFactory(t, config)
+	parent := &cobra.Command{Use: "root"}
+	s.Mount(parent, f)
+	parent.SetArgs([]string{s.Command, "--as", "user"})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if err := parent.Execute(); err != nil {
+		t.Fatalf("shortcut execution failed: %v", err)
+	}
+	return stdout.String()
+}
+
+// mountCitationTestShortcut mounts s on a fresh parent command and returns the
+// mounted cobra.Command, mirroring mountTestShortcut in
+// runner_json_shorthand_test.go. Mount-time panics (the citation contract
+// violations under test) surface synchronously from this call.
+func mountCitationTestShortcut(t *testing.T, s *Shortcut) *cobra.Command {
+	t.Helper()
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	parent := &cobra.Command{Use: "root"}
+	s.Mount(parent, f)
+	cmd, _, err := parent.Find([]string{s.Command})
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	return cmd
+}
+
+func TestLegacyCitationInjectedWhenEnabled(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+	called := false
+	stdout := runCitationTestShortcut(t, citationTestShortcut(&called), nil)
+	if !called {
+		t.Fatal("Build not called with gate on")
+	}
+	if !strings.Contains(stdout, "\"citations\"") {
+		t.Fatalf("envelope missing citations: %s", stdout)
+	}
+}
+
+func TestLegacyCitationByteIdenticalWhenDisabled(t *testing.T) {
+	called := false
+	shortcutWith := citationTestShortcut(&called)
+	shortcutWithout := citationTestShortcut(new(bool))
+	shortcutWithout.Citation = nil
+
+	t.Setenv(envvars.CliCitation, "0")
+	withDecl := runCitationTestShortcut(t, shortcutWith, nil)
+	withoutDecl := runCitationTestShortcut(t, shortcutWithout, nil)
+	if withDecl != withoutDecl {
+		t.Fatalf("gate-off output differs:\nwith decl: %s\nwithout: %s", withDecl, withoutDecl)
+	}
+	if called {
+		t.Fatal("Build must not run when gate is off")
+	}
+}
+
+func TestLegacyCitationMountPanics(t *testing.T) {
+	cases := []func(s *Shortcut){
+		func(s *Shortcut) { s.Risk = "" },
+		func(s *Shortcut) { s.Risk = "write" },
+		func(s *Shortcut) { s.Citation.SourceTypes = nil },
+		func(s *Shortcut) { s.Citation.Build = nil },
+	}
+	for i, mutate := range cases {
+		s := citationTestShortcut(new(bool))
+		mutate(s)
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("case %d: mount must panic", i)
+				}
+			}()
+			mountCitationTestShortcut(t, s)
+		}()
+	}
+}
+
+// TestLegacyCitationOutRawInjectedWhenEnabled mirrors
+// TestLegacyCitationInjectedWhenEnabled for RuntimeContext.OutRaw, the
+// HTML-escaping-disabled sibling of Out. citationProvider is wired
+// identically on both methods (runner.go); this proves that wiring end to
+// end for OutRaw specifically rather than relying on Out's coverage as a
+// stand-in.
+func TestLegacyCitationOutRawInjectedWhenEnabled(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+	called := false
+	s := citationTestShortcut(&called)
+	s.Execute = func(ctx context.Context, rt *RuntimeContext) error {
+		rt.OutRaw(map[string]any{"k": "<v>"}, nil)
+		return nil
+	}
+	stdout := runCitationTestShortcut(t, s, nil)
+	if !called {
+		t.Fatal("Build not called with gate on")
+	}
+	if !strings.Contains(stdout, "\"citations\"") {
+		t.Fatalf("OutRaw envelope missing citations: %s", stdout)
+	}
+}
+
+// TestLegacyCitationOutFormatRawInjectedWhenEnabled mirrors
+// TestLegacyCitationInjectedWhenEnabled for RuntimeContext.OutFormatRaw, the
+// HTML-escaping-disabled sibling of OutFormat, proving the same
+// citationProvider wiring on the --format-aware raw path.
+func TestLegacyCitationOutFormatRawInjectedWhenEnabled(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+	called := false
+	s := citationTestShortcut(&called)
+	s.Execute = func(ctx context.Context, rt *RuntimeContext) error {
+		rt.OutFormatRaw(map[string]any{"k": "<v>"}, nil, func(w io.Writer) { fmt.Fprint(w, "k: v\n") })
+		return nil
+	}
+	stdout := runCitationTestShortcut(t, s, nil)
+	if !called {
+		t.Fatal("Build not called with gate on")
+	}
+	if !strings.Contains(stdout, "\"citations\"") {
+		t.Fatalf("OutFormatRaw envelope missing citations: %s", stdout)
+	}
+}
+
+// TestLegacyCitationTableFormatDoesNotBuild pins that OutFormat's "table"
+// (non-JSON-envelope) branch never invokes the citation builder: citations
+// are an envelope-only concept, and Build must not run just because a
+// command happens to declare one.
+func TestLegacyCitationTableFormatDoesNotBuild(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+	called := false
+	s := &Shortcut{
+		Service: "testsvc", Command: "+cite-table", Description: "test", Risk: "read",
+		Flags: []Flag{{Name: "format", Default: "table", Enum: []string{"table", "json"}, Desc: "fmt"}},
+		Citation: &CitationDefinition{
+			SourceTypes: []citation.SourceType{citation.SourceWiki},
+			Build: func(rt *RuntimeContext, data any) []citation.Citation {
+				called = true
+				return []citation.Citation{{SourceType: citation.SourceWiki, URL: "https://x.example/1", Title: "t"}}
+			},
+		},
+		Execute: func(ctx context.Context, rt *RuntimeContext) error {
+			rt.OutFormat(map[string]any{"k": "v"}, nil, func(w io.Writer) { fmt.Fprint(w, "k: v\n") })
+			return nil
+		},
+	}
+	stdout := runCitationTestShortcut(t, s, nil)
+	if called {
+		t.Fatal("Build must not run when --format renders outside the JSON envelope")
+	}
+	if strings.Contains(stdout, "\"citations\"") {
+		t.Fatalf("table output must not contain citations: %s", stdout)
+	}
+}

--- a/shortcuts/common/citation_test.go
+++ b/shortcuts/common/citation_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+func TestWrapCitationBuilderDisabledReturnsNil(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "0")
+	called := false
+	wrapped := wrapCitationBuilder(&bytes.Buffer{}, "lark x +y", []citation.SourceType{citation.SourceWiki},
+		func() []citation.Citation { called = true; return nil })
+	if wrapped != nil {
+		t.Fatal("wrapped builder must be nil when gate is off")
+	}
+	if called {
+		t.Fatal("builder must not run when gate is off")
+	}
+}
+
+func TestWrapCitationBuilderNilBuildReturnsNil(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+	if wrapCitationBuilder(&bytes.Buffer{}, "lark x +y", []citation.SourceType{citation.SourceWiki}, nil) != nil {
+		t.Fatal("nil build must wrap to nil")
+	}
+}
+
+func TestWrapCitationBuilderValidation(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+	var errOut bytes.Buffer
+	wrapped := wrapCitationBuilder(&errOut, "lark x +y", []citation.SourceType{citation.SourceWiki},
+		func() []citation.Citation {
+			return []citation.Citation{
+				{SourceType: citation.SourceWiki, URL: "https://ok.example/1", Title: "keep"},
+				{SourceType: citation.SourceUnset, URL: "https://ok.example/2", Title: "unset"},
+				{SourceType: citation.SourceMessage, URL: "https://ok.example/3", Title: "undeclared"},
+				{SourceType: citation.SourceWiki, URL: "http://plain.example/4", Title: "http"},
+				{SourceType: citation.SourceWiki, URL: "file:///etc/passwd", Title: "file"},
+				{SourceType: citation.SourceWiki, URL: "/relative/path", Title: "relative"},
+				{SourceType: citation.SourceWiki, URL: "", Title: "no-url-silent"},
+			}
+		})
+	got := wrapped()
+	if len(got) != 1 || got[0].Title != "keep" {
+		t.Fatalf("wrapped() = %#v, want only the valid entry", got)
+	}
+	warnings := errOut.String()
+	for _, want := range []string{
+		"warning: lark x +y: dropped citation: source_type is unset",
+		"warning: lark x +y: dropped citation: source_type 6 is not declared by this command",
+		"warning: lark x +y: dropped citation: url is not an absolute https URL",
+	} {
+		if !strings.Contains(warnings, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, warnings)
+		}
+	}
+	// http/file/relative 共 3 条 url 告警
+	if n := strings.Count(warnings, "url is not an absolute https URL"); n != 3 {
+		t.Errorf("url warnings = %d, want 3", n)
+	}
+	// 无 url 条目静默丢弃，不产生告警
+	if strings.Contains(warnings, "no-url") || strings.Count(warnings, "warning:") != 5 {
+		t.Errorf("unexpected warnings:\n%s", warnings)
+	}
+}
+
+func TestValidateCitationDeclaration(t *testing.T) {
+	valid := &CitationDefinition{SourceTypes: []citation.SourceType{citation.SourceWiki}}
+	if err := validateCitationDeclaration(valid, "read"); err != nil {
+		t.Fatalf("valid declaration rejected: %v", err)
+	}
+	// Use a calculated unallocated source type to verify validation rejects undefined types
+	unallocated := citation.SourceType(int(citation.SourceMeetingNote) + 100)
+	cases := []struct {
+		name string
+		def  *CitationDefinition
+		risk string
+	}{
+		{"risk not explicit read", valid, ""},
+		{"risk write", valid, "write"},
+		{"empty source types", &CitationDefinition{}, "read"},
+		{"unset source type", &CitationDefinition{SourceTypes: []citation.SourceType{citation.SourceUnset}}, "read"},
+		{"unallocated source type", &CitationDefinition{SourceTypes: []citation.SourceType{unallocated}}, "read"},
+	}
+	for _, tc := range cases {
+		if err := validateCitationDeclaration(tc.def, tc.risk); err == nil {
+			t.Errorf("%s: want error, got nil", tc.name)
+		}
+	}
+}

--- a/shortcuts/common/citation_typed_test.go
+++ b/shortcuts/common/citation_typed_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
+	"github.com/spf13/cobra"
+)
+
+type citeArgs struct{}
+type citeData struct {
+	ID string `json:"id" schema:"required" doc:"id"`
+}
+
+func citationTypedDefinition() Definition[citeArgs, citeData] {
+	return Definition[citeArgs, citeData]{
+		Metadata: CommandMetadata{
+			Service: "testsvc", Command: "+tcite", Description: "test", Risk: RiskRead,
+			Authorization: AuthorizationDefinition{Identities: map[Identity]IdentityAuthorization{IdentityUser: {}}},
+		},
+		Output: OutputDefinition{
+			Citation: &CitationDefinition{SourceTypes: []citation.SourceType{citation.SourceWiki}},
+		},
+		Hooks: Hooks[citeArgs, citeData]{
+			Execute: func(_ context.Context, _ CommandContext, _ *citeArgs) (Result[citeData], error) {
+				return Success(citeData{ID: "x"}), nil
+			},
+			BuildCitation: func(_ context.Context, _ CommandContext, _ *citeArgs, d citeData) []citation.Citation {
+				return []citation.Citation{{SourceType: citation.SourceWiki, URL: "https://x.example/" + d.ID, Title: "t"}}
+			},
+		},
+	}
+}
+
+func TestTypedCitationDefinePanics(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(d *Definition[citeArgs, citeData])
+	}{
+		{"citation without hook", func(d *Definition[citeArgs, citeData]) { d.Hooks.BuildCitation = nil }},
+		{"hook without citation", func(d *Definition[citeArgs, citeData]) { d.Output.Citation = nil }},
+		{"empty source types", func(d *Definition[citeArgs, citeData]) { d.Output.Citation.SourceTypes = nil }},
+		{"unset source type", func(d *Definition[citeArgs, citeData]) {
+			d.Output.Citation.SourceTypes = []citation.SourceType{citation.SourceUnset}
+		}},
+		{"risk write", func(d *Definition[citeArgs, citeData]) { d.Metadata.Risk = RiskWrite }},
+		{"legacy build set", func(d *Definition[citeArgs, citeData]) {
+			d.Output.Citation.Build = func(*RuntimeContext, any) []citation.Citation { return nil }
+		}},
+	}
+	for _, tc := range cases {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("%s: Define must panic", tc.name)
+				}
+			}()
+			d := citationTypedDefinition()
+			tc.mutate(&d)
+			Define(d)
+		}()
+	}
+}
+
+func TestTypedCitationValidDefineCompiles(t *testing.T) {
+	s := Define(citationTypedDefinition())
+	if s.typed == nil || s.typed.output.Citation == nil || s.typed.hooks.buildCitation == nil {
+		t.Fatal("compiled command must carry citation declaration and adapted hook")
+	}
+}
+
+// TestTypedCitationCompilesForBothOutputModes pins the registration invariant
+// that a citation declaration requires a JSON-envelope output mode, exercised
+// on its live surface: Define must accept a citation declaration under both
+// output modes the framework defines today,
+// because both always carry a JSON envelope (OutputGeneric always lists
+// "json" first in its format set; OutputFixedJSON is JSON-only). There is no
+// way to construct a third OutputMode through Define — validateOutput
+// already rejects any Mode outside these two before validateTypedCitation
+// runs — so a negative case for this check cannot be built through the
+// public API; see TestOutputModeIncludesJSON for the check's fail-closed
+// behavior on a hypothetical future mode.
+func TestTypedCitationCompilesForBothOutputModes(t *testing.T) {
+	for _, mode := range []OutputMode{OutputGeneric, OutputFixedJSON} {
+		d := citationTypedDefinition()
+		d.Output.Mode = mode
+		s := Define(d)
+		if s.typed == nil || s.typed.output.Citation == nil {
+			t.Fatalf("mode %q: compiled command must carry citation declaration", mode)
+		}
+	}
+}
+
+// TestOutputModeIncludesJSON exercises the compile-check-#5 helper directly.
+// The false branch documents the invariant the check protects: a
+// hypothetical future OutputMode must be added to the switch explicitly, or
+// a citation declaration against it fails Define instead of silently
+// compiling with no way to ever emit a citations envelope.
+func TestOutputModeIncludesJSON(t *testing.T) {
+	if !outputModeIncludesJSON(OutputGeneric) {
+		t.Error("OutputGeneric must include JSON in its format set")
+	}
+	if !outputModeIncludesJSON(OutputFixedJSON) {
+		t.Error("OutputFixedJSON must include JSON in its format set")
+	}
+	if outputModeIncludesJSON(OutputMode("future_mode")) {
+		t.Error("an unrecognized OutputMode must not be treated as including JSON")
+	}
+}
+
+func TestTypedCitationSchemaProjection(t *testing.T) {
+	s := Define(citationTypedDefinition())
+	contract := s.typed.contract
+	if contract.Meta.Citation == nil {
+		t.Fatal("_meta.citation missing")
+	}
+	c := contract.Meta.Citation
+	if c.Env != envvars.CliCitation || c.EnabledValue != "1" || c.EnvelopeKey != "citations" {
+		t.Fatalf("_meta.citation = %#v", c)
+	}
+	if len(c.SourceTypes) != 1 || c.SourceTypes[0] != citation.SourceWiki {
+		t.Fatalf("_meta.citation.source_types = %#v", c.SourceTypes)
+	}
+}
+
+// runTypedCitationShortcut mounts and executes an already-Defined typed
+// shortcut, mirroring runTypedFixture's Mount+Execute+capture-stdout pattern
+// (typed_runner_test.go), and returns captured stdout.
+func runTypedCitationShortcut(t *testing.T, shortcut Shortcut) string {
+	t.Helper()
+	factory, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "cite-app", AppSecret: "cite-secret", Brand: core.BrandFeishu})
+	root := &cobra.Command{Use: "lark-cli", SilenceUsage: true, SilenceErrors: true}
+	service := &cobra.Command{Use: "testsvc"}
+	root.AddCommand(service)
+	shortcut.Mount(service, factory)
+	root.SetArgs([]string{"testsvc", "+tcite", "--as", "user"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return stdout.String()
+}
+
+func TestTypedCitationEmittedWhenEnabled(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+	stdout := runTypedCitationShortcut(t, Define(citationTypedDefinition()))
+	if !strings.Contains(stdout, "\"citations\"") {
+		t.Fatalf("typed envelope missing citations: %s", stdout)
+	}
+}
+
+// TestTypedShortcutLegacyCitationFieldMountPanics pins that a typed shortcut
+// which also sets the public Shortcut.Citation field (the legacy mount
+// point) fails loud at Mount time instead of silently ignoring it.
+// mountDeclarative only ever consults Shortcut.Citation on the legacy path
+// (typed == nil); a typed command's citation declaration lives on
+// Output.Citation / Hooks.BuildCitation, so an externally-set
+// Shortcut.Citation on a typed shortcut is always a mistake worth panicking
+// on rather than a silent no-op.
+func TestTypedShortcutLegacyCitationFieldMountPanics(t *testing.T) {
+	s := Define(citationTypedDefinition())
+	s.Citation = &CitationDefinition{SourceTypes: []citation.SourceType{citation.SourceWiki}}
+	defer func() {
+		if recover() == nil {
+			t.Fatal("mount must panic when a typed shortcut also sets Shortcut.Citation")
+		}
+	}()
+	mountCitationTestShortcut(t, &s)
+}
+
+func TestTypedCitationAbsentWhenDisabled(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "0")
+	stdout := runTypedCitationShortcut(t, Define(citationTypedDefinition()))
+	if strings.Contains(stdout, "citations") {
+		t.Fatalf("gate-off typed envelope must omit citations: %s", stdout)
+	}
+}

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/citation"
 	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/cmdmeta"
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -52,6 +53,7 @@ type RuntimeContext struct {
 	larkSDK        *lark.Client                      // eagerly initialized in mountDeclarative
 	stdinConsumed  bool                              // set when an Input flag has consumed stdin (`-`); guards against a second flag also using `-` within the same call
 	inputResolved  map[string]bool                   // flags whose value was replaced by @file / stdin content in resolveInputFlags; see InputResolvedFromSource
+	citation       *CitationDefinition               // legacy citation declaration captured at runtime construction
 }
 
 // ── Identity ──
@@ -732,13 +734,26 @@ func wrapLegacyPrettyRenderer(prettyFn func(w io.Writer)) output.PrettyRenderer 
 	}
 }
 
+// citationProvider wraps this command's citation declaration for one output
+// payload. The emitter invokes the returned closure only when the result
+// actually goes through an envelope.
+func (ctx *RuntimeContext) citationProvider(data any) func() []citation.Citation {
+	if ctx.citation == nil {
+		return nil
+	}
+	return wrapCitationBuilder(ctx.Factory.IOStreams.ErrOut, ctx.Cmd.CommandPath(),
+		ctx.citation.SourceTypes,
+		func() []citation.Citation { return ctx.citation.Build(ctx, data) })
+}
+
 // Out prints a success JSON envelope to stdout.
 func (ctx *RuntimeContext) Out(data interface{}, meta *output.Meta) {
 	ctx.handleEmitterError(ctx.newEmitter().Success(data, output.EmitOptions{
-		Format: "",
-		Raw:    false,
-		JQ:     ctx.JqExpr,
-		Meta:   meta,
+		Format:    "",
+		Raw:       false,
+		JQ:        ctx.JqExpr,
+		Meta:      meta,
+		Citations: ctx.citationProvider(data),
 	}))
 }
 
@@ -747,10 +762,11 @@ func (ctx *RuntimeContext) Out(data interface{}, meta *output.Meta) {
 // that should be preserved as-is in JSON output.
 func (ctx *RuntimeContext) OutRaw(data interface{}, meta *output.Meta) {
 	ctx.handleEmitterError(ctx.newEmitter().Success(data, output.EmitOptions{
-		Format: "",
-		Raw:    true,
-		JQ:     ctx.JqExpr,
-		Meta:   meta,
+		Format:    "",
+		Raw:       true,
+		JQ:        ctx.JqExpr,
+		Meta:      meta,
+		Citations: ctx.citationProvider(data),
 	}))
 }
 
@@ -783,11 +799,12 @@ func (ctx *RuntimeContext) OutPartialFailure(data interface{}, meta *output.Meta
 // The Emitter handles content safety scanning for every format.
 func (ctx *RuntimeContext) OutFormat(data interface{}, meta *output.Meta, prettyFn func(w io.Writer)) {
 	ctx.handleEmitterError(ctx.newEmitter().Success(data, output.EmitOptions{
-		Format: ctx.Format,
-		Raw:    false,
-		JQ:     ctx.JqExpr,
-		Meta:   meta,
-		Pretty: wrapLegacyPrettyRenderer(prettyFn),
+		Format:    ctx.Format,
+		Raw:       false,
+		JQ:        ctx.JqExpr,
+		Meta:      meta,
+		Pretty:    wrapLegacyPrettyRenderer(prettyFn),
+		Citations: ctx.citationProvider(data),
 	}))
 }
 
@@ -795,11 +812,12 @@ func (ctx *RuntimeContext) OutFormat(data interface{}, meta *output.Meta, pretty
 // Use this when the data contains XML/HTML content that should be preserved as-is.
 func (ctx *RuntimeContext) OutFormatRaw(data interface{}, meta *output.Meta, prettyFn func(w io.Writer)) {
 	ctx.handleEmitterError(ctx.newEmitter().Success(data, output.EmitOptions{
-		Format: ctx.Format,
-		Raw:    true,
-		JQ:     ctx.JqExpr,
-		Meta:   meta,
-		Pretty: wrapLegacyPrettyRenderer(prettyFn),
+		Format:    ctx.Format,
+		Raw:       true,
+		JQ:        ctx.JqExpr,
+		Meta:      meta,
+		Pretty:    wrapLegacyPrettyRenderer(prettyFn),
+		Citations: ctx.citationProvider(data),
 	}))
 }
 
@@ -864,6 +882,17 @@ func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f
 	if shortcut.typed != nil {
 		if err := validateTypedFlagMountPlan(shortcut.typed, shortcut.PrintFlagSchema != nil, Risk(shortcut.Risk)); err != nil {
 			panic(fmt.Sprintf("typed shortcut %s %s: %v", shortcut.Service, shortcut.Command, err))
+		}
+		if shortcut.Citation != nil {
+			panic(fmt.Sprintf("typed shortcut %s %s: declare citations via Output.Citation, not Shortcut.Citation", shortcut.Service, shortcut.Command))
+		}
+	}
+	if shortcut.typed == nil && shortcut.Citation != nil {
+		if err := validateCitationDeclaration(shortcut.Citation, shortcut.Risk); err != nil {
+			panic(fmt.Sprintf("legacy shortcut %s %s: %v", shortcut.Service, shortcut.Command, err))
+		}
+		if shortcut.Citation.Build == nil {
+			panic(fmt.Sprintf("legacy shortcut %s %s: citation requires a Build hook", shortcut.Service, shortcut.Command))
 		}
 	}
 	if len(shortcut.AuthTypes) == 0 {
@@ -1130,6 +1159,7 @@ func newRuntimeContext(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, conf
 		botOnly:    botOnly,
 		resolvedAs: as,
 		Factory:    f,
+		citation:   s.Citation,
 	}
 	rctx.declaredScopes = s.DeclaredScopesForIdentity(string(rctx.As()))
 	rctx.apiClientFunc = sync.OnceValues(func() (*client.APIClient, error) {

--- a/shortcuts/common/typed_compiler.go
+++ b/shortcuts/common/typed_compiler.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"reflect"
 	"strings"
+
+	"github.com/larksuite/cli/internal/citation"
 )
 
 // Define compiles a Typed Shortcut definition. Invalid definitions are
@@ -65,6 +67,9 @@ func compileDefinition[Args any, Data any](definition Definition[Args, Data]) (*
 		return nil, err
 	}
 	if err := validateOutputHooks(definition.Output, rendererMarkers(definition.Hooks.Renderers)); err != nil {
+		return nil, err
+	}
+	if err := validateTypedCitation(definition.Output.Citation, definition.Hooks.BuildCitation != nil, metadata.Risk, definition.Output.Mode); err != nil {
 		return nil, err
 	}
 	command := &compiledCommand{
@@ -195,6 +200,46 @@ func validateScopeList(scopes []string, path string) error {
 	return nil
 }
 
+// validateTypedCitation enforces that Output.Citation and Hooks.BuildCitation
+// are declared together, that the typed path does not carry the legacy
+// Build builder, that the command's output mode can actually carry a JSON
+// envelope (citations ride the envelope; a mode whose format set drops JSON
+// would compile a declaration nothing ever emits), and defers the rest to
+// the shared citation contract.
+func validateTypedCitation(def *CitationDefinition, hasHook bool, risk Risk, mode OutputMode) error {
+	if def == nil && !hasHook {
+		return nil
+	}
+	if def == nil || !hasHook {
+		return fmt.Errorf("Output.Citation and Hooks.BuildCitation must be set together")
+	}
+	if def.Build != nil {
+		return fmt.Errorf("Output.Citation.Build is legacy-only; use Hooks.BuildCitation")
+	}
+	if !outputModeIncludesJSON(mode) {
+		return fmt.Errorf("citation requires an output mode whose format set includes JSON, got %q", mode)
+	}
+	return validateCitationDeclaration(def, string(risk))
+}
+
+// outputModeIncludesJSON reports whether mode's format set includes a JSON
+// envelope. Both OutputGeneric (typedOutputFormats always lists "json" first,
+// selectable by --format json and the default) and OutputFixedJSON (every
+// successful invocation is a JSON envelope) satisfy this today, so this
+// check is vacuously true for every mode validateOutput currently accepts.
+// It is written as an explicit enumeration rather than a default-true
+// fallback so a future OutputMode that drops JSON support fails this check
+// at Define time instead of silently compiling a citation declaration that
+// nothing will ever emit.
+func outputModeIncludesJSON(mode OutputMode) bool {
+	switch mode {
+	case OutputGeneric, OutputFixedJSON:
+		return true
+	default:
+		return false
+	}
+}
+
 func adaptHooks[Args any, Data any](hooks Hooks[Args, Data]) compiledHooks {
 	adapted := compiledHooks{newArgs: func() any { return new(Args) }}
 	if hooks.Normalize != nil {
@@ -215,6 +260,11 @@ func adaptHooks[Args any, Data any](hooks Hooks[Args, Data]) compiledHooks {
 	adapted.execute = func(ctx context.Context, cc CommandContext, args any) (compiledResult, error) {
 		result, err := hooks.Execute(ctx, cc, args.(*Args))
 		return compiledResult{data: result.Data, outcome: result.Outcome, meta: result.Meta}, err
+	}
+	if hooks.BuildCitation != nil {
+		adapted.buildCitation = func(ctx context.Context, cc CommandContext, args any, data any) []citation.Citation {
+			return hooks.BuildCitation(ctx, cc, args.(*Args), data.(Data))
+		}
 	}
 	if len(hooks.Renderers) > 0 {
 		adapted.renderers = make(map[string]func(io.Writer, any) error, len(hooks.Renderers))

--- a/shortcuts/common/typed_contract.go
+++ b/shortcuts/common/typed_contract.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"io"
 	"reflect"
+
+	"github.com/larksuite/cli/internal/citation"
 )
 
 type compiledCommand struct {
@@ -58,4 +60,6 @@ type compiledHooks struct {
 	dryRun    func(context.Context, CommandContext, any) *DryRunAPI
 	execute   func(context.Context, CommandContext, any) (compiledResult, error)
 	renderers map[string]func(io.Writer, any) error
+
+	buildCitation func(context.Context, CommandContext, any, any) []citation.Citation
 }

--- a/shortcuts/common/typed_definition.go
+++ b/shortcuts/common/typed_definition.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/citation"
 	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/core"
 )
@@ -169,6 +170,11 @@ type Hooks[Args any, Data any] struct {
 	DryRun    func(context.Context, CommandContext, *Args) *DryRunAPI
 	Execute   func(context.Context, CommandContext, *Args) (Result[Data], error)
 	Renderers map[string]Renderer[Data]
+
+	// BuildCitation builds this result's citations from the final output and
+	// the bound args. It runs only when the gate is on and the result goes
+	// through an envelope; it must not call any API and must not fail.
+	BuildCitation func(context.Context, CommandContext, *Args, Data) []citation.Citation
 }
 
 type Renderer[Data any] func(io.Writer, Data) error

--- a/shortcuts/common/typed_output.go
+++ b/shortcuts/common/typed_output.go
@@ -16,6 +16,11 @@ type OutputDefinition struct {
 	// envelopes and jq JSON output. It does not enable bare stdout output or
 	// bypass content-safety scanning.
 	DisableHTMLEscaping bool
+
+	// Citation declares this read command's citation capability. Only
+	// SourceTypes is honored on the typed path; the builder lives in
+	// Hooks.BuildCitation so it can see typed *Args and Data.
+	Citation *CitationDefinition
 }
 
 // ResultMetaDefinition declares which standard envelope metadata a command may

--- a/shortcuts/common/typed_runner.go
+++ b/shortcuts/common/typed_runner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/citation"
 	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
@@ -67,7 +68,16 @@ func runTypedShortcut(cmdFactory *cmdutil.Factory, runtime *RuntimeContext, shor
 	if err := validateTypedResultProtocol(command, result); err != nil {
 		return err
 	}
-	return emitTypedResult(runtime, command, result)
+	var citations func() []citation.Citation
+	if command.hooks.buildCitation != nil && result.outcome != "" {
+		boundArgs, resultData := bound.value, result.data
+		citations = wrapCitationBuilder(cmdFactory.IOStreams.ErrOut, runtime.Cmd.CommandPath(),
+			command.output.Citation.SourceTypes,
+			func() []citation.Citation {
+				return command.hooks.buildCitation(runtime.ctx, commandContext, boundArgs, resultData)
+			})
+	}
+	return emitTypedResult(runtime, command, result, citations)
 }
 
 func validateTypedStdinInputs(runtime *RuntimeContext, command *compiledCommand) error {
@@ -108,7 +118,7 @@ func validateTypedStdinInputs(runtime *RuntimeContext, command *compiledCommand)
 	return nil
 }
 
-func emitTypedResult(runtime *RuntimeContext, command *compiledCommand, result compiledResult) error {
+func emitTypedResult(runtime *RuntimeContext, command *compiledCommand, result compiledResult, citations func() []citation.Citation) error {
 	if result.outcome == "" {
 		return errs.NewInternalError(errs.SubtypeUnknown, "typed Execute returned a Result without Outcome")
 	}
@@ -124,7 +134,7 @@ func emitTypedResult(runtime *RuntimeContext, command *compiledCommand, result c
 		// injected --format flag existed but output was always JSON.
 		format = ""
 	}
-	options := output.EmitOptions{Format: format, Raw: command.output.DisableHTMLEscaping, JQ: runtime.JqExpr, Pretty: pretty, Meta: outputMetaFromTyped(result.meta)}
+	options := output.EmitOptions{Format: format, Raw: command.output.DisableHTMLEscaping, JQ: runtime.JqExpr, Pretty: pretty, Meta: outputMetaFromTyped(result.meta), Citations: citations}
 	switch result.outcome {
 	case OutcomeSuccess:
 		runtime.handleEmitterError(runtime.newEmitter().Success(result.data, options))

--- a/shortcuts/common/typed_schema.go
+++ b/shortcuts/common/typed_schema.go
@@ -3,7 +3,12 @@
 
 package common
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/envvars"
+)
 
 // typedSchemaContract is intentionally private during migration. Compiler and
 // snapshot tests consume it now; public cmd/schema registration happens only
@@ -62,6 +67,26 @@ type typedSchemaMeta struct {
 	Outcomes        typedSchemaOutcomes      `json:"outcomes"`
 	ResultMeta      *typedSchemaNode         `json:"result_meta,omitempty"`
 	Artifacts       []ArtifactDefinition     `json:"artifacts"`
+	Citation        *typedSchemaCitation     `json:"citation,omitempty"`
+}
+
+type typedSchemaCitation struct {
+	Env          string                `json:"env"`
+	EnabledValue string                `json:"enabled_value"`
+	EnvelopeKey  string                `json:"envelope_key"`
+	SourceTypes  []citation.SourceType `json:"source_types"`
+}
+
+func typedCitationSchema(def *CitationDefinition) *typedSchemaCitation {
+	if def == nil {
+		return nil
+	}
+	return &typedSchemaCitation{
+		Env:          envvars.CliCitation,
+		EnabledValue: "1",
+		EnvelopeKey:  "citations",
+		SourceTypes:  append([]citation.SourceType{}, def.SourceTypes...),
+	}
 }
 
 type typedSchemaAuthorization struct {
@@ -167,6 +192,7 @@ func buildTypedSchemaContract(command *compiledCommand) typedSchemaContract {
 			Outcomes:   typedSchemaOutcomes{Success: typedSchemaOutcome{Supported: true, EnvelopeOK: true, ExitCode: 0, Stdout: "result_envelope"}, PartialFailure: partial},
 			ResultMeta: typedResultMetaSchema(command.output.Meta),
 			Artifacts:  append([]ArtifactDefinition{}, command.output.Artifacts...),
+			Citation:   typedCitationSchema(command.output.Citation),
 		},
 	}
 }

--- a/shortcuts/common/types.go
+++ b/shortcuts/common/types.go
@@ -96,6 +96,11 @@ type Shortcut struct {
 	// tweak the command; cmd.Parent() is available at this point.
 	PostMount func(cmd *cobra.Command)
 
+	// Citation declares this read command's citation capability. Declaring it
+	// requires explicit Risk "read", a non-empty allocated SourceTypes set and
+	// a Build hook; violations panic at mount time. See CitationDefinition.
+	Citation *CitationDefinition
+
 	// typed is the fully compiled contract produced by Define. It remains
 	// private so legacy registry and public Schema cannot observe a partially
 	// migrated Typed Shortcut.

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	convertlib "github.com/larksuite/cli/shortcuts/im/convert_lib"
@@ -178,6 +181,7 @@ var ImChatMessageList = common.Shortcut{
 		// Emit: pagination completion belongs to framework metadata; the
 		// business payload remains compatible for existing consumers.
 		outData := map[string]interface{}{
+			"chat_id":    chatId,
 			"messages":   messages,
 			"total":      len(messages),
 			"has_more":   hasMore,
@@ -210,6 +214,10 @@ var ImChatMessageList = common.Shortcut{
 			fmt.Fprintf(w, "\n%d message(s)\ntip: use --format json to view full message content\n", len(messages))
 		})
 		return nil
+	},
+	Citation: &common.CitationDefinition{
+		SourceTypes: []citation.SourceType{citation.SourceMessage},
+		Build:       chatMessagesListCitations,
 	},
 }
 
@@ -282,4 +290,66 @@ func resolveChatIDForMessagesList(runtime *common.RuntimeContext, dryRun bool) (
 		return "", errs.NewAPIError(errs.SubtypeNotFound, "P2P chat not found for this user")
 	}
 	return chatId, nil
+}
+
+// chatMessageCitation builds one message's citation. The URL opens the chat
+// via the brand's applink endpoint; title is a 50-rune excerpt of the text.
+func chatMessageCitation(brand core.LarkBrand, chatID, messageID, text, createTime string) citation.Citation {
+	entry := citation.Citation{
+		SourceType:  citation.SourceMessage,
+		Snippet:     text,
+		Title:       truncateRunes(text, 50),
+		PublishTime: citation.Time(createTime),
+	}
+	if chatID != "" {
+		entry.URL = core.ResolveEndpoints(brand).AppLink + "/client/chat/open?openChatId=" + url.QueryEscape(chatID)
+		if messageID != "" {
+			entry.ResourceID = chatID + "/" + messageID
+		}
+	}
+	return entry
+}
+
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "…"
+}
+
+// chatMessagesListCitations adapts the final output payload to per-message
+// citations. It tolerates both concrete and interface slice shapes and
+// returns nil on any unexpected shape instead of failing the command.
+func chatMessagesListCitations(rt *common.RuntimeContext, data any) []citation.Citation {
+	out, ok := data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	chatID, _ := out["chat_id"].(string)
+	brand := core.BrandFeishu
+	if rt != nil && rt.Config != nil {
+		brand = rt.Config.Brand
+	}
+	var items []map[string]interface{}
+	switch v := out["messages"].(type) {
+	case []map[string]interface{}:
+		items = v
+	case []interface{}:
+		for _, entry := range v {
+			if m, ok := entry.(map[string]interface{}); ok {
+				items = append(items, m)
+			}
+		}
+	default:
+		return nil
+	}
+	citations := make([]citation.Citation, 0, len(items))
+	for _, msg := range items {
+		messageID, _ := msg["message_id"].(string)
+		text, _ := msg["content"].(string)
+		createTime, _ := msg["create_time"].(string)
+		citations = append(citations, chatMessageCitation(brand, chatID, messageID, text, createTime))
+	}
+	return citations
 }

--- a/shortcuts/im/im_chat_messages_list_citation_test.go
+++ b/shortcuts/im/im_chat_messages_list_citation_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/core"
+)
+
+func TestChatMessageCitation(t *testing.T) {
+	c := chatMessageCitation(core.BrandFeishu, "oc_1", "om_1", "hello world", "2026-07-27 21:26")
+	if c.SourceType != citation.SourceMessage {
+		t.Errorf("source_type = %d", c.SourceType)
+	}
+	if c.URL != "https://applink.feishu.cn/client/chat/open?openChatId=oc_1" {
+		t.Errorf("url = %q", c.URL)
+	}
+	if c.Title != "hello world" || c.Snippet != "hello world" {
+		t.Errorf("title/snippet = %q %q", c.Title, c.Snippet)
+	}
+	if c.ResourceID != "oc_1/om_1" {
+		t.Errorf("resource_id = %q", c.ResourceID)
+	}
+	if c.PublishTime != citation.Time("2026-07-27 21:26") {
+		t.Errorf("publish_time = %q", c.PublishTime)
+	}
+}
+
+func TestChatMessageCitationTitleTruncation(t *testing.T) {
+	long := strings.Repeat("字", 60)
+	c := chatMessageCitation(core.BrandFeishu, "oc_1", "om_1", long, "")
+	wantTitle := strings.Repeat("字", 50) + "…"
+	if c.Title != wantTitle {
+		t.Errorf("title = %q (len %d), want 50 runes + ellipsis", c.Title, len([]rune(c.Title)))
+	}
+	if c.Snippet != long {
+		t.Error("snippet must keep full text")
+	}
+}
+
+func TestChatMessagesListCitationsBuilder(t *testing.T) {
+	data := map[string]interface{}{
+		"chat_id": "oc_1",
+		"messages": []map[string]interface{}{
+			{"message_id": "om_1", "content": "hello", "create_time": "2026-07-27 21:26"},
+			{"message_id": "", "content": "no-id-still-builds", "create_time": ""},
+		},
+	}
+	got := chatMessagesListCitations(nil, data)
+	if len(got) != 2 {
+		t.Fatalf("builder = %#v, want 2 entries", got)
+	}
+	if got[0].ResourceID != "oc_1/om_1" {
+		t.Errorf("resource_id = %q", got[0].ResourceID)
+	}
+}
+
+func TestChatMessagesListCitationsBuilderBadShape(t *testing.T) {
+	if chatMessagesListCitations(nil, "not a map") != nil {
+		t.Error("non-map data must yield nil")
+	}
+	if chatMessagesListCitations(nil, map[string]interface{}{"messages": "wrong"}) != nil {
+		t.Error("wrong messages shape must yield nil")
+	}
+}

--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -111,11 +113,14 @@ var WikiNodeGet = common.Define(common.Definition[wikiNodeGetArgs, wikiNodeGetDa
 			{Name: "token", Mode: common.AliasIndependent, Conflict: common.AliasTrimmedEqualOrError, Hidden: true, Deprecated: true},
 		}}},
 	}},
-	Output: common.OutputDefinition{Data: common.DataDefinition{Overrides: []common.DataField{
-		{Path: "/updated_at", Shape: common.OneOfShape{Variants: []common.ValueShape{
-			common.StringShape{Format: "date-time"}, common.ConstShape{Value: ""},
-		}}},
-	}}},
+	Output: common.OutputDefinition{
+		Data: common.DataDefinition{Overrides: []common.DataField{
+			{Path: "/updated_at", Shape: common.OneOfShape{Variants: []common.ValueShape{
+				common.StringShape{Format: "date-time"}, common.ConstShape{Value: ""},
+			}}},
+		}},
+		Citation: &common.CitationDefinition{SourceTypes: []citation.SourceType{citation.SourceWiki}},
+	},
 	Hooks: common.Hooks[wikiNodeGetArgs, wikiNodeGetData]{
 		Normalize: func(_ context.Context, _ common.CommandContext, args *wikiNodeGetArgs) error {
 			spec, err := parseWikiNodeGetSpec(args.NodeToken, args.ObjType, args.SpaceID)
@@ -153,6 +158,9 @@ var WikiNodeGet = common.Define(common.Definition[wikiNodeGetArgs, wikiNodeGetDa
 			renderWikiNodeGetPretty(w, data.toMap())
 			return nil
 		}},
+		BuildCitation: func(_ context.Context, c common.CommandContext, _ *wikiNodeGetArgs, d wikiNodeGetData) []citation.Citation {
+			return wikiNodeCitation(c.Config().Brand, d.SpaceID, d.NodeToken, d.Title, d.ObjEditTime)
+		},
 	},
 })
 
@@ -364,6 +372,33 @@ func wikiNodeGetOutput(node *wikiNodeRecord, raw map[string]interface{}) map[str
 	out["updated_at"] = formatWikiTimestamp(objEditRaw)
 
 	return out
+}
+
+// wikiNodeCitation builds the node's citation entry for the envelope-level
+// citations array. The URL uses the brand's applink deep link
+// (applink.<brand>/client/wiki/open?wikiToken=<token>), not the
+// www.feishu.cn/wiki/<token> web link that wikiNodeGetOutput's doc comment
+// above deliberately omits from `data`: that web form is a non-canonical
+// redirect and would mislead in a read/confirm command's structured output.
+// The applink form doesn't carry that problem — it is the documented
+// client-side deep-link contract, gated behind LARKSUITE_CLI_CITATION (off by
+// default) and surfaced only in the top-level citations array, never in
+// `data`. So the two decisions coexist: `data` still emits no url; citations
+// may carry an applink url. An empty nodeToken yields an empty URL and the
+// framework drops the entry (citation.Normalize).
+func wikiNodeCitation(brand core.LarkBrand, spaceID, nodeToken, title, objEditTime string) []citation.Citation {
+	entry := citation.Citation{
+		SourceType:  citation.SourceWiki,
+		Title:       title,
+		PublishTime: citation.Time(objEditTime),
+	}
+	if nodeToken != "" {
+		entry.URL = core.ResolveEndpoints(brand).AppLink + "/client/wiki/open?wikiToken=" + url.QueryEscape(nodeToken)
+		if spaceID != "" {
+			entry.ResourceID = spaceID + "/" + nodeToken
+		}
+	}
+	return []citation.Citation{entry}
 }
 
 // formatWikiTimestamp turns a Lark unix-seconds string (the format used by

--- a/shortcuts/wiki/wiki_node_get_citation_test.go
+++ b/shortcuts/wiki/wiki_node_get_citation_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/core"
+)
+
+func TestWikiNodeCitation(t *testing.T) {
+	got := wikiNodeCitation(core.BrandFeishu, "spc1", "wikcnTok", "标题", "1721996760")
+	if len(got) != 1 {
+		t.Fatalf("wikiNodeCitation() = %#v, want 1 entry", got)
+	}
+	c := got[0]
+	if c.SourceType != citation.SourceWiki {
+		t.Errorf("source_type = %d", c.SourceType)
+	}
+	if c.URL != "https://applink.feishu.cn/client/wiki/open?wikiToken=wikcnTok" {
+		t.Errorf("url = %q", c.URL)
+	}
+	if c.Title != "标题" || c.ResourceID != "spc1/wikcnTok" {
+		t.Errorf("title/resource_id = %q %q", c.Title, c.ResourceID)
+	}
+	if c.PublishTime != citation.Time("1721996760") {
+		t.Errorf("publish_time = %q", c.PublishTime)
+	}
+}
+
+func TestWikiNodeCitationLarkBrand(t *testing.T) {
+	got := wikiNodeCitation(core.BrandLark, "spc1", "wikcnTok", "t", "")
+	if got[0].URL != "https://applink.larksuite.com/client/wiki/open?wikiToken=wikcnTok" {
+		t.Errorf("lark brand url = %q", got[0].URL)
+	}
+	if got[0].PublishTime != "" {
+		t.Errorf("empty edit time must omit publish_time, got %q", got[0].PublishTime)
+	}
+}
+
+func TestWikiNodeCitationEmptyToken(t *testing.T) {
+	got := wikiNodeCitation(core.BrandFeishu, "spc1", "", "t", "")
+	if len(got) != 1 || got[0].URL != "" {
+		t.Fatalf("empty token must yield empty url (Normalize drops it): %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary

AI-agent hosts need read commands to return uniform citation entries so rendered answers can link back to their sources. This PR adds a framework-level citation capability: a `citations` array on the top-level JSON success envelope, gated by the `LARKSUITE_CLI_CITATION=1` environment variable (default off, byte-identical output when off), with declaration entry points for both the legacy and typed shortcut paths and two pilot commands. Stacked on `feat/typed-shortcut-help-integration` (the typed path integrates with `common.Define`).

## Changes

- Add `internal/citation` domain package: `Citation` wire type, `SourceType` enum, exact-match `Enabled()` gate, `Normalize()` (drops URL-less entries), and `Time()` RFC3339 normalization with explicit offsets
- Register `LARKSUITE_CLI_CITATION` in `internal/envvars/envvars.go`
- Carry lazy citations on the success envelope: `Envelope.Citations` + `EmitOptions.Citations` closure invoked only inside `emitEnvelope` (`internal/output/envelope.go`, `internal/output/emitter.go`); table/csv/ndjson/pretty/stream paths structurally never build citations
- Add shared declaration and runtime validation in `shortcuts/common/citation.go`: `CitationDefinition`, registration-time checks (explicit read risk, allocated source types), per-entry runtime validation (declared source type, absolute https URL) with drop-and-warn semantics that never fail the command
- Wire the legacy path: `Shortcut.Citation` declaration, `citationProvider` on `Out`/`OutRaw`/`OutFormat`/`OutFormatRaw`, mount-time panic on invalid declarations (`shortcuts/common/types.go`, `shortcuts/common/runner.go`)
- Wire the typed path: `Output.Citation` + `Hooks.BuildCitation`, compile-time checks inside `Define`, lazy closure threaded through `emitTypedResult`, and a `_meta.citation` schema projection (`shortcuts/common/typed_*.go`)
- Pilot commands: `wiki +node-get` (typed, applink URL built from the brand endpoint resolver) and `im +chat-messages-list` (legacy, per-message citations; also exposes the resolved `chat_id` in `data` as a generally useful additive key)
- Guard test banning int literal source types under `shortcuts/` (`internal/citation/literal_guard_test.go`)

## Test Plan

- [x] build, `go vet`, and unit tests passed (`go test ./cmd/... ./internal/... ./shortcuts/...`)
- [x] gate-off byte-identical output covered by contract tests; non-envelope formats proven lazy via panic-probe tests
- [ ] skipped: integration suite has one failure in `tests/plugin_e2e` (`TestConcealedForkProjectsRetainedSchemaCatalog`) that reproduces identically on the base branch commit and is unrelated to this change
- [x] containerized E2E suite passed (2/2 test functions covering 11 scenarios: gate on/off byte-identical data, per-message citations, table/jq/dry-run/page-all boundaries)
- [x] offline acceptance checks passed (5/5 scenarios: gate independence, error paths, non-envelope formats, gate strictness, jq filtering)
- [x] manual verification: `LARKSUITE_CLI_CITATION=1 ./lark-cli wiki +node-get --node-token <token> --dry-run` and `--format table` runs confirmed no citations and byte-identical `data` against the gate-off runs

## Related Issues

N/A
