### PR TITLE
feat(config): add DeepSeek Harness as a bind source

### DIFF
--- a/cmd/config/bind.go
+++ b/cmd/config/bind.go
@@ -73,9 +73,9 @@ func newCmdConfigBind(
 	cmd := &cobra.Command{
 		Use:   "bind",
 		Short: "Bind Agent config to a workspace (source / app-id / force)",
-		Long: `Bind an AI Agent's (OpenClaw / Hermes / Lark Channel) Feishu credentials to a lark-cli workspace.
+		Long: `Bind an AI Agent's (OpenClaw / Hermes / Lark Channel / DeepSeek Harness) Feishu credentials to a lark-cli workspace.
 
---source is auto-detected from env (OPENCLAW_HOME / HERMES_HOME / LARK_CHANNEL); pass it only to override.
+--source is auto-detected from env (OPENCLAW_HOME / HERMES_HOME / LARK_CHANNEL / DSH_HOME); pass it only to override.
 
 For AI agents — DO NOT bind without user confirmation. Binding may
 overwrite an existing one and locks in an identity policy. Ask the user:
@@ -100,6 +100,9 @@ Interactive terminal use: run with no flags to enter the TUI form.`,
   lark-cli config bind --source hermes --identity user-default
   lark-cli config bind --source lark-channel
 
+  # Inside a DeepSeek Harness agent the source is already detected:
+  lark-cli config bind --identity bot-only
+
   # Interactive (terminal user) — TUI prompts for everything:
   lark-cli config bind`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -111,7 +114,7 @@ Interactive terminal use: run with no flags to enter the TUI form.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Source, "source", "", "Agent source to bind from (openclaw|hermes|lark-channel); auto-detected from env signals when omitted")
+	cmd.Flags().StringVar(&opts.Source, "source", "", "Agent source to bind from (openclaw|hermes|lark-channel|dsh); auto-detected from env signals when omitted")
 	cmd.Flags().StringVar(&opts.AppID, "app-id", "", "App ID to bind (required for OpenClaw multi-account)")
 	cmd.Flags().StringVar(&opts.Identity, "identity", "", "identity preset (bot-only|user-default); defaults to bot-only in flag mode (safer: no impersonation)")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "confirm a risky transition (currently: bot-only → user-default identity change in flag mode)")
@@ -194,8 +197,8 @@ type existingBinding struct {
 //     fall back to a TUI prompt (TUI mode) or an error (flag mode).
 func finalizeSource(opts *BindOptions) (string, error) {
 	explicit := strings.TrimSpace(strings.ToLower(opts.Source))
-	if explicit != "" && explicit != "openclaw" && explicit != "hermes" && explicit != "lark-channel" {
-		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --source %q; valid values: openclaw, hermes, lark-channel", explicit).WithParam("--source")
+	if explicit != "" && explicit != "openclaw" && explicit != "hermes" && explicit != "lark-channel" && explicit != "dsh" {
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --source %q; valid values: openclaw, hermes, lark-channel, dsh", explicit).WithParam("--source")
 	}
 
 	var detected string
@@ -206,6 +209,8 @@ func finalizeSource(opts *BindOptions) (string, error) {
 		detected = "hermes"
 	case core.WorkspaceLarkChannel:
 		detected = "lark-channel"
+	case core.WorkspaceDSH:
+		detected = "dsh"
 	}
 
 	// Explicit and env detection must agree when both are present. Reject
@@ -242,7 +247,7 @@ func finalizeSource(opts *BindOptions) (string, error) {
 	}
 	return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
 		"cannot determine Agent source: no --source flag and no Agent environment detected").
-		WithHint("pass --source openclaw|hermes|lark-channel, or run this command inside the corresponding Agent context").
+		WithHint("pass --source openclaw|hermes|lark-channel|dsh, or run this command inside the corresponding Agent context").
 		WithParam("--source")
 }
 
@@ -541,6 +546,8 @@ func tuiSelectSource(opts *BindOptions) (string, error) {
 		source = "hermes"
 	case core.WorkspaceLarkChannel:
 		source = "lark-channel"
+	case core.WorkspaceDSH:
+		source = "dsh"
 	default:
 		source = "openclaw" // default first option
 	}
@@ -549,6 +556,7 @@ func tuiSelectSource(opts *BindOptions) (string, error) {
 	openclawPath := resolveOpenClawConfigPath()
 	hermesEnvPath := resolveHermesEnvPath()
 	larkChannelPath := resolveLarkChannelConfigPath()
+	dshPath := resolveDSHSettingsPath()
 
 	form := huh.NewForm(
 		huh.NewGroup(
@@ -559,6 +567,7 @@ func tuiSelectSource(opts *BindOptions) (string, error) {
 					huh.NewOption(fmt.Sprintf(msg.SourceOpenClaw, openclawPath), "openclaw"),
 					huh.NewOption(fmt.Sprintf(msg.SourceHermes, hermesEnvPath), "hermes"),
 					huh.NewOption(fmt.Sprintf(msg.SourceLarkChannel, larkChannelPath), "lark-channel"),
+					huh.NewOption(fmt.Sprintf(msg.SourceDSH, dshPath), "dsh"),
 				).
 				Value(&source),
 		),

--- a/cmd/config/bind_messages.go
+++ b/cmd/config/bind_messages.go
@@ -19,6 +19,7 @@ type bindMsg struct {
 	SourceOpenClaw    string // format: resolved config path.
 	SourceHermes      string // format: resolved dotenv path.
 	SourceLarkChannel string // format: resolved config path.
+	SourceDSH         string // format: resolved config path.
 
 	// Account selection (OpenClaw multi-account).
 	// Format: source display name ("OpenClaw" | "Hermes"), brand.
@@ -103,6 +104,7 @@ var bindMsgZh = &bindMsg{
 	SourceOpenClaw:    "OpenClaw — 配置文件: %s",
 	SourceHermes:      "Hermes — 配置文件: %s",
 	SourceLarkChannel: "Lark Channel — 配置文件: %s",
+	SourceDSH:         "DeepSeek Harness — 配置文件: %s",
 
 	SelectAccount: "检测到 %s 中已配置多个%s应用，请选择一个",
 
@@ -138,6 +140,7 @@ var bindMsgEn = &bindMsg{
 	SourceOpenClaw:    "OpenClaw — config: %s",
 	SourceHermes:      "Hermes — config: %s",
 	SourceLarkChannel: "Lark Channel — config: %s",
+	SourceDSH:         "DeepSeek Harness — config: %s",
 
 	// Args order (source, brand) matches the Chinese template; %[N]s lets the
 	// English reading order differ while the caller passes args in one order.

--- a/cmd/config/bind_test.go
+++ b/cmd/config/bind_test.go
@@ -367,7 +367,7 @@ func TestConfigBindRun_InvalidSource(t *testing.T) {
 	err := configBindRun(&BindOptions{Factory: f, Source: "invalid"})
 	assertExitError(t, err, output.ExitValidation, wantErrDetail{
 		Type:    "validation",
-		Message: `invalid --source "invalid"; valid values: openclaw, hermes, lark-channel`,
+		Message: `invalid --source "invalid"; valid values: openclaw, hermes, lark-channel, dsh`,
 	})
 }
 
@@ -385,16 +385,16 @@ func TestConfigBindRun_MissingSourceNonTTY(t *testing.T) {
 	assertExitError(t, err, output.ExitValidation, wantErrDetail{
 		Type:    "validation",
 		Message: "cannot determine Agent source: no --source flag and no Agent environment detected",
-		Hint:    "pass --source openclaw|hermes|lark-channel, or run this command inside the corresponding Agent context",
+		Hint:    "pass --source openclaw|hermes|lark-channel|dsh, or run this command inside the corresponding Agent context",
 	})
 }
 
 // clearAgentEnv removes every env var that DetectWorkspaceFromEnv treats as
 // an Agent signal, so tests exercising the "no signals" path stay isolated
 // from whatever the host shell exported. Prefix-based instead of an explicit
-// list — when DetectWorkspaceFromEnv gains a new OPENCLAW_* / HERMES_* signal,
-// this helper does not need to be updated and tests do not silently misroute.
-// t.Setenv restores the original values after the test returns.
+// list — when DetectWorkspaceFromEnv gains a new OPENCLAW_* / HERMES_* / DSH_*
+// signal, this helper does not need to be updated and tests do not silently
+// misroute. t.Setenv restores the original values after the test returns.
 func clearAgentEnv(t *testing.T) {
 	t.Helper()
 	for _, kv := range os.Environ() {
@@ -405,6 +405,7 @@ func clearAgentEnv(t *testing.T) {
 		k := kv[:idx]
 		if strings.HasPrefix(k, "OPENCLAW_") ||
 			strings.HasPrefix(k, "HERMES_") ||
+			strings.HasPrefix(k, "DSH_") ||
 			k == "LARK_CHANNEL" {
 			t.Setenv(k, "")
 		}
@@ -793,6 +794,217 @@ func TestConfigBindRun_LarkChannelEmptySecret(t *testing.T) {
 		Type:    "config",
 		Message: "accounts.app.secret is empty in " + configPath,
 		Hint:    "run lark-channel-bridge's setup to populate the app credential",
+	})
+}
+
+// writeDSHFixture writes the DeepSeek Harness settings document under the
+// harness home directory, and points DSH_HOME at it.
+func writeDSHFixture(t *testing.T, harnessHome, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(harnessHome, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(harnessHome, "settings.yaml")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("DSH_HOME", harnessHome)
+	return path
+}
+
+// Happy path: --source dsh reads the settings document under DSH_HOME and
+// records the bind under the dsh workspace.
+func TestConfigBindRun_DSH_Success(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+	writeDSHFixture(t, t.TempDir(), "lark-channel:\n  appId: cli_dsh_main\n  appSecret: dsh_secret\n")
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	if err := configBindRun(&BindOptions{Factory: f, Source: "dsh"}); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	envelope := map[string]any{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	if envelope["workspace"] != "dsh" {
+		t.Errorf("workspace = %v, want %q", envelope["workspace"], "dsh")
+	}
+	if envelope["app_id"] != "cli_dsh_main" {
+		t.Errorf("app_id = %v, want %q", envelope["app_id"], "cli_dsh_main")
+	}
+}
+
+// The harness injects DSH_SHELL into every shell it manages, so an agent never
+// has to pass --source.
+func TestConfigBindRun_AutoDetect_DSHFromEnv(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+	writeDSHFixture(t, t.TempDir(), "lark-channel:\n  appId: cli_dsh_auto\n  appSecret: s\n")
+	t.Setenv("DSH_SHELL", "1")
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	if err := configBindRun(&BindOptions{Factory: f}); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	envelope := map[string]any{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	if envelope["workspace"] != "dsh" {
+		t.Errorf("workspace = %v, want %q", envelope["workspace"], "dsh")
+	}
+}
+
+// The section stores the raw open-platform URL, not a brand name, so the Lark
+// deployment is only recognised if the domain is mapped rather than parsed.
+func TestConfigBindRun_DSH_LarkDomainBrand(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+	writeDSHFixture(t, t.TempDir(),
+		"lark-channel:\n  appId: cli_dsh_lark\n  appSecret: s\n  domain: https://open.larksuite.com\n")
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	if err := configBindRun(&BindOptions{Factory: f, Source: "dsh"}); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	core.SetCurrentWorkspace(core.WorkspaceDSH)
+	multi, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("load workspace config: %v", err)
+	}
+	if len(multi.Apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(multi.Apps))
+	}
+	if got := string(multi.Apps[0].Brand); got != "lark" {
+		t.Errorf("Brand = %q, want %q (a larksuite domain must map to Lark)", got, "lark")
+	}
+}
+
+// An absent domain is the Feishu deployment — the field is only written when
+// the operator points the plugin at Lark.
+func TestConfigBindRun_DSH_DefaultBrandIsFeishu(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+	writeDSHFixture(t, t.TempDir(), "lark-channel:\n  appId: cli_dsh_feishu\n  appSecret: s\n")
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	if err := configBindRun(&BindOptions{Factory: f, Source: "dsh"}); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	core.SetCurrentWorkspace(core.WorkspaceDSH)
+	multi, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("load workspace config: %v", err)
+	}
+	if got := string(multi.Apps[0].Brand); got != "feishu" {
+		t.Errorf("Brand = %q, want %q", got, "feishu")
+	}
+}
+
+// The workspace exists so a harness-hosted bind cannot disturb the config a
+// developer uses from their own terminal.
+func TestConfigBindRun_DSH_LeavesLocalConfigUntouched(t *testing.T) {
+	saveWorkspace(t)
+	configDir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", configDir)
+	clearAgentEnv(t)
+
+	localPath := filepath.Join(configDir, "config.json")
+	localBefore := []byte(`{"apps":[{"appId":"cli_local_untouched"}]}` + "\n")
+	if err := os.WriteFile(localPath, localBefore, 0600); err != nil {
+		t.Fatalf("seed local config: %v", err)
+	}
+	writeDSHFixture(t, t.TempDir(), "lark-channel:\n  appId: cli_dsh_iso\n  appSecret: s\n")
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	if err := configBindRun(&BindOptions{Factory: f, Source: "dsh"}); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	localAfter, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read local config: %v", err)
+	}
+	if string(localAfter) != string(localBefore) {
+		t.Errorf("local config was modified:\n before: %s\n after:  %s", localBefore, localAfter)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "dsh", "config.json")); err != nil {
+		t.Errorf("expected the bind under the dsh workspace: %v", err)
+	}
+}
+
+// --source dsh inside an OpenClaw environment is almost always the wrong
+// context; the mismatch is rejected before any prompt or write.
+func TestConfigBindRun_SourceEnvMismatch_DSHFlagInOpenClawEnv(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+	t.Setenv("OPENCLAW_CLI", "1")
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	err := configBindRun(&BindOptions{Factory: f, Source: "dsh"})
+	assertExitError(t, err, output.ExitValidation, wantErrDetail{
+		Type:    "validation",
+		Message: `--source "dsh" does not match detected Agent environment (openclaw)`,
+		Hint:    "remove --source to auto-detect, or run this command in the correct Agent context",
+	})
+}
+
+func TestConfigBindRun_DSHMissingFile(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+
+	harnessHome := t.TempDir() // empty — no settings document written
+	t.Setenv("DSH_HOME", harnessHome)
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	err := configBindRun(&BindOptions{Factory: f, Source: "dsh"})
+	configPath := filepath.Join(harnessHome, "settings.yaml")
+	assertExitError(t, err, output.ExitAuth, wantErrDetail{
+		Type:    "config",
+		Message: "cannot read " + configPath + ": open " + configPath + ": no such file or directory",
+		Hint:    "verify the DeepSeek Harness lark-channel plugin is installed and has completed onboarding",
+	})
+}
+
+// A harness that never onboarded the channel still has a settings document —
+// it just has no lark-channel section to bind.
+func TestConfigBindRun_DSHMissingSection(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+	configPath := writeDSHFixture(t, t.TempDir(), "ui-onboarding:\n  welcomeNoticeVersion: 2026-08-13.1\n")
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	err := configBindRun(&BindOptions{Factory: f, Source: "dsh"})
+	assertExitError(t, err, output.ExitAuth, wantErrDetail{
+		Type:    "config",
+		Message: "lark-channel.appId missing in " + configPath,
+		Hint:    "complete the plugin's first-boot QR onboarding so it persists appId/appSecret into this file",
+	})
+}
+
+func TestConfigBindRun_DSHEmptySecret(t *testing.T) {
+	saveWorkspace(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	clearAgentEnv(t)
+	configPath := writeDSHFixture(t, t.TempDir(), "lark-channel:\n  appId: cli_dsh_no_secret\n  appSecret: \"\"\n")
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	err := configBindRun(&BindOptions{Factory: f, Source: "dsh"})
+	assertExitError(t, err, output.ExitAuth, wantErrDetail{
+		Type:    "config",
+		Message: "lark-channel.appSecret is empty in " + configPath,
+		Hint:    "complete the plugin's first-boot QR onboarding so it persists appId/appSecret into this file",
 	})
 }
 

--- a/cmd/config/binder.go
+++ b/cmd/config/binder.go
@@ -15,6 +15,10 @@ import (
 	"github.com/larksuite/cli/internal/vfs"
 )
 
+// dshSettingsFile is the DeepSeek Harness settings document, held directly in
+// the harness home directory.
+const dshSettingsFile = "settings.yaml"
+
 // Candidate is the source-agnostic view of a bindable account.
 // It carries only the identity fields needed by selectCandidate / TUI;
 // secrets remain inside the SourceBinder implementation.
@@ -48,6 +52,8 @@ func newBinder(source string, opts *BindOptions) (SourceBinder, error) {
 		return &hermesBinder{opts: opts, path: resolveHermesEnvPath()}, nil
 	case "lark-channel":
 		return &larkChannelBinder{opts: opts, path: resolveLarkChannelConfigPath()}, nil
+	case "dsh":
+		return &dshBinder{opts: opts, path: resolveDSHSettingsPath()}, nil
 	default:
 		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "unsupported source: %s", source).WithParam("--source")
 	}
@@ -331,6 +337,78 @@ func (b *larkChannelBinder) Build(appID string) (*core.AppConfig, error) {
 }
 
 // ──────────────────────────────────────────────────────────────
+// dshBinder
+// ──────────────────────────────────────────────────────────────
+
+// dshBinder binds from the DeepSeek Harness settings document, the same way
+// openclawBinder reads openclaw.json and hermesBinder reads Hermes's .env: the
+// host's own config file, at a path derived from the host's own home variable.
+// The lark-channel plugin persists its app credential into that document
+// during onboarding, so there is no separate handoff artifact to read.
+type dshBinder struct {
+	opts *BindOptions
+	path string
+
+	// Cached between ListCandidates and Build so we don't re-read the file.
+	cfg *binding.DSHSettingsRoot
+}
+
+func (b *dshBinder) Name() string       { return "dsh" }
+func (b *dshBinder) ConfigPath() string { return b.path }
+
+func (b *dshBinder) ListCandidates() ([]Candidate, error) {
+	cfg, err := binding.ReadDSHSettings(b.path)
+	if err != nil {
+		return nil, errs.NewConfigError(errs.SubtypeInvalidConfig, "cannot read %s: %v", b.path, err).
+			WithHint("verify the DeepSeek Harness lark-channel plugin is installed and has completed onboarding").
+			WithCause(err)
+	}
+	if cfg.LarkChannel.AppID == "" {
+		return nil, errs.NewConfigError(errs.SubtypeNotConfigured, "lark-channel.appId missing in %s", b.path).
+			WithHint("complete the plugin's first-boot QR onboarding so it persists appId/appSecret into this file")
+	}
+	b.cfg = cfg
+	return []Candidate{{AppID: cfg.LarkChannel.AppID, Label: "default"}}, nil
+}
+
+func (b *dshBinder) Build(appID string) (*core.AppConfig, error) {
+	if b.cfg == nil {
+		return nil, errs.NewInternalError(errs.SubtypeSDKError, "internal: Build called before ListCandidates")
+	}
+	if b.cfg.LarkChannel.AppID != appID {
+		return nil, errs.NewInternalError(errs.SubtypeSDKError, "internal: appID %q does not match config", appID)
+	}
+	if b.cfg.LarkChannel.AppSecret == "" {
+		return nil, errs.NewConfigError(errs.SubtypeInvalidClient, "lark-channel.appSecret is empty in %s", b.path).
+			WithHint("complete the plugin's first-boot QR onboarding so it persists appId/appSecret into this file")
+	}
+
+	stored, err := core.ForStorage(appID, core.PlainSecret(b.cfg.LarkChannel.AppSecret), b.opts.Factory.Keychain)
+	if err != nil {
+		return nil, errs.NewInternalError(errs.SubtypeStorage, "keychain unavailable: %v", err).
+			WithHint("use file: reference in config to bypass keychain").
+			WithCause(err)
+	}
+
+	return &core.AppConfig{
+		AppId:     appID,
+		AppSecret: stored,
+		Brand:     dshBrand(b.cfg.LarkChannel.Domain),
+	}, nil
+}
+
+// dshBrand maps the plugin's open-platform domain to a brand. The settings
+// document stores the raw URL rather than a brand name, so it cannot go
+// through core.ParseBrand, which only recognises the literal "lark". Mirrors
+// the plugin's own rule (dsh-lark/src/runtime.ts: domain.includes('larksuite')).
+func dshBrand(domain string) core.LarkBrand {
+	if strings.Contains(domain, "larksuite") {
+		return core.BrandLark
+	}
+	return core.BrandFeishu
+}
+
+// ──────────────────────────────────────────────────────────────
 // Source-specific helpers (path / dotenv / brand) — kept private to this package.
 // Moved here from bind.go so bind.go can focus on orchestration.
 // ──────────────────────────────────────────────────────────────
@@ -345,6 +423,8 @@ func sourceDisplayName(source string) string {
 		return "Hermes"
 	case "lark-channel":
 		return "Lark Channel"
+	case "dsh":
+		return "DeepSeek Harness"
 	default:
 		return source
 	}
@@ -380,6 +460,24 @@ func resolveLarkChannelConfigPath() string {
 		fmt.Fprintf(os.Stderr, "warning: unable to determine home directory: %v\n", err)
 	}
 	return filepath.Join(home, ".lark-channel", "config.json")
+}
+
+// resolveDSHSettingsPath returns the path to the DeepSeek Harness settings
+// document. Respects DSH_HOME; defaults to ~/.dsh/settings.yaml — the same
+// shape as resolveHermesEnvPath's HERMES_HOME handling.
+//
+// DSH_HOME is authoritative here because the harness injects it into every
+// shell it spawns (shell-env's collect()), after discarding inherited DSH_*
+// values — so a relocated harness home reaches this process intact.
+func resolveDSHSettingsPath() string {
+	if harnessHome := strings.TrimSpace(os.Getenv("DSH_HOME")); harnessHome != "" {
+		return filepath.Join(expandHome(harnessHome), dshSettingsFile)
+	}
+	home, err := vfs.UserHomeDir()
+	if err != nil || home == "" {
+		fmt.Fprintf(os.Stderr, "warning: unable to determine home directory: %v\n", err)
+	}
+	return filepath.Join(home, ".dsh", dshSettingsFile)
 }
 
 // resolveOpenClawConfigPath resolves openclaw.json path using the same priority

--- a/cmd/config/binder_test.go
+++ b/cmd/config/binder_test.go
@@ -187,6 +187,45 @@ func TestResolveLarkChannelConfigPath_Default(t *testing.T) {
 	}
 }
 
+func TestResolveDSHSettingsPath_Default(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DSH_HOME", "")
+
+	got := resolveDSHSettingsPath()
+	want := filepath.Join(home, ".dsh", "settings.yaml")
+	if got != want {
+		t.Fatalf("resolveDSHSettingsPath() = %q, want %q", got, want)
+	}
+}
+
+// DSH_HOME is injected into every harness-managed shell, so deriving from it is
+// what makes the dsh source work with no operator setup.
+func TestResolveDSHSettingsPath_FromHarnessHome(t *testing.T) {
+	home := t.TempDir()
+	harnessHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DSH_HOME", harnessHome)
+
+	got := resolveDSHSettingsPath()
+	want := filepath.Join(harnessHome, "settings.yaml")
+	if got != want {
+		t.Fatalf("resolveDSHSettingsPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDSHSettingsPath_ExpandsTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DSH_HOME", "~/relocated-dsh")
+
+	got := resolveDSHSettingsPath()
+	want := filepath.Join(home, "relocated-dsh", "settings.yaml")
+	if got != want {
+		t.Fatalf("resolveDSHSettingsPath() = %q, want %q", got, want)
+	}
+}
+
 func TestResolveLarkChannelConfigPath_EnvOverride(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/binding/dsh_settings.go
+++ b/internal/binding/dsh_settings.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package binding
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// DSHSettingsRoot captures $DSH_HOME/settings.yaml, the settings document the
+// DeepSeek Harness settings service persists. Every plugin owns one top-level
+// section keyed by its namespace; only the lark-channel plugin's section holds
+// a Feishu credential, so every other section is ignored — the same
+// forward-compatible posture ReadLarkChannelConfig takes.
+type DSHSettingsRoot struct {
+	LarkChannel DSHLarkChannelSection `yaml:"lark-channel"`
+}
+
+// DSHLarkChannelSection is the lark-channel plugin's settings section.
+// Field names mirror the plugin's own cordis config schema
+// (dsh-lark/src/config.ts), which is what the settings service serializes;
+// the section's other fields (cwd, provider, model, preset, output, …) drive
+// the chat channel and carry nothing lark-cli binds.
+type DSHLarkChannelSection struct {
+	AppID     string `yaml:"appId"`
+	AppSecret string `yaml:"appSecret"`
+	// Domain is the open-platform URL the plugin was configured with, stored
+	// raw rather than as a brand name. Absent means the Feishu deployment.
+	Domain string `yaml:"domain"`
+}
+
+// ReadDSHSettings reads and parses $DSH_HOME/settings.yaml.
+func ReadDSHSettings(path string) (*DSHSettingsRoot, error) {
+	data, err := vfs.ReadFile(path)
+	if err != nil {
+		return nil, err // caller formats user-facing message with path context
+	}
+
+	var root DSHSettingsRoot
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("invalid YAML in %s: %w", path, err)
+	}
+
+	return &root, nil
+}

--- a/internal/binding/dsh_settings_test.go
+++ b/internal/binding/dsh_settings_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package binding
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSettings writes a settings document and returns its path.
+func writeSettings(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "settings.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return p
+}
+
+func TestReadDSHSettings_Valid(t *testing.T) {
+	p := writeSettings(t, `lark-channel:
+  appId: cli_abc123
+  appSecret: plain_secret
+`)
+
+	root, err := ReadDSHSettings(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := root.LarkChannel.AppID; got != "cli_abc123" {
+		t.Errorf("AppID = %q, want %q", got, "cli_abc123")
+	}
+	if got := root.LarkChannel.AppSecret; got != "plain_secret" {
+		t.Errorf("AppSecret = %q, want %q", got, "plain_secret")
+	}
+	// An absent domain is the Feishu deployment; the caller maps it.
+	if got := root.LarkChannel.Domain; got != "" {
+		t.Errorf("Domain = %q, want empty", got)
+	}
+}
+
+// The settings document is shared by every plugin that registers a section, so
+// a foreign section must not interfere with the one we read.
+func TestReadDSHSettings_IgnoresForeignSections(t *testing.T) {
+	p := writeSettings(t, `ui-onboarding:
+  welcomeNoticeVersion: 2026-08-13.1
+lark-channel:
+  appId: cli_shared
+  appSecret: s
+  domain: https://open.larksuite.com
+  output: stream
+  requireMention: true
+`)
+
+	root, err := ReadDSHSettings(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := root.LarkChannel.AppID; got != "cli_shared" {
+		t.Errorf("AppID = %q, want %q", got, "cli_shared")
+	}
+	// The Lark deployment is identified by the raw open-platform URL, not a
+	// brand name — the section stores whatever the plugin was configured with.
+	if got := root.LarkChannel.Domain; got != "https://open.larksuite.com" {
+		t.Errorf("Domain = %q, want the larksuite URL", got)
+	}
+}
+
+// A harness that has never onboarded the channel still has a settings
+// document; the section is simply absent.
+func TestReadDSHSettings_MissingSection(t *testing.T) {
+	p := writeSettings(t, "ui-onboarding:\n  welcomeNoticeVersion: 2026-08-13.1\n")
+
+	root, err := ReadDSHSettings(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root.LarkChannel.AppID != "" {
+		t.Errorf("AppID = %q, want empty", root.LarkChannel.AppID)
+	}
+}
+
+func TestReadDSHSettings_InvalidYAML(t *testing.T) {
+	p := writeSettings(t, "lark-channel:\n  appId: [unclosed\n")
+
+	if _, err := ReadDSHSettings(p); err == nil {
+		t.Fatal("expected an error for malformed YAML, got nil")
+	} else if !strings.Contains(err.Error(), p) {
+		t.Errorf("error must name the file, got: %v", err)
+	}
+}
+
+func TestReadDSHSettings_MissingFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "settings.yaml")
+
+	if _, err := ReadDSHSettings(p); err == nil {
+		t.Fatal("expected an error for a missing file, got nil")
+	}
+}

--- a/internal/core/workspace.go
+++ b/internal/core/workspace.go
@@ -32,6 +32,10 @@ const (
 	// lark-channel-bridge in subprocesses it spawns (e.g. claude). See
 	// DetectWorkspaceFromEnv for the detection rule.
 	WorkspaceLarkChannel Workspace = "lark-channel"
+
+	// WorkspaceDSH activates inside a shell the DeepSeek Harness manages.
+	// See DetectWorkspaceFromEnv for the detection rule.
+	WorkspaceDSH Workspace = "dsh"
 )
 
 // currentWorkspace holds the workspace for the current process invocation.
@@ -98,7 +102,19 @@ func (w Workspace) IsLocal() bool {
 //  3. LARK_CHANNEL == "1" → WorkspaceLarkChannel. Set by lark-channel-bridge
 //     when spawning subprocesses (e.g. claude). Single boolean marker —
 //     mirrors the OPENCLAW_CLI / HERMES_QUIET style.
-//  4. Otherwise → WorkspaceLocal
+//  4. Any DeepSeek Harness signal → WorkspaceDSH. Every variable here is minted
+//     per shell call by the harness's shell-environment registry, which
+//     discards inherited DSH_* values before injecting its own snapshot — so
+//     unlike the OPENCLAW_* / HERMES_* signals above, a stale value exported in
+//     the user's own terminal cannot reach this process.
+//     - DSH_SHELL == "1": injected unconditionally into every harness-managed
+//     shell; the closest analogue of OPENCLAW_CLI / LARK_CHANNEL.
+//     - DSH_HOME:         also injected unconditionally, and the path the
+//     settings document is read from (see resolveDSHSettingsPath).
+//     - DSH_SESSION_ID:   the acting agent's session identity. Supplementary
+//     only — the harness omits it for shell calls that carry no agent, so it
+//     cannot carry the detection on its own.
+//  5. Otherwise → WorkspaceLocal
 func DetectWorkspaceFromEnv(getenv func(string) string) Workspace {
 	if getenv("OPENCLAW_CLI") == "1" ||
 		getenv("OPENCLAW_HOME") != "" ||
@@ -119,6 +135,11 @@ func DetectWorkspaceFromEnv(getenv func(string) string) Workspace {
 	}
 	if getenv("LARK_CHANNEL") == "1" {
 		return WorkspaceLarkChannel
+	}
+	if getenv("DSH_SHELL") == "1" ||
+		getenv("DSH_HOME") != "" ||
+		getenv("DSH_SESSION_ID") != "" {
+		return WorkspaceDSH
 	}
 	return WorkspaceLocal
 }
@@ -151,6 +172,7 @@ func GetBaseConfigDir() string {
 //   - WorkspaceOpenClaw → GetBaseConfigDir()/openclaw
 //   - WorkspaceHermes → GetBaseConfigDir()/hermes
 //   - WorkspaceLarkChannel → GetBaseConfigDir()/lark-channel
+//   - WorkspaceDSH → GetBaseConfigDir()/dsh
 func GetRuntimeDir() string {
 	base := GetBaseConfigDir()
 	ws := CurrentWorkspace()

--- a/internal/core/workspace_test.go
+++ b/internal/core/workspace_test.go
@@ -144,6 +144,50 @@ func TestDetectWorkspaceFromEnv(t *testing.T) {
 			env:    map[string]string{"HERMES_HOME": "/Users/me/.hermes", "LARK_CHANNEL": "1"},
 			expect: WorkspaceHermes,
 		},
+		{
+			// The harness injects this into every shell it manages, which is
+			// what makes it the primary signal rather than the session vars.
+			name:   "DSH_SHELL=1 alone → dsh",
+			env:    map[string]string{"DSH_SHELL": "1"},
+			expect: WorkspaceDSH,
+		},
+		{
+			name:   "DSH_HOME alone → dsh",
+			env:    map[string]string{"DSH_HOME": "/Users/me/.dsh"},
+			expect: WorkspaceDSH,
+		},
+		{
+			// Supplementary: the harness omits it for shell calls that carry
+			// no agent, so it must not be the only thing detection rests on.
+			name:   "DSH_SESSION_ID alone → dsh",
+			env:    map[string]string{"DSH_SESSION_ID": "lark-oc_9f2b"},
+			expect: WorkspaceDSH,
+		},
+		{
+			name:   "empty DSH values → local",
+			env:    map[string]string{"DSH_SHELL": "", "DSH_HOME": "", "DSH_SESSION_ID": ""},
+			expect: WorkspaceLocal,
+		},
+		{
+			name:   "DSH_SHELL set to something other than 1 → local",
+			env:    map[string]string{"DSH_SHELL": "/bin/zsh"},
+			expect: WorkspaceLocal,
+		},
+		{
+			name:   "LARK_CHANNEL=1 + DSH_SHELL → lark-channel wins (priority over dsh)",
+			env:    map[string]string{"LARK_CHANNEL": "1", "DSH_SHELL": "1"},
+			expect: WorkspaceLarkChannel,
+		},
+		{
+			name:   "HERMES_HOME + DSH_SHELL → hermes wins (priority over dsh)",
+			env:    map[string]string{"HERMES_HOME": "/Users/me/.hermes", "DSH_SHELL": "1"},
+			expect: WorkspaceHermes,
+		},
+		{
+			name:   "OPENCLAW_CLI=1 + DSH_SHELL → openclaw wins (priority over dsh)",
+			env:    map[string]string{"OPENCLAW_CLI": "1", "DSH_SHELL": "1"},
+			expect: WorkspaceOpenClaw,
+		},
 	}
 
 	for _, tt := range tests {
@@ -167,6 +211,7 @@ func TestWorkspaceDisplay(t *testing.T) {
 		{WorkspaceOpenClaw, "openclaw"},
 		{WorkspaceHermes, "hermes"},
 		{WorkspaceLarkChannel, "lark-channel"},
+		{WorkspaceDSH, "dsh"},
 	}
 	for _, tt := range tests {
 		if got := tt.ws.Display(); got != tt.expect {
@@ -237,6 +282,17 @@ func TestGetRuntimeDir(t *testing.T) {
 	want = filepath.Join(tmp, "lark-channel")
 	if got := GetRuntimeDir(); got != want {
 		t.Errorf("lark-channel: GetRuntimeDir() = %q, want %q", got, want)
+	}
+
+	// DSH → base/dsh, so a harness-hosted bind never touches the local config
+	SetCurrentWorkspace(WorkspaceDSH)
+	want = filepath.Join(tmp, "dsh")
+	if got := GetRuntimeDir(); got != want {
+		t.Errorf("dsh: GetRuntimeDir() = %q, want %q", got, want)
+	}
+	want = filepath.Join(tmp, "dsh", "config.json")
+	if got := GetConfigPath(); got != want {
+		t.Errorf("dsh: GetConfigPath() = %q, want %q", got, want)
 	}
 }
 

--- a/tests/cli_e2e/config/bind_test.go
+++ b/tests/cli_e2e/config/bind_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 // clearAgentEnv removes every env var that DetectWorkspaceFromEnv treats as
-// an Agent signal (OPENCLAW_* / HERMES_* / LARK_CHANNEL). Prefix-based so the
-// helper stays correct when DetectWorkspaceFromEnv adds new signals; tests
-// no longer drift silently. Mirrors cmd/config/bind_test.go's helper.
+// an Agent signal (OPENCLAW_* / HERMES_* / DSH_* / LARK_CHANNEL). Prefix-based
+// so the helper stays correct when DetectWorkspaceFromEnv adds new signals;
+// tests no longer drift silently. Mirrors cmd/config/bind_test.go's helper.
 func clearAgentEnv(t *testing.T) {
 	t.Helper()
 	for _, kv := range os.Environ() {
@@ -31,6 +31,7 @@ func clearAgentEnv(t *testing.T) {
 		k := kv[:idx]
 		if strings.HasPrefix(k, "OPENCLAW_") ||
 			strings.HasPrefix(k, "HERMES_") ||
+			strings.HasPrefix(k, "DSH_") ||
 			k == "LARK_CHANNEL" {
 			t.Setenv(k, "")
 		}
@@ -105,7 +106,7 @@ func TestBind_InvalidSource(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assertStderrError(t, result, 2, "validation",
-		`invalid --source "invalid"; valid values: openclaw, hermes, lark-channel`, "")
+		`invalid --source "invalid"; valid values: openclaw, hermes, lark-channel, dsh`, "")
 }
 
 func TestBind_MissingSource_NonTTY(t *testing.T) {
@@ -129,7 +130,7 @@ func TestBind_MissingSource_NonTTY(t *testing.T) {
 	// from the typed config errors below.
 	assertStderrError(t, result, 2, "validation",
 		"cannot determine Agent source: no --source flag and no Agent environment detected",
-		"pass --source openclaw|hermes|lark-channel, or run this command inside the corresponding Agent context")
+		"pass --source openclaw|hermes|lark-channel|dsh, or run this command inside the corresponding Agent context")
 }
 
 func TestBind_Hermes_Success(t *testing.T) {
@@ -451,4 +452,107 @@ func TestBind_LarkChannel_AutoDetect(t *testing.T) {
 		assert.Equal(t, "lark-channel", errType,
 			"non-zero exit should be from lark-channel bind path\nstderr:\n%s", result.Stderr)
 	}
+}
+
+// writeDSHSettings creates a fake settings document under a harness home and
+// points DSH_HOME at it — the same handoff the harness performs for every
+// shell it manages.
+func writeDSHSettings(t *testing.T, harnessHome, appID, appSecret, domain string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(harnessHome, 0700))
+	content := "lark-channel:\n  appId: " + appID + "\n  appSecret: " + appSecret + "\n"
+	if domain != "" {
+		content += "  domain: " + domain + "\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(harnessHome, "settings.yaml"), []byte(content), 0600))
+	t.Setenv("DSH_HOME", harnessHome)
+}
+
+// TestBind_DSH_Success exercises the full end-to-end happy path: the harness
+// settings document under DSH_HOME → bind reads its lark-channel section →
+// workspace config written to LARKSUITE_CLI_CONFIG_DIR/dsh/config.json.
+func TestBind_DSH_Success(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	configDir := setupTempConfig(t)
+	clearAgentEnv(t)
+	writeDSHSettings(t, t.TempDir(), "cli_dsh_e2e", "dsh_secret", "https://open.larksuite.com")
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"config", "bind", "--source", "dsh"},
+	})
+	require.NoError(t, err)
+
+	if result.ExitCode == 0 {
+		stdout := result.Stdout
+		assert.True(t, gjson.Get(stdout, "ok").Bool(), "stdout:\n%s", stdout)
+		assert.Equal(t, "dsh", gjson.Get(stdout, "workspace").String(), "stdout:\n%s", stdout)
+		assert.Equal(t, "cli_dsh_e2e", gjson.Get(stdout, "app_id").String(), "stdout:\n%s", stdout)
+
+		expectedConfigPath := filepath.Join(configDir, "dsh", "config.json")
+		assert.Equal(t, expectedConfigPath, gjson.Get(stdout, "config_path").String(), "stdout:\n%s", stdout)
+
+		data, readErr := os.ReadFile(expectedConfigPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, "cli_dsh_e2e", gjson.GetBytes(data, "apps.0.appId").String())
+		// The section stores the open-platform URL, so the brand only lands
+		// correctly if the domain is mapped rather than parsed as a name.
+		assert.Equal(t, "lark", gjson.GetBytes(data, "apps.0.brand").String())
+	} else {
+		// Keychain failure acceptable in CI; verify the error came from the
+		// dsh binder (i.e. routing was correct) rather than another path.
+		errType := gjson.Get(result.Stderr, "error.type").String()
+		assert.Equal(t, "dsh", errType,
+			"non-zero exit should be from dsh bind path\nstderr:\n%s", result.Stderr)
+	}
+}
+
+// TestBind_DSH_AutoDetect verifies DSH_SHELL=1 alone routes the no-flag bind
+// into the dsh workspace — the harness injects it into every shell it manages,
+// which is what lets an agent bind without passing --source.
+func TestBind_DSH_AutoDetect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	setupTempConfig(t)
+	clearAgentEnv(t)
+	writeDSHSettings(t, t.TempDir(), "cli_dsh_auto", "auto_secret", "")
+	t.Setenv("DSH_SHELL", "1")
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"config", "bind"}, // no --source
+	})
+	require.NoError(t, err)
+
+	if result.ExitCode == 0 {
+		assert.Equal(t, "dsh", gjson.Get(result.Stdout, "workspace").String(),
+			"stdout:\n%s", result.Stdout)
+	} else {
+		errType := gjson.Get(result.Stderr, "error.type").String()
+		assert.Equal(t, "dsh", errType,
+			"non-zero exit should be from dsh bind path\nstderr:\n%s", result.Stderr)
+	}
+}
+
+// TestBind_DSH_MissingFile verifies the routed error path when the harness has
+// no settings document: the hint must point at the plugin's onboarding, not at
+// `config init` (which would create a parallel local app).
+func TestBind_DSH_MissingFile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	setupTempConfig(t)
+	clearAgentEnv(t)
+	harnessHome := t.TempDir() // empty — no settings.yaml
+	t.Setenv("DSH_HOME", harnessHome)
+
+	configPath := filepath.Join(harnessHome, "settings.yaml")
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"config", "bind", "--source", "dsh"},
+	})
+	require.NoError(t, err)
+	assertStderrError(t, result, 3, "config",
+		"cannot read "+configPath+": open "+configPath+": no such file or directory",
+		"verify the DeepSeek Harness lark-channel plugin is installed and has completed onboarding")
 }


### PR DESCRIPTION
## What

Adds `dsh` as a `config bind` source, so an agent running inside a [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) shell can bind lark-cli to the harness's own Feishu bot credential.

## Why

Without it, an agent in a harness shell has two bad options: run `config init`, which creates a parallel app, or bind into the operator's own `~/.lark-cli` and overwrite the configuration they use from their terminal. This is the same problem the `openclaw` / `hermes` / `lark-channel` sources already solve for their hosts.

## How

Reads the credential from the host's own config file, exactly as the existing sources do:

| source | file | fields |
|---|---|---|
| `openclaw` | `~/.openclaw/openclaw.json` | `channels.feishu.appId/appSecret` |
| `hermes` | `~/.hermes/.env` | `FEISHU_APP_ID` / `FEISHU_APP_SECRET` |
| **`dsh`** | **`$DSH_HOME/settings.yaml`** | **`lark-channel.appId` / `lark-channel.appSecret`** |

That section is what the harness's lark-channel plugin persists through the host settings service during onboarding. No handoff artifact and no environment channel is involved — which matters, because the harness scrubs credential-shaped names (`/KEY|PASSWORD|SECRET|TOKEN/i`) from every shell it spawns, so an env-var reference could never resolve there.

`gopkg.in/yaml.v3` is already a direct dependency; no new module is added.

### Detection

Keys on the markers the harness mints per shell call, after discarding inherited `DSH_*` values:

- `DSH_SHELL == "1"` and `DSH_HOME` — injected unconditionally into every harness-managed shell, so they carry the routing (the analogue of `OPENCLAW_CLI` / `LARK_CHANNEL`)
- `DSH_SESSION_ID` — supplementary only; the harness omits it for shell calls that carry no agent, so it cannot carry detection alone

Because inherited `DSH_*` is discarded before the harness injects its own snapshot, a stale value exported in the operator's terminal cannot misroute this process — a guarantee the `OPENCLAW_*` / `HERMES_*` signals do not have.

### Brand

The settings section stores the raw open-platform URL, not a brand name, so the domain is mapped rather than passed to `core.ParseBrand` (which only recognises the literal `"lark"` and would silently classify a `larksuite.com` URL as Feishu).

## Verification

- Full unit suite green; `tests/cli_e2e/config` green
- New e2e coverage for `dsh` (success incl. brand assertion, `DSH_SHELL` auto-detect, missing-file hint), matching the depth the `hermes` / `lark-channel` sources already have
- Verified end-to-end against a real harness `settings.yaml`: no-flag bind under `DSH_SHELL=1` routed to the `dsh` workspace, wrote a keychain-referenced secret, left the local config byte-identical, and the resulting bot token authenticated successfully against the open platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek Harness (`dsh`) as a configuration source.
  * Automatically detects DeepSeek Harness environments and supports manual source selection.
  * Reads Lark Channel credentials from DeepSeek Harness settings and securely saves them.
  * Supports Lark and Feishu domains with localized configuration-path messages.
  * Provides clearer guidance when settings are missing or invalid.

* **Tests**
  * Added coverage for detection, validation, path resolution, credential handling, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->