### PR TITLE
feat: add minutes transcript degradation logic

### DIFF
--- a/shortcuts/minutes/minutes_detail.go
+++ b/shortcuts/minutes/minutes_detail.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
-	"github.com/larksuite/cli/internal/auth"
-	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -33,14 +31,11 @@ const (
 	minutesDetailNoReadPermissionCode = 2091005
 	minutesDetailWaitTimeoutDefault   = 300
 	minutesDetailWaitIntervalDefault  = 15
+	minutesDetailBasicScope           = "minutes:minutes.basic:read"
+	minutesDetailArtifactsScope       = "minutes:minutes.artifacts:read"
 )
 
 var validMinuteTokenDetail = regexp.MustCompile(`^[a-z0-9]+$`)
-
-var scopesDetailMinuteTokens = []string{
-	"minutes:minutes.basic:read",
-	"minutes:minutes.artifacts:read",
-}
 
 // minuteDetailItem represents a single minute detail result.
 type minuteDetailItem struct {
@@ -97,7 +92,7 @@ func fetchMinuteDetail(ctx context.Context, runtime *common.RuntimeContext, minu
 	needTranscript := runtime.Bool("transcript")
 	needKeyword := runtime.Bool("keyword")
 
-	if needSummary || needTodo || needChapter || needTranscript || needKeyword {
+	if len(artifactFlags) > 0 {
 		artData, err := callMinutesDetailAPIUntilReady(ctx, runtime, waitReady, waitTimeout, waitInterval, func() (map[string]interface{}, error) {
 			return runtime.CallAPITyped(http.MethodGet,
 				fmt.Sprintf("/open-apis/minutes/v1/minutes/%s/artifacts", validate.EncodePathSegment(minuteToken)), nil, nil)
@@ -280,13 +275,14 @@ func sanitizeDetailDirName(title, minuteToken string) string {
 
 // MinutesDetail queries minute details with selective artifact flags.
 var MinutesDetail = common.Shortcut{
-	Service:     "minutes",
-	Command:     "+detail",
-	Description: "Query minute details with selective artifact flags (summary, todo, chapter, transcript, keyword)",
-	Risk:        "read",
-	Scopes:      []string{"minutes:minutes.basic:read", "minutes:minutes.artifacts:read"},
-	AuthTypes:   []string{"user", "bot"},
-	HasFormat:   true,
+	Service:           "minutes",
+	Command:           "+detail",
+	Description:       "Query minute details with selective artifact flags (summary, todo, chapter, transcript, keyword)",
+	Risk:              "read",
+	Scopes:            []string{minutesDetailBasicScope},
+	ConditionalScopes: []string{minutesDetailArtifactsScope},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
 	Flags: []common.Flag{
 		{Name: "minute-tokens", Desc: "minute tokens, comma-separated for batch", Required: true},
 		{Name: "summary", Type: "bool", Desc: "include summary"},
@@ -316,14 +312,9 @@ var MinutesDetail = common.Shortcut{
 				return err
 			}
 		}
-		// dynamic scope check
-		result, err := runtime.Factory.Credential.ResolveToken(ctx, credential.NewTokenSpec(runtime.As(), runtime.Config.AppID))
-		if err == nil && result != nil && result.Scopes != "" {
-			if missing := auth.MissingScopes(result.Scopes, scopesDetailMinuteTokens); len(missing) > 0 {
-				return errs.NewPermissionError(errs.SubtypeMissingScope,
-					"missing required scope(s): %s", strings.Join(missing, ", ")).
-					WithMissingScopes(missing...).
-					WithIdentity(string(runtime.As()))
+		if len(requestedMinutesDetailArtifactFlags(runtime)) > 0 {
+			if err := runtime.EnsureScopes([]string{minutesDetailArtifactsScope}); err != nil {
+				return err
 			}
 		}
 		return nil
@@ -334,7 +325,7 @@ var MinutesDetail = common.Shortcut{
 			GET("/open-apis/minutes/v1/minutes/{minute_token}").
 			Set("minute_tokens", common.SplitCSV(tokens))
 
-		if runtime.Bool("summary") || runtime.Bool("todo") || runtime.Bool("chapter") || runtime.Bool("transcript") || runtime.Bool("keyword") {
+		if len(requestedMinutesDetailArtifactFlags(runtime)) > 0 {
 			d.GET("/open-apis/minutes/v1/minutes/{minute_token}/artifacts")
 		}
 		return d

--- a/shortcuts/minutes/minutes_detail_test.go
+++ b/shortcuts/minutes/minutes_detail_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -19,10 +20,21 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+// minutesDetailScopedTokenResolver returns a token with caller-controlled scopes
+// so tests can deterministically exercise the shortcut scope preflight.
+type minutesDetailScopedTokenResolver struct {
+	scopes string
+}
+
+func (r *minutesDetailScopedTokenResolver) ResolveToken(ctx context.Context, req credential.TokenSpec) (*credential.TokenResult, error) {
+	return &credential.TokenResult{Token: "test-token", Scopes: r.scopes}, nil
+}
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -140,6 +152,60 @@ func TestDetail_Validation_InvalidToken(t *testing.T) {
 	}
 	if ve.Param != "--minute-tokens" {
 		t.Errorf("Param = %q, want --minute-tokens", ve.Param)
+	}
+}
+
+func TestDetail_ArtifactScopeIsConditional(t *testing.T) {
+	if got := MinutesDetail.Scopes; !reflect.DeepEqual(got, []string{minutesDetailBasicScope}) {
+		t.Fatalf("Scopes = %v, want only %s", got, minutesDetailBasicScope)
+	}
+	if got := MinutesDetail.ConditionalScopes; !reflect.DeepEqual(got, []string{minutesDetailArtifactsScope}) {
+		t.Fatalf("ConditionalScopes = %v, want [%s]", got, minutesDetailArtifactsScope)
+	}
+}
+
+func TestDetail_Validation_BasicReadDoesNotRequireArtifactsScope(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	f.Credential = credential.NewCredentialProvider(nil, nil, &minutesDetailScopedTokenResolver{scopes: minutesDetailBasicScope}, nil)
+	reg.Register(detailMinuteGetStub("tokbasiconly", "note_basic", "Basic Only"))
+
+	err := detailMountAndRun(t, MinutesDetail, []string{"+detail", "--minute-tokens", "tokbasiconly", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("metadata +detail should not require %s: %v", minutesDetailArtifactsScope, err)
+	}
+	m := firstDetailMinute(t, stdout.Bytes())
+	if m["note_id"] != "note_basic" {
+		t.Fatalf("note_id = %v, want note_basic", m["note_id"])
+	}
+}
+
+func TestDetail_Validation_TranscriptRequiresArtifactsScope(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	f.Credential = credential.NewCredentialProvider(nil, nil, &minutesDetailScopedTokenResolver{scopes: minutesDetailBasicScope}, nil)
+
+	err := detailMountAndRun(t, MinutesDetail, []string{"+detail", "--minute-tokens", "toktrans", "--transcript", "--as", "user"}, f, nil)
+	if err == nil {
+		t.Fatal("expected missing_scope error for --transcript without artifacts:read")
+	}
+	var permErr *errs.PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *errs.PermissionError, got %T: %v", err, err)
+	}
+	if permErr.Subtype != errs.SubtypeMissingScope {
+		t.Fatalf("Subtype = %q, want %q", permErr.Subtype, errs.SubtypeMissingScope)
+	}
+	if permErr.Identity != "user" {
+		t.Fatalf("Identity = %q, want user", permErr.Identity)
+	}
+	foundScope := false
+	for _, s := range permErr.MissingScopes {
+		if s == minutesDetailArtifactsScope {
+			foundScope = true
+			break
+		}
+	}
+	if !foundScope {
+		t.Fatalf("MissingScopes must include %s, got %v", minutesDetailArtifactsScope, permErr.MissingScopes)
 	}
 }
 

--- a/shortcuts/minutes/skill_docs_test.go
+++ b/shortcuts/minutes/skill_docs_test.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
 )
 
 func hasAuthType(authTypes []string, want string) bool {
@@ -82,5 +84,42 @@ func TestMinutesApplyPermissionHasReference(t *testing.T) {
 	skill := readSkillDoc(t, "skills/lark-minutes/SKILL.md")
 	if !strings.Contains(skill, "[`+apply-permission`](references/lark-minutes-apply-permission.md)") {
 		t.Error("skills/lark-minutes/SKILL.md Shortcuts table must link +apply-permission to its reference doc")
+	}
+}
+
+func hasFlag(flags []common.Flag, want string) bool {
+	for _, f := range flags {
+		if f.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMeetingSummaryWorkflowDocumentsMinuteTokenFallback pins the fallback that
+// issue #2379 found missing: the meeting-summary workflow used to tell the agent
+// to report "无纪要" whenever a meeting had no note_id, even though such meetings
+// often still carry a readable minute_token. It also pins the fallback commands
+// against the flag names the shortcuts actually declare, since +detail takes the
+// plural --minute-tokens while +apply-permission takes the singular form.
+func TestMeetingSummaryWorkflowDocumentsMinuteTokenFallback(t *testing.T) {
+	if !hasFlag(MinutesDetail.Flags, "minute-tokens") {
+		t.Fatalf("MinutesDetail flags = %v, want minute-tokens", MinutesDetail.Flags)
+	}
+	if !hasFlag(MinutesApplyPermission.Flags, "minute-token") {
+		t.Fatalf("MinutesApplyPermission flags = %v, want minute-token", MinutesApplyPermission.Flags)
+	}
+
+	workflow := readSkillDoc(t, "skills/lark-workflow-meeting-summary/SKILL.md")
+	for _, must := range []string{
+		"minutes +detail --minute-tokens",
+		"minutes +apply-permission --minute-token ",
+		"--transcript",
+		"--output-dir",
+		"No read permission",
+	} {
+		if !strings.Contains(workflow, must) {
+			t.Errorf("lark-workflow-meeting-summary/SKILL.md must cover %q so a missing note_id is not reported as 无纪要", must)
+		}
 	}
 }

--- a/skills/lark-workflow-meeting-summary/SKILL.md
+++ b/skills/lark-workflow-meeting-summary/SKILL.md
@@ -29,6 +29,7 @@ metadata:
 ```bash
 lark-cli auth login --domain vc        # 基础（查询+纪要）
 lark-cli auth login --domain vc,drive   # 含读取纪要文档正文、生成文档
+lark-cli auth login --domain vc,drive,minutes  # 含无 note_id 时的妙记备选路径
 ```
 
 ## 工作流
@@ -80,8 +81,17 @@ lark-cli note +detail --note-id "note_id"
 ```
 - 根据上一步搜集到的 `meeting-id` 查询。
 - 单次最多查询 50 个，超过 50 个需分批调用。
-- 部分会议没有 `note_id` 或报错 `no notes available`，在最终输出中标注"无纪要"。
+- 部分会议没有 `note_id` 或报错 `no notes available`，**不要直接标注"无纪要"**：先看 `vc +detail` 是否返回了 `minute_token`，有则走下面的妙记备选路径；`note_id` 和 `minute_token` 都没有时才标注"无纪要"。
 - 记录每个纪要的 `note_id`（纪要 ID）、`note_display_type`（展示类型：`unknown` / `normal` / `unified`）、`note_doc_token`（纪要文档 Token）和 `verbatim_doc_token`（逐字稿文档 Token）。
+
+> **妙记备选路径（无 `note_id`、有 `minute_token` 时）**：智能纪要与妙记是两条独立产物链路，缺少智能纪要不代表这场会没有内容。
+>
+> ```bash
+> # --minute-tokens 是复数形式（+download 同）；--output-dir 只接受相对路径
+> lark-cli minutes +detail --minute-tokens "<minute_token>" --transcript --output-dir ./transcripts --as user
+> ```
+>
+> 逐字稿会落盘，供 Step 4 基于原始发言独立提炼（不要照搬 AI 总结）。若返回 `No read permission`（`2091005`），先把无权限事实告知用户，用户明确同意后再用单数 flag 申请：`lark-cli minutes +apply-permission --minute-token "<minute_token>" --perm view --as user`；申请需 owner 在客户端批准后才可重试。详见 [lark-minutes](../lark-minutes/SKILL.md)。
 
 > **逐字稿路由按 `note_display_type` 决定**（详见 [vc-domain-boundaries.md](../lark-vc/references/vc-domain-boundaries.md) 的 Note 域）：
 > - `normal`：逐字稿是独立文档，链接/正文走 `verbatim_doc_token`。
@@ -119,4 +129,5 @@ lark-cli docs +update --doc "<url_or_token>" --command append --doc-format markd
 - [lark-shared](../lark-shared/SKILL.md) — 认证、权限（必读）
 - [lark-vc](../lark-vc/SKILL.md) — `+search`、`+detail` 详细用法
 - [lark-note](../lark-note/SKILL.md) — `note +detail`、`note +transcript`（unified 纪要逐字稿）
+- [lark-minutes](../lark-minutes/SKILL.md) — `minutes +detail`、`+apply-permission`（无 `note_id` 时的妙记备选路径）
 - [lark-doc](../lark-doc/SKILL.md) — `+fetch`、`+create`、`+update` 详细用法


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fallback workflow for meetings without a note ID, using available minute tokens to retrieve transcripts.
  * Added guidance for handling missing transcript permissions, including user-approved permission requests.
  * Added support for authentication across video conferencing, drive, and minutes services.

* **Bug Fixes**
  * Improved artifact permission handling so basic minute details remain available without transcript access.
  * Transcript requests now provide clearer missing-permission errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->