### PR TITLE
docs(lark-doc): note str_replace parses Markdown inline syntax in XML mode

### DIFF
--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -78,7 +78,7 @@ lark-cli docs +update --doc "xx" --command block_delete --start-block-id blkFirs
 - 每次写操作后都按 block ID 已变化处理。新插入或复制的内容一定使用新 ID；替换、删除和覆盖会使旧 ID 失效；移动会改变章节与 range 语义。
 - 同一 block 有多处修改时，应合并为一次 `block_replace`，避免连续使用旧 ID。
 - `str_replace` 的 `--content` 即使在 `--doc-format xml` 下也按 Markdown 解析行内标记：`**x**`、`__x__` 转加粗，`*x*`、`_x_` 转斜体，`~~x~~`、`~x~` 转删除线，`` `x` `` 转行内代码，`$x$` 转公式，`[x](url)` 转链接；`+create`、`append`、`block_insert_after`、`block_replace` 都按字面量写入。行内样式一律直接写 `<b>`、`<em>`、`<del>`、`<code>`、`<latex>`、`<a>`，不要依赖 Markdown 写法。
-- 含 `*`、`_`、`~`、`` ` ``、`$`、`[x](url)` 的字面文本（正则、`**kwargs`、shell 命令、代码标识符）用 `block_replace` 写入，不要用 `str_replace`：转换是静默的（`result` 仍为 `success`、`warnings` 为空），且相邻被转换片段之间的空格会丢失，`*a* _b_` 会合成一个斜体 `ab`。
+- 含 `*`、`_`、`~`、`` ` ``、`$`、`[x](url)` 的字面文本（正则、`**kwargs`、shell 命令、代码标识符）不要用 `str_replace`，改用 `block_replace` 整块重写，`--content` 给完整 block 而非片段：转换是静默的（`result` 仍为 `success`、`warnings` 为空），且相邻被转换片段之间的空格会丢失，`*a* _b_` 会合成一个斜体 `ab`。
 - `str_replace` 里的 `\` 转义不可靠：只有当同一 `--content` 里还含反引号时反斜杠才会被消耗，否则 `\_`、`\~` 会原样留在正文。`docs +fetch` 取回的字面 `**x**` 用 `str_replace` 回写会变成加粗，不是幂等操作。
 
 ## 返回值

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -77,8 +77,9 @@ lark-cli docs +update --doc "xx" --command block_delete --start-block-id blkFirs
 
 - 每次写操作后都按 block ID 已变化处理。新插入或复制的内容一定使用新 ID；替换、删除和覆盖会使旧 ID 失效；移动会改变章节与 range 语义。
 - 同一 block 有多处修改时，应合并为一次 `block_replace`，避免连续使用旧 ID。
-- `str_replace` 的 `--content` 即使在 `--doc-format xml` 下也按 Markdown 解析行内标记：`**x**`、`__x__` 转成加粗，`_x_` 转成斜体，`~~x~~` 转成删除线，`` `x` `` 转成行内代码，`[x](url)` 转成链接；`+create`、`append`、`block_insert_after`、`block_replace` 均按字面量写入。行内样式一律直接写 `<b>`、`<em>`、`<del>`、`<code>`、`<a>`，不要依赖 Markdown 写法。
-- 用 `str_replace` 写含 `*`、`_`、`~`、`` ` ``、`[]()` 的字面文本（正则、`kwargs`、shell 命令、代码标识符）时必须用 `\` 转义，否则会被静默转成富文本节点，且 `result` 仍为 `success`、`warnings` 为空。同理，`docs +fetch` 取回的字面 `**x**` 原样回写会变成加粗。
+- `str_replace` 的 `--content` 即使在 `--doc-format xml` 下也按 Markdown 解析行内标记：`**x**`、`__x__` 转加粗，`*x*`、`_x_` 转斜体，`~~x~~`、`~x~` 转删除线，`` `x` `` 转行内代码，`$x$` 转公式，`[x](url)` 转链接；`+create`、`append`、`block_insert_after`、`block_replace` 都按字面量写入。行内样式一律直接写 `<b>`、`<em>`、`<del>`、`<code>`、`<latex>`、`<a>`，不要依赖 Markdown 写法。
+- 含 `*`、`_`、`~`、`` ` ``、`$`、`[x](url)` 的字面文本（正则、`**kwargs`、shell 命令、代码标识符）用 `block_replace` 写入，不要用 `str_replace`：转换是静默的（`result` 仍为 `success`、`warnings` 为空），且相邻被转换片段之间的空格会丢失，`*a* _b_` 会合成一个斜体 `ab`。
+- `str_replace` 里的 `\` 转义不可靠：只有当同一 `--content` 里还含反引号时反斜杠才会被消耗，否则 `\_`、`\~` 会原样留在正文。`docs +fetch` 取回的字面 `**x**` 用 `str_replace` 回写会变成加粗，不是幂等操作。
 
 ## 返回值
 

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -77,6 +77,8 @@ lark-cli docs +update --doc "xx" --command block_delete --start-block-id blkFirs
 
 - 每次写操作后都按 block ID 已变化处理。新插入或复制的内容一定使用新 ID；替换、删除和覆盖会使旧 ID 失效；移动会改变章节与 range 语义。
 - 同一 block 有多处修改时，应合并为一次 `block_replace`，避免连续使用旧 ID。
+- `str_replace` 的 `--content` 即使在 `--doc-format xml` 下也按 Markdown 解析行内标记：`**x**`、`__x__` 转成加粗，`_x_` 转成斜体，`~~x~~` 转成删除线，`` `x` `` 转成行内代码，`[x](url)` 转成链接；`+create`、`append`、`block_insert_after`、`block_replace` 均按字面量写入。行内样式一律直接写 `<b>`、`<em>`、`<del>`、`<code>`、`<a>`，不要依赖 Markdown 写法。
+- 用 `str_replace` 写含 `*`、`_`、`~`、`` ` ``、`[]()` 的字面文本（正则、`kwargs`、shell 命令、代码标识符）时必须用 `\` 转义，否则会被静默转成富文本节点，且 `result` 仍为 `success`、`warnings` 为空。同理，`docs +fetch` 取回的字面 `**x**` 原样回写会变成加粗。
 
 ## 返回值
 


### PR DESCRIPTION
## Summary
Document that `docs +update --command str_replace` parses Markdown inline syntax in its `--content` even under `--doc-format xml`, while `+create`, `append`, `block_insert_after` and `block_replace` store the same characters literally. Agents currently have no way to know this from the CLI surface, so `str_replace` silently turns `**kwargs`, regex snippets and shell backticks into rich-text nodes with `result: success` and empty `warnings`.

## Changes
- Add two rules to `通用安全规则` in `skills/lark-doc/references/lark-doc-update.md`: which markers `str_replace` converts (`**x**`, `__x__`, `_x_`, `~~x~~`, `` `x` ``, `[x](url)`) versus the literal block paths, and the `\` escape requirement plus the resulting fetch/write non-idempotency.

## Test Plan
- [x] Verified against a live document on `lark-cli` 1.0.87 (`--as user`): the same payload written through `str_replace` produced `<b>` / `<em>` / `<del>` / `<code>` / `<a>` nodes, while `docs +create`, `append`, `block_insert_after` and `block_replace` kept it literal; `\*\*stars\*\*` came back as literal `**stars**`. Test documents were deleted afterwards.
- [x] `node scripts/skill-format-check/index.js` passes.
- [x] `bash scripts/check-doc-tokens.sh skills` reports no findings in the touched file (the 5 pre-existing findings are in unrelated `lark-wiki` / `lark-base` / `lark-approval` references).
- [ ] `make quality-gate` was **not** run locally: it depends on `make build`, and no Go toolchain is available in this environment (`/bin/sh: go: command not found`). This change touches only skill reference Markdown, no command, help or schema surface. Relying on CI.

## Related Issues
- #2405


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 细化写入安全规则，明确 `str_replace` 对 Markdown 行内语法（包括删除线、公式等）及对应 XML 标签的解析方式。
  * 含特殊字符的字面文本应使用 `block_replace`，避免内容被静默转换为富文本。
  * 补充空格丢失、反斜杠转义不可靠及回写结果可能非幂等等注意事项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->