### PR TITLE
fix(lark-im): remove corner_radius from column in metric-card example

### DIFF
--- a/skills/lark-im/references/card/lark-im-card-style.md
+++ b/skills/lark-im/references/card/lark-im-card-style.md
@@ -139,6 +139,7 @@
 - 数值：用 `##` 放大（**唯一允许用 markdown 标题的特例**），可配 `<font>` 上色。
 - 描述：`<font color='grey'>` + `text_size: "notation"`。
 - 居中 `text_align: "center"`；列背景 `background_style: "grey-50"`；`padding: "12px"`；`vertical_spacing: "2px"`。
+- **注意：`column` 不支持 `corner_radius`**（卡片 2.0 组件规范里没有该属性，发送会报 `200621 unknown property`）。需要圆角时，把内容放进 `interactive_container`（见下方第 4 节描边卡片模式），那里支持。
 
 ```json
 {
@@ -147,7 +148,7 @@
   "horizontal_spacing": "12px",
   "columns": [
     { "tag": "column", "width": "weighted", "weight": 1,
-      "background_style": "grey-50", "corner_radius": "8px",
+      "background_style": "grey-50",
       "padding": "12px", "vertical_spacing": "2px",
       "elements": [
         { "tag": "markdown", "content": "## <font color='blue'>5,483</font>", "text_align": "center" },


### PR DESCRIPTION
修复 #2371。

`lark-im-card-style.md` 第 3 节指标卡示例里，`corner_radius` 写在了 `column` 上。卡片 2.0 的 `column` 不支持这个属性，照着示例发的卡片会被平台拒绝（200621 unknown property），错误只在发送时才暴露。

改动两处：
- 示例里删掉 `column` 上的 `corner_radius`（`background_style` / `padding` / `vertical_spacing` 保留，这些合法）
- 加一行提醒：`column` 不支持圆角，需要圆角的场景包一层 `interactive_container`（第 4 节就是这个写法）

纯文档改动，没动代码。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified KPI card styling guidance for rounded corners.
  * Updated the KPI example to remove an unsupported setting and recommend the appropriate alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->