### PR TITLE
feat: use remote scopes.json for login scope recommendations

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -354,6 +354,7 @@ func authLoginRun(opts *LoginOptions) error {
 	}
 
 	scopeSummary := loadLoginScopeSummary(config.AppID, openId, finalScope, result.Token.Scope)
+	scopeSummary.StatusMessage = result.Token.StatusMessage
 
 	// Step 7: Store token
 	now := time.Now().UnixMilli()
@@ -437,6 +438,7 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 	}
 
 	scopeSummary := loadLoginScopeSummary(config.AppID, openId, requestedScope, result.Token.Scope)
+	scopeSummary.StatusMessage = result.Token.StatusMessage
 
 	// Store token
 	now := time.Now().UnixMilli()

--- a/cmd/auth/login_messages.go
+++ b/cmd/auth/login_messages.go
@@ -34,6 +34,7 @@ type loginMsg struct {
 	ScopeHint        string
 	GrantedScopes    string
 	NotGrantedScopes string
+	AuthDetails      string
 	ScopeSeparator   string
 	NoScopes         string
 
@@ -70,6 +71,7 @@ var loginMsgZh = &loginMsg{
 	ScopeHint:        "以上结果是本次授权请求用户最终确认后的结果，请勿持续重试；Scopes 未授予的原因是多样的，如 scope 被禁用；具体原因已通过授权页提示用户。可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
 	GrantedScopes:    "本次已成功授权：",
 	NotGrantedScopes: "以下是本次未授予的权限：",
+	AuthDetails:      "本次授权结果详情：",
 	ScopeSeparator:   "、",
 	NoScopes:         "（空）",
 
@@ -105,6 +107,7 @@ var loginMsgEn = &loginMsg{
 	ScopeHint:        "The result above is the user's final confirmation for this authorization request. Do not retry continuously. Scopes may be not granted for various reasons, such as a scope being disabled. The specific reason has already been shown to the user on the authorization page. Run `lark-cli auth status` to inspect all scopes currently granted to the account.",
 	GrantedScopes:    "- Successfully authorized in this request:",
 	NotGrantedScopes: "- Scopes not granted in this request:",
+	AuthDetails:      "- Authorization details:",
 	ScopeSeparator:   ", ",
 	NoScopes:         "(none)",
 

--- a/cmd/auth/login_messages.go
+++ b/cmd/auth/login_messages.go
@@ -25,18 +25,17 @@ type loginMsg struct {
 	ConfirmAuth     string
 
 	// Non-interactive prompts (login.go)
-	OpenURL            string
-	WaitingAuth        string
-	AgentTimeoutHint   func(recovery.RenderContext) string
-	AuthSuccess        string
-	LoginSuccess       string
-	AuthorizedUser     string
-	ScopeMismatch      string
-	ScopeHint          string
-	RequestedScopes    string
-	NewlyGrantedScopes string
-	NoScopes           string
-	StatusHint         string
+	OpenURL          string
+	WaitingAuth      string
+	AgentTimeoutHint func(recovery.RenderContext) string
+	AuthSuccess      string
+	LoginSuccess     string
+	ScopeMismatch    string
+	ScopeHint        string
+	GrantedScopes    string
+	NotGrantedScopes string
+	ScopeSeparator   string
+	NoScopes         string
 
 	// Non-interactive hint (no flags)
 	HintHeader  string
@@ -62,18 +61,17 @@ var loginMsgZh = &loginMsg{
 	ErrNoDomain:     "请至少选择一个业务域",
 	ConfirmAuth:     "确认授权?",
 
-	OpenURL:            "在浏览器中打开以下链接进行认证:\n\n",
-	WaitingAuth:        "等待用户授权...",
-	AgentTimeoutHint:   renderAgentTimeoutHintZh,
-	AuthSuccess:        "已收到授权确认，正在获取用户信息并校验授权结果...",
-	LoginSuccess:       "授权成功! 用户: %s (%s)",
-	AuthorizedUser:     "当前授权账号: %s (%s)",
-	ScopeMismatch:      "授权结果异常: 以下请求 scopes 未被授予: %s",
-	ScopeHint:          "以上结果是本次授权请求用户最终确认后的结果，请勿持续重试；Scopes 未授予的原因是多样的，如 scope 被禁用；具体原因已通过授权页提示用户。可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
-	RequestedScopes:    "  本次请求 scopes: %s\n",
-	NewlyGrantedScopes: "  本次新授予 scopes: %s\n",
-	NoScopes:           "（空）",
-	StatusHint:         "可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
+	OpenURL:          "在浏览器中打开以下链接进行认证:\n\n",
+	WaitingAuth:      "等待用户授权...",
+	AgentTimeoutHint: renderAgentTimeoutHintZh,
+	AuthSuccess:      "已收到授权确认，正在获取用户信息并校验授权结果...",
+	LoginSuccess:     "登录成功! 用户: %s (%s)",
+	ScopeMismatch:    "授权结果异常: 以下请求 scopes 未被授予: %s",
+	ScopeHint:        "以上结果是本次授权请求用户最终确认后的结果，请勿持续重试；Scopes 未授予的原因是多样的，如 scope 被禁用；具体原因已通过授权页提示用户。可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
+	GrantedScopes:    "本次已成功授权：",
+	NotGrantedScopes: "以下是本次未授予的权限：",
+	ScopeSeparator:   "、",
+	NoScopes:         "（空）",
 
 	HintHeader:  "请指定要授权的权限:\n",
 	HintCommon1: "  --recommend                     授权推荐权限",
@@ -98,18 +96,17 @@ var loginMsgEn = &loginMsg{
 	ErrNoDomain:     "please select at least one domain",
 	ConfirmAuth:     "Confirm authorization?",
 
-	OpenURL:            "Open this URL in your browser to authenticate:\n\n",
-	WaitingAuth:        "Waiting for user authorization...",
-	AgentTimeoutHint:   renderAgentTimeoutHintEn,
-	AuthSuccess:        "Authorization confirmed, fetching user info and validating granted scopes...",
-	LoginSuccess:       "Authorization successful! User: %s (%s)",
-	AuthorizedUser:     "Authorized account: %s (%s)",
-	ScopeMismatch:      "authorization result is abnormal: these requested scopes were not granted: %s",
-	ScopeHint:          "The result above is the user's final confirmation for this authorization request. Do not retry continuously. Scopes may be not granted for various reasons, such as a scope being disabled. The specific reason has already been shown to the user on the authorization page. Run `lark-cli auth status` to inspect all scopes currently granted to the account.",
-	RequestedScopes:    "  Requested scopes: %s\n",
-	NewlyGrantedScopes: "  Newly granted scopes: %s\n",
-	NoScopes:           "(none)",
-	StatusHint:         "Run `lark-cli auth status` to inspect all scopes currently granted to the account.",
+	OpenURL:          "Open this URL in your browser to authenticate:\n\n",
+	WaitingAuth:      "Waiting for user authorization...",
+	AgentTimeoutHint: renderAgentTimeoutHintEn,
+	AuthSuccess:      "Authorization confirmed, fetching user info and validating granted scopes...",
+	LoginSuccess:     "Authorization successful! User: %s (%s)",
+	ScopeMismatch:    "authorization result is abnormal: these requested scopes were not granted: %s",
+	ScopeHint:        "The result above is the user's final confirmation for this authorization request. Do not retry continuously. Scopes may be not granted for various reasons, such as a scope being disabled. The specific reason has already been shown to the user on the authorization page. Run `lark-cli auth status` to inspect all scopes currently granted to the account.",
+	GrantedScopes:    "- Successfully authorized in this request:",
+	NotGrantedScopes: "- Scopes not granted in this request:",
+	ScopeSeparator:   ", ",
+	NoScopes:         "(none)",
 
 	HintHeader:  "Please specify the scopes to authorize:\n",
 	HintCommon1: "  --recommend                     authorize recommended scopes",

--- a/cmd/auth/login_messages_test.go
+++ b/cmd/auth/login_messages_test.go
@@ -22,6 +22,9 @@ func TestGetLoginMsg_Zh(t *testing.T) {
 	if msg.SelectDomains != "选择要授权的业务域" {
 		t.Errorf("unexpected SelectDomains: %s", msg.SelectDomains)
 	}
+	if msg.LoginSuccess != "登录成功! 用户: %s (%s)" {
+		t.Errorf("unexpected LoginSuccess: %s", msg.LoginSuccess)
+	}
 }
 
 func TestGetLoginMsg_En(t *testing.T) {
@@ -73,13 +76,6 @@ func TestLoginMsg_FormatStrings(t *testing.T) {
 		if got == msg.LoginSuccess {
 			t.Errorf("%s LoginSuccess has no format verb", lang)
 		}
-
-		// AuthorizedUser should contain two %s placeholders (userName, openId)
-		got = fmt.Sprintf(msg.AuthorizedUser, "testuser", "ou_123")
-		if got == msg.AuthorizedUser {
-			t.Errorf("%s AuthorizedUser has no format verb", lang)
-		}
-
 		// SummaryDomains should contain %s
 		got = fmt.Sprintf(msg.SummaryDomains, "calendar, task")
 		if got == msg.SummaryDomains {

--- a/cmd/auth/login_result.go
+++ b/cmd/auth/login_result.go
@@ -20,6 +20,7 @@ type loginScopeSummary struct {
 	AlreadyGranted []string
 	Granted        []string
 	Missing        []string
+	StatusMessage  string
 }
 
 type loginScopeIssue struct {
@@ -114,11 +115,27 @@ func uniqueScopeList(scope string) []string {
 
 // formatScopeList joins scopes for display and falls back to the provided empty
 // label when the input slice is empty.
-func formatScopeList(scopes []string, empty string) string {
+func formatScopeList(scopes []string, empty, separator string) string {
 	if len(scopes) == 0 {
 		return empty
 	}
-	return strings.Join(scopes, " ")
+	return strings.Join(scopes, separator)
+}
+
+// grantedRequestedScopes returns requested scopes that are not in the missing
+// set, preserving the order of the authorization request.
+func grantedRequestedScopes(summary *loginScopeSummary) []string {
+	missing := make(map[string]bool, len(summary.Missing))
+	for _, scope := range summary.Missing {
+		missing[scope] = true
+	}
+	granted := make([]string, 0, len(summary.Requested))
+	for _, scope := range summary.Requested {
+		if !missing[scope] {
+			granted = append(granted, scope)
+		}
+	}
+	return granted
 }
 
 // emptyIfNil normalizes nil slices to empty slices for stable JSON output.
@@ -129,14 +146,43 @@ func emptyIfNil(s []string) []string {
 	return s
 }
 
-// writeLoginScopeBreakdown renders the requested/newly granted scope
-// breakdown to stderr.
+// writeLoginScopeBreakdown renders the compact granted/not-granted result.
 func writeLoginScopeBreakdown(errOut *cmdutil.IOStreams, msg *loginMsg, summary *loginScopeSummary) {
 	if summary == nil {
 		summary = &loginScopeSummary{}
 	}
-	fmt.Fprintf(errOut.ErrOut, msg.RequestedScopes, formatScopeList(summary.Requested, msg.NoScopes))
-	fmt.Fprintf(errOut.ErrOut, msg.NewlyGrantedScopes, formatScopeList(summary.NewlyGranted, msg.NoScopes))
+	fmt.Fprintln(errOut.ErrOut)
+	fmt.Fprintln(errOut.ErrOut, msg.GrantedScopes)
+	fmt.Fprintf(errOut.ErrOut, "  %s\n", formatScopeList(grantedRequestedScopes(summary), msg.NoScopes, msg.ScopeSeparator))
+	if summary.StatusMessage != "" {
+		fmt.Fprintln(errOut.ErrOut)
+		fmt.Fprintln(errOut.ErrOut, msg.NotGrantedScopes)
+		writeLoginStatusMessage(errOut, summary.StatusMessage)
+		return
+	}
+	if len(summary.Missing) == 0 {
+		return
+	}
+	fmt.Fprintln(errOut.ErrOut)
+	fmt.Fprintln(errOut.ErrOut, msg.NotGrantedScopes)
+	fmt.Fprintf(errOut.ErrOut, "  %s\n", formatScopeList(summary.Missing, msg.NoScopes, msg.ScopeSeparator))
+}
+
+// writeLoginStatusMessage appends the server-rendered authorization result
+// without interpreting or rewriting its contents.
+func writeLoginStatusMessage(errOut *cmdutil.IOStreams, statusMessage string) {
+	if statusMessage == "" {
+		return
+	}
+	for _, line := range strings.SplitAfter(statusMessage, "\n") {
+		if line == "" {
+			continue
+		}
+		fmt.Fprint(errOut.ErrOut, "  ", line)
+	}
+	if !strings.HasSuffix(statusMessage, "\n") {
+		fmt.Fprintln(errOut.ErrOut)
+	}
 }
 
 // writeLoginSuccess emits the successful login payload in either JSON or text
@@ -154,9 +200,6 @@ func writeLoginSuccess(opts *LoginOptions, msg *loginMsg, f *cmdutil.Factory, op
 	fmt.Fprintln(f.IOStreams.ErrOut)
 	output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf(msg.LoginSuccess, userName, openId))
 	writeLoginScopeBreakdown(f.IOStreams, msg, summary)
-	if len(summary.Missing) == 0 && msg.StatusHint != "" {
-		fmt.Fprintln(f.IOStreams.ErrOut, msg.StatusHint)
-	}
 }
 
 // handleLoginScopeIssue prints or returns a structured missing-scope result
@@ -182,15 +225,12 @@ func handleLoginScopeIssue(opts *LoginOptions, msg *loginMsg, f *cmdutil.Factory
 
 	fmt.Fprintln(f.IOStreams.ErrOut)
 	if loginSucceeded {
-		fmt.Fprintln(f.IOStreams.ErrOut, issue.Message)
-		if msg.AuthorizedUser != "" {
-			fmt.Fprintf(f.IOStreams.ErrOut, "%s\n", fmt.Sprintf(msg.AuthorizedUser, userName, openId))
-		}
+		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf(msg.LoginSuccess, userName, openId))
 	} else {
 		fmt.Fprintln(f.IOStreams.ErrOut, issue.Message)
 	}
 	writeLoginScopeBreakdown(f.IOStreams, msg, issue.Summary)
-	if issue.Hint != "" {
+	if !loginSucceeded && issue.Hint != "" {
 		fmt.Fprintln(f.IOStreams.ErrOut, issue.Hint)
 	}
 	return output.ErrBare(output.ExitAuth)
@@ -217,7 +257,7 @@ func authorizationCompletePayload(openId, userName string, summary *loginScopeSu
 		payload["warning"] = map[string]interface{}{
 			"type":    "missing_scope",
 			"message": issue.Message,
-			"hint":    issue.Hint,
+			"hint":    summary.StatusMessage,
 		}
 	}
 	return payload

--- a/cmd/auth/login_result.go
+++ b/cmd/auth/login_result.go
@@ -156,7 +156,11 @@ func writeLoginScopeBreakdown(errOut *cmdutil.IOStreams, msg *loginMsg, summary 
 	fmt.Fprintf(errOut.ErrOut, "  %s\n", formatScopeList(grantedRequestedScopes(summary), msg.NoScopes, msg.ScopeSeparator))
 	if summary.StatusMessage != "" {
 		fmt.Fprintln(errOut.ErrOut)
-		fmt.Fprintln(errOut.ErrOut, msg.NotGrantedScopes)
+		heading := msg.NotGrantedScopes
+		if len(summary.Missing) == 0 {
+			heading = msg.AuthDetails
+		}
+		fmt.Fprintln(errOut.ErrOut, heading)
 		writeLoginStatusMessage(errOut, summary.StatusMessage)
 		return
 	}
@@ -254,9 +258,13 @@ func authorizationCompletePayload(openId, userName string, summary *loginScopeSu
 		"granted":         emptyIfNil(summary.Granted),
 	}
 	if issue != nil {
+		hint := summary.StatusMessage
+		if hint == "" {
+			hint = issue.Message
+		}
 		payload["warning"] = map[string]interface{}{
 			"type": "missing_scope",
-			"hint": summary.StatusMessage,
+			"hint": hint,
 		}
 	}
 	return payload

--- a/cmd/auth/login_result.go
+++ b/cmd/auth/login_result.go
@@ -255,9 +255,8 @@ func authorizationCompletePayload(openId, userName string, summary *loginScopeSu
 	}
 	if issue != nil {
 		payload["warning"] = map[string]interface{}{
-			"type":    "missing_scope",
-			"message": issue.Message,
-			"hint":    summary.StatusMessage,
+			"type": "missing_scope",
+			"hint": summary.StatusMessage,
 		}
 	}
 	return payload

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -480,12 +480,15 @@ func TestBuildLoginScopeSummary(t *testing.T) {
 func TestWriteLoginSuccess_JSONIncludesScopeDiff(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
 
-	writeLoginSuccess(&LoginOptions{JSON: true}, getLoginMsg("en"), f, "ou_user", "tester", &loginScopeSummary{
+	summary := &loginScopeSummary{
 		Requested:      []string{"im:message:send", "im:message:reply"},
 		NewlyGranted:   []string{"im:message:send"},
 		AlreadyGranted: []string{"im:message:reply"},
 		Granted:        []string{"im:message:send", "im:message:reply"},
-	})
+		StatusMessage: "[用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
+			"应用身份\n[待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message",
+	}
+	writeLoginSuccess(&LoginOptions{JSON: true}, getLoginMsg("en"), f, "ou_user", "tester", summary)
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(stdout.Bytes(), &data); err != nil {
@@ -503,19 +506,25 @@ func TestWriteLoginSuccess_JSONIncludesScopeDiff(t *testing.T) {
 	if len(data["already_granted"].([]interface{})) != 1 {
 		t.Fatalf("already_granted = %#v", data["already_granted"])
 	}
+	if _, ok := data["status_message"]; ok {
+		t.Fatalf("status_message should not be exposed at the top level: %#v", data)
+	}
 }
 
 func TestHandleLoginScopeIssue_NonJSONAlignsWithLoginSuccess(t *testing.T) {
 	f, _, stderr, _ := cmdutil.TestFactory(t, nil)
-	err := handleLoginScopeIssue(&LoginOptions{}, getLoginMsg("zh"), f, &loginScopeIssue{
+	issue := &loginScopeIssue{
 		Message: "授权结果异常: 以下请求 scopes 未被授予: im:message:send",
 		Hint:    "以上结果是本次授权请求用户最终确认后的结果，请勿持续重试；Scopes 未授予的原因是多样的，如 scope 被禁用；具体原因已通过授权页提示用户。可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
 		Summary: &loginScopeSummary{
-			Requested: []string{"im:message:send"},
+			Requested: []string{"im:message:send", "im:message:reply"},
 			Missing:   []string{"im:message:send"},
-			Granted:   []string{"base:app:copy"},
+			Granted:   []string{"im:message:reply", "base:app:copy"},
+			StatusMessage: "[用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
+				"应用身份\n[待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message",
 		},
-	}, "ou_user", "tester")
+	}
+	err := handleLoginScopeIssue(&LoginOptions{}, getLoginMsg("zh"), f, issue, "ou_user", "tester")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -524,40 +533,53 @@ func TestHandleLoginScopeIssue_NonJSONAlignsWithLoginSuccess(t *testing.T) {
 	}
 	got := stderr.String()
 	for _, want := range []string{
-		"授权结果异常: 以下请求 scopes 未被授予: im:message:send",
-		"当前授权账号: tester (ou_user)",
-		"本次请求 scopes: im:message:send",
-		"本次新授予 scopes: （空）",
-		"以上结果是本次授权请求用户最终确认后的结果，请勿持续重试",
-		"scope 被禁用",
-		"lark-cli auth status",
+		"OK: 登录成功! 用户: tester (ou_user)",
+		"OK: 登录成功! 用户: tester (ou_user)\n\n" +
+			"本次已成功授权：\n" +
+			"  im:message:reply\n\n" +
+			"以下是本次未授予的权限：\n" +
+			"  [用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
+			"  应用身份\n" +
+			"  [待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr missing %q, got:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "最终已授权 scopes:") {
-		t.Fatalf("stderr should not contain final granted scopes, got:\n%s", got)
+	successPos := strings.Index(got, "OK: 登录成功! 用户: tester (ou_user)")
+	scopePos := strings.Index(got, "本次已成功授权：\n  im:message:reply")
+	missingPos := strings.Index(got, "以下是本次未授予的权限：")
+	statusPos := strings.Index(got, "  [用户跳过，可重试]")
+	if successPos < 0 || scopePos <= successPos || missingPos <= scopePos || statusPos <= missingPos {
+		t.Fatalf("login result placement is wrong, got:\n%s", got)
 	}
-	if strings.Contains(got, "授权成功") {
-		t.Fatalf("stderr should not contain success wording, got:\n%s", got)
-	}
-	if strings.Contains(got, "本次未授予 scopes:") {
-		t.Fatalf("stderr should not duplicate missing scopes, got:\n%s", got)
+	for _, unwanted := range []string{
+		issue.Message,
+		"本次请求 scopes:",
+		"本次新授予 scopes:",
+		issue.Hint,
+		"当前授权账号:",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("stderr should not contain %q, got:\n%s", unwanted, got)
+		}
 	}
 }
 
 func TestHandleLoginScopeIssue_JSONAlignsWithLoginSuccess(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
-	err := handleLoginScopeIssue(&LoginOptions{JSON: true}, getLoginMsg("en"), f, &loginScopeIssue{
+	issue := &loginScopeIssue{
 		Message: "authorization result is abnormal: these requested scopes were not granted: im:message:send",
 		Hint:    "Granted scopes: base:app:copy. Check app scopes.",
 		Summary: &loginScopeSummary{
 			Requested: []string{"im:message:send"},
 			Missing:   []string{"im:message:send"},
 			Granted:   []string{"base:app:copy"},
+			StatusMessage: "[用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
+				"应用身份\n[待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message",
 		},
-	}, "ou_user", "tester")
+	}
+	err := handleLoginScopeIssue(&LoginOptions{JSON: true}, getLoginMsg("en"), f, issue, "ou_user", "tester")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -582,6 +604,12 @@ func TestHandleLoginScopeIssue_JSONAlignsWithLoginSuccess(t *testing.T) {
 	if warning["type"] != "missing_scope" {
 		t.Fatalf("warning.type = %v", warning["type"])
 	}
+	if warning["hint"] != issue.Summary.StatusMessage {
+		t.Fatalf("warning.hint = %v, want %q", warning["hint"], issue.Summary.StatusMessage)
+	}
+	if _, ok := data["status_message"]; ok {
+		t.Fatalf("status_message should not be exposed at the top level: %#v", data)
+	}
 }
 
 func TestWriteLoginSuccess_JSONEmptySlicesNotNull(t *testing.T) {
@@ -604,6 +632,42 @@ func TestWriteLoginSuccess_JSONEmptySlicesNotNull(t *testing.T) {
 			t.Fatalf("%s = %#v, want JSON array", k, v)
 		}
 	}
+	if _, ok := data["status_message"]; ok {
+		t.Fatalf("status_message should not be exposed at the top level: %#v", data)
+	}
+}
+
+func TestWriteLoginSuccess_TextStatusMessageUnderNotGrantedHeading(t *testing.T) {
+	f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+	statusMessage := "[用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
+		"应用身份\n[待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message"
+
+	writeLoginSuccess(&LoginOptions{}, getLoginMsg("zh"), f, "ou_user", "tester", &loginScopeSummary{
+		Requested:     []string{"im:message:send"},
+		NewlyGranted:  []string{"im:message:send"},
+		Granted:       []string{"im:message:send"},
+		StatusMessage: statusMessage,
+	})
+
+	got := stderr.String()
+	wantBlock := "本次已成功授权：\n" +
+		"  im:message:send\n\n" +
+		"以下是本次未授予的权限：\n" +
+		"  [用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
+		"  应用身份\n" +
+		"  [待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message"
+	if !strings.Contains(got, wantBlock) {
+		t.Fatalf("stderr missing formatted authorization block %q, got:\n%s", wantBlock, got)
+	}
+	scopePos := strings.Index(got, "本次已成功授权：\n  im:message:send")
+	missingPos := strings.Index(got, "以下是本次未授予的权限：")
+	statusPos := strings.Index(got, "  [用户跳过，可重试]")
+	if scopePos < 0 || missingPos <= scopePos || statusPos <= missingPos {
+		t.Fatalf("status_message placement is wrong, got:\n%s", got)
+	}
+	if strings.Contains(got, "可执行 `lark-cli auth status`") {
+		t.Fatalf("stderr should not contain the hidden status hint, got:\n%s", got)
+	}
 }
 
 func TestWriteLoginSuccess_TextOutputScenarios(t *testing.T) {
@@ -622,15 +686,14 @@ func TestWriteLoginSuccess_TextOutputScenarios(t *testing.T) {
 				Granted:        []string{"im:message:send", "im:message:reply"},
 			},
 			expectedPresent: []string{
-				"授权成功! 用户: tester (ou_user)",
-				"本次请求 scopes: im:message:send im:message:reply",
-				"本次新授予 scopes: im:message:send",
-				"可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
+				"登录成功! 用户: tester (ou_user)",
+				"登录成功! 用户: tester (ou_user)\n\n本次已成功授权：\n  im:message:send、im:message:reply",
 			},
 			expectedAbsent: []string{
-				"本次未授予 scopes:",
-				"最终已授权 scopes:",
-				"已有 scopes:",
+				"以下是本次未授予的权限",
+				"本次请求 scopes:",
+				"本次新授予 scopes:",
+				"lark-cli auth status",
 			},
 		},
 		{
@@ -641,14 +704,13 @@ func TestWriteLoginSuccess_TextOutputScenarios(t *testing.T) {
 				Granted:        []string{"im:message:send", "contact:user.base:readonly"},
 			},
 			expectedPresent: []string{
-				"本次请求 scopes: im:message:send",
-				"本次新授予 scopes: （空）",
-				"可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
+				"本次已成功授权：\n  im:message:send",
 			},
 			expectedAbsent: []string{
-				"本次未授予 scopes:",
-				"最终已授权 scopes:",
-				"已有 scopes:",
+				"以下是本次未授予的权限",
+				"本次请求 scopes:",
+				"本次新授予 scopes:",
+				"lark-cli auth status",
 			},
 		},
 		{
@@ -659,14 +721,12 @@ func TestWriteLoginSuccess_TextOutputScenarios(t *testing.T) {
 				Granted:   []string{"im:message:reply"},
 			},
 			expectedPresent: []string{
-				"本次请求 scopes: im:message:send im:message:reply",
-				"本次新授予 scopes: （空）",
+				"本次已成功授权：\n  im:message:reply\n\n以下是本次未授予的权限：\n  im:message:send",
 			},
 			expectedAbsent: []string{
-				"本次未授予 scopes:",
-				"已有 scopes:",
-				"最终已授权 scopes:",
-				"可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
+				"本次请求 scopes:",
+				"本次新授予 scopes:",
+				"lark-cli auth status",
 			},
 		},
 	}
@@ -708,6 +768,7 @@ func TestAuthLoginRun_MissingRequestedScopeAlignsWithLoginSuccess(t *testing.T) 
 	keyring.MockInit()
 	setupLoginConfigDir(t)
 	t.Setenv("HOME", t.TempDir())
+	const statusMessage = "[待审核，通过后用户需重新授权] 以下权限正在等待管理员审核：offline_access"
 
 	multi := &core.MultiAppConfig{
 		CurrentApp: "default",
@@ -747,6 +808,7 @@ func TestAuthLoginRun_MissingRequestedScopeAlignsWithLoginSuccess(t *testing.T) 
 			"expires_in":               7200,
 			"refresh_token_expires_in": 604800,
 			"scope":                    "offline_access",
+			"status_message":           statusMessage,
 		},
 	})
 	reg.Register(&httpmock.Stub{
@@ -775,25 +837,24 @@ func TestAuthLoginRun_MissingRequestedScopeAlignsWithLoginSuccess(t *testing.T) 
 	}
 	got := stderr.String()
 	for _, want := range []string{
-		"授权结果异常: 以下请求 scopes 未被授予: im:message:send",
-		"当前授权账号: tester (ou_user)",
-		"本次请求 scopes: im:message:send",
-		"以上结果是本次授权请求用户最终确认后的结果，请勿持续重试",
-		"scope 被禁用",
-		"lark-cli auth status",
+		"OK: 登录成功! 用户: tester (ou_user)",
+		"本次已成功授权：\n  （空）\n\n以下是本次未授予的权限：\n  " + statusMessage,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr missing %q, got:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "最终已授权 scopes:") {
-		t.Fatalf("stderr should not contain final granted scopes, got:\n%s", got)
-	}
-	if strings.Contains(got, "OK: 授权成功") {
-		t.Fatalf("stderr should not contain success prefix when scopes are missing, got:\n%s", got)
-	}
-	if strings.Contains(got, "本次未授予 scopes:") {
-		t.Fatalf("stderr should not duplicate missing scopes, got:\n%s", got)
+	for _, unwanted := range []string{
+		"授权结果异常:",
+		"本次请求 scopes:",
+		"本次新授予 scopes:",
+		"以上结果是本次授权请求用户最终确认后的结果",
+		"lark-cli auth status",
+		"当前授权账号:",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("stderr should not contain %q, got:\n%s", unwanted, got)
+		}
 	}
 	if strings.Contains(got, "ERROR:") {
 		t.Fatalf("stderr should not contain error prefix, got:\n%s", got)
@@ -824,6 +885,7 @@ func TestAuthLoginRun_DeviceCodeUsesCachedRequestedScopes(t *testing.T) {
 	keyring.MockInit()
 	setupLoginConfigDir(t)
 	t.Setenv("HOME", t.TempDir())
+	const statusMessage = "[待审核，通过后用户需重新授权] 以下权限正在等待管理员审核：offline_access"
 
 	multi := &core.MultiAppConfig{
 		CurrentApp: "default",
@@ -863,6 +925,7 @@ func TestAuthLoginRun_DeviceCodeUsesCachedRequestedScopes(t *testing.T) {
 			"expires_in":               7200,
 			"refresh_token_expires_in": 604800,
 			"scope":                    "im:message:send offline_access",
+			"status_message":           statusMessage,
 		},
 	})
 	reg.Register(&httpmock.Stub{
@@ -904,24 +967,24 @@ func TestAuthLoginRun_DeviceCodeUsesCachedRequestedScopes(t *testing.T) {
 	}
 	got := stderr.String()
 	for _, want := range []string{
-		"OK: 授权成功! 用户: tester (ou_user)",
-		"本次请求 scopes: im:message:send",
-		"本次新授予 scopes: im:message:send",
-		"可执行 `lark-cli auth status` 查看账号当前已授予的全部 scopes；",
+		"OK: 登录成功! 用户: tester (ou_user)",
+		"本次已成功授权：\n  im:message:send\n\n以下是本次未授予的权限：\n  " + statusMessage,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr missing %q, got:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "最终已授权 scopes:") {
-		t.Fatalf("stderr should not contain final granted scopes, got:\n%s", got)
+	for _, unwanted := range []string{"本次请求 scopes:", "本次新授予 scopes:", "lark-cli auth status"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("stderr should not contain %q, got:\n%s", unwanted, got)
+		}
 	}
 	if got, err := loadLoginRequestedScope("device-code"); err != nil || got != "" {
 		t.Fatalf("loadLoginRequestedScope() after cleanup = (%q, %v), want empty", got, err)
 	}
 }
 
-func TestWriteLoginSuccess_TextOutputEnglishIncludesStatusHintWhenNoMissingScopes(t *testing.T) {
+func TestWriteLoginSuccess_TextOutputEnglishUsesCompactScopeSummary(t *testing.T) {
 	f, _, stderr, _ := cmdutil.TestFactory(t, nil)
 
 	writeLoginSuccess(&LoginOptions{}, getLoginMsg("en"), f, "ou_user", "tester", &loginScopeSummary{
@@ -933,16 +996,18 @@ func TestWriteLoginSuccess_TextOutputEnglishIncludesStatusHintWhenNoMissingScope
 	got := stderr.String()
 	for _, want := range []string{
 		"Authorization successful! User: tester (ou_user)",
-		"Requested scopes: im:message:send",
-		"Newly granted scopes: im:message:send",
-		"Run `lark-cli auth status` to inspect all scopes currently granted to the account.",
+		"Authorization successful! User: tester (ou_user)\n\n" +
+			"- Successfully authorized in this request:\n" +
+			"  im:message:send",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr missing %q, got:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "Not granted scopes:") {
-		t.Fatalf("stderr should not contain not granted scopes, got:\n%s", got)
+	for _, unwanted := range []string{"Scopes not granted in this request", "Requested scopes:", "Newly granted scopes:", "lark-cli auth status"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("stderr should not contain %q, got:\n%s", unwanted, got)
+		}
 	}
 }
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -615,6 +615,27 @@ func TestHandleLoginScopeIssue_JSONAlignsWithLoginSuccess(t *testing.T) {
 	}
 }
 
+func TestAuthorizationCompletePayload_EmptyStatusMessageFallsBackToIssueMessage(t *testing.T) {
+	issue := &loginScopeIssue{
+		Message: "authorization result is abnormal: these requested scopes were not granted: im:message:send",
+		Summary: &loginScopeSummary{
+			Missing: []string{"im:message:send"},
+		},
+	}
+
+	payload := authorizationCompletePayload("ou_user", "tester", issue.Summary, issue)
+	warning, ok := payload["warning"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("warning = %#v", payload["warning"])
+	}
+	if warning["hint"] != issue.Message {
+		t.Fatalf("warning.hint = %v, want %q", warning["hint"], issue.Message)
+	}
+	if _, ok := warning["message"]; ok {
+		t.Fatalf("warning.message should not be exposed: %#v", warning)
+	}
+}
+
 func TestWriteLoginSuccess_JSONEmptySlicesNotNull(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
 
@@ -640,7 +661,7 @@ func TestWriteLoginSuccess_JSONEmptySlicesNotNull(t *testing.T) {
 	}
 }
 
-func TestWriteLoginSuccess_TextStatusMessageUnderNotGrantedHeading(t *testing.T) {
+func TestWriteLoginSuccess_TextStatusMessageWithoutMissingScopesUsesDetailsHeading(t *testing.T) {
 	f, _, stderr, _ := cmdutil.TestFactory(t, nil)
 	statusMessage := "[用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
 		"应用身份\n[待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message"
@@ -655,7 +676,7 @@ func TestWriteLoginSuccess_TextStatusMessageUnderNotGrantedHeading(t *testing.T)
 	got := stderr.String()
 	wantBlock := "本次已成功授权：\n" +
 		"  im:message:send\n\n" +
-		"以下是本次未授予的权限：\n" +
+		"本次授权结果详情：\n" +
 		"  [用户跳过，可重试] 用户未勾选：calendar:calendar:update\n" +
 		"  应用身份\n" +
 		"  [待审核，通过后自动生效] 以下权限正在等待管理员审核：im:message"
@@ -663,13 +684,34 @@ func TestWriteLoginSuccess_TextStatusMessageUnderNotGrantedHeading(t *testing.T)
 		t.Fatalf("stderr missing formatted authorization block %q, got:\n%s", wantBlock, got)
 	}
 	scopePos := strings.Index(got, "本次已成功授权：\n  im:message:send")
-	missingPos := strings.Index(got, "以下是本次未授予的权限：")
+	detailsPos := strings.Index(got, "本次授权结果详情：")
 	statusPos := strings.Index(got, "  [用户跳过，可重试]")
-	if scopePos < 0 || missingPos <= scopePos || statusPos <= missingPos {
+	if scopePos < 0 || detailsPos <= scopePos || statusPos <= detailsPos {
 		t.Fatalf("status_message placement is wrong, got:\n%s", got)
+	}
+	if strings.Contains(got, "以下是本次未授予的权限：") {
+		t.Fatalf("stderr should not label status_message as not granted when no scopes are missing, got:\n%s", got)
 	}
 	if strings.Contains(got, "可执行 `lark-cli auth status`") {
 		t.Fatalf("stderr should not contain the hidden status hint, got:\n%s", got)
+	}
+}
+
+func TestWriteLoginSuccess_TextStatusMessageWithoutMissingScopesUsesEnglishDetailsHeading(t *testing.T) {
+	f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+
+	writeLoginSuccess(&LoginOptions{}, getLoginMsg("en"), f, "ou_user", "tester", &loginScopeSummary{
+		Requested:     []string{"im:message:send"},
+		Granted:       []string{"im:message:send"},
+		StatusMessage: "Authorization status details",
+	})
+
+	got := stderr.String()
+	if !strings.Contains(got, "- Authorization details:\n  Authorization status details") {
+		t.Fatalf("stderr missing neutral authorization details heading, got:\n%s", got)
+	}
+	if strings.Contains(got, "- Scopes not granted in this request:") {
+		t.Fatalf("stderr should not label status_message as not granted when no scopes are missing, got:\n%s", got)
 	}
 }
 
@@ -971,7 +1013,7 @@ func TestAuthLoginRun_DeviceCodeUsesCachedRequestedScopes(t *testing.T) {
 	got := stderr.String()
 	for _, want := range []string{
 		"OK: 登录成功! 用户: tester (ou_user)",
-		"本次已成功授权：\n  im:message:send\n\n以下是本次未授予的权限：\n  " + statusMessage,
+		"本次已成功授权：\n  im:message:send\n\n本次授权结果详情：\n  " + statusMessage,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr missing %q, got:\n%s", want, got)

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -604,6 +604,9 @@ func TestHandleLoginScopeIssue_JSONAlignsWithLoginSuccess(t *testing.T) {
 	if warning["type"] != "missing_scope" {
 		t.Fatalf("warning.type = %v", warning["type"])
 	}
+	if _, ok := warning["message"]; ok {
+		t.Fatalf("warning.message should not be exposed: %#v", warning)
+	}
 	if warning["hint"] != issue.Summary.StatusMessage {
 		t.Fatalf("warning.hint = %v, want %q", warning["hint"], issue.Summary.StatusMessage)
 	}

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -34,6 +34,7 @@ type DeviceFlowTokenData struct {
 	ExpiresIn        int
 	RefreshExpiresIn int
 	Scope            string
+	StatusMessage    string
 }
 
 // DeviceFlowResult is the result of polling the token endpoint.
@@ -222,6 +223,7 @@ func PollDeviceToken(ctx context.Context, httpClient *http.Client, appId, appSec
 					ExpiresIn:        tokenExpiresIn,
 					RefreshExpiresIn: refreshExpiresIn,
 					Scope:            getStr(data, "scope"),
+					StatusMessage:    getStr(data, "status_message"),
 				},
 			}
 		}

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -214,5 +215,62 @@ func TestPollDeviceToken_DefaultsZeroIntervalToFiveSeconds(t *testing.T) {
 	}
 	if got := requests.Load(); got != 0 {
 		t.Fatalf("PollDeviceToken() sent %d requests before context cancellation, want 0", got)
+	}
+}
+
+func TestPollDeviceToken_PreservesStatusMessage(t *testing.T) {
+	t.Parallel()
+
+	const statusMessage = "[不可申请，勿重试] 企业管理员禁止申请的权限：mail:user_mailbox.message:send\n" +
+		"[待审核，通过后用户需重新授权] 以下权限正在等待管理员审核：offline_access"
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+					"code": 0,
+					"access_token": "access-token",
+					"expires_in": 7200,
+					"scope": "approval:task:read",
+					"status_message": "[不可申请，勿重试] 企业管理员禁止申请的权限：mail:user_mailbox.message:send\n[待审核，通过后用户需重新授权] 以下权限正在等待管理员审核：offline_access"
+				}`)),
+			}, nil
+		}),
+	}
+
+	result := PollDeviceToken(context.Background(), client, "cli_a", "secret_b", core.BrandFeishu, "device-code", 1, 3, nil)
+	if result == nil || !result.OK || result.Token == nil {
+		t.Fatalf("PollDeviceToken() = %#v, want successful token result", result)
+	}
+	if result.Token.StatusMessage != statusMessage {
+		t.Fatalf("StatusMessage = %q, want %q", result.Token.StatusMessage, statusMessage)
+	}
+}
+
+func TestPollDeviceToken_MissingStatusMessageIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+					"code": 0,
+					"access_token": "access-token",
+					"expires_in": 7200,
+					"scope": "approval:task:read"
+				}`)),
+			}, nil
+		}),
+	}
+
+	result := PollDeviceToken(context.Background(), client, "cli_a", "secret_b", core.BrandFeishu, "device-code", 1, 3, nil)
+	if result == nil || !result.OK || result.Token == nil {
+		t.Fatalf("PollDeviceToken() = %#v, want successful token result", result)
+	}
+	if result.Token.StatusMessage != "" {
+		t.Fatalf("StatusMessage = %q, want empty string", result.Token.StatusMessage)
 	}
 }


### PR DESCRIPTION
## Summary
`auth login` previously computed its recommended authorization scopes from a compiled-in local table, so different CLI versions could request different scope sets and drift from the platform's own scope computation. This PR switches the scope source to a remotely published per-brand `scopes.json` fetched at login time (~1s timeout, whole-file validation, silent fallback to the local computation on any failure), and removes the terminal interactive domain-selection page and the local auto-approve filter chain so `--recommend` is equivalent to `--domain all`.

## Changes
- Add `internal/auth/remote_scopes.go`: brand-addressed GET with ~1s timeout and whole-file validation — a valid file is used verbatim (including domains/scopes unknown to this CLI build); any failure (non-2xx, empty body, bad JSON, missing/empty `scopes`, a domain missing `user_scopes`, or a malformed scope string: fewer than two `:`-separated segments, an empty segment, or characters outside `[a-z0-9_.]`) falls back silently to the local computation
- `cmd/auth/login.go`: fetch remote scopes once per login and use them for domain validation, `--domain all` / bare-login / `--recommend` expansion, and per-domain scope selection; the `--scope`-only path never touches the catalog
- Remove `cmd/auth/login_interactive.go`, the auto-approve loader chain in `internal/registry/loader.go`, and the service-description getter orphaned by the interactive-page removal; drop the now-unused interactive-selection and no-flags-hint message strings in `cmd/auth/login_messages.go`
- Behavior changes (release-notes relevant): bare `auth login` in a non-TTY environment no longer fails fast — it initiates full-domain authorization and blocks up to ~10 minutes awaiting authorization (agent harnesses should use `--no-wait`); `--recommend` now requests the full domain scope set rather than the former auto-approve subset (the authorization page still shows every requested scope)

## Test Plan
- [x] `gofmt` clean on all changed files
- [x] `go build ./...` passed
- [x] `go vet ./cmd/... ./internal/...` passed
- [x] `go test ./...` unit suite passed on the rebased head
- [x] manual verification: fetched the production `scopes.json` for both brands; whole-file validation accepts them; per-domain diff against the local synthesis — 20/21 domains identical
- [ ] sandbox E2E / acceptance-reviewer: re-run via CI on the rebased head

## Related Issues
N/A