### PR TITLE
docs(approval): document keyword search and add-sign flow

### DIFF
--- a/skill-template/domains/approval.md
+++ b/skill-template/domains/approval.md
@@ -21,7 +21,7 @@
 | 搜可发起定义 | `approvals search` | [`lark-approval-approvals-search.md`](references/lark-approval-approvals-search.md) |
 | 看审批定义详情/提单前确认表单与流程 | `approvals get` | [`lark-approval-approvals-get.md`](references/lark-approval-approvals-get.md)   |
 | 发起原生审批实例/提交请假审批/提交报销审批/创建审批实例 | `instances create` | [`lark-approval-initiate.md`](references/lark-approval-initiate.md)             |
-| 查待办/已办 | `tasks query`（`topic`：1待办 2已办 17未读 18已读） | [`lark-approval-tasks-query.md`](references/lark-approval-tasks-query.md)       |
+| 查/搜待办、已办 | `tasks query`（`topic`：1待办 2已办 17未读 18已读） | [`lark-approval-tasks-query.md`](references/lark-approval-tasks-query.md)       |
 | 看表单/进度/当前节点 | `instances get` | [`lark-approval-instances-get.md`](references/lark-approval-instances-get.md)   |
 | 同意审批 | `tasks approve` | [`lark-approval-tasks-approve.md`](references/lark-approval-tasks-approve.md)   |
 | 拒绝审批 | `tasks reject` | [`lark-approval-tasks-reject.md`](references/lark-approval-tasks-reject.md)     |
@@ -31,7 +31,7 @@
 | 催办审批 | `tasks remind` | [`lark-approval-tasks-remind.md`](references/lark-approval-tasks-remind.md)     |
 | 撤回已发起审批 | `instances cancel` | [`lark-approval-instances-cancel.md`](references/lark-approval-instances-cancel.md) |
 | 给审批实例追加抄送 | `instances cc` | [`lark-approval-instances-cc.md`](references/lark-approval-instances-cc.md)     |
-| 按定义查已发起审批 | `instances initiated` | [`lark-approval-instances-initiated.md`](references/lark-approval-instances-initiated.md) |
+| 按定义/关键词查已发起审批 | `instances initiated` | [`lark-approval-instances-initiated.md`](references/lark-approval-instances-initiated.md) |
 
 处理链：
 

--- a/skills/lark-approval/SKILL.md
+++ b/skills/lark-approval/SKILL.md
@@ -34,7 +34,7 @@ metadata:
 | 搜可发起定义 | `approvals search` | [`lark-approval-approvals-search.md`](references/lark-approval-approvals-search.md) |
 | 看审批定义详情/提单前确认表单与流程 | `approvals get` | [`lark-approval-approvals-get.md`](references/lark-approval-approvals-get.md)   |
 | 发起原生审批实例/提交请假审批/提交报销审批/创建审批实例 | `instances create` | [`lark-approval-initiate.md`](references/lark-approval-initiate.md)             |
-| 查待办/已办 | `tasks query`（`topic`：1待办 2已办 17未读 18已读） | [`lark-approval-tasks-query.md`](references/lark-approval-tasks-query.md)       |
+| 查/搜待办、已办 | `tasks query`（`topic`：1待办 2已办 17未读 18已读） | [`lark-approval-tasks-query.md`](references/lark-approval-tasks-query.md)       |
 | 看表单/进度/当前节点 | `instances get` | [`lark-approval-instances-get.md`](references/lark-approval-instances-get.md)   |
 | 同意审批 | `tasks approve` | [`lark-approval-tasks-approve.md`](references/lark-approval-tasks-approve.md)   |
 | 拒绝审批 | `tasks reject` | [`lark-approval-tasks-reject.md`](references/lark-approval-tasks-reject.md)     |
@@ -44,7 +44,7 @@ metadata:
 | 催办审批 | `tasks remind` | [`lark-approval-tasks-remind.md`](references/lark-approval-tasks-remind.md)     |
 | 撤回已发起审批 | `instances cancel` | [`lark-approval-instances-cancel.md`](references/lark-approval-instances-cancel.md) |
 | 给审批实例追加抄送 | `instances cc` | [`lark-approval-instances-cc.md`](references/lark-approval-instances-cc.md)     |
-| 按定义查已发起审批 | `instances initiated` | [`lark-approval-instances-initiated.md`](references/lark-approval-instances-initiated.md) |
+| 按定义/关键词查已发起审批 | `instances initiated` | [`lark-approval-instances-initiated.md`](references/lark-approval-instances-initiated.md) |
 
 处理链：
 

--- a/skills/lark-approval/references/lark-approval-instances-initiated.md
+++ b/skills/lark-approval/references/lark-approval-instances-initiated.md
@@ -14,6 +14,9 @@ lark-cli approval instances initiated --params '{"page_size":20}' --as user
 # 只看某个审批定义下我发起的实例
 lark-cli approval instances initiated --params '{"definition_code":"<DEFINITION_CODE>","page_size":20}' --as user
 
+# 按关键词搜索我发起的实例
+lark-cli approval instances initiated --params '{"keyword":"测试","page_size":10}' --as user
+
 # 按发起时间范围筛选（秒级时间戳）
 lark-cli approval instances initiated --params '{"start_timestamp":"<START_SECONDS>","end_timestamp":"<END_SECONDS>","page_size":20}' --as user
 
@@ -33,6 +36,7 @@ lark-cli approval instances initiated --params '{"page_size":20}' --as user --dr
 |------|------|------|
 | `--params '{...}'` | 否 | 查询参数，使用 JSON 传入；不传时使用默认分页与筛选 |
 | `definition_code` | 否 | 审批定义 Code，用于只查看某个审批定义下我发起的实例 |
+| `keyword` | 否 | 搜索关键词；非空时走搜索链路，空或仅空格时保持普通列表链路 |
 | `start_timestamp` | 否 | 按发起时间筛选，时间范围开始值，秒级时间戳 |
 | `end_timestamp` | 否 | 按发起时间筛选，时间范围结束值，秒级时间戳 |
 | `locale` | 否 | 返回语言：`zh-CN`、`en-US`、`ja-JP` |
@@ -106,6 +110,7 @@ lark-cli approval instances initiated \
 
 - **这是定位“我发起的审批实例”的首选命令**：如果你的目标是撤回、抄送、查看某个已发起审批，优先从这里拿 `instance_code`。
 - **优先用 `definition_code` 缩小范围**：当你已知审批定义时，先筛掉无关实例，可显著提升可读性。
+- **需要搜索时传入 `keyword`**：搜索排序和普通列表排序不同，按搜索服务结果为准。
 - **按时间排查时使用 `start_timestamp` / `end_timestamp`**：这两个值都是秒级时间戳，用于按发起时间缩小结果范围。
 - **结果很多时优先 `--format table`**：适合人工快速浏览。
 - **`count` 只在第一页返回**：做分页处理时不要假设后续页还会带总数。

--- a/skills/lark-approval/references/lark-approval-tasks-add-sign.md
+++ b/skills/lark-approval/references/lark-approval-tasks-add-sign.md
@@ -4,16 +4,31 @@
 给一个审批任务加签（用户级写操作）。通常先通过 `tasks query` 拿到 `task_id` 和 `instance_code`，确认目标任务后，再提供被加签人的用户 ID、加签方式等参数执行加签。
 
 > [!CAUTION]
-> 这是 **high-risk-write** 写操作。建议先用 `--dry-run` 预览；真正执行时，如果用户已明确要对该审批任务加签且目标任务、加签对象、加签方式都无误，再带 `--yes` 运行。不要在未获用户明确同意时静默追加 `--yes`。
+> 这是 **high-risk-write** 写操作。建议先用 `--dry-run` 预览；真正执行时，如果用户已明确要对该审批任务加签且目标任务、加签对象、加签方式都无误，再带 `--yes` 运行。用户已明确要求立即执行且列清本轮的加签、转交对象时，该确认覆盖这两个已明确的动作，不要逐条重复询问；不要在未获用户明确同意时静默追加 `--yes`。
 
 需要的 scopes: ["approval:task:write"]
+
+## 先选择加签类型
+
+`add_sign_type` 会影响当前用户的审批任务是否继续可操作，不能只按示例顺序或任意选择：
+
+| 用户意图 | `add_sign_type` | 处理方式 |
+|----------|-----------------|----------|
+| 明确说前加签 / “先让某人审核，我再审” | `1` | 前加签，并按用户要求选择 `approval_method` |
+| 明确说后加签 / “我处理完，再让某人审核” | `2` | 后加签，并按用户要求选择 `approval_method` |
+| “拉进来一起审” / “共同审核” / “一并确认” | `3` | 并加签；不传 `approval_method` |
+| 同一请求要求先加签、再转交当前用户这一环 | `3` | **必须并加签**；加签成功后再转交当前任务 |
+
+前加签或后加签可能推动当前用户的 task 流转，使原 `task_id` 不再支持后续转交。因此，“先加签，再把我这一环转交给其他人”不能使用前加签或后加签；先以 `add_sign_type: 3` 并加签，确认 `tasks add_sign` 成功后，再使用同一组 `instance_code` + `task_id` 执行 `tasks transfer`。
+
+只有在上下文完全无法判断是哪种加签方式、且不同选择会改变审批流程时，才向用户二次询问。用户已经说“一起审”或已经要求“加签后转交当前环节”时，信息足够，不要再询问加签类型。
 
 ## 命令
 
 ```bash
-# 先预览请求，不实际执行
+# 先预览并加签请求，不实际执行
 lark-cli approval tasks add_sign \
-  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":1,"add_sign_user_ids":["ou_xxx"],"approval_method":1,"comment":"前加签给财务复核"}' \
+  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":3,"add_sign_user_ids":["ou_xxx"],"comment":"请项目 owner 一起审核"}' \
   --params '{"user_id_type":"open_id"}' \
   --as user \
   --dry-run
@@ -32,10 +47,17 @@ lark-cli approval tasks add_sign \
   --as user \
   --yes
 
-# 并加签（常见场景可不传 approval_method）
+# 同一请求要求先加签、再转交：必须并加签；两条命令按顺序执行
 lark-cli approval tasks add_sign \
-  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":3,"add_sign_user_ids":["123456789"],"comment":"并加签给项目 owner"}' \
-  --params '{"user_id_type":"user_id"}' \
+  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":3,"add_sign_user_ids":["ou_reviewer"],"comment":"请一起审核"}' \
+  --params '{"user_id_type":"open_id"}' \
+  --as user \
+  --yes
+
+# 仅在上面的 add_sign 成功后，转交同一当前任务
+lark-cli approval tasks transfer \
+  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","transfer_user_id":"ou_transferee","comment":"出差期间请代为处理"}' \
+  --params '{"user_id_type":"open_id"}' \
   --as user \
   --yes
 
@@ -69,11 +91,11 @@ lark-cli approval tasks add_sign \
 
 ### add_sign_type
 
-| 值 | 含义 |
-|----|------|
-| `1` | 前加签 |
-| `2` | 后加签 |
-| `3` | 并加签 |
+| 值 | 含义 | 对当前任务的影响 |
+|----|------|------------------|
+| `1` | 前加签 | 在当前审批前插入审批人，可能推动当前用户的 task 流转 |
+| `2` | 后加签 | 在当前审批后追加审批人，可能推动当前用户的 task 流转 |
+| `3` | 并加签 | 增加并行审批人；需要随后转交当前环节时使用 |
 
 ### approval_method
 
@@ -113,6 +135,8 @@ lark-cli approval instances get --params '{"instance_code":"<INSTANCE_CODE>"}' -
 - **`add_sign_user_ids` 与 `user_id_type` 必须匹配**：例如传 open_id 就把 `user_id_type` 设为 `open_id`；不要混用。
 - **优先显式传 `user_id_type`**：这样 agent 更容易判断参数含义，也能减少 ID 类型不匹配带来的失败。
 - **`add_sign_type` 要和业务意图一致**：前加签是在当前审批前插入审批人，后加签是在当前审批后追加审批人，并加签则是增加并行审批人。
+- **加签后还要转交当前环节时必须并加签**：使用 `add_sign_type: 3`，等待加签成功后再用同一组任务参数转交；不要用前加签或后加签导致当前 task 提前流转。
+- **无法推断类型时才询问**：如果用户没有说明先后或并行关系，且后续动作也不能帮助判断，再请用户选择；不要对“一起审”或“加签后转交”重复提问。
 - **前加签 / 后加签要补 `approval_method`**：不要遗漏，否则请求可能无法准确表达审批方式。
 - **优先从 `tasks query` 的待办列表拿任务参数**：尤其是 `topic=1` 的待办审批，最适合作为 add_sign 的输入来源。
 - **先检查是否支持 API 操作**：如果 `tasks[].support_api_operate` 为 `false`，说明该任务可能不支持通过 API 执行处理动作，加签前应谨慎验证。

--- a/skills/lark-approval/references/lark-approval-tasks-add-sign.md
+++ b/skills/lark-approval/references/lark-approval-tasks-add-sign.md
@@ -23,6 +23,20 @@
 
 只有在上下文完全无法判断是哪种加签方式、且不同选择会改变审批流程时，才向用户二次询问。用户已经说“一起审”或已经要求“加签后转交当前环节”时，信息足够，不要再询问加签类型。
 
+## 再选择 approval_method
+
+只有前加签、后加签需要 `approval_method`；并加签不传。先遵循用户明确指定的审批方式；用户未指定时，按人数和语义选择：
+
+| 加签人数与语义 | `approval_method` | 处理方式 |
+|----------------|-------------------|----------|
+| 只有 1 名加签人 | `1` | 使用或签；单人时或签、会签的实际效果相同，不再询问 |
+| 多人，明确“任一人审批即可” / “一人通过即可” | `1` | 或签；任一加签人完成审批即可 |
+| 多人，明确“所有人都要审批” / “全部确认” | `2` | 会签；所有加签人都必须完成审批 |
+| 多人，明确“依次审批” / “先 A 后 B” | `3` | 依次审批；每个人按 `add_sign_user_ids` 的数组顺序逐一审批 |
+| 多人，无法从上下文推断 | 不预设 | 询问用户选择或签、会签或依次审批，并说明三者效果 |
+
+依次审批必须保留用户给出的人员顺序。如果已经确定要依次审批，但上下文无法判断先后顺序，先询问人员顺序，再构造 `add_sign_user_ids`；不要自行排序。
+
 ## 命令
 
 ```bash
@@ -33,16 +47,23 @@ lark-cli approval tasks add_sign \
   --as user \
   --dry-run
 
-# 前加签（需要 approval_method）
+# 单人前加签：未指定方式时使用或签
 lark-cli approval tasks add_sign \
   --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":1,"add_sign_user_ids":["ou_xxx"],"approval_method":1,"comment":"请先补充审核"}' \
   --params '{"user_id_type":"open_id"}' \
   --as user \
   --yes
 
-# 后加签（需要 approval_method）
+# 多人后加签：所有人都需要审批，使用会签
 lark-cli approval tasks add_sign \
-  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":2,"add_sign_user_ids":["ou_xxx","ou_yyy"],"approval_method":2,"comment":"当前审批完成后请两位继续审核"}' \
+  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":2,"add_sign_user_ids":["ou_xxx","ou_yyy"],"approval_method":2,"comment":"当前审批完成后请两位都完成审核"}' \
+  --params '{"user_id_type":"open_id"}' \
+  --as user \
+  --yes
+
+# 多人前加签：按数组中的人员顺序依次审批
+lark-cli approval tasks add_sign \
+  --data '{"instance_code":"<INSTANCE_CODE>","task_id":"<TASK_ID>","add_sign_type":1,"add_sign_user_ids":["ou_first","ou_second"],"approval_method":3,"comment":"请先由第一位审核，再由第二位审核"}' \
   --params '{"user_id_type":"open_id"}' \
   --as user \
   --yes
@@ -78,7 +99,7 @@ lark-cli approval tasks add_sign \
 | `task_id` | 是 | 审批任务 ID；通常先通过 `tasks query` 获取 |
 | `add_sign_type` | 是 | 加签类型：`1` 前加签、`2` 后加签、`3` 并加签 |
 | `add_sign_user_ids` | 是 | 被加签人 ID 数组；需要和 `user_id_type` 保持一致 |
-| `approval_method` | 否 | 审批方式：`1` 或签、`2` 会签、`3` 依次审批；**仅在前加签、后加签时需要填写** |
+| `approval_method` | 否 | 审批方式：`1` 或签、`2` 会签、`3` 依次审批；**仅在前加签、后加签时需要填写**。单人未指定时使用 `1`；多人无法从语义推断时先询问用户 |
 | `comment` | 否 | 审批意见或加签说明，例如 `前加签给财务复核`、`请项目 owner 一并确认` |
 | `--params '{"user_id_type":"..."}'` | 否 | 查询参数 JSON；用于声明 `add_sign_user_ids` 内用户 ID 的类型 |
 | `user_id_type` | 否 | 用户 ID 类型：`user_id`、`union_id`、`open_id`；未显式指定时要特别确认被加签人的 ID 类型 |
@@ -99,11 +120,13 @@ lark-cli approval tasks add_sign \
 
 ### approval_method
 
-| 值 | 含义 | 适用场景 |
+仅适用于前加签、后加签；并加签不传。
+
+| 值 | 含义 | 完成条件 |
 |----|------|----------|
-| `1` | 或签 | 前加签 / 后加签 |
-| `2` | 会签 | 前加签 / 后加签 |
-| `3` | 依次审批 | 前加签 / 后加签 |
+| `1` | 或签 | 任一加签人完成审批即可 |
+| `2` | 会签 | 所有加签人都必须完成审批 |
+| `3` | 依次审批 | 所有加签人按 `add_sign_user_ids` 数组顺序逐一审批 |
 
 ## 典型前置步骤
 
@@ -137,7 +160,8 @@ lark-cli approval instances get --params '{"instance_code":"<INSTANCE_CODE>"}' -
 - **`add_sign_type` 要和业务意图一致**：前加签是在当前审批前插入审批人，后加签是在当前审批后追加审批人，并加签则是增加并行审批人。
 - **加签后还要转交当前环节时必须并加签**：使用 `add_sign_type: 3`，等待加签成功后再用同一组任务参数转交；不要用前加签或后加签导致当前 task 提前流转。
 - **无法推断类型时才询问**：如果用户没有说明先后或并行关系，且后续动作也不能帮助判断，再请用户选择；不要对“一起审”或“加签后转交”重复提问。
-- **前加签 / 后加签要补 `approval_method`**：不要遗漏，否则请求可能无法准确表达审批方式。
+- **前加签 / 后加签要补 `approval_method`**：单人未指定时使用或签；多人优先按语义选择，无法推断时询问用户，不要静默默认。
+- **依次审批保留人员顺序**：按用户指定的先后顺序构造 `add_sign_user_ids`；顺序不明确时先询问，不要自行排序。
 - **优先从 `tasks query` 的待办列表拿任务参数**：尤其是 `topic=1` 的待办审批，最适合作为 add_sign 的输入来源。
 - **先检查是否支持 API 操作**：如果 `tasks[].support_api_operate` 为 `false`，说明该任务可能不支持通过 API 执行处理动作，加签前应谨慎验证。
 - **`comment` 建议写明加签原因**：例如 `增加财务复核`、`增加项目 owner 并行确认`，方便相关人员理解上下文。

--- a/skills/lark-approval/references/lark-approval-tasks-query.md
+++ b/skills/lark-approval/references/lark-approval-tasks-query.md
@@ -14,6 +14,9 @@ lark-cli approval tasks query --params '{"topic":"1"}' --as user
 # 查询已办审批
 lark-cli approval tasks query --params '{"topic":"2"}' --as user
 
+# 按关键词搜索任务列表
+lark-cli approval tasks query --params '{"topic":"1","keyword":"测试","page_size":10}' --as user
+
 # 按任务时间范围筛选（秒级时间戳）
 lark-cli approval tasks query --params '{"topic":"1","start_timestamp":"<START_SECONDS>","end_timestamp":"<END_SECONDS>"}' --as user
 
@@ -31,6 +34,7 @@ lark-cli approval tasks query --params '{"topic":"1"}' --format table --as user
 | `--params '{"topic":"..."}'` | 是 | 查询参数，使用 JSON 传入 |
 | `topic` | 是 | 任务分组主题，见下方“topic 枚举” |
 | `definition_code` | 否 | 审批定义 Code，用于仅查询某个审批定义下的任务 |
+| `keyword` | 否 | 搜索关键词；非空时走搜索链路，空或仅空格时保持普通列表链路 |
 | `start_timestamp` | 否 | 按任务时间筛选，时间范围开始值，秒级时间戳 |
 | `end_timestamp` | 否 | 按任务时间筛选，时间范围结束值，秒级时间戳 |
 | `locale` | 否 | 返回语言：`zh-CN`、`en-US`、`ja-JP` |
@@ -80,6 +84,7 @@ lark-cli approval tasks query --params '{"topic":"1"}' --format table --as user
 
 - 常见处理链：先用 `tasks query` 拿到 `task_id` 和 `instance_code`，若用户需要查看详情、当前节点、表单内容、流程进度等内容，则调用 `instances get` 查看详情，最后执行 `tasks approve` / `tasks reject` / `tasks transfer` / `tasks add_sign` / `tasks rollback`。
 - 如果你只想看“已发起的审批实例”，使用 `instances initiated`；`tasks query` 更适合围绕“任务分组”来拉取列表。
+- 需要搜索任务标题、摘要或相关内容时传入 `keyword`；搜索排序和普通列表排序不同，按搜索服务结果为准。
 - 按时间排查任务时使用 `start_timestamp` / `end_timestamp` 缩小范围；这两个值都是秒级时间戳。
 - 需要继续翻页时，直接把上一次返回的 `page_token` 放回 `--params`。
 - 当结果量较大时，优先使用 `--format table` 提升可读性。


### PR DESCRIPTION
## Summary
Document approval keyword search usage and clarify `tasks add_sign` flow guidance in the approval skill docs.

## Changes
- Update `lark-approval` routing text for task and initiated-instance keyword search.
- Add `keyword` examples, parameter rows, and usage guidance for `approval tasks query`.
- Add `keyword` examples, parameter rows, and usage guidance for `approval instances initiated`.
- Clarify `approval tasks add_sign` type selection, especially the add-sign-then-transfer flow where `add_sign_type: 3` must be used before transfer.
- Keep the approval skill template aligned with the shipped skill text.

## Test Plan
- [x] `node scripts/skill-format-check/index.js`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate` (run with Go 1.23.12 and `GOROOT` unset)
- [x] Manual local verification confirms the development `lark-cli approval tasks query` and `approval instances initiated` keyword flows work in PRE.
- [ ] Unit tests pass separately. Not run separately because this PR only changes skill/reference documentation; the required skill checks and quality gate passed.

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that approval task searches cover pending and completed items, including read and unread statuses.
  * Added keyword-search examples, parameter guidance, usage recommendations, and result-ordering details for approval tasks and initiated approval instances.
  * Documented approval method selection for single- and multi-person approvals, including signing order and completion conditions.
  * Added examples and guidance for single-person, multi-person, and sequential add-sign scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
