### PR TITLE
fix: honor recovered E2E retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,7 @@ jobs:
           name: CLI E2E Tests
           path: cli-e2e-report.xml
           reporter: java-junit
+          fail-on-error: false
           use-actions-summary: true
           list-suites: all
           list-tests: all


### PR DESCRIPTION
## Summary
Prevent the JUnit publishing step from marking live E2E as failed when gotestsum successfully recovers an initially failing test through its configured retries.

## Changes
- Keep gotestsum as the authority for the final live E2E result.
- Publish the complete JUnit retry history without making recovered failures fail the report step.

## Test Plan
- [x] Real gotestsum v1.12.3 fixture: the first attempt failed and retry 1 passed; final exit code was 0.
- [x] Ran the pinned dorny/test-reporter v3.0.0 against that recovered JUnit report with fail-on-error disabled; final exit code was 0.
- [x] Persistent-failure fixture failed initially and on both retries; final gotestsum exit code was 1.
- [x] `make script-test` (164 tests passed).

## Related Issues
- None