### PR TITLE
fix(auth): preserve stored token read errors

### DIFF
--- a/cmd/auth/check.go
+++ b/cmd/auth/check.go
@@ -74,7 +74,10 @@ func authCheckRunWithRecovery(opts *CheckOptions, projector *recovery.Projector)
 		return output.ErrBare(1)
 	}
 
-	stored := larkauth.GetStoredToken(config.AppID, config.UserOpenId)
+	stored, err := larkauth.GetStoredToken(config.AppID, config.UserOpenId)
+	if err != nil {
+		return err
+	}
 	if stored == nil {
 		output.PrintJson(f.IOStreams.Out, map[string]interface{}{"ok": false, "error": "no_token", "missing": required})
 		return output.ErrBare(1)

--- a/cmd/auth/check_test.go
+++ b/cmd/auth/check_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	larkauth "github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/keychain"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/recovery"
 	"github.com/larksuite/cli/internal/surface"
@@ -80,6 +82,34 @@ func TestAuthCheckRun_NoStoredToken_ExitOneWithStdoutOnly(t *testing.T) {
 	}
 	if payload["error"] != "no_token" {
 		t.Errorf("stdout.error = %v, want 'no_token'", payload["error"])
+	}
+}
+
+func TestAuthCheckRun_CorruptStoredTokenReturnsStorageError(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_DATA_DIR", t.TempDir())
+
+	cfg := &core.CliConfig{
+		AppID:      "test-app-corrupt",
+		AppSecret:  "test-secret",
+		Brand:      core.BrandFeishu,
+		UserOpenId: "ou_corrupt",
+		UserName:   "tester",
+	}
+	if err := keychain.Set(keychain.LarkCliService, cfg.AppID+":"+cfg.UserOpenId,
+		`{"accessToken":"sensitive-access-token"`); err != nil {
+		t.Fatalf("keychain.Set() error = %v", err)
+	}
+	f, stdout, _, _ := cmdutil.TestFactory(t, cfg)
+
+	err := authCheckRun(&CheckOptions{Factory: f, Scope: "calendar:calendar:read"})
+	var storageErr *errs.InternalError
+	if !errors.As(err, &storageErr) || storageErr.Subtype != errs.SubtypeStorage {
+		t.Fatalf("authCheckRun() error = %T %v, want internal/storage", err, err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no false no_token result", stdout.String())
 	}
 }
 

--- a/cmd/auth/list.go
+++ b/cmd/auth/list.go
@@ -109,7 +109,10 @@ func authListRunWithRecovery(opts *ListOptions, projector *recovery.Projector) e
 
 	var items []map[string]interface{}
 	for _, u := range app.Users {
-		stored := larkauth.GetStoredToken(app.AppId, u.UserOpenId)
+		stored, err := larkauth.GetStoredToken(app.AppId, u.UserOpenId)
+		if err != nil {
+			return err
+		}
 		status := "no_token"
 		if stored != nil {
 			status = larkauth.TokenStatus(stored)

--- a/cmd/auth/login_result.go
+++ b/cmd/auth/login_result.go
@@ -59,7 +59,11 @@ func ensureRequestedScopesGranted(requestedScope, grantedScope string, msg *logi
 // previously stored scopes, and the newly granted scopes from the current login.
 func loadLoginScopeSummary(appID, openId, requestedScope, grantedScope string) *loginScopeSummary {
 	previousScope := ""
-	if previous := larkauth.GetStoredToken(appID, openId); previous != nil {
+	// Reading the previous token is best-effort here: a successful login must be
+	// able to replace corrupt stored data. SetStoredToken remains the authoritative
+	// storage check later in the flow.
+	previous, _ := larkauth.GetStoredToken(appID, openId)
+	if previous != nil {
 		previousScope = previous.Scope
 	}
 	return buildLoginScopeSummary(requestedScope, previousScope, grantedScope)

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -798,7 +798,10 @@ func TestAuthLoginRun_MissingRequestedScopeAlignsWithLoginSuccess(t *testing.T) 
 	if strings.Contains(got, "ERROR:") {
 		t.Fatalf("stderr should not contain error prefix, got:\n%s", got)
 	}
-	stored := larkauth.GetStoredToken("cli_test", "ou_user")
+	stored, err := larkauth.GetStoredToken("cli_test", "ou_user")
+	if err != nil {
+		t.Fatalf("GetStoredToken() error = %v", err)
+	}
 	if stored == nil {
 		t.Fatal("expected token to be stored when authorization succeeds with missing scopes")
 	}

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -83,7 +83,10 @@ func authLogoutRun(opts *LogoutOptions) error {
 
 	for _, user := range app.Users {
 		if httpErr == nil && secretErr == nil {
-			if token := larkauth.GetStoredToken(app.AppId, user.UserOpenId); token != nil {
+			token, err := larkauth.GetStoredToken(app.AppId, user.UserOpenId)
+			if err != nil {
+				fmt.Fprintf(f.IOStreams.ErrOut, "Warning: failed to read token for revocation for %s: %v\n", user.UserOpenId, err)
+			} else if token != nil {
 				revokeToken := token.RefreshToken
 				tokenTypeHint := "refresh_token"
 				if revokeToken == "" {

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -207,7 +207,10 @@ func TestAuthLogoutRun_RevokesTokenAndClearsLocalState(t *testing.T) {
 	if got := stderr.String(); !strings.Contains(got, "Logged out") {
 		t.Fatalf("stderr = %q, want Logged out", got)
 	}
-	if got := larkauth.GetStoredToken("cli_test", "ou_user"); got != nil {
+	if got, err := larkauth.GetStoredToken("cli_test", "ou_user"); err != nil || got != nil {
+		if err != nil {
+			t.Fatalf("GetStoredToken() error = %v", err)
+		}
 		t.Fatalf("expected stored token removed, got %#v", got)
 	}
 	saved, err := core.LoadMultiAppConfig()
@@ -277,7 +280,10 @@ func TestAuthLogoutRun_FallsBackToAccessTokenWhenRefreshTokenMissing(t *testing.
 	if got := stderr.String(); !strings.Contains(got, "Logged out") {
 		t.Fatalf("stderr = %q, want Logged out", got)
 	}
-	if got := larkauth.GetStoredToken("cli_test", "ou_user"); got != nil {
+	if got, err := larkauth.GetStoredToken("cli_test", "ou_user"); err != nil || got != nil {
+		if err != nil {
+			t.Fatalf("GetStoredToken() error = %v", err)
+		}
 		t.Fatalf("expected stored token removed, got %#v", got)
 	}
 	saved, err := core.LoadMultiAppConfig()
@@ -343,7 +349,10 @@ func TestAuthLogoutRun_RevokeFailureStillClearsLocalState(t *testing.T) {
 	if !strings.Contains(gotErr, "Logged out") {
 		t.Fatalf("stderr = %q, want Logged out", gotErr)
 	}
-	if got := larkauth.GetStoredToken("cli_test", "ou_user"); got != nil {
+	if got, err := larkauth.GetStoredToken("cli_test", "ou_user"); err != nil || got != nil {
+		if err != nil {
+			t.Fatalf("GetStoredToken() error = %v", err)
+		}
 		t.Fatalf("expected stored token removed, got %#v", got)
 	}
 	saved, err := core.LoadMultiAppConfig()

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -120,6 +120,8 @@ func addEffectiveVerification(result map[string]interface{}, d identitydiag.Resu
 
 func addStatusNote(result map[string]interface{}, d identitydiag.Result, canAuthLogin bool) {
 	switch {
+	case d.User.Status == identitydiag.StatusStorageError:
+		result["note"] = "User credential storage is unavailable; resolve the storage error before using user identity."
 	case !d.User.Available && d.Bot.Available:
 		note := "User identity is " + identitydiag.StatusMessage(d.User.Status) + "; bot identity is ready for bot/tenant API calls."
 		if canAuthLogin {

--- a/cmd/auth/status_test.go
+++ b/cmd/auth/status_test.go
@@ -6,11 +6,13 @@ package auth
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/identitydiag"
 )
 
 func TestAuthStatusRun_SplitsBotAndUserIdentity(t *testing.T) {
@@ -76,6 +78,19 @@ func TestAuthStatusRun_VerifyReportsBotIdentity(t *testing.T) {
 	}
 	if got.Identities.User.Status != "missing" {
 		t.Fatalf("user status = %q, want missing", got.Identities.User.Status)
+	}
+}
+
+func TestAddStatusNote_StorageErrorDoesNotSuggestLogin(t *testing.T) {
+	result := map[string]interface{}{}
+	addStatusNote(result, identitydiag.Result{
+		Bot:  identitydiag.Identity{Status: identitydiag.StatusReady, Available: true},
+		User: identitydiag.Identity{Status: identitydiag.StatusStorageError},
+	}, true)
+
+	note, _ := result["note"].(string)
+	if !strings.Contains(note, "storage") || strings.Contains(note, "auth login") {
+		t.Fatalf("note = %q, want storage guidance without re-login suggestion", note)
 	}
 }
 

--- a/cmd/profile/list.go
+++ b/cmd/profile/list.go
@@ -96,7 +96,10 @@ func profileListRun(f *cmdutil.Factory) error {
 
 		if len(app.Users) > 0 {
 			item.User = app.Users[0].UserName
-			stored := larkauth.GetStoredToken(app.AppId, app.Users[0].UserOpenId)
+			stored, err := larkauth.GetStoredToken(app.AppId, app.Users[0].UserOpenId)
+			if err != nil {
+				return err
+			}
 			if stored != nil {
 				item.TokenStatus = larkauth.TokenStatus(stored)
 			}

--- a/internal/auth/token_store.go
+++ b/internal/auth/token_store.go
@@ -43,12 +43,9 @@ func MaskToken(token string) string {
 }
 
 // GetStoredToken reads the stored UAT for a given (appId, userOpenId) pair.
-func GetStoredToken(appId, userOpenId string) *StoredUAToken {
-	token, _ := readStoredToken(appId, userOpenId)
-	return token
-}
-
-func readStoredToken(appId, userOpenId string) (*StoredUAToken, error) {
+// A missing credential returns (nil, nil); storage and decoding failures are
+// returned so callers cannot misreport an inaccessible credential as missing.
+func GetStoredToken(appId, userOpenId string) (*StoredUAToken, error) {
 	jsonStr, err := keychain.Get(keychain.LarkCliService, accountKey(appId, userOpenId))
 	if err != nil {
 		storageErr := errs.NewInternalError(errs.SubtypeStorage,
@@ -143,7 +140,7 @@ func compareAndSwapStoredToken(appID, userOpenID string, expected, updated *Stor
 			"cannot compare and swap stored tokens for different accounts")
 	}
 
-	current, err := readStoredToken(appID, userOpenID)
+	current, err := GetStoredToken(appID, userOpenID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -169,7 +166,7 @@ func compareAndDeleteStoredToken(appID, userOpenID string, expected *StoredUATok
 			"cannot compare and delete a stored token for a different account")
 	}
 
-	current, err := readStoredToken(appID, userOpenID)
+	current, err := GetStoredToken(appID, userOpenID)
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/auth/token_store.go
+++ b/internal/auth/token_store.go
@@ -65,6 +65,12 @@ func GetStoredToken(appId, userOpenId string) (*StoredUAToken, error) {
 			"failed to decode stored token: %v", err).
 			WithCause(errors.Join(errStoredTokenCorrupt, err))
 	}
+	if token.AppId == "" || token.UserOpenId == "" ||
+		token.AppId != appId || token.UserOpenId != userOpenId {
+		return nil, errs.NewInternalError(errs.SubtypeStorage,
+			"stored token account identity is missing or does not match its storage key").
+			WithCause(errStoredTokenCorrupt)
+	}
 	return &token, nil
 }
 

--- a/internal/auth/token_store_test.go
+++ b/internal/auth/token_store_test.go
@@ -33,6 +33,22 @@ func mustGetStoredToken(t *testing.T, appID, userOpenID string) *StoredUAToken {
 	return token
 }
 
+func requireStoredTokenCorrupt(t *testing.T, err error, sensitiveValues ...string) {
+	t.Helper()
+	var storageErr *errs.InternalError
+	if !errors.As(err, &storageErr) || storageErr.Subtype != errs.SubtypeStorage {
+		t.Fatalf("error = %T %v, want internal/storage", err, err)
+	}
+	if !errors.Is(err, errStoredTokenCorrupt) {
+		t.Fatalf("error = %v, want corrupt-token cause", err)
+	}
+	for _, sensitive := range sensitiveValues {
+		if sensitive != "" && strings.Contains(err.Error(), sensitive) {
+			t.Fatalf("error leaked stored token content %q: %v", sensitive, err)
+		}
+	}
+}
+
 func TestGetStoredTokenDistinguishesMissingFromCorrupt(t *testing.T) {
 	setupStoredTokenTest(t)
 
@@ -50,15 +66,63 @@ func TestGetStoredTokenDistinguishesMissingFromCorrupt(t *testing.T) {
 	if stored != nil || err == nil {
 		t.Fatalf("corrupt token = (%#v, %v), want (nil, error)", stored, err)
 	}
-	var storageErr *errs.InternalError
-	if !errors.As(err, &storageErr) || storageErr.Subtype != errs.SubtypeStorage {
-		t.Fatalf("error = %T %v, want internal/storage", err, err)
+	requireStoredTokenCorrupt(t, err, sensitive)
+}
+
+func TestGetStoredTokenRejectsInvalidAccountIdentity(t *testing.T) {
+	setupStoredTokenTest(t)
+
+	tests := []struct {
+		name            string
+		appID           string
+		userOpenID      string
+		record          string
+		sensitiveValues []string
+	}{
+		{
+			name:            "missing app ID",
+			appID:           "cli_missing_app",
+			userOpenID:      "ou_missing_app",
+			record:          `{"userOpenId":"ou_missing_app","accessToken":"access-missing-app"}`,
+			sensitiveValues: []string{"access-missing-app"},
+		},
+		{
+			name:            "missing user open ID",
+			appID:           "cli_missing_user",
+			userOpenID:      "ou_missing_user",
+			record:          `{"appId":"cli_missing_user","refreshToken":"refresh-missing-user"}`,
+			sensitiveValues: []string{"refresh-missing-user"},
+		},
+		{
+			name:       "mismatched app ID",
+			appID:      "cli_expected_app",
+			userOpenID: "ou_expected_app",
+			record: `{"appId":"cli_stored_app","userOpenId":"ou_expected_app",` +
+				`"accessToken":"access-mismatched-app"}`,
+			sensitiveValues: []string{"cli_stored_app", "access-mismatched-app"},
+		},
+		{
+			name:       "mismatched user open ID",
+			appID:      "cli_expected_user",
+			userOpenID: "ou_expected_user",
+			record: `{"appId":"cli_expected_user","userOpenId":"ou_stored_user",` +
+				`"refreshToken":"refresh-mismatched-user"}`,
+			sensitiveValues: []string{"ou_stored_user", "refresh-mismatched-user"},
+		},
 	}
-	if !errors.Is(err, errStoredTokenCorrupt) {
-		t.Fatalf("error = %v, want corrupt-token cause", err)
-	}
-	if strings.Contains(err.Error(), sensitive) {
-		t.Fatalf("error leaked stored token content: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := keychain.Set(keychain.LarkCliService, accountKey(tt.appID, tt.userOpenID),
+				tt.record); err != nil {
+				t.Fatalf("keychain.Set() error = %v", err)
+			}
+			stored, err := GetStoredToken(tt.appID, tt.userOpenID)
+			if stored != nil || err == nil {
+				t.Fatalf("invalid identity token = (%#v, %v), want (nil, error)", stored, err)
+			}
+			requireStoredTokenCorrupt(t, err, tt.sensitiveValues...)
+		})
 	}
 }
 

--- a/internal/auth/token_store_test.go
+++ b/internal/auth/token_store_test.go
@@ -4,10 +4,14 @@
 package auth
 
 import (
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/keychain"
 	"github.com/zalando/go-keyring"
 )
 
@@ -18,6 +22,44 @@ func setupStoredTokenTest(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_DATA_DIR", filepath.Join(root, "data"))
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", filepath.Join(root, "config"))
 	keyring.MockInit()
+}
+
+func mustGetStoredToken(t *testing.T, appID, userOpenID string) *StoredUAToken {
+	t.Helper()
+	token, err := GetStoredToken(appID, userOpenID)
+	if err != nil {
+		t.Fatalf("GetStoredToken() error = %v", err)
+	}
+	return token
+}
+
+func TestGetStoredTokenDistinguishesMissingFromCorrupt(t *testing.T) {
+	setupStoredTokenTest(t)
+
+	stored, err := GetStoredToken("cli_missing", "ou_missing")
+	if err != nil || stored != nil {
+		t.Fatalf("missing token = (%#v, %v), want (nil, nil)", stored, err)
+	}
+
+	const sensitive = "sensitive-access-token"
+	if err := keychain.Set(keychain.LarkCliService, accountKey("cli_corrupt", "ou_corrupt"),
+		`{"accessToken":"`+sensitive+`"`); err != nil {
+		t.Fatalf("keychain.Set() error = %v", err)
+	}
+	stored, err = GetStoredToken("cli_corrupt", "ou_corrupt")
+	if stored != nil || err == nil {
+		t.Fatalf("corrupt token = (%#v, %v), want (nil, error)", stored, err)
+	}
+	var storageErr *errs.InternalError
+	if !errors.As(err, &storageErr) || storageErr.Subtype != errs.SubtypeStorage {
+		t.Fatalf("error = %T %v, want internal/storage", err, err)
+	}
+	if !errors.Is(err, errStoredTokenCorrupt) {
+		t.Fatalf("error = %v, want corrupt-token cause", err)
+	}
+	if strings.Contains(err.Error(), sensitive) {
+		t.Fatalf("error leaked stored token content: %v", err)
+	}
 }
 
 func TestStoredTokenGenerationGuard(t *testing.T) {
@@ -88,7 +130,7 @@ func TestStoredTokenGenerationGuard(t *testing.T) {
 		}
 		return err
 	})
-	if current := GetStoredToken(generation0.AppId, generation0.UserOpenId); current != nil {
+	if current := mustGetStoredToken(t, generation0.AppId, generation0.UserOpenId); current != nil {
 		t.Fatalf("stored token = %#v, want removed", current)
 	}
 }

--- a/internal/auth/uat_client.go
+++ b/internal/auth/uat_client.go
@@ -58,7 +58,7 @@ func NewUATCallOptions(cfg *core.CliConfig, errOut io.Writer) UATCallOptions {
 
 // GetValidAccessToken obtains a valid access token for the given user.
 func GetValidAccessToken(httpClient *http.Client, opts UATCallOptions) (string, error) {
-	stored, err := readStoredToken(opts.AppId, opts.UserOpenId)
+	stored, err := GetStoredToken(opts.AppId, opts.UserOpenId)
 	if errors.Is(err, errStoredTokenCorrupt) {
 		return "", newNeedUserAuthorizationError(opts.UserOpenId, err, recovery.UserAuthorization())
 	}
@@ -88,7 +88,7 @@ func GetValidAccessToken(httpClient *http.Client, opts UATCallOptions) (string, 
 func refreshWithLock(httpClient *http.Client, opts UATCallOptions) (*StoredUAToken, error) {
 	var refreshed *StoredUAToken
 	err := withTokenStorageLock(opts.AppId, opts.UserOpenId, func() error {
-		freshStored, err := readStoredToken(opts.AppId, opts.UserOpenId)
+		freshStored, err := GetStoredToken(opts.AppId, opts.UserOpenId)
 		if errors.Is(err, errStoredTokenCorrupt) {
 			return newNeedUserAuthorizationError(opts.UserOpenId, err, recovery.UserAuthorization())
 		}

--- a/internal/auth/uat_client_refresh_test.go
+++ b/internal/auth/uat_client_refresh_test.go
@@ -147,7 +147,7 @@ func TestGetValidAccessTokenRetriesAndStoresSuccessfulRefresh(t *testing.T) {
 	if accessToken != "access-new" || calls.Load() != 2 {
 		t.Fatalf("refresh result = (%q, %d calls), want access-new after one retry", accessToken, calls.Load())
 	}
-	current := GetStoredToken(stored.AppId, stored.UserOpenId)
+	current := mustGetStoredToken(t, stored.AppId, stored.UserOpenId)
 	if current == nil || current.RefreshToken != "refresh-new" || current.Scope != stored.Scope || current.GrantedAt != stored.GrantedAt {
 		t.Fatalf("stored token = %#v, want refreshed generation with stable metadata", current)
 	}
@@ -274,7 +274,7 @@ func TestRefreshFailureDeterminesStoredTokenDisposition(t *testing.T) {
 			if calls.Load() != tt.wantCalls {
 				t.Fatalf("request count = %d, want %d", calls.Load(), tt.wantCalls)
 			}
-			current := GetStoredToken(stored.AppId, stored.UserOpenId)
+			current := mustGetStoredToken(t, stored.AppId, stored.UserOpenId)
 			if tt.wantPreserved {
 				if current == nil || current.RefreshToken != stored.RefreshToken {
 					t.Fatalf("stored token = %#v, want original generation preserved", current)
@@ -334,7 +334,7 @@ func TestRefreshDoesNotOverwriteNewerGeneration(t *testing.T) {
 			}}, &calls)
 
 			accessToken, err := GetValidAccessToken(client, newRefreshTestOptions(stored))
-			current := GetStoredToken(stored.AppId, stored.UserOpenId)
+			current := mustGetStoredToken(t, stored.AppId, stored.UserOpenId)
 			if tt.deleteNext {
 				if !IsNeedUserAuthorizationError(err) || accessToken != "" || current != nil {
 					t.Fatalf("logout result = (access=%q, err=%v, stored=%#v), want deleted generation", accessToken, err, current)
@@ -439,7 +439,7 @@ func TestRefreshStopsBeforeRequestWhenStorageProbeFails(t *testing.T) {
 	if _, ok := errs.ProblemOf(err); !ok || !errors.Is(err, sentinel) {
 		t.Fatalf("error = %v (%T), want typed storage failure preserving cause", err, err)
 	}
-	current := GetStoredToken(stored.AppId, stored.UserOpenId)
+	current := mustGetStoredToken(t, stored.AppId, stored.UserOpenId)
 	if current == nil || current.RefreshToken != stored.RefreshToken {
 		t.Fatalf("stored token = %#v, want original token preserved", current)
 	}
@@ -462,7 +462,7 @@ func TestExpiredRefreshTokenIsClearedWithoutRequest(t *testing.T) {
 	if accessToken != "" || !IsNeedUserAuthorizationError(err) {
 		t.Fatalf("expired refresh result = (access=%q, err=%v), want authorization required", accessToken, err)
 	}
-	if calls.Load() != 0 || GetStoredToken(stored.AppId, stored.UserOpenId) != nil {
+	if calls.Load() != 0 || mustGetStoredToken(t, stored.AppId, stored.UserOpenId) != nil {
 		t.Fatalf("expired refresh made %d request(s) or left token stored", calls.Load())
 	}
 }

--- a/internal/credential/credential_provider.go
+++ b/internal/credential/credential_provider.go
@@ -128,7 +128,10 @@ func (s defaultTokenSource) ResolveIdentityHint(ctx context.Context, acct *Accou
 		hint.AutoAs = core.AsBot
 		return hint, nil
 	}
-	stored := getStoredToken(acct.AppID, acct.UserOpenId)
+	stored, err := getStoredToken(acct.AppID, acct.UserOpenId)
+	if err != nil {
+		return nil, err
+	}
 	if stored == nil {
 		hint.AutoAs = core.AsBot
 		return hint, nil

--- a/internal/credential/credential_provider_test.go
+++ b/internal/credential/credential_provider_test.go
@@ -264,11 +264,11 @@ func TestCredentialProvider_ResolveIdentityHint_DefaultSourceUsesStoredTokenStat
 		getStoredTokenStatus = origTokenStatus
 	})
 
-	getStoredToken = func(appID, userOpenID string) *auth.StoredUAToken {
+	getStoredToken = func(appID, userOpenID string) (*auth.StoredUAToken, error) {
 		if appID != "default_app" || userOpenID != "ou_default" {
 			t.Fatalf("GetStoredToken() args = (%q, %q), want (%q, %q)", appID, userOpenID, "default_app", "ou_default")
 		}
-		return &auth.StoredUAToken{AppId: appID, UserOpenId: userOpenID}
+		return &auth.StoredUAToken{AppId: appID, UserOpenId: userOpenID}, nil
 	}
 	getStoredTokenStatus = func(token *auth.StoredUAToken) string {
 		return "valid"
@@ -300,9 +300,9 @@ func TestCredentialProvider_ResolveIdentityHint_CachesResult(t *testing.T) {
 
 	storedCalls := 0
 	statusCalls := 0
-	getStoredToken = func(appID, userOpenID string) *auth.StoredUAToken {
+	getStoredToken = func(appID, userOpenID string) (*auth.StoredUAToken, error) {
 		storedCalls++
-		return &auth.StoredUAToken{AppId: appID, UserOpenId: userOpenID}
+		return &auth.StoredUAToken{AppId: appID, UserOpenId: userOpenID}, nil
 	}
 	getStoredTokenStatus = func(token *auth.StoredUAToken) string {
 		statusCalls++
@@ -331,6 +331,27 @@ func TestCredentialProvider_ResolveIdentityHint_CachesResult(t *testing.T) {
 	}
 	if statusCalls != 1 {
 		t.Fatalf("TokenStatus() calls = %d, want 1", statusCalls)
+	}
+}
+
+func TestCredentialProvider_ResolveIdentityHint_PropagatesStoredTokenError(t *testing.T) {
+	origGetStoredToken := getStoredToken
+	t.Cleanup(func() { getStoredToken = origGetStoredToken })
+
+	sentinel := errors.New("stored token unavailable")
+	getStoredToken = func(string, string) (*auth.StoredUAToken, error) {
+		return nil, sentinel
+	}
+	cp := NewCredentialProvider(
+		nil,
+		&mockDefaultAcct{account: &Account{AppID: "default_app", Brand: core.BrandFeishu, UserOpenId: "ou_default"}},
+		&mockDefaultToken{result: &TokenResult{Token: "default_tok"}},
+		nil,
+	)
+
+	hint, err := cp.ResolveIdentityHint(context.Background())
+	if hint != nil || !errors.Is(err, sentinel) {
+		t.Fatalf("ResolveIdentityHint() = (%#v, %v), want (nil, stored-token error)", hint, err)
 	}
 }
 

--- a/internal/credential/default_provider.go
+++ b/internal/credential/default_provider.go
@@ -151,7 +151,10 @@ func (p *DefaultTokenProvider) resolveUAT(ctx context.Context) (*TokenResult, er
 	if err != nil {
 		return nil, err
 	}
-	stored := auth.GetStoredToken(acct.AppID, acct.UserOpenId)
+	stored, err := auth.GetStoredToken(acct.AppID, acct.UserOpenId)
+	if err != nil {
+		return nil, err
+	}
 	scopes := ""
 	if stored != nil {
 		scopes = stored.Scope

--- a/internal/identitydiag/diagnostics.go
+++ b/internal/identitydiag/diagnostics.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	extcred "github.com/larksuite/cli/extension/credential"
 	larkauth "github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -27,6 +28,7 @@ const (
 	StatusMissing       = "missing"
 	StatusNeedsRefresh  = "needs_refresh"
 	StatusVerifyFailed  = "verify_failed"
+	StatusStorageError  = "storage_error"
 )
 
 // verifyTimeout bounds each network call made during --verify so that a
@@ -295,7 +297,15 @@ func diagnoseUser(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, 
 		UserName: cfg.UserName,
 		OpenID:   cfg.UserOpenId,
 	}
-	stored := larkauth.GetStoredToken(cfg.AppID, cfg.UserOpenId)
+	stored, err := larkauth.GetStoredToken(cfg.AppID, cfg.UserOpenId)
+	if err != nil {
+		id.Status = StatusStorageError
+		id.Message = "User identity: stored token unavailable: " + err.Error()
+		if problem, ok := errs.ProblemOf(err); ok {
+			id.Hint = problem.Hint
+		}
+		return id
+	}
 	if stored == nil {
 		id.Status = StatusMissing
 		id.Message = "User identity: missing (no token in keychain for " + cfg.UserOpenId + ")"
@@ -456,6 +466,8 @@ func StatusMessage(status string) string {
 		return "not configured"
 	case StatusVerifyFailed:
 		return "verify failed"
+	case StatusStorageError:
+		return "storage error"
 	case StatusNeedsRefresh:
 		return "needs refresh"
 	case StatusMissing:

--- a/internal/identitydiag/diagnostics_test.go
+++ b/internal/identitydiag/diagnostics_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/keychain"
 	"github.com/zalando/go-keyring"
 )
 
@@ -304,6 +305,7 @@ func TestStatusMessage(t *testing.T) {
 		StatusReady:         StatusReady,
 		StatusNotConfigured: "not configured",
 		StatusVerifyFailed:  "verify failed",
+		StatusStorageError:  "storage error",
 		StatusNeedsRefresh:  "needs refresh",
 		StatusMissing:       "missing",
 		"unknown":           "unknown",
@@ -312,6 +314,33 @@ func TestStatusMessage(t *testing.T) {
 		if got := StatusMessage(in); got != want {
 			t.Errorf("StatusMessage(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestDiagnose_UserStorageErrorIsNotMissing(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_DATA_DIR", t.TempDir())
+
+	cfg := &core.CliConfig{
+		AppID:      "test-app-corrupt",
+		AppSecret:  "secret",
+		Brand:      core.BrandFeishu,
+		UserOpenId: "ou_corrupt",
+		UserName:   "tester",
+	}
+	if err := keychain.Set(keychain.LarkCliService, cfg.AppID+":"+cfg.UserOpenId,
+		`{"accessToken":"sensitive-access-token"`); err != nil {
+		t.Fatalf("keychain.Set() error = %v", err)
+	}
+
+	f, _, _, _ := cmdutil.TestFactory(t, cfg)
+	got := Diagnose(context.Background(), f, cfg, false)
+	if got.User.Status != StatusStorageError || got.User.Available {
+		t.Fatalf("user = %#v, want storage_error and unavailable", got.User)
+	}
+	if strings.Contains(got.User.Message, "sensitive-access-token") {
+		t.Fatalf("diagnostic leaked stored token content: %s", got.User.Message)
 	}
 }
 

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -2368,7 +2368,10 @@ func validateConfirmSendScope(runtime *common.RuntimeContext) error {
 	if appID == "" || userOpenId == "" {
 		return nil
 	}
-	stored := auth.GetStoredToken(appID, userOpenId)
+	stored, err := auth.GetStoredToken(appID, userOpenId)
+	if err != nil {
+		return err
+	}
 	if stored == nil {
 		return nil
 	}
@@ -2392,7 +2395,10 @@ func validateFolderReadScope(runtime *common.RuntimeContext) error {
 	if appID == "" || userOpenId == "" {
 		return nil
 	}
-	stored := auth.GetStoredToken(appID, userOpenId)
+	stored, err := auth.GetStoredToken(appID, userOpenId)
+	if err != nil {
+		return err
+	}
 	if stored == nil {
 		return nil
 	}
@@ -2416,7 +2422,10 @@ func validateLabelReadScope(runtime *common.RuntimeContext) error {
 	if appID == "" || userOpenId == "" {
 		return nil
 	}
-	stored := auth.GetStoredToken(appID, userOpenId)
+	stored, err := auth.GetStoredToken(appID, userOpenId)
+	if err != nil {
+		return err
+	}
 	if stored == nil {
 		return nil
 	}

--- a/shortcuts/mail/mail_message_manage_test.go
+++ b/shortcuts/mail/mail_message_manage_test.go
@@ -172,7 +172,10 @@ func TestMessageTrash_Metadata(t *testing.T) {
 
 func TestMessageModify_LabelOnlyDoesNotRequireFolderReadScope(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
-	token := auth.GetStoredToken("test-app", "ou_testuser")
+	token, err := auth.GetStoredToken("test-app", "ou_testuser")
+	if err != nil {
+		t.Fatalf("GetStoredToken() error = %v", err)
+	}
 	if token == nil {
 		t.Fatal("expected test token")
 	}
@@ -184,7 +187,7 @@ func TestMessageModify_LabelOnlyDoesNotRequireFolderReadScope(t *testing.T) {
 	id := messageManageID("1")
 	post := stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
 
-	err := runMountedMailShortcut(t, MailMessageModify, []string{
+	err = runMountedMailShortcut(t, MailMessageModify, []string{
 		"+message-modify",
 		"--message-ids", id,
 		"--remove-label-ids", "UNREAD",

--- a/shortcuts/mail/mail_triage_test.go
+++ b/shortcuts/mail/mail_triage_test.go
@@ -2132,7 +2132,11 @@ func TestMailTriageCustomFolderResolvesOnceAcrossListPages(t *testing.T) {
 	// is the load-bearing "exactly once" assertion).
 	const folderScope = "mail:user_mailbox.folder:read"
 	cfg := mailTestConfig()
-	if stored := auth.GetStoredToken(cfg.AppID, cfg.UserOpenId); stored != nil {
+	stored, err := auth.GetStoredToken(cfg.AppID, cfg.UserOpenId)
+	if err != nil {
+		t.Fatalf("GetStoredToken() error = %v", err)
+	}
+	if stored != nil {
 		if !strings.Contains(stored.Scope, folderScope) {
 			stored.Scope = stored.Scope + " " + folderScope
 			if err := auth.SetStoredToken(stored); err != nil {

--- a/sidecar/server-multi-tenant-demo/auth_bridge.go
+++ b/sidecar/server-multi-tenant-demo/auth_bridge.go
@@ -342,7 +342,11 @@ func (ab *authBridge) handleStatus(w http.ResponseWriter, _ *http.Request, body 
 			continue
 		}
 		for _, u := range app.Users {
-			stored := larkauth.GetStoredToken(ab.appID, u.UserOpenId)
+			stored, err := larkauth.GetStoredToken(ab.appID, u.UserOpenId)
+			if err != nil {
+				jsonError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
 			status := "unknown"
 			if stored != nil {
 				status = larkauth.TokenStatus(stored)
@@ -368,7 +372,11 @@ func (ab *authBridge) handleStatus(w http.ResponseWriter, _ *http.Request, body 
 		resp["client_id"] = clientID
 		resp["mapped_open_id"] = mappedOpenID
 		if mappedOpenID != "" {
-			stored := larkauth.GetStoredToken(ab.appID, mappedOpenID)
+			stored, err := larkauth.GetStoredToken(ab.appID, mappedOpenID)
+			if err != nil {
+				jsonError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
 			if stored != nil {
 				resp["mapped_status"] = larkauth.TokenStatus(stored)
 				for _, u := range users {


### PR DESCRIPTION
## Summary

Preserve stored user-token read failures so inaccessible or corrupt credentials are no longer reported as missing. This keeps the existing typed storage error and keychain recovery hint visible to commands and diagnostics.

## Changes

- Make `internal/auth.GetStoredToken` return both the stored token and any storage or decoding error, then migrate callers to handle the distinction explicitly.
- Propagate failures through automatic identity selection, auth/profile commands, mail scope validation, and the sidecar status endpoint.
- Report `storage_error` from identity diagnostics and avoid suggesting a new login when credential storage is the actual problem.
- Keep login replacement and logout cleanup recoverable when an old token is corrupt, while surfacing a warning when revocation cannot read the token.
- Add regression coverage for absent versus corrupt credentials, typed error propagation, false `no_token` prevention, recovery guidance, and sensitive-value redaction.

## Test Plan

- [x] `gofmt` reports no unformatted changed files
- [x] `git diff --check`
- [ ] Unit tests pass (GitHub Actions; project dependencies were intentionally not downloaded locally)
- [ ] Manual local verification confirms the `lark-cli auth status --json --verify` flow works as expected

## Related Issues

- Fixes #1925


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication commands now distinguish missing credentials from unreadable or corrupted credential storage.
  * Invalid or mismatched stored credentials are rejected safely without exposing sensitive token data.
  * Storage and token retrieval errors are surfaced consistently instead of being treated as missing tokens.
  * Logout safely skips revocation when credentials cannot be read and provides a warning.
  * Profile, mail shortcuts, identity diagnostics, and status checks now report credential-storage issues accurately.
  * The multi-tenant status endpoint returns an appropriate server error when credential lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->