### PR TITLE
fix(apps): bound plugin archive extraction

### DIFF
--- a/shortcuts/apps/apps_plugin_install.go
+++ b/shortcuts/apps/apps_plugin_install.go
@@ -299,6 +299,10 @@ func pluginStageTGZ(tgzData []byte, parentDir string) (string, error) {
 }
 
 func pluginReplaceDirectory(stagedDir, destDir string) error {
+	return pluginReplaceDirectoryWithRename(stagedDir, destDir, os.Rename) //nolint:forbidigo // same-filesystem staged replacement and rollback.
+}
+
+func pluginReplaceDirectoryWithRename(stagedDir, destDir string, rename func(string, string) error) error {
 	parentDir := filepath.Dir(destDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil { //nolint:forbidigo // local project-owned node_modules directory.
 		return err
@@ -307,12 +311,17 @@ func pluginReplaceDirectory(stagedDir, destDir string) error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(backupRoot) //nolint:forbidigo // remove prior version after successful replacement or rollback.
+	removeBackup := true
+	defer func() {
+		if removeBackup {
+			_ = os.RemoveAll(backupRoot) //nolint:forbidigo // remove prior version after successful replacement or rollback.
+		}
+	}()
 
 	backupDir := filepath.Join(backupRoot, "previous")
 	hadExisting := false
 	if _, err := os.Lstat(destDir); err == nil { //nolint:forbidigo // local project directory state check.
-		if err := os.Rename(destDir, backupDir); err != nil { //nolint:forbidigo // preserve current version for rollback.
+		if err := rename(destDir, backupDir); err != nil {
 			return err
 		}
 		hadExisting = true
@@ -320,10 +329,11 @@ func pluginReplaceDirectory(stagedDir, destDir string) error {
 		return err
 	}
 
-	if err := os.Rename(stagedDir, destDir); err != nil { //nolint:forbidigo // same-filesystem staged replacement.
+	if err := rename(stagedDir, destDir); err != nil {
 		if hadExisting {
-			if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil { //nolint:forbidigo // best-effort rollback of current version.
-				return fmt.Errorf("replace plugin: %w; restore previous plugin: %v", err, restoreErr) //nolint:forbidigo // intermediate helper error; callers wrap as typed
+			if restoreErr := rename(backupDir, destDir); restoreErr != nil {
+				removeBackup = false
+				return fmt.Errorf("replace plugin: %w; restore previous plugin: %v; previous plugin preserved at %s", err, restoreErr, backupDir) //nolint:forbidigo // intermediate helper error; callers wrap as typed
 			}
 		}
 		return err

--- a/shortcuts/apps/apps_plugin_install.go
+++ b/shortcuts/apps/apps_plugin_install.go
@@ -139,19 +139,18 @@ func pluginInstallOne(ctx context.Context, rctx *common.RuntimeContext, projectP
 		return err
 	}
 
-	// Extract to node_modules
+	// Extract beside the destination and replace only after validation succeeds.
 	destDir, err := secureModulePath(projectPath, key)
 	if err != nil {
 		return err
 	}
-	if err := os.RemoveAll(destDir); err != nil { //nolint:forbidigo // shortcuts cannot import internal/vfs; clean before extract.
-		return appsFileIOError(err, "cannot clean %s", destDir)
-	}
-	if err := os.MkdirAll(destDir, 0o755); err != nil { //nolint:forbidigo
-		return appsFileIOError(err, "cannot create %s", destDir)
-	}
-	if err := pluginExtractTGZ(bytes.NewReader(tgzData), destDir); err != nil {
+	stagedDir, err := pluginStageTGZ(tgzData, filepath.Dir(destDir))
+	if err != nil {
 		return appsFileIOError(err, "cannot extract plugin package for %s", key)
+	}
+	defer os.RemoveAll(stagedDir) //nolint:forbidigo // best-effort cleanup if replacement fails.
+	if err := pluginReplaceDirectory(stagedDir, destDir); err != nil {
+		return appsFileIOError(err, "cannot replace plugin package for %s", key)
 	}
 
 	// Check peer dependencies
@@ -255,25 +254,14 @@ func pluginInstallLocal(rctx *common.RuntimeContext, projectPath, tgzPath string
 		version = "0.0.0"
 	}
 
-	// Move to node_modules
+	// Move to node_modules without deleting the previous version until the
+	// staged package is ready to replace it.
 	destDir, err := secureModulePath(projectPath, key)
 	if err != nil {
 		return err
 	}
-	if err := os.RemoveAll(destDir); err != nil { //nolint:forbidigo
-		return appsFileIOError(err, "cannot clean %s", destDir)
-	}
-	if err := os.MkdirAll(filepath.Dir(destDir), 0o755); err != nil { //nolint:forbidigo
-		return appsFileIOError(err, "cannot create parent dir for %s", destDir)
-	}
-	if err := os.Rename(tmpDir, destDir); err != nil { //nolint:forbidigo
-		// rename may fail across filesystems; fall back to re-extract
-		if err2 := os.MkdirAll(destDir, 0o755); err2 != nil { //nolint:forbidigo
-			return appsFileIOError(err2, "cannot create %s", destDir)
-		}
-		if err2 := pluginExtractTGZ(bytes.NewReader(tgzData), destDir); err2 != nil {
-			return appsFileIOError(err2, "cannot extract plugin to %s", destDir)
-		}
+	if err := pluginReplaceDirectory(tmpDir, destDir); err != nil {
+		return appsFileIOError(err, "cannot replace plugin package for %s", key)
 	}
 
 	// Update package.json actionPlugins
@@ -292,6 +280,54 @@ func pluginInstallLocal(rctx *common.RuntimeContext, projectPath, tgzPath string
 	rctx.OutFormat(result, nil, func(w io.Writer) {
 		fmt.Fprintf(w, "✓ Installed %s@%s (from local %s)\n", key, version, tgzPath)
 	})
+	return nil
+}
+
+func pluginStageTGZ(tgzData []byte, parentDir string) (string, error) {
+	if err := os.MkdirAll(parentDir, 0o755); err != nil { //nolint:forbidigo // local project-owned node_modules directory.
+		return "", err
+	}
+	stagedDir, err := os.MkdirTemp(parentDir, ".plugin-install-*") //nolint:forbidigo // same filesystem as destination for rename.
+	if err != nil {
+		return "", err
+	}
+	if err := pluginExtractTGZ(bytes.NewReader(tgzData), stagedDir); err != nil {
+		_ = os.RemoveAll(stagedDir) //nolint:forbidigo // discard rejected partial extraction.
+		return "", err
+	}
+	return stagedDir, nil
+}
+
+func pluginReplaceDirectory(stagedDir, destDir string) error {
+	parentDir := filepath.Dir(destDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil { //nolint:forbidigo // local project-owned node_modules directory.
+		return err
+	}
+	backupRoot, err := os.MkdirTemp(parentDir, ".plugin-backup-*") //nolint:forbidigo // unique same-filesystem rollback location.
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(backupRoot) //nolint:forbidigo // remove prior version after successful replacement or rollback.
+
+	backupDir := filepath.Join(backupRoot, "previous")
+	hadExisting := false
+	if _, err := os.Lstat(destDir); err == nil { //nolint:forbidigo // local project directory state check.
+		if err := os.Rename(destDir, backupDir); err != nil { //nolint:forbidigo // preserve current version for rollback.
+			return err
+		}
+		hadExisting = true
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := os.Rename(stagedDir, destDir); err != nil { //nolint:forbidigo // same-filesystem staged replacement.
+		if hadExisting {
+			if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil { //nolint:forbidigo // best-effort rollback of current version.
+				return fmt.Errorf("replace plugin: %w; restore previous plugin: %v", err, restoreErr) //nolint:forbidigo // intermediate helper error; callers wrap as typed
+			}
+		}
+		return err
+	}
 	return nil
 }
 

--- a/shortcuts/apps/apps_plugin_install_test.go
+++ b/shortcuts/apps/apps_plugin_install_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/internal/httpmock"
@@ -18,6 +19,17 @@ import (
 func TestPluginInstall_SinglePlugin(t *testing.T) {
 	dir := t.TempDir()
 	writeTestPkgJSON(t, dir, map[string]interface{}{})
+	oldPluginDir := filepath.Join(dir, "node_modules", "@test", "my-plugin")
+	if err := os.MkdirAll(oldPluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oldPluginDir, "package.json"), []byte(`{"version":"0.9.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldMarker := filepath.Join(oldPluginDir, "old.txt")
+	if err := os.WriteFile(oldMarker, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	chdirTest(t, dir)
 
 	factory, stdout, reg := newAppsExecuteFactory(t)
@@ -65,6 +77,9 @@ func TestPluginInstall_SinglePlugin(t *testing.T) {
 	manifestPath := filepath.Join(dir, "node_modules", "@test/my-plugin", "manifest.json")
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Fatalf("manifest.json not extracted: %v", err)
+	}
+	if _, err := os.Stat(oldMarker); !os.IsNotExist(err) {
+		t.Fatalf("old plugin content must be replaced after successful extraction, stat error = %v", err)
 	}
 
 	// Verify package.json updated
@@ -155,6 +170,117 @@ func TestPluginExtractTGZ_PathTraversal(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(destDir, "..", "..", "etc", "passwd")); err == nil {
 		t.Error("path traversal should have been blocked")
+	}
+}
+
+func TestPluginExtractTGZ_RejectsAggregateExpandedSize(t *testing.T) {
+	tgzData := buildTestTGZ(t, map[string]string{
+		"first.txt":  "123456",
+		"second.txt": "12345",
+	})
+	destDir := t.TempDir()
+	err := pluginExtractTGZWithLimits(bytes.NewReader(tgzData), destDir, pluginExtractLimits{
+		maxEntryBytes: 10,
+		maxTotalBytes: 10,
+		maxEntries:    10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "expanded size limit") {
+		t.Fatalf("extract error = %v, want expanded size limit", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "second.txt")); !os.IsNotExist(err) {
+		t.Fatalf("second entry must not be created after aggregate limit failure, stat error = %v", err)
+	}
+}
+
+func TestPluginExtractTGZ_RejectsOversizedEntryWithoutTruncation(t *testing.T) {
+	tgzData := buildTestTGZ(t, map[string]string{"large.txt": "12345"})
+	destDir := t.TempDir()
+	err := pluginExtractTGZWithLimits(bytes.NewReader(tgzData), destDir, pluginExtractLimits{
+		maxEntryBytes: 4,
+		maxTotalBytes: 10,
+		maxEntries:    10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("extract error = %v, want entry size limit", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "large.txt")); !os.IsNotExist(err) {
+		t.Fatalf("oversized entry must not be truncated to disk, stat error = %v", err)
+	}
+}
+
+func TestPluginExtractTGZ_RejectsTooManyEntries(t *testing.T) {
+	tgzData := buildTestTGZ(t, map[string]string{
+		"first.txt":  "1",
+		"second.txt": "2",
+		"third.txt":  "3",
+	})
+	destDir := t.TempDir()
+	err := pluginExtractTGZWithLimits(bytes.NewReader(tgzData), destDir, pluginExtractLimits{
+		maxEntryBytes: 10,
+		maxTotalBytes: 10,
+		maxEntries:    2,
+	})
+	if err == nil || !strings.Contains(err.Error(), "entry limit") {
+		t.Fatalf("extract error = %v, want entry limit", err)
+	}
+}
+
+func TestPluginInstall_RejectedArchivePreservesExistingPlugin(t *testing.T) {
+	dir := t.TempDir()
+	writeTestPkgJSON(t, dir, map[string]interface{}{
+		"actionPlugins": map[string]interface{}{"@test/my-plugin": "0.9.0"},
+	})
+	pluginDir := filepath.Join(dir, "node_modules", "@test", "my-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	markerPath := filepath.Join(pluginDir, "keep.txt")
+	if err := os.WriteFile(filepath.Join(pluginDir, "package.json"), []byte(`{"version":"0.9.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(markerPath, []byte("old plugin"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTest(t, dir)
+
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/spark/v1/plugin/versions/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"items": []interface{}{
+				map[string]interface{}{"key": "@test/my-plugin", "version": "1.0.0"},
+			}},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:      "POST",
+		URL:         "/open-apis/spark/v1/plugin/versions/download_package",
+		RawBody:     []byte("not a gzip stream"),
+		ContentType: "application/octet-stream",
+	})
+
+	err := runAppsShortcut(t, AppsPluginInstall, []string{
+		"+plugin-install", "--name", "@test/my-plugin", "--version", "1.0.0",
+		"--format", "json", "--as", "user",
+	}, factory, stdout)
+	if err == nil {
+		t.Fatal("install should reject malformed plugin archive")
+	}
+	data, readErr := os.ReadFile(markerPath)
+	if readErr != nil {
+		t.Fatalf("existing plugin was not preserved: %v", readErr)
+	}
+	if string(data) != "old plugin" {
+		t.Fatalf("existing marker = %q, want old plugin", data)
+	}
+	staged, globErr := filepath.Glob(filepath.Join(filepath.Dir(pluginDir), ".plugin-install-*"))
+	if globErr != nil {
+		t.Fatal(globErr)
+	}
+	if len(staged) != 0 {
+		t.Fatalf("rejected staging directories were not cleaned up: %v", staged)
 	}
 }
 

--- a/shortcuts/apps/apps_plugin_install_test.go
+++ b/shortcuts/apps/apps_plugin_install_test.go
@@ -8,11 +8,14 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
 )
 
@@ -268,6 +271,16 @@ func TestPluginInstall_RejectedArchivePreservesExistingPlugin(t *testing.T) {
 	if err == nil {
 		t.Fatal("install should reject malformed plugin archive")
 	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("install error is not structured: %v", err)
+	}
+	if problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeFileIO {
+		t.Fatalf("error classification = %s/%s, want %s/%s", problem.Category, problem.Subtype, errs.CategoryInternal, errs.SubtypeFileIO)
+	}
+	if !errors.Is(err, gzip.ErrHeader) {
+		t.Fatalf("malformed gzip cause not preserved: %v", err)
+	}
 	data, readErr := os.ReadFile(markerPath)
 	if readErr != nil {
 		t.Fatalf("existing plugin was not preserved: %v", readErr)
@@ -284,6 +297,59 @@ func TestPluginInstall_RejectedArchivePreservesExistingPlugin(t *testing.T) {
 	}
 }
 
+func TestPluginReplaceDirectory_RollbackFailurePreservesBackup(t *testing.T) {
+	root := t.TempDir()
+	stagedDir := filepath.Join(root, "staged")
+	destDir := filepath.Join(root, "plugin")
+	if err := os.MkdirAll(stagedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, "keep.txt"), []byte("old plugin"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	replaceErr := errors.New("replace failed")
+	restoreErr := errors.New("restore failed")
+	renameCalls := 0
+	err := pluginReplaceDirectoryWithRename(stagedDir, destDir, func(oldPath, newPath string) error {
+		renameCalls++
+		switch renameCalls {
+		case 1:
+			return os.Rename(oldPath, newPath)
+		case 2:
+			return replaceErr
+		case 3:
+			return restoreErr
+		default:
+			t.Fatalf("unexpected rename call %d", renameCalls)
+			return nil
+		}
+	})
+	if !errors.Is(err, replaceErr) {
+		t.Fatalf("replace error = %v, want preserved replacement cause", err)
+	}
+	if !strings.Contains(err.Error(), "previous plugin preserved at") {
+		t.Fatalf("replace error = %v, want backup recovery path", err)
+	}
+	backups, globErr := filepath.Glob(filepath.Join(root, ".plugin-backup-*", "previous", "keep.txt"))
+	if globErr != nil {
+		t.Fatal(globErr)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("preserved backup files = %v, want one", backups)
+	}
+	data, readErr := os.ReadFile(backups[0])
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != "old plugin" {
+		t.Fatalf("preserved backup = %q, want old plugin", data)
+	}
+}
+
 // buildTestTGZ creates a .tgz in memory with files under a "package/" prefix.
 func buildTestTGZ(t *testing.T, files map[string]string) []byte {
 	t.Helper()
@@ -291,7 +357,13 @@ func buildTestTGZ(t *testing.T, files map[string]string) []byte {
 	gz := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gz)
 
-	for name, content := range files {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		content := files[name]
 		tw.WriteHeader(&tar.Header{
 			Name:     "package/" + name,
 			Size:     int64(len(content)),

--- a/shortcuts/apps/plugin_common.go
+++ b/shortcuts/apps/plugin_common.go
@@ -344,12 +344,33 @@ func pluginInstalledVersion(projectPath, pluginKey string) string {
 
 // ── tgz extraction ──
 
-const pluginExtractMaxBytes = 10 * 1024 * 1024
+const (
+	// Remote plugin packages are capped at 10 MiB compressed. Keep both a
+	// per-file limit and an archive-wide expansion budget so compression ratio
+	// and entry count cannot turn one accepted package into unbounded local IO.
+	pluginExtractMaxEntryBytes = 10 * 1024 * 1024
+	pluginExtractMaxTotalBytes = 100 * 1024 * 1024
+	pluginExtractMaxEntries    = 10_000
+)
+
+type pluginExtractLimits struct {
+	maxEntryBytes int64
+	maxTotalBytes int64
+	maxEntries    int
+}
 
 // pluginExtractTGZ extracts a gzipped tar archive into destDir, stripping the
 // first path component (npm convention: tarballs contain a "package/" prefix).
 // Path traversal entries are silently skipped.
 func pluginExtractTGZ(r io.Reader, destDir string) error {
+	return pluginExtractTGZWithLimits(r, destDir, pluginExtractLimits{
+		maxEntryBytes: pluginExtractMaxEntryBytes,
+		maxTotalBytes: pluginExtractMaxTotalBytes,
+		maxEntries:    pluginExtractMaxEntries,
+	})
+}
+
+func pluginExtractTGZWithLimits(r io.Reader, destDir string, limits pluginExtractLimits) error {
 	gz, err := gzip.NewReader(r)
 	if err != nil {
 		return fmt.Errorf("gzip: %w", err) //nolint:forbidigo // intermediate helper error; callers wrap as typed
@@ -358,6 +379,8 @@ func pluginExtractTGZ(r io.Reader, destDir string) error {
 
 	cleanDest := filepath.Clean(destDir) + string(filepath.Separator)
 	tr := tar.NewReader(gz)
+	var totalBytes int64
+	entries := 0
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -365,6 +388,10 @@ func pluginExtractTGZ(r io.Reader, destDir string) error {
 		}
 		if err != nil {
 			return fmt.Errorf("tar: %w", err) //nolint:forbidigo // intermediate helper error; callers wrap as typed
+		}
+		entries++
+		if entries > limits.maxEntries {
+			return fmt.Errorf("tar archive exceeds %d-entry limit", limits.maxEntries) //nolint:forbidigo // intermediate helper error; callers wrap as typed
 		}
 
 		name := pluginStripFirstComponent(hdr.Name)
@@ -389,6 +416,16 @@ func pluginExtractTGZ(r io.Reader, destDir string) error {
 				return err
 			}
 		case tar.TypeReg:
+			if hdr.Size < 0 {
+				return fmt.Errorf("tar entry %q has invalid negative size %d", hdr.Name, hdr.Size) //nolint:forbidigo // intermediate helper error; callers wrap as typed
+			}
+			if hdr.Size > limits.maxEntryBytes {
+				return fmt.Errorf("tar entry %q exceeds %d-byte size limit", hdr.Name, limits.maxEntryBytes) //nolint:forbidigo // intermediate helper error; callers wrap as typed
+			}
+			if hdr.Size > limits.maxTotalBytes-totalBytes {
+				return fmt.Errorf("tar archive exceeds %d-byte expanded size limit", limits.maxTotalBytes) //nolint:forbidigo // intermediate helper error; callers wrap as typed
+			}
+			totalBytes += hdr.Size
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { //nolint:forbidigo
 				return err
 			}
@@ -396,7 +433,7 @@ func pluginExtractTGZ(r io.Reader, destDir string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(f, io.LimitReader(tr, pluginExtractMaxBytes)); err != nil {
+			if _, err := io.CopyN(f, tr, hdr.Size); err != nil {
 				if cerr := f.Close(); cerr != nil {
 					return fmt.Errorf("copy tar entry: %w; close file: %w", err, cerr) //nolint:forbidigo // intermediate helper error; callers wrap as typed
 				}


### PR DESCRIPTION
限制单个条目、累计解压大小和条目数量。
解压失败时保留旧插件，避免留下不完整安装。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin installations now preserve the currently installed version if the new package is invalid or cannot be installed.
  * Replacing a plugin removes stale files from the previous version after a successful installation.
  * Improved cleanup prevents temporary installation files from being left behind.
  * Plugin archives exceeding per-file, total-size, or entry-count limits are rejected to improve installation safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->