### PR TITLE
docs: document docs +fetch comment contract

### DIFF
--- a/affordance/docs.md
+++ b/affordance/docs.md
@@ -18,6 +18,10 @@ Create a new Lark document from DocxXML or Markdown, optionally in a folder or W
 ## +fetch
 Read an entire Lark document, or limit the result to an outline, section, block range, or keyword match.
 
+### Tips
+- Comments are always included in the response with no flag to disable it; expect `reference_map.comments` regardless of `--doc-format`.
+- `--doc-format xml` marks commented content inline via a `comment-refs` attribute; `markdown`/`im-markdown` carry no inline ref — comments there live only in `reference_map.comments`.
+
 ### Skills
 - lark-doc/references/lark-doc-fetch.md
 

--- a/content_embed_affordance_test.go
+++ b/content_embed_affordance_test.go
@@ -52,6 +52,10 @@ func TestEmbeddedDocsAffordanceComplementsShortcutMetadata(t *testing.T) {
 			useWhen: []string{
 				"Read an entire Lark document, or limit the result to an outline, section, block range, or keyword match.",
 			},
+			tips: []string{
+				"Comments are always included in the response with no flag to disable it; expect `reference_map.comments` regardless of `--doc-format`.",
+				"`--doc-format xml` marks commented content inline via a `comment-refs` attribute; `markdown`/`im-markdown` carry no inline ref — comments there live only in `reference_map.comments`.",
+			},
 		},
 		"+update": {
 			description: "Update a Lark document",


### PR DESCRIPTION
## Summary

Add a Tips section to the `docs +fetch` affordance covering three implicit contracts that were implemented in #2341 but never surfaced outside `shortcuts/doc` and the skill reference: comments are always included in the response with no flag to disable it, XML marks commented content inline via a `comment-refs` attribute, and markdown/im-markdown surface comments only through `reference_map.comments`.

## Changes

- Add `### Tips` under `## +fetch` in `affordance/docs.md`
- Sync the golden affordance test in `content_embed_affordance_test.go` that previously pinned `+fetch` to an empty Tips list

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed
- [x] regression test: `go test ./tests/cli_e2e/docs/... -run "TestDocsFetchCommentsFlagIsRemovedFromHelpAndRejected|TestDocsCommandsHideFormatHelpButKeepCompatibility|TestDocsFetchDryRun"` passed
- [x] manual verification: `make build && ./lark-cli docs +fetch --help` — confirms the two new Tips render correctly

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining how comments are included in `+fetch` responses.
  * Documented differences in how comments are represented in XML and Markdown formats.

* **Tests**
  * Updated validation to confirm the new `+fetch` documentation tips are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->