### PR TITLE
feat: support skills layout during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ script-test:
 	bash scripts/ci-workflow.test.sh
 	bash scripts/release-workflow.test.sh
 	bash scripts/semantic-review-workflow.test.sh
-	$(NODE) --test scripts/e2e_domains.test.js scripts/fetch_e2e_tat.test.js scripts/install.test.js scripts/release-preflight.test.js scripts/release-publish-policy.test.js scripts/semantic-review-verify-artifact.test.js scripts/pr-quality-summary.test.js scripts/semantic-review-publish.test.js scripts/ci-quality-summary-publish.test.js
+	$(NODE) --test scripts/e2e_domains.test.js scripts/fetch_e2e_tat.test.js scripts/install.test.js scripts/install-wizard.test.js scripts/release-preflight.test.js scripts/release-publish-policy.test.js scripts/semantic-review-verify-artifact.test.js scripts/pr-quality-summary.test.js scripts/semantic-review-publish.test.js scripts/ci-quality-summary-publish.test.js
 
 # ./extension/... keeps the public plugin SDK in the default test matrix.
 unit-test: fetch_meta

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Choose **one** of the following methods:
 npx @larksuite/cli@latest install
 ```
 
+To install the aggregated `lark-suite` layout instead of separate skills:
+
+```bash
+npx @larksuite/cli@latest install --skills-layout suite
+```
+
 **Option 2 — From source:**
 
 Requires Go `v1.23`+ and Python 3.

--- a/README.zh.md
+++ b/README.zh.md
@@ -75,6 +75,12 @@
 npx @larksuite/cli@latest install
 ```
 
+如需安装聚合后的 `lark-suite` 布局，而不是默认的独立 Skills：
+
+```bash
+npx @larksuite/cli@latest install --skills-layout suite
+```
+
 **方式二 — 从源码安装：**
 
 需要 Go `v1.23`+ 和 Python 3。

--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -81,6 +81,17 @@ func syncSuite(runner SkillsRunner, source string, plan SyncPlan, installed []in
 	return nil
 }
 
+func cleanupSeparate(runner SkillsRunner, plan SyncPlan, installed []installedSkill) error {
+	removeSet := toSet(installedOfficialNames(installed, plan.CleanupOfficial))
+	for _, name := range plan.OfficialSkills {
+		delete(removeSet, name)
+	}
+	if hasInstalledSkill(installed, "lark-suite") {
+		removeSet["lark-suite"] = true
+	}
+	return removeSkills(runner, sortedKeys(removeSet))
+}
+
 func prepareSuite(suitePath string, official, target []string) error {
 	referencesPath := filepath.Join(suitePath, "references")
 	archived, err := listDirectSubdirs(referencesPath)

--- a/internal/skillscheck/sync.go
+++ b/internal/skillscheck/sync.go
@@ -429,12 +429,7 @@ func syncLayout(runner SkillsRunner, source string, layout Layout, plan SyncPlan
 			return fmt.Errorf("archive install failed: %s", resultDetail(result))
 		}
 	}
-	if hasInstalledSkill(installed, "lark-suite") {
-		if result := runner.RemoveGlobalSkills([]string{"lark-suite"}); result == nil || result.Err != nil {
-			return fmt.Errorf("remove lark-suite failed: %s", resultDetail(result))
-		}
-	}
-	return nil
+	return cleanupSeparate(runner, plan, installed)
 }
 
 func fallbackSeparate(opts SyncOptions, previous *SkillsState, readable bool, local []string, installed []installedSkill, plan *SyncPlan, reasons []string) *SyncResult {
@@ -467,14 +462,12 @@ func fallbackSeparate(opts SyncOptions, previous *SkillsState, readable bool, lo
 			Force:  opts.Force,
 		}
 	}
-	if hasInstalledSkill(installed, "lark-suite") {
-		if result := opts.Runner.RemoveGlobalSkills([]string{"lark-suite"}); result == nil || result.Err != nil {
-			return &SyncResult{Action: "failed", Layout: LayoutSeparate, Err: fmt.Errorf("remove lark-suite failed: %s", resultDetail(result)), Force: opts.Force}
-		}
-	}
 	if plan == nil {
 		empty := SyncPlan{Version: opts.Version}
 		plan = &empty
+	}
+	if err := cleanupSeparate(opts.Runner, *plan, installed); err != nil {
+		return &SyncResult{Action: "failed", Layout: LayoutSeparate, Err: err, Force: opts.Force}
 	}
 	warning := ""
 	if installResult != nil {

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/larksuite/cli/internal/selfupdate"
+	"github.com/larksuite/cli/internal/vfs"
 )
 
 func TestParseSkillsListIgnoresUnsupportedFormat(t *testing.T) {
@@ -687,7 +688,7 @@ func TestSyncSkillsPublishedSkillChangesReachOldLayoutInstallations(t *testing.T
 		}
 		oldSuite := t.TempDir()
 		for _, name := range []string{"lark-calendar", "lark-retired"} {
-			if err := os.MkdirAll(filepath.Join(oldSuite, "references", name), 0o755); err != nil {
+			if err := vfs.MkdirAll(filepath.Join(oldSuite, "references", name), 0o755); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -185,17 +185,18 @@ func TestPlanForceRestoresAllOfficial(t *testing.T) {
 }
 
 type fakeSkillsRunner struct {
-	sources       []string
-	indexes       map[string]string
-	indexErrors   map[string]error
-	installErrors map[string]error
-	stageErrors   map[string]error
-	stageChildren map[string][]string
-	globalJSON    string
-	installs      []string
-	removals      [][]string
-	localSuite    string
-	stages        []string
+	sources            []string
+	indexes            map[string]string
+	indexErrors        map[string]error
+	installErrors      map[string]error
+	stageErrors        map[string]error
+	stageChildren      map[string][]string
+	globalJSON         string
+	installs           []string
+	removals           [][]string
+	localSuite         string
+	localSuiteChildren []string
+	stages             []string
 }
 
 func officialSkillsIndexOutput(names ...string) string {
@@ -269,6 +270,11 @@ func (f *fakeSkillsRunner) StageSuite(source, dir string) *selfupdate.NpmResult 
 }
 func (f *fakeSkillsRunner) InstallLocalSuite(path string) *selfupdate.NpmResult {
 	f.localSuite = path
+	children, err := listDirectSubdirs(filepath.Join(path, "references"))
+	if err != nil {
+		return &selfupdate.NpmResult{Err: err}
+	}
+	f.localSuiteChildren = children
 	return &selfupdate.NpmResult{}
 }
 func (f *fakeSkillsRunner) RemoveGlobalSkills(names []string) *selfupdate.NpmResult {
@@ -619,6 +625,95 @@ func TestSyncSkillsSwitchToSuiteRemovesPreviouslyOfficialSkillMissingFromIndex(t
 		t.Fatalf("removals = %v, want one removal call", runner.removals)
 	}
 	assertStrings(t, runner.removals[0], []string{"lark-calendar", "lark-retired"})
+}
+
+func TestSyncSkillsPublishedSkillChangesReachOldLayoutInstallations(t *testing.T) {
+	previousState := SkillsState{
+		Version:              "1.0.32",
+		OfficialSkills:       []string{"lark-calendar", "lark-retired"},
+		UpdatedSkills:        []string{"lark-calendar", "lark-retired"},
+		AddedOfficialSkills:  []string{"lark-retired"},
+		SkippedDeletedSkills: []string{"lark-retired"},
+	}
+	assertCurrentState := func(t *testing.T, wantLayout Layout) {
+		t.Helper()
+		state, ok, err := ReadState()
+		if err != nil || !ok {
+			t.Fatalf("ReadState() = (%+v, %v, %v)", state, ok, err)
+		}
+		if state.Version != "1.0.33" || state.Layout != wantLayout {
+			t.Fatalf("state = %+v, want version 1.0.33 and layout %s", state, wantLayout)
+		}
+		assertStrings(t, state.OfficialSkills, []string{"lark-calendar", "lark-mail"})
+		assertStrings(t, state.UpdatedSkills, []string{"lark-calendar", "lark-mail"})
+		assertStrings(t, state.AddedOfficialSkills, []string{"lark-mail"})
+		assertStrings(t, state.SkippedDeletedSkills, []string{})
+	}
+
+	t.Run("separate", func(t *testing.T) {
+		t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+		state := previousState
+		state.Layout = LayoutSeparate
+		if err := WriteState(state); err != nil {
+			t.Fatal(err)
+		}
+		runner := &fakeSkillsRunner{
+			sources:       []string{"primary"},
+			indexes:       map[string]string{"primary": officialSkillsIndexOutput("lark-calendar", "lark-mail")},
+			indexErrors:   map[string]error{},
+			installErrors: map[string]error{},
+			stageErrors:   map[string]error{},
+			globalJSON:    globalSkillsJSONOutput("lark-calendar", "lark-retired", "lark-user-owned"),
+		}
+
+		result := SyncSkills(SyncOptions{Version: "1.0.33", Runner: runner, Now: time.Now})
+		if result.Err != nil {
+			t.Fatal(result.Err)
+		}
+		assertStrings(t, runner.installs, []string{"primary:lark-calendar,lark-mail"})
+		if len(runner.removals) != 1 {
+			t.Fatalf("removals = %v, want one removal call", runner.removals)
+		}
+		assertStrings(t, runner.removals[0], []string{"lark-retired"})
+		assertCurrentState(t, LayoutSeparate)
+	})
+
+	t.Run("suite", func(t *testing.T) {
+		t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+		state := previousState
+		state.Layout = LayoutSuite
+		if err := WriteState(state); err != nil {
+			t.Fatal(err)
+		}
+		oldSuite := t.TempDir()
+		for _, name := range []string{"lark-calendar", "lark-retired"} {
+			if err := os.MkdirAll(filepath.Join(oldSuite, "references", name), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		runner := &fakeSkillsRunner{
+			sources:       []string{"primary"},
+			indexes:       map[string]string{"primary": officialSkillsIndexOutput("lark-calendar", "lark-mail")},
+			indexErrors:   map[string]error{},
+			installErrors: map[string]error{},
+			stageErrors:   map[string]error{},
+			globalJSON: fmt.Sprintf(
+				`[{"name":"lark-suite","path":%q,"scope":"global"},{"name":"lark-user-owned","path":"/tmp/lark-user-owned","scope":"global"}]`,
+				oldSuite,
+			),
+		}
+
+		result := SyncSkills(SyncOptions{Version: "1.0.33", Runner: runner, Now: time.Now})
+		if result.Err != nil {
+			t.Fatal(result.Err)
+		}
+		assertStrings(t, runner.stages, []string{"primary"})
+		assertStrings(t, runner.localSuiteChildren, []string{"lark-calendar", "lark-mail"})
+		if len(runner.removals) != 0 {
+			t.Fatalf("removals = %v, want user-owned Skill untouched", runner.removals)
+		}
+		assertCurrentState(t, LayoutSuite)
+	})
 }
 
 func TestSyncSkillsSwitchToSeparateRemovesSuite(t *testing.T) {

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -195,6 +195,7 @@ type fakeSkillsRunner struct {
 	globalJSON         string
 	installs           []string
 	removals           [][]string
+	removeError        error
 	localSuite         string
 	localSuiteChildren []string
 	stages             []string
@@ -280,7 +281,7 @@ func (f *fakeSkillsRunner) InstallLocalSuite(path string) *selfupdate.NpmResult 
 }
 func (f *fakeSkillsRunner) RemoveGlobalSkills(names []string) *selfupdate.NpmResult {
 	f.removals = append(f.removals, append([]string{}, names...))
-	return &selfupdate.NpmResult{}
+	return &selfupdate.NpmResult{Err: f.removeError}
 }
 
 const suiteFixture = `---
@@ -722,9 +723,12 @@ func TestSyncSkillsSwitchToSeparateRemovesSuite(t *testing.T) {
 		name        string
 		indexErrors map[string]error
 		wantInstall string
+		removeError error
+		wantError   bool
 	}{
 		{name: "official source", indexErrors: map[string]error{}, wantInstall: "primary:lark-calendar,lark-mail"},
 		{name: "GitHub fallback", indexErrors: map[string]error{"primary": fmt.Errorf("down")}, wantInstall: "larksuite/cli:lark-calendar,lark-mail"},
+		{name: "cleanup failure", indexErrors: map[string]error{}, removeError: fmt.Errorf("remove failed"), wantError: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
@@ -744,9 +748,16 @@ func TestSyncSkillsSwitchToSeparateRemovesSuite(t *testing.T) {
 				installErrors: map[string]error{},
 				stageErrors:   map[string]error{},
 				globalJSON:    fmt.Sprintf(`[{"name":"lark-suite","path":%q,"scope":"global"}]`, suite),
+				removeError:   test.removeError,
 			}
 
 			result := SyncSkills(SyncOptions{Version: "1.0.33", Layout: LayoutSeparate, Runner: runner, Now: time.Now})
+			if test.wantError {
+				if result.Err == nil {
+					t.Fatal("expected lark-suite cleanup failure")
+				}
+				return
+			}
 			if result.Err != nil {
 				t.Fatal(result.Err)
 			}

--- a/scripts/install-wizard.js
+++ b/scripts/install-wizard.js
@@ -35,6 +35,7 @@ const messages = {
     step2Spinner:   "正在安装 Skills...",
     step2Done:      "Skills 已安装",
     step2Fail:      "Skills 安装失败。运行以下命令重试: npx skills add %s -y -g",
+    step2LayoutFail: "Skills 安装失败。运行以下命令重试: lark-cli update --skills-layout %s",
     step3:          "正在配置应用...",
     step3NotFound:  "未找到 lark-cli，终止",
     step3Found:     "发现已配置应用 (App ID: %s)，继续使用？",
@@ -64,6 +65,7 @@ const messages = {
     step2Spinner:   "Installing skills...",
     step2Done:      "Skills installed",
     step2Fail:      "Failed to install skills. Run manually: npx skills add %s -y -g",
+    step2LayoutFail: "Failed to install skills. Run manually: lark-cli update --skills-layout %s",
     step3:          "Configuring app...",
     step3NotFound:  "lark-cli not found. Aborting",
     step3Found:     "Found existing app (App ID: %s). Use this app?",
@@ -216,6 +218,26 @@ function parseLangArg() {
   return null;
 }
 
+/** Parse --skills-layout from process.argv, returns "separate", "suite", or null. */
+function parseSkillsLayoutArg() {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    let value;
+    if (args[i] === "--skills-layout") {
+      value = args[i + 1];
+    } else if (args[i].startsWith("--skills-layout=")) {
+      value = args[i].slice("--skills-layout=".length);
+    } else {
+      continue;
+    }
+
+    const layout = (value || "").toLowerCase();
+    if (layout === "separate" || layout === "suite") return layout;
+    throw new Error("--skills-layout must be one of separate or suite");
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Steps
 // ---------------------------------------------------------------------------
@@ -271,10 +293,19 @@ async function skillsAlreadyInstalled() {
   }
 }
 
-async function stepInstallSkills(msg) {
+async function stepInstallSkills(msg, requestedLayout) {
   const s = p.spinner();
   s.start(msg.step2Spinner);
   try {
+    if (requestedLayout) {
+      const larkCli = whichLarkCli();
+      if (!larkCli) throw new Error("lark-cli not found");
+      await runSilentAsync(larkCli, ["update", "--skills-layout", requestedLayout], {
+        timeout: 120000,
+      });
+      s.stop(msg.step2Done);
+      return;
+    }
     if (await skillsAlreadyInstalled()) {
       s.stop(msg.step2Skip);
       return;
@@ -290,7 +321,10 @@ async function stepInstallSkills(msg) {
     }
     s.stop(msg.step2Done);
   } catch (_) {
-    s.stop(fmt(msg.step2Fail, SKILLS_REPO_FALLBACK));
+    const failure = requestedLayout
+      ? fmt(msg.step2LayoutFail, requestedLayout)
+      : fmt(msg.step2Fail, SKILLS_REPO_FALLBACK);
+    s.stop(failure);
     process.exit(1);
   }
 }
@@ -363,18 +397,19 @@ async function main() {
   const isInteractive = !!process.stdin.isTTY;
   const lang = isInteractive ? await stepSelectLang() : (parseLangArg() || "en");
   const msg = messages[lang];
+  const skillsLayout = parseSkillsLayoutArg();
 
   if (isInteractive) {
     p.intro(msg.setup);
     await stepInstallGlobally(msg);
-    await stepInstallSkills(msg);
+    await stepInstallSkills(msg, skillsLayout);
     await stepConfigInit(msg, lang);
     await stepAuthLogin(msg);
     p.outro(msg.done);
   } else {
     console.log(msg.setup);
     await stepInstallGlobally(msg);
-    await stepInstallSkills(msg);
+    await stepInstallSkills(msg, skillsLayout);
     console.log(msg.nonTtyHint);
   }
 }

--- a/scripts/install-wizard.js
+++ b/scripts/install-wizard.js
@@ -305,15 +305,21 @@ async function stepInstallSkills(msg, requestedLayout) {
       const output = await runSilentAsync(larkCli, ["update", "--skills-layout", requestedLayout, "--json"], {
         timeout: 120000,
       });
-      s.stop(msg.step2Done);
+      let doneMessage = msg.step2Done;
+      let warning = "";
       try {
         const result = JSON.parse(output.toString());
+        if (result.skills_action === "in_sync") {
+          doneMessage = msg.step2Skip;
+        }
         if (typeof result.skills_warning === "string" && result.skills_warning) {
-          p.log.warn(result.skills_warning);
+          warning = result.skills_warning;
         }
       } catch (_) {
         // A successful update with non-JSON output should not fail installation.
       }
+      s.stop(doneMessage);
+      if (warning) p.log.warn(warning);
       return;
     }
     if (await skillsAlreadyInstalled()) {

--- a/scripts/install-wizard.js
+++ b/scripts/install-wizard.js
@@ -36,6 +36,7 @@ const messages = {
     step2Done:      "Skills 已安装",
     step2Fail:      "Skills 安装失败。运行以下命令重试: npx skills add %s -y -g",
     step2LayoutFail: "Skills 安装失败。运行以下命令重试: lark-cli update --skills-layout %s",
+    layoutInvalid:  "--skills-layout 必须是 separate 或 suite",
     step3:          "正在配置应用...",
     step3NotFound:  "未找到 lark-cli，终止",
     step3Found:     "发现已配置应用 (App ID: %s)，继续使用？",
@@ -66,6 +67,7 @@ const messages = {
     step2Done:      "Skills installed",
     step2Fail:      "Failed to install skills. Run manually: npx skills add %s -y -g",
     step2LayoutFail: "Failed to install skills. Run manually: lark-cli update --skills-layout %s",
+    layoutInvalid:  "--skills-layout must be one of separate or suite",
     step3:          "Configuring app...",
     step3NotFound:  "lark-cli not found. Aborting",
     step3Found:     "Found existing app (App ID: %s). Use this app?",
@@ -300,10 +302,18 @@ async function stepInstallSkills(msg, requestedLayout) {
     if (requestedLayout) {
       const larkCli = whichLarkCli();
       if (!larkCli) throw new Error("lark-cli not found");
-      await runSilentAsync(larkCli, ["update", "--skills-layout", requestedLayout], {
+      const output = await runSilentAsync(larkCli, ["update", "--skills-layout", requestedLayout, "--json"], {
         timeout: 120000,
       });
       s.stop(msg.step2Done);
+      try {
+        const result = JSON.parse(output.toString());
+        if (typeof result.skills_warning === "string" && result.skills_warning) {
+          p.log.warn(result.skills_warning);
+        }
+      } catch (_) {
+        // A successful update with non-JSON output should not fail installation.
+      }
       return;
     }
     if (await skillsAlreadyInstalled()) {
@@ -397,7 +407,13 @@ async function main() {
   const isInteractive = !!process.stdin.isTTY;
   const lang = isInteractive ? await stepSelectLang() : (parseLangArg() || "en");
   const msg = messages[lang];
-  const skillsLayout = parseSkillsLayoutArg();
+  let skillsLayout;
+  try {
+    skillsLayout = parseSkillsLayoutArg();
+  } catch (_) {
+    p.log.error(msg.layoutInvalid);
+    process.exit(1);
+  }
 
   if (isInteractive) {
     p.intro(msg.setup);

--- a/scripts/install-wizard.test.js
+++ b/scripts/install-wizard.test.js
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+const { pathToFileURL } = require("node:url");
+
+const runScript = path.join(__dirname, "run.js");
+const unixOnly = { skip: process.platform === "win32" };
+
+function writeExecutable(file, content) {
+  fs.writeFileSync(file, content, { mode: 0o755 });
+}
+
+function makeFixture(t, cliExitCode = 0) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "install-wizard-"));
+  const fakeBin = path.join(root, "fake-bin");
+  const prefix = path.join(root, "npm-prefix");
+  const commandLog = path.join(root, "commands.log");
+  const promptsStub = path.join(root, "prompts-stub.mjs");
+  const loader = path.join(root, "prompts-loader.mjs");
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+  fs.writeFileSync(promptsStub, `
+export const log = { info() {}, success() {}, warn() {}, error() {}, step() {} };
+export function spinner() { return { start() {}, stop(message) { console.error(message); } }; }
+export function cancel(message) { console.error(message); }
+export function isCancel() { return false; }
+`);
+  fs.writeFileSync(loader, `
+const stub = new URL("./prompts-stub.mjs", import.meta.url).href;
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "@clack/prompts") return { url: stub, shortCircuit: true };
+  return nextResolve(specifier, context);
+}
+`);
+
+  writeExecutable(path.join(fakeBin, "npm"), `#!/bin/sh
+case "$1" in
+  list) printf '%s\n' '@larksuite/cli@1.0.0' ;;
+  view) printf '%s\n' '1.0.0' ;;
+  prefix) printf '%s\n' "$FAKE_NPM_PREFIX" ;;
+  *) exit 97 ;;
+esac
+`);
+  writeExecutable(path.join(fakeBin, "npx"), `#!/bin/sh
+printf 'npx:%s\n' "$*" >> "$COMMAND_TEST_LOG"
+printf '%s\n' 'lark-existing'
+`);
+  writeExecutable(path.join(prefix, "bin", "lark-cli"), `#!/bin/sh
+printf 'lark-cli:%s\n' "$*" >> "$COMMAND_TEST_LOG"
+exit "$LARK_CLI_EXIT_CODE"
+`);
+
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return {
+    commandLog,
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+      FAKE_NPM_PREFIX: prefix,
+      LARK_CLI_EXIT_CODE: String(cliExitCode),
+      COMMAND_TEST_LOG: commandLog,
+      NO_COLOR: "1",
+      NODE_OPTIONS: `--no-warnings --experimental-loader=${pathToFileURL(loader).href}`,
+    },
+  };
+}
+
+function runInstall(args, env) {
+  return spawnSync(process.execPath, [runScript, "install", "--lang", "en", ...args], {
+    cwd: path.join(__dirname, ".."),
+    encoding: "utf8",
+    env,
+  });
+}
+
+function readIfPresent(file) {
+  return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
+}
+
+for (const [name, args, layout] of [
+  ["suite layout", ["--skills-layout", "suite"], "suite"],
+  ["equals form for separate layout", ["--skills-layout=separate"], "separate"],
+]) {
+  test(`install applies ${name} even when skills already exist`, unixOnly, (t) => {
+    const fixture = makeFixture(t);
+    const result = runInstall(args, fixture.env);
+
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.equal(readIfPresent(fixture.commandLog), `lark-cli:update --skills-layout ${layout}\n`);
+  });
+}
+
+test("install without a layout keeps the existing skills skip behavior", unixOnly, (t) => {
+  const fixture = makeFixture(t);
+  const result = runInstall([], fixture.env);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.equal(readIfPresent(fixture.commandLog), "npx:-y skills ls -g\n");
+});
+
+test("install rejects an unsupported skills layout before changing skills", unixOnly, (t) => {
+  const fixture = makeFixture(t);
+  const result = runInstall(["--skills-layout", "hybrid"], fixture.env);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout + result.stderr, /--skills-layout must be one of separate or suite/);
+  assert.equal(readIfPresent(fixture.commandLog), "");
+});
+
+test("install reports the layout-specific retry command when synchronization fails", unixOnly, (t) => {
+  const fixture = makeFixture(t, 9);
+  const result = runInstall(["--skills-layout", "suite"], fixture.env);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout + result.stderr, /lark-cli update --skills-layout suite/);
+  assert.equal(readIfPresent(fixture.commandLog), "lark-cli:update --skills-layout suite\n");
+});

--- a/scripts/install-wizard.test.js
+++ b/scripts/install-wizard.test.js
@@ -134,13 +134,23 @@ test("install rejects an unsupported skills layout before changing skills", unix
   assert.equal(readIfPresent(fixture.commandLog), "");
 });
 
+test("install rejects a missing skills layout value before changing skills", unixOnly, (t) => {
+  const fixture = makeFixture(t);
+  const result = runInstall(["--skills-layout"], fixture.env, "zh");
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout + result.stderr, /--skills-layout 必须是 separate 或 suite/);
+  assert.doesNotMatch(result.stdout + result.stderr, /Unexpected error/);
+  assert.equal(readIfPresent(fixture.commandLog), "");
+});
+
 test("install surfaces a skills warning returned by update", unixOnly, (t) => {
   const warning = "used the GitHub legacy fallback; installed Skill content may be incomplete";
   const fixture = makeFixture(t, 0, JSON.stringify({ skills_warning: warning }));
   const result = runInstall(["--skills-layout", "separate"], fixture.env);
 
   assert.equal(result.status, 0, result.stdout + result.stderr);
-  assert.match(result.stdout + result.stderr, new RegExp(warning));
+  assert.ok((result.stdout + result.stderr).includes(warning));
   assert.equal(readIfPresent(fixture.commandLog), "lark-cli:update --skills-layout separate --json\n");
 });
 

--- a/scripts/install-wizard.test.js
+++ b/scripts/install-wizard.test.js
@@ -16,7 +16,7 @@ function writeExecutable(file, content) {
   fs.writeFileSync(file, content, { mode: 0o755 });
 }
 
-function makeFixture(t, cliExitCode = 0) {
+function makeFixture(t, cliExitCode = 0, cliOutput = "") {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "install-wizard-"));
   const fakeBin = path.join(root, "fake-bin");
   const prefix = path.join(root, "npm-prefix");
@@ -27,7 +27,10 @@ function makeFixture(t, cliExitCode = 0) {
   fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
 
   fs.writeFileSync(promptsStub, `
-export const log = { info() {}, success() {}, warn() {}, error() {}, step() {} };
+export const log = {
+  info() {}, success() {}, error(message) { console.error(message); },
+  warn(message) { console.error(message); }, step() {},
+};
 export function spinner() { return { start() {}, stop(message) { console.error(message); } }; }
 export function cancel(message) { console.error(message); }
 export function isCancel() { return false; }
@@ -54,6 +57,7 @@ printf '%s\n' 'lark-existing'
 `);
   writeExecutable(path.join(prefix, "bin", "lark-cli"), `#!/bin/sh
 printf 'lark-cli:%s\n' "$*" >> "$COMMAND_TEST_LOG"
+printf '%s' "$LARK_CLI_OUTPUT"
 exit "$LARK_CLI_EXIT_CODE"
 `);
 
@@ -65,6 +69,7 @@ exit "$LARK_CLI_EXIT_CODE"
       PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
       FAKE_NPM_PREFIX: prefix,
       LARK_CLI_EXIT_CODE: String(cliExitCode),
+      LARK_CLI_OUTPUT: cliOutput,
       COMMAND_TEST_LOG: commandLog,
       NO_COLOR: "1",
       NODE_OPTIONS: `--no-warnings --experimental-loader=${pathToFileURL(loader).href}`,
@@ -72,8 +77,8 @@ exit "$LARK_CLI_EXIT_CODE"
   };
 }
 
-function runInstall(args, env) {
-  return spawnSync(process.execPath, [runScript, "install", "--lang", "en", ...args], {
+function runInstall(args, env, lang = "en") {
+  return spawnSync(process.execPath, [runScript, "install", "--lang", lang, ...args], {
     cwd: path.join(__dirname, ".."),
     encoding: "utf8",
     env,
@@ -93,7 +98,7 @@ for (const [name, args, layout] of [
     const result = runInstall(args, fixture.env);
 
     assert.equal(result.status, 0, result.stdout + result.stderr);
-    assert.equal(readIfPresent(fixture.commandLog), `lark-cli:update --skills-layout ${layout}\n`);
+    assert.equal(readIfPresent(fixture.commandLog), `lark-cli:update --skills-layout ${layout} --json\n`);
   });
 }
 
@@ -107,11 +112,22 @@ test("install without a layout keeps the existing skills skip behavior", unixOnl
 
 test("install rejects an unsupported skills layout before changing skills", unixOnly, (t) => {
   const fixture = makeFixture(t);
-  const result = runInstall(["--skills-layout", "hybrid"], fixture.env);
+  const result = runInstall(["--skills-layout", "hybrid"], fixture.env, "zh");
 
   assert.equal(result.status, 1);
-  assert.match(result.stdout + result.stderr, /--skills-layout must be one of separate or suite/);
+  assert.match(result.stdout + result.stderr, /--skills-layout 必须是 separate 或 suite/);
+  assert.doesNotMatch(result.stdout + result.stderr, /Unexpected error/);
   assert.equal(readIfPresent(fixture.commandLog), "");
+});
+
+test("install surfaces a skills warning returned by update", unixOnly, (t) => {
+  const warning = "used the GitHub legacy fallback; installed Skill content may be incomplete";
+  const fixture = makeFixture(t, 0, JSON.stringify({ skills_warning: warning }));
+  const result = runInstall(["--skills-layout", "separate"], fixture.env);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout + result.stderr, new RegExp(warning));
+  assert.equal(readIfPresent(fixture.commandLog), "lark-cli:update --skills-layout separate --json\n");
 });
 
 test("install reports the layout-specific retry command when synchronization fails", unixOnly, (t) => {
@@ -120,5 +136,5 @@ test("install reports the layout-specific retry command when synchronization fai
 
   assert.equal(result.status, 1);
   assert.match(result.stdout + result.stderr, /lark-cli update --skills-layout suite/);
-  assert.equal(readIfPresent(fixture.commandLog), "lark-cli:update --skills-layout suite\n");
+  assert.equal(readIfPresent(fixture.commandLog), "lark-cli:update --skills-layout suite --json\n");
 });

--- a/scripts/install-wizard.test.js
+++ b/scripts/install-wizard.test.js
@@ -94,13 +94,27 @@ for (const [name, args, layout] of [
   ["equals form for separate layout", ["--skills-layout=separate"], "separate"],
 ]) {
   test(`install applies ${name} even when skills already exist`, unixOnly, (t) => {
-    const fixture = makeFixture(t);
+    const fixture = makeFixture(t, 0, JSON.stringify({ skills_action: "synced" }));
     const result = runInstall(args, fixture.env);
 
     assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout + result.stderr, /Skills installed/);
     assert.equal(readIfPresent(fixture.commandLog), `lark-cli:update --skills-layout ${layout} --json\n`);
   });
 }
+
+test("install reports an unchanged explicit layout like the existing skills path", unixOnly, (t) => {
+  const fixture = makeFixture(t, 0, JSON.stringify({
+    action: "already_up_to_date",
+    skills_action: "in_sync",
+  }));
+  const result = runInstall(["--skills-layout", "suite"], fixture.env);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout + result.stderr, /Already installed\. Skipped/);
+  assert.doesNotMatch(result.stdout + result.stderr, /Skills installed/);
+  assert.equal(readIfPresent(fixture.commandLog), "lark-cli:update --skills-layout suite --json\n");
+});
 
 test("install without a layout keeps the existing skills skip behavior", unixOnly, (t) => {
   const fixture = makeFixture(t);


### PR DESCRIPTION
## Summary

Allow the npm/npx installation wizard to select the Skills layout during installation. Explicit layout requests reuse the existing `lark-cli update` synchronization path, while the default installation flow remains unchanged.

## Changes

- Accept `--skills-layout separate` and `--skills-layout suite` in the installation wizard, including the `--skills-layout=<value>` form.
- Delegate explicit layout installation to `lark-cli update --skills-layout <layout> --json`.
- Surface structured Skills fallback warnings, preserve the existing skipped result for an unchanged layout, and report invalid or missing layout values with localized parameter errors.
- Remove installed official Skills that disappeared from the latest official index in `separate` layout, while preserving user-owned Skills.
- Rewrite successful synchronization state from the latest official set so retired Skills do not remain in state arrays.
- Document suite installation in the English and Chinese quick-start guides.
- Add regression coverage for layout forwarding, validation, warnings, failures, published Skill additions/removals, state cleanup, and user-owned Skill preservation.

## Test Plan

- [x] `make script-test` (172 tests passed)
- [x] `node --test scripts/install-wizard.test.js` (8 tests passed)
- [x] `go test ./internal/skillscheck -count=1`
- [x] Manual release-change matrix: add-only and delete-only updates in both `separate` and `suite` layouts
- [x] `npm pack --dry-run --ignore-scripts`

## Related Issues

- Related to #1385
- Related to #1497
