### PR TITLE
feat: auto-upgrade bare lark-cli without y/N confirmation

### DIFF
--- a/cmd/root_upgrade.go
+++ b/cmd/root_upgrade.go
@@ -4,10 +4,7 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
-	"io"
-	"strings"
 
 	"github.com/larksuite/cli/internal/build"
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -37,18 +34,6 @@ var checkRootCachedUpdate = update.CheckCached
 // AND no flag tokens in the raw invocation.
 func isBareRootInvocation(args []string) bool {
 	return len(args) == 0 && len(flagTokensInArgs(rawInvocationArgs)) == 0
-}
-
-// readYes reads one line and reports whether it is an affirmative y/yes.
-// EOF / empty / anything else → false (default No, matching the [y/N] prompt).
-func readYes(r io.Reader) bool {
-	line, _ := bufio.NewReader(r).ReadString('\n')
-	switch strings.ToLower(strings.TrimSpace(line)) {
-	case "y", "yes":
-		return true
-	default:
-		return false
-	}
 }
 
 // offerRootUpgrade prompts for an interactive upgrade when running bare
@@ -81,10 +66,7 @@ func offerRootUpgrade(f *cmdutil.Factory, cmd *cobra.Command, projector *recover
 	// update subcommand rather than calling RunNpmInstall directly, otherwise
 	// that line disappears and the user approves a global install without ever
 	// being told what gets installed.
-	fmt.Fprintf(ios.ErrOut, "A newer lark-cli is available (current %s). Upgrade now? [y/N]: ", info.Current)
-	if !readYes(ios.In) {
-		return
-	}
+	fmt.Fprintf(ios.ErrOut, "A newer lark-cli is available (current %s). Updating automatically...\n", info.Current)
 	runRootUpgrade(cmd)
 }
 

--- a/cmd/root_upgrade_test.go
+++ b/cmd/root_upgrade_test.go
@@ -29,18 +29,6 @@ func writeUpdateState(t *testing.T, dir, latest string) {
 	}
 }
 
-func TestReadYes(t *testing.T) {
-	cases := map[string]bool{
-		"y\n": true, "Y\n": true, "yes\n": true, "YES\n": true, " y \n": true,
-		"n\n": false, "\n": false, "": false, "nope\n": false, "yeah\n": false,
-	}
-	for in, want := range cases {
-		if got := readYes(strings.NewReader(in)); got != want {
-			t.Errorf("readYes(%q) = %v, want %v", in, got, want)
-		}
-	}
-}
-
 func TestIsBareRootInvocation(t *testing.T) {
 	orig := rawInvocationArgs
 	t.Cleanup(func() { rawInvocationArgs = orig })
@@ -78,23 +66,18 @@ func TestOfferRootUpgrade(t *testing.T) {
 	cases := []struct {
 		name                string
 		in, out, err        bool
-		input               string
 		latest              string // "" → no state file (CheckCached nil)
 		optOut              bool
 		wantPrompt, wantRun bool
 	}{
-		{"all-tty+y", true, true, true, "y\n", "2.0.0", false, true, true},
-		{"all-tty+yes", true, true, true, "yes\n", "2.0.0", false, true, true},
-		{"all-tty+n", true, true, true, "n\n", "2.0.0", false, true, false},
-		{"all-tty+empty", true, true, true, "\n", "2.0.0", false, true, false},
-		{"all-tty+eof", true, true, true, "", "2.0.0", false, true, false},
-		{"stdin-not-tty", false, true, true, "y\n", "2.0.0", false, false, false},
-		{"stdout-not-tty", true, false, true, "y\n", "2.0.0", false, false, false},
-		{"stderr-not-tty", true, true, false, "y\n", "2.0.0", false, false, false},
-		{"no-newer-version", true, true, true, "y\n", "", false, false, false},
-		{"already-latest", true, true, true, "y\n", "1.0.0", false, false, false}, // post-upgrade: current == cached latest → no prompt
-		{"cache-older-than-current", true, true, true, "y\n", "0.9.0", false, false, false},
-		{"opt-out", true, true, true, "y\n", "2.0.0", true, false, false},
+		{"all-tty", true, true, true, "2.0.0", false, true, true},
+		{"stdin-not-tty", false, true, true, "2.0.0", false, false, false},
+		{"stdout-not-tty", true, false, true, "2.0.0", false, false, false},
+		{"stderr-not-tty", true, true, false, "2.0.0", false, false, false},
+		{"no-newer-version", true, true, true, "", false, false, false},
+		{"already-latest", true, true, true, "1.0.0", false, false, false}, // post-upgrade: current == cached latest → no prompt
+		{"cache-older-than-current", true, true, true, "0.9.0", false, false, false},
+		{"opt-out", true, true, true, "2.0.0", true, false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -118,7 +101,7 @@ func TestOfferRootUpgrade(t *testing.T) {
 
 			var errBuf bytes.Buffer
 			f := &cmdutil.Factory{IOStreams: &cmdutil.IOStreams{
-				In:               strings.NewReader(tc.input),
+				In:               strings.NewReader(""),
 				Out:              &bytes.Buffer{},
 				ErrOut:           &errBuf,
 				IsTerminal:       tc.in,


### PR DESCRIPTION
## Summary
Bare `lark-cli` invocations no longer wait for a `[y/N]` keypress before upgrading. When a cached newer version is detected in an interactive terminal session, the CLI now upgrades automatically.

## Changes
- `offerRootUpgrade` prints a one-line notice and calls `runRootUpgrade` directly, instead of prompting and blocking on stdin.
- Removed the now-unused `readYes` helper and its dedicated test.
- All four existing trigger gates are unchanged: concealed-capability check, three-way TTY detection (stdin/stdout/stderr), bare-invocation detection, and cached-update presence.
- `lark-cli update` itself (install-method detection, binary verification, rollback, skills sync) is unmodified.

## Test Plan
- [x] Unit tests pass (`go test ./cmd/...`), including updated `TestOfferRootUpgrade` cases covering all TTY gates, opt-out, and version-comparison branches
- [x] Manual local verification confirms the `lark-cli` bare-invocation flow works as expected: in a pseudo-TTY with a cached newer version, the CLI upgrades without any keypress; with stdout/stderr redirected (non-TTY), no upgrade output appears

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Root upgrades now proceed automatically when a cached update is available.
  - Removed the interactive confirmation prompt and decline option.
- **Bug Fixes**
  - Simplified upgrade handling for non-interactive environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->