### PR TITLE
feat(base): support button block type in dashboard

### DIFF
--- a/shortcuts/base/base_dashboard_execute_test.go
+++ b/shortcuts/base/base_dashboard_execute_test.go
@@ -927,6 +927,181 @@ func TestBaseDashboardBlockExecuteUpdate_TextType(t *testing.T) {
 	})
 }
 
+// ── Button Block Tests ────────────────────────────────────────────────
+
+// TestBaseDashboardBlockExecuteCreate_ButtonType tests creating button blocks bound to a workflow.
+func TestBaseDashboardBlockExecuteCreate_ButtonType(t *testing.T) {
+	t.Run("valid button block", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"block_id": "blk_btn",
+					"name":     "同步按钮",
+					"type":     "button",
+					"data_config": map[string]interface{}{
+						"workflow_id": "wkf_abc123",
+					},
+				},
+			},
+		})
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "同步按钮", "--type", "button",
+			"--data-config", `{"workflow_id":"wkf_abc123"}`,
+		}
+		if err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout); err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		got := stdout.String()
+		if !strings.Contains(got, `"blk_btn"`) || !strings.Contains(got, `"created": true`) {
+			t.Fatalf("stdout=%s", got)
+		}
+	})
+
+	t.Run("button block missing workflow_id", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "Bad", "--type", "button",
+			"--data-config", `{}`,
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for missing workflow_id")
+		}
+		if got := err.Error(); !strings.Contains(got, "workflow_id") || !strings.Contains(got, "data_config 校验失败") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("button block missing data-config", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "NoConfig", "--type", "button",
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for missing data-config")
+		}
+		if got := err.Error(); !strings.Contains(got, "workflow_id") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("button block empty workflow_id", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "Empty", "--type", "button",
+			"--data-config", `{"workflow_id":""}`,
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for empty workflow_id")
+		}
+		if got := err.Error(); !strings.Contains(got, "workflow_id") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("button block no-validate skips check", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"block_id": "blk_btn2",
+					"name":     "NoValidate",
+					"type":     "button",
+				},
+			},
+		})
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "NoValidate", "--type", "button",
+			"--data-config", `{}`,
+			"--no-validate",
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		got := stdout.String()
+		if !strings.Contains(got, `"created": true`) {
+			t.Fatalf("stdout=%s", got)
+		}
+	})
+}
+
+// TestBaseDashboardBlockExecuteUpdate_ButtonType tests updating button block workflow binding.
+func TestBaseDashboardBlockExecuteUpdate_ButtonType(t *testing.T) {
+	t.Run("update button workflow_id", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "PATCH",
+			URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks/blk_btn",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"block_id": "blk_btn",
+					"name":     "更新按钮",
+					"type":     "button",
+					"data_config": map[string]interface{}{
+						"workflow_id": "wkf_new456",
+					},
+				},
+			},
+		})
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_001", "--block-id", "blk_btn",
+			"--name", "更新按钮",
+			"--data-config", `{"workflow_id":"wkf_new456"}`,
+		}
+		if err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout); err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		got := stdout.String()
+		if !strings.Contains(got, `"updated": true`) || !strings.Contains(got, "wkf_new456") {
+			t.Fatalf("stdout=%s", got)
+		}
+	})
+
+	t.Run("update button with empty workflow_id fails", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_001", "--block-id", "blk_btn",
+			"--data-config", `{"workflow_id":""}`,
+		}
+		err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for empty workflow_id")
+		}
+		if got := err.Error(); !strings.Contains(got, "workflow_id") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// TestBaseDashboardDryRun_ButtonType tests the --dry-run output for button block create.
+func TestBaseDashboardDryRun_ButtonType(t *testing.T) {
+	factory, stdout, _ := newExecuteFactory(t)
+	args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+		"--name", "Sync", "--type", "button",
+		"--data-config", `{"workflow_id":"wkf_dry001"}`,
+		"--dry-run", "--format", "pretty",
+	}
+	if err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "POST /open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks") {
+		t.Fatalf("stdout=%s", got)
+	}
+	if !strings.Contains(got, "wkf_dry001") {
+		t.Fatalf("stdout=%s", got)
+	}
+}
+
 // ── Dashboard Arrange ────────────────────────────────────────────────
 
 // TestBaseDashboardExecuteArrange tests the +dashboard-arrange command for auto-arranging dashboard blocks.

--- a/shortcuts/base/block_data_config.go
+++ b/shortcuts/base/block_data_config.go
@@ -25,6 +25,10 @@ var chartBlockTypes = []string{
 // ({"text": "..."}).
 var textBlockTypes = []string{"text"}
 
+// buttonBlockTypes are the button block types. Dashboard button components
+// trigger a workflow when clicked; their data_config carries the workflow_id.
+var buttonBlockTypes = []string{"button"}
+
 func matchesBlockType(blockType string, candidates []string) bool {
 	trimmed := strings.ToLower(strings.TrimSpace(blockType))
 	for _, candidate := range candidates {
@@ -36,6 +40,8 @@ func matchesBlockType(blockType string, candidates []string) bool {
 }
 
 func isTextBlockType(blockType string) bool { return matchesBlockType(blockType, textBlockTypes) }
+
+func isButtonBlockType(blockType string) bool { return matchesBlockType(blockType, buttonBlockTypes) }
 
 func isChartBlockType(blockType string) bool { return matchesBlockType(blockType, chartBlockTypes) }
 
@@ -111,13 +117,16 @@ func normalizeDataConfig(cfg map[string]interface{}) map[string]interface{} {
 }
 
 // validateBlockDataConfig validates data_config based on block type.
-// Text blocks only need a text field; everything else falls through to the
-// dashboard chart rules. BaseApp list validation lives in
-// app_list_block_data_config.go and never enters this dashboard path.
+// Text blocks only need a text field; button blocks need a workflow_id;
+// everything else falls through to the dashboard chart rules. BaseApp list
+// validation lives in app_list_block_data_config.go and never enters this
+// dashboard path.
 func validateBlockDataConfig(blockType string, cfg map[string]interface{}) []string {
 	switch {
 	case isTextBlockType(blockType):
 		return validateTextDataConfig(blockType, cfg)
+	case isButtonBlockType(blockType):
+		return validateButtonDataConfig(blockType, cfg)
 	default:
 		return validateChartDataConfig(cfg)
 	}
@@ -128,6 +137,18 @@ func validateTextDataConfig(blockType string, cfg map[string]interface{}) []stri
 	var problems []string
 	if txt, _ := cfg["text"].(string); strings.TrimSpace(txt) == "" {
 		problems = append(problems, fmt.Sprintf("%s 类型组件缺少必填字段 text", strings.TrimSpace(blockType)))
+	}
+	return problems
+}
+
+// validateButtonDataConfig validates the button data_config shape.
+// Button components trigger a workflow when clicked; data_config must carry
+// a non-empty workflow_id referencing an existing workflow.
+func validateButtonDataConfig(blockType string, cfg map[string]interface{}) []string {
+	var problems []string
+	wfID, _ := cfg["workflow_id"].(string)
+	if strings.TrimSpace(wfID) == "" {
+		problems = append(problems, fmt.Sprintf("%s 类型组件缺少必填字段 workflow_id；先用 +workflow-list 查看已有工作流，将 wkf 前缀的 ID 填入", strings.TrimSpace(blockType)))
 	}
 	return problems
 }

--- a/shortcuts/base/dashboard_block_create.go
+++ b/shortcuts/base/dashboard_block_create.go
@@ -24,7 +24,7 @@ var BaseDashboardBlockCreate = common.Shortcut{
 		baseTokenFlag(true),
 		dashboardIDFlag(true),
 		{Name: "name", Desc: "block name", Required: true},
-		{Name: "type", Desc: "block type: column(柱状图)|bar(条形图)|line(折线图)|pie(饼图)|ring(环形图)|area(面积图)|combo(组合图)|scatter(散点图)|funnel(漏斗图)|wordCloud(词云)|radar(雷达图)|statistics(指标卡)|text(文本). Read lark-base-dashboard-block-config.md before creating.", Required: true},
+		{Name: "type", Desc: "block type: column(柱状图)|bar(条形图)|line(折线图)|pie(饼图)|ring(环形图)|area(面积图)|combo(组合图)|scatter(散点图)|funnel(漏斗图)|wordCloud(词云)|radar(雷达图)|statistics(指标卡)|text(文本)|button(按钮). Read lark-base-dashboard-block-config.md before creating.", Required: true},
 		{Name: "data-config", Desc: "data_config JSON object; read lark-base-dashboard-block-config.md for the SSOT"},
 		{Name: "user-id-type", Desc: "user ID type for user fields in filters: open_id / union_id / user_id"},
 		{Name: "no-validate", Type: "bool", Desc: "skip local data_config validation and normalization; send data_config as-is"},
@@ -32,6 +32,7 @@ var BaseDashboardBlockCreate = common.Shortcut{
 	Tips: []string{
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Dashboard Note" --type text --data-config '{"text":"# Sales Dashboard"}'`,
+		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Sync Button" --type button --data-config '{"workflow_id":"wkf_xxx"}'`,
 		"Before creating data-backed blocks, use +table-list and +field-list to confirm real table and field names.",
 		"data_config uses table and field names, not table_id or field_id.",
 		"Read lark-base-dashboard-block-config.md as the SSOT for chart templates, filters, metric rules, and type-specific fields; do not invent data_config from natural language.",
@@ -49,6 +50,9 @@ var BaseDashboardBlockCreate = common.Shortcut{
 			// text 类型必须提供 data-config（含 text 内容）
 			if strings.ToLower(runtime.Str("type")) == "text" {
 				return errs.NewValidationError(errs.SubtypeInvalidArgument, "text 类型组件必须提供 data-config，包含必填字段 text").WithParam("--data-config")
+			}
+			if strings.ToLower(runtime.Str("type")) == "button" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "button 类型组件必须提供 data-config，包含必填字段 workflow_id").WithParam("--data-config")
 			}
 			return nil
 		}

--- a/shortcuts/base/dashboard_block_update.go
+++ b/shortcuts/base/dashboard_block_update.go
@@ -50,7 +50,12 @@ var BaseDashboardBlockUpdate = common.Shortcut{
 			return err
 		}
 		norm := normalizeDataConfig(cfg)
-		// update 时不做强类型校验（不传 type），让后端验证具体字段
+		// update 时若 data_config 含 workflow_id 字段，按 button 类型校验
+		if _, hasButton := norm["workflow_id"]; hasButton {
+			if problems := validateButtonDataConfig("button", norm); len(problems) > 0 {
+				return formatDataConfigErrors(problems)
+			}
+		}
 		b, _ := json.Marshal(norm)
 		_ = runtime.Cmd.Flags().Set("data-config", string(b))
 		return nil

--- a/skills/lark-base/references/lark-base-dashboard-block-config.md
+++ b/skills/lark-base/references/lark-base-dashboard-block-config.md
@@ -19,6 +19,7 @@ Block 的 `data_config` 字段因 `type` 不同而变化。本文档是 Dashboar
 | `radar` | 雷达图 |
 | `statistics` | 指标卡 |
 | `text` | 文本（支持 Markdown） |
+| `button` | 按钮（触发工作流） |
 
 ## 字段类型与操作符速查（AI 决策用）
 
@@ -55,6 +56,14 @@ user / created_by / updated_by: is, isNot, isEmpty, isNotEmpty
 | 字段 | 类型 | 说明 |
 |------|------|------|
 | `text` | string | **必填**。支持 Markdown 语法，详见下方说明 |
+
+### button 类型特殊结构
+
+`button` 类型组件用于在仪表盘上放置可点击按钮，点击后触发已绑定的自动化工作流（workflow）。**不需要数据源配置**（无 `table_name`、`series`、`group_by`、`filter`）。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `workflow_id` | string | **必填**。绑定的工作流 ID（`wkf_` 前缀）。先用 `+workflow-list` 查看已有工作流并获取 ID；如需新建工作流，使用 `+workflow-create` 创建后再绑定 |
 
 **支持的 Markdown 语法：**
 
@@ -381,6 +390,16 @@ user / created_by / updated_by: is, isNot, isEmpty, isNotEmpty
 ```
 
 > **注意**：text 类型组件不需要 `table_name`、`series`、`group_by`、`filter` 等数据源相关字段。
+
+按钮组件（触发工作流）：
+
+```json
+{
+  "workflow_id": "wkf_xxx"
+}
+```
+
+> **注意**：button 类型组件只需要 `workflow_id` 字段，不需要 `table_name`、`series`、`group_by`、`filter` 等数据源相关字段。先用 `+workflow-list` 获取已有工作流 ID（`wkf_` 前缀），或用 `+workflow-create` 创建新工作流后再绑定。
 
 ## 常见错误与修复
 


### PR DESCRIPTION
## Summary

Add button component support to dashboard block create/update commands. Button blocks trigger a workflow when clicked; `data_config` requires a non-empty `workflow_id` (`wkf_` prefix).

## Changes

- **block_data_config.go**: add `buttonBlockTypes`, `isButtonBlockType`, `validateButtonDataConfig`
- **dashboard_block_create.go**: add `button` to type enum, validate logic, tips example
- **dashboard_block_update.go**: validate `workflow_id` field on update
- **lark-base-dashboard-block-config.md**: document button type (enum, data_config structure, template)
- **base_dashboard_execute_test.go**: add 8 button test cases (create valid/missing/empty/no-validate, update valid/empty, dry-run)

## Usage

```bash
lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id>   --name "Sync Button" --type button --data-config '{"workflow_id":"wkf_xxx"}'
```

## Validation

- `go build ./shortcuts/base/` — pass
- `go test ./shortcuts/base/ -count=1` — all pass (incl. 8 new button tests, no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for button blocks in dashboards.
  - Buttons can trigger workflows using a required `workflow_id`.
  - Added creation and update validation for button configurations.
  - Added dry-run support and a `--no-validate` option for button blocks.

- **Documentation**
  - Added button block configuration guidance, requirements, and templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->