### PR TITLE
fix(im): make reaction scope conditional

### DIFF
--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -24,15 +24,16 @@ const (
 )
 
 var ImChatMessageList = common.Shortcut{
-	Service:     "im",
-	Command:     "+chat-messages-list",
-	Description: "List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range, --order asc/desc sorting, auto-pagination",
-	Risk:        "read",
-	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:           "im",
+	Command:           "+chat-messages-list",
+	Description:       "List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range, --order asc/desc sorting, auto-pagination",
+	Risk:              "read",
+	Scopes:            []string{"im:message:readonly"},
+	UserScopes:        []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user"},
+	BotScopes:         []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	ConditionalScopes: []string{messageReactionReadScope},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
 	Flags: append([]common.Flag{
 		{Name: "chat-id", Desc: "(required, mutually exclusive with --user-id) chat ID (oc_xxx)"},
 		{Name: "user-id", Desc: "(required, mutually exclusive with --chat-id; user identity only) user open_id (ou_xxx)"},
@@ -115,7 +116,7 @@ var ImChatMessageList = common.Shortcut{
 		if _, err := buildChatMessageListRequest(runtime, chatId); err != nil {
 			return err
 		}
-		return nil
+		return ensureMessageReactionScope(runtime)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if _, err := common.ValidatePageSizeTyped(runtime, "page-size", chatMessagesListDefaultPageSize, 1, chatMessagesListMaxPageSize); err != nil {

--- a/shortcuts/im/im_message_reaction_scope.go
+++ b/shortcuts/im/im_message_reaction_scope.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import "github.com/larksuite/cli/shortcuts/common"
+
+const messageReactionReadScope = "im:message.reactions:read"
+
+// ensureMessageReactionScope keeps reaction enrichment opt-in at the scope
+// layer as well as the request layer. Pure builder tests construct partial
+// runtime contexts, so only run the token preflight for mounted commands.
+func ensureMessageReactionScope(runtime *common.RuntimeContext) error {
+	if runtime.Bool("no-reactions") || runtime.Factory == nil || runtime.Factory.Credential == nil || runtime.Config == nil {
+		return nil
+	}
+	return runtime.EnsureScopes([]string{messageReactionReadScope})
+}

--- a/shortcuts/im/im_message_reaction_scope_test.go
+++ b/shortcuts/im/im_message_reaction_scope_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+func TestMessagePullShortcutsDeclareReactionScopeAsConditional(t *testing.T) {
+	shortcuts := []common.Shortcut{
+		ImChatMessageList,
+		ImMessagesMGet,
+		ImThreadsMessagesList,
+		ImMessagesSearch,
+	}
+
+	for _, shortcut := range shortcuts {
+		for _, identity := range []string{"user", "bot"} {
+			t.Run(shortcut.Command+"/"+identity, func(t *testing.T) {
+				if slices.Contains(shortcut.ScopesForIdentity(identity), messageReactionReadScope) {
+					t.Fatalf("ScopesForIdentity(%q) contains conditional reaction scope", identity)
+				}
+				if !slices.Contains(shortcut.ConditionalScopesForIdentity(identity), messageReactionReadScope) {
+					t.Fatalf("ConditionalScopesForIdentity(%q) missing %q", identity, messageReactionReadScope)
+				}
+				if !slices.Contains(shortcut.DeclaredScopesForIdentity(identity), messageReactionReadScope) {
+					t.Fatalf("DeclaredScopesForIdentity(%q) missing %q", identity, messageReactionReadScope)
+				}
+			})
+		}
+	}
+}
+
+func TestChatMessagesListNoReactionsSkipsReactionScopePreflight(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{})
+	f.Credential = credential.NewCredentialProvider(nil, nil, scopedTokenResolver{
+		scopes: "im:message.group_msg:get_as_user im:message.p2p_msg:get_as_user",
+	}, nil)
+
+	err := mountAndRunIMShortcut(t, ImChatMessageList, f,
+		"+chat-messages-list",
+		"--chat-id", "oc_test",
+		"--as", "user",
+		"--no-reactions",
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("--no-reactions should not require %s: %v", messageReactionReadScope, err)
+	}
+}
+
+func TestChatMessagesListDefaultRequiresReactionScope(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{})
+	f.Credential = credential.NewCredentialProvider(nil, nil, scopedTokenResolver{
+		scopes: "im:message.group_msg:get_as_user im:message.p2p_msg:get_as_user",
+	}, nil)
+
+	err := mountAndRunIMShortcut(t, ImChatMessageList, f,
+		"+chat-messages-list",
+		"--chat-id", "oc_test",
+		"--as", "user",
+		"--dry-run",
+	)
+	if err == nil {
+		t.Fatalf("default enrichment should require %s", messageReactionReadScope)
+	}
+	var permErr *errs.PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *errs.PermissionError, got %T", err)
+	}
+	if permErr.Subtype != errs.SubtypeMissingScope {
+		t.Fatalf("Subtype = %q, want %q", permErr.Subtype, errs.SubtypeMissingScope)
+	}
+	if !strings.Contains(err.Error(), messageReactionReadScope) {
+		t.Fatalf("error = %q, want missing scope %q", err, messageReactionReadScope)
+	}
+}
+
+func mountAndRunIMShortcut(t *testing.T, shortcut common.Shortcut, f *cmdutil.Factory, args ...string) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "im"}
+	shortcut.Mount(parent, f)
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	return parent.Execute()
+}

--- a/shortcuts/im/im_messages_mget.go
+++ b/shortcuts/im/im_messages_mget.go
@@ -18,15 +18,16 @@ import (
 const maxMGetMessageIDs = 50
 
 var ImMessagesMGet = common.Shortcut{
-	Service:     "im",
-	Command:     "+messages-mget",
-	Description: "Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies",
-	Risk:        "read",
-	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:           "im",
+	Command:           "+messages-mget",
+	Description:       "Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies",
+	Risk:              "read",
+	Scopes:            []string{"im:message:readonly"},
+	UserScopes:        []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user"},
+	BotScopes:         []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	ConditionalScopes: []string{messageReactionReadScope},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
 	Flags: []common.Flag{
 		{Name: "message-ids", Aliases: []string{"message-id"}, Desc: "message IDs, comma-separated (om_xxx,om_yyy)", Required: true},
 		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},
@@ -58,7 +59,7 @@ var ImMessagesMGet = common.Shortcut{
 				return err
 			}
 		}
-		return nil
+		return ensureMessageReactionScope(runtime)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		ids := common.SplitCSV(runtime.Str("message-ids"))

--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -27,13 +27,14 @@ const (
 )
 
 var ImMessagesSearch = common.Shortcut{
-	Service:     "im",
-	Command:     "+messages-search",
-	Description: "Search messages across chats (supports keyword, sender, time range filters) with user or bot identity; filters by chat/sender/attachment/time, enriches results via mget and chats batch_query",
-	Risk:        "read",
-	Scopes:      []string{"search:message", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:           "im",
+	Command:           "+messages-search",
+	Description:       "Search messages across chats (supports keyword, sender, time range filters) with user or bot identity; filters by chat/sender/attachment/time, enriches results via mget and chats batch_query",
+	Risk:              "read",
+	Scopes:            []string{"search:message"},
+	ConditionalScopes: []string{messageReactionReadScope},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
 	Flags: []common.Flag{
 		{Name: "query", Aliases: []string{"keyword"}, Desc: "search keyword"},
 		{Name: "chat-id", Desc: "limit to chat IDs, comma-separated"},
@@ -83,8 +84,10 @@ var ImMessagesSearch = common.Shortcut{
 		return d
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		_, err := buildMessagesSearchRequest(runtime)
-		return err
+		if _, err := buildMessagesSearchRequest(runtime); err != nil {
+			return err
+		}
+		return ensureMessageReactionScope(runtime)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		req, err := buildMessagesSearchRequest(runtime)

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -24,15 +24,16 @@ const (
 )
 
 var ImThreadsMessagesList = common.Shortcut{
-	Service:     "im",
-	Command:     "+threads-messages-list",
-	Description: "List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports --order asc/desc sorting, auto-pagination",
-	Risk:        "read",
-	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:           "im",
+	Command:           "+threads-messages-list",
+	Description:       "List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports --order asc/desc sorting, auto-pagination",
+	Risk:              "read",
+	Scopes:            []string{"im:message:readonly"},
+	UserScopes:        []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user"},
+	BotScopes:         []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	ConditionalScopes: []string{messageReactionReadScope},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
 	Flags: append([]common.Flag{
 		{Name: "thread", Aliases: []string{"thread-id"}, Desc: "thread ID (om_xxx or omt_xxx)", Required: true},
 		{Name: "order", Aliases: []string{"sort"}, Default: "asc", Desc: "sort order: asc | desc", Enum: []string{"asc", "desc"}},
@@ -88,7 +89,10 @@ var ImThreadsMessagesList = common.Shortcut{
 		if _, err := common.ValidatePageSizeTyped(runtime, "page-size", threadsMessagesListDefaultPageSize, 1, threadsMessagesListMaxPageSize); err != nil {
 			return err
 		}
-		return common.ValidatePageAllFlags(runtime)
+		if err := common.ValidatePageAllFlags(runtime); err != nil {
+			return err
+		}
+		return ensureMessageReactionScope(runtime)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		pageSize, err := common.ValidatePageSizeTyped(runtime, "page-size", threadsMessagesListDefaultPageSize, 1, threadsMessagesListMaxPageSize)

--- a/skills/lark-im/references/lark-im-message-enrichment.md
+++ b/skills/lark-im/references/lark-im-message-enrichment.md
@@ -36,7 +36,7 @@ Use `--download-resources` when you want the binaries on disk in one pass; other
 
 ## Scope requirement
 
-The default enrichment requires `im:message.reactions:read`, already declared in each shortcut's `UserScopes` / `BotScopes` (or `Scopes` for the search command), so the framework's pre-flight check surfaces a `missing_scope` error before the request is sent. Bots that were registered before this scope was added need an incremental authorization in the Feishu developer console; users can run:
+The default enrichment requires `im:message.reactions:read`. The four message-pulling shortcuts declare it as a conditional scope and pre-flight it whenever reaction enrichment is enabled, so a missing grant surfaces before the request is sent. Pass `--no-reactions` to skip both the enrichment request and this conditional scope requirement. Bots that were registered before this scope was added need an incremental authorization in the Feishu developer console; users can run:
 
 ```bash
 lark-cli auth login --scope "im:message.reactions:read"

--- a/tests/cli_e2e/im/im_reaction_enrichment_dryrun_test.go
+++ b/tests/cli_e2e/im/im_reaction_enrichment_dryrun_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+const reactionsBatchQueryPath = "/open-apis/im/v1/messages/reactions/batch_query"
+
+// TestIM_ReactionEnrichmentDryRun pins the observable half of the conditional
+// reaction scope: enrichment is a second request, so --no-reactions must leave
+// the plan with the message read alone. If the flag stopped suppressing the
+// batch_query, requiring im:message.reactions:read only when enrichment runs
+// would be wrong regardless of how the scope is declared.
+func TestIM_ReactionEnrichmentDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	tests := []struct {
+		name       string
+		args       []string
+		method     string
+		path       string
+		pathPrefix string
+		defaultAs  string
+	}{
+		{
+			name:   "chat-messages-list",
+			args:   []string{"im", "+chat-messages-list", "--chat-id", "oc_dryrun"},
+			method: http.MethodGet,
+			path:   "/open-apis/im/v1/messages",
+		},
+		{
+			name:   "threads-messages-list",
+			args:   []string{"im", "+threads-messages-list", "--thread", "omt_dryrun"},
+			method: http.MethodGet,
+			path:   "/open-apis/im/v1/messages",
+		},
+		{
+			name:   "messages-mget",
+			args:   []string{"im", "+messages-mget", "--message-ids", "om_dryrun"},
+			method: http.MethodGet,
+			// mget carries its query inline in the planned URL
+			pathPrefix: "/open-apis/im/v1/messages/mget",
+		},
+		{
+			name:      "messages-search",
+			args:      []string{"im", "+messages-search", "--query", "release"},
+			method:    http.MethodPost,
+			path:      "/open-apis/im/v1/messages/search",
+			defaultAs: "user",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			as := tc.defaultAs
+			if as == "" {
+				as = "bot"
+			}
+
+			t.Run("default enriches", func(t *testing.T) {
+				args := append(append([]string{}, tc.args...), "--dry-run")
+				result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: args, DefaultAs: as})
+				require.NoError(t, err)
+				result.AssertExitCode(t, 0)
+
+				out := result.Stdout
+				assertPlannedRead(t, out, tc.method, tc.path, tc.pathPrefix)
+				require.Equal(t, reactionsBatchQueryPath, clie2e.DryRunGet(out, "api.1.url").String(),
+					"enrichment request missing from the default plan; stdout:\n%s", out)
+				require.Equal(t, http.MethodPost, clie2e.DryRunGet(out, "api.1.method").String(), "stdout:\n%s", out)
+			})
+
+			t.Run("no-reactions skips enrichment", func(t *testing.T) {
+				args := append(append([]string{}, tc.args...), "--no-reactions", "--dry-run")
+				result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: args, DefaultAs: as})
+				require.NoError(t, err)
+				result.AssertExitCode(t, 0)
+
+				out := result.Stdout
+				assertPlannedRead(t, out, tc.method, tc.path, tc.pathPrefix)
+				require.False(t, clie2e.DryRunGet(out, "api.1").Exists(),
+					"--no-reactions still planned a second request; stdout:\n%s", out)
+			})
+		})
+	}
+}
+
+// assertPlannedRead checks the message read that every one of these shortcuts
+// plans first. mget encodes its query into the planned URL, so it is matched by
+// prefix instead of equality.
+func assertPlannedRead(t *testing.T, stdout, method, path, pathPrefix string) {
+	t.Helper()
+
+	require.Equal(t, method, clie2e.DryRunGet(stdout, "api.0.method").String(), "stdout:\n%s", stdout)
+	url := clie2e.DryRunGet(stdout, "api.0.url").String()
+	if pathPrefix != "" {
+		require.True(t, strings.HasPrefix(url, pathPrefix),
+			"planned url %q does not start with %q; stdout:\n%s", url, pathPrefix, stdout)
+		return
+	}
+	require.Equal(t, path, url, "stdout:\n%s", stdout)
+}


### PR DESCRIPTION
## Summary

Make the reaction scope conditional for message-pulling shortcuts so `--no-reactions` can fetch messages without requiring `im:message.reactions:read`. The default enrichment path still preflights the reaction scope before sending a request.

## Changes

- Move `im:message.reactions:read` from unconditional scopes to `ConditionalScopes` for the four message-pulling shortcuts.
- Enforce the conditional scope from validation only when reaction enrichment is enabled.
- Add command-level regression tests for both the opt-out and default paths, plus scope declaration coverage and updated documentation.
- Add a dry-run E2E under `tests/cli_e2e/im/` covering all four shortcuts.

## Test Plan

Run against `84f94143` as the base, after rebasing onto current `main`.

| Check | Result |
| --- | --- |
| `make unit-test` | pass, all packages |
| `make vet` | pass |
| `make fmt-check` | pass |
| `make build` | pass |
| `make quality-gate` | pass |
| `go mod tidy`, then `git diff --exit-code -- go.mod go.sum` | unchanged |
| `golangci-lint run --new-from-rev=<base>` | `0 issues` |
| `go run -C lint . --changed-from <base> ..` | pass |
| `go test -C lint ./... -count=1` | pass |
| `node scripts/skill-format-check/index.js` | pass |
| `go test ./tests/cli_e2e/im/ -run TestIM_ReactionEnrichmentDryRun` | pass, 8 subtests |

`make quality-gate` emits one pre-existing warning unrelated to this change: `im +feed-shortcut-list looks like a list command without an explicit default limit flag`. It is not introduced here — `main` raises the same `default_output` warning for `base +base-block-list`, `+form-questions-list` and `+record-search`.

### Revert-failing regression

`TestMessagePullShortcutsDeclareReactionScopeAsConditional` is the test that fails if this change is reverted. Verified by restoring the four shortcut files to the base commit and re-running it:

```
im_message_reaction_scope_test.go:32: ScopesForIdentity("bot") contains conditional reaction scope
FAIL	github.com/larksuite/cli/shortcuts/im
```

### What the dry-run E2E does and does not cover

`--no-reactions` already suppressed the `POST /open-apis/im/v1/messages/reactions/batch_query` call before this change, so the planned request set is identical with and without the fix, and a dry-run assertion cannot demonstrate the scope change. I confirmed that: the new test passes on the base commit too.

It is included because the conditional scope is only correct while enrichment really is a separate, suppressible request. If enrichment ever became unconditional, requiring `im:message.reactions:read` only when it runs would silently become wrong, and nothing at the command boundary asserted that premise. The test pins it for all four shortcuts: the default plan carries the enrichment POST, `--no-reactions` leaves the message read alone.

### Live E2E: not run, and why

Per the shortcut-change table this is a bug fix whose risk reaches the API boundary, so live E2E would normally be required. There is no deterministic, cleanable live flow for it.

The behaviour under test is which scopes are demanded, so a live assertion needs two tenant app configurations that differ only in whether `im:message.reactions:read` is granted, and it has to prove `--no-reactions` succeeds under the narrower one. Scope grants are tenant-level app configuration; a test cannot create or revoke them, so the flow is neither self-contained nor cleanable, and hard-coding two app credentials would leak tenant state and make the lane environment-dependent.

Fixture conditions that would make it runnable: a second tenant app credential in the live lane, provisioned without the reaction scope and with a stable chat fixture, exposed alongside `TEST_TENANT_ACCESS_TOKEN`. I have not added one.

Substitute evidence, all deterministic and offline:

- scope declarations asserted per shortcut per identity (`ScopesForIdentity`, `ConditionalScopesForIdentity`, `DeclaredScopesForIdentity`)
- validation asserted to demand the reaction scope only when enrichment is enabled, for both the opt-out and default paths
- the dry-run E2E above, pinning that `--no-reactions` removes the enrichment request

CI is authoritative. Live E2E is the one relevant check I did not run.

## Related Issues

- Fixes #2352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reaction permissions are now requested only when reaction enrichment is enabled.
  * Commands using `--no-reactions` skip reaction loading and related permission checks.
  * Improved validation for message lists, searches, threads, pagination, and message retrieval.
  * Prevented unnecessary permission errors when reaction data is not requested.

* **Documentation**
  * Clarified when reaction permissions are required and when they can be omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

Rebased onto `84f94143` on 2026-08-27 so the branch is current; the patch is byte-identical to before the rebase (339 changed lines across 8 files) and every check above was re-run on the new base.

---

### On the empty checks column

`CI`, `PR Preview Package` and `Skill Format Check` are sitting at
`action_required` on this branch — GitHub holds workflow runs for an outside
contributor until a maintainer approves them, so no CI result has been produced
yet. The check matrix above is what I ran locally against the stated base; it is
not a substitute for CI, and I am not claiming CI passed. Happy to push again if
approving the runs surfaces anything.
