### PR TITLE
test(drive): retry transient async cleanup contention

### DIFF
--- a/tests/cli_e2e/drive/drive_delete_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_delete_workflow_test.go
@@ -5,7 +5,6 @@ package drive
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -153,32 +152,4 @@ func assertDriveDeleteTaskSucceeded(t *testing.T, ctx context.Context, taskID st
 	failedField := gjson.Get(taskResult.Stdout, "data.failed")
 	require.True(t, failedField.Exists(), "task result must report data.failed\nstdout:\n%s", taskResult.Stdout)
 	require.False(t, failedField.Bool(), "stdout:\n%s", taskResult.Stdout)
-}
-
-// isTransientDriveDeleteFailure reports whether a failed drive +delete carries
-// the one backend error this workflow tolerates: the async delete task
-// transiently reporting a terminal "fail" state (observed as flake in CI; the
-// resource is usually deleted regardless). Everything else — crashes, protocol
-// regressions, auth or parameter errors — stays fatal.
-func isTransientDriveDeleteFailure(result *clie2e.Result) bool {
-	if result == nil {
-		return false
-	}
-	for _, raw := range []string{result.Stderr, result.Stdout} {
-		idx := strings.Index(raw, "{")
-		if idx < 0 {
-			continue
-		}
-		payload := raw[idx:]
-		if !gjson.Valid(payload) {
-			continue
-		}
-		errObj := gjson.Get(payload, "error")
-		if errObj.Get("type").String() == "api" &&
-			errObj.Get("subtype").String() == "server_error" &&
-			errObj.Get("message").String() == "drive task failed" {
-			return true
-		}
-	}
-	return false
 }

--- a/tests/cli_e2e/drive/helpers.go
+++ b/tests/cli_e2e/drive/helpers.go
@@ -17,6 +17,10 @@ import (
 const (
 	driveDeleteVisibilityTimeout = 30 * time.Second
 	driveDeleteVisibilityPoll    = 3 * time.Second
+
+	driveDeleteTaskFailureMaxAttempts    = 5
+	driveDeleteTaskFailureInitialBackoff = 2 * time.Second
+	driveDeleteTaskFailureMaxBackoff     = 8 * time.Second
 )
 
 var driveDeleteVisibilityWait = clie2e.WaitOptions{
@@ -80,7 +84,33 @@ func CreateDriveFolder(t *testing.T, parentT *testing.T, ctx context.Context, na
 // returned a suppressed not_found or partial API error but the resource still
 // exists.
 func DeleteDriveResourceAndVerify(ctx context.Context, token, docType, defaultAs string) (*clie2e.Result, error) {
-	return deleteDriveResourceAndVerify(ctx, token, docType, defaultAs, driveDeleteVisibilityWait)
+	backoff := driveDeleteTaskFailureInitialBackoff
+	var (
+		result *clie2e.Result
+		err    error
+	)
+	for attempt := 1; attempt <= driveDeleteTaskFailureMaxAttempts; attempt++ {
+		result, err = deleteDriveResourceAndVerify(ctx, token, docType, defaultAs, driveDeleteVisibilityWait)
+		if err == nil || clie2e.IsCleanupWarning(err) || !isTransientDriveDeleteFailure(result) {
+			return result, err
+		}
+		if attempt == driveDeleteTaskFailureMaxAttempts {
+			return result, err
+		}
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return result, ctx.Err()
+		case <-timer.C:
+		}
+		backoff *= 2
+		if backoff > driveDeleteTaskFailureMaxBackoff {
+			backoff = driveDeleteTaskFailureMaxBackoff
+		}
+	}
+	return result, err
 }
 
 func deleteDriveResourceAndVerify(ctx context.Context, token, docType, defaultAs string, visibilityWait clie2e.WaitOptions) (*clie2e.Result, error) {
@@ -175,6 +205,32 @@ func isDriveMetaQuerySuccessful(stdout string) bool {
 	}
 	if code := gjson.Get(stdout, "code"); code.Exists() {
 		return code.Int() == 0
+	}
+	return false
+}
+
+// isTransientDriveDeleteFailure reports whether a failed drive +delete carries
+// the backend task failure caused by concurrent deletes under the same folder.
+// Other failures remain fatal.
+func isTransientDriveDeleteFailure(result *clie2e.Result) bool {
+	if result == nil {
+		return false
+	}
+	for _, raw := range []string{result.Stderr, result.Stdout} {
+		idx := strings.Index(raw, "{")
+		if idx < 0 {
+			continue
+		}
+		payload := raw[idx:]
+		if !gjson.Valid(payload) {
+			continue
+		}
+		errObj := gjson.Get(payload, "error")
+		if errObj.Get("type").String() == "api" &&
+			errObj.Get("subtype").String() == "server_error" &&
+			errObj.Get("message").String() == "drive task failed" {
+			return true
+		}
 	}
 	return false
 }

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	slidesCleanupMaxAttempts    = 3
+	slidesCleanupMaxAttempts    = 5
 	slidesCleanupInitialBackoff = 2 * time.Second
 	slidesCleanupMaxBackoff     = 8 * time.Second
 )

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -16,8 +16,15 @@ import (
 
 	"github.com/larksuite/cli/internal/vfs"
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	drivee2e "github.com/larksuite/cli/tests/cli_e2e/drive"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+)
+
+const (
+	slidesCleanupMaxAttempts    = 3
+	slidesCleanupInitialBackoff = 2 * time.Second
+	slidesCleanupMaxBackoff     = 8 * time.Second
 )
 
 func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
@@ -51,15 +58,7 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
 		defer cleanupCancel()
 
-		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
-			Args: []string{
-				"drive", "+delete",
-				"--file-token", presentationID,
-				"--type", "slides",
-				"--yes",
-			},
-			DefaultAs: "bot",
-		})
+		deleteResult, deleteErr := deleteSlidesPresentationWithRetry(parentT, cleanupCtx, presentationID)
 		clie2e.ReportCleanupFailure(parentT, "delete presentation "+presentationID, deleteResult, deleteErr)
 	})
 	slideID := gjson.Get(createResult.Stdout, "data.slide_ids.0").String()
@@ -147,6 +146,62 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 	_, decodedFormat, err := image.DecodeConfig(fixedImageFile)
 	require.NoError(t, err)
 	require.Equal(t, actualFormat, decodedFormat, fixedOutputResult.Stdout)
+}
+
+func deleteSlidesPresentationWithRetry(t *testing.T, ctx context.Context, presentationID string) (*clie2e.Result, error) {
+	t.Helper()
+
+	backoff := slidesCleanupInitialBackoff
+	var (
+		result *clie2e.Result
+		err    error
+	)
+	for attempt := 1; attempt <= slidesCleanupMaxAttempts; attempt++ {
+		result, err = drivee2e.DeleteDriveResourceAndVerify(ctx, presentationID, "slides", "bot")
+		if err == nil || clie2e.IsCleanupWarning(err) || !isTransientDriveTaskFailure(result) {
+			return result, err
+		}
+		if attempt == slidesCleanupMaxAttempts {
+			return result, err
+		}
+
+		t.Logf("drive +delete attempt %d failed and slides %s still exists; retrying in %s: stderr=%s", attempt, presentationID, backoff, result.Stderr)
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return result, ctx.Err()
+		case <-timer.C:
+		}
+		backoff *= 2
+		if backoff > slidesCleanupMaxBackoff {
+			backoff = slidesCleanupMaxBackoff
+		}
+	}
+	return result, err
+}
+
+func isTransientDriveTaskFailure(result *clie2e.Result) bool {
+	if result == nil {
+		return false
+	}
+	for _, raw := range []string{result.Stderr, result.Stdout} {
+		idx := strings.Index(raw, "{")
+		if idx < 0 {
+			continue
+		}
+		payload := raw[idx:]
+		if !gjson.Valid(payload) {
+			continue
+		}
+		errObj := gjson.Get(payload, "error")
+		if errObj.Get("type").String() == "api" &&
+			errObj.Get("subtype").String() == "server_error" &&
+			errObj.Get("message").String() == "drive task failed" {
+			return true
+		}
+	}
+	return false
 }
 
 func requireScreenshotPathUnderDir(t *testing.T, path, dir string) {

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -21,12 +21,6 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const (
-	slidesCleanupMaxAttempts    = 5
-	slidesCleanupInitialBackoff = 2 * time.Second
-	slidesCleanupMaxBackoff     = 8 * time.Second
-)
-
 func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 	clie2e.SkipWithoutTenantAccessToken(t)
 
@@ -58,7 +52,7 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
 		defer cleanupCancel()
 
-		deleteResult, deleteErr := deleteSlidesPresentationWithRetry(parentT, cleanupCtx, presentationID)
+		deleteResult, deleteErr := drivee2e.DeleteDriveResourceAndVerify(cleanupCtx, presentationID, "slides", "bot")
 		clie2e.ReportCleanupFailure(parentT, "delete presentation "+presentationID, deleteResult, deleteErr)
 	})
 	slideID := gjson.Get(createResult.Stdout, "data.slide_ids.0").String()
@@ -146,62 +140,6 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 	_, decodedFormat, err := image.DecodeConfig(fixedImageFile)
 	require.NoError(t, err)
 	require.Equal(t, actualFormat, decodedFormat, fixedOutputResult.Stdout)
-}
-
-func deleteSlidesPresentationWithRetry(t *testing.T, ctx context.Context, presentationID string) (*clie2e.Result, error) {
-	t.Helper()
-
-	backoff := slidesCleanupInitialBackoff
-	var (
-		result *clie2e.Result
-		err    error
-	)
-	for attempt := 1; attempt <= slidesCleanupMaxAttempts; attempt++ {
-		result, err = drivee2e.DeleteDriveResourceAndVerify(ctx, presentationID, "slides", "bot")
-		if err == nil || clie2e.IsCleanupWarning(err) || !isTransientDriveTaskFailure(result) {
-			return result, err
-		}
-		if attempt == slidesCleanupMaxAttempts {
-			return result, err
-		}
-
-		t.Logf("drive +delete attempt %d failed and slides %s still exists; retrying in %s: stderr=%s", attempt, presentationID, backoff, result.Stderr)
-		timer := time.NewTimer(backoff)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return result, ctx.Err()
-		case <-timer.C:
-		}
-		backoff *= 2
-		if backoff > slidesCleanupMaxBackoff {
-			backoff = slidesCleanupMaxBackoff
-		}
-	}
-	return result, err
-}
-
-func isTransientDriveTaskFailure(result *clie2e.Result) bool {
-	if result == nil {
-		return false
-	}
-	for _, raw := range []string{result.Stderr, result.Stdout} {
-		idx := strings.Index(raw, "{")
-		if idx < 0 {
-			continue
-		}
-		payload := raw[idx:]
-		if !gjson.Valid(payload) {
-			continue
-		}
-		errObj := gjson.Get(payload, "error")
-		if errObj.Get("type").String() == "api" &&
-			errObj.Get("subtype").String() == "server_error" &&
-			errObj.Get("message").String() == "drive task failed" {
-			return true
-		}
-	}
-	return false
 }
 
 func requireScreenshotPathUnderDir(t *testing.T, path, dir string) {


### PR DESCRIPTION
## Summary

Stabilize Drive-backed E2E cleanup when concurrent deletes under the same folder make an asynchronous delete task report `server_error: drive task failed`.

## Changes

- Centralize the targeted retry in `drive.DeleteDriveResourceAndVerify` so Slides, Docs, Sheets, Base, Wiki, and Drive cleanups share one policy.
- Verify the resource's real terminal state after each failed delete; retry only when it still exists.
- Retry only the exact `api/server_error/drive task failed` envelope, with five attempts and 2s/4s/8s/8s bounded backoff.
- Keep unrelated permission, validation, authentication, and protocol failures fatal.
- Simplify the Slides screenshot cleanup back to a direct shared-helper call.

## Impact

CLI behavior is unchanged. Live E2E teardown becomes more resilient to the backend's same-folder delete lock while preserving bounded failure behavior.

## Root Cause

Live E2E jobs and Go packages run concurrently against the same test bot. Drive serializes deletes within a folder, so overlapping cleanup tasks can collide and one async task may terminate with `drive task failed`.

## Test Plan

- [x] `gofmt`
- [x] `git diff --check`
- [x] `go vet ./tests/cli_e2e/drive ./tests/cli_e2e/slides`
- [x] Ran `TestSlidesScreenshotAliasesLiveE2E` in Docker with the fixed E2E app credentials: presentation creation and shared-helper cleanup succeeded; screenshot execution is blocked because that app lacks `slides:presentation:screenshot`
- [ ] Full live retry path in CI

## Related Issues

- Supersedes #2396 after renaming the fork branch from `codex/` to `fix/`; GitHub automatically closed the cross-fork PR during the branch rename.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when deleting Drive resources by retrying transient backend failures with capped exponential backoff.
  - Preserved immediate handling for successful, warning, non-transient, exhausted, and canceled operations.
  - Standardized cleanup behavior in Slides workflows to provide more consistent resource deletion verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->