### PR TITLE
feat(sheets): surface a before_you_edit notice on sheet-mutating commands

### DIFF
--- a/internal/beforeyouedit/notice.go
+++ b/internal/beforeyouedit/notice.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package beforeyouedit carries a process-level "read this before you edit"
+// pointer for sheet-mutating commands. The notice is surfaced in JSON output
+// envelopes under "_notice.before_you_edit", mirroring internal/deprecation.
+//
+// Unlike the update/skills notices wired in cmd/root.go, this one registers
+// itself with the output package directly (see init), so it also surfaces in
+// distributions that assemble the command tree via cmd.Build without running
+// the root entry point's setupNotices — e.g. embedder binaries.
+//
+// A CLI process runs exactly one shortcut, so a single process-level slot is
+// sufficient: the command's hooks record the notice before producing output,
+// and the output layer reads it back when building the envelope.
+package beforeyouedit
+
+import (
+	"sync/atomic"
+
+	"github.com/larksuite/cli/internal/output"
+)
+
+// Notice points the calling agent at the skill reference that governs the
+// edit it is about to make.
+type Notice struct {
+	Command string `json:"command"`
+	Message string `json:"message"`
+}
+
+// pending stores the latest notice for the current process.
+var pending atomic.Pointer[Notice]
+
+// SetPending stores the notice for consumption by the output layer.
+// Pass nil to clear.
+func SetPending(n *Notice) { pending.Store(n) }
+
+// GetPending returns the pending notice, or nil.
+func GetPending() *Notice { return pending.Load() }
+
+func init() {
+	output.RegisterBuiltinNotice(func() (string, interface{}) {
+		n := GetPending()
+		if n == nil {
+			return "", nil
+		}
+		return "before_you_edit", map[string]interface{}{
+			"command": n.Command,
+			"message": n.Message,
+		}
+	})
+}

--- a/internal/beforeyouedit/notice_test.go
+++ b/internal/beforeyouedit/notice_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package beforeyouedit
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/output"
+)
+
+// The builtin provider must surface the pending notice through output.GetNotice
+// even when the entry point never wires output.PendingNotice — that is the
+// whole point of registering from init instead of cmd/root.go setupNotices.
+func TestBuiltinNoticeSurfacesWithoutPendingNoticeWiring(t *testing.T) {
+	orig := output.PendingNotice
+	output.PendingNotice = nil
+	t.Cleanup(func() { output.PendingNotice = orig; SetPending(nil) })
+
+	SetPending(nil)
+	if got := output.GetNotice(); got != nil {
+		t.Fatalf("GetNotice() with no pending notice = %v, want nil", got)
+	}
+
+	SetPending(&Notice{Command: "+workbook-import", Message: "read the reference"})
+	got := output.GetNotice()
+	if got == nil {
+		t.Fatal("GetNotice() = nil, want before_you_edit entry")
+	}
+	entry, ok := got["before_you_edit"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("GetNotice()[before_you_edit] = %v, want map", got["before_you_edit"])
+	}
+	if entry["command"] != "+workbook-import" || entry["message"] != "read the reference" {
+		t.Fatalf("unexpected notice entry: %v", entry)
+	}
+}
+
+// Builtin notices must merge with, not replace, the entry-point-wired hook.
+func TestBuiltinNoticeMergesWithPendingNotice(t *testing.T) {
+	orig := output.PendingNotice
+	output.PendingNotice = func() map[string]interface{} {
+		return map[string]interface{}{"update": "available"}
+	}
+	t.Cleanup(func() { output.PendingNotice = orig; SetPending(nil) })
+
+	SetPending(&Notice{Command: "+cells-set", Message: "m"})
+	got := output.GetNotice()
+	if got["update"] != "available" {
+		t.Fatalf("wired notice lost in merge: %v", got)
+	}
+	if _, ok := got["before_you_edit"]; !ok {
+		t.Fatalf("builtin notice missing in merge: %v", got)
+	}
+}

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -56,11 +56,36 @@ type PaginationMeta struct {
 // Returns nil when there is nothing to report.
 var PendingNotice func() map[string]interface{}
 
+// builtinNotices are process-local notice providers that do not depend on the
+// entry point wiring PendingNotice (cmd/root.go). They surface in every
+// distribution — including embedders that assemble the command tree via
+// cmd.Build and never run setupNotices. Registration happens from package
+// init functions (single goroutine, before main), so no locking is needed.
+var builtinNotices []func() (key string, value interface{})
+
+// RegisterBuiltinNotice adds a provider whose non-nil value is merged into the
+// "_notice" envelope block under the returned key. Call from package init only.
+func RegisterBuiltinNotice(fn func() (string, interface{})) {
+	builtinNotices = append(builtinNotices, fn)
+}
+
 // GetNotice returns the current pending notice for struct-based callers.
-// Returns nil when there is nothing to report.
+// It merges the entry-point-wired PendingNotice hook (when set) with any
+// registered builtin providers. Returns nil when there is nothing to report.
 func GetNotice() map[string]interface{} {
-	if PendingNotice == nil {
-		return nil
+	var merged map[string]interface{}
+	if PendingNotice != nil {
+		merged = PendingNotice()
 	}
-	return PendingNotice()
+	for _, fn := range builtinNotices {
+		key, value := fn()
+		if key == "" || value == nil {
+			continue
+		}
+		if merged == nil {
+			merged = map[string]interface{}{}
+		}
+		merged[key] = value
+	}
+	return merged
 }

--- a/shortcuts/register.go
+++ b/shortcuts/register.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/beforeyouedit"
 	"github.com/larksuite/cli/internal/cmdmeta"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
@@ -75,7 +76,7 @@ func init() {
 	allShortcuts = append(allShortcuts, drive.Shortcuts()...)
 	allShortcuts = append(allShortcuts, im.Shortcuts()...)
 	allShortcuts = append(allShortcuts, contact_shortcuts.Shortcuts()...)
-	allShortcuts = append(allShortcuts, sheets.Shortcuts()...)
+	allShortcuts = append(allShortcuts, wrapSheetsBeforeYouEdit(sheets.Shortcuts())...)
 	// Backward-compatible sheets shortcuts (pre-refactor command names),
 	// kept under shortcuts/sheets/backward so external callers relying on the
 	// old `+create`, `+read`, `+write`, ... commands keep working alongside the
@@ -371,6 +372,72 @@ func applySheetsCompatGroups(svc *cobra.Command) {
 	// deprecated group from `sheets --help` (see sheetsUsageTemplate). The
 	// aliases remain grouped and executable, just no longer advertised here.
 	svc.SetUsageTemplate(sheetsUsageTemplate)
+}
+
+// sheetsBeforeYouEdit maps sheet-mutating commands to the skill reference an
+// agent should read before making that edit. Grouped by edit intent; commands
+// not listed here carry no notice. Read the reference with:
+//
+//	lark-cli skills read lark-sheets references/<file>
+var sheetsBeforeYouEdit = map[string]string{
+	// Bringing a local file online / starting a new workbook: the imported
+	// sheet is about to be edited in place — keep originals intact, prefer
+	// formulas over precomputed values, and preserve existing styles.
+	"+workbook-import": "before editing the imported sheet: write results to new sheets/columns and keep original rows intact; prefer formulas over precomputed static values (Lark formula syntax differs from Excel — read references/lark-sheets-formula-translation.md before writing formulas); preserve untouched styles. Style inheritance checklist: references/lark-sheets-visual-standards.md (run: lark-cli skills read lark-sheets references/lark-sheets-visual-standards.md)",
+	"+workbook-create": "before filling the new workbook: prefer formulas over precomputed static values (Lark formula syntax differs from Excel — read references/lark-sheets-formula-translation.md first); visual/style standards: references/lark-sheets-visual-standards.md (run: lark-cli skills read lark-sheets references/lark-sheets-visual-standards.md)",
+
+	// Data writes into an existing table: extending without inheriting the
+	// neighboring styles (fonts / borders / banding / row heights) is the most
+	// common visual regression; verify by re-reading the written range.
+	"+table-put":    "when writing into an existing table, inherit adjacent styles (fonts/borders/banding/row heights) and re-read the written range to verify — checklist: references/lark-sheets-write-cells.md (run: lark-cli skills read lark-sheets references/lark-sheets-write-cells.md)",
+	"+csv-put":      "when writing into an existing table, inherit adjacent styles (fonts/borders/banding/row heights) and re-read the written range to verify — checklist: references/lark-sheets-write-cells.md (run: lark-cli skills read lark-sheets references/lark-sheets-write-cells.md)",
+	"+cells-set":    "when writing into an existing table, inherit adjacent styles (fonts/borders/banding/row heights) and re-read the written range to verify — checklist: references/lark-sheets-write-cells.md (run: lark-cli skills read lark-sheets references/lark-sheets-write-cells.md)",
+	"+batch-update": "batch writes are fail-fast without a unified rollback: on failure, re-read the touched ranges before re-sending — semantics: references/lark-sheets-batch-update.md (run: lark-cli skills read lark-sheets references/lark-sheets-batch-update.md)",
+
+	// Structure edits: +dim-insert inherits styles but NOT row heights — new
+	// rows fall back to the default height and clip long text.
+	"+dim-insert": "--inherit-style does not inherit row heights: read the neighbor row_height first and follow up with +rows-resize when inserting rows for long text — details: references/lark-sheets-sheet-structure.md (run: lark-cli skills read lark-sheets references/lark-sheets-sheet-structure.md)",
+
+	// Structure reads are the natural pre-edit checkpoint: point the agent at
+	// the per-scenario routing table before it starts mutating.
+	"+workbook-info": "pick the per-scenario reference before you act: the scenario-to-command table in SKILL.md lists which references/lark-sheets-*.md to read for each edit (run: lark-cli skills read lark-sheets SKILL.md)",
+	"+sheet-info":    "pick the per-scenario reference before you act: the scenario-to-command table in SKILL.md lists which references/lark-sheets-*.md to read for each edit (run: lark-cli skills read lark-sheets SKILL.md)",
+}
+
+// wrapSheetsBeforeYouEdit decorates sheet commands so that invoking one records
+// a process-level "read this before you edit" pointer, surfaced in the JSON
+// "_notice.before_you_edit" envelope block. Same decoration pattern as
+// wrapSheetsBackwardDeprecation below: Validate/Execute/OnInvoke all store the
+// same pointer so the notice survives validation failures and --dry-run.
+func wrapSheetsBeforeYouEdit(list []common.Shortcut) []common.Shortcut {
+	for i := range list {
+		message, ok := sheetsBeforeYouEdit[list[i].Command]
+		if !ok {
+			continue
+		}
+		notice := &beforeyouedit.Notice{Command: list[i].Command, Message: message}
+		if origValidate := list[i].Validate; origValidate != nil {
+			list[i].Validate = func(ctx context.Context, runtime *common.RuntimeContext) error {
+				beforeyouedit.SetPending(notice)
+				return origValidate(ctx, runtime)
+			}
+		}
+		if origExecute := list[i].Execute; origExecute != nil {
+			list[i].Execute = func(ctx context.Context, runtime *common.RuntimeContext) error {
+				beforeyouedit.SetPending(notice)
+				return origExecute(ctx, runtime)
+			}
+		}
+		if origOnInvoke := list[i].OnInvoke; origOnInvoke != nil {
+			list[i].OnInvoke = func() {
+				beforeyouedit.SetPending(notice)
+				origOnInvoke()
+			}
+		} else {
+			list[i].OnInvoke = func() { beforeyouedit.SetPending(notice) }
+		}
+	}
+	return list
 }
 
 // wrapSheetsBackwardDeprecation decorates each backward-compatibility sheets


### PR DESCRIPTION
## Why

Agents driving `lark-cli sheets` routinely regress on style inheritance, Lark-vs-Excel formula semantics and row heights because the governing skill reference never enters their context. Prose in SKILL.md only reaches sessions that read it (and re-read it on follow-up turns); the command output is the one channel every session parses.

Measured on a 661-session evaluation batch: 81.7% of sessions invoke lark-cli, and the import/write/read commands decorated here cover 80.8% — including 100% of the multi-turn edit workload where document-side guidance never lands.

## What

- `internal/beforeyouedit`: process-level notice slot, mirroring `internal/deprecation`. Registers with the output package from `init()`, so it also surfaces in embedder distributions that assemble the command tree via `cmd.Build` without running the root entry point's `setupNotices` (where `output.PendingNotice` is normally wired).
- `internal/output`: `RegisterBuiltinNotice` + `GetNotice` now merges the wired `PendingNotice` hook with builtin providers.
- `shortcuts/register.go`: `wrapSheetsBeforeYouEdit` decorates 9 sheet commands with per-intent guidance (same Validate/Execute/OnInvoke decoration pattern as `wrapSheetsBackwardDeprecation`; pre-existing OnInvoke hooks are chained). Messages point at `lark-cli skills read lark-sheets references/...` — the embedded skill content, version-matched to the binary by `internal/skillscheck`.

## Verification

- `go test ./internal/beforeyouedit ./internal/output ./shortcuts` — pass (re-run on top of current main 679ebd52)
- `go vet` / `gofmt` clean
- Real binary dry-run shows the notice in the envelope: `lark-cli sheets +workbook-info --spreadsheet-token x --dry-run` → `"_notice": {"before_you_edit": {"command": "+workbook-info", "message": "..."}}`
- A unit test pins the `PendingNotice == nil` (embedder) path and the merge path.

## Notes

- JSON/jq/raw/partial-failure and the stderr error envelope all carry `_notice` already; `--format pretty/table/csv/ndjson` never carried it and still does not.
- No envelope schema lock exists; e2e assertions are key-based — additive field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added before-you-edit notices for sheet shortcut commands.
  * Notices now appear in JSON output with the relevant command and message.
  * Notices are supported across validation, execution, invocation, and dry-run flows.
  * Multiple notices can be combined without replacing existing entries.

* **Bug Fixes**
  * Ensured notices remain available when validation fails or no explicit pending notice is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->