### PR TITLE
docs(slides): document chart_auto_fix capability for charts

### DIFF
--- a/skills/lark-slides/references/xml/xml-schema-quick-ref.md
+++ b/skills/lark-slides/references/xml/xml-schema-quick-ref.md
@@ -352,6 +352,21 @@ XSD 中的 `title`、`headline`、`sub-headline`、`body`、`caption` 主要出�
 
 隐藏 `<chart>` 的图例只能通过不写或删除 `<chartLegend>` 实现，`<chartLegend>` 不支持 `position="none"`。
 
+`<chart>` 支持自动修复能力 `chart_auto_fix`：开启后，服务端会在写入前自动校正图表数据与结构上的常见问题（如缺失的必需子元素、分类/系列格式不规范等），尽量保证图表可正常渲染。在含 `<chart>` 的页面上，通过在 `<slide>` 内写一条 XML 注释 marker 来声明：
+
+```xml
+<slide xmlns="https://www.larkoffice.com/sml/2.0">
+  <!-- slide-engine-experiment:chart_auto_fix=true -->
+  <data>
+    <chart> ... </chart>
+  </data>
+</slide>
+```
+
+- 取值 `true`（开启自动修复）或 `false`（关闭，按原样写入），大小写不敏感；其他值会被服务端拒绝并报参数错误。
+- 每页最多一条 marker；解析后会从 XML 中移除，不出现在最终内容里。
+- 不写 marker 时按关闭处理。生成图表时，若不确定图表 XML 是否完全规范，写 `chart_auto_fix=true` 以获得服务端兜底修复。
+
 详细用法见 [slides_xml_schema_definition.xml](slides_xml_schema_definition.xml)。
 
 ### embed


### PR DESCRIPTION
## Summary

- 在 lark-slides 技能文档 `xml-schema-quick-ref.md` 的 `### chart` 章节新增 `chart_auto_fix` 说明，用于测试 chart_auto_fix 功能。
- 图表页可通过 `slide-engine-experiment:chart_auto_fix=<true|false>` 的 XML 注释 marker 声明是否开启 chart_auto_fix。

## Note

- 评测用文档改动，**不用于合入 main**；开 PR 仅为方便评测方 review diff。

## Test plan

- [ ] Review 文档 diff：仅 `### chart` 章节新增 chart_auto_fix 小节