### PR TITLE
docs(contact): slim skill docs from 273 to 139 lines

### DIFF
--- a/skills/lark-contact/SKILL.md
+++ b/skills/lark-contact/SKILL.md
@@ -1,46 +1,47 @@
 ---
 name: lark-contact
 version: 1.0.0
-description: "飞书 / Lark 通讯录:按姓名 / 邮箱解析成 open_id,或按 open_id 反查姓名 / 部门 / 邮箱 / 联系方式 / 个人状态 / 签名,以及按关键词搜索当前用户可见的机器人 / 智能体(agent)。当用户提到一个名字要下一步发消息 / 排日程,或拿到 open_id 想查具体信息时使用。不负责部门树遍历、按部门列员工、组织架构图,这类需求走原生 OpenAPI。"
+description: "飞书 / Lark 通讯录:按姓名 / 邮箱解析成 open_id,或按 open_id 反查姓名 / 部门 / 邮箱 / 联系方式 / 个人状态 / 签名,以及按关键词搜索机器人 / 智能体(agent),可限定某个群。当用户提到一个名字要下一步发消息 / 排日程,拿到 open_id 想查具体信息,或要查某个群里的机器人时使用。不负责部门树遍历、按部门列员工、组织架构图,这类需求走原生 OpenAPI。"
 metadata:
   requires:
     bins: ["lark-cli"]
   cliHelp: "lark-cli contact --help"
 ---
 
+开始前先读 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)(认证、权限处理)。
+
 ## 选哪个命令
 
-**user 身份和 bot 身份是两条完全独立的路径**。先确定当前身份,再按下表选命令:
+**user 和 bot 是两条独立路径**,先确定身份再选命令:
 
 | 想做什么 | user 身份 | bot 身份 |
 |---|---|---|
 | 按姓名 / 邮箱搜员工拿 open_id | [`+search-user`](references/lark-contact-search-user.md) | 不支持 |
-| 按关键词搜索当前用户可见的机器人 / 智能体 | [`+search-bot`](references/lark-contact-search-bot.md) | 不支持 |
-| 已知 open_id 取他人资料 | `+search-user --user-ids <id>` | [`+get-user --user-id <id>`](references/lark-contact-get-user.md) |
-| 查看自己 | `+get-user` 或 `+search-user --user-ids me` | 不支持 |
+| 按关键词搜机器人 / 智能体 | [`+search-bot`](references/lark-contact-search-bot.md) | 不支持 |
+| 只搜某个群里的机器人 | `+search-bot --query <词> --chat-ids <群ID>` | 不支持 |
+| 已知 open_id(`ou_`)取他人资料 | `+search-user --user-ids <id>` | [`+get-user --user-id <id>`](references/lark-contact-get-user.md) |
+| 已知的 ID 是 `on_`(union_id) 或 user_id | `+get-user --user-id <id> --user-id-type union_id`(是 user_id 就传 `user_id`) | 同左 |
+| 要英文 / 其它语种下的展示名 | `+search-user --lang en_us`(可配 `--query` 或 `--user-ids`) | 不支持 |
+| 查看自己 | `+get-user`(不带 `--user-id`) 或 `+search-user --user-ids me` | 不支持 |
 | 查同事的个人状态 / 签名 | `user_profiles batch_query` | 不支持 |
 
 已知 open_id 只是想发消息 / 排日程,不必经过 contact —— 直接 [`lark-im`](../lark-im/SKILL.md) / [`lark-calendar`](../lark-calendar/SKILL.md)。
 
-### 名字没说清是人还是机器人 / 智能体
+名字没说清是人还是机器人时(如「和 reviewDuck 约个会」):含 bot / agent / AI / 助手 / 机器人 / 智能体 / assistant 等明显特征的先搜机器人;不确定的话两边都搜一下。
 
-用户给的名字常常不表明类型。例如「和 reviewDuck 约个会」里的 reviewDuck 可能是同事昵称,也可能是机器人。
-- 名字含 bot / agent / AI / 助手 / 机器人 / 智能体 / assistant 等明显特征时,反过来先搜机器人更快
-- 不确定的话两边都搜一下
-
-## 典型场景
-
-找张三给他发消息:先搜,确认 open_id,再发:
+## 命令写法
 
 ```bash
-lark-cli contact +search-user --query "张三" --has-chatted --as user
-lark-cli im +messages-send --user-id ou_xxx --text "Hi!"
+lark-cli contact +search-user --query "张三" --as user   # 别默认带 --has-chatted 一类 filter,会把没聊过的人筛掉
+lark-cli contact +search-bot --query '会议助手' --as user
+lark-cli contact +search-bot --queries '会议助手,日报助手,审批助手' --as user
 ```
 
-批量查同事的个人状态 / 个性签名(先用 schema 看参数)。
+`bots: []` 不等于没有——只加在某个群里的机器人,要带 `--chat-ids <群ID>` 才搜得到。
+
+批量查个人状态 / 个性签名:
 
 ```bash
-lark-cli schema contact.user_profiles.batch_query
 lark-cli contact user_profiles batch_query \
   --params '{"user_id_type":"open_id"}' \
   --data '{"user_ids":["ou_xxx","ou_yyy"],"query_option":{"include_personal_status":true,"include_description":true}}' \
@@ -49,23 +50,14 @@ lark-cli contact user_profiles batch_query \
 
 搜索命中多条且后续操作有副作用(发消息、邀请会议等),把候选列给用户挑;不要擅自选第一条。
 
-## 搜索机器人 / 智能体
-
-`+search-bot` 使用 user 身份按关键词搜索当前用户可见的机器人,返回 `ou_` 开头的机器人 open_id。参数细节等见 [`lark-contact-search-bot.md`](references/lark-contact-search-bot.md)。
-
-```bash
-lark-cli contact +search-bot --query '会议助手' --as user
-lark-cli contact +search-bot --queries '会议助手,日报助手,审批助手' --as user
-```
+能力边界拿不准时,先跑一条 `+search-user` 看实际返回再据实回答,不要读完文档就断言不支持。
 
 ## 注意事项
 
-- **41050 / Permission denied** 受当前身份的可见范围限制(三条命令都可能遇到)。细节见 [`lark-shared`](../lark-shared/SKILL.md)。
 - **跨租户用户**(`is_cross_tenant=true`)多数业务字段为空字符串,这是飞书可见性规则,下游做空值兜底。
-- **ID 类型**:`+get-user` 可通过 `--user-id-type` 使用 `open_id`、`union_id` 或 `user_id`;`+search-user` 使用用户 open_id;`+search-bot` 不支持按 ID 查询,它按关键词搜索并返回机器人 open_id。
+- **ID 类型**:`--user-id-type` 归 `+get-user`,`--user-ids` / `me` 归 `+search-user`,跨命令配串报 unknown flag(但 `+get-user --user-id me` 是服务端报错)。`+search-bot` 只按关键词搜、不吃 ID,返回的机器人 open_id 也是 `ou_`。
 
 ## 不在本 skill 范围
 
-- 发消息 / 查聊天记录 → [`lark-im`](../lark-im/SKILL.md)
-- 排日程 / 邀请会议 → [`lark-calendar`](../lark-calendar/SKILL.md)
 - 部门树 / 按部门列员工 / 组织架构 → [`lark-openapi-explorer`](../lark-openapi-explorer/SKILL.md) 查找原生接口
+- 查聊天记录 / 看群成员 → [`lark-im`](../lark-im/SKILL.md)

--- a/skills/lark-contact/references/lark-contact-get-user.md
+++ b/skills/lark-contact/references/lark-contact-get-user.md
@@ -3,13 +3,10 @@
 按 ID 取用户基本信息(姓名等)。
 
 ```bash
-# 取自己
+# 取自己(只有 user 身份能省略 --user-id)
 lark-cli contact +get-user --as user
 
-# bot 按 ID 取他人
-lark-cli contact +get-user --user-id ou_xxx --as bot
-
-# 按 union_id / user_id 取(默认 open_id)
+# bot 身份按 ID 取他人;ID 不是 open_id 时要显式指定类型
 lark-cli contact +get-user --user-id <id> --user-id-type union_id --as bot
 ```
 

--- a/skills/lark-contact/references/lark-contact-search-bot.md
+++ b/skills/lark-contact/references/lark-contact-search-bot.md
@@ -1,60 +1,22 @@
 # +search-bot
 
-按关键词搜索当前用户可见的机器人。仅支持 user 身份,需要 `search:bot` 权限。
+按关键词搜索当前用户可见的机器人,返回的机器人 open_id 同样是 `ou_` 开头。
 
-- ✅ 用关键词搜索机器人并获取 open_id
-- ✅ 一次搜索多个关键词(`--queries`)
-- ✅ 在指定群范围内搜索机器人(`--chat-ids`)
+## 关键 flag
 
-## 参数
-
-必须传 `--query` 或 `--queries`。`--chat-ids` 指定搜索范围,`--has-chatted` 筛选已聊过的机器人;两者都不能单独使用。
+必须传 `--query` 或 `--queries`;`--chat-ids` / `--has-chatted` 都不能单独使用。
 
 | Flag | 说明 |
 |---|---|
 | `--query <text>` | 搜索一个关键词,最多 50 个字符 |
-| `--queries <csv>` | 并行搜索多个关键词,最多 20 个;每个最多 50 个字符。不能和 `--query` 一起使用 |
+| `--queries <csv>` | 并行搜索多个关键词,最多 20 个;不能和 `--query` 一起使用 |
 | `--chat-ids <csv>` | 只在指定群内搜索,最多 100 个群;支持群 ID 或群链接 |
-| `--has-chatted` | 只返回聊过天的机器人;不需要时不要传此参数 |
+| `--has-chatted` | 只返回聊过天的机器人。**不是默认写法**,不需要时不要传 |
 | `--page-size <n>` | 返回条数,1–30,默认 20 |
 
-```bash
-lark-cli contact +search-bot --query '会议助手' --as user
-lark-cli contact +search-bot --query '助手' --has-chatted --as user
-lark-cli contact +search-bot --queries '会议助手,日报助手,审批助手' --as user
-```
+## 输出与选择
 
-## 输出
-
-| 字段 | 类型 | 说明 | 空值时 |
-|---|---|---|---|
-| `open_id` | string | 机器人 ID | 始终非空 |
-| `name` | string | 机器人名称 | 空字符串 |
-| `description` | string | 机器人简介 | 字段省略 |
-| `chat_id` | string | 与机器人的单聊 ID | 空字符串 |
-| `enable_join_group` | bool | 是否允许加入群聊 | — |
-| `is_agent` | bool | 是否是智能体 | — |
-| `tenant_id` | string | 租户标识 | 字段省略 |
-| `match_segments` | string[] | 命中的文本片段 | 无命中时为 `[]` |
-
-### 没有分页
-
-不支持分页。`has_more=true` 时改用更具体的关键词,或调整搜索范围。
-
-### 多条命中怎么选
-
-命中多个机器人时,结合 `description` 和 `is_agent` 判断。后续要发消息或拉群时,让用户确认目标,不要直接选择第一条。
-
-```bash
-lark-cli contact +search-bot --query '会议助手' \
-  --jq '.data.bots[] | select((.description // "") | contains("<功能关键词>"))' --as user
-```
-
-## fanout(`--queries`)
-
-输出为 `{bots[], queries[], notice?}`。`has_more` 只出现在每个关键词的结果中。
-
-- `bots[].matched_query`:该结果对应的关键词
-- `queries[]`:每个关键词的执行结果,格式为 `{query, error?, has_more, notice?}`
-- 部分关键词失败时保留其他结果;全部失败时命令报错
-- `--chat-ids` 和 `--has-chatted` 对所有关键词生效
+- 关键字段:`is_agent`(是否是智能体)、`enable_join_group`(是否允许加入群聊)、`description`(简介,为空时字段省略)、`chat_id`(与机器人的单聊 ID,为空表示没有单聊)。
+- **多条命中怎么选**:结合 `description` 和 `is_agent` 判断。后续要发消息或拉群时,让用户确认目标,不要直接选择第一条。
+- **不支持分页**。`has_more=true` 时改用更具体的关键词,或用 `--chat-ids` 收窄范围。
+- `--queries` 模式:每条结果带 `matched_query`;`queries[]` 给每个关键词的执行结果;部分关键词失败时保留其他结果,全部失败时命令报错;`--chat-ids` / `--has-chatted` 对所有关键词生效。

--- a/skills/lark-contact/references/lark-contact-search-user.md
+++ b/skills/lark-contact/references/lark-contact-search-user.md
@@ -1,14 +1,5 @@
 # +search-user
 
-仅支持 user 身份。
-
-## 适用范围
-
-- ✅ 已知姓名 / 邮箱 / 「聊过的人」想找出 open_id
-- ✅ 已知一组 open_id 想批量校验或回填字段(`--user-ids`,最多 100,支持 `me`)
-- ✅ 按聊天关系 / 在职状态 / 租户边界 / 企业邮箱等维度筛选员工
-- ❌ 已知 open_id 想发消息 → 直接走 `lark-im`,不经过本命令
-
 ## 关键 flag
 
 `--query` / `--queries` / `--user-ids` / bool filter 至少传一个。bool filter 显式传 `=false` 会报错——不传等于不过滤。
@@ -16,108 +7,32 @@
 | Flag | 作用 |
 |---|---|
 | `--query <text>` | 关键词(姓名 / 邮箱 / 手机号),≤ 50 rune |
-| `--queries <csv>` | 多个关键词并行搜,**最多 20 条**;与 `--query` / `--user-ids` 互斥;输出新 shape(见下) |
+| `--queries <csv>` | 多个关键词并行搜,**最多 20 条**;与 `--query` / `--user-ids` 互斥 |
 | `--user-ids <csv>` | open_id 列表,≤ 100;支持 `me` 表示自己;与 `--query` 同传时把搜索范围限定在该集合 |
-| `--has-chatted` | 仅搜聊过天的 |
-| `--has-enterprise-email` | 仅搜有企业邮箱的 |
-| `--exclude-external-users` | 仅搜同租户(排除外部联系人) |
-| `--left-organization` | 仅搜已离职的 |
 | `--lang <locale>` | 覆盖 `localized_name` 的语种(如 `zh_cn` / `en_us` / `ja_jp`) |
+| `--has-chatted` / `--has-enterprise-email` / `--exclude-external-users` / `--left-organization` | 各自维度的筛选。**都不是默认写法**——加上就会把不满足该维度的人整批筛掉 |
 | `--page-size <n>` | 单页大小 1-30,默认 20 |
-
-## 常用例子
-
-```bash
-# 按姓名搜,看候选确认是哪个张三
-lark-cli contact +search-user --query "张三" --has-chatted
-
-# 按完整邮箱搜(命中通常唯一,适合作后续命令的输入)
-lark-cli contact +search-user --query "alice@example.com"
-
-# 查看自己
-lark-cli contact +search-user --user-ids me
-
-# 批量回填:已知一组 open_id,取姓名 / 邮箱 / 部门
-lark-cli contact +search-user --user-ids "ou_a,ou_b,ou_c" --format json
-
-# 多 filter 组合:同租户的、有企业邮箱的「王」姓员工
-lark-cli contact +search-user --query "王" --exclude-external-users --has-enterprise-email
-
-# filter-only 枚举:列出所有"聊过天的离职同事"(无关键词)
-lark-cli contact +search-user --has-chatted --left-organization
-```
 
 ## 批量并行查询 (fanout)
 
-一次查多个名字:
+一次查多个名字,比逐个 `--query` 少很多往返:
 
 ```bash
 lark-cli contact +search-user --queries "Alice,Bob,张三"
 ```
 
-- 每行 user 带 `matched_query`,标识来自哪个 query
-- `queries[]` 每个输入一条 `{query, error?, has_more}`,失败的有 `error`
+- 每行 user 带 `matched_query`,标识来自哪个 query;`queries[]` 按输入顺序每个一条 `{query, error?, has_more}`
 - 部分失败不影响其它 query;全部失败才 exit 非 0
+- bool filter 对每个 query 都生效;重复条目静默去重,全空 csv (`,,,`) 报错
 
-```bash
-# bool filter 对每个 query 都生效
-lark-cli contact +search-user --queries "Alice,Bob" --has-chatted
+## 命令输出里看不出来的语义
 
-# 与 --query / --user-ids 互斥
-lark-cli contact +search-user --queries "a" --query "b"   # ❌ exit 2
-```
-
-约束:
-- 最多 20 条; 每条 ≤ 50 字符
-- 重复条目静默去重;全空 csv (`,,,`) 报错
-
-## 同名 disambiguation
-
-搜常见姓名常返回多条同名结果。后续操作若有副作用(发消息、邀请会议等),把候选列给用户挑;**不要擅自选**。
-
-筛选信号(可信度从高到低):`chat_recency_hint`(近期联系过) > `enterprise_email` 前缀 > `department` 关键词。`localized_name` 同名时无区分作用。
-
-```bash
-# 用 jq 按部门精筛
-lark-cli contact +search-user --query "张三" \
-  --jq '.data.users[] | select(.department | contains("<部门关键词>"))'
-```
-
-## 注意事项
-
+- **同名 disambiguation 的筛选信号**(可信度从高到低):`chat_recency_hint`(近期联系过) > `enterprise_email` 前缀 > `department` 关键词。`localized_name` 同名时无区分作用。
+- **`--lang` 只影响输出展示名**(`localized_name` 就是按 `--lang` / brand 选出的展示名,兜底为 open_id),不影响匹配字段。
+- **`is_activated`**:是否已激活飞书账号。未激活也可投递消息,但用户可能看不到。
+- **`is_cross_tenant=true`**(外部联系人)的业务字段可能是空字符串,需做空值兜底。
+- **`department`**:部门路径,服务端可能用 `-` 拼层级,层级数不固定,**按可子串匹配的字符串处理**。
+- **`p2p_chat_id`**:与当前用户的 P2P 会话 ID(`oc_...`),空表示从未私聊过;可作为接受 `--chat-id` 的 IM 命令的输入。`has_chatted` 是它的派生字段。
+- **`signature`**(个性签名)为空时字段不出现。
 - **不会自动翻页**。`has_more=true` 表示需要 refine query。
-- **`--lang` 只影响输出展示名**,不影响匹配字段。
 - **`--query` 与 `--user-ids` 同时设**:`--user-ids` 限定搜索范围,`--query` 在该集合内匹配。
-
-## 输出字段 contract
-
-跨租户用户(`is_cross_tenant=true`)的业务字段可能为空字符串,需做空值兜底。
-
-| 字段 | 类型 | 说明 | 跨租户 |
-|---|---|---|---|
-| `open_id` | string | 稳定标识,后续命令的输入 | 始终非空 |
-| `localized_name` | string | 按 `--lang` / brand 选出的展示名 | 始终非空(兜底为 open_id) |
-| `email` | string | 个人邮箱 | 可能为空 |
-| `enterprise_email` | string | 企业邮箱 | 可能为空 |
-| `is_activated` | bool | 是否已激活飞书账号(未激活也可投递消息,但用户可能看不到) | 可能 false |
-| `is_cross_tenant` | bool | 是否跨租户用户(同公司=false,外部联系人=true) | — |
-| `p2p_chat_id` | string | 与当前用户的 P2P 会话 ID(`oc_...`);空表示从未私聊过。可作为接受 `--chat-id` 的 IM 命令的输入 | 可能为空 |
-| `has_chatted` | bool | `p2p_chat_id != ""` 的派生字段 | — |
-| `department` | string | 部门路径,服务端可能用 `-` 拼层级,层级数不固定。**按可子串匹配的字符串处理** | 可能为空 |
-| `signature` | string (optional) | 用户个性签名;空时字段不出现 | 可能不出现 |
-| `chat_recency_hint` | string | 最近联系的提示文案,仅供展示 | 可能为空 |
-| `match_segments` | string[] | 关键词命中的字符串片段,用于高亮展示;无命中则为空数组 | — |
-
-### `--queries` 模式额外字段
-
-`data.users[]` 每条多 `matched_query` (string),指明本行来自哪个 query。
-
-`data.queries[]` 按输入顺序、dedup 后每个 query 一条:
-
-| 字段 | 类型 | 说明 |
-|---|---|---|
-| `query` | string | 该输入 |
-| `error` | string (optional) | 失败原因;成功时不出现 |
-| `has_more` | bool | 该 query 还有更多结果 |
-
-fanout 模式无顶层 `data.has_more`。


### PR DESCRIPTION
## Summary

Land the result of an evaluation-driven optimization run on the `lark-contact` skill docs: 273 -> 139 lines. Usage mirrors that `--help`, the command schema, or the response JSON already cover are removed; the rules the model actually gets wrong are kept, and the load-bearing ones are hoisted into `SKILL.md` where they are always loaded.

Measured over 37 cases x 5 repeats, effect does not regress.

## Changes

- `references/lark-contact-search-user.md` 123 -> 38 lines: drop the applicability list, 7 of 8 examples and the output-field tables; keep `--queries` fanout, `--user-ids me`, bool-filter and pagination semantics, same-name disambiguation, and cross-tenant empty fields.
- `references/lark-contact-search-bot.md` 60 -> 22 lines: drop the capability checklist, output-field table and jq example; keep the `--query` / `--queries` / `--chat-ids` / `--has-chatted` constraints and the four fields that drive the next action.
- `references/lark-contact-get-user.md` 19 -> 16 lines: merge the two ID-type examples.
- `SKILL.md` 71 -> 63 lines (3,760 B -> 3,705 B): merge two overlapping sections, drop notes that duplicate other skills, and add four routing splits that were buried in near-unread references (`--chat-ids` group scope, `on_` / union_id, `--lang`, self lookup).
- Correct two ID-type statements against `shortcuts/contact`: `--user-id-type` now names `user_id` alongside `union_id`, and `+get-user --user-id me` is a server-side error rather than an unknown flag.
- Restore four lines the slimming should not have taken: the canonical `lark-shared` prefix line (matching the 17 other `lark-*` skills), the "chat history / group members -> `lark-im`" exit, a cue to run one `+search-user` before concluding a capability is missing, and `--lang` written as the general flag it is.

## Test Plan

- [x] `make unit-test` passed
- [x] `make quality-gate` passed (`--changed-from origin/main`)
- [x] `scripts/check-skill-wire-vocab.sh` clean
- [x] Evaluation: 37 cases x 5 repeats per version, sealed verdict PASS
- [x] Verified the ID-type corrections and `--lang` against `contact_get_user.go` and `contact_search_user.go`

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified contact lookup guidance, including authentication, identity types, self-lookup, localized names, ambiguity handling, and capability checks.
  - Added guidance for batch user-profile queries and bot searches, including query limits, filtering, pagination, result selection, and failure handling.
  - Documented chat-scoped bot searches and delegation for chat history and member queries.
  - Simplified command examples and clarified flag requirements, ID formats, and behavior across tenants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->