### PR TITLE
feat(minutes): classify +apply-permission as high-risk-write

### DIFF
--- a/shortcuts/minutes/minutes_apply_permission.go
+++ b/shortcuts/minutes/minutes_apply_permission.go
@@ -19,7 +19,7 @@ var MinutesApplyPermission = common.Shortcut{
 	Service:     "minutes",
 	Command:     "+apply-permission",
 	Description: "Apply for view or edit permission on a minute",
-	Risk:        "write",
+	Risk:        "high-risk-write",
 	Scopes:      []string{"minutes:permission:apply"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{

--- a/shortcuts/minutes/minutes_apply_permission_test.go
+++ b/shortcuts/minutes/minutes_apply_permission_test.go
@@ -158,7 +158,7 @@ func TestMinutesApplyPermission_Execute(t *testing.T) {
 		"+apply-permission",
 		"--minute-token", minutesApplyPermissionTestToken,
 		"--perm", "edit",
-		"--format", "json", "--as", "user",
+		"--format", "json", "--as", "user", "--yes",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -188,5 +188,36 @@ func TestMinutesApplyPermission_Execute(t *testing.T) {
 	}
 	if envelope.Data.Perm != "edit" {
 		t.Errorf("data.perm = %q, want edit", envelope.Data.Perm)
+	}
+}
+
+// TestMinutesApplyPermission_RequiresConfirmation pins the high-risk-write
+// classification: without --yes the runner's confirmation gate must fire
+// before Execute runs, returning a typed confirmation_required error and
+// touching no API.
+func TestMinutesApplyPermission_RequiresConfirmation(t *testing.T) {
+	if MinutesApplyPermission.Risk != "high-risk-write" {
+		t.Fatalf("Risk=%q want high-risk-write", MinutesApplyPermission.Risk)
+	}
+
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	err := mountAndRun(t, MinutesApplyPermission, []string{
+		"+apply-permission",
+		"--minute-token", minutesApplyPermissionTestToken,
+		"--perm", "view",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected confirmation_required error without --yes")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if problem.Subtype != errs.SubtypeConfirmationRequired {
+		t.Fatalf("subtype=%q want %q", problem.Subtype, errs.SubtypeConfirmationRequired)
 	}
 }

--- a/skills/lark-minutes/SKILL.md
+++ b/skills/lark-minutes/SKILL.md
@@ -81,7 +81,7 @@ metadata:
 
 ### 3. 申请妙记权限
 
-遇到妙记没有查看或编辑权限时，引导用户申请对应权限；只有用户明确要申请时，才调用 `minutes +apply-permission`。使用前必读 [`+apply-permission` reference](references/lark-minutes-apply-permission.md)（write 操作，含 user/bot 身份与权限语义）。
+遇到妙记没有查看或编辑权限时，引导用户申请对应权限；只有用户明确要申请时，才调用 `minutes +apply-permission`。使用前必读 [`+apply-permission` reference](references/lark-minutes-apply-permission.md)（**高敏写操作**，含 user/bot 身份与权限语义）。
 
 只有当用户明确要求"申请查看权限"、"申请编辑权限"、"帮我申请这条妙记权限"时，才调用：
 

--- a/skills/lark-minutes/references/lark-minutes-apply-permission.md
+++ b/skills/lark-minutes/references/lark-minutes-apply-permission.md
@@ -1,6 +1,6 @@
 # minutes +apply-permission
 
-向妙记所有者发起查看或编辑权限申请。**写操作**，只在用户明确要求申请权限时才调用；调用后不代表立即获得权限，只是提交了一条申请。
+向妙记所有者发起查看或编辑权限申请。**高敏写操作（high-risk-write）**，会向妙记所有者推送申请通知，只在用户明确要求申请权限时才调用；调用后不代表立即获得权限，只是提交了一条申请。作为高敏操作，执行前需要用户明确确认。
 
 本 skill 对应 shortcut：`lark-cli minutes +apply-permission`（调用 `POST /open-apis/minutes/v1/minutes/{minute_token}/permissions/apply`）。支持 `--as user` / `--as bot`。
 


### PR DESCRIPTION
## Summary
- Reclassify the `minutes +apply-permission` shortcut from `write` to `high-risk-write`, so the framework confirmation gate requires an explicit `--yes` before sending a permission request to the minute owner.
- Update `skills/lark-minutes/SKILL.md` and the `+apply-permission` reference doc to describe it as a high-risk write operation that needs explicit user confirmation.
- Add a regression test pinning the confirmation gate (`confirmation_required` when `--yes` is omitted) and update the existing execute test to pass `--yes`.

## Test plan
- [x] `go test ./shortcuts/minutes/... ./shortcuts/vc/...`
- [x] `node scripts/skill-format-check/index.js`
- [ ] CI `make quality-gate` (diff-scoped; runs in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Applying minutes permissions is now classified as a high-risk action.
  * Explicit confirmation is required before sending a permission application notification.
  * Commands without confirmation are safely blocked before any action is taken.
* **Documentation**
  * Updated minutes guidance to reflect the new confirmation requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->