### PR TITLE
docs(im): document chat.join_requests in the lark-im skill

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -163,6 +163,11 @@ lark-cli im <resource> <method> [flags] # 调用 API
   - `update` — 设置自己的群昵称。Set or update your own nickname in the chat (self-only). Identity: `user` only (`user_access_token`); `nickname` must be a non-empty string (max 300 bytes). Use DELETE to clear it.
   - `delete` — 清空自己的群昵称。Clear your own nickname in the chat (self-only). Identity: `user` only (`user_access_token`).
 
+### chat.join_requests
+
+  - `list` — 列出群的待审批入群申请（仅群主/管理员，user_access_token）。List pending join requests for a chat. Identity: `user` only (`user_access_token`); the caller must be the chat owner or an admin. Paginated (`page_size` 1-100); stop on `has_more == false` — `page_token` is returned even on the last page, so paging while it is present never terminates.
+  - `handle` — 批量审批入群申请（approve/reject，仅群主/管理员，user_access_token）。Approve or reject pending join requests in bulk (1-50 items, processed in order). Identity: `user` only (`user_access_token`); the caller must be the chat owner or an admin. `results[]` mirrors `items[]` in count and order — check each `result` (`success` / `failed` / `already_handled`); exit 0 does not mean every item succeeded.
+
 ### chat.managers
 
   - `add_managers` — 指定群管理员。Identity: supports `user` and `bot`; only the group owner can add managers; max 10 managers per chat (20 for super-large chats), and at most 5 bots per request.
@@ -237,6 +242,8 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `chat.managers.delete_managers` | `im:chat.managers:write_only` |
 | `chat.moderation.get` | `im:chat.moderation:read` |
 | `chat.moderation.update` | `im:chat:moderation:write_only` |
+| `chat.join_requests.list` | `im:chat.membership_application:read` |
+| `chat.join_requests.handle` | `im:chat.membership_application:write` |
 | `+messages-read-status` | user: `im:message:readonly` (recommended), `im:message`, or `im:message:get_as_user` |
 | `+message-read-users` | user: `im:message:readonly` (recommended), `im:message`, `im:message:basic`, or `im:message:get_as_user`; bot: `im:message:readonly` |
 | `messages.read_status` | `im:message:readonly` (recommended), `im:message`, or `im:message:get_as_user` |


### PR DESCRIPTION
## Summary

Expose the two Feishu OpenAPI group join-request endpoints in the `im` domain: listing a chat's pending join requests and approving or rejecting them in bulk. This is the CLI-side skill documentation for the change; the command surface itself is generated from the registry and needs no Go code.

## Changes

- Document the new `chat.join_requests` resource in `skills/lark-im/SKILL.md` (`list` / `handle`)
- Add the two matching rows to the scope table

Command surface:

```bash
lark-cli im chat.join_requests list   --chat-id oc_xxx [--page-size 1-100] [--page-all]
lark-cli im chat.join_requests handle --chat-id oc_xxx \
  --data '{"items":[{"member_id":"ou_xxx","action":"approve"}]}'
```

Both methods are user identity only (`user_access_token`) and require the caller to be the chat owner or an admin. `list` is `risk: read`, `handle` is `risk: write`.

Two behaviours are called out in the skill text because they are not discoverable from `lark-cli schema`:

- **Pagination.** `page_token` is returned even when `has_more` is `false`, so an agent that pages while `page_token` is present never terminates. Stop on `has_more == false`. The built-in `--page-all` already keys off `has_more` and is unaffected.
- **Partial failure.** `results[]` mirrors the request `items[]` in count and order; each entry carries `success` / `failed` / `already_handled`. Exit 0 does not mean every item succeeded.

The CLI resource is named `chat.join_requests` rather than the upstream `chat.membership_application`: the upstream name does not read as "pending join requests", is the longest resource name in the domain, and is singular where every other collection resource in `im` is plural. `docUrl` and the OAuth scopes keep the upstream name, so the official docs stay one hop away.

This file is edited by hand rather than regenerated. `skill-template/domains/im.md` last changed in 7675185f while this file has five later commits that edited it directly (#2319, #2223, #2194, #2146, #1906), so a full `gen-skills` run silently reverts them. Reconciling the template with this file is left as separate work.

## Test Plan

- [x] Unit tests pass — `internal/registry`, `cmd/service`, `cmd/schema`, `cmd`, `shortcuts/im` and 12 more packages green
- [x] Manual local verification confirms the `lark-cli im chat.join_requests` flow works as expected

Verified against a live tenant with a real pending request:

- `list` returns the pending entry with `applicant`, `inviter`, `reason`, `apply_source` and `apply_time`
- `--page-all` terminates on the first page despite the trailing `page_token`
- `handle` with `approve` returns `results[0].result: "success"`; the approved user is then present in `chat.members get`, and `list` returns `total: 0`
- replaying the same `handle` returns `results[0].result: "already_handled"`
- `lark-cli schema` reports `risk: read` / `risk: write` and `user`-only identity for the two methods

Not covered: rejecting a real request, and the `failed` branch of `results[]`. Both need a request that can be sacrificed to the test.

The pre-existing failures in `tests/cli_e2e/*` are unrelated — they need live credentials this environment does not have, and the failing test set is byte-identical before and after this change.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for viewing pending chat join requests.
  * Documented bulk approval and rejection workflows, including permissions, pagination, batch handling, and individual results.
  * Updated the permissions reference with the required read and write scopes.
  * Clarified how pending requests and approval or rejection outcomes are represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->