### PR TITLE
fix(im): make reactions scope conditional so --no-reactions passes pre-flight (fixes #2352)

### DIFF
--- a/shortcuts/im/convert_lib/reactions.go
+++ b/shortcuts/im/convert_lib/reactions.go
@@ -142,11 +142,13 @@ func markAllReactionNodes(messages []map[string]interface{}) {
 		case []map[string]interface{}:
 			markAllReactionNodes(nested)
 		case []interface{}:
+			typed := make([]map[string]interface{}, 0, len(nested))
 			for _, raw := range nested {
 				if m, ok := raw.(map[string]interface{}); ok {
-					m["reactions_error"] = true
+					typed = append(typed, m)
 				}
 			}
+			markAllReactionNodes(typed)
 		}
 	}
 }

--- a/shortcuts/im/convert_lib/reactions.go
+++ b/shortcuts/im/convert_lib/reactions.go
@@ -27,6 +27,12 @@ const reactionsBatchQueryMaxQueries = 20
 // ~700ms) the effective rate stays well under 6/s.
 const reactionsBatchQueryConcurrency = 4
 
+// ImMessageReactionsReadScope is required only when reaction enrichment is
+// actually requested (the default mode). The message-listing shortcuts declare
+// it as a conditional scope, so --no-reactions does not fail the scope
+// pre-flight (issue #2352); it is enforced lazily here instead.
+const ImMessageReactionsReadScope = "im:message.reactions:read"
+
 // EnrichReactions enriches messages with their reactions by calling the
 // im.reactions.batch_query API. Messages are modified in place: each message
 // that the server returns reactions for gets a "reactions" map attached.
@@ -53,6 +59,16 @@ const reactionsBatchQueryConcurrency = 4
 // batches of size <= 20 before invoking the API.
 func EnrichReactions(runtime *common.RuntimeContext, messages []map[string]interface{}) {
 	if len(messages) == 0 {
+		return
+	}
+
+	// The reactions scope is conditional: --no-reactions callers never reach
+	// this function, so enforce it lazily here (not in the unconditional
+	// pre-flight) and fail soft like the other enrichment failure modes.
+	if err := runtime.EnsureScopes([]string{ImMessageReactionsReadScope}); err != nil {
+		warnSyncf(nil, runtime.IO().ErrOut,
+			"warning: reactions_batch_query_skipped: %v\n", err)
+		markAllReactionNodes(messages)
 		return
 	}
 
@@ -114,6 +130,25 @@ func EnrichReactions(runtime *common.RuntimeContext, messages []map[string]inter
 		}()
 	}
 	wg.Wait()
+}
+
+// markAllReactionNodes marks every message map (including nested thread
+// replies) with reactions_error: true, matching fetchReactionsBatch's failure
+// marker so consumers handle skipped enrichment uniformly.
+func markAllReactionNodes(messages []map[string]interface{}) {
+	for _, msg := range messages {
+		msg["reactions_error"] = true
+		switch nested := msg["thread_replies"].(type) {
+		case []map[string]interface{}:
+			markAllReactionNodes(nested)
+		case []interface{}:
+			for _, raw := range nested {
+				if m, ok := raw.(map[string]interface{}); ok {
+					m["reactions_error"] = true
+				}
+			}
+		}
+	}
 }
 
 // collectMessageNodes walks messages (and any nested thread_replies) and

--- a/shortcuts/im/convert_lib/reactions_test.go
+++ b/shortcuts/im/convert_lib/reactions_test.go
@@ -408,3 +408,32 @@ func TestEnrichReactions_DuplicateMessageID(t *testing.T) {
 		t.Fatalf("dup entries reactions differ: %#v vs %#v", firstReactions, secondReactions)
 	}
 }
+
+// TestEnrichReactions_MissingScopeMarksAllNodes pins the conditional-scope
+// contract (issue #2352): when the runtime token lacks the reactions scope,
+// enrichment must not call the API and every message node (including nested
+// thread replies) is marked reactions_error instead of aborting the command.
+func TestEnrichReactions_MissingScopeMarksAllNodes(t *testing.T) {
+	apiCalled := false
+	runtime := newBotConvertlibRuntimeWithScopes(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		apiCalled = true
+		return convertlibJSONResponse(200, map[string]interface{}{"code": 0, "data": map[string]interface{}{}}), nil
+	}), "im:message:readonly")
+
+	parent := map[string]interface{}{"message_id": "om_a"}
+	child := map[string]interface{}{"message_id": "om_a1"}
+	parent["thread_replies"] = []map[string]interface{}{child}
+	messages := []map[string]interface{}{parent}
+
+	EnrichReactions(runtime, messages)
+
+	if apiCalled {
+		t.Fatalf("batch_query must not be called when the reactions scope is missing")
+	}
+	if parent["reactions_error"] != true {
+		t.Fatalf("parent missing reactions_error flag: %#v", parent)
+	}
+	if child["reactions_error"] != true {
+		t.Fatalf("nested thread reply missing reactions_error flag: %#v", child)
+	}
+}

--- a/shortcuts/im/convert_lib/reactions_test.go
+++ b/shortcuts/im/convert_lib/reactions_test.go
@@ -437,3 +437,36 @@ func TestEnrichReactions_MissingScopeMarksAllNodes(t *testing.T) {
 		t.Fatalf("nested thread reply missing reactions_error flag: %#v", child)
 	}
 }
+
+// TestEnrichReactions_MissingScopeMarksInterfaceBackedNestedNodes pins the
+// []interface{} branch of markAllReactionNodes: interface-backed thread
+// replies must be recursed into so grandchildren are flagged too.
+func TestEnrichReactions_MissingScopeMarksInterfaceBackedNestedNodes(t *testing.T) {
+	apiCalled := false
+	runtime := newBotConvertlibRuntimeWithScopes(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		apiCalled = true
+		return convertlibJSONResponse(200, map[string]interface{}{"code": 0, "data": map[string]interface{}{}}), nil
+	}), "im:message:readonly")
+
+	grandchild := map[string]interface{}{"message_id": "om_a2"}
+	child := map[string]interface{}{"message_id": "om_a1"}
+	child["thread_replies"] = []interface{}{grandchild}
+	parent := map[string]interface{}{"message_id": "om_a"}
+	parent["thread_replies"] = []interface{}{child}
+	messages := []map[string]interface{}{parent}
+
+	EnrichReactions(runtime, messages)
+
+	if apiCalled {
+		t.Fatalf("batch_query must not be called when the reactions scope is missing")
+	}
+	if parent["reactions_error"] != true {
+		t.Fatalf("parent missing reactions_error flag: %#v", parent)
+	}
+	if child["reactions_error"] != true {
+		t.Fatalf("interface-backed reply missing reactions_error flag: %#v", child)
+	}
+	if grandchild["reactions_error"] != true {
+		t.Fatalf("grandchild (nested inside interface-backed reply) missing reactions_error flag: %#v", grandchild)
+	}
+}

--- a/shortcuts/im/convert_lib/runtime_test.go
+++ b/shortcuts/im/convert_lib/runtime_test.go
@@ -21,10 +21,12 @@ import (
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
-type staticConvertlibTokenResolver struct{}
+type staticConvertlibTokenResolver struct {
+	scopes string
+}
 
 func (s *staticConvertlibTokenResolver) ResolveToken(_ context.Context, _ credential.TokenSpec) (*credential.TokenResult, error) {
-	return &credential.TokenResult{Token: "test-token"}, nil
+	return &credential.TokenResult{Token: "test-token", Scopes: s.scopes}, nil
 }
 
 type convertlibRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -53,6 +55,13 @@ func setConvertlibRuntimeField(t *testing.T, runtime *common.RuntimeContext, fie
 }
 
 func newBotConvertlibRuntime(t *testing.T, rt http.RoundTripper) *common.RuntimeContext {
+	return newBotConvertlibRuntimeWithScopes(t, rt, ImMessageReactionsReadScope)
+}
+
+// newBotConvertlibRuntimeWithScopes builds a convert-lib runtime whose token
+// carries the given granted scopes (space-separated). The default helper
+// grants the reactions scope, mirroring a properly configured bot.
+func newBotConvertlibRuntimeWithScopes(t *testing.T, rt http.RoundTripper, scopes string) *common.RuntimeContext {
 	t.Helper()
 
 	httpClient := &http.Client{Transport: rt}
@@ -68,7 +77,7 @@ func newBotConvertlibRuntime(t *testing.T, rt http.RoundTripper) *common.Runtime
 		AppSecret: "test-secret",
 		Brand:     core.BrandFeishu,
 	}
-	testCred := credential.NewCredentialProvider(nil, nil, &staticConvertlibTokenResolver{}, nil)
+	testCred := credential.NewCredentialProvider(nil, nil, &staticConvertlibTokenResolver{scopes: scopes}, nil)
 	runtime := &common.RuntimeContext{
 		Config: cfg,
 		Factory: &cmdutil.Factory{

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -24,15 +24,17 @@ const (
 )
 
 var ImChatMessageList = common.Shortcut{
-	Service:     "im",
-	Command:     "+chat-messages-list",
-	Description: "List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range, --order asc/desc sorting, auto-pagination",
-	Risk:        "read",
-	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:               "im",
+	Command:               "+chat-messages-list",
+	Description:           "List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range, --order asc/desc sorting, auto-pagination",
+	Risk:                  "read",
+	Scopes:                []string{"im:message:readonly"},
+	UserScopes:            []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user"},
+	BotScopes:             []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	ConditionalUserScopes: []string{convertlib.ImMessageReactionsReadScope},
+	ConditionalBotScopes:  []string{convertlib.ImMessageReactionsReadScope},
+	AuthTypes:             []string{"user", "bot"},
+	HasFormat:             true,
 	Flags: append([]common.Flag{
 		{Name: "chat-id", Desc: "(required, mutually exclusive with --user-id) chat ID (oc_xxx)"},
 		{Name: "user-id", Desc: "(required, mutually exclusive with --chat-id; user identity only) user open_id (ou_xxx)"},

--- a/shortcuts/im/im_messages_mget.go
+++ b/shortcuts/im/im_messages_mget.go
@@ -18,15 +18,17 @@ import (
 const maxMGetMessageIDs = 50
 
 var ImMessagesMGet = common.Shortcut{
-	Service:     "im",
-	Command:     "+messages-mget",
-	Description: "Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies",
-	Risk:        "read",
-	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:               "im",
+	Command:               "+messages-mget",
+	Description:           "Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies",
+	Risk:                  "read",
+	Scopes:                []string{"im:message:readonly"},
+	UserScopes:            []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user"},
+	BotScopes:             []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	ConditionalUserScopes: []string{convertlib.ImMessageReactionsReadScope},
+	ConditionalBotScopes:  []string{convertlib.ImMessageReactionsReadScope},
+	AuthTypes:             []string{"user", "bot"},
+	HasFormat:             true,
 	Flags: []common.Flag{
 		{Name: "message-ids", Aliases: []string{"message-id"}, Desc: "message IDs, comma-separated (om_xxx,om_yyy)", Required: true},
 		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},

--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -27,13 +27,14 @@ const (
 )
 
 var ImMessagesSearch = common.Shortcut{
-	Service:     "im",
-	Command:     "+messages-search",
-	Description: "Search messages across chats (supports keyword, sender, time range filters) with user or bot identity; filters by chat/sender/attachment/time, enriches results via mget and chats batch_query",
-	Risk:        "read",
-	Scopes:      []string{"search:message", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:           "im",
+	Command:           "+messages-search",
+	Description:       "Search messages across chats (supports keyword, sender, time range filters) with user or bot identity; filters by chat/sender/attachment/time, enriches results via mget and chats batch_query",
+	Risk:              "read",
+	Scopes:            []string{"search:message"},
+	ConditionalScopes: []string{convertlib.ImMessageReactionsReadScope},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
 	Flags: []common.Flag{
 		{Name: "query", Aliases: []string{"keyword"}, Desc: "search keyword"},
 		{Name: "chat-id", Desc: "limit to chat IDs, comma-separated"},

--- a/shortcuts/im/im_reactions_scope_test.go
+++ b/shortcuts/im/im_reactions_scope_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
+	convertlib "github.com/larksuite/cli/shortcuts/im/convert_lib"
+)
+
+// TestReactionsScopeIsConditional pins issue #2352: the reactions scope must
+// NOT be part of the unconditional pre-flight scope set (ScopesForIdentity) —
+// otherwise --no-reactions still fails without im:message.reactions:read —
+// while remaining declared (DeclaredScopesForIdentity) for metadata and
+// diagnostics, and enforced lazily by EnrichReactions at enrichment time.
+func TestReactionsScopeIsConditional(t *testing.T) {
+	shortcuts := []struct {
+		name string
+		s    *common.Shortcut
+	}{
+		{"+chat-messages-list", &ImChatMessageList},
+		{"+messages-mget", &ImMessagesMGet},
+		{"+threads-messages-list", &ImThreadsMessagesList},
+		{"+messages-search", &ImMessagesSearch},
+	}
+
+	for _, sc := range shortcuts {
+		for _, identity := range []string{"user", "bot"} {
+			if got := sc.s.ScopesForIdentity(identity); contains(got, convertlib.ImMessageReactionsReadScope) {
+				t.Errorf("%s: reactions scope is UNCONDITIONAL for identity %q (pre-flight would require it even with --no-reactions): %v",
+					sc.name, identity, got)
+			}
+			declared := sc.s.DeclaredScopesForIdentity(identity)
+			if !contains(declared, convertlib.ImMessageReactionsReadScope) {
+				t.Errorf("%s: reactions scope missing from declared scopes for identity %q: %v",
+					sc.name, identity, declared)
+			}
+		}
+	}
+}
+
+func contains(list []string, item string) bool {
+	for _, s := range list {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -24,15 +24,17 @@ const (
 )
 
 var ImThreadsMessagesList = common.Shortcut{
-	Service:     "im",
-	Command:     "+threads-messages-list",
-	Description: "List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports --order asc/desc sorting, auto-pagination",
-	Risk:        "read",
-	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:               "im",
+	Command:               "+threads-messages-list",
+	Description:           "List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports --order asc/desc sorting, auto-pagination",
+	Risk:                  "read",
+	Scopes:                []string{"im:message:readonly"},
+	UserScopes:            []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user"},
+	BotScopes:             []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	ConditionalUserScopes: []string{convertlib.ImMessageReactionsReadScope},
+	ConditionalBotScopes:  []string{convertlib.ImMessageReactionsReadScope},
+	AuthTypes:             []string{"user", "bot"},
+	HasFormat:             true,
 	Flags: append([]common.Flag{
 		{Name: "thread", Aliases: []string{"thread-id"}, Desc: "thread ID (om_xxx or omt_xxx)", Required: true},
 		{Name: "order", Aliases: []string{"sort"}, Default: "asc", Desc: "sort order: asc | desc", Enum: []string{"asc", "desc"}},


### PR DESCRIPTION
Fixes #2352

## Problem

`lark-cli im +chat-messages-list --no-reactions` (and the sibling `+messages-mget`, `+threads-messages-list`, `+messages-search`) still fails its scope pre-flight with `missing required scope(s): im:message.reactions:read` even though reactions enrichment is explicitly disabled.

The shortcuts declared `im:message.reactions:read` in the **unconditional** `UserScopes`/`BotScopes` (or `Scopes`), so the framework's pre-flight required it on every invocation regardless of `--no-reactions`.

## Changes

- **`shortcuts/im/convert_lib/reactions.go`**: `EnrichReactions` now enforces the reactions scope lazily via `runtime.EnsureScopes(...)` — the narrowest cohesive boundary shared by all four message-listing shortcuts — and fails soft on a missing scope (stderr warning + `reactions_error: true` on every message node including nested thread replies), matching the other enrichment failure modes. Never aborts main message output.
- **`shortcuts/im/im_chat_messages_list.go`**, **`im_messages_mget.go`**, **`im_threads_messages_list.go`**, **`im_messages_search.go`**: the reactions scope moved from `UserScopes`/`BotScopes`/`Scopes` into `ConditionalUserScopes`/`ConditionalBotScopes` (or `ConditionalScopes`), so the unconditional pre-flight no longer requires it — while `DeclaredScopesForIdentity` still surfaces it for metadata/diagnostics and `--no-reactions` callers never hit `EnsureScopes`.
- **Tests**: `TestReactionsScopeIsConditional` (scope is conditional for all four shortcuts, both identities), `TestEnrichReactions_MissingScopeMarksAllNodes` (missing scope → no API call, all nodes flagged, command output preserved); the convert-lib test token now grants the reactions scope by default (representative configured bot), with a scoped variant helper.

## Verification

- `go vet ./shortcuts/im/... ./shortcuts/common/...` — clean.
- `go test ./shortcuts/im/...` — all pass except `TestDownloadResourcePathSafety`, a pre-existing Windows-only path-separator assertion (`filepath.Join` backslashes vs expected forward slashes) in an untouched file; CI runs on Linux.
- `gofmt` clean on all touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reaction data is now optional for message, search, and thread shortcuts.
  * Messages continue loading when reaction access is unavailable, with affected messages and nested replies marked accordingly.
* **Bug Fixes**
  * Prevented unnecessary reaction API requests when the required permission is missing.
  * Improved handling of recursively nested thread replies.
* **Tests**
  * Added coverage for missing permissions, skipped API requests, and nested reply handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->