### PR TITLE
feat(slides): add kickoff reminder for empty presentations

### DIFF
--- a/shortcuts/slides/slides_create.go
+++ b/shortcuts/slides/slides_create.go
@@ -211,10 +211,15 @@ var SlidesCreate = common.Shortcut{
 
 		// Prefer the URL returned by presentation.create. Fall back to a local
 		// brand-standard URL only when the API omits it.
-		if url := common.GetString(data, "url"); url != "" {
-			result["url"] = url
-		} else if url := common.BuildResourceURL(runtime.Config.Brand, "slides", presentationID); url != "" {
-			result["url"] = url
+		presentationURL := common.GetString(data, "url")
+		if presentationURL == "" {
+			presentationURL = common.BuildResourceURL(runtime.Config.Brand, "slides", presentationID)
+		}
+		if presentationURL != "" {
+			result["url"] = presentationURL
+			if len(slides) == 0 {
+				result["message"] = fmt.Sprintf("成功创建空白幻灯片，url：%s，请给用户推送开工通知。", presentationURL)
+			}
 		}
 
 		if grant := common.AutoGrantCurrentUserDrivePermission(runtime, presentationID, "slides"); grant != nil {

--- a/shortcuts/slides/slides_create_test.go
+++ b/shortcuts/slides/slides_create_test.go
@@ -674,8 +674,9 @@ func TestSlidesCreateWithSlidesDryRun(t *testing.T) {
 	}
 }
 
-// TestSlidesCreateWithoutSlidesUnchanged verifies existing behavior when --slides is not passed.
-func TestSlidesCreateWithoutSlidesUnchanged(t *testing.T) {
+// TestSlidesCreateWithoutSlidesReturnsNotificationMessage verifies that an empty
+// presentation includes a user-facing kickoff-notification reminder.
+func TestSlidesCreateWithoutSlidesReturnsNotificationMessage(t *testing.T) {
 	t.Parallel()
 
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
@@ -707,6 +708,9 @@ func TestSlidesCreateWithoutSlidesUnchanged(t *testing.T) {
 	}
 	if data["title"] != "No Slides" {
 		t.Fatalf("title = %v, want No Slides", data["title"])
+	}
+	if data["message"] != "成功创建空白幻灯片，url：https://www.feishu.cn/slides/pres_no_slides，请给用户推送开工通知。" {
+		t.Fatalf("message = %v, want empty-presentation notification reminder", data["message"])
 	}
 	if _, ok := data["slide_ids"]; ok {
 		t.Fatalf("did not expect slide_ids when --slides not passed")


### PR DESCRIPTION
## Summary
- Add a kickoff-notification reminder when `slides +create` creates an empty presentation.
- Include the resolved presentation URL in the returned message.
- Add a regression assertion for the empty-presentation response.

## Validation
- `gofmt -d shortcuts/slides/slides_create.go shortcuts/slides/slides_create_test.go`
- `git diff --check`
- `go build` and `go test` were not run due to the ARM environment constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creating an empty presentation now displays a success message with its presentation URL and a reminder to add content.

* **Bug Fixes**
  * Presentation creation now uses the URL provided by the service when available, with a fallback URL used otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->