### PR TITLE
fix(api): reject query strings and fragments in paths

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -15,7 +15,6 @@ import (
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
-	"github.com/larksuite/cli/internal/validate"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	"github.com/spf13/cobra"
 )
@@ -47,13 +46,19 @@ type APIOptions struct {
 
 var urlPrefixRe = regexp.MustCompile(`https?://[^/]+(/open-apis/.+)`)
 
-func normalisePath(raw string) string {
+func normalisePath(raw string) (string, error) {
+	if strings.ContainsAny(raw, "?#") {
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"path must not contain a query string or fragment").
+			WithHint("pass query parameters with --params and omit URL fragments").
+			WithParam("path")
+	}
 	if matches := urlPrefixRe.FindStringSubmatch(raw); len(matches) > 1 {
 		raw = matches[1]
 	} else if !strings.HasPrefix(raw, "/open-apis/") {
 		raw = "/open-apis/" + strings.TrimPrefix(raw, "/")
 	}
-	return validate.StripQueryFragment(raw)
+	return raw, nil
 }
 
 // NewCmdApi creates the api command. If runF is non-nil it is called instead of apiRun (test hook).
@@ -136,6 +141,10 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, *cmdutil.FileUploa
 			WithHint("pass the verb as the first argument, e.g. lark-cli api GET /open-apis/...").
 			WithParam("<method>")
 	}
+	path, err := normalisePath(opts.Path)
+	if err != nil {
+		return client.RawApiRequest{}, nil, err
+	}
 
 	// Validate --file mutual exclusions first.
 	if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, opts.Method); err != nil {
@@ -163,7 +172,7 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, *cmdutil.FileUploa
 
 	request := client.RawApiRequest{
 		Method: opts.Method,
-		URL:    normalisePath(opts.Path),
+		URL:    path,
 		Params: params,
 		As:     opts.As,
 	}

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -103,6 +103,32 @@ func TestApiCmd_DryRun(t *testing.T) {
 	}
 }
 
+func TestApiCmd_RejectsInlineQuery(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+
+	cmd := newTestApiCmd(f, nil)
+	cmd.SetArgs([]string{"GET", "/open-apis/contact/v3/users?user_id_type=open_id", "--as", "bot", "--dry-run"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected inline query to be rejected")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T, want *errs.ValidationError", err)
+	}
+	if validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "path" {
+		t.Fatalf("validation error = %#v, want invalid_argument for path", validationErr)
+	}
+	if !strings.Contains(validationErr.Hint, "--params") {
+		t.Fatalf("validation hint = %q, want --params recovery", validationErr.Hint)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no dry-run request for rejected input", stdout.String())
+	}
+}
+
 func TestApiCmd_DryRunWithJq(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
 		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
@@ -786,23 +812,50 @@ func requireProblem(t *testing.T, err error, category errs.Category, subtype err
 	}
 }
 
-func TestNormalisePath_StripsQueryAndFragment(t *testing.T) {
+func TestNormalisePath(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		raw  string
 		want string
 	}{
 		{"plain path", "/open-apis/test", "/open-apis/test"},
-		{"with query", "/open-apis/test?admin=true", "/open-apis/test"},
-		{"with fragment", "/open-apis/test#section", "/open-apis/test"},
-		{"with both", "/open-apis/test?a=1#frag", "/open-apis/test"},
-		{"full URL with query", "https://open.feishu.cn/open-apis/foo?bar=1", "/open-apis/foo"},
-		{"short path with query", "contact/v3/users?page_size=50", "/open-apis/contact/v3/users"},
+		{"full URL", "https://open.feishu.cn/open-apis/foo", "/open-apis/foo"},
+		{"short path", "contact/v3/users", "/open-apis/contact/v3/users"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := normalisePath(tt.raw)
+			got, err := normalisePath(tt.raw)
+			if err != nil {
+				t.Fatalf("normalisePath(%q) returned error: %v", tt.raw, err)
+			}
 			if got != tt.want {
 				t.Errorf("normalisePath(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalisePath_RejectsQueryAndFragment(t *testing.T) {
+	for _, raw := range []string{
+		"/open-apis/test?admin=true",
+		"/open-apis/test#section",
+		"/open-apis/test?a=1#frag",
+		"https://open.feishu.cn/open-apis/foo?bar=1",
+		"contact/v3/users?page_size=50",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			got, err := normalisePath(raw)
+			if err == nil {
+				t.Fatalf("normalisePath(%q) = %q, want validation error", raw, got)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("normalisePath(%q) error = %T, want *errs.ValidationError", raw, err)
+			}
+			if validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "path" {
+				t.Fatalf("validation error = %#v, want invalid_argument for path", validationErr)
+			}
+			if !strings.Contains(validationErr.Hint, "--params") {
+				t.Fatalf("validation hint = %q, want --params recovery", validationErr.Hint)
 			}
 		})
 	}

--- a/internal/validate/input.go
+++ b/internal/validate/input.go
@@ -28,15 +28,3 @@ func RejectCRLF(value, fieldName string) error {
 	}
 	return nil
 }
-
-// StripQueryFragment removes any ?query or #fragment suffix from a URL path.
-// API parameters must go through structured --params flags, not embedded in
-// the path, to prevent parameter injection and behaviour confusion.
-func StripQueryFragment(path string) string {
-	for i := 0; i < len(path); i++ {
-		if path[i] == '?' || path[i] == '#' {
-			return path[:i]
-		}
-	}
-	return path
-}

--- a/internal/validate/input_test.go
+++ b/internal/validate/input_test.go
@@ -60,26 +60,3 @@ func TestRejectControlChars_FiltersControlCharsAndDangerousUnicode(t *testing.T)
 		})
 	}
 }
-
-func TestStripQueryFragment(t *testing.T) {
-	for _, tt := range []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"no query or fragment", "/open-apis/test", "/open-apis/test"},
-		{"query only", "/open-apis/test?admin=true", "/open-apis/test"},
-		{"fragment only", "/open-apis/test#section", "/open-apis/test"},
-		{"query and fragment", "/open-apis/test?a=1#frag", "/open-apis/test"},
-		{"empty string", "", ""},
-		{"query at start", "?foo=bar", ""},
-		{"fragment at start", "#frag", ""},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			got := StripQueryFragment(tt.in)
-			if got != tt.want {
-				t.Errorf("StripQueryFragment(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
-	}
-}


### PR DESCRIPTION
## Summary

Reject query strings and URL fragments embedded in raw API paths instead of silently removing them. The validation error points callers to `--params`, so invalid requests fail locally with an actionable recovery path.

## Changes

- Return a typed `validation/invalid_argument` error for inline query strings or fragments.
- Remove the obsolete path-stripping helper and add command-level and normalization regression coverage.

## Test Plan

- [x] `go test -race -count=1 ./cmd/api ./internal/validate`
- [x] `make fmt-check`
- [x] `make vet`
- [x] `QUALITY_GATE_CHANGED_FROM=upstream/main make quality-gate`
- [x] `go run -C lint . --changed-from upstream/main ..`
- [x] `go test -C lint ./... -count=1`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [ ] `make unit-test` (Go 1.26.1 SIGSEGVs before tests start when the target combines `-race` with `-gcflags="all=-N -l"`; the focused race tests above pass)

## Related Issues

- Fixes #2326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API paths containing inline query strings or fragments are now rejected with a clear validation error.
  * Requests direct users to provide query parameters through the supported `--params` option.
  * Prevents query strings and fragments from being silently removed during path processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->