### PR TITLE
feat(slides): add overview and region screenshots

### DIFF
--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -55,8 +55,7 @@ var SlidesScreenshot = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{"slides:presentation:screenshot"},
 	// wiki:node:read is required only for wiki URLs; slides:presentation:read
-	// is required by --overview to enumerate the current page order and by
-	// --region to resolve the presentation's logical canvas.
+	// is required only by --overview to enumerate the current page order.
 	ConditionalScopes: []string{"wiki:node:read", "slides:presentation:read"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
@@ -71,12 +70,12 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "overview", Type: "bool", Desc: "render every current slide into one local overview PNG; cannot be combined with slide selectors, --content, or --region"},
 		{Name: "overview-page", Type: "int", Default: "1", Desc: "1-based overview page; each overview contains at most 20 slides"},
 		{Name: "overview-columns", Type: "int", Default: "4", Desc: "number of columns in --overview output (1-10)"},
-		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in its presentation canvas; cannot be combined with --overview"},
+		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in the rendered screenshot pixels; cannot be combined with --overview"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		overview := runtime.Bool("overview")
 		if runtime.Changed("region") && strings.TrimSpace(runtime.Str("region")) == "" {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region cannot be empty").WithParam("--region").WithHint("provide x,y,width,height in the presentation canvas")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region cannot be empty").WithParam("--region").WithHint("provide x,y,width,height in rendered screenshot pixels")
 		}
 		region, regionSet, err := parseSlidesScreenshotRegion(runtime.Str("region"))
 		if err != nil {
@@ -145,11 +144,11 @@ var SlidesScreenshot = common.Shortcut{
 			if err := validateSlidesScreenshotSelectorLimit(selectorCount); err != nil {
 				return err
 			}
-			// Both modes read the presentation XML before rendering. Keep this
+			// Overview reads the presentation XML before rendering. Keep this
 			// conditional preflight in Validate so --dry-run reports the same
 			// authorization requirement as execution, and a wiki URL cannot reach
 			// its resolve call before a missing Slides read scope is surfaced.
-			if overview || regionSet {
+			if overview {
 				if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
 					return err
 				}
@@ -237,11 +236,6 @@ var SlidesScreenshot = common.Shortcut{
 				dry.Desc(fmt.Sprintf("Fetch %d slide screenshot(s) and save files under %s", len(slideIDs)+len(slideNumbers), runtime.Str("output-dir")))
 			}
 		}
-		if _, regionSet, _ := parseSlidesScreenshotRegion(runtime.Str("region")); regionSet {
-			dry.Desc("Fetch presentation XML to resolve the region canvas before rendering the selected slide").
-				GET(fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))).
-				Params(map[string]interface{}{"revision_id": -1})
-		}
 		body := map[string]interface{}{}
 		if len(slideIDs) > 0 {
 			body["slide_ids"] = slideIDs
@@ -287,16 +281,8 @@ var SlidesScreenshot = common.Shortcut{
 			return err
 		}
 		var region slidesScreenshotRegion
-		var canvas slidesScreenshotCanvas
 		if parsed, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
 			region = parsed
-			canvas, err = fetchSlidesScreenshotCanvas(runtime, presentationID)
-			if err != nil {
-				return err
-			}
-			if err := validateSlidesScreenshotRegionBounds(region, canvas); err != nil {
-				return err
-			}
 		}
 
 		url := fmt.Sprintf(
@@ -318,7 +304,7 @@ var SlidesScreenshot = common.Shortcut{
 
 		var crop map[string]interface{}
 		if _, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
-			crop, err = cropSlidesScreenshotResponse(data, region, canvas)
+			crop, err = cropSlidesScreenshotResponse(data, region)
 			if err != nil {
 				return err
 			}
@@ -689,6 +675,7 @@ func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]in
 	if err != nil {
 		return nil, slidesScreenshotImageDataCauseError(slideID, err, "decode screenshot: %s", err)
 	}
+	config, _, configErr := image.DecodeConfig(bytes.NewReader(imageBytes))
 	var path string
 	if outputPath != "" {
 		path, err = writeUniqueScreenshotPath(runtime, slideScreenshotOutputPathForFormat(outputPath, ext), imageBytes)
@@ -705,13 +692,21 @@ func saveSlideScreenshotImage(runtime *common.RuntimeContext, item map[string]in
 	if err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{
+	result := map[string]interface{}{
 		"slide_id":     slideID,
 		"slide_number": slideScreenshotInt(item, "slide_number"),
 		"format":       label,
 		"path":         path,
 		"size":         len(imageBytes),
-	}, nil
+	}
+	// Preserve the shortcut's established behavior for an opaque server payload
+	// that is saved successfully but cannot be decoded locally. Real screenshot
+	// images always carry image_size; omitting it here avoids changing the
+	// historical save contract into a new decode failure.
+	if configErr == nil {
+		result["image_size"] = map[string]int{"width": config.Width, "height": config.Height}
+	}
+	return result, nil
 }
 
 func slideScreenshotOutputExtMatches(outputExt string, responseExt string) bool {
@@ -919,15 +914,13 @@ func isScreenshotFileNotExist(err error) bool {
 
 type slidesScreenshotRegion struct{ X, Y, Width, Height int }
 
-type slidesScreenshotCanvas struct{ Width, Height int }
-
 func parseSlidesScreenshotRegion(raw string) (slidesScreenshotRegion, bool, error) {
 	if strings.TrimSpace(raw) == "" {
 		return slidesScreenshotRegion{}, false, nil
 	}
 	parts := strings.Split(raw, ",")
 	if len(parts) != 4 {
-		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must be x,y,width,height in the presentation canvas").WithParam("--region")
+		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must be x,y,width,height in rendered screenshot pixels").WithParam("--region")
 	}
 	vals := [4]int{}
 	for i, part := range parts {
@@ -944,16 +937,16 @@ func parseSlidesScreenshotRegion(raw string) (slidesScreenshotRegion, bool, erro
 	return r, true, nil
 }
 
-func validateSlidesScreenshotRegionBounds(region slidesScreenshotRegion, canvas slidesScreenshotCanvas) error {
-	// Compare the remaining canvas size instead of adding X+Width so hostile
+func validateSlidesScreenshotRegionBounds(region slidesScreenshotRegion, imageSize image.Point) error {
+	// Compare the remaining image size instead of adding X+Width so hostile
 	// integer inputs cannot wrap before the bounds check.
-	if region.X >= canvas.Width || region.Y >= canvas.Height || region.Width > canvas.Width-region.X || region.Height > canvas.Height-region.Y {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must stay within the %dx%d presentation canvas", canvas.Width, canvas.Height).WithParam("--region").WithHint(fmt.Sprintf("use x+width<=%d and y+height<=%d", canvas.Width, canvas.Height))
+	if region.X >= imageSize.X || region.Y >= imageSize.Y || region.Width > imageSize.X-region.X || region.Height > imageSize.Y-region.Y {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must stay within the %dx%d rendered screenshot", imageSize.X, imageSize.Y).WithParam("--region").WithHint(fmt.Sprintf("use x+width<=%d and y+height<=%d", imageSize.X, imageSize.Y))
 	}
 	return nil
 }
 
-func cropSlidesScreenshotResponse(data map[string]interface{}, region slidesScreenshotRegion, canvas slidesScreenshotCanvas) (map[string]interface{}, error) {
+func cropSlidesScreenshotResponse(data map[string]interface{}, region slidesScreenshotRegion) (map[string]interface{}, error) {
 	items := common.GetSlice(data, "slide_images")
 	if len(items) != 1 {
 		return nil, slidesScreenshotAPIDataError(data, "--region requires exactly one rendered slide image")
@@ -972,12 +965,11 @@ func cropSlidesScreenshotResponse(data map[string]interface{}, region slidesScre
 		return nil, slidesScreenshotImageDataCauseError(common.GetString(item, "slide_id"), err, "decode screenshot image for --region: %s", err)
 	}
 	bounds := src.Bounds()
-	x0 := region.X * bounds.Dx() / canvas.Width
-	y0 := region.Y * bounds.Dy() / canvas.Height
-	x1 := int(math.Ceil(float64((region.X+region.Width)*bounds.Dx()) / float64(canvas.Width)))
-	y1 := int(math.Ceil(float64((region.Y+region.Height)*bounds.Dy()) / float64(canvas.Height)))
-	dst := image.NewRGBA(image.Rect(0, 0, x1-x0, y1-y0))
-	draw.Draw(dst, dst.Bounds(), src, image.Point{X: x0, Y: y0}, draw.Src)
+	if err := validateSlidesScreenshotRegionBounds(region, bounds.Size()); err != nil {
+		return nil, err
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, region.Width, region.Height))
+	draw.Draw(dst, dst.Bounds(), src, image.Point{X: bounds.Min.X + region.X, Y: bounds.Min.Y + region.Y}, draw.Src)
 	var out bytes.Buffer
 	if err := png.Encode(&out, dst); err != nil {
 		return nil, errs.NewInternalError(errs.SubtypeFileIO, "encode --region screenshot: %v", err).WithCause(err)
@@ -985,51 +977,11 @@ func cropSlidesScreenshotResponse(data map[string]interface{}, region slidesScre
 	item["data"] = base64.StdEncoding.EncodeToString(out.Bytes())
 	item["format"] = 1
 	return map[string]interface{}{
-		"canvas":            map[string]interface{}{"width": canvas.Width, "height": canvas.Height, "unit": "slide_canvas"},
-		"requested":         map[string]int{"x": region.X, "y": region.Y, "width": region.Width, "height": region.Height},
-		"source_image_size": map[string]int{"width": bounds.Dx(), "height": bounds.Dy()},
-		"pixel_rect":        map[string]int{"x": x0, "y": y0, "width": x1 - x0, "height": y1 - y0},
-		"format":            "png",
+		"requested_pixel_rect": map[string]int{"x": region.X, "y": region.Y, "width": region.Width, "height": region.Height},
+		"source_image_size":    map[string]int{"width": bounds.Dx(), "height": bounds.Dy()},
+		"output_image_size":    map[string]int{"width": region.Width, "height": region.Height},
+		"format":               "png",
 	}, nil
-}
-
-func fetchSlidesScreenshotCanvas(runtime *common.RuntimeContext, presentationID string) (slidesScreenshotCanvas, error) {
-	if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
-		return slidesScreenshotCanvas{}, err
-	}
-	data, err := runtime.CallAPITyped("GET", fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID)), map[string]interface{}{"revision_id": -1}, nil)
-	if err != nil {
-		return slidesScreenshotCanvas{}, err
-	}
-	return slidesScreenshotCanvasFromXML(common.GetString(common.GetMap(data, "xml_presentation"), "content"))
-}
-
-func slidesScreenshotCanvasFromXML(content string) (slidesScreenshotCanvas, error) {
-	d := xml.NewDecoder(strings.NewReader(content))
-	for {
-		tok, err := d.Token()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return slidesScreenshotCanvas{}, errs.NewAPIError(errs.SubtypeInvalidResponse, "parse presentation XML for --region: %v", err).WithCause(err)
-		}
-		start, ok := tok.(xml.StartElement)
-		if !ok || start.Name.Local != "presentation" {
-			continue
-		}
-		attrs := map[string]string{}
-		for _, attr := range start.Attr {
-			attrs[attr.Name.Local] = attr.Value
-		}
-		width, widthErr := strconv.Atoi(attrs["width"])
-		height, heightErr := strconv.Atoi(attrs["height"])
-		if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
-			return slidesScreenshotCanvas{}, errs.NewAPIError(errs.SubtypeInvalidResponse, "presentation XML for --region must contain positive integer width and height")
-		}
-		return slidesScreenshotCanvas{Width: width, Height: height}, nil
-	}
-	return slidesScreenshotCanvas{}, errs.NewAPIError(errs.SubtypeInvalidResponse, "presentation XML for --region is missing a presentation root")
 }
 
 func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
@@ -1109,7 +1061,8 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 		index := start + i + 1
 		slides[i] = map[string]interface{}{"index": index, "label": fmt.Sprintf("#%02d", index), "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
 	}
-	overviewData := map[string]interface{}{"path": path, "format": "png", "size": map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}, "columns": runtime.Int("overview-columns"), "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
+	overviewImageSize := map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}
+	overviewData := map[string]interface{}{"path": path, "format": "png", "size": overviewImageSize, "image_size": overviewImageSize, "columns": runtime.Int("overview-columns"), "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
 	if overviewPage > 1 {
 		overviewData["previous_overview_page"] = overviewPage - 1
 	}

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -7,7 +7,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/xml"
 	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	_ "image/jpeg"
+	"image/png"
+	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,11 +29,15 @@ import (
 	"github.com/larksuite/cli/internal/util"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
+	xdraw "golang.org/x/image/draw"
 )
 
 const (
 	defaultSlidesScreenshotDir = ".lark-slides/screenshots"
 	maxSlidesPerScreenshot     = 10
+	defaultOverviewColumns     = 4
+	slideCanvasWidth           = 960
+	slideCanvasHeight          = 540
 )
 
 var (
@@ -54,8 +66,31 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "output", Desc: "preferred relative output path for a single screenshot (extension optional; .png, .jpg, or .jpeg)"},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
 		{Name: "output-name", Desc: "file name stem for --content render output"},
+		{Name: "overview", Type: "bool", Desc: "render every current slide into one local overview PNG; cannot be combined with slide selectors, --content, or --region"},
+		{Name: "overview-columns", Type: "int", Default: "4", Desc: "number of columns in --overview output (1-10)"},
+		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in the 960x540 slide canvas; cannot be combined with --overview"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		overview := runtime.Bool("overview")
+		region, regionSet, err := parseSlidesScreenshotRegion(runtime.Str("region"))
+		if err != nil {
+			return err
+		}
+		if overview && regionSet {
+			return slidesScreenshotFlagErrorf("--overview cannot be combined with --region")
+		}
+		if regionSet && runtime.Changed("content") {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region cannot be combined with --content").WithParams(
+				errs.InvalidParam{Name: "--region", Reason: "only crops an existing slide selected by --slide-id or --slide-number"},
+				errs.InvalidParam{Name: "--content", Reason: "render mode does not select an existing slide"},
+			)
+		}
+		if overview && (runtime.Changed("content") || slidesScreenshotHasSelectorInput(runtime)) {
+			return slidesScreenshotFlagErrorf("--overview requires --presentation without --content or slide selectors")
+		}
+		if overview && (runtime.Int("overview-columns") < 1 || runtime.Int("overview-columns") > 10) {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-columns must be between 1 and 10").WithParam("--overview-columns")
+		}
 		renderMode := runtime.Changed("content")
 		selectorCount := 1
 		if renderMode {
@@ -82,10 +117,19 @@ var SlidesScreenshot = common.Shortcut{
 					return err
 				}
 			}
-			if len(slideIDs) == 0 && len(slideNumbers) == 0 {
+			if !overview && len(slideIDs) == 0 && len(slideNumbers) == 0 {
 				return slidesScreenshotMissingSelectorError()
 			}
 			selectorCount = len(slideIDs) + len(slideNumbers)
+			if overview {
+				// Overview is one synthesized local image even though it deliberately
+				// has no page selector. Keep --output's single-file contract usable.
+				selectorCount = 1
+			}
+			if regionSet && selectorCount != 1 {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region requires exactly one slide selector").WithParam("--region").WithHint("use one --slide-id or one --slide-number")
+			}
+			_ = region
 			if err := validateSlidesScreenshotSelectorLimit(selectorCount); err != nil {
 				return err
 			}
@@ -133,6 +177,14 @@ var SlidesScreenshot = common.Shortcut{
 
 		presentationID := ref.Token
 		dry := common.NewDryRunAPI()
+		if runtime.Bool("overview") {
+			if ref.Kind == "wiki" {
+				presentationID = "<resolved_slides_token>"
+				dry.Desc("3-step orchestration: resolve wiki → fetch current slide IDs → render batches and compose a local overview PNG").GET("/open-apis/wiki/v2/spaces/get_node").Params(map[string]interface{}{"token": ref.Token})
+			}
+			dry.Desc("Fetch current presentation XML to enumerate stable slide IDs; then render batches of at most 10 pages and compose one local overview PNG").GET(fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))).Params(map[string]interface{}{"revision_id": -1})
+			return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded locally and composed into overview PNG during execution")
+		}
 		if ref.Kind == "wiki" {
 			presentationID = "<resolved_slides_token>"
 			dry.Desc("2-step orchestration: resolve wiki → fetch slide screenshot(s)").
@@ -161,6 +213,9 @@ var SlidesScreenshot = common.Shortcut{
 		return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded to local files during execution")
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if runtime.Bool("overview") {
+			return executeSlidesScreenshotOverview(runtime)
+		}
 		if runtime.Changed("content") {
 			return executeRenderScreenshot(runtime)
 		}
@@ -205,6 +260,11 @@ var SlidesScreenshot = common.Shortcut{
 			return enrichSlidesScreenshotSelectorError(err, slideNumbers)
 		}
 
+		if region, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
+			if err := cropSlidesScreenshotResponse(data, region); err != nil {
+				return err
+			}
+		}
 		saved, err := saveSlideScreenshots(runtime, data, outputTarget.safeOutputDir, presentationID, outputTarget.requested)
 		if err != nil {
 			return err
@@ -212,6 +272,9 @@ var SlidesScreenshot = common.Shortcut{
 		result := map[string]interface{}{
 			"xml_presentation_id": presentationID,
 			"screenshots":         saved,
+		}
+		if region, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
+			result["region"] = map[string]interface{}{"canvas": map[string]int{"x": region.X, "y": region.Y, "width": region.Width, "height": region.Height}, "unit": "slide_canvas_960x540", "format": "png"}
 		}
 		setSlidesScreenshotResultOutput(result, outputTarget, saved)
 		runtime.Out(result, nil)
@@ -794,4 +857,229 @@ func writeUniqueScreenshotPath(runtime *common.RuntimeContext, outputPath string
 
 func isScreenshotFileNotExist(err error) bool {
 	return os.IsNotExist(err)
+}
+
+type slidesScreenshotRegion struct{ X, Y, Width, Height int }
+
+func parseSlidesScreenshotRegion(raw string) (slidesScreenshotRegion, bool, error) {
+	if strings.TrimSpace(raw) == "" {
+		return slidesScreenshotRegion{}, false, nil
+	}
+	parts := strings.Split(raw, ",")
+	if len(parts) != 4 {
+		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must be x,y,width,height in the 960x540 slide canvas").WithParam("--region")
+	}
+	vals := [4]int{}
+	for i, part := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil {
+			return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region values must be integers").WithParam("--region")
+		}
+		vals[i] = n
+	}
+	r := slidesScreenshotRegion{vals[0], vals[1], vals[2], vals[3]}
+	if r.X < 0 || r.Y < 0 || r.Width <= 0 || r.Height <= 0 || r.X+r.Width > slideCanvasWidth || r.Y+r.Height > slideCanvasHeight {
+		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must stay within the 960x540 slide canvas").WithParam("--region").WithHint("use non-negative x,y and positive width,height with x+width<=960 and y+height<=540")
+	}
+	return r, true, nil
+}
+
+func cropSlidesScreenshotResponse(data map[string]interface{}, region slidesScreenshotRegion) error {
+	items := common.GetSlice(data, "slide_images")
+	if len(items) != 1 {
+		return slidesScreenshotAPIDataError(data, "--region requires exactly one rendered slide image")
+	}
+	item, ok := items[0].(map[string]interface{})
+	if !ok {
+		return slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide_images[0]")
+	}
+	encoded := common.GetString(item, "data")
+	b, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return slidesScreenshotImageDataCauseError(common.GetString(item, "slide_id"), err, "decode screenshot for --region: %s", err)
+	}
+	src, _, err := image.Decode(bytes.NewReader(b))
+	if err != nil {
+		return slidesScreenshotImageDataCauseError(common.GetString(item, "slide_id"), err, "decode screenshot image for --region: %s", err)
+	}
+	bounds := src.Bounds()
+	x0 := region.X * bounds.Dx() / slideCanvasWidth
+	y0 := region.Y * bounds.Dy() / slideCanvasHeight
+	x1 := int(math.Ceil(float64((region.X+region.Width)*bounds.Dx()) / slideCanvasWidth))
+	y1 := int(math.Ceil(float64((region.Y+region.Height)*bounds.Dy()) / slideCanvasHeight))
+	dst := image.NewRGBA(image.Rect(0, 0, x1-x0, y1-y0))
+	draw.Draw(dst, dst.Bounds(), src, image.Point{X: x0, Y: y0}, draw.Src)
+	var out bytes.Buffer
+	if err := png.Encode(&out, dst); err != nil {
+		return errs.NewInternalError(errs.SubtypeFileIO, "encode --region screenshot: %v", err).WithCause(err)
+	}
+	item["data"] = base64.StdEncoding.EncodeToString(out.Bytes())
+	item["format"] = 1
+	return nil
+}
+
+func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
+	ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
+	if err != nil {
+		return err
+	}
+	if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
+		return err
+	}
+	presentationID, err := resolvePresentationID(runtime, ref)
+	if err != nil {
+		return err
+	}
+	data, err := runtime.CallAPITyped("GET", fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID)), map[string]interface{}{"revision_id": -1}, nil)
+	if err != nil {
+		return err
+	}
+	content := common.GetString(common.GetMap(data, "xml_presentation"), "content")
+	ids, err := slidesScreenshotIDsFromXML(content)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview found no current slide IDs").WithHint("verify the presentation contains slides, then retry")
+	}
+	thumbs := make([]image.Image, 0, len(ids))
+	for start := 0; start < len(ids); start += maxSlidesPerScreenshot {
+		end := start + maxSlidesPerScreenshot
+		if end > len(ids) {
+			end = len(ids)
+		}
+		url := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s/slide_images", validate.EncodePathSegment(presentationID))
+		pageData, err := doSlidesScreenshotAPIJSONWithLogID(runtime, "POST", url, larkcore.QueryParams{}, map[string]interface{}{"slide_ids": ids[start:end]})
+		if err != nil {
+			return err
+		}
+		for _, raw := range common.GetSlice(pageData, "slide_images") {
+			item, ok := raw.(map[string]interface{})
+			if !ok {
+				return slidesScreenshotAPIDataError(pageData, "slides screenshot returned invalid slide image")
+			}
+			b, err := base64.StdEncoding.DecodeString(common.GetString(item, "data"))
+			if err != nil {
+				return err
+			}
+			img, _, err := image.Decode(bytes.NewReader(b))
+			if err != nil {
+				return err
+			}
+			thumbs = append(thumbs, img)
+		}
+	}
+	overview, cells := composeSlidesOverview(thumbs, runtime.Int("overview-columns"))
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, overview); err != nil {
+		return errs.NewInternalError(errs.SubtypeFileIO, "encode overview PNG: %v", err).WithCause(err)
+	}
+	target, err := resolveSlidesScreenshotOutputTarget(runtime)
+	if err != nil {
+		return err
+	}
+	path := target.requested
+	if path == "" {
+		path = filepath.Join(target.safeOutputDir, safeScreenshotFileBase(presentationID)+"_overview.png")
+	} else if ext := strings.ToLower(filepath.Ext(path)); ext != "" && ext != ".png" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview output must be .png").WithParam("--output")
+	}
+	path, err = writeUniqueScreenshotPath(runtime, path, encoded.Bytes())
+	if err != nil {
+		return err
+	}
+	slides := make([]map[string]interface{}, len(ids))
+	for i, id := range ids {
+		cell := cells[i]
+		slides[i] = map[string]interface{}{"index": i + 1, "label": fmt.Sprintf("#%02d", i+1), "slide_id": id, "slide_number": i + 1, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
+	}
+	runtime.Out(map[string]interface{}{"xml_presentation_id": presentationID, "overview": map[string]interface{}{"path": path, "format": "png", "size": map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}, "columns": runtime.Int("overview-columns"), "slides": slides}}, nil)
+	return nil
+}
+
+func slidesScreenshotIDsFromXML(content string) ([]string, error) {
+	d := xml.NewDecoder(strings.NewReader(content))
+	var ids []string
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "parse presentation XML for --overview: %v", err).WithCause(err)
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "slide" {
+			continue
+		}
+		for _, a := range start.Attr {
+			if a.Name.Local == "id" && strings.TrimSpace(a.Value) != "" {
+				ids = append(ids, a.Value)
+				break
+			}
+		}
+	}
+	return ids, nil
+}
+
+type overviewCell struct {
+	row, column     int
+	tile, thumbnail image.Rectangle
+}
+
+func overviewRectOutput(r image.Rectangle) map[string]int {
+	return map[string]int{"x": r.Min.X, "y": r.Min.Y, "width": r.Dx(), "height": r.Dy()}
+}
+
+func composeSlidesOverview(images []image.Image, columns int) (*image.RGBA, []overviewCell) {
+	if columns < 1 {
+		columns = defaultOverviewColumns
+	}
+	const thumbW, thumbH, headerH, pad = 320, 180, 40, 16
+	rows := int(math.Ceil(float64(len(images)) / float64(columns)))
+	tileH := headerH + thumbH
+	out := image.NewRGBA(image.Rect(0, 0, columns*thumbW+(columns+1)*pad, rows*tileH+(rows+1)*pad))
+	draw.Draw(out, out.Bounds(), &image.Uniform{C: color.White}, image.Point{}, draw.Src)
+	cells := make([]overviewCell, len(images))
+	for i, src := range images {
+		r, c := i/columns, i%columns
+		x, y := pad+c*(thumbW+pad), pad+r*(tileH+pad)
+		tile := image.Rect(x, y, x+thumbW, y+tileH)
+		thumbnail := image.Rect(x, y+headerH, x+thumbW, y+tileH)
+		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 20, G: 35, B: 58, A: 255}}, image.Point{}, draw.Src)
+		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
+		drawOverviewIndex(out, image.Pt(x+14, y+7), i+1)
+		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
+	}
+	return out, cells
+}
+
+var overviewDigitPixels = map[rune][]string{
+	'#': {"01010", "11111", "01010", "11111", "01010"},
+	'0': {"01110", "10001", "10011", "10101", "11001", "10001", "01110"},
+	'1': {"00100", "01100", "00100", "00100", "00100", "00100", "01110"},
+	'2': {"01110", "10001", "00001", "00010", "00100", "01000", "11111"},
+	'3': {"11110", "00001", "00001", "01110", "00001", "00001", "11110"},
+	'4': {"00010", "00110", "01010", "10010", "11111", "00010", "00010"},
+	'5': {"11111", "10000", "11110", "00001", "00001", "10001", "01110"},
+	'6': {"00110", "01000", "10000", "11110", "10001", "10001", "01110"},
+	'7': {"11111", "00001", "00010", "00100", "01000", "01000", "01000"},
+	'8': {"01110", "10001", "10001", "01110", "10001", "10001", "01110"},
+	'9': {"01110", "10001", "10001", "01111", "00001", "00010", "11100"},
+}
+
+func drawOverviewIndex(dst draw.Image, at image.Point, index int) {
+	const scale, gap = 4, 5
+	x := at.X
+	for _, ch := range fmt.Sprintf("#%02d", index) {
+		glyph := overviewDigitPixels[ch]
+		for y, row := range glyph {
+			for col, on := range row {
+				if on == '1' {
+					draw.Draw(dst, image.Rect(x+col*scale, at.Y+y*scale, x+(col+1)*scale, at.Y+(y+1)*scale), &image.Uniform{C: color.White}, image.Point{}, draw.Src)
+				}
+			}
+		}
+		x += (len(glyph[0]) + gap) * scale
+	}
 }

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -878,7 +879,10 @@ func parseSlidesScreenshotRegion(raw string) (slidesScreenshotRegion, bool, erro
 		vals[i] = n
 	}
 	r := slidesScreenshotRegion{vals[0], vals[1], vals[2], vals[3]}
-	if r.X < 0 || r.Y < 0 || r.Width <= 0 || r.Height <= 0 || r.X+r.Width > slideCanvasWidth || r.Y+r.Height > slideCanvasHeight {
+	// Compare the remaining canvas size instead of adding X+Width. Apart from
+	// being equivalent for valid values, this cannot wrap on a hostile integer
+	// input before the bounds check runs.
+	if r.X < 0 || r.Y < 0 || r.Width <= 0 || r.Height <= 0 || r.Width > slideCanvasWidth-r.X || r.Height > slideCanvasHeight-r.Y {
 		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must stay within the 960x540 slide canvas").WithParam("--region").WithHint("use non-negative x,y and positive width,height with x+width<=960 and y+height<=540")
 	}
 	return r, true, nil
@@ -953,21 +957,11 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 		if err != nil {
 			return err
 		}
-		for _, raw := range common.GetSlice(pageData, "slide_images") {
-			item, ok := raw.(map[string]interface{})
-			if !ok {
-				return slidesScreenshotAPIDataError(pageData, "slides screenshot returned invalid slide image")
-			}
-			b, err := base64.StdEncoding.DecodeString(common.GetString(item, "data"))
-			if err != nil {
-				return err
-			}
-			img, _, err := image.Decode(bytes.NewReader(b))
-			if err != nil {
-				return err
-			}
-			thumbs = append(thumbs, img)
+		batch, err := slidesScreenshotOverviewImages(pageData, ids[start:end])
+		if err != nil {
+			return err
 		}
+		thumbs = append(thumbs, batch...)
 	}
 	overview, cells := composeSlidesOverview(thumbs, runtime.Int("overview-columns"))
 	var encoded bytes.Buffer
@@ -997,13 +991,60 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	return nil
 }
 
+// slidesScreenshotOverviewImages verifies that the API response is a bijection
+// with requestedIDs, then returns its images in request order. The API's array
+// order is deliberately not trusted: a mismatched thumbnail makes the overview
+// index unsafe for an agent to use in a later per-slide review.
+func slidesScreenshotOverviewImages(data map[string]interface{}, requestedIDs []string) ([]image.Image, error) {
+	items := common.GetSlice(data, "slide_images")
+	if len(items) != len(requestedIDs) {
+		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned %d images for %d requested slide IDs", len(items), len(requestedIDs))
+	}
+	requested := make(map[string]struct{}, len(requestedIDs))
+	for _, id := range requestedIDs {
+		requested[id] = struct{}{}
+	}
+	byID := make(map[string]map[string]interface{}, len(items))
+	for _, raw := range items {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide image")
+		}
+		id := common.GetString(item, "slide_id")
+		if _, ok := requested[id]; !ok || id == "" {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned unexpected slide_id %q", id)
+		}
+		if _, duplicate := byID[id]; duplicate {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned duplicate slide_id %q", id)
+		}
+		byID[id] = item
+	}
+	images := make([]image.Image, 0, len(requestedIDs))
+	for _, id := range requestedIDs {
+		item, ok := byID[id]
+		if !ok {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot did not return requested slide_id %q", id)
+		}
+		b, err := base64.StdEncoding.DecodeString(common.GetString(item, "data"))
+		if err != nil {
+			return nil, slidesScreenshotImageDataCauseError(id, err, "decode screenshot for --overview: %s", err)
+		}
+		img, _, err := image.Decode(bytes.NewReader(b))
+		if err != nil {
+			return nil, slidesScreenshotImageDataCauseError(id, err, "decode screenshot image for --overview: %s", err)
+		}
+		images = append(images, img)
+	}
+	return images, nil
+}
+
 func slidesScreenshotIDsFromXML(content string) ([]string, error) {
 	d := xml.NewDecoder(strings.NewReader(content))
 	var ids []string
 	for {
 		tok, err := d.Token()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "parse presentation XML for --overview: %v", err).WithCause(err)

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -74,6 +74,9 @@ var SlidesScreenshot = common.Shortcut{
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		overview := runtime.Bool("overview")
+		if runtime.Changed("region") && strings.TrimSpace(runtime.Str("region")) == "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region cannot be empty").WithParam("--region").WithHint("provide x,y,width,height in the presentation canvas")
+		}
 		region, regionSet, err := parseSlidesScreenshotRegion(runtime.Str("region"))
 		if err != nil {
 			return err
@@ -154,6 +157,12 @@ var SlidesScreenshot = common.Shortcut{
 			}
 			if err := validateScreenshotOutputPath(runtime, runtime.Str("output")); err != nil {
 				return err
+			}
+			if overview {
+				ext := strings.ToLower(filepath.Ext(runtime.Str("output")))
+				if ext != "" && ext != ".png" {
+					return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview output must be .png").WithParam("--output")
+				}
 			}
 		} else {
 			if !renderMode && runtime.Changed("output-name") {
@@ -1065,8 +1074,8 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	path := target.requested
 	if path == "" {
 		path = filepath.Join(target.safeOutputDir, safeScreenshotFileBase(presentationID)+"_overview.png")
-	} else if ext := strings.ToLower(filepath.Ext(path)); ext != "" && ext != ".png" {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview output must be .png").WithParam("--output")
+	} else if filepath.Ext(path) == "" {
+		path += ".png"
 	}
 	path, err = writeUniqueScreenshotPath(runtime, path, encoded.Bytes())
 	if err != nil {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -1058,7 +1058,7 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 		slides[i] = map[string]interface{}{"index": index, "label": fmt.Sprintf("#%02d", index), "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
 	}
 	overviewImageSize := map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}
-	overviewData := map[string]interface{}{"path": path, "format": "png", "size": overviewImageSize, "image_size": overviewImageSize, "columns": defaultOverviewColumns, "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
+	overviewData := map[string]interface{}{"path": path, "format": "png", "size": encoded.Len(), "image_size": overviewImageSize, "columns": defaultOverviewColumns, "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
 	if overviewPage > 1 {
 		overviewData["previous_overview_page"] = overviewPage - 1
 	}

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -1175,11 +1175,26 @@ func composeSlidesOverviewFromIndex(images []image.Image, columns int, firstInde
 		tile := image.Rect(x, y, x+thumbW, y+tileH)
 		thumbnail := image.Rect(x, y+headerH, x+thumbW, y+tileH)
 		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 20, G: 35, B: 58, A: 255}}, image.Point{}, draw.Src)
-		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
+		// The tile geometry is intentionally fixed so overview indices remain easy
+		// for agents to locate. Only the page content is aspect-fitted within it.
+		draw.Draw(out, thumbnail, &image.Uniform{C: color.RGBA{R: 226, G: 232, B: 240, A: 255}}, image.Point{}, draw.Src)
+		xdraw.CatmullRom.Scale(out, slidesOverviewThumbnailContentRect(thumbnail, src.Bounds()), src, src.Bounds(), draw.Over, nil)
 		drawOverviewIndex(out, image.Pt(x+14, y+7), firstIndex+i)
 		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
 	}
 	return out, cells
+}
+
+func slidesOverviewThumbnailContentRect(thumbnail, source image.Rectangle) image.Rectangle {
+	if source.Dx() <= 0 || source.Dy() <= 0 {
+		return thumbnail
+	}
+	scale := math.Min(float64(thumbnail.Dx())/float64(source.Dx()), float64(thumbnail.Dy())/float64(source.Dy()))
+	width := min(thumbnail.Dx(), int(math.Round(float64(source.Dx())*scale)))
+	height := min(thumbnail.Dy(), int(math.Round(float64(source.Dy())*scale)))
+	x := thumbnail.Min.X + (thumbnail.Dx()-width)/2
+	y := thumbnail.Min.Y + (thumbnail.Dy()-height)/2
+	return image.Rect(x, y, x+width, y+height)
 }
 
 var overviewDigitPixels = map[rune][]string{

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -1188,23 +1188,32 @@ func composeSlidesOverviewFromIndex(images []image.Image, columns int, firstInde
 	if columns < 1 {
 		columns = defaultOverviewColumns
 	}
-	const thumbW, thumbH, headerH, pad = 320, 180, 40, 16
+	const thumbW, thumbH, headerH, pad = 320, 180, 24, 16
 	rows := int(math.Ceil(float64(len(images)) / float64(columns)))
 	tileH := headerH + thumbH
 	out := image.NewRGBA(image.Rect(0, 0, columns*thumbW+(columns+1)*pad, rows*tileH+(rows+1)*pad))
-	draw.Draw(out, out.Bounds(), &image.Uniform{C: color.White}, image.Point{}, draw.Src)
+	draw.Draw(out, out.Bounds(), &image.Uniform{C: color.RGBA{R: 246, G: 247, B: 249, A: 255}}, image.Point{}, draw.Src)
 	cells := make([]overviewCell, len(images))
 	for i, src := range images {
 		r, c := i/columns, i%columns
 		x, y := pad+c*(thumbW+pad), pad+r*(tileH+pad)
 		tile := image.Rect(x, y, x+thumbW, y+tileH)
 		thumbnail := image.Rect(x, y+headerH, x+thumbW, y+tileH)
-		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 20, G: 35, B: 58, A: 255}}, image.Point{}, draw.Src)
+		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 49, G: 50, B: 53, A: 255}}, image.Point{}, draw.Src)
 		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
-		drawOverviewIndex(out, image.Pt(x+14, y+7), firstIndex+i)
+		drawOverviewThumbnailBorder(out, thumbnail)
+		drawOverviewIndex(out, image.Pt(x+9, y+5), firstIndex+i)
 		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
 	}
 	return out, cells
+}
+
+func drawOverviewThumbnailBorder(dst draw.Image, thumbnail image.Rectangle) {
+	border := &image.Uniform{C: color.RGBA{R: 205, G: 208, B: 213, A: 255}}
+	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Min.Y, thumbnail.Max.X, thumbnail.Min.Y+1), border, image.Point{}, draw.Src)
+	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Max.Y-1, thumbnail.Max.X, thumbnail.Max.Y), border, image.Point{}, draw.Src)
+	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Min.Y, thumbnail.Min.X+1, thumbnail.Max.Y), border, image.Point{}, draw.Src)
+	draw.Draw(dst, image.Rect(thumbnail.Max.X-1, thumbnail.Min.Y, thumbnail.Max.X, thumbnail.Max.Y), border, image.Point{}, draw.Src)
 }
 
 var overviewDigitPixels = map[rune][]string{
@@ -1222,7 +1231,7 @@ var overviewDigitPixels = map[rune][]string{
 }
 
 func drawOverviewIndex(dst draw.Image, at image.Point, index int) {
-	const scale, gap = 4, 5
+	const scale, gap = 2, 3
 	x := at.X
 	for _, ch := range fmt.Sprintf("#%02d", index) {
 		glyph := overviewDigitPixels[ch]

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -1175,26 +1175,11 @@ func composeSlidesOverviewFromIndex(images []image.Image, columns int, firstInde
 		tile := image.Rect(x, y, x+thumbW, y+tileH)
 		thumbnail := image.Rect(x, y+headerH, x+thumbW, y+tileH)
 		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 20, G: 35, B: 58, A: 255}}, image.Point{}, draw.Src)
-		// The tile geometry is intentionally fixed so overview indices remain easy
-		// for agents to locate. Only the page content is aspect-fitted within it.
-		draw.Draw(out, thumbnail, &image.Uniform{C: color.RGBA{R: 226, G: 232, B: 240, A: 255}}, image.Point{}, draw.Src)
-		xdraw.CatmullRom.Scale(out, slidesOverviewThumbnailContentRect(thumbnail, src.Bounds()), src, src.Bounds(), draw.Over, nil)
+		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
 		drawOverviewIndex(out, image.Pt(x+14, y+7), firstIndex+i)
 		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
 	}
 	return out, cells
-}
-
-func slidesOverviewThumbnailContentRect(thumbnail, source image.Rectangle) image.Rectangle {
-	if source.Dx() <= 0 || source.Dy() <= 0 {
-		return thumbnail
-	}
-	scale := math.Min(float64(thumbnail.Dx())/float64(source.Dx()), float64(thumbnail.Dy())/float64(source.Dy()))
-	width := min(thumbnail.Dx(), int(math.Round(float64(source.Dx())*scale)))
-	height := min(thumbnail.Dy(), int(math.Round(float64(source.Dy())*scale)))
-	x := thumbnail.Min.X + (thumbnail.Dx()-width)/2
-	y := thumbnail.Min.Y + (thumbnail.Dy()-height)/2
-	return image.Rect(x, y, x+width, y+height)
 }
 
 var overviewDigitPixels = map[rune][]string{

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -67,8 +67,8 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "output", Desc: "preferred relative output path for a single screenshot (extension optional; .png, .jpg, or .jpeg)"},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
 		{Name: "output-name", Desc: "file name stem for --content render output"},
-		{Name: "overview", Type: "bool", Desc: "render every current slide into one local overview PNG; cannot be combined with slide selectors, --content, or --region"},
-		{Name: "overview-page", Type: "int", Default: "1", Desc: "1-based overview page; each overview contains at most 20 slides"},
+		{Name: "overview", Type: "bool", Desc: "render one indexed overview PNG containing up to 20 current slides; use --overview-page for additional slides; cannot be combined with slide selectors, --content, or --region"},
+		{Name: "overview-page", Type: "int", Default: "1", Desc: "1-based overview page (up to 20 slides); continue with next_overview_page while has_next is true"},
 		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in the rendered screenshot pixels; cannot be combined with --overview"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -996,8 +996,7 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	content := common.GetString(common.GetMap(data, "xml_presentation"), "content")
-	ids, err := slidesScreenshotIDsFromXML(content)
+	ids, err := slidesScreenshotOverviewIDs(data)
 	if err != nil {
 		return err
 	}
@@ -1124,16 +1123,30 @@ func slidesScreenshotOverviewImages(data map[string]interface{}, requestedIDs []
 func slidesScreenshotIDsFromXML(content string) ([]string, error) {
 	d := xml.NewDecoder(strings.NewReader(content))
 	var ids []string
+	seenRoot := false
 	for {
 		tok, err := d.Token()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				if !seenRoot {
+					return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "presentation XML for --overview has no root element")
+				}
 				break
 			}
 			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "parse presentation XML for --overview: %v", err).WithCause(err)
 		}
 		start, ok := tok.(xml.StartElement)
-		if !ok || start.Name.Local != "slide" {
+		if !ok {
+			continue
+		}
+		if !seenRoot {
+			seenRoot = true
+			if start.Name.Local != "presentation" {
+				return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "presentation XML for --overview has root element %q, want presentation", start.Name.Local)
+			}
+			continue
+		}
+		if start.Name.Local != "slide" {
 			continue
 		}
 		for _, a := range start.Attr {
@@ -1144,6 +1157,18 @@ func slidesScreenshotIDsFromXML(content string) ([]string, error) {
 		}
 	}
 	return ids, nil
+}
+
+func slidesScreenshotOverviewIDs(data map[string]interface{}) ([]string, error) {
+	presentation, ok := data["xml_presentation"].(map[string]interface{})
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "xml_presentation response for --overview must be an object")
+	}
+	content, ok := presentation["content"].(string)
+	if !ok || strings.TrimSpace(content) == "" {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "xml_presentation.content response for --overview must be a non-empty string")
+	}
+	return slidesScreenshotIDsFromXML(content)
 }
 
 type overviewCell struct {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -36,6 +36,7 @@ import (
 const (
 	defaultSlidesScreenshotDir = ".lark-slides/screenshots"
 	maxSlidesPerScreenshot     = 10
+	maxSlidesPerOverview       = 20
 	defaultOverviewColumns     = 4
 	slideCanvasWidth           = 960
 	slideCanvasHeight          = 540
@@ -68,6 +69,7 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
 		{Name: "output-name", Desc: "file name stem for --content render output"},
 		{Name: "overview", Type: "bool", Desc: "render every current slide into one local overview PNG; cannot be combined with slide selectors, --content, or --region"},
+		{Name: "overview-page", Type: "int", Default: "1", Desc: "1-based overview page; each overview contains at most 20 slides"},
 		{Name: "overview-columns", Type: "int", Default: "4", Desc: "number of columns in --overview output (1-10)"},
 		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in the 960x540 slide canvas; cannot be combined with --overview"},
 	},
@@ -91,6 +93,12 @@ var SlidesScreenshot = common.Shortcut{
 		}
 		if overview && (runtime.Int("overview-columns") < 1 || runtime.Int("overview-columns") > 10) {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-columns must be between 1 and 10").WithParam("--overview-columns")
+		}
+		if runtime.Changed("overview-page") && !overview {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-page requires --overview").WithParam("--overview-page")
+		}
+		if overview && runtime.Int("overview-page") < 1 {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-page must be at least 1").WithParam("--overview-page")
 		}
 		renderMode := runtime.Changed("content")
 		selectorCount := 1
@@ -183,7 +191,7 @@ var SlidesScreenshot = common.Shortcut{
 				presentationID = "<resolved_slides_token>"
 				dry.Desc("3-step orchestration: resolve wiki → fetch current slide IDs → render batches and compose a local overview PNG").GET("/open-apis/wiki/v2/spaces/get_node").Params(map[string]interface{}{"token": ref.Token})
 			}
-			dry.Desc("Fetch current presentation XML to enumerate stable slide IDs; then render batches of at most 10 pages and compose one local overview PNG").GET(fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))).Params(map[string]interface{}{"revision_id": -1})
+			dry.Desc(fmt.Sprintf("Fetch current presentation XML, then render overview page %d (at most %d slides) in batches of at most 10 pages and compose one local overview PNG", runtime.Int("overview-page"), maxSlidesPerOverview)).GET(fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))).Params(map[string]interface{}{"revision_id": -1})
 			return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded locally and composed into overview PNG during execution")
 		}
 		if ref.Kind == "wiki" {
@@ -946,24 +954,35 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	if len(ids) == 0 {
 		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview found no current slide IDs").WithHint("verify the presentation contains slides, then retry")
 	}
-	thumbs := make([]image.Image, 0, len(ids))
-	for start := 0; start < len(ids); start += maxSlidesPerScreenshot {
-		end := start + maxSlidesPerScreenshot
-		if end > len(ids) {
-			end = len(ids)
+	overviewPage := runtime.Int("overview-page")
+	maxPage := (len(ids) + maxSlidesPerOverview - 1) / maxSlidesPerOverview
+	if overviewPage > maxPage {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview-page %d is outside this %d-slide presentation", overviewPage, len(ids)).WithParam("--overview-page").WithHint(fmt.Sprintf("use a value between 1 and %d", maxPage))
+	}
+	start := (overviewPage - 1) * maxSlidesPerOverview
+	end := start + maxSlidesPerOverview
+	if end > len(ids) {
+		end = len(ids)
+	}
+	pageIDs := ids[start:end]
+	thumbs := make([]image.Image, 0, len(pageIDs))
+	for batchStart := 0; batchStart < len(pageIDs); batchStart += maxSlidesPerScreenshot {
+		batchEnd := batchStart + maxSlidesPerScreenshot
+		if batchEnd > len(pageIDs) {
+			batchEnd = len(pageIDs)
 		}
 		url := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s/slide_images", validate.EncodePathSegment(presentationID))
-		pageData, err := doSlidesScreenshotAPIJSONWithLogID(runtime, "POST", url, larkcore.QueryParams{}, map[string]interface{}{"slide_ids": ids[start:end]})
+		pageData, err := doSlidesScreenshotAPIJSONWithLogID(runtime, "POST", url, larkcore.QueryParams{}, map[string]interface{}{"slide_ids": pageIDs[batchStart:batchEnd]})
 		if err != nil {
 			return err
 		}
-		batch, err := slidesScreenshotOverviewImages(pageData, ids[start:end])
+		batch, err := slidesScreenshotOverviewImages(pageData, pageIDs[batchStart:batchEnd])
 		if err != nil {
 			return err
 		}
 		thumbs = append(thumbs, batch...)
 	}
-	overview, cells := composeSlidesOverview(thumbs, runtime.Int("overview-columns"))
+	overview, cells := composeSlidesOverviewFromIndex(thumbs, runtime.Int("overview-columns"), start+1)
 	var encoded bytes.Buffer
 	if err := png.Encode(&encoded, overview); err != nil {
 		return errs.NewInternalError(errs.SubtypeFileIO, "encode overview PNG: %v", err).WithCause(err)
@@ -982,12 +1001,20 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	slides := make([]map[string]interface{}, len(ids))
-	for i, id := range ids {
+	slides := make([]map[string]interface{}, len(pageIDs))
+	for i, id := range pageIDs {
 		cell := cells[i]
-		slides[i] = map[string]interface{}{"index": i + 1, "label": fmt.Sprintf("#%02d", i+1), "slide_id": id, "slide_number": i + 1, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
+		index := start + i + 1
+		slides[i] = map[string]interface{}{"index": index, "label": fmt.Sprintf("#%02d", index), "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
 	}
-	runtime.Out(map[string]interface{}{"xml_presentation_id": presentationID, "overview": map[string]interface{}{"path": path, "format": "png", "size": map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}, "columns": runtime.Int("overview-columns"), "slides": slides}}, nil)
+	overviewData := map[string]interface{}{"path": path, "format": "png", "size": map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}, "columns": runtime.Int("overview-columns"), "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
+	if overviewPage > 1 {
+		overviewData["previous_overview_page"] = overviewPage - 1
+	}
+	if end < len(ids) {
+		overviewData["next_overview_page"] = overviewPage + 1
+	}
+	runtime.Out(map[string]interface{}{"xml_presentation_id": presentationID, "overview": overviewData}, nil)
 	return nil
 }
 
@@ -1073,6 +1100,10 @@ func overviewRectOutput(r image.Rectangle) map[string]int {
 }
 
 func composeSlidesOverview(images []image.Image, columns int) (*image.RGBA, []overviewCell) {
+	return composeSlidesOverviewFromIndex(images, columns, 1)
+}
+
+func composeSlidesOverviewFromIndex(images []image.Image, columns int, firstIndex int) (*image.RGBA, []overviewCell) {
 	if columns < 1 {
 		columns = defaultOverviewColumns
 	}
@@ -1089,7 +1120,7 @@ func composeSlidesOverview(images []image.Image, columns int) (*image.RGBA, []ov
 		thumbnail := image.Rect(x, y+headerH, x+thumbW, y+tileH)
 		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 20, G: 35, B: 58, A: 255}}, image.Point{}, draw.Src)
 		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
-		drawOverviewIndex(out, image.Pt(x+14, y+7), i+1)
+		drawOverviewIndex(out, image.Pt(x+14, y+7), firstIndex+i)
 		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
 	}
 	return out, cells

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -56,8 +56,9 @@ var SlidesScreenshot = common.Shortcut{
 	Description: "Save up to 10 slide screenshots to local files without printing Base64 image data",
 	Risk:        "read",
 	Scopes:      []string{"slides:presentation:screenshot"},
-	// wiki:node:read is required only when --presentation is a wiki URL.
-	ConditionalScopes: []string{"wiki:node:read"},
+	// wiki:node:read is required only for wiki URLs; slides:presentation:read
+	// is required only by --overview to enumerate the current page order.
+	ConditionalScopes: []string{"wiki:node:read", "slides:presentation:read"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
 		listModePresentationRefFlag(),

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -38,8 +38,6 @@ const (
 	maxSlidesPerScreenshot     = 10
 	maxSlidesPerOverview       = 20
 	defaultOverviewColumns     = 4
-	slideCanvasWidth           = 960
-	slideCanvasHeight          = 540
 )
 
 var (
@@ -72,7 +70,7 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "overview", Type: "bool", Desc: "render every current slide into one local overview PNG; cannot be combined with slide selectors, --content, or --region"},
 		{Name: "overview-page", Type: "int", Default: "1", Desc: "1-based overview page; each overview contains at most 20 slides"},
 		{Name: "overview-columns", Type: "int", Default: "4", Desc: "number of columns in --overview output (1-10)"},
-		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in the 960x540 slide canvas; cannot be combined with --overview"},
+		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in its presentation canvas; cannot be combined with --overview"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		overview := runtime.Bool("overview")
@@ -208,6 +206,11 @@ var SlidesScreenshot = common.Shortcut{
 				dry.Desc(fmt.Sprintf("Fetch %d slide screenshot(s) and save files under %s", len(slideIDs)+len(slideNumbers), runtime.Str("output-dir")))
 			}
 		}
+		if _, regionSet, _ := parseSlidesScreenshotRegion(runtime.Str("region")); regionSet {
+			dry.Desc("Fetch presentation XML to resolve the region canvas before rendering the selected slide").
+				GET(fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))).
+				Params(map[string]interface{}{"revision_id": -1})
+		}
 		body := map[string]interface{}{}
 		if len(slideIDs) > 0 {
 			body["slide_ids"] = slideIDs
@@ -252,6 +255,18 @@ var SlidesScreenshot = common.Shortcut{
 		if err != nil {
 			return err
 		}
+		var region slidesScreenshotRegion
+		var canvas slidesScreenshotCanvas
+		if parsed, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
+			region = parsed
+			canvas, err = fetchSlidesScreenshotCanvas(runtime, presentationID)
+			if err != nil {
+				return err
+			}
+			if err := validateSlidesScreenshotRegionBounds(region, canvas); err != nil {
+				return err
+			}
+		}
 
 		url := fmt.Sprintf(
 			"/open-apis/slides_ai/v1/xml_presentations/%s/slide_images",
@@ -270,8 +285,10 @@ var SlidesScreenshot = common.Shortcut{
 			return enrichSlidesScreenshotSelectorError(err, slideNumbers)
 		}
 
-		if region, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
-			if err := cropSlidesScreenshotResponse(data, region); err != nil {
+		var crop map[string]interface{}
+		if _, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
+			crop, err = cropSlidesScreenshotResponse(data, region, canvas)
+			if err != nil {
 				return err
 			}
 		}
@@ -283,8 +300,8 @@ var SlidesScreenshot = common.Shortcut{
 			"xml_presentation_id": presentationID,
 			"screenshots":         saved,
 		}
-		if region, set, _ := parseSlidesScreenshotRegion(runtime.Str("region")); set {
-			result["region"] = map[string]interface{}{"canvas": map[string]int{"x": region.X, "y": region.Y, "width": region.Width, "height": region.Height}, "unit": "slide_canvas_960x540", "format": "png"}
+		if crop != nil {
+			result["region"] = crop
 		}
 		setSlidesScreenshotResultOutput(result, outputTarget, saved)
 		runtime.Out(result, nil)
@@ -871,13 +888,15 @@ func isScreenshotFileNotExist(err error) bool {
 
 type slidesScreenshotRegion struct{ X, Y, Width, Height int }
 
+type slidesScreenshotCanvas struct{ Width, Height int }
+
 func parseSlidesScreenshotRegion(raw string) (slidesScreenshotRegion, bool, error) {
 	if strings.TrimSpace(raw) == "" {
 		return slidesScreenshotRegion{}, false, nil
 	}
 	parts := strings.Split(raw, ",")
 	if len(parts) != 4 {
-		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must be x,y,width,height in the 960x540 slide canvas").WithParam("--region")
+		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must be x,y,width,height in the presentation canvas").WithParam("--region")
 	}
 	vals := [4]int{}
 	for i, part := range parts {
@@ -888,47 +907,98 @@ func parseSlidesScreenshotRegion(raw string) (slidesScreenshotRegion, bool, erro
 		vals[i] = n
 	}
 	r := slidesScreenshotRegion{vals[0], vals[1], vals[2], vals[3]}
-	// Compare the remaining canvas size instead of adding X+Width. Apart from
-	// being equivalent for valid values, this cannot wrap on a hostile integer
-	// input before the bounds check runs.
-	if r.X < 0 || r.Y < 0 || r.Width <= 0 || r.Height <= 0 || r.Width > slideCanvasWidth-r.X || r.Height > slideCanvasHeight-r.Y {
-		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must stay within the 960x540 slide canvas").WithParam("--region").WithHint("use non-negative x,y and positive width,height with x+width<=960 and y+height<=540")
+	if r.X < 0 || r.Y < 0 || r.Width <= 0 || r.Height <= 0 {
+		return slidesScreenshotRegion{}, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--region requires non-negative x,y and positive width,height").WithParam("--region")
 	}
 	return r, true, nil
 }
 
-func cropSlidesScreenshotResponse(data map[string]interface{}, region slidesScreenshotRegion) error {
+func validateSlidesScreenshotRegionBounds(region slidesScreenshotRegion, canvas slidesScreenshotCanvas) error {
+	// Compare the remaining canvas size instead of adding X+Width so hostile
+	// integer inputs cannot wrap before the bounds check.
+	if region.X >= canvas.Width || region.Y >= canvas.Height || region.Width > canvas.Width-region.X || region.Height > canvas.Height-region.Y {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--region must stay within the %dx%d presentation canvas", canvas.Width, canvas.Height).WithParam("--region").WithHint(fmt.Sprintf("use x+width<=%d and y+height<=%d", canvas.Width, canvas.Height))
+	}
+	return nil
+}
+
+func cropSlidesScreenshotResponse(data map[string]interface{}, region slidesScreenshotRegion, canvas slidesScreenshotCanvas) (map[string]interface{}, error) {
 	items := common.GetSlice(data, "slide_images")
 	if len(items) != 1 {
-		return slidesScreenshotAPIDataError(data, "--region requires exactly one rendered slide image")
+		return nil, slidesScreenshotAPIDataError(data, "--region requires exactly one rendered slide image")
 	}
 	item, ok := items[0].(map[string]interface{})
 	if !ok {
-		return slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide_images[0]")
+		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide_images[0]")
 	}
 	encoded := common.GetString(item, "data")
 	b, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return slidesScreenshotImageDataCauseError(common.GetString(item, "slide_id"), err, "decode screenshot for --region: %s", err)
+		return nil, slidesScreenshotImageDataCauseError(common.GetString(item, "slide_id"), err, "decode screenshot for --region: %s", err)
 	}
 	src, _, err := image.Decode(bytes.NewReader(b))
 	if err != nil {
-		return slidesScreenshotImageDataCauseError(common.GetString(item, "slide_id"), err, "decode screenshot image for --region: %s", err)
+		return nil, slidesScreenshotImageDataCauseError(common.GetString(item, "slide_id"), err, "decode screenshot image for --region: %s", err)
 	}
 	bounds := src.Bounds()
-	x0 := region.X * bounds.Dx() / slideCanvasWidth
-	y0 := region.Y * bounds.Dy() / slideCanvasHeight
-	x1 := int(math.Ceil(float64((region.X+region.Width)*bounds.Dx()) / slideCanvasWidth))
-	y1 := int(math.Ceil(float64((region.Y+region.Height)*bounds.Dy()) / slideCanvasHeight))
+	x0 := region.X * bounds.Dx() / canvas.Width
+	y0 := region.Y * bounds.Dy() / canvas.Height
+	x1 := int(math.Ceil(float64((region.X+region.Width)*bounds.Dx()) / float64(canvas.Width)))
+	y1 := int(math.Ceil(float64((region.Y+region.Height)*bounds.Dy()) / float64(canvas.Height)))
 	dst := image.NewRGBA(image.Rect(0, 0, x1-x0, y1-y0))
 	draw.Draw(dst, dst.Bounds(), src, image.Point{X: x0, Y: y0}, draw.Src)
 	var out bytes.Buffer
 	if err := png.Encode(&out, dst); err != nil {
-		return errs.NewInternalError(errs.SubtypeFileIO, "encode --region screenshot: %v", err).WithCause(err)
+		return nil, errs.NewInternalError(errs.SubtypeFileIO, "encode --region screenshot: %v", err).WithCause(err)
 	}
 	item["data"] = base64.StdEncoding.EncodeToString(out.Bytes())
 	item["format"] = 1
-	return nil
+	return map[string]interface{}{
+		"canvas":            map[string]interface{}{"width": canvas.Width, "height": canvas.Height, "unit": "slide_canvas"},
+		"requested":         map[string]int{"x": region.X, "y": region.Y, "width": region.Width, "height": region.Height},
+		"source_image_size": map[string]int{"width": bounds.Dx(), "height": bounds.Dy()},
+		"pixel_rect":        map[string]int{"x": x0, "y": y0, "width": x1 - x0, "height": y1 - y0},
+		"format":            "png",
+	}, nil
+}
+
+func fetchSlidesScreenshotCanvas(runtime *common.RuntimeContext, presentationID string) (slidesScreenshotCanvas, error) {
+	if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
+		return slidesScreenshotCanvas{}, err
+	}
+	data, err := runtime.CallAPITyped("GET", fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID)), map[string]interface{}{"revision_id": -1}, nil)
+	if err != nil {
+		return slidesScreenshotCanvas{}, err
+	}
+	return slidesScreenshotCanvasFromXML(common.GetString(common.GetMap(data, "xml_presentation"), "content"))
+}
+
+func slidesScreenshotCanvasFromXML(content string) (slidesScreenshotCanvas, error) {
+	d := xml.NewDecoder(strings.NewReader(content))
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return slidesScreenshotCanvas{}, errs.NewAPIError(errs.SubtypeInvalidResponse, "parse presentation XML for --region: %v", err).WithCause(err)
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "presentation" {
+			continue
+		}
+		attrs := map[string]string{}
+		for _, attr := range start.Attr {
+			attrs[attr.Name.Local] = attr.Value
+		}
+		width, widthErr := strconv.Atoi(attrs["width"])
+		height, heightErr := strconv.Atoi(attrs["height"])
+		if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
+			return slidesScreenshotCanvas{}, errs.NewAPIError(errs.SubtypeInvalidResponse, "presentation XML for --region must contain positive integer width and height")
+		}
+		return slidesScreenshotCanvas{Width: width, Height: height}, nil
+	}
+	return slidesScreenshotCanvas{}, errs.NewAPIError(errs.SubtypeInvalidResponse, "presentation XML for --region is missing a presentation root")
 }
 
 func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -55,7 +55,8 @@ var SlidesScreenshot = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{"slides:presentation:screenshot"},
 	// wiki:node:read is required only for wiki URLs; slides:presentation:read
-	// is required only by --overview to enumerate the current page order.
+	// is required by --overview to enumerate the current page order and by
+	// --region to resolve the presentation's logical canvas.
 	ConditionalScopes: []string{"wiki:node:read", "slides:presentation:read"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
@@ -144,6 +145,15 @@ var SlidesScreenshot = common.Shortcut{
 			if err := validateSlidesScreenshotSelectorLimit(selectorCount); err != nil {
 				return err
 			}
+			// Both modes read the presentation XML before rendering. Keep this
+			// conditional preflight in Validate so --dry-run reports the same
+			// authorization requirement as execution, and a wiki URL cannot reach
+			// its resolve call before a missing Slides read scope is surfaced.
+			if overview || regionSet {
+				if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
+					return err
+				}
+			}
 		}
 		if runtime.Changed("output") {
 			if runtime.Changed("output-dir") {
@@ -197,9 +207,21 @@ var SlidesScreenshot = common.Shortcut{
 		if runtime.Bool("overview") {
 			if ref.Kind == "wiki" {
 				presentationID = "<resolved_slides_token>"
-				dry.Desc("3-step orchestration: resolve wiki → fetch current slide IDs → render batches and compose a local overview PNG").GET("/open-apis/wiki/v2/spaces/get_node").Params(map[string]interface{}{"token": ref.Token})
+				dry.GET("/open-apis/wiki/v2/spaces/get_node").
+					Desc("Resolve the wiki node to its Slides presentation before reading the overview page").
+					Params(map[string]interface{}{"token": ref.Token})
 			}
-			dry.Desc(fmt.Sprintf("Fetch current presentation XML, then render overview page %d (at most %d slides) in batches of at most 10 pages and compose one local overview PNG", runtime.Int("overview-page"), maxSlidesPerOverview)).GET(fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))).Params(map[string]interface{}{"revision_id": -1})
+			overviewURL := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))
+			screenshotURL := overviewURL + "/slide_images"
+			dry.GET(overviewURL).
+				Desc(fmt.Sprintf("Fetch current presentation XML to select overview page %d (at most %d slides)", runtime.Int("overview-page"), maxSlidesPerOverview)).
+				Params(map[string]interface{}{"revision_id": -1})
+			dry.POST(screenshotURL).
+				Desc("Render the first dynamic overview batch (slide IDs 1-10 of the selected overview page)").
+				Body(map[string]interface{}{"slide_ids": []string{"<overview page slide IDs 1-10>"}})
+			dry.POST(screenshotURL).
+				Desc("Render the optional second dynamic overview batch (slide IDs 11-20; sent only when the selected page has more than 10 slides)").
+				Body(map[string]interface{}{"slide_ids": []string{"<overview page slide IDs 11-20, if present>"}})
 			return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded locally and composed into overview PNG during execution")
 		}
 		if ref.Kind == "wiki" {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -69,7 +69,6 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "output-name", Desc: "file name stem for --content render output"},
 		{Name: "overview", Type: "bool", Desc: "render every current slide into one local overview PNG; cannot be combined with slide selectors, --content, or --region"},
 		{Name: "overview-page", Type: "int", Default: "1", Desc: "1-based overview page; each overview contains at most 20 slides"},
-		{Name: "overview-columns", Type: "int", Default: "4", Desc: "number of columns in --overview output (1-10)"},
 		{Name: "region", Desc: "crop exactly one existing slide as x,y,width,height in the rendered screenshot pixels; cannot be combined with --overview"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
@@ -92,9 +91,6 @@ var SlidesScreenshot = common.Shortcut{
 		}
 		if overview && (runtime.Changed("content") || slidesScreenshotHasSelectorInput(runtime)) {
 			return slidesScreenshotFlagErrorf("--overview requires --presentation without --content or slide selectors")
-		}
-		if overview && (runtime.Int("overview-columns") < 1 || runtime.Int("overview-columns") > 10) {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-columns must be between 1 and 10").WithParam("--overview-columns")
 		}
 		if runtime.Changed("overview-page") && !overview {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-page requires --overview").WithParam("--overview-page")
@@ -1036,7 +1032,7 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 		}
 		thumbs = append(thumbs, batch...)
 	}
-	overview, cells := composeSlidesOverviewFromIndex(thumbs, runtime.Int("overview-columns"), start+1)
+	overview, cells := composeSlidesOverviewFromIndex(thumbs, defaultOverviewColumns, start+1)
 	var encoded bytes.Buffer
 	if err := png.Encode(&encoded, overview); err != nil {
 		return errs.NewInternalError(errs.SubtypeFileIO, "encode overview PNG: %v", err).WithCause(err)
@@ -1062,7 +1058,7 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 		slides[i] = map[string]interface{}{"index": index, "label": fmt.Sprintf("#%02d", index), "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
 	}
 	overviewImageSize := map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}
-	overviewData := map[string]interface{}{"path": path, "format": "png", "size": overviewImageSize, "image_size": overviewImageSize, "columns": runtime.Int("overview-columns"), "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
+	overviewData := map[string]interface{}{"path": path, "format": "png", "size": overviewImageSize, "image_size": overviewImageSize, "columns": defaultOverviewColumns, "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
 	if overviewPage > 1 {
 		overviewData["previous_overview_page"] = overviewPage - 1
 	}

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -1065,7 +1065,12 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	if end < len(ids) {
 		overviewData["next_overview_page"] = overviewPage + 1
 	}
-	runtime.Out(map[string]interface{}{"xml_presentation_id": presentationID, "overview": overviewData}, nil)
+	result := map[string]interface{}{"xml_presentation_id": presentationID, "overview": overviewData}
+	// Overview is one synthesized local image. Mirror the normal screenshot
+	// output locator at the root while retaining overview.path and its paging
+	// metadata for overview-aware consumers.
+	setSlidesScreenshotResultOutput(result, target, []map[string]interface{}{{"path": path}})
+	runtime.Out(result, nil)
 	return nil
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -59,6 +59,19 @@ func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotOverviewFlagDescriptionsExposePagination(t *testing.T) {
+	descriptions := make(map[string]string)
+	for _, flag := range SlidesScreenshot.Flags {
+		descriptions[flag.Name] = flag.Desc
+	}
+	if got := descriptions["overview"]; !strings.Contains(got, "one indexed overview PNG containing up to 20") || !strings.Contains(got, "--overview-page") {
+		t.Fatalf("--overview description = %q, want single-page limit and pagination guidance", got)
+	}
+	if got := descriptions["overview-page"]; !strings.Contains(got, "next_overview_page") || !strings.Contains(got, "has_next") {
+		t.Fatalf("--overview-page description = %q, want response-driven pagination guidance", got)
+	}
+}
+
 func TestSlidesScreenshotRegionParser(t *testing.T) {
 	got, set, err := parseSlidesScreenshotRegion("120,80,480,220")
 	if err != nil || !set || got != (slidesScreenshotRegion{X: 120, Y: 80, Width: 480, Height: 220}) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -52,6 +52,24 @@ func TestSlidesScreenshotRegionParser(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotRejectsExplicitEmptyRegion(t *testing.T) {
+	for _, args := range [][]string{
+		{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--region", "", "--dry-run", "--as", "user"},
+		{"+screenshot", "--presentation", "pres_abc", "--overview", "--region", "", "--dry-run", "--as", "user"},
+	} {
+		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
+		if err == nil {
+			t.Fatalf("args %#v succeeded, want validation error", args)
+		}
+		p, ok := errs.ProblemOf(err)
+		var validation *errs.ValidationError
+		if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument || !errors.As(err, &validation) || validation.Param != "--region" {
+			t.Fatalf("args %#v problem = %#v, want validation/invalid_argument for --region", args, p)
+		}
+	}
+}
+
 func TestSlidesScreenshotRegionUsesPresentationCanvas(t *testing.T) {
 	canvas, err := slidesScreenshotCanvasFromXML(`<presentation width="1024" height="768"><slide id="p1"/></presentation>`)
 	if err != nil || canvas != (slidesScreenshotCanvas{Width: 1024, Height: 768}) {
@@ -315,6 +333,23 @@ func TestSlidesScreenshotOverviewAllowsSingleOutputDryRun(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotOverviewRejectsNonPNGOutputDuringValidation(t *testing.T) {
+	for _, output := range []string{"shots/overview.jpg", "shots/overview.jpeg"} {
+		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+			"+screenshot", "--presentation", "pres_overview", "--overview", "--output", output, "--dry-run", "--as", "user",
+		})
+		if err == nil {
+			t.Fatalf("output %q succeeded, want validation error", output)
+		}
+		p, ok := errs.ProblemOf(err)
+		var validation *errs.ValidationError
+		if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument || !errors.As(err, &validation) || validation.Param != "--output" {
+			t.Fatalf("output %q problem = %#v, want validation/invalid_argument for --output", output, p)
+		}
+	}
+}
+
 func TestSlidesScreenshotOverviewPageValidation(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	for _, args := range [][]string{
@@ -359,7 +394,7 @@ func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testi
 		}},
 	}})
 
-	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--output", "shots/overview.png", "--as", "user"}); err != nil {
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--output", "shots/overview", "--as", "user"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	decoded, err := os.Open(filepath.Join(dir, "shots", "overview.png"))

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"image/draw"
 	"image/png"
 	"net/http"
 	"os"
@@ -300,6 +301,43 @@ func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testin
 	}
 	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 252 {
 		t.Fatalf("overview size = %v", out.Bounds())
+	}
+}
+
+func TestComposeSlidesOverviewAspectFitsPageContent(t *testing.T) {
+	background := color.RGBA{R: 226, G: 232, B: 240, A: 255}
+	sourceColor := color.RGBA{R: 19, G: 42, B: 77, A: 255}
+	for _, tc := range []struct {
+		name    string
+		size    image.Point
+		content image.Rectangle
+	}{
+		{name: "widescreen fills thumbnail", size: image.Pt(960, 540), content: image.Rect(0, 0, 320, 180)},
+		{name: "four by three leaves side mattes", size: image.Pt(1024, 768), content: image.Rect(40, 0, 280, 180)},
+		{name: "square leaves side mattes", size: image.Pt(800, 800), content: image.Rect(70, 0, 250, 180)},
+		{name: "portrait leaves side mattes", size: image.Pt(540, 960), content: image.Rect(109, 0, 210, 180)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := image.NewRGBA(image.Rectangle{Max: tc.size})
+			draw.Draw(src, src.Bounds(), &image.Uniform{C: sourceColor}, image.Point{}, draw.Src)
+			out, cells := composeSlidesOverview([]image.Image{src}, 1)
+			thumbnail := cells[0].thumbnail
+			wantContent := tc.content.Add(thumbnail.Min)
+			if got := slidesOverviewThumbnailContentRect(thumbnail, src.Bounds()); got != wantContent {
+				t.Fatalf("content rect = %v, want %v", got, wantContent)
+			}
+			if got := color.RGBAModel.Convert(out.At(wantContent.Min.X+wantContent.Dx()/2, wantContent.Min.Y+wantContent.Dy()/2)).(color.RGBA); got != sourceColor {
+				t.Fatalf("content color = %#v, want %#v", got, sourceColor)
+			}
+			if wantContent.Min.X > thumbnail.Min.X {
+				if got := color.RGBAModel.Convert(out.At(thumbnail.Min.X, thumbnail.Min.Y+thumbnail.Dy()/2)).(color.RGBA); got != background {
+					t.Fatalf("left matte = %#v, want %#v", got, background)
+				}
+			}
+			if thumbnail.Dx() != 320 || thumbnail.Dy() != 180 || out.Bounds() != image.Rect(0, 0, 352, 252) {
+				t.Fatalf("thumbnail=%v overview=%v, want stable overview geometry", thumbnail, out.Bounds())
+			}
+		})
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -507,7 +507,7 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 	if !ok {
 		t.Fatalf("overview = %#v", data["overview"])
 	}
-	if overview["total_slides"] != float64(41) || overview["overview_page"] != float64(2) || overview["page_size"] != float64(20) || overview["has_previous"] != true || overview["has_next"] != true || overview["previous_overview_page"] != float64(1) || overview["next_overview_page"] != float64(3) {
+	if overview["total_slides"] != float64(41) || overview["overview_page"] != float64(2) || overview["page_size"] != float64(20) || overview["columns"] != float64(4) || overview["has_previous"] != true || overview["has_next"] != true || overview["previous_overview_page"] != float64(1) || overview["next_overview_page"] != float64(3) {
 		t.Fatalf("overview navigation = %#v", overview)
 	}
 	rangeData, _ := overview["slide_range"].(map[string]interface{})

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -12,6 +12,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -44,10 +45,160 @@ func TestSlidesScreenshotRegionParser(t *testing.T) {
 	if err != nil || !set || got != (slidesScreenshotRegion{X: 120, Y: 80, Width: 480, Height: 220}) {
 		t.Fatalf("parseSlidesScreenshotRegion() = %#v, %v, %v", got, set, err)
 	}
-	for _, raw := range []string{"1,2,3", "-1,0,1,1", "0,0,961,1", "0,0,0,1", "9223372036854775807,0,1,1"} {
+	for _, raw := range []string{"1,2,3", "-1,0,1,1", "0,0,0,1"} {
 		if _, _, err := parseSlidesScreenshotRegion(raw); err == nil {
 			t.Fatalf("parseSlidesScreenshotRegion(%q) succeeded", raw)
 		}
+	}
+}
+
+func TestSlidesScreenshotRegionUsesPresentationCanvas(t *testing.T) {
+	canvas, err := slidesScreenshotCanvasFromXML(`<presentation width="1024" height="768"><slide id="p1"/></presentation>`)
+	if err != nil || canvas != (slidesScreenshotCanvas{Width: 1024, Height: 768}) {
+		t.Fatalf("canvas = %#v, %v", canvas, err)
+	}
+	region := slidesScreenshotRegion{X: 120, Y: 80, Width: 480, Height: 220}
+	if err := validateSlidesScreenshotRegionBounds(region, canvas); err != nil {
+		t.Fatalf("unexpected bounds error: %v", err)
+	}
+	if err := validateSlidesScreenshotRegionBounds(slidesScreenshotRegion{X: 600, Y: 0, Width: 500, Height: 1}, canvas); err == nil {
+		t.Fatal("expected dynamic canvas bounds error")
+	}
+	for _, xml := range []string{`<presentation width="0" height="768"/>`, `<presentation width="wide" height="768"/>`, `<slide/>`} {
+		_, err := slidesScreenshotCanvasFromXML(xml)
+		p, ok := errs.ProblemOf(err)
+		if !ok || p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeInvalidResponse {
+			t.Fatalf("xml %q error = %#v, want api/invalid_response", xml, p)
+		}
+	}
+}
+
+func TestSlidesScreenshotRegionDynamicBoundsCoverCanvasEdges(t *testing.T) {
+	canvas := slidesScreenshotCanvas{Width: 1024, Height: 768}
+	maxInt := int(^uint(0) >> 1)
+	for _, region := range []slidesScreenshotRegion{
+		{X: 0, Y: 0, Width: 1024, Height: 768},
+		{X: 1023, Y: 767, Width: 1, Height: 1},
+	} {
+		if err := validateSlidesScreenshotRegionBounds(region, canvas); err != nil {
+			t.Fatalf("region %#v rejected: %v", region, err)
+		}
+	}
+	for _, region := range []slidesScreenshotRegion{
+		{X: 1024, Y: 0, Width: 1, Height: 1},
+		{X: 0, Y: 768, Width: 1, Height: 1},
+		{X: 1023, Y: 0, Width: 2, Height: 1},
+		{X: 0, Y: 767, Width: 1, Height: 2},
+		{X: maxInt, Y: 0, Width: 1, Height: 1},
+	} {
+		if err := validateSlidesScreenshotRegionBounds(region, canvas); err == nil {
+			t.Fatalf("region %#v succeeded, want bounds error", region)
+		}
+	}
+}
+
+func TestSlidesScreenshotRegionRejectsOutOfBoundsBeforeRendering(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation width="1024" height="768"><slide id="p1"/></presentation>`}},
+	}})
+	postCalled := false
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Optional: true, OnMatch: func(_ *http.Request) {
+		postCalled = true
+	}})
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--region", "1000,0,100,1", "--as", "user"})
+	if err == nil {
+		t.Fatal("expected dynamic canvas bounds error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %#v, want validation/invalid_argument", p)
+	}
+	if postCalled {
+		t.Fatal("screenshot POST was called after region bounds rejection")
+	}
+}
+
+func TestSlidesScreenshotRegionStopsBeforeRenderingWhenCanvasReadFails(t *testing.T) {
+	tests := []struct {
+		name string
+		stub *httpmock.Stub
+	}{
+		{
+			name: "invalid canvas XML",
+			stub: &httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+				"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation width="wide" height="768"/>`}},
+			}},
+		},
+		{
+			name: "read transport error",
+			stub: &httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Error: errors.New("read presentation failed")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			reg.Register(tt.stub)
+			postCalled := false
+			reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Optional: true, OnMatch: func(_ *http.Request) {
+				postCalled = true
+			}})
+			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--region", "0,0,1,1", "--as", "user"})
+			if err == nil {
+				t.Fatal("expected canvas read error")
+			}
+			if postCalled {
+				t.Fatal("screenshot POST was called after canvas read failure")
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotRegionExecutionUsesPresentationCanvas(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	source := image.NewRGBA(image.Rect(0, 0, 1600, 1200))
+	var sourcePNG bytes.Buffer
+	if err := png.Encode(&sourcePNG, source); err != nil {
+		t.Fatal(err)
+	}
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation width="1024" height="768"><slide id="p1"/></presentation>`}},
+	}})
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{{"slide_id": "p1", "format": 1, "data": base64.StdEncoding.EncodeToString(sourcePNG.Bytes())}}},
+	}})
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--region", "120,80,480,220", "--output", "region.png", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	croppedFile, err := os.Open(filepath.Join(dir, "region.png"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer croppedFile.Close()
+	cropped, err := png.Decode(croppedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cropped.Bounds().Dx() != 751 || cropped.Bounds().Dy() != 344 {
+		t.Fatalf("cropped size = %dx%d, want 751x344", cropped.Bounds().Dx(), cropped.Bounds().Dy())
+	}
+	data := decodeShortcutData(t, stdout)
+	region, ok := data["region"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("region = %#v", data["region"])
+	}
+	canvas, _ := region["canvas"].(map[string]interface{})
+	if canvas["width"] != float64(1024) || canvas["height"] != float64(768) || canvas["unit"] != "slide_canvas" {
+		t.Fatalf("canvas = %#v", canvas)
+	}
+	pixelRect, _ := region["pixel_rect"].(map[string]interface{})
+	if pixelRect["x"] != float64(187) || pixelRect["y"] != float64(125) || pixelRect["width"] != float64(751) || pixelRect["height"] != float64(344) {
+		t.Fatalf("pixel_rect = %#v", pixelRect)
+	}
+	if region["format"] != "png" {
+		t.Fatalf("format = %#v", region["format"])
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"image/draw"
 	"image/png"
 	"net/http"
 	"os"
@@ -301,43 +300,6 @@ func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testin
 	}
 	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 252 {
 		t.Fatalf("overview size = %v", out.Bounds())
-	}
-}
-
-func TestComposeSlidesOverviewAspectFitsPageContent(t *testing.T) {
-	background := color.RGBA{R: 226, G: 232, B: 240, A: 255}
-	sourceColor := color.RGBA{R: 19, G: 42, B: 77, A: 255}
-	for _, tc := range []struct {
-		name    string
-		size    image.Point
-		content image.Rectangle
-	}{
-		{name: "widescreen fills thumbnail", size: image.Pt(960, 540), content: image.Rect(0, 0, 320, 180)},
-		{name: "four by three leaves side mattes", size: image.Pt(1024, 768), content: image.Rect(40, 0, 280, 180)},
-		{name: "square leaves side mattes", size: image.Pt(800, 800), content: image.Rect(70, 0, 250, 180)},
-		{name: "portrait leaves side mattes", size: image.Pt(540, 960), content: image.Rect(109, 0, 210, 180)},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			src := image.NewRGBA(image.Rectangle{Max: tc.size})
-			draw.Draw(src, src.Bounds(), &image.Uniform{C: sourceColor}, image.Point{}, draw.Src)
-			out, cells := composeSlidesOverview([]image.Image{src}, 1)
-			thumbnail := cells[0].thumbnail
-			wantContent := tc.content.Add(thumbnail.Min)
-			if got := slidesOverviewThumbnailContentRect(thumbnail, src.Bounds()); got != wantContent {
-				t.Fatalf("content rect = %v, want %v", got, wantContent)
-			}
-			if got := color.RGBAModel.Convert(out.At(wantContent.Min.X+wantContent.Dx()/2, wantContent.Min.Y+wantContent.Dy()/2)).(color.RGBA); got != sourceColor {
-				t.Fatalf("content color = %#v, want %#v", got, sourceColor)
-			}
-			if wantContent.Min.X > thumbnail.Min.X {
-				if got := color.RGBAModel.Convert(out.At(thumbnail.Min.X, thumbnail.Min.Y+thumbnail.Dy()/2)).(color.RGBA); got != background {
-					t.Fatalf("left matte = %#v, want %#v", got, background)
-				}
-			}
-			if thumbnail.Dx() != 320 || thumbnail.Dy() != 180 || out.Bounds() != image.Rect(0, 0, 352, 252) {
-				t.Fatalf("thumbnail=%v overview=%v, want stable overview geometry", thumbnail, out.Bounds())
-			}
-		})
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"image"
+	"image/color"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,6 +34,85 @@ func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	want := []string{"slides:presentation:screenshot", "wiki:node:read"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("declared scopes = %#v, want %#v", got, want)
+	}
+}
+
+func TestSlidesScreenshotRegionParser(t *testing.T) {
+	got, set, err := parseSlidesScreenshotRegion("120,80,480,220")
+	if err != nil || !set || got != (slidesScreenshotRegion{X: 120, Y: 80, Width: 480, Height: 220}) {
+		t.Fatalf("parseSlidesScreenshotRegion() = %#v, %v, %v", got, set, err)
+	}
+	for _, raw := range []string{"1,2,3", "-1,0,1,1", "0,0,961,1", "0,0,0,1"} {
+		if _, _, err := parseSlidesScreenshotRegion(raw); err == nil {
+			t.Fatalf("parseSlidesScreenshotRegion(%q) succeeded", raw)
+		}
+	}
+}
+
+func TestSlidesScreenshotIDsFromXMLPreservesPageOrder(t *testing.T) {
+	ids, err := slidesScreenshotIDsFromXML(`<presentation><slide id="p1"/><slide id="p2"/><slide/></presentation>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ids, []string{"p1", "p2"}) {
+		t.Fatalf("ids = %#v", ids)
+	}
+}
+
+func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 960, 540))
+	drawQuadrant := func(r image.Rectangle, c color.RGBA) {
+		for y := r.Min.Y; y < r.Max.Y; y++ {
+			for x := r.Min.X; x < r.Max.X; x++ {
+				src.SetRGBA(x, y, c)
+			}
+		}
+	}
+	drawQuadrant(image.Rect(0, 0, 480, 270), color.RGBA{R: 255, A: 255})
+	drawQuadrant(image.Rect(480, 0, 960, 270), color.RGBA{G: 255, A: 255})
+	drawQuadrant(image.Rect(0, 270, 480, 540), color.RGBA{B: 255, A: 255})
+	drawQuadrant(image.Rect(480, 270, 960, 540), color.RGBA{R: 255, G: 255, A: 255})
+	out, cells := composeSlidesOverview([]image.Image{src}, 1)
+	if len(cells) != 1 || cells[0].thumbnail.Dx() != 320 || cells[0].thumbnail.Dy() != 180 {
+		t.Fatalf("cells = %#v", cells)
+	}
+	thumb := cells[0].thumbnail
+	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+80, thumb.Min.Y+45)).(color.RGBA); got.R < 200 || got.G > 50 {
+		t.Fatalf("top-left thumbnail = %#v, want red", got)
+	}
+	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+240, thumb.Min.Y+135)).(color.RGBA); got.R < 200 || got.G < 200 {
+		t.Fatalf("bottom-right thumbnail = %#v, want yellow", got)
+	}
+	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 252 {
+		t.Fatalf("overview size = %v", out.Bounds())
+	}
+}
+
+func TestSlidesScreenshotOverviewAllowsSingleOutputDryRun(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot", "--presentation", "pres_overview", "--overview", "--output", "shots/overview.png", "--dry-run", "--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("overview --output: %v", err)
+	}
+	data := decodeShortcutData(t, stdout)
+	if data["output"] != "shots/overview.png" {
+		t.Fatalf("output = %#v", data["output"])
+	}
+}
+
+func TestSlidesScreenshotRejectsRegionWithContent(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot", "--content", `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data/></slide>`, "--region", "0,0,120,120", "--dry-run", "--as", "user",
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %#v", p)
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -5,6 +5,7 @@ package slides
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -21,8 +22,17 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/httpmock"
 )
+
+type slidesScreenshotScopeResolver struct {
+	result *credential.TokenResult
+}
+
+func (r *slidesScreenshotScopeResolver) ResolveToken(context.Context, credential.TokenSpec) (*credential.TokenResult, error) {
+	return r.result, nil
+}
 
 func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	base := []string{"slides:presentation:screenshot"}
@@ -330,6 +340,79 @@ func TestSlidesScreenshotOverviewAllowsSingleOutputDryRun(t *testing.T) {
 	data := decodeShortcutData(t, stdout)
 	if data["output"] != "shots/overview.png" {
 		t.Fatalf("output = %#v", data["output"])
+	}
+}
+
+func TestSlidesScreenshotOverviewDryRunListsDynamicScreenshotBatches(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot", "--presentation", "pres_overview", "--overview", "--dry-run", "--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("overview dry-run: %v", err)
+	}
+	steps := decodeShortcutDryRunAPI(t, stdout)
+	if len(steps) != 3 {
+		t.Fatalf("dry-run calls = %#v, want XML GET plus two screenshot-batch POSTs", steps)
+	}
+	assertDryRunStep(t, steps, 0, "GET", "/open-apis/slides_ai/v1/xml_presentations/pres_overview")
+	for i, wantID := range []string{"<overview page slide IDs 1-10>", "<overview page slide IDs 11-20, if present>"} {
+		step := assertDryRunStep(t, steps, i+1, "POST", "/open-apis/slides_ai/v1/xml_presentations/pres_overview/slide_images")
+		body, ok := step["body"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("api[%d].body = %#v, want object", i+1, step["body"])
+		}
+		slideIDs, ok := body["slide_ids"].([]interface{})
+		if !ok || len(slideIDs) != 1 || slideIDs[0] != wantID {
+			t.Fatalf("api[%d].body.slide_ids = %#v, want [%q]", i+1, body["slide_ids"], wantID)
+		}
+	}
+	if !strings.Contains(steps[2]["desc"].(string), "optional second") {
+		t.Fatalf("second batch description = %#v, want optional marker", steps[2]["desc"])
+	}
+}
+
+func TestSlidesScreenshotOverviewWikiDryRunListsResolveXMLAndBatches(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot", "--presentation", "https://example.feishu.cn/wiki/wiki_token", "--overview", "--dry-run", "--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("wiki overview dry-run: %v", err)
+	}
+	steps := decodeShortcutDryRunAPI(t, stdout)
+	if len(steps) != 4 {
+		t.Fatalf("dry-run calls = %#v, want wiki GET, XML GET, and two screenshot-batch POSTs", steps)
+	}
+	assertDryRunStep(t, steps, 0, "GET", "/open-apis/wiki/v2/spaces/get_node")
+	for i := 1; i < len(steps); i++ {
+		wantMethod := "POST"
+		wantURL := "/open-apis/slides_ai/v1/xml_presentations/%3Cresolved_slides_token%3E/slide_images"
+		if i == 1 {
+			wantMethod = "GET"
+			wantURL = "/open-apis/slides_ai/v1/xml_presentations/%3Cresolved_slides_token%3E"
+		}
+		assertDryRunStep(t, steps, i, wantMethod, wantURL)
+	}
+}
+
+func TestSlidesScreenshotOverviewAndRegionPreflightPresentationReadScope(t *testing.T) {
+	for _, args := range [][]string{
+		{"+screenshot", "--presentation", "pres_overview", "--overview", "--dry-run", "--as", "user"},
+		{"+screenshot", "--presentation", "pres_region", "--slide-id", "p1", "--region", "0,0,1,1", "--dry-run", "--as", "user"},
+	} {
+		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+		f.Credential = credential.NewCredentialProvider(nil, nil, &slidesScreenshotScopeResolver{
+			result: &credential.TokenResult{Token: "test-token", Scopes: "slides:presentation:screenshot"},
+		}, nil)
+		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
+		if err == nil {
+			t.Fatalf("args %#v succeeded, want missing presentation read scope", args)
+		}
+		var permission *errs.PermissionError
+		if !errors.As(err, &permission) || permission.Subtype != errs.SubtypeMissingScope || !reflect.DeepEqual(permission.MissingScopes, []string{"slides:presentation:read"}) {
+			t.Fatalf("args %#v error = %#v, want missing slides:presentation:read", args, err)
+		}
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -157,6 +158,23 @@ func TestSlidesScreenshotOverviewAllowsSingleOutputDryRun(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotOverviewPageValidation(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	for _, args := range [][]string{
+		{"+screenshot", "--presentation", "pres_abc", "--overview-page", "2", "--dry-run", "--as", "user"},
+		{"+screenshot", "--presentation", "pres_abc", "--overview", "--overview-page", "0", "--dry-run", "--as", "user"},
+	} {
+		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
+		if err == nil {
+			t.Fatalf("args %#v succeeded, want validation error", args)
+		}
+		p, ok := errs.ProblemOf(err)
+		if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+			t.Fatalf("args %#v problem = %#v, want validation/invalid_argument", args, p)
+		}
+	}
+}
+
 func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
@@ -199,6 +217,69 @@ func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testi
 	// The first cell is p1 according to XML, although p2 arrived first.
 	if got := color.RGBAModel.Convert(overview.At(16+160, 56+90)).(color.RGBA); got.R < 200 || got.G > 50 {
 		t.Fatalf("first overview cell = %#v, want p1/red", got)
+	}
+}
+
+func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	var xml strings.Builder
+	xml.WriteString("<presentation>")
+	for i := 1; i <= 41; i++ {
+		fmt.Fprintf(&xml, `<slide id="p%d"/>`, i)
+	}
+	xml.WriteString("</presentation>")
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.SetRGBA(0, 0, color.RGBA{B: 255, A: 255})
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, img); err != nil {
+		t.Fatal(err)
+	}
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": xml.String()}},
+	}})
+	responseFor := func(start, end int) map[string]interface{} {
+		items := make([]map[string]interface{}, 0, end-start+1)
+		for i := start; i <= end; i++ {
+			items = append(items, map[string]interface{}{"slide_id": fmt.Sprintf("p%d", i), "data": base64.StdEncoding.EncodeToString(encoded.Bytes())})
+		}
+		return map[string]interface{}{"code": 0, "data": map[string]interface{}{"slide_images": items}}
+	}
+	for _, batch := range []struct{ start, end int }{{21, 30}, {31, 40}} {
+		batch := batch
+		reg.Register(&httpmock.Stub{
+			Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+			Body:       responseFor(batch.start, batch.end),
+			BodyFilter: func(body []byte) bool { return strings.Contains(string(body), fmt.Sprintf("p%d", batch.start)) },
+		})
+	}
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--overview-page", "2", "--output", "shots/overview.png", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutData(t, stdout)
+	overview, ok := data["overview"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("overview = %#v", data["overview"])
+	}
+	if overview["total_slides"] != float64(41) || overview["overview_page"] != float64(2) || overview["page_size"] != float64(20) || overview["has_previous"] != true || overview["has_next"] != true || overview["previous_overview_page"] != float64(1) || overview["next_overview_page"] != float64(3) {
+		t.Fatalf("overview navigation = %#v", overview)
+	}
+	rangeData, _ := overview["slide_range"].(map[string]interface{})
+	if rangeData["start"] != float64(21) || rangeData["end"] != float64(40) {
+		t.Fatalf("slide_range = %#v", rangeData)
+	}
+	slides, _ := overview["slides"].([]interface{})
+	if len(slides) != 20 {
+		t.Fatalf("slides = %#v", slides)
+	}
+	slide, _ := slides[0].(map[string]interface{})
+	if slide["index"] != float64(21) || slide["label"] != "#21" || slide["slide_id"] != "p21" {
+		t.Fatalf("slide = %#v", slide)
+	}
+	last, _ := slides[19].(map[string]interface{})
+	if last["index"] != float64(40) || last["label"] != "#40" || last["slide_id"] != "p40" {
+		t.Fatalf("last slide = %#v", last)
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -464,6 +464,38 @@ func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testi
 	if got := color.RGBAModel.Convert(overview.At(16+160, 56+90)).(color.RGBA); got.R < 200 || got.G > 50 {
 		t.Fatalf("first overview cell = %#v, want p1/red", got)
 	}
+	data := decodeShortcutData(t, stdout)
+	output, _ := data["output"].(string)
+	if filepath.Base(output) != "overview.png" || filepath.Base(filepath.Dir(output)) != "shots" || data["requested_output"] != "shots/overview" || data["output_adjusted"] != true {
+		t.Fatalf("overview root output = %#v", data)
+	}
+	overviewData, _ := data["overview"].(map[string]interface{})
+	if overviewData["path"] != data["output"] {
+		t.Fatalf("overview path = %#v, want root output %#v", overviewData["path"], data["output"])
+	}
+}
+
+func TestSlidesScreenshotOverviewExecutionSetsDefaultOutputDir(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation><slide id="p1"/></presentation>`}},
+	}})
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{{"slide_id": "p1", "data": testSlidesScreenshotPNG(t, 960, 540)}}},
+	}})
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutData(t, stdout)
+	if data["output_dir"] != defaultSlidesScreenshotDir {
+		t.Fatalf("output_dir = %#v, want %q", data["output_dir"], defaultSlidesScreenshotDir)
+	}
+	overviewData, _ := data["overview"].(map[string]interface{})
+	if overviewData["path"] == "" {
+		t.Fatalf("overview = %#v, want saved path", overviewData)
+	}
 }
 
 func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -542,6 +542,13 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 	if overview["total_slides"] != float64(41) || overview["overview_page"] != float64(2) || overview["page_size"] != float64(20) || overview["columns"] != float64(4) || overview["has_previous"] != true || overview["has_next"] != true || overview["previous_overview_page"] != float64(1) || overview["next_overview_page"] != float64(3) {
 		t.Fatalf("overview navigation = %#v", overview)
 	}
+	if _, ok := overview["size"].(float64); !ok || overview["size"].(float64) <= 0 {
+		t.Fatalf("overview.size = %#v, want positive encoded-byte count", overview["size"])
+	}
+	imageSize, _ := overview["image_size"].(map[string]interface{})
+	if imageSize["width"] != float64(1360) || imageSize["height"] != float64(1196) {
+		t.Fatalf("overview.image_size = %#v, want 1360x1196", imageSize)
+	}
 	rangeData, _ := overview["slide_range"].(map[string]interface{})
 	if rangeData["start"] != float64(21) || rangeData["end"] != float64(40) {
 		t.Fatalf("slide_range = %#v", rangeData)

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -33,7 +33,7 @@ func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	}
 
 	got := SlidesScreenshot.DeclaredScopesForIdentity("user")
-	want := []string{"slides:presentation:screenshot", "wiki:node:read"}
+	want := []string{"slides:presentation:screenshot", "wiki:node:read", "slides:presentation:read"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("declared scopes = %#v, want %#v", got, want)
 	}
@@ -247,7 +247,6 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 		return map[string]interface{}{"code": 0, "data": map[string]interface{}{"slide_images": items}}
 	}
 	for _, batch := range []struct{ start, end int }{{21, 30}, {31, 40}} {
-		batch := batch
 		reg.Register(&httpmock.Stub{
 			Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
 			Body:       responseFor(batch.start, batch.end),

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -34,6 +34,15 @@ func (r *slidesScreenshotScopeResolver) ResolveToken(context.Context, credential
 	return r.result, nil
 }
 
+func testSlidesScreenshotPNG(t *testing.T, width, height int) string {
+	t.Helper()
+	var out bytes.Buffer
+	if err := png.Encode(&out, image.NewRGBA(image.Rect(0, 0, width, height))); err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(out.Bytes())
+}
+
 func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	base := []string{"slides:presentation:screenshot"}
 	if got := SlidesScreenshot.ScopesForIdentity("user"); !reflect.DeepEqual(got, base) {
@@ -80,109 +89,52 @@ func TestSlidesScreenshotRejectsExplicitEmptyRegion(t *testing.T) {
 	}
 }
 
-func TestSlidesScreenshotRegionUsesPresentationCanvas(t *testing.T) {
-	canvas, err := slidesScreenshotCanvasFromXML(`<presentation width="1024" height="768"><slide id="p1"/></presentation>`)
-	if err != nil || canvas != (slidesScreenshotCanvas{Width: 1024, Height: 768}) {
-		t.Fatalf("canvas = %#v, %v", canvas, err)
-	}
-	region := slidesScreenshotRegion{X: 120, Y: 80, Width: 480, Height: 220}
-	if err := validateSlidesScreenshotRegionBounds(region, canvas); err != nil {
-		t.Fatalf("unexpected bounds error: %v", err)
-	}
-	if err := validateSlidesScreenshotRegionBounds(slidesScreenshotRegion{X: 600, Y: 0, Width: 500, Height: 1}, canvas); err == nil {
-		t.Fatal("expected dynamic canvas bounds error")
-	}
-	for _, xml := range []string{`<presentation width="0" height="768"/>`, `<presentation width="wide" height="768"/>`, `<slide/>`} {
-		_, err := slidesScreenshotCanvasFromXML(xml)
-		p, ok := errs.ProblemOf(err)
-		if !ok || p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeInvalidResponse {
-			t.Fatalf("xml %q error = %#v, want api/invalid_response", xml, p)
-		}
-	}
-}
-
-func TestSlidesScreenshotRegionDynamicBoundsCoverCanvasEdges(t *testing.T) {
-	canvas := slidesScreenshotCanvas{Width: 1024, Height: 768}
+func TestSlidesScreenshotRegionBoundsCoverScreenshotEdges(t *testing.T) {
+	imageSize := image.Point{X: 1600, Y: 1200}
 	maxInt := int(^uint(0) >> 1)
 	for _, region := range []slidesScreenshotRegion{
-		{X: 0, Y: 0, Width: 1024, Height: 768},
-		{X: 1023, Y: 767, Width: 1, Height: 1},
+		{X: 0, Y: 0, Width: 1600, Height: 1200},
+		{X: 1599, Y: 1199, Width: 1, Height: 1},
 	} {
-		if err := validateSlidesScreenshotRegionBounds(region, canvas); err != nil {
+		if err := validateSlidesScreenshotRegionBounds(region, imageSize); err != nil {
 			t.Fatalf("region %#v rejected: %v", region, err)
 		}
 	}
 	for _, region := range []slidesScreenshotRegion{
-		{X: 1024, Y: 0, Width: 1, Height: 1},
-		{X: 0, Y: 768, Width: 1, Height: 1},
-		{X: 1023, Y: 0, Width: 2, Height: 1},
-		{X: 0, Y: 767, Width: 1, Height: 2},
+		{X: 1600, Y: 0, Width: 1, Height: 1},
+		{X: 0, Y: 1200, Width: 1, Height: 1},
+		{X: 1599, Y: 0, Width: 2, Height: 1},
+		{X: 0, Y: 1199, Width: 1, Height: 2},
 		{X: maxInt, Y: 0, Width: 1, Height: 1},
 	} {
-		if err := validateSlidesScreenshotRegionBounds(region, canvas); err == nil {
+		if err := validateSlidesScreenshotRegionBounds(region, imageSize); err == nil {
 			t.Fatalf("region %#v succeeded, want bounds error", region)
 		}
 	}
 }
 
-func TestSlidesScreenshotRegionRejectsOutOfBoundsBeforeRendering(t *testing.T) {
+func TestSlidesScreenshotRegionRejectsOutOfBoundsAfterRendering(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation width="1024" height="768"><slide id="p1"/></presentation>`}},
-	}})
 	postCalled := false
-	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Optional: true, OnMatch: func(_ *http.Request) {
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", OnMatch: func(_ *http.Request) {
 		postCalled = true
+	}, Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{{"slide_id": "p1", "format": 1, "data": testSlidesScreenshotPNG(t, 1600, 1200)}}},
 	}})
-	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--region", "1000,0,100,1", "--as", "user"})
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--region", "1599,0,2,1", "--as", "user"})
 	if err == nil {
-		t.Fatal("expected dynamic canvas bounds error")
+		t.Fatal("expected screenshot bounds error")
 	}
 	p, ok := errs.ProblemOf(err)
 	if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
 		t.Fatalf("problem = %#v, want validation/invalid_argument", p)
 	}
-	if postCalled {
-		t.Fatal("screenshot POST was called after region bounds rejection")
+	if !postCalled {
+		t.Fatal("screenshot POST was not called before image-pixel bounds rejection")
 	}
 }
 
-func TestSlidesScreenshotRegionStopsBeforeRenderingWhenCanvasReadFails(t *testing.T) {
-	tests := []struct {
-		name string
-		stub *httpmock.Stub
-	}{
-		{
-			name: "invalid canvas XML",
-			stub: &httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-				"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation width="wide" height="768"/>`}},
-			}},
-		},
-		{
-			name: "read transport error",
-			stub: &httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Error: errors.New("read presentation failed")},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-			reg.Register(tt.stub)
-			postCalled := false
-			reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Optional: true, OnMatch: func(_ *http.Request) {
-				postCalled = true
-			}})
-			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--region", "0,0,1,1", "--as", "user"})
-			if err == nil {
-				t.Fatal("expected canvas read error")
-			}
-			if postCalled {
-				t.Fatal("screenshot POST was called after canvas read failure")
-			}
-		})
-	}
-}
-
-func TestSlidesScreenshotRegionExecutionUsesPresentationCanvas(t *testing.T) {
+func TestSlidesScreenshotRegionExecutionUsesScreenshotPixels(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
 	source := image.NewRGBA(image.Rect(0, 0, 1600, 1200))
@@ -191,9 +143,6 @@ func TestSlidesScreenshotRegionExecutionUsesPresentationCanvas(t *testing.T) {
 		t.Fatal(err)
 	}
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation width="1024" height="768"><slide id="p1"/></presentation>`}},
-	}})
 	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
 		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{{"slide_id": "p1", "format": 1, "data": base64.StdEncoding.EncodeToString(sourcePNG.Bytes())}}},
 	}})
@@ -209,24 +158,49 @@ func TestSlidesScreenshotRegionExecutionUsesPresentationCanvas(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cropped.Bounds().Dx() != 751 || cropped.Bounds().Dy() != 344 {
-		t.Fatalf("cropped size = %dx%d, want 751x344", cropped.Bounds().Dx(), cropped.Bounds().Dy())
+	if cropped.Bounds().Dx() != 480 || cropped.Bounds().Dy() != 220 {
+		t.Fatalf("cropped size = %dx%d, want 480x220", cropped.Bounds().Dx(), cropped.Bounds().Dy())
 	}
 	data := decodeShortcutData(t, stdout)
 	region, ok := data["region"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("region = %#v", data["region"])
 	}
-	canvas, _ := region["canvas"].(map[string]interface{})
-	if canvas["width"] != float64(1024) || canvas["height"] != float64(768) || canvas["unit"] != "slide_canvas" {
-		t.Fatalf("canvas = %#v", canvas)
+	requested, _ := region["requested_pixel_rect"].(map[string]interface{})
+	if requested["x"] != float64(120) || requested["y"] != float64(80) || requested["width"] != float64(480) || requested["height"] != float64(220) {
+		t.Fatalf("requested_pixel_rect = %#v", requested)
 	}
-	pixelRect, _ := region["pixel_rect"].(map[string]interface{})
-	if pixelRect["x"] != float64(187) || pixelRect["y"] != float64(125) || pixelRect["width"] != float64(751) || pixelRect["height"] != float64(344) {
-		t.Fatalf("pixel_rect = %#v", pixelRect)
+	sourceSize, _ := region["source_image_size"].(map[string]interface{})
+	if sourceSize["width"] != float64(1600) || sourceSize["height"] != float64(1200) {
+		t.Fatalf("source_image_size = %#v", sourceSize)
 	}
 	if region["format"] != "png" {
 		t.Fatalf("format = %#v", region["format"])
+	}
+	screenshots, _ := data["screenshots"].([]interface{})
+	saved, _ := screenshots[0].(map[string]interface{})
+	imageSize, _ := saved["image_size"].(map[string]interface{})
+	if imageSize["width"] != float64(480) || imageSize["height"] != float64(220) {
+		t.Fatalf("saved image_size = %#v", imageSize)
+	}
+}
+
+func TestSlidesScreenshotReturnsSourceImageSize(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{{"slide_id": "p1", "format": 1, "data": testSlidesScreenshotPNG(t, 960, 540)}}},
+	}})
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--slide-id", "p1", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutData(t, stdout)
+	screenshots, _ := data["screenshots"].([]interface{})
+	saved, _ := screenshots[0].(map[string]interface{})
+	imageSize, _ := saved["image_size"].(map[string]interface{})
+	if imageSize["width"] != float64(960) || imageSize["height"] != float64(540) {
+		t.Fatalf("image_size = %#v", imageSize)
 	}
 }
 
@@ -396,11 +370,8 @@ func TestSlidesScreenshotOverviewWikiDryRunListsResolveXMLAndBatches(t *testing.
 	}
 }
 
-func TestSlidesScreenshotOverviewAndRegionPreflightPresentationReadScope(t *testing.T) {
-	for _, args := range [][]string{
-		{"+screenshot", "--presentation", "pres_overview", "--overview", "--dry-run", "--as", "user"},
-		{"+screenshot", "--presentation", "pres_region", "--slide-id", "p1", "--region", "0,0,1,1", "--dry-run", "--as", "user"},
-	} {
+func TestSlidesScreenshotOverviewPreflightPresentationReadScope(t *testing.T) {
+	for _, args := range [][]string{{"+screenshot", "--presentation", "pres_overview", "--overview", "--dry-run", "--as", "user"}} {
 		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 		f.Credential = credential.NewCredentialProvider(nil, nil, &slidesScreenshotScopeResolver{
 			result: &credential.TokenResult{Token: "test-token", Scopes: "slides:presentation:screenshot"},

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -368,7 +368,7 @@ func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testin
 	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+240, thumb.Min.Y+135)).(color.RGBA); got.R < 200 || got.G < 200 {
 		t.Fatalf("bottom-right thumbnail = %#v, want yellow", got)
 	}
-	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 252 {
+	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 236 {
 		t.Fatalf("overview size = %v", out.Bounds())
 	}
 }
@@ -616,8 +616,8 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 		t.Fatalf("overview.size = %#v, want positive encoded-byte count", overview["size"])
 	}
 	imageSize, _ := overview["image_size"].(map[string]interface{})
-	if imageSize["width"] != float64(1360) || imageSize["height"] != float64(1196) {
-		t.Fatalf("overview.image_size = %#v, want 1360x1196", imageSize)
+	if imageSize["width"] != float64(1360) || imageSize["height"] != float64(1116) {
+		t.Fatalf("overview.image_size = %#v, want 1360x1116", imageSize)
 	}
 	rangeData, _ := overview["slide_range"].(map[string]interface{})
 	if rangeData["start"] != float64(21) || rangeData["end"] != float64(40) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -274,6 +274,63 @@ func TestSlidesScreenshotIDsFromXMLPreservesPageOrder(t *testing.T) {
 	}
 }
 
+func TestSlidesScreenshotOverviewRejectsMalformedPresentationResponseBeforeScreenshot(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{name: "missing presentation", data: map[string]interface{}{}},
+		{name: "presentation is not object", data: map[string]interface{}{"xml_presentation": "not-an-object"}},
+		{name: "missing content", data: map[string]interface{}{"xml_presentation": map[string]interface{}{}}},
+		{name: "content is not string", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": 42}}},
+		{name: "blank content", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": " \n\t "}}},
+		{name: "malformed xml", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<presentation>"}}},
+		{name: "wrong root", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<document><slide id=\"p1\"/></document>"}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			postCalled := false
+			reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+				"code": 0, "data": tc.data,
+			}})
+			reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", OnMatch: func(_ *http.Request) {
+				postCalled = true
+			}, Body: map[string]interface{}{
+				"code": 0, "data": map[string]interface{}{"slide_images": []interface{}{}},
+			}, Optional: true})
+
+			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"})
+			if err == nil {
+				t.Fatal("expected invalid response error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok || p.Category != errs.CategoryInternal || p.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("problem = %#v, want internal/invalid_response", p)
+			}
+			if postCalled {
+				t.Fatal("screenshot POST was called after malformed presentation response")
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotOverviewTreatsEmptyPresentationAsFailedPrecondition(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<presentation/>"}},
+	}})
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"})
+	if err == nil {
+		t.Fatal("expected empty presentation error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("problem = %#v, want validation/failed_precondition", p)
+	}
+}
+
 func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testing.T) {
 	src := image.NewRGBA(image.Rect(0, 0, 960, 540))
 	drawQuadrant := func(r image.Rectangle, c color.RGBA) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -252,6 +252,12 @@ func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequeste
 			if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeInvalidResponse {
 				t.Fatalf("problem = %#v, want api/invalid_response", p)
 			}
+			if tc.name == "invalid base64" {
+				var corrupt base64.CorruptInputError
+				if !errors.As(err, &corrupt) {
+					t.Fatalf("error = %v, want preserved base64.CorruptInputError cause", err)
+				}
+			}
 		})
 	}
 }

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"image"
 	"image/color"
+	"image/png"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -42,10 +43,64 @@ func TestSlidesScreenshotRegionParser(t *testing.T) {
 	if err != nil || !set || got != (slidesScreenshotRegion{X: 120, Y: 80, Width: 480, Height: 220}) {
 		t.Fatalf("parseSlidesScreenshotRegion() = %#v, %v, %v", got, set, err)
 	}
-	for _, raw := range []string{"1,2,3", "-1,0,1,1", "0,0,961,1", "0,0,0,1"} {
+	for _, raw := range []string{"1,2,3", "-1,0,1,1", "0,0,961,1", "0,0,0,1", "9223372036854775807,0,1,1"} {
 		if _, _, err := parseSlidesScreenshotRegion(raw); err == nil {
 			t.Fatalf("parseSlidesScreenshotRegion(%q) succeeded", raw)
 		}
+	}
+}
+
+func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequestedID(t *testing.T) {
+	pngData := func(c color.RGBA) string {
+		t.Helper()
+		img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+		for y := 0; y < 2; y++ {
+			for x := 0; x < 2; x++ {
+				img.SetRGBA(x, y, c)
+			}
+		}
+		var out bytes.Buffer
+		if err := png.Encode(&out, img); err != nil {
+			t.Fatal(err)
+		}
+		return base64.StdEncoding.EncodeToString(out.Bytes())
+	}
+	imageItem := func(id, data string) map[string]interface{} {
+		return map[string]interface{}{"slide_id": id, "data": data}
+	}
+	red, green := pngData(color.RGBA{R: 255, A: 255}), pngData(color.RGBA{G: 255, A: 255})
+
+	ordered, err := slidesScreenshotOverviewImages(map[string]interface{}{"slide_images": []interface{}{imageItem("p2", green), imageItem("p1", red)}}, []string{"p1", "p2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := color.RGBAModel.Convert(ordered[0].At(0, 0)).(color.RGBA); got.R != 255 || got.G != 0 {
+		t.Fatalf("first image = %#v, want p1/red", got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{name: "missing", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red)}}},
+		{name: "duplicate", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red), imageItem("p1", red)}}},
+		{name: "unexpected", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red), imageItem("p3", green)}}},
+		{name: "invalid base64", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", "not-base64"), imageItem("p2", green)}}},
+		{name: "invalid image", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", base64.StdEncoding.EncodeToString([]byte("not an image"))), imageItem("p2", green)}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := slidesScreenshotOverviewImages(tc.data, []string{"p1", "p2"})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("error = %T %v, want typed problem", err, err)
+			}
+			if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("problem = %#v, want api/invalid_response", p)
+			}
+		})
 	}
 }
 
@@ -99,6 +154,51 @@ func TestSlidesScreenshotOverviewAllowsSingleOutputDryRun(t *testing.T) {
 	data := decodeShortcutData(t, stdout)
 	if data["output"] != "shots/overview.png" {
 		t.Fatalf("output = %#v", data["output"])
+	}
+}
+
+func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	encodePNG := func(c color.RGBA) string {
+		img := image.NewRGBA(image.Rect(0, 0, 960, 540))
+		for y := 0; y < 540; y++ {
+			for x := 0; x < 960; x++ {
+				img.SetRGBA(x, y, c)
+			}
+		}
+		var out bytes.Buffer
+		if err := png.Encode(&out, img); err != nil {
+			t.Fatal(err)
+		}
+		return base64.StdEncoding.EncodeToString(out.Bytes())
+	}
+	red, green := encodePNG(color.RGBA{R: 255, A: 255}), encodePNG(color.RGBA{G: 255, A: 255})
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation><slide id="p1"/><slide id="p2"/></presentation>`}},
+	}})
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{
+			{"slide_id": "p2", "data": green}, {"slide_id": "p1", "data": red},
+		}},
+	}})
+
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--output", "shots/overview.png", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	decoded, err := os.Open(filepath.Join(dir, "shots", "overview.png"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer decoded.Close()
+	overview, err := png.Decode(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The first cell is p1 according to XML, although p2 arrived first.
+	if got := color.RGBAModel.Convert(overview.At(16+160, 56+90)).(color.RGBA); got.R < 200 || got.G > 50 {
+		t.Fatalf("first overview cell = %#v, want p1/red", got)
 	}
 }
 

--- a/tests/cli_e2e/slides/coverage.md
+++ b/tests/cli_e2e/slides/coverage.md
@@ -1,9 +1,9 @@
 # Slides CLI E2E Coverage
 
 ## Metrics
-- Denominator: 6 leaf commands
-- Covered: 5
-- Coverage: 83.3%
+- Denominator: 7 leaf commands
+- Covered: 6
+- Coverage: 85.7%
 
 ## Summary
 - TestSlides_CreateWorkflowAsUser: proves the user slides workflow through `create presentation with slide as user` and `get created presentation xml as user`; creates a fresh presentation, asserts returned IDs, then reads back the XML content to prove the title and slide body persisted.
@@ -15,6 +15,8 @@
 - TestSlides_HistoryWorkflow: opt-in live round-trip coverage for `+update-slide`; creates a presentation, updates its page in place, asserts the returned `slide_id`, the persisted marker, and that an element written back with its original id keeps that id, then reverts through slide history and self-cleans. It runs only when `LARK_SLIDES_HISTORY_E2E=1` and therefore does not yet exercise the default live lane.
 - TestSlidesReplaceSlideNormalizationDryRunE2E / TestSlidesReplaceSlideEmptyReplacementDryRunE2E / TestSlidesReplaceSlideDryRunE2E: dry-run coverage for `+replace-slide` through the built binary. The normalization case proves `replace` / `insert`, `target_id`, `content`, and `element` become a canonical request and that structured output records all conversions. The other cases preserve the strict boundary: an actually-empty canonical payload still fails, while a legitimate mixed `block_replace` + `block_insert` batch remains unchanged.
 - TestSlides_ReplaceSlideAliasWorkflowAsUser: live alias round trip on a throwaway presentation. It reads server-assigned block IDs, replaces one target through `replace` / `target_id` / `content`, inserts another through `insert` / `element`, reads the deck back to prove both writes persisted in the requested position while a control block survived, and deletes the presentation in cleanup.
+- TestSlidesScreenshotOverviewDryRunE2E / TestSlidesScreenshotRegionDryRunE2E: execute the compiled CLI without remote writes. The overview case pins XML enumeration followed by two dynamic screenshot-batch placeholders; the region case pins its single-slide screenshot request and local output routing.
+- TestSlidesScreenshotOverviewAndRegionLiveE2E: creates a two-page throwaway deck, verifies overview indexing, fixed four-column PNG geometry, slide-id mapping and output path, then verifies a pixel-region crop's audit metadata and decoded PNG dimensions before cleanup.
 - Blocked area: `slides +media-upload` is still uncovered because it needs a deterministic local image fixture plus XML follow-up proof that is separate from the base create/read workflow.
 
 ## Command Table
@@ -26,4 +28,5 @@
 | ✓ | slides +delete-slide | shortcut | slides_slide_add_delete_dryrun_test.go::TestSlidesDeleteSlideDryRunE2E, TestSlidesDeleteSlideWikiDryRunE2E; slides_slide_add_delete_workflow_test.go::TestSlides_SlideAddDeleteWorkflowAsUser | `--slide-id`; `--revision-id`; wiki URL | live delete runs on a throwaway deck; readback proves the neighbours survive |
 | ✓ | slides +update-slide | shortcut | slides_update_slide_dryrun_test.go::TestSlidesUpdateSlideDryRunE2E (+ alias / refusal cases); slides_update_slide_workflow_test.go::TestSlidesUpdateSlideLiveE2E; slides_history_workflow_test.go::TestSlides_HistoryWorkflow (opt-in history/revert) | `--presentation`; `--slide-id`; `--content "<slide ...>"`; `--revision-id` | default live CI proves a real in-place update and readback; opt-in workflow adds history/revert and element-id preservation |
 | ✓ | slides +replace-slide | shortcut | slides_replace_slide_dryrun_test.go::TestSlidesReplaceSlideNormalizationDryRunE2E, TestSlidesReplaceSlideEmptyReplacementDryRunE2E, TestSlidesReplaceSlideDryRunE2E; slides_replace_slide_workflow_test.go::TestSlides_ReplaceSlideAliasWorkflowAsUser | `--presentation`; `--slide-id`; canonical and compatibility `--parts` shapes | dry-run pins canonical request construction and validation; live workflow proves alias replace/insert persistence, target ID preservation, insertion ordering, control-block survival, and cleanup |
+| ✓ | slides +screenshot | shortcut | slides_screenshot_dryrun_test.go::TestSlidesScreenshotOverviewDryRunE2E, TestSlidesScreenshotRegionDryRunE2E; slides_screenshot_workflow_test.go::TestSlidesScreenshotOverviewAndRegionLiveE2E | `--overview`; `--overview-page`; `--region`; `--slide-id`; `--output` | dry-run pins XML-read and dynamic batch declaration for overview plus region request routing; live workflow verifies overview index/path/image contract and PNG region crop metadata |
 | ✕ | slides +media-upload | shortcut |  | none | needs a stable local image fixture plus follow-up slide XML proof |

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -5,6 +5,7 @@ package slides
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -285,4 +286,63 @@ func TestSlidesScreenshotEmptySlideIDDryRunE2E(t *testing.T) {
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
 	require.Equal(t, "/open-apis/slides_ai/v1/slide_image/render", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
+}
+
+func TestSlidesScreenshotOverviewDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation", "presScreenshotOverview",
+			"--overview",
+			"--overview-page", "2",
+			"--output", "overview-page-02",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, int64(3), gjson.Get(result.Stdout, "data.api.#").Int(), result.Stdout)
+	require.Equal(t, "GET", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
+	require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotOverview", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
+	require.Equal(t, int64(-1), gjson.Get(result.Stdout, "data.api.0.params.revision_id").Int(), result.Stdout)
+	for _, index := range []int{1, 2} {
+		require.Equal(t, "POST", gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".method").String(), result.Stdout)
+		require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotOverview/slide_images", gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".url").String(), result.Stdout)
+		require.Len(t, gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".body.slide_ids").Array(), 1, result.Stdout)
+	}
+	require.Equal(t, "overview-page-02", gjson.Get(result.Stdout, "data.output").String(), result.Stdout)
+}
+
+func TestSlidesScreenshotRegionDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation", "presScreenshotRegion",
+			"--slide-id", "p1",
+			"--region", "120,80,480,220",
+			"--output", "region.png",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, int64(1), gjson.Get(result.Stdout, "data.api.#").Int(), result.Stdout)
+	require.Equal(t, "POST", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
+	require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotRegion/slide_images", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
+	require.Equal(t, "p1", gjson.Get(result.Stdout, "data.api.0.body.slide_ids.0").String(), result.Stdout)
+	require.Equal(t, "region.png", gjson.Get(result.Stdout, "data.output").String(), result.Stdout)
 }

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -216,9 +216,9 @@ func TestSlidesScreenshotOverviewAndRegionLiveE2E(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "png", overviewFormat, overviewResult.Stdout)
 	require.Equal(t, 1360, overviewConfig.Width, overviewResult.Stdout)
-	require.Equal(t, 252, overviewConfig.Height, overviewResult.Stdout)
+	require.Equal(t, 236, overviewConfig.Height, overviewResult.Stdout)
 	require.Equal(t, int64(1360), overview.Get("image_size.width").Int(), overviewResult.Stdout)
-	require.Equal(t, int64(252), overview.Get("image_size.height").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(236), overview.Get("image_size.height").Int(), overviewResult.Stdout)
 
 	regionResult, err := clie2e.RunCmd(ctx, clie2e.Request{
 		Args: []string{

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -149,6 +149,113 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 	require.Equal(t, actualFormat, decodedFormat, fixedOutputResult.Stdout)
 }
 
+func TestSlidesScreenshotOverviewAndRegionLiveE2E(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	title := "slides-screenshot-overview-region-e2e-" + suffix
+	slideXML := func(marker string) string {
+		return `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + marker + `</p></content></shape></data></slide>`
+	}
+	slidesJSON, err := json.Marshal([]string{slideXML(title + "-one"), slideXML(title + "-two")})
+	require.NoError(t, err)
+
+	createResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"slides", "+create", "--title", title, "--slides", string(slidesJSON)},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	createResult.AssertExitCode(t, 0)
+	createResult.AssertStdoutStatus(t, true)
+	presentationID := gjson.Get(createResult.Stdout, "data.xml_presentation_id").String()
+	require.NotEmpty(t, presentationID, createResult.Stdout)
+	slideIDs := gjson.Get(createResult.Stdout, "data.slide_ids").Array()
+	require.Len(t, slideIDs, 2, createResult.Stdout)
+	parentT.Cleanup(func() {
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+			Args:      []string{"drive", "+delete", "--file-token", presentationID, "--type", "slides", "--yes"},
+			DefaultAs: "bot",
+		})
+		clie2e.ReportCleanupFailure(parentT, "delete presentation "+presentationID, deleteResult, deleteErr)
+	})
+
+	workDir := t.TempDir()
+	overviewResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"slides", "+screenshot", "--presentation", presentationID, "--overview", "--output", "overview.png"},
+		DefaultAs: "bot",
+		WorkDir:   workDir,
+	})
+	require.NoError(t, err)
+	overviewResult.AssertExitCode(t, 0)
+	overviewResult.AssertStdoutStatus(t, true)
+	overview := gjson.Get(overviewResult.Stdout, "data.overview")
+	require.Equal(t, int64(4), overview.Get("columns").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(2), overview.Get("total_slides").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(1), overview.Get("overview_page").Int(), overviewResult.Stdout)
+	slides := overview.Get("slides").Array()
+	require.Len(t, slides, 2, overviewResult.Stdout)
+	for i, slideID := range slideIDs {
+		require.Equal(t, int64(i+1), slides[i].Get("index").Int(), overviewResult.Stdout)
+		require.Equal(t, slideID.String(), slides[i].Get("slide_id").String(), overviewResult.Stdout)
+		require.Equal(t, int64(0), slides[i].Get("row").Int(), overviewResult.Stdout)
+		require.Equal(t, int64(i), slides[i].Get("column").Int(), overviewResult.Stdout)
+	}
+	overviewPath := overview.Get("path").String()
+	require.Equal(t, overviewPath, gjson.Get(overviewResult.Stdout, "data.output").String(), overviewResult.Stdout)
+	requireScreenshotPathUnderDir(t, overviewPath, workDir)
+	overviewFile, err := vfs.Open(overviewPath)
+	require.NoError(t, err)
+	defer overviewFile.Close()
+	overviewConfig, overviewFormat, err := image.DecodeConfig(overviewFile)
+	require.NoError(t, err)
+	require.Equal(t, "png", overviewFormat, overviewResult.Stdout)
+	require.Equal(t, 1360, overviewConfig.Width, overviewResult.Stdout)
+	require.Equal(t, 252, overviewConfig.Height, overviewResult.Stdout)
+	require.Equal(t, int64(1360), overview.Get("image_size.width").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(252), overview.Get("image_size.height").Int(), overviewResult.Stdout)
+
+	regionResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot", "--presentation", presentationID,
+			"--slide-id", slideIDs[0].String(), "--region", "0,0,240,135", "--output", "region.png",
+		},
+		DefaultAs: "bot",
+		WorkDir:   workDir,
+	})
+	require.NoError(t, err)
+	regionResult.AssertExitCode(t, 0)
+	regionResult.AssertStdoutStatus(t, true)
+	region := gjson.Get(regionResult.Stdout, "data.region")
+	require.Equal(t, int64(0), region.Get("requested_pixel_rect.x").Int(), regionResult.Stdout)
+	require.Equal(t, int64(0), region.Get("requested_pixel_rect.y").Int(), regionResult.Stdout)
+	require.Equal(t, int64(240), region.Get("requested_pixel_rect.width").Int(), regionResult.Stdout)
+	require.Equal(t, int64(135), region.Get("requested_pixel_rect.height").Int(), regionResult.Stdout)
+	require.GreaterOrEqual(t, region.Get("source_image_size.width").Int(), int64(240), regionResult.Stdout)
+	require.GreaterOrEqual(t, region.Get("source_image_size.height").Int(), int64(135), regionResult.Stdout)
+	screenshot := gjson.Get(regionResult.Stdout, "data.screenshots.0")
+	require.Equal(t, slideIDs[0].String(), screenshot.Get("slide_id").String(), regionResult.Stdout)
+	require.Equal(t, "png", screenshot.Get("format").String(), regionResult.Stdout)
+	require.Equal(t, int64(240), screenshot.Get("image_size.width").Int(), regionResult.Stdout)
+	require.Equal(t, int64(135), screenshot.Get("image_size.height").Int(), regionResult.Stdout)
+	regionPath := screenshot.Get("path").String()
+	require.Equal(t, regionPath, gjson.Get(regionResult.Stdout, "data.output").String(), regionResult.Stdout)
+	requireScreenshotPathUnderDir(t, regionPath, workDir)
+	regionFile, err := vfs.Open(regionPath)
+	require.NoError(t, err)
+	defer regionFile.Close()
+	regionConfig, regionFormat, err := image.DecodeConfig(regionFile)
+	require.NoError(t, err)
+	require.Equal(t, "png", regionFormat, regionResult.Stdout)
+	require.Equal(t, 240, regionConfig.Width, regionResult.Stdout)
+	require.Equal(t, 135, regionConfig.Height, regionResult.Stdout)
+}
+
 func requireScreenshotPathUnderDir(t *testing.T, path, dir string) {
 	t.Helper()
 	canonicalPath, err := filepath.EvalSymlinks(path)


### PR DESCRIPTION
## Summary

Extend `slides +screenshot` with two AI-oriented visual review modes:

- `--overview`: generate an indexed overview PNG for quickly inspecting a presentation.
- `--region`: crop a precise area from one rendered slide screenshot.

## Overview

- Render up to 20 slides in one overview page.
- Use a stable four-column grid with visible global labels such as `#01` and `#21`.
- Return an `index → slide_id` mapping so agents can safely select pages for detailed review.
- Preserve global slide numbering across overview pages.
- Return pagination metadata including:
  - `total_slides`
  - `overview_page`
  - `slide_range`
  - `has_previous` / `previous_overview_page`
  - `has_next` / `next_overview_page`
- Fetch screenshots in batches of at most 10 slides and compose the final PNG locally.
- Require callers to continue through `next_overview_page` while `has_next=true` to cover the complete presentation.

## Region screenshots

- Accept `--region x,y,width,height` for exactly one existing slide.
- Interpret coordinates in the actual rendered screenshot pixels.
- Validate positive dimensions and image bounds before cropping.
- Encode the cropped result as PNG.
- Return auditable metadata:
  - requested pixel rectangle
  - source image size
  - output image size
  - output format

## Validation and contracts

- Reject empty or malformed `--region` values.
- Enforce selector and mode mutual exclusions.
- Validate overview output requirements before remote requests.
- Preflight the conditional presentation read scope required by overview.
- Include the XML GET and up to two screenshot POST requests in overview dry-run output.
- Report malformed overview XML responses as `internal/invalid_response` instead of treating them as empty presentations.
- Preserve the normal screenshot output locator contract at the result root.
- Return numeric encoded byte size separately from `image_size`.
- Verify that returned overview images map bijectively to the requested slide IDs before composing the indexed image.

## Testing

Added or expanded coverage for:

- overview pagination and global indexes
- overview output metadata and PNG dimensions
- malformed XML and image responses
- empty, invalid and out-of-bounds regions
- pixel-region cropping and metadata
- conditional scope preflight
- overview dry-run orchestration
- built-CLI dry-run behavior
- live overview and region screenshot workflows