### PR TITLE
feat(slides): add screenshot overview

### DIFF
--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -1003,7 +1003,7 @@ func slidesScreenshotOverviewImages(data map[string]interface{}, requestedNumber
 		}
 		id := common.GetString(item, "slide_id")
 		if id == "" {
-			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned no slide_id for slide_number %d", number)
+			id = strconv.Itoa(number)
 		}
 		b, err := base64.StdEncoding.DecodeString(common.GetString(item, "data"))
 		if err != nil {

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -1063,6 +1063,19 @@ func overviewRectOutput(r image.Rectangle) map[string]int {
 	return map[string]int{"x": r.Min.X, "y": r.Min.Y, "width": r.Dx(), "height": r.Dy()}
 }
 
+func overviewImageRect(tile image.Rectangle, src image.Image) image.Rectangle {
+	srcSize := src.Bounds().Size()
+	scale := math.Min(
+		float64(tile.Dx())/float64(srcSize.X),
+		float64(tile.Dy())/float64(srcSize.Y),
+	)
+	width := int(math.Round(float64(srcSize.X) * scale))
+	height := int(math.Round(float64(srcSize.Y) * scale))
+	x := tile.Min.X + (tile.Dx()-width)/2
+	y := tile.Min.Y + (tile.Dy()-height)/2
+	return image.Rect(x, y, x+width, y+height)
+}
+
 func composeSlidesOverview(images []image.Image, columns int) (*image.RGBA, []overviewCell) {
 	if columns < 1 {
 		columns = defaultOverviewColumns
@@ -1077,9 +1090,10 @@ func composeSlidesOverview(images []image.Image, columns int) (*image.RGBA, []ov
 		r, c := i/columns, i%columns
 		x, y := pad+c*(thumbW+pad), pad+r*(tileH+pad)
 		tile := image.Rect(x, y, x+thumbW, y+tileH)
-		thumbnail := image.Rect(x, y, x+thumbW, y+tileH)
+		draw.Draw(out, tile, &image.Uniform{C: color.White}, image.Point{}, draw.Src)
+		thumbnail := overviewImageRect(tile, src)
 		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
-		drawOverviewThumbnailBorder(out, thumbnail)
+		drawOverviewThumbnailBorder(out, tile)
 		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
 	}
 	return out, cells

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -914,7 +914,7 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 		}
 		thumbs = append(thumbs, batch...)
 	}
-	overview, cells := composeSlidesOverviewFromIndex(thumbs, defaultOverviewColumns, start+1)
+	overview, cells := composeSlidesOverview(thumbs, defaultOverviewColumns)
 	var encoded bytes.Buffer
 	if err := png.Encode(&encoded, overview); err != nil {
 		return errs.NewInternalError(errs.SubtypeFileIO, "encode overview PNG: %v", err).WithCause(err)
@@ -937,7 +937,7 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	for i, id := range pageIDs {
 		cell := cells[i]
 		index := start + i + 1
-		slides[i] = map[string]interface{}{"index": index, "label": fmt.Sprintf("#%02d", index), "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
+		slides[i] = map[string]interface{}{"index": index, "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
 	}
 	overviewImageSize := map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}
 	overviewData := map[string]interface{}{"path": path, "format": "png", "size": encoded.Len(), "image_size": overviewImageSize, "columns": defaultOverviewColumns, "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
@@ -1064,16 +1064,12 @@ func overviewRectOutput(r image.Rectangle) map[string]int {
 }
 
 func composeSlidesOverview(images []image.Image, columns int) (*image.RGBA, []overviewCell) {
-	return composeSlidesOverviewFromIndex(images, columns, 1)
-}
-
-func composeSlidesOverviewFromIndex(images []image.Image, columns int, firstIndex int) (*image.RGBA, []overviewCell) {
 	if columns < 1 {
 		columns = defaultOverviewColumns
 	}
-	const thumbW, thumbH, headerH, pad = 320, 180, 24, 16
+	const thumbW, thumbH, pad = 320, 180, 16
 	rows := int(math.Ceil(float64(len(images)) / float64(columns)))
-	tileH := headerH + thumbH
+	tileH := thumbH
 	out := image.NewRGBA(image.Rect(0, 0, columns*thumbW+(columns+1)*pad, rows*tileH+(rows+1)*pad))
 	draw.Draw(out, out.Bounds(), &image.Uniform{C: color.RGBA{R: 246, G: 247, B: 249, A: 255}}, image.Point{}, draw.Src)
 	cells := make([]overviewCell, len(images))
@@ -1081,11 +1077,9 @@ func composeSlidesOverviewFromIndex(images []image.Image, columns int, firstInde
 		r, c := i/columns, i%columns
 		x, y := pad+c*(thumbW+pad), pad+r*(tileH+pad)
 		tile := image.Rect(x, y, x+thumbW, y+tileH)
-		thumbnail := image.Rect(x, y+headerH, x+thumbW, y+tileH)
-		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 49, G: 50, B: 53, A: 255}}, image.Point{}, draw.Src)
+		thumbnail := image.Rect(x, y, x+thumbW, y+tileH)
 		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
 		drawOverviewThumbnailBorder(out, thumbnail)
-		drawOverviewIndex(out, image.Pt(x+9, y+5), firstIndex+i)
 		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
 	}
 	return out, cells
@@ -1097,34 +1091,4 @@ func drawOverviewThumbnailBorder(dst draw.Image, thumbnail image.Rectangle) {
 	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Max.Y-1, thumbnail.Max.X, thumbnail.Max.Y), border, image.Point{}, draw.Src)
 	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Min.Y, thumbnail.Min.X+1, thumbnail.Max.Y), border, image.Point{}, draw.Src)
 	draw.Draw(dst, image.Rect(thumbnail.Max.X-1, thumbnail.Min.Y, thumbnail.Max.X, thumbnail.Max.Y), border, image.Point{}, draw.Src)
-}
-
-var overviewDigitPixels = map[rune][]string{
-	'#': {"01010", "11111", "01010", "11111", "01010"},
-	'0': {"01110", "10001", "10011", "10101", "11001", "10001", "01110"},
-	'1': {"00100", "01100", "00100", "00100", "00100", "00100", "01110"},
-	'2': {"01110", "10001", "00001", "00010", "00100", "01000", "11111"},
-	'3': {"11110", "00001", "00001", "01110", "00001", "00001", "11110"},
-	'4': {"00010", "00110", "01010", "10010", "11111", "00010", "00010"},
-	'5': {"11111", "10000", "11110", "00001", "00001", "10001", "01110"},
-	'6': {"00110", "01000", "10000", "11110", "10001", "10001", "01110"},
-	'7': {"11111", "00001", "00010", "00100", "01000", "01000", "01000"},
-	'8': {"01110", "10001", "10001", "01110", "10001", "10001", "01110"},
-	'9': {"01110", "10001", "10001", "01111", "00001", "00010", "11100"},
-}
-
-func drawOverviewIndex(dst draw.Image, at image.Point, index int) {
-	const scale, gap = 2, 3
-	x := at.X
-	for _, ch := range fmt.Sprintf("#%02d", index) {
-		glyph := overviewDigitPixels[ch]
-		for y, row := range glyph {
-			for col, on := range row {
-				if on == '1' {
-					draw.Draw(dst, image.Rect(x+col*scale, at.Y+y*scale, x+(col+1)*scale, at.Y+(y+1)*scale), &image.Uniform{C: color.White}, image.Point{}, draw.Src)
-				}
-			}
-		}
-		x += (len(glyph[0]) + gap) * scale
-	}
 }

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -7,7 +7,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/xml"
+	"errors"
 	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	_ "image/jpeg"
+	"image/png"
+	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,11 +30,14 @@ import (
 	"github.com/larksuite/cli/internal/util"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
+	xdraw "golang.org/x/image/draw"
 )
 
 const (
 	defaultSlidesScreenshotDir = ".lark-slides/screenshots"
 	maxSlidesPerScreenshot     = 10
+	maxSlidesPerOverview       = 20
+	defaultOverviewColumns     = 4
 )
 
 var (
@@ -42,8 +54,9 @@ var SlidesScreenshot = common.Shortcut{
 	Description: "Save up to 10 slide screenshots to local files without printing Base64 image data",
 	Risk:        "read",
 	Scopes:      []string{"slides:presentation:screenshot"},
-	// wiki:node:read is required only when --presentation is a wiki URL.
-	ConditionalScopes: []string{"wiki:node:read"},
+	// wiki:node:read is required only for wiki URLs; slides:presentation:read
+	// is required only by --overview to enumerate the current page order.
+	ConditionalScopes: []string{"wiki:node:read", "slides:presentation:read"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
 		listModePresentationRefFlag(),
@@ -54,8 +67,20 @@ var SlidesScreenshot = common.Shortcut{
 		{Name: "output", Desc: "preferred relative output path for a single screenshot (extension optional; .png, .jpg, or .jpeg)"},
 		{Name: "output-dir", Default: defaultSlidesScreenshotDir, Desc: "relative directory for saved screenshots"},
 		{Name: "output-name", Desc: "file name stem for --content render output"},
+		{Name: "overview", Type: "bool", Desc: "render one indexed overview PNG containing up to 20 current slides; use --overview-page for additional slides; cannot be combined with slide selectors or --content"},
+		{Name: "overview-page", Type: "int", Default: "1", Desc: "1-based overview page (up to 20 slides); continue with next_overview_page while has_next is true"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		overview := runtime.Bool("overview")
+		if overview && (runtime.Changed("content") || slidesScreenshotHasSelectorInput(runtime)) {
+			return slidesScreenshotFlagErrorf("--overview requires --presentation without --content or slide selectors")
+		}
+		if runtime.Changed("overview-page") && !overview {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-page requires --overview").WithParam("--overview-page")
+		}
+		if overview && runtime.Int("overview-page") < 1 {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview-page must be at least 1").WithParam("--overview-page")
+		}
 		renderMode := runtime.Changed("content")
 		selectorCount := 1
 		if renderMode {
@@ -82,12 +107,26 @@ var SlidesScreenshot = common.Shortcut{
 					return err
 				}
 			}
-			if len(slideIDs) == 0 && len(slideNumbers) == 0 {
+			if !overview && len(slideIDs) == 0 && len(slideNumbers) == 0 {
 				return slidesScreenshotMissingSelectorError()
 			}
 			selectorCount = len(slideIDs) + len(slideNumbers)
+			if overview {
+				// Overview is one synthesized local image even though it deliberately
+				// has no page selector. Keep --output's single-file contract usable.
+				selectorCount = 1
+			}
 			if err := validateSlidesScreenshotSelectorLimit(selectorCount); err != nil {
 				return err
+			}
+			// Overview reads the presentation XML before rendering. Keep this
+			// conditional preflight in Validate so --dry-run reports the same
+			// authorization requirement as execution, and a wiki URL cannot reach
+			// its resolve call before a missing Slides read scope is surfaced.
+			if overview {
+				if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
+					return err
+				}
 			}
 		}
 		if runtime.Changed("output") {
@@ -102,6 +141,12 @@ var SlidesScreenshot = common.Shortcut{
 			}
 			if err := validateScreenshotOutputPath(runtime, runtime.Str("output")); err != nil {
 				return err
+			}
+			if overview {
+				ext := strings.ToLower(filepath.Ext(runtime.Str("output")))
+				if ext != "" && ext != ".png" {
+					return errs.NewValidationError(errs.SubtypeInvalidArgument, "--overview output must be .png").WithParam("--output")
+				}
 			}
 		} else {
 			if !renderMode && runtime.Changed("output-name") {
@@ -133,6 +178,26 @@ var SlidesScreenshot = common.Shortcut{
 
 		presentationID := ref.Token
 		dry := common.NewDryRunAPI()
+		if runtime.Bool("overview") {
+			if ref.Kind == "wiki" {
+				presentationID = "<resolved_slides_token>"
+				dry.GET("/open-apis/wiki/v2/spaces/get_node").
+					Desc("Resolve the wiki node to its Slides presentation before reading the overview page").
+					Params(map[string]interface{}{"token": ref.Token})
+			}
+			overviewURL := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))
+			screenshotURL := overviewURL + "/slide_images"
+			dry.GET(overviewURL).
+				Desc(fmt.Sprintf("Fetch current presentation XML to select overview page %d (at most %d slides)", runtime.Int("overview-page"), maxSlidesPerOverview)).
+				Params(map[string]interface{}{"revision_id": -1})
+			dry.POST(screenshotURL).
+				Desc("Render the first dynamic overview batch (slide IDs 1-10 of the selected overview page)").
+				Body(map[string]interface{}{"slide_ids": []string{"<overview page slide IDs 1-10>"}})
+			dry.POST(screenshotURL).
+				Desc("Render the optional second dynamic overview batch (slide IDs 11-20; sent only when the selected page has more than 10 slides)").
+				Body(map[string]interface{}{"slide_ids": []string{"<overview page slide IDs 11-20, if present>"}})
+			return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded locally and composed into overview PNG during execution")
+		}
 		if ref.Kind == "wiki" {
 			presentationID = "<resolved_slides_token>"
 			dry.Desc("2-step orchestration: resolve wiki → fetch slide screenshot(s)").
@@ -161,6 +226,9 @@ var SlidesScreenshot = common.Shortcut{
 		return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded to local files during execution")
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if runtime.Bool("overview") {
+			return executeSlidesScreenshotOverview(runtime)
+		}
 		if runtime.Changed("content") {
 			return executeRenderScreenshot(runtime)
 		}
@@ -187,7 +255,6 @@ var SlidesScreenshot = common.Shortcut{
 		if err != nil {
 			return err
 		}
-
 		url := fmt.Sprintf(
 			"/open-apis/slides_ai/v1/xml_presentations/%s/slide_images",
 			validate.EncodePathSegment(presentationID),
@@ -794,4 +861,270 @@ func writeUniqueScreenshotPath(runtime *common.RuntimeContext, outputPath string
 
 func isScreenshotFileNotExist(err error) bool {
 	return os.IsNotExist(err)
+}
+
+func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
+	ref, err := parsePresentationRef(slidesScreenshotPresentation(runtime))
+	if err != nil {
+		return err
+	}
+	if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
+		return err
+	}
+	presentationID, err := resolvePresentationID(runtime, ref)
+	if err != nil {
+		return err
+	}
+	data, err := runtime.CallAPITyped("GET", fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID)), map[string]interface{}{"revision_id": -1}, nil)
+	if err != nil {
+		return err
+	}
+	ids, err := slidesScreenshotOverviewIDs(data)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview found no current slide IDs").WithHint("verify the presentation contains slides, then retry")
+	}
+	overviewPage := runtime.Int("overview-page")
+	maxPage := (len(ids) + maxSlidesPerOverview - 1) / maxSlidesPerOverview
+	if overviewPage > maxPage {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview-page %d is outside this %d-slide presentation", overviewPage, len(ids)).WithParam("--overview-page").WithHint(fmt.Sprintf("use a value between 1 and %d", maxPage))
+	}
+	start := (overviewPage - 1) * maxSlidesPerOverview
+	end := start + maxSlidesPerOverview
+	if end > len(ids) {
+		end = len(ids)
+	}
+	pageIDs := ids[start:end]
+	thumbs := make([]image.Image, 0, len(pageIDs))
+	for batchStart := 0; batchStart < len(pageIDs); batchStart += maxSlidesPerScreenshot {
+		batchEnd := batchStart + maxSlidesPerScreenshot
+		if batchEnd > len(pageIDs) {
+			batchEnd = len(pageIDs)
+		}
+		url := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s/slide_images", validate.EncodePathSegment(presentationID))
+		pageData, err := doSlidesScreenshotAPIJSONWithLogID(runtime, "POST", url, larkcore.QueryParams{}, map[string]interface{}{"slide_ids": pageIDs[batchStart:batchEnd]})
+		if err != nil {
+			return err
+		}
+		batch, err := slidesScreenshotOverviewImages(pageData, pageIDs[batchStart:batchEnd])
+		if err != nil {
+			return err
+		}
+		thumbs = append(thumbs, batch...)
+	}
+	overview, cells := composeSlidesOverviewFromIndex(thumbs, defaultOverviewColumns, start+1)
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, overview); err != nil {
+		return errs.NewInternalError(errs.SubtypeFileIO, "encode overview PNG: %v", err).WithCause(err)
+	}
+	target, err := resolveSlidesScreenshotOutputTarget(runtime)
+	if err != nil {
+		return err
+	}
+	path := target.requested
+	if path == "" {
+		path = filepath.Join(target.safeOutputDir, safeScreenshotFileBase(presentationID)+"_overview.png")
+	} else if filepath.Ext(path) == "" {
+		path += ".png"
+	}
+	path, err = writeUniqueScreenshotPath(runtime, path, encoded.Bytes())
+	if err != nil {
+		return err
+	}
+	slides := make([]map[string]interface{}, len(pageIDs))
+	for i, id := range pageIDs {
+		cell := cells[i]
+		index := start + i + 1
+		slides[i] = map[string]interface{}{"index": index, "label": fmt.Sprintf("#%02d", index), "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
+	}
+	overviewImageSize := map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}
+	overviewData := map[string]interface{}{"path": path, "format": "png", "size": encoded.Len(), "image_size": overviewImageSize, "columns": defaultOverviewColumns, "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
+	if overviewPage > 1 {
+		overviewData["previous_overview_page"] = overviewPage - 1
+	}
+	if end < len(ids) {
+		overviewData["next_overview_page"] = overviewPage + 1
+	}
+	result := map[string]interface{}{"xml_presentation_id": presentationID, "overview": overviewData}
+	// Overview is one synthesized local image. Mirror the normal screenshot
+	// output locator at the root while retaining overview.path and its paging
+	// metadata for overview-aware consumers.
+	setSlidesScreenshotResultOutput(result, target, []map[string]interface{}{{"path": path}})
+	runtime.Out(result, nil)
+	return nil
+}
+
+// slidesScreenshotOverviewImages verifies that the API response is a bijection
+// with requestedIDs, then returns its images in request order. The API's array
+// order is deliberately not trusted: a mismatched thumbnail makes the overview
+// index unsafe for an agent to use in a later per-slide review.
+func slidesScreenshotOverviewImages(data map[string]interface{}, requestedIDs []string) ([]image.Image, error) {
+	items := common.GetSlice(data, "slide_images")
+	if len(items) != len(requestedIDs) {
+		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned %d images for %d requested slide IDs", len(items), len(requestedIDs))
+	}
+	requested := make(map[string]struct{}, len(requestedIDs))
+	for _, id := range requestedIDs {
+		requested[id] = struct{}{}
+	}
+	byID := make(map[string]map[string]interface{}, len(items))
+	for _, raw := range items {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide image")
+		}
+		id := common.GetString(item, "slide_id")
+		if _, ok := requested[id]; !ok || id == "" {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned unexpected slide_id %q", id)
+		}
+		if _, duplicate := byID[id]; duplicate {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned duplicate slide_id %q", id)
+		}
+		byID[id] = item
+	}
+	images := make([]image.Image, 0, len(requestedIDs))
+	for _, id := range requestedIDs {
+		item, ok := byID[id]
+		if !ok {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot did not return requested slide_id %q", id)
+		}
+		b, err := base64.StdEncoding.DecodeString(common.GetString(item, "data"))
+		if err != nil {
+			return nil, slidesScreenshotImageDataCauseError(id, err, "decode screenshot for --overview: %s", err)
+		}
+		img, _, err := image.Decode(bytes.NewReader(b))
+		if err != nil {
+			return nil, slidesScreenshotImageDataCauseError(id, err, "decode screenshot image for --overview: %s", err)
+		}
+		images = append(images, img)
+	}
+	return images, nil
+}
+
+func slidesScreenshotIDsFromXML(content string) ([]string, error) {
+	d := xml.NewDecoder(strings.NewReader(content))
+	var ids []string
+	seenRoot := false
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				if !seenRoot {
+					return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "presentation XML for --overview has no root element")
+				}
+				break
+			}
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "parse presentation XML for --overview: %v", err).WithCause(err)
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if !seenRoot {
+			seenRoot = true
+			if start.Name.Local != "presentation" {
+				return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "presentation XML for --overview has root element %q, want presentation", start.Name.Local)
+			}
+			continue
+		}
+		if start.Name.Local != "slide" {
+			continue
+		}
+		for _, a := range start.Attr {
+			if a.Name.Local == "id" && strings.TrimSpace(a.Value) != "" {
+				ids = append(ids, a.Value)
+				break
+			}
+		}
+	}
+	return ids, nil
+}
+
+func slidesScreenshotOverviewIDs(data map[string]interface{}) ([]string, error) {
+	presentation, ok := data["xml_presentation"].(map[string]interface{})
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "xml_presentation response for --overview must be an object")
+	}
+	content, ok := presentation["content"].(string)
+	if !ok || strings.TrimSpace(content) == "" {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "xml_presentation.content response for --overview must be a non-empty string")
+	}
+	return slidesScreenshotIDsFromXML(content)
+}
+
+type overviewCell struct {
+	row, column     int
+	tile, thumbnail image.Rectangle
+}
+
+func overviewRectOutput(r image.Rectangle) map[string]int {
+	return map[string]int{"x": r.Min.X, "y": r.Min.Y, "width": r.Dx(), "height": r.Dy()}
+}
+
+func composeSlidesOverview(images []image.Image, columns int) (*image.RGBA, []overviewCell) {
+	return composeSlidesOverviewFromIndex(images, columns, 1)
+}
+
+func composeSlidesOverviewFromIndex(images []image.Image, columns int, firstIndex int) (*image.RGBA, []overviewCell) {
+	if columns < 1 {
+		columns = defaultOverviewColumns
+	}
+	const thumbW, thumbH, headerH, pad = 320, 180, 24, 16
+	rows := int(math.Ceil(float64(len(images)) / float64(columns)))
+	tileH := headerH + thumbH
+	out := image.NewRGBA(image.Rect(0, 0, columns*thumbW+(columns+1)*pad, rows*tileH+(rows+1)*pad))
+	draw.Draw(out, out.Bounds(), &image.Uniform{C: color.RGBA{R: 246, G: 247, B: 249, A: 255}}, image.Point{}, draw.Src)
+	cells := make([]overviewCell, len(images))
+	for i, src := range images {
+		r, c := i/columns, i%columns
+		x, y := pad+c*(thumbW+pad), pad+r*(tileH+pad)
+		tile := image.Rect(x, y, x+thumbW, y+tileH)
+		thumbnail := image.Rect(x, y+headerH, x+thumbW, y+tileH)
+		draw.Draw(out, image.Rect(x, y, x+thumbW, y+headerH), &image.Uniform{C: color.RGBA{R: 49, G: 50, B: 53, A: 255}}, image.Point{}, draw.Src)
+		xdraw.CatmullRom.Scale(out, thumbnail, src, src.Bounds(), draw.Over, nil)
+		drawOverviewThumbnailBorder(out, thumbnail)
+		drawOverviewIndex(out, image.Pt(x+9, y+5), firstIndex+i)
+		cells[i] = overviewCell{row: r, column: c, tile: tile, thumbnail: thumbnail}
+	}
+	return out, cells
+}
+
+func drawOverviewThumbnailBorder(dst draw.Image, thumbnail image.Rectangle) {
+	border := &image.Uniform{C: color.RGBA{R: 205, G: 208, B: 213, A: 255}}
+	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Min.Y, thumbnail.Max.X, thumbnail.Min.Y+1), border, image.Point{}, draw.Src)
+	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Max.Y-1, thumbnail.Max.X, thumbnail.Max.Y), border, image.Point{}, draw.Src)
+	draw.Draw(dst, image.Rect(thumbnail.Min.X, thumbnail.Min.Y, thumbnail.Min.X+1, thumbnail.Max.Y), border, image.Point{}, draw.Src)
+	draw.Draw(dst, image.Rect(thumbnail.Max.X-1, thumbnail.Min.Y, thumbnail.Max.X, thumbnail.Max.Y), border, image.Point{}, draw.Src)
+}
+
+var overviewDigitPixels = map[rune][]string{
+	'#': {"01010", "11111", "01010", "11111", "01010"},
+	'0': {"01110", "10001", "10011", "10101", "11001", "10001", "01110"},
+	'1': {"00100", "01100", "00100", "00100", "00100", "00100", "01110"},
+	'2': {"01110", "10001", "00001", "00010", "00100", "01000", "11111"},
+	'3': {"11110", "00001", "00001", "01110", "00001", "00001", "11110"},
+	'4': {"00010", "00110", "01010", "10010", "11111", "00010", "00010"},
+	'5': {"11111", "10000", "11110", "00001", "00001", "10001", "01110"},
+	'6': {"00110", "01000", "10000", "11110", "10001", "10001", "01110"},
+	'7': {"11111", "00001", "00010", "00100", "01000", "01000", "01000"},
+	'8': {"01110", "10001", "10001", "01110", "10001", "10001", "01110"},
+	'9': {"01110", "10001", "10001", "01111", "00001", "00010", "11100"},
+}
+
+func drawOverviewIndex(dst draw.Image, at image.Point, index int) {
+	const scale, gap = 2, 3
+	x := at.X
+	for _, ch := range fmt.Sprintf("#%02d", index) {
+		glyph := overviewDigitPixels[ch]
+		for y, row := range glyph {
+			for col, on := range row {
+				if on == '1' {
+					draw.Draw(dst, image.Rect(x+col*scale, at.Y+y*scale, x+(col+1)*scale, at.Y+(y+1)*scale), &image.Uniform{C: color.White}, image.Point{}, draw.Src)
+				}
+			}
+		}
+		x += (len(glyph[0]) + gap) * scale
+	}
 }

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -7,15 +7,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/xml"
-	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"image/draw"
 	_ "image/jpeg"
 	"image/png"
-	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -54,9 +51,8 @@ var SlidesScreenshot = common.Shortcut{
 	Description: "Save up to 10 slide screenshots to local files without printing Base64 image data",
 	Risk:        "read",
 	Scopes:      []string{"slides:presentation:screenshot"},
-	// wiki:node:read is required only for wiki URLs; slides:presentation:read
-	// is required only by --overview to enumerate the current page order.
-	ConditionalScopes: []string{"wiki:node:read", "slides:presentation:read"},
+	// wiki:node:read is required only when --presentation is a wiki URL.
+	ConditionalScopes: []string{"wiki:node:read"},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
 		listModePresentationRefFlag(),
@@ -119,15 +115,6 @@ var SlidesScreenshot = common.Shortcut{
 			if err := validateSlidesScreenshotSelectorLimit(selectorCount); err != nil {
 				return err
 			}
-			// Overview reads the presentation XML before rendering. Keep this
-			// conditional preflight in Validate so --dry-run reports the same
-			// authorization requirement as execution, and a wiki URL cannot reach
-			// its resolve call before a missing Slides read scope is surfaced.
-			if overview {
-				if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
-					return err
-				}
-			}
 		}
 		if runtime.Changed("output") {
 			if runtime.Changed("output-dir") {
@@ -185,17 +172,14 @@ var SlidesScreenshot = common.Shortcut{
 					Desc("Resolve the wiki node to its Slides presentation before reading the overview page").
 					Params(map[string]interface{}{"token": ref.Token})
 			}
-			overviewURL := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID))
-			screenshotURL := overviewURL + "/slide_images"
-			dry.GET(overviewURL).
-				Desc(fmt.Sprintf("Fetch current presentation XML to select overview page %d (at most %d slides)", runtime.Int("overview-page"), maxSlidesPerOverview)).
-				Params(map[string]interface{}{"revision_id": -1})
+			screenshotURL := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s/slide_images", validate.EncodePathSegment(presentationID))
+			start := (runtime.Int("overview-page")-1)*maxSlidesPerOverview + 1
 			dry.POST(screenshotURL).
-				Desc("Render the first dynamic overview batch (slide IDs 1-10 of the selected overview page)").
-				Body(map[string]interface{}{"slide_ids": []string{"<overview page slide IDs 1-10>"}})
+				Desc("Render the first overview batch by page number; the response supplies total_count and revision").
+				Body(map[string]interface{}{"slide_numbers": slidesScreenshotNumberRange(start, start+maxSlidesPerScreenshot-1)})
 			dry.POST(screenshotURL).
-				Desc("Render the optional second dynamic overview batch (slide IDs 11-20; sent only when the selected page has more than 10 slides)").
-				Body(map[string]interface{}{"slide_ids": []string{"<overview page slide IDs 11-20, if present>"}})
+				Desc("Render the optional second overview batch when total_count reaches it").
+				Body(map[string]interface{}{"slide_numbers": slidesScreenshotNumberRange(start+maxSlidesPerScreenshot, start+maxSlidesPerOverview-1)})
 			return setSlidesScreenshotDryRunOutput(dry, runtime).Set("base64_output", "suppressed; decoded locally and composed into overview PNG during execution")
 		}
 		if ref.Kind == "wiki" {
@@ -868,51 +852,64 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	if err := runtime.EnsureScopes([]string{"slides:presentation:read"}); err != nil {
-		return err
-	}
 	presentationID, err := resolvePresentationID(runtime, ref)
 	if err != nil {
 		return err
 	}
-	data, err := runtime.CallAPITyped("GET", fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s", validate.EncodePathSegment(presentationID)), map[string]interface{}{"revision_id": -1}, nil)
-	if err != nil {
-		return err
-	}
-	ids, err := slidesScreenshotOverviewIDs(data)
-	if err != nil {
-		return err
-	}
-	if len(ids) == 0 {
-		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview found no current slide IDs").WithHint("verify the presentation contains slides, then retry")
-	}
 	overviewPage := runtime.Int("overview-page")
-	maxPage := (len(ids) + maxSlidesPerOverview - 1) / maxSlidesPerOverview
+	start := (overviewPage-1)*maxSlidesPerOverview + 1
+	url := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s/slide_images", validate.EncodePathSegment(presentationID))
+	firstData, err := doSlidesScreenshotAPIJSONWithLogID(runtime, "POST", url, larkcore.QueryParams{}, map[string]interface{}{"slide_numbers": slidesScreenshotNumberRange(start, start+maxSlidesPerScreenshot-1)})
+	if err != nil {
+		return err
+	}
+	total, err := slidesScreenshotOverviewTotalCount(firstData)
+	if err != nil {
+		return err
+	}
+	if total == 0 {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview found no slides").WithHint("verify the presentation contains slides, then retry")
+	}
+	firstRevision, hasFirstRevision := slidesScreenshotOverviewRevision(firstData)
+	maxPage := (total + maxSlidesPerOverview - 1) / maxSlidesPerOverview
 	if overviewPage > maxPage {
-		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview-page %d is outside this %d-slide presentation", overviewPage, len(ids)).WithParam("--overview-page").WithHint(fmt.Sprintf("use a value between 1 and %d", maxPage))
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "--overview-page %d is outside this %d-slide presentation", overviewPage, total).WithParam("--overview-page").WithHint(fmt.Sprintf("use a value between 1 and %d", maxPage))
 	}
-	start := (overviewPage - 1) * maxSlidesPerOverview
-	end := start + maxSlidesPerOverview
-	if end > len(ids) {
-		end = len(ids)
+	end := start + maxSlidesPerOverview - 1
+	if end > total {
+		end = total
 	}
-	pageIDs := ids[start:end]
-	thumbs := make([]image.Image, 0, len(pageIDs))
-	for batchStart := 0; batchStart < len(pageIDs); batchStart += maxSlidesPerScreenshot {
-		batchEnd := batchStart + maxSlidesPerScreenshot
-		if batchEnd > len(pageIDs) {
-			batchEnd = len(pageIDs)
-		}
-		url := fmt.Sprintf("/open-apis/slides_ai/v1/xml_presentations/%s/slide_images", validate.EncodePathSegment(presentationID))
-		pageData, err := doSlidesScreenshotAPIJSONWithLogID(runtime, "POST", url, larkcore.QueryParams{}, map[string]interface{}{"slide_ids": pageIDs[batchStart:batchEnd]})
+	firstEnd := start + maxSlidesPerScreenshot - 1
+	if firstEnd > end {
+		firstEnd = end
+	}
+	pageSlides, err := slidesScreenshotOverviewImages(firstData, slidesScreenshotNumberRange(start, firstEnd))
+	if err != nil {
+		return err
+	}
+	if firstEnd < end {
+		secondData, err := doSlidesScreenshotAPIJSONWithLogID(runtime, "POST", url, larkcore.QueryParams{}, map[string]interface{}{"slide_numbers": slidesScreenshotNumberRange(firstEnd+1, end)})
 		if err != nil {
 			return err
 		}
-		batch, err := slidesScreenshotOverviewImages(pageData, pageIDs[batchStart:batchEnd])
+		if secondTotal, err := slidesScreenshotOverviewTotalCount(secondData); err != nil || secondTotal != total {
+			if err != nil {
+				return err
+			}
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "slides screenshot total_count changed from %d to %d while generating overview", total, secondTotal)
+		}
+		if secondRevision, hasSecondRevision := slidesScreenshotOverviewRevision(secondData); hasFirstRevision && hasSecondRevision && secondRevision != firstRevision {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "slides screenshot revision changed from %s to %s while generating overview", firstRevision, secondRevision)
+		}
+		secondSlides, err := slidesScreenshotOverviewImages(secondData, slidesScreenshotNumberRange(firstEnd+1, end))
 		if err != nil {
 			return err
 		}
-		thumbs = append(thumbs, batch...)
+		pageSlides = append(pageSlides, secondSlides...)
+	}
+	thumbs := make([]image.Image, len(pageSlides))
+	for i := range pageSlides {
+		thumbs[i] = pageSlides[i].image
 	}
 	overview, cells := composeSlidesOverview(thumbs, defaultOverviewColumns)
 	var encoded bytes.Buffer
@@ -933,18 +930,17 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	slides := make([]map[string]interface{}, len(pageIDs))
-	for i, id := range pageIDs {
+	slides := make([]map[string]interface{}, len(pageSlides))
+	for i, pageSlide := range pageSlides {
 		cell := cells[i]
-		index := start + i + 1
-		slides[i] = map[string]interface{}{"index": index, "slide_id": id, "slide_number": index, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
+		slides[i] = map[string]interface{}{"index": pageSlide.number, "slide_id": pageSlide.id, "slide_number": pageSlide.number, "row": cell.row, "column": cell.column, "tile": overviewRectOutput(cell.tile), "thumbnail": overviewRectOutput(cell.thumbnail)}
 	}
 	overviewImageSize := map[string]int{"width": overview.Bounds().Dx(), "height": overview.Bounds().Dy()}
-	overviewData := map[string]interface{}{"path": path, "format": "png", "size": encoded.Len(), "image_size": overviewImageSize, "columns": defaultOverviewColumns, "total_slides": len(ids), "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start + 1, "end": end}, "has_previous": overviewPage > 1, "has_next": end < len(ids), "slides": slides}
+	overviewData := map[string]interface{}{"path": path, "format": "png", "size": encoded.Len(), "image_size": overviewImageSize, "columns": defaultOverviewColumns, "total_slides": total, "overview_page": overviewPage, "page_size": maxSlidesPerOverview, "slide_range": map[string]int{"start": start, "end": end}, "has_previous": overviewPage > 1, "has_next": end < total, "slides": slides}
 	if overviewPage > 1 {
 		overviewData["previous_overview_page"] = overviewPage - 1
 	}
-	if end < len(ids) {
+	if end < total {
 		overviewData["next_overview_page"] = overviewPage + 1
 	}
 	result := map[string]interface{}{"xml_presentation_id": presentationID, "overview": overviewData}
@@ -956,39 +952,58 @@ func executeSlidesScreenshotOverview(runtime *common.RuntimeContext) error {
 	return nil
 }
 
+type slidesScreenshotOverviewImage struct {
+	id     string
+	number int
+	image  image.Image
+}
+
+func slidesScreenshotNumberRange(start, end int) []int {
+	if end < start {
+		return nil
+	}
+	values := make([]int, 0, end-start+1)
+	for value := start; value <= end; value++ {
+		values = append(values, value)
+	}
+	return values
+}
+
 // slidesScreenshotOverviewImages verifies that the API response is a bijection
-// with requestedIDs, then returns its images in request order. The API's array
-// order is deliberately not trusted: a mismatched thumbnail makes the overview
-// index unsafe for an agent to use in a later per-slide review.
-func slidesScreenshotOverviewImages(data map[string]interface{}, requestedIDs []string) ([]image.Image, error) {
+// with requested page numbers, then returns its images in page order.
+func slidesScreenshotOverviewImages(data map[string]interface{}, requestedNumbers []int) ([]slidesScreenshotOverviewImage, error) {
 	items := common.GetSlice(data, "slide_images")
-	if len(items) != len(requestedIDs) {
-		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned %d images for %d requested slide IDs", len(items), len(requestedIDs))
+	if len(items) != len(requestedNumbers) {
+		return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned %d images for %d requested slide numbers", len(items), len(requestedNumbers))
 	}
-	requested := make(map[string]struct{}, len(requestedIDs))
-	for _, id := range requestedIDs {
-		requested[id] = struct{}{}
+	requested := make(map[int]struct{}, len(requestedNumbers))
+	for _, number := range requestedNumbers {
+		requested[number] = struct{}{}
 	}
-	byID := make(map[string]map[string]interface{}, len(items))
+	byNumber := make(map[int]map[string]interface{}, len(items))
 	for _, raw := range items {
 		item, ok := raw.(map[string]interface{})
 		if !ok {
 			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned invalid slide image")
 		}
-		id := common.GetString(item, "slide_id")
-		if _, ok := requested[id]; !ok || id == "" {
-			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned unexpected slide_id %q", id)
+		number := slideScreenshotInt(item, "slide_number")
+		if _, ok := requested[number]; !ok || number < 1 {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned unexpected slide_number %d", number)
 		}
-		if _, duplicate := byID[id]; duplicate {
-			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned duplicate slide_id %q", id)
+		if _, duplicate := byNumber[number]; duplicate {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned duplicate slide_number %d", number)
 		}
-		byID[id] = item
+		byNumber[number] = item
 	}
-	images := make([]image.Image, 0, len(requestedIDs))
-	for _, id := range requestedIDs {
-		item, ok := byID[id]
+	images := make([]slidesScreenshotOverviewImage, 0, len(requestedNumbers))
+	for _, number := range requestedNumbers {
+		item, ok := byNumber[number]
 		if !ok {
-			return nil, slidesScreenshotAPIDataError(data, "slides screenshot did not return requested slide_id %q", id)
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot did not return requested slide_number %d", number)
+		}
+		id := common.GetString(item, "slide_id")
+		if id == "" {
+			return nil, slidesScreenshotAPIDataError(data, "slides screenshot returned no slide_id for slide_number %d", number)
 		}
 		b, err := base64.StdEncoding.DecodeString(common.GetString(item, "data"))
 		if err != nil {
@@ -998,60 +1013,52 @@ func slidesScreenshotOverviewImages(data map[string]interface{}, requestedIDs []
 		if err != nil {
 			return nil, slidesScreenshotImageDataCauseError(id, err, "decode screenshot image for --overview: %s", err)
 		}
-		images = append(images, img)
+		images = append(images, slidesScreenshotOverviewImage{id: id, number: number, image: img})
 	}
 	return images, nil
 }
 
-func slidesScreenshotIDsFromXML(content string) ([]string, error) {
-	d := xml.NewDecoder(strings.NewReader(content))
-	var ids []string
-	seenRoot := false
-	for {
-		tok, err := d.Token()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				if !seenRoot {
-					return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "presentation XML for --overview has no root element")
-				}
-				break
-			}
-			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "parse presentation XML for --overview: %v", err).WithCause(err)
-		}
-		start, ok := tok.(xml.StartElement)
+func slidesScreenshotOverviewTotalCount(data map[string]interface{}) (int, error) {
+	for _, key := range []string{"total_count", "totalCount", "TotalCount"} {
+		value, ok := data[key]
 		if !ok {
 			continue
 		}
-		if !seenRoot {
-			seenRoot = true
-			if start.Name.Local != "presentation" {
-				return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "presentation XML for --overview has root element %q, want presentation", start.Name.Local)
+		switch value := value.(type) {
+		case float64:
+			if value >= 0 && value == math.Trunc(value) {
+				return int(value), nil
 			}
-			continue
-		}
-		if start.Name.Local != "slide" {
-			continue
-		}
-		for _, a := range start.Attr {
-			if a.Name.Local == "id" && strings.TrimSpace(a.Value) != "" {
-				ids = append(ids, a.Value)
-				break
+		case int:
+			if value >= 0 {
+				return value, nil
+			}
+		case string:
+			count, err := strconv.Atoi(value)
+			if err == nil && count >= 0 {
+				return count, nil
+			}
+		default:
+			count, err := strconv.Atoi(fmt.Sprint(value))
+			if err == nil && count >= 0 {
+				return count, nil
 			}
 		}
+		return 0, errs.NewInternalError(errs.SubtypeInvalidResponse, "slides screenshot returned invalid %s", key)
 	}
-	return ids, nil
+	return 0, errs.NewInternalError(errs.SubtypeInvalidResponse, "slides screenshot returned no total_count for --overview")
 }
 
-func slidesScreenshotOverviewIDs(data map[string]interface{}) ([]string, error) {
-	presentation, ok := data["xml_presentation"].(map[string]interface{})
-	if !ok {
-		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "xml_presentation response for --overview must be an object")
+func slidesScreenshotOverviewRevision(data map[string]interface{}) (string, bool) {
+	for _, key := range []string{"revision", "revision_id", "Revision"} {
+		if value, ok := data[key]; ok && value != nil {
+			revision := strings.TrimSpace(fmt.Sprint(value))
+			if revision != "" {
+				return revision, true
+			}
+		}
 	}
-	content, ok := presentation["content"].(string)
-	if !ok || strings.TrimSpace(content) == "" {
-		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "xml_presentation.content response for --overview must be a non-empty string")
-	}
-	return slidesScreenshotIDsFromXML(content)
+	return "", false
 }
 
 type overviewCell struct {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -103,6 +103,15 @@ func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequeste
 		t.Fatalf("first image = %#v, want p1/red", got)
 	}
 
+	withoutID := map[string]interface{}{"slide_number": 1, "data": red}
+	fallback, err := slidesScreenshotOverviewImages(map[string]interface{}{"slide_images": []interface{}{withoutID}}, []int{1})
+	if err != nil {
+		t.Fatalf("missing slide_id: %v", err)
+	}
+	if got, want := fallback[0].id, "1"; got != want {
+		t.Fatalf("fallback slide_id = %q, want %q", got, want)
+	}
+
 	for _, tc := range []struct {
 		name string
 		data map[string]interface{}

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -14,7 +14,6 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -54,7 +53,7 @@ func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	}
 
 	got := SlidesScreenshot.DeclaredScopesForIdentity("user")
-	want := []string{"slides:presentation:screenshot", "wiki:node:read", "slides:presentation:read"}
+	want := []string{"slides:presentation:screenshot", "wiki:node:read"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("declared scopes = %#v, want %#v", got, want)
 	}
@@ -76,7 +75,7 @@ func TestSlidesScreenshotOverviewFlagDescriptionsExposePagination(t *testing.T) 
 	}
 }
 
-func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequestedID(t *testing.T) {
+func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequestedNumber(t *testing.T) {
 	pngData := func(c color.RGBA) string {
 		t.Helper()
 		img := image.NewRGBA(image.Rect(0, 0, 2, 2))
@@ -91,16 +90,16 @@ func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequeste
 		}
 		return base64.StdEncoding.EncodeToString(out.Bytes())
 	}
-	imageItem := func(id, data string) map[string]interface{} {
-		return map[string]interface{}{"slide_id": id, "data": data}
+	imageItem := func(id string, number int, data string) map[string]interface{} {
+		return map[string]interface{}{"slide_id": id, "slide_number": number, "data": data}
 	}
 	red, green := pngData(color.RGBA{R: 255, A: 255}), pngData(color.RGBA{G: 255, A: 255})
 
-	ordered, err := slidesScreenshotOverviewImages(map[string]interface{}{"slide_images": []interface{}{imageItem("p2", green), imageItem("p1", red)}}, []string{"p1", "p2"})
+	ordered, err := slidesScreenshotOverviewImages(map[string]interface{}{"slide_images": []interface{}{imageItem("p2", 2, green), imageItem("p1", 1, red)}}, []int{1, 2})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := color.RGBAModel.Convert(ordered[0].At(0, 0)).(color.RGBA); got.R != 255 || got.G != 0 {
+	if got := color.RGBAModel.Convert(ordered[0].image.At(0, 0)).(color.RGBA); got.R != 255 || got.G != 0 {
 		t.Fatalf("first image = %#v, want p1/red", got)
 	}
 
@@ -108,14 +107,14 @@ func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequeste
 		name string
 		data map[string]interface{}
 	}{
-		{name: "missing", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red)}}},
-		{name: "duplicate", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red), imageItem("p1", red)}}},
-		{name: "unexpected", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red), imageItem("p3", green)}}},
-		{name: "invalid base64", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", "not-base64"), imageItem("p2", green)}}},
-		{name: "invalid image", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", base64.StdEncoding.EncodeToString([]byte("not an image"))), imageItem("p2", green)}}},
+		{name: "missing", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", 1, red)}}},
+		{name: "duplicate", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", 1, red), imageItem("p2", 1, red)}}},
+		{name: "unexpected", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", 1, red), imageItem("p3", 3, green)}}},
+		{name: "invalid base64", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", 1, "not-base64"), imageItem("p2", 2, green)}}},
+		{name: "invalid image", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", 1, base64.StdEncoding.EncodeToString([]byte("not an image"))), imageItem("p2", 2, green)}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := slidesScreenshotOverviewImages(tc.data, []string{"p1", "p2"})
+			_, err := slidesScreenshotOverviewImages(tc.data, []int{1, 2})
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -136,62 +135,19 @@ func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequeste
 	}
 }
 
-func TestSlidesScreenshotIDsFromXMLPreservesPageOrder(t *testing.T) {
-	ids, err := slidesScreenshotIDsFromXML(`<presentation><slide id="p1"/><slide id="p2"/><slide/></presentation>`)
-	if err != nil {
-		t.Fatal(err)
+func TestSlidesScreenshotOverviewRejectsMissingTotalCount(t *testing.T) {
+	if _, err := slidesScreenshotOverviewTotalCount(map[string]interface{}{}); err == nil {
+		t.Fatal("expected missing total_count error")
 	}
-	if !reflect.DeepEqual(ids, []string{"p1", "p2"}) {
-		t.Fatalf("ids = %#v", ids)
-	}
-}
-
-func TestSlidesScreenshotOverviewRejectsMalformedPresentationResponseBeforeScreenshot(t *testing.T) {
-	tests := []struct {
-		name string
-		data map[string]interface{}
-	}{
-		{name: "missing presentation", data: map[string]interface{}{}},
-		{name: "presentation is not object", data: map[string]interface{}{"xml_presentation": "not-an-object"}},
-		{name: "missing content", data: map[string]interface{}{"xml_presentation": map[string]interface{}{}}},
-		{name: "content is not string", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": 42}}},
-		{name: "blank content", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": " \n\t "}}},
-		{name: "malformed xml", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<presentation>"}}},
-		{name: "wrong root", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<document><slide id=\"p1\"/></document>"}}},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-			postCalled := false
-			reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-				"code": 0, "data": tc.data,
-			}})
-			reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", OnMatch: func(_ *http.Request) {
-				postCalled = true
-			}, Body: map[string]interface{}{
-				"code": 0, "data": map[string]interface{}{"slide_images": []interface{}{}},
-			}, Optional: true})
-
-			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"})
-			if err == nil {
-				t.Fatal("expected invalid response error")
-			}
-			p, ok := errs.ProblemOf(err)
-			if !ok || p.Category != errs.CategoryInternal || p.Subtype != errs.SubtypeInvalidResponse {
-				t.Fatalf("problem = %#v, want internal/invalid_response", p)
-			}
-			if postCalled {
-				t.Fatal("screenshot POST was called after malformed presentation response")
-			}
-		})
+	if _, err := slidesScreenshotOverviewTotalCount(map[string]interface{}{"total_count": -1.0}); err == nil {
+		t.Fatal("expected invalid total_count error")
 	}
 }
 
-func TestSlidesScreenshotOverviewTreatsEmptyPresentationAsFailedPrecondition(t *testing.T) {
+func TestSlidesScreenshotOverviewTreatsEmptyResponseAsFailedPrecondition(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<presentation/>"}},
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"total_count": 0, "slide_images": []interface{}{}},
 	}})
 	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"})
 	if err == nil {
@@ -245,23 +201,27 @@ func TestSlidesScreenshotOverviewDryRunListsDynamicScreenshotBatches(t *testing.
 		t.Fatalf("overview dry-run: %v", err)
 	}
 	steps := decodeShortcutDryRunAPI(t, stdout)
-	if len(steps) != 3 {
-		t.Fatalf("dry-run calls = %#v, want XML GET plus two screenshot-batch POSTs", steps)
+	if len(steps) != 2 {
+		t.Fatalf("dry-run calls = %#v, want two screenshot-batch POSTs", steps)
 	}
-	assertDryRunStep(t, steps, 0, "GET", "/open-apis/slides_ai/v1/xml_presentations/pres_overview")
-	for i, wantID := range []string{"<overview page slide IDs 1-10>", "<overview page slide IDs 11-20, if present>"} {
-		step := assertDryRunStep(t, steps, i+1, "POST", "/open-apis/slides_ai/v1/xml_presentations/pres_overview/slide_images")
+	for i, wantNumbers := range [][]int{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {11, 12, 13, 14, 15, 16, 17, 18, 19, 20}} {
+		step := assertDryRunStep(t, steps, i, "POST", "/open-apis/slides_ai/v1/xml_presentations/pres_overview/slide_images")
 		body, ok := step["body"].(map[string]interface{})
 		if !ok {
 			t.Fatalf("api[%d].body = %#v, want object", i+1, step["body"])
 		}
-		slideIDs, ok := body["slide_ids"].([]interface{})
-		if !ok || len(slideIDs) != 1 || slideIDs[0] != wantID {
-			t.Fatalf("api[%d].body.slide_ids = %#v, want [%q]", i+1, body["slide_ids"], wantID)
+		slideNumbers, ok := body["slide_numbers"].([]interface{})
+		if !ok || len(slideNumbers) != len(wantNumbers) {
+			t.Fatalf("api[%d].body.slide_numbers = %#v", i+1, body["slide_numbers"])
+		}
+		for j, want := range wantNumbers {
+			if slideNumbers[j] != float64(want) {
+				t.Fatalf("api[%d].body.slide_numbers = %#v", i+1, slideNumbers)
+			}
 		}
 	}
-	if !strings.Contains(steps[2]["desc"].(string), "optional second") {
-		t.Fatalf("second batch description = %#v, want optional marker", steps[2]["desc"])
+	if !strings.Contains(steps[1]["desc"].(string), "optional second") {
+		t.Fatalf("second batch description = %#v, want optional marker", steps[1]["desc"])
 	}
 }
 
@@ -274,35 +234,12 @@ func TestSlidesScreenshotOverviewWikiDryRunListsResolveXMLAndBatches(t *testing.
 		t.Fatalf("wiki overview dry-run: %v", err)
 	}
 	steps := decodeShortcutDryRunAPI(t, stdout)
-	if len(steps) != 4 {
-		t.Fatalf("dry-run calls = %#v, want wiki GET, XML GET, and two screenshot-batch POSTs", steps)
+	if len(steps) != 3 {
+		t.Fatalf("dry-run calls = %#v, want wiki GET and two screenshot-batch POSTs", steps)
 	}
 	assertDryRunStep(t, steps, 0, "GET", "/open-apis/wiki/v2/spaces/get_node")
 	for i := 1; i < len(steps); i++ {
-		wantMethod := "POST"
-		wantURL := "/open-apis/slides_ai/v1/xml_presentations/%3Cresolved_slides_token%3E/slide_images"
-		if i == 1 {
-			wantMethod = "GET"
-			wantURL = "/open-apis/slides_ai/v1/xml_presentations/%3Cresolved_slides_token%3E"
-		}
-		assertDryRunStep(t, steps, i, wantMethod, wantURL)
-	}
-}
-
-func TestSlidesScreenshotOverviewPreflightPresentationReadScope(t *testing.T) {
-	for _, args := range [][]string{{"+screenshot", "--presentation", "pres_overview", "--overview", "--dry-run", "--as", "user"}} {
-		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-		f.Credential = credential.NewCredentialProvider(nil, nil, &slidesScreenshotScopeResolver{
-			result: &credential.TokenResult{Token: "test-token", Scopes: "slides:presentation:screenshot"},
-		}, nil)
-		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
-		if err == nil {
-			t.Fatalf("args %#v succeeded, want missing presentation read scope", args)
-		}
-		var permission *errs.PermissionError
-		if !errors.As(err, &permission) || permission.Subtype != errs.SubtypeMissingScope || !reflect.DeepEqual(permission.MissingScopes, []string{"slides:presentation:read"}) {
-			t.Fatalf("args %#v error = %#v, want missing slides:presentation:read", args, err)
-		}
+		assertDryRunStep(t, steps, i, "POST", "/open-apis/slides_ai/v1/xml_presentations/%3Cresolved_slides_token%3E/slide_images")
 	}
 }
 
@@ -340,7 +277,7 @@ func TestSlidesScreenshotOverviewPageValidation(t *testing.T) {
 	}
 }
 
-func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testing.T) {
+func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideNumber(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
 	encodePNG := func(c color.RGBA) string {
@@ -358,12 +295,9 @@ func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testi
 	}
 	red, green := encodePNG(color.RGBA{R: 255, A: 255}), encodePNG(color.RGBA{G: 255, A: 255})
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation><slide id="p1"/><slide id="p2"/></presentation>`}},
-	}})
 	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{
-			{"slide_id": "p2", "data": green}, {"slide_id": "p1", "data": red},
+		"code": 0, "data": map[string]interface{}{"total_count": 2, "slide_images": []map[string]interface{}{
+			{"slide_id": "p2", "slide_number": 2, "data": green}, {"slide_id": "p1", "slide_number": 1, "data": red},
 		}},
 	}})
 
@@ -379,8 +313,7 @@ func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The first cell is p1 according to XML, although p2 arrived first.
-	if got := color.RGBAModel.Convert(overview.At(16+160, 56+90)).(color.RGBA); got.R < 200 || got.G > 50 {
+	if got := color.RGBAModel.Convert(overview.At(16+160, 16+90)).(color.RGBA); got.R < 200 || got.G > 50 {
 		t.Fatalf("first overview cell = %#v, want p1/red", got)
 	}
 	data := decodeShortcutData(t, stdout)
@@ -398,11 +331,8 @@ func TestSlidesScreenshotOverviewExecutionSetsDefaultOutputDir(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation><slide id="p1"/></presentation>`}},
-	}})
 	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{{"slide_id": "p1", "data": testSlidesScreenshotPNG(t, 960, 540)}}},
+		"code": 0, "data": map[string]interface{}{"total_count": 1, "slide_images": []map[string]interface{}{{"slide_id": "p1", "slide_number": 1, "data": testSlidesScreenshotPNG(t, 960, 540)}}},
 	}})
 	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -420,12 +350,6 @@ func TestSlidesScreenshotOverviewExecutionSetsDefaultOutputDir(t *testing.T) {
 func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) {
 	dir := t.TempDir()
 	withSlidesTestWorkingDir(t, dir)
-	var xml strings.Builder
-	xml.WriteString("<presentation>")
-	for i := 1; i <= 41; i++ {
-		fmt.Fprintf(&xml, `<slide id="p%d"/>`, i)
-	}
-	xml.WriteString("</presentation>")
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.SetRGBA(0, 0, color.RGBA{B: 255, A: 255})
 	var encoded bytes.Buffer
@@ -433,21 +357,20 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 		t.Fatal(err)
 	}
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
-		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": xml.String()}},
-	}})
 	responseFor := func(start, end int) map[string]interface{} {
 		items := make([]map[string]interface{}, 0, end-start+1)
 		for i := start; i <= end; i++ {
-			items = append(items, map[string]interface{}{"slide_id": fmt.Sprintf("p%d", i), "data": base64.StdEncoding.EncodeToString(encoded.Bytes())})
+			items = append(items, map[string]interface{}{"slide_id": fmt.Sprintf("p%d", i), "slide_number": i, "data": base64.StdEncoding.EncodeToString(encoded.Bytes())})
 		}
-		return map[string]interface{}{"code": 0, "data": map[string]interface{}{"slide_images": items}}
+		return map[string]interface{}{"code": 0, "data": map[string]interface{}{"total_count": 41, "slide_images": items}}
 	}
 	for _, batch := range []struct{ start, end int }{{21, 30}, {31, 40}} {
 		reg.Register(&httpmock.Stub{
 			Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
-			Body:       responseFor(batch.start, batch.end),
-			BodyFilter: func(body []byte) bool { return strings.Contains(string(body), fmt.Sprintf("p%d", batch.start)) },
+			Body: responseFor(batch.start, batch.end),
+			BodyFilter: func(body []byte) bool {
+				return strings.Contains(string(body), fmt.Sprintf("\"slide_numbers\":[%d", batch.start))
+			},
 		})
 	}
 	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--overview-page", "2", "--output", "shots/overview.png", "--as", "user"}); err != nil {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -43,28 +43,6 @@ func testSlidesScreenshotPNG(t *testing.T, width, height int) string {
 	return base64.StdEncoding.EncodeToString(out.Bytes())
 }
 
-func assertOverviewIndexPixels(t *testing.T, img image.Image, at image.Point, index int) {
-	t.Helper()
-	const scale, gap = 2, 3
-	x := at.X
-	for _, ch := range fmt.Sprintf("#%02d", index) {
-		glyph := overviewDigitPixels[ch]
-		for y, row := range glyph {
-			for col, on := range row {
-				got := color.RGBAModel.Convert(img.At(x+col*scale, at.Y+y*scale)).(color.RGBA)
-				if on == '1' {
-					if got.R < 240 || got.G < 240 || got.B < 240 {
-						t.Fatalf("index #%d glyph %q pixel (%d,%d) = %#v, want white", index, ch, col, y, got)
-					}
-				} else if got.R > 100 || got.G > 100 || got.B > 100 {
-					t.Fatalf("index #%d glyph %q pixel (%d,%d) = %#v, want dark background", index, ch, col, y, got)
-				}
-			}
-		}
-		x += (len(glyph[0]) + gap) * scale
-	}
-}
-
 func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	base := []string{"slides:presentation:screenshot"}
 	if got := SlidesScreenshot.ScopesForIdentity("user"); !reflect.DeepEqual(got, base) {
@@ -248,7 +226,7 @@ func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testin
 	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+240, thumb.Min.Y+135)).(color.RGBA); got.R < 200 || got.G < 200 {
 		t.Fatalf("bottom-right thumbnail = %#v, want yellow", got)
 	}
-	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 236 {
+	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 212 {
 		t.Fatalf("overview size = %v", out.Bounds())
 	}
 }
@@ -496,8 +474,8 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 		t.Fatalf("overview.size = %#v, want positive encoded-byte count", overview["size"])
 	}
 	imageSize, _ := overview["image_size"].(map[string]interface{})
-	if imageSize["width"] != float64(1360) || imageSize["height"] != float64(1116) {
-		t.Fatalf("overview.image_size = %#v, want 1360x1116", imageSize)
+	if imageSize["width"] != float64(1360) || imageSize["height"] != float64(996) {
+		t.Fatalf("overview.image_size = %#v, want 1360x996", imageSize)
 	}
 	rangeData, _ := overview["slide_range"].(map[string]interface{})
 	if rangeData["start"] != float64(21) || rangeData["end"] != float64(40) {
@@ -508,26 +486,13 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 		t.Fatalf("slides = %#v", slides)
 	}
 	slide, _ := slides[0].(map[string]interface{})
-	if slide["index"] != float64(21) || slide["label"] != "#21" || slide["slide_id"] != "p21" {
+	if slide["index"] != float64(21) || slide["slide_id"] != "p21" {
 		t.Fatalf("slide = %#v", slide)
 	}
 	last, _ := slides[19].(map[string]interface{})
-	if last["index"] != float64(40) || last["label"] != "#40" || last["slide_id"] != "p40" {
+	if last["index"] != float64(40) || last["slide_id"] != "p40" {
 		t.Fatalf("last slide = %#v", last)
 	}
-	overviewFile, err := os.Open(overview["path"].(string))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer overviewFile.Close()
-	overviewImage, _, err := image.Decode(overviewFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	firstTile, _ := slide["tile"].(map[string]interface{})
-	lastTile, _ := last["tile"].(map[string]interface{})
-	assertOverviewIndexPixels(t, overviewImage, image.Pt(int(firstTile["x"].(float64))+9, int(firstTile["y"].(float64))+5), 21)
-	assertOverviewIndexPixels(t, overviewImage, image.Pt(int(lastTile["x"].(float64))+9, int(lastTile["y"].(float64))+5), 40)
 }
 
 func TestSlidesScreenshotCompatibilityAliases(t *testing.T) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -43,6 +43,28 @@ func testSlidesScreenshotPNG(t *testing.T, width, height int) string {
 	return base64.StdEncoding.EncodeToString(out.Bytes())
 }
 
+func assertOverviewIndexPixels(t *testing.T, img image.Image, at image.Point, index int) {
+	t.Helper()
+	const scale, gap = 2, 3
+	x := at.X
+	for _, ch := range fmt.Sprintf("#%02d", index) {
+		glyph := overviewDigitPixels[ch]
+		for y, row := range glyph {
+			for col, on := range row {
+				got := color.RGBAModel.Convert(img.At(x+col*scale, at.Y+y*scale)).(color.RGBA)
+				if on == '1' {
+					if got.R < 240 || got.G < 240 || got.B < 240 {
+						t.Fatalf("index #%d glyph %q pixel (%d,%d) = %#v, want white", index, ch, col, y, got)
+					}
+				} else if got.R > 100 || got.G > 100 || got.B > 100 {
+					t.Fatalf("index #%d glyph %q pixel (%d,%d) = %#v, want dark background", index, ch, col, y, got)
+				}
+			}
+		}
+		x += (len(glyph[0]) + gap) * scale
+	}
+}
+
 func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	base := []string{"slides:presentation:screenshot"}
 	if got := SlidesScreenshot.ScopesForIdentity("user"); !reflect.DeepEqual(got, base) {
@@ -493,6 +515,19 @@ func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) 
 	if last["index"] != float64(40) || last["label"] != "#40" || last["slide_id"] != "p40" {
 		t.Fatalf("last slide = %#v", last)
 	}
+	overviewFile, err := os.Open(overview["path"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer overviewFile.Close()
+	overviewImage, _, err := image.Decode(overviewFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstTile, _ := slide["tile"].(map[string]interface{})
+	lastTile, _ := last["tile"].(map[string]interface{})
+	assertOverviewIndexPixels(t, overviewImage, image.Pt(int(firstTile["x"].(float64))+9, int(firstTile["y"].(float64))+5), 21)
+	assertOverviewIndexPixels(t, overviewImage, image.Pt(int(lastTile["x"].(float64))+9, int(lastTile["y"].(float64))+5), 40)
 }
 
 func TestSlidesScreenshotCompatibilityAliases(t *testing.T) {

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -5,9 +5,15 @@ package slides
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -16,8 +22,26 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/httpmock"
 )
+
+type slidesScreenshotScopeResolver struct {
+	result *credential.TokenResult
+}
+
+func (r *slidesScreenshotScopeResolver) ResolveToken(context.Context, credential.TokenSpec) (*credential.TokenResult, error) {
+	return r.result, nil
+}
+
+func testSlidesScreenshotPNG(t *testing.T, width, height int) string {
+	t.Helper()
+	var out bytes.Buffer
+	if err := png.Encode(&out, image.NewRGBA(image.Rect(0, 0, width, height))); err != nil {
+		t.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(out.Bytes())
+}
 
 func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	base := []string{"slides:presentation:screenshot"}
@@ -29,9 +53,445 @@ func TestSlidesScreenshotDeclaredScopes(t *testing.T) {
 	}
 
 	got := SlidesScreenshot.DeclaredScopesForIdentity("user")
-	want := []string{"slides:presentation:screenshot", "wiki:node:read"}
+	want := []string{"slides:presentation:screenshot", "wiki:node:read", "slides:presentation:read"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("declared scopes = %#v, want %#v", got, want)
+	}
+}
+
+func TestSlidesScreenshotOverviewFlagDescriptionsExposePagination(t *testing.T) {
+	descriptions := make(map[string]string)
+	for _, flag := range SlidesScreenshot.Flags {
+		descriptions[flag.Name] = flag.Desc
+	}
+	if got, want := descriptions["presentation"], presentationRefDescription+"; list mode only"; got != want {
+		t.Fatalf("presentation description = %q, want %q", got, want)
+	}
+	if got := descriptions["overview"]; !strings.Contains(got, "one indexed overview PNG containing up to 20") || !strings.Contains(got, "--overview-page") {
+		t.Fatalf("--overview description = %q, want single-page limit and pagination guidance", got)
+	}
+	if got := descriptions["overview-page"]; !strings.Contains(got, "next_overview_page") || !strings.Contains(got, "has_next") {
+		t.Fatalf("--overview-page description = %q, want response-driven pagination guidance", got)
+	}
+}
+
+func TestSlidesScreenshotOverviewImagesRejectsInvalidResponseAndOrdersByRequestedID(t *testing.T) {
+	pngData := func(c color.RGBA) string {
+		t.Helper()
+		img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+		for y := 0; y < 2; y++ {
+			for x := 0; x < 2; x++ {
+				img.SetRGBA(x, y, c)
+			}
+		}
+		var out bytes.Buffer
+		if err := png.Encode(&out, img); err != nil {
+			t.Fatal(err)
+		}
+		return base64.StdEncoding.EncodeToString(out.Bytes())
+	}
+	imageItem := func(id, data string) map[string]interface{} {
+		return map[string]interface{}{"slide_id": id, "data": data}
+	}
+	red, green := pngData(color.RGBA{R: 255, A: 255}), pngData(color.RGBA{G: 255, A: 255})
+
+	ordered, err := slidesScreenshotOverviewImages(map[string]interface{}{"slide_images": []interface{}{imageItem("p2", green), imageItem("p1", red)}}, []string{"p1", "p2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := color.RGBAModel.Convert(ordered[0].At(0, 0)).(color.RGBA); got.R != 255 || got.G != 0 {
+		t.Fatalf("first image = %#v, want p1/red", got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{name: "missing", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red)}}},
+		{name: "duplicate", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red), imageItem("p1", red)}}},
+		{name: "unexpected", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", red), imageItem("p3", green)}}},
+		{name: "invalid base64", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", "not-base64"), imageItem("p2", green)}}},
+		{name: "invalid image", data: map[string]interface{}{"slide_images": []interface{}{imageItem("p1", base64.StdEncoding.EncodeToString([]byte("not an image"))), imageItem("p2", green)}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := slidesScreenshotOverviewImages(tc.data, []string{"p1", "p2"})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("error = %T %v, want typed problem", err, err)
+			}
+			if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("problem = %#v, want api/invalid_response", p)
+			}
+			if tc.name == "invalid base64" {
+				var corrupt base64.CorruptInputError
+				if !errors.As(err, &corrupt) {
+					t.Fatalf("error = %v, want preserved base64.CorruptInputError cause", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotIDsFromXMLPreservesPageOrder(t *testing.T) {
+	ids, err := slidesScreenshotIDsFromXML(`<presentation><slide id="p1"/><slide id="p2"/><slide/></presentation>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ids, []string{"p1", "p2"}) {
+		t.Fatalf("ids = %#v", ids)
+	}
+}
+
+func TestSlidesScreenshotOverviewRejectsMalformedPresentationResponseBeforeScreenshot(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{name: "missing presentation", data: map[string]interface{}{}},
+		{name: "presentation is not object", data: map[string]interface{}{"xml_presentation": "not-an-object"}},
+		{name: "missing content", data: map[string]interface{}{"xml_presentation": map[string]interface{}{}}},
+		{name: "content is not string", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": 42}}},
+		{name: "blank content", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": " \n\t "}}},
+		{name: "malformed xml", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<presentation>"}}},
+		{name: "wrong root", data: map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<document><slide id=\"p1\"/></document>"}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			postCalled := false
+			reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+				"code": 0, "data": tc.data,
+			}})
+			reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", OnMatch: func(_ *http.Request) {
+				postCalled = true
+			}, Body: map[string]interface{}{
+				"code": 0, "data": map[string]interface{}{"slide_images": []interface{}{}},
+			}, Optional: true})
+
+			err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"})
+			if err == nil {
+				t.Fatal("expected invalid response error")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok || p.Category != errs.CategoryInternal || p.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("problem = %#v, want internal/invalid_response", p)
+			}
+			if postCalled {
+				t.Fatal("screenshot POST was called after malformed presentation response")
+			}
+		})
+	}
+}
+
+func TestSlidesScreenshotOverviewTreatsEmptyPresentationAsFailedPrecondition(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": "<presentation/>"}},
+	}})
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"})
+	if err == nil {
+		t.Fatal("expected empty presentation error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("problem = %#v, want validation/failed_precondition", p)
+	}
+}
+
+func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 960, 540))
+	drawQuadrant := func(r image.Rectangle, c color.RGBA) {
+		for y := r.Min.Y; y < r.Max.Y; y++ {
+			for x := r.Min.X; x < r.Max.X; x++ {
+				src.SetRGBA(x, y, c)
+			}
+		}
+	}
+	drawQuadrant(image.Rect(0, 0, 480, 270), color.RGBA{R: 255, A: 255})
+	drawQuadrant(image.Rect(480, 0, 960, 270), color.RGBA{G: 255, A: 255})
+	drawQuadrant(image.Rect(0, 270, 480, 540), color.RGBA{B: 255, A: 255})
+	drawQuadrant(image.Rect(480, 270, 960, 540), color.RGBA{R: 255, G: 255, A: 255})
+	out, cells := composeSlidesOverview([]image.Image{src}, 1)
+	if len(cells) != 1 || cells[0].thumbnail.Dx() != 320 || cells[0].thumbnail.Dy() != 180 {
+		t.Fatalf("cells = %#v", cells)
+	}
+	thumb := cells[0].thumbnail
+	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+80, thumb.Min.Y+45)).(color.RGBA); got.R < 200 || got.G > 50 {
+		t.Fatalf("top-left thumbnail = %#v, want red", got)
+	}
+	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+240, thumb.Min.Y+135)).(color.RGBA); got.R < 200 || got.G < 200 {
+		t.Fatalf("bottom-right thumbnail = %#v, want yellow", got)
+	}
+	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 236 {
+		t.Fatalf("overview size = %v", out.Bounds())
+	}
+}
+
+func TestSlidesScreenshotOverviewAllowsSingleOutputDryRun(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot", "--presentation", "pres_overview", "--overview", "--output", "shots/overview.png", "--dry-run", "--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("overview --output: %v", err)
+	}
+	data := decodeShortcutData(t, stdout)
+	if data["output"] != "shots/overview.png" {
+		t.Fatalf("output = %#v", data["output"])
+	}
+}
+
+func TestSlidesScreenshotOverviewDryRunListsDynamicScreenshotBatches(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot", "--presentation", "pres_overview", "--overview", "--dry-run", "--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("overview dry-run: %v", err)
+	}
+	steps := decodeShortcutDryRunAPI(t, stdout)
+	if len(steps) != 3 {
+		t.Fatalf("dry-run calls = %#v, want XML GET plus two screenshot-batch POSTs", steps)
+	}
+	assertDryRunStep(t, steps, 0, "GET", "/open-apis/slides_ai/v1/xml_presentations/pres_overview")
+	for i, wantID := range []string{"<overview page slide IDs 1-10>", "<overview page slide IDs 11-20, if present>"} {
+		step := assertDryRunStep(t, steps, i+1, "POST", "/open-apis/slides_ai/v1/xml_presentations/pres_overview/slide_images")
+		body, ok := step["body"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("api[%d].body = %#v, want object", i+1, step["body"])
+		}
+		slideIDs, ok := body["slide_ids"].([]interface{})
+		if !ok || len(slideIDs) != 1 || slideIDs[0] != wantID {
+			t.Fatalf("api[%d].body.slide_ids = %#v, want [%q]", i+1, body["slide_ids"], wantID)
+		}
+	}
+	if !strings.Contains(steps[2]["desc"].(string), "optional second") {
+		t.Fatalf("second batch description = %#v, want optional marker", steps[2]["desc"])
+	}
+}
+
+func TestSlidesScreenshotOverviewWikiDryRunListsResolveXMLAndBatches(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+		"+screenshot", "--presentation", "https://example.feishu.cn/wiki/wiki_token", "--overview", "--dry-run", "--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("wiki overview dry-run: %v", err)
+	}
+	steps := decodeShortcutDryRunAPI(t, stdout)
+	if len(steps) != 4 {
+		t.Fatalf("dry-run calls = %#v, want wiki GET, XML GET, and two screenshot-batch POSTs", steps)
+	}
+	assertDryRunStep(t, steps, 0, "GET", "/open-apis/wiki/v2/spaces/get_node")
+	for i := 1; i < len(steps); i++ {
+		wantMethod := "POST"
+		wantURL := "/open-apis/slides_ai/v1/xml_presentations/%3Cresolved_slides_token%3E/slide_images"
+		if i == 1 {
+			wantMethod = "GET"
+			wantURL = "/open-apis/slides_ai/v1/xml_presentations/%3Cresolved_slides_token%3E"
+		}
+		assertDryRunStep(t, steps, i, wantMethod, wantURL)
+	}
+}
+
+func TestSlidesScreenshotOverviewPreflightPresentationReadScope(t *testing.T) {
+	for _, args := range [][]string{{"+screenshot", "--presentation", "pres_overview", "--overview", "--dry-run", "--as", "user"}} {
+		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+		f.Credential = credential.NewCredentialProvider(nil, nil, &slidesScreenshotScopeResolver{
+			result: &credential.TokenResult{Token: "test-token", Scopes: "slides:presentation:screenshot"},
+		}, nil)
+		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
+		if err == nil {
+			t.Fatalf("args %#v succeeded, want missing presentation read scope", args)
+		}
+		var permission *errs.PermissionError
+		if !errors.As(err, &permission) || permission.Subtype != errs.SubtypeMissingScope || !reflect.DeepEqual(permission.MissingScopes, []string{"slides:presentation:read"}) {
+			t.Fatalf("args %#v error = %#v, want missing slides:presentation:read", args, err)
+		}
+	}
+}
+
+func TestSlidesScreenshotOverviewRejectsNonPNGOutputDuringValidation(t *testing.T) {
+	for _, output := range []string{"shots/overview.jpg", "shots/overview.jpeg"} {
+		f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{
+			"+screenshot", "--presentation", "pres_overview", "--overview", "--output", output, "--dry-run", "--as", "user",
+		})
+		if err == nil {
+			t.Fatalf("output %q succeeded, want validation error", output)
+		}
+		p, ok := errs.ProblemOf(err)
+		var validation *errs.ValidationError
+		if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument || !errors.As(err, &validation) || validation.Param != "--output" {
+			t.Fatalf("output %q problem = %#v, want validation/invalid_argument for --output", output, p)
+		}
+	}
+}
+
+func TestSlidesScreenshotOverviewPageValidation(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	for _, args := range [][]string{
+		{"+screenshot", "--presentation", "pres_abc", "--overview-page", "2", "--dry-run", "--as", "user"},
+		{"+screenshot", "--presentation", "pres_abc", "--overview", "--overview-page", "0", "--dry-run", "--as", "user"},
+	} {
+		err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, args)
+		if err == nil {
+			t.Fatalf("args %#v succeeded, want validation error", args)
+		}
+		p, ok := errs.ProblemOf(err)
+		if !ok || p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeInvalidArgument {
+			t.Fatalf("args %#v problem = %#v, want validation/invalid_argument", args, p)
+		}
+	}
+}
+
+func TestSlidesScreenshotOverviewExecutionOrdersServerResponseBySlideID(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	encodePNG := func(c color.RGBA) string {
+		img := image.NewRGBA(image.Rect(0, 0, 960, 540))
+		for y := 0; y < 540; y++ {
+			for x := 0; x < 960; x++ {
+				img.SetRGBA(x, y, c)
+			}
+		}
+		var out bytes.Buffer
+		if err := png.Encode(&out, img); err != nil {
+			t.Fatal(err)
+		}
+		return base64.StdEncoding.EncodeToString(out.Bytes())
+	}
+	red, green := encodePNG(color.RGBA{R: 255, A: 255}), encodePNG(color.RGBA{G: 255, A: 255})
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation><slide id="p1"/><slide id="p2"/></presentation>`}},
+	}})
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{
+			{"slide_id": "p2", "data": green}, {"slide_id": "p1", "data": red},
+		}},
+	}})
+
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--output", "shots/overview", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	decoded, err := os.Open(filepath.Join(dir, "shots", "overview.png"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer decoded.Close()
+	overview, err := png.Decode(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The first cell is p1 according to XML, although p2 arrived first.
+	if got := color.RGBAModel.Convert(overview.At(16+160, 56+90)).(color.RGBA); got.R < 200 || got.G > 50 {
+		t.Fatalf("first overview cell = %#v, want p1/red", got)
+	}
+	data := decodeShortcutData(t, stdout)
+	output, _ := data["output"].(string)
+	if filepath.Base(output) != "overview.png" || filepath.Base(filepath.Dir(output)) != "shots" || data["requested_output"] != "shots/overview" || data["output_adjusted"] != true {
+		t.Fatalf("overview root output = %#v", data)
+	}
+	overviewData, _ := data["overview"].(map[string]interface{})
+	if overviewData["path"] != data["output"] {
+		t.Fatalf("overview path = %#v, want root output %#v", overviewData["path"], data["output"])
+	}
+}
+
+func TestSlidesScreenshotOverviewExecutionSetsDefaultOutputDir(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": `<presentation><slide id="p1"/></presentation>`}},
+	}})
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"slide_images": []map[string]interface{}{{"slide_id": "p1", "data": testSlidesScreenshotPNG(t, 960, 540)}}},
+	}})
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutData(t, stdout)
+	if data["output_dir"] != defaultSlidesScreenshotDir {
+		t.Fatalf("output_dir = %#v, want %q", data["output_dir"], defaultSlidesScreenshotDir)
+	}
+	overviewData, _ := data["overview"].(map[string]interface{})
+	if overviewData["path"] == "" {
+		t.Fatalf("overview = %#v, want saved path", overviewData)
+	}
+}
+
+func TestSlidesScreenshotOverviewExecutionPaginatesAtTwentySlides(t *testing.T) {
+	dir := t.TempDir()
+	withSlidesTestWorkingDir(t, dir)
+	var xml strings.Builder
+	xml.WriteString("<presentation>")
+	for i := 1; i <= 41; i++ {
+		fmt.Fprintf(&xml, `<slide id="p%d"/>`, i)
+	}
+	xml.WriteString("</presentation>")
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.SetRGBA(0, 0, color.RGBA{B: 255, A: 255})
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, img); err != nil {
+		t.Fatal(err)
+	}
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"xml_presentation": map[string]interface{}{"content": xml.String()}},
+	}})
+	responseFor := func(start, end int) map[string]interface{} {
+		items := make([]map[string]interface{}, 0, end-start+1)
+		for i := start; i <= end; i++ {
+			items = append(items, map[string]interface{}{"slide_id": fmt.Sprintf("p%d", i), "data": base64.StdEncoding.EncodeToString(encoded.Bytes())})
+		}
+		return map[string]interface{}{"code": 0, "data": map[string]interface{}{"slide_images": items}}
+	}
+	for _, batch := range []struct{ start, end int }{{21, 30}, {31, 40}} {
+		reg.Register(&httpmock.Stub{
+			Method: "POST", URL: "/open-apis/slides_ai/v1/xml_presentations/pres_abc/slide_images",
+			Body:       responseFor(batch.start, batch.end),
+			BodyFilter: func(body []byte) bool { return strings.Contains(string(body), fmt.Sprintf("p%d", batch.start)) },
+		})
+	}
+	if err := runSlidesShortcut(t, f, stdout, SlidesScreenshot, []string{"+screenshot", "--presentation", "pres_abc", "--overview", "--overview-page", "2", "--output", "shots/overview.png", "--as", "user"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutData(t, stdout)
+	overview, ok := data["overview"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("overview = %#v", data["overview"])
+	}
+	if overview["total_slides"] != float64(41) || overview["overview_page"] != float64(2) || overview["page_size"] != float64(20) || overview["columns"] != float64(4) || overview["has_previous"] != true || overview["has_next"] != true || overview["previous_overview_page"] != float64(1) || overview["next_overview_page"] != float64(3) {
+		t.Fatalf("overview navigation = %#v", overview)
+	}
+	if _, ok := overview["size"].(float64); !ok || overview["size"].(float64) <= 0 {
+		t.Fatalf("overview.size = %#v, want positive encoded-byte count", overview["size"])
+	}
+	imageSize, _ := overview["image_size"].(map[string]interface{})
+	if imageSize["width"] != float64(1360) || imageSize["height"] != float64(1116) {
+		t.Fatalf("overview.image_size = %#v, want 1360x1116", imageSize)
+	}
+	rangeData, _ := overview["slide_range"].(map[string]interface{})
+	if rangeData["start"] != float64(21) || rangeData["end"] != float64(40) {
+		t.Fatalf("slide_range = %#v", rangeData)
+	}
+	slides, _ := overview["slides"].([]interface{})
+	if len(slides) != 20 {
+		t.Fatalf("slides = %#v", slides)
+	}
+	slide, _ := slides[0].(map[string]interface{})
+	if slide["index"] != float64(21) || slide["label"] != "#21" || slide["slide_id"] != "p21" {
+		t.Fatalf("slide = %#v", slide)
+	}
+	last, _ := slides[19].(map[string]interface{})
+	if last["index"] != float64(40) || last["label"] != "#40" || last["slide_id"] != "p40" {
+		t.Fatalf("last slide = %#v", last)
 	}
 }
 

--- a/shortcuts/slides/slides_screenshot_test.go
+++ b/shortcuts/slides/slides_screenshot_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"image/draw"
 	"image/png"
 	"net/http"
 	"os"
@@ -202,29 +203,19 @@ func TestSlidesScreenshotOverviewTreatsEmptyPresentationAsFailedPrecondition(t *
 	}
 }
 
-func TestComposeSlidesOverviewScalesWholeSlideAndProvidesIndexGeometry(t *testing.T) {
-	src := image.NewRGBA(image.Rect(0, 0, 960, 540))
-	drawQuadrant := func(r image.Rectangle, c color.RGBA) {
-		for y := r.Min.Y; y < r.Max.Y; y++ {
-			for x := r.Min.X; x < r.Max.X; x++ {
-				src.SetRGBA(x, y, c)
-			}
-		}
-	}
-	drawQuadrant(image.Rect(0, 0, 480, 270), color.RGBA{R: 255, A: 255})
-	drawQuadrant(image.Rect(480, 0, 960, 270), color.RGBA{G: 255, A: 255})
-	drawQuadrant(image.Rect(0, 270, 480, 540), color.RGBA{B: 255, A: 255})
-	drawQuadrant(image.Rect(480, 270, 960, 540), color.RGBA{R: 255, G: 255, A: 255})
+func TestComposeSlidesOverviewPreservesAspectRatioAndProvidesGeometry(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 600, 800))
+	draw.Draw(src, src.Bounds(), &image.Uniform{C: color.RGBA{R: 255, A: 255}}, image.Point{}, draw.Src)
 	out, cells := composeSlidesOverview([]image.Image{src}, 1)
-	if len(cells) != 1 || cells[0].thumbnail.Dx() != 320 || cells[0].thumbnail.Dy() != 180 {
+	if len(cells) != 1 || cells[0].tile.Dx() != 320 || cells[0].tile.Dy() != 180 || cells[0].thumbnail.Dx() != 135 || cells[0].thumbnail.Dy() != 180 {
 		t.Fatalf("cells = %#v", cells)
 	}
 	thumb := cells[0].thumbnail
-	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+80, thumb.Min.Y+45)).(color.RGBA); got.R < 200 || got.G > 50 {
-		t.Fatalf("top-left thumbnail = %#v, want red", got)
+	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+thumb.Dx()/2, thumb.Min.Y+thumb.Dy()/2)).(color.RGBA); got.R < 200 || got.G > 50 {
+		t.Fatalf("thumbnail center = %#v, want red", got)
 	}
-	if got := color.RGBAModel.Convert(out.At(thumb.Min.X+240, thumb.Min.Y+135)).(color.RGBA); got.R < 200 || got.G < 200 {
-		t.Fatalf("bottom-right thumbnail = %#v, want yellow", got)
+	if got := color.RGBAModel.Convert(out.At(cells[0].tile.Min.X+20, cells[0].tile.Min.Y+cells[0].tile.Dy()/2)).(color.RGBA); got.R < 240 || got.G < 240 || got.B < 240 {
+		t.Fatalf("left letterbox = %#v, want white", got)
 	}
 	if out.Bounds().Dx() != 352 || out.Bounds().Dy() != 212 {
 		t.Fatalf("overview size = %v", out.Bounds())

--- a/skills/lark-slides/references/cli/lark-slides-screenshot.md
+++ b/skills/lark-slides/references/cli/lark-slides-screenshot.md
@@ -29,13 +29,15 @@ lark-cli slides +screenshot --as user \
 
 | 参数 | 必需 | 说明 |
 |------|------|------|
-| `--presentation` | list 模式必需 | `xml_presentation_id`、`/slides/` URL，或解析后为 slides 的 `/wiki/` URL。传 `--content` 时不能使用 |
+| `--presentation` | list / overview 模式必需 | `xml_presentation_id`、`/slides/` URL，或解析后为 slides 的 `/wiki/` URL。传 `--content` 时不能使用 |
 | `--slide-id` | list 模式与 `--slide-number` 二选一 | 页面 short ID；不能与 `--slide-number` 同时使用；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-id slide_1,slide_2`）；一次最多 10 个 ID |
 | `--slide-number` | list 模式与 `--slide-id` 二选一 | 页面页号；不能与 `--slide-id` 同时使用；多页截图时重复传入，或用逗号分隔一次传多个（如 `--slide-number 1,2,3`）；一次最多 10 个页码 |
 | `--content` | render 模式必需 | 要直接渲染的 `<slide>` XML 片段；支持直接传值、`@file`、`-` stdin。传入后不能同时传 `--slide-id` / `--slide-number` |
-| `--output` | 否 | 单张截图的期望相对输出路径，可不写扩展名，显式扩展名只支持 `.png`、`.jpg`、`.jpeg`。只能选择一页，不能与 `--output-dir` / `--output-name` 同时使用；最终路径以返回的 `output` 为准 |
+| `--output` | 否 | 单张截图或 overview 图片的期望相对输出路径，可不写扩展名。普通单张截图的显式扩展名支持 `.png`、`.jpg`、`.jpeg`；overview 的显式扩展名只能是 `.png`。只能选择一页或使用 `--overview`，不能与 `--output-dir` / `--output-name` 同时使用；最终路径以返回的 `output` 为准 |
 | `--output-dir` | 否 | 输出目录，默认 `.lark-slides/screenshots`；必须是当前目录内的相对路径 |
 | `--output-name` | 否 | 仅用于 `--content` render 模式设置输出文件名 stem。普通页面截图传入该参数会返回 `validation/invalid_argument`（`param: --output-name`）并提示改用 `--output` |
+| `--overview` | 否 | 输出当前演示文稿的一张索引总览 PNG。每个 overview 页最多包含 20 页幻灯片，按固定 4 列排列；不与 `--slide-id`、`--slide-number`、`--content` 同时使用 |
+| `--overview-page` | 否，默认 `1` | 从 1 开始的 overview 页号，仅与 `--overview` 同时使用。返回值中的 `has_next`、`next_overview_page`、`has_previous`、`previous_overview_page` 表示分页状态 |
 
 ## 示例
 
@@ -100,6 +102,13 @@ lark-cli slides +screenshot --as user \
   }
 }
 ```
+
+`--overview` 的 `data.overview` 包含：
+
+- `path`、`format`、`size`、`image_size`：合成 PNG 的本地路径、格式、字节数和像素尺寸。
+- `columns`（固定为 `4`）、`total_slides`、`overview_page`、`page_size`、`slide_range`：网格和分页信息。
+- `has_previous`、`previous_overview_page`、`has_next`、`next_overview_page`：存在时表示相邻 overview 页。
+- `slides[]`：当前 overview 页内每张幻灯片的 `index`、`label`、`slide_id`、`slide_number`、`row`、`column`、`tile` 和 `thumbnail`。后两者为 `{x,y,width,height}` 像素矩形。
 
 ## 注意事项
 

--- a/skills/lark-slides/references/cli/lark-slides-screenshot.md
+++ b/skills/lark-slides/references/cli/lark-slides-screenshot.md
@@ -103,13 +103,6 @@ lark-cli slides +screenshot --as user \
 }
 ```
 
-`--overview` 的 `data.overview` 包含：
-
-- `path`、`format`、`size`、`image_size`：合成 PNG 的本地路径、格式、字节数和像素尺寸。
-- `columns`（固定为 `4`）、`total_slides`、`overview_page`、`page_size`、`slide_range`：网格和分页信息。
-- `has_previous`、`previous_overview_page`、`has_next`、`next_overview_page`：存在时表示相邻 overview 页。
-- `slides[]`：当前 overview 页内每张幻灯片的 `index`、`label`、`slide_id`、`slide_number`、`row`、`column`、`tile` 和 `thumbnail`。后两者为 `{x,y,width,height}` 像素矩形。
-
 ## 注意事项
 
 1. 优先使用 `slides +screenshot` 保存本地图片，不要把图片 Base64 打到 stdout。

--- a/tests/cli_e2e/slides/coverage.md
+++ b/tests/cli_e2e/slides/coverage.md
@@ -1,9 +1,9 @@
 # Slides CLI E2E Coverage
 
 ## Metrics
-- Denominator: 6 leaf commands
-- Covered: 5
-- Coverage: 83.3%
+- Denominator: 7 leaf commands
+- Covered: 6
+- Coverage: 85.7%
 
 ## Summary
 - TestSlides_CreateWorkflowAsUser: proves the user slides workflow through `create presentation with slide as user` and `get created presentation xml as user`; creates a fresh presentation, asserts returned IDs, then reads back the XML content to prove the title and slide body persisted.
@@ -15,6 +15,8 @@
 - TestSlides_HistoryWorkflow: opt-in live round-trip coverage for `+update-slide`; creates a presentation, updates its page in place, asserts the returned `slide_id`, the persisted marker, and that an element written back with its original id keeps that id, then reverts through slide history and self-cleans. It runs only when `LARK_SLIDES_HISTORY_E2E=1` and therefore does not yet exercise the default live lane.
 - TestSlidesReplaceSlideNormalizationDryRunE2E / TestSlidesReplaceSlideEmptyReplacementDryRunE2E / TestSlidesReplaceSlideDryRunE2E: dry-run coverage for `+replace-slide` through the built binary. The normalization case proves `replace` / `insert`, `target_id`, `content`, and `element` become a canonical request and that structured output records all conversions. The other cases preserve the strict boundary: an actually-empty canonical payload still fails, while a legitimate mixed `block_replace` + `block_insert` batch remains unchanged.
 - TestSlides_ReplaceSlideAliasWorkflowAsUser: live alias round trip on a throwaway presentation. It reads server-assigned block IDs, replaces one target through `replace` / `target_id` / `content`, inserts another through `insert` / `element`, reads the deck back to prove both writes persisted in the requested position while a control block survived, and deletes the presentation in cleanup.
+- TestSlidesScreenshotOverviewDryRunE2E: executes the compiled CLI without remote writes and pins XML enumeration followed by two dynamic screenshot-batch placeholders.
+- TestSlidesScreenshotOverviewLiveE2E: creates a two-page throwaway deck and verifies overview indexing, fixed four-column PNG geometry, slide-id mapping, and output path before cleanup.
 - Blocked area: `slides +media-upload` is still uncovered because it needs a deterministic local image fixture plus XML follow-up proof that is separate from the base create/read workflow.
 
 ## Command Table
@@ -26,4 +28,5 @@
 | ✓ | slides +delete-slide | shortcut | slides_slide_add_delete_dryrun_test.go::TestSlidesDeleteSlideDryRunE2E, TestSlidesDeleteSlideWikiDryRunE2E; slides_slide_add_delete_workflow_test.go::TestSlides_SlideAddDeleteWorkflowAsUser | `--slide-id`; `--revision-id`; wiki URL | live delete runs on a throwaway deck; readback proves the neighbours survive |
 | ✓ | slides +update-slide | shortcut | slides_update_slide_dryrun_test.go::TestSlidesUpdateSlideDryRunE2E (+ alias / refusal cases); slides_update_slide_workflow_test.go::TestSlidesUpdateSlideLiveE2E; slides_history_workflow_test.go::TestSlides_HistoryWorkflow (opt-in history/revert) | `--presentation`; `--slide-id`; `--content "<slide ...>"`; `--revision-id` | default live CI proves a real in-place update and readback; opt-in workflow adds history/revert and element-id preservation |
 | ✓ | slides +replace-slide | shortcut | slides_replace_slide_dryrun_test.go::TestSlidesReplaceSlideNormalizationDryRunE2E, TestSlidesReplaceSlideEmptyReplacementDryRunE2E, TestSlidesReplaceSlideDryRunE2E; slides_replace_slide_workflow_test.go::TestSlides_ReplaceSlideAliasWorkflowAsUser | `--presentation`; `--slide-id`; canonical and compatibility `--parts` shapes | dry-run pins canonical request construction and validation; live workflow proves alias replace/insert persistence, target ID preservation, insertion ordering, control-block survival, and cleanup |
+| ✓ | slides +screenshot | shortcut | slides_screenshot_dryrun_test.go::TestSlidesScreenshotOverviewDryRunE2E; slides_screenshot_workflow_test.go::TestSlidesScreenshotOverviewLiveE2E | `--overview`; `--overview-page`; `--output` | dry-run pins XML-read and dynamic batch declaration; live workflow verifies overview index/path/image contract |
 | ✕ | slides +media-upload | shortcut |  | none | needs a stable local image fixture plus follow-up slide XML proof |

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -5,6 +5,7 @@ package slides
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -285,4 +286,36 @@ func TestSlidesScreenshotEmptySlideIDDryRunE2E(t *testing.T) {
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
 	require.Equal(t, "/open-apis/slides_ai/v1/slide_image/render", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
+}
+
+func TestSlidesScreenshotOverviewDryRunE2E(t *testing.T) {
+	setSlidesDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"slides", "+screenshot",
+			"--presentation", "presScreenshotOverview",
+			"--overview",
+			"--overview-page", "2",
+			"--output", "overview-page-02",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, int64(3), gjson.Get(result.Stdout, "data.api.#").Int(), result.Stdout)
+	require.Equal(t, "GET", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
+	require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotOverview", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
+	require.Equal(t, int64(-1), gjson.Get(result.Stdout, "data.api.0.params.revision_id").Int(), result.Stdout)
+	for _, index := range []int{1, 2} {
+		require.Equal(t, "POST", gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".method").String(), result.Stdout)
+		require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotOverview/slide_images", gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".url").String(), result.Stdout)
+		require.Len(t, gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".body.slide_ids").Array(), 1, result.Stdout)
+	}
+	require.Equal(t, "overview-page-02", gjson.Get(result.Stdout, "data.output").String(), result.Stdout)
 }

--- a/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_dryrun_test.go
@@ -5,7 +5,6 @@ package slides
 
 import (
 	"context"
-	"strconv"
 	"testing"
 	"time"
 
@@ -308,14 +307,13 @@ func TestSlidesScreenshotOverviewDryRunE2E(t *testing.T) {
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
 
-	require.Equal(t, int64(3), gjson.Get(result.Stdout, "data.api.#").Int(), result.Stdout)
-	require.Equal(t, "GET", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
-	require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotOverview", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
-	require.Equal(t, int64(-1), gjson.Get(result.Stdout, "data.api.0.params.revision_id").Int(), result.Stdout)
-	for _, index := range []int{1, 2} {
-		require.Equal(t, "POST", gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".method").String(), result.Stdout)
-		require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotOverview/slide_images", gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".url").String(), result.Stdout)
-		require.Len(t, gjson.Get(result.Stdout, "data.api."+strconv.Itoa(index)+".body.slide_ids").Array(), 1, result.Stdout)
+	require.Equal(t, int64(2), gjson.Get(result.Stdout, "data.api.#").Int(), result.Stdout)
+	for index, wantStart := range map[string]int64{"0": 21, "1": 31} {
+		require.Equal(t, "POST", gjson.Get(result.Stdout, "data.api."+index+".method").String(), result.Stdout)
+		require.Equal(t, "/open-apis/slides_ai/v1/xml_presentations/presScreenshotOverview/slide_images", gjson.Get(result.Stdout, "data.api."+index+".url").String(), result.Stdout)
+		values := gjson.Get(result.Stdout, "data.api."+index+".body.slide_numbers").Array()
+		require.Len(t, values, 10, result.Stdout)
+		require.Equal(t, wantStart, values[0].Int(), result.Stdout)
 	}
 	require.Equal(t, "overview-page-02", gjson.Get(result.Stdout, "data.output").String(), result.Stdout)
 }

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -149,6 +149,79 @@ func TestSlidesScreenshotAliasesLiveE2E(t *testing.T) {
 	require.Equal(t, actualFormat, decodedFormat, fixedOutputResult.Stdout)
 }
 
+func TestSlidesScreenshotOverviewLiveE2E(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+
+	parentT := t
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	suffix := clie2e.GenerateSuffix()
+	title := "slides-screenshot-overview-e2e-" + suffix
+	slideXML := func(marker string) string {
+		return `<slide xmlns="https://www.larkoffice.com/sml/2.0"><data><shape type="text" topLeftX="80" topLeftY="80" width="800" height="120"><content textType="title"><p>` + marker + `</p></content></shape></data></slide>`
+	}
+	slidesJSON, err := json.Marshal([]string{slideXML(title + "-one"), slideXML(title + "-two")})
+	require.NoError(t, err)
+
+	createResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"slides", "+create", "--title", title, "--slides", string(slidesJSON)},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	createResult.AssertExitCode(t, 0)
+	createResult.AssertStdoutStatus(t, true)
+	presentationID := gjson.Get(createResult.Stdout, "data.xml_presentation_id").String()
+	require.NotEmpty(t, presentationID, createResult.Stdout)
+	parentT.Cleanup(func() {
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+			Args:      []string{"drive", "+delete", "--file-token", presentationID, "--type", "slides", "--yes"},
+			DefaultAs: "bot",
+		})
+		clie2e.ReportCleanupFailure(parentT, "delete presentation "+presentationID, deleteResult, deleteErr)
+	})
+	slideIDs := gjson.Get(createResult.Stdout, "data.slide_ids").Array()
+	require.Len(t, slideIDs, 2, createResult.Stdout)
+
+	workDir := t.TempDir()
+	overviewResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"slides", "+screenshot", "--presentation", presentationID, "--overview", "--output", "overview.png"},
+		DefaultAs: "bot",
+		WorkDir:   workDir,
+	})
+	require.NoError(t, err)
+	overviewResult.AssertExitCode(t, 0)
+	overviewResult.AssertStdoutStatus(t, true)
+	overview := gjson.Get(overviewResult.Stdout, "data.overview")
+	require.Equal(t, int64(4), overview.Get("columns").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(2), overview.Get("total_slides").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(1), overview.Get("overview_page").Int(), overviewResult.Stdout)
+	slides := overview.Get("slides").Array()
+	require.Len(t, slides, 2, overviewResult.Stdout)
+	for i, slideID := range slideIDs {
+		require.Equal(t, int64(i+1), slides[i].Get("index").Int(), overviewResult.Stdout)
+		require.Equal(t, slideID.String(), slides[i].Get("slide_id").String(), overviewResult.Stdout)
+		require.Equal(t, int64(0), slides[i].Get("row").Int(), overviewResult.Stdout)
+		require.Equal(t, int64(i), slides[i].Get("column").Int(), overviewResult.Stdout)
+	}
+	overviewPath := overview.Get("path").String()
+	require.Equal(t, overviewPath, gjson.Get(overviewResult.Stdout, "data.output").String(), overviewResult.Stdout)
+	requireScreenshotPathUnderDir(t, overviewPath, workDir)
+	overviewFile, err := vfs.Open(overviewPath)
+	require.NoError(t, err)
+	defer overviewFile.Close()
+	overviewConfig, overviewFormat, err := image.DecodeConfig(overviewFile)
+	require.NoError(t, err)
+	require.Equal(t, "png", overviewFormat, overviewResult.Stdout)
+	require.Equal(t, 1360, overviewConfig.Width, overviewResult.Stdout)
+	require.Equal(t, 236, overviewConfig.Height, overviewResult.Stdout)
+	require.Equal(t, int64(1360), overview.Get("image_size.width").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(236), overview.Get("image_size.height").Int(), overviewResult.Stdout)
+
+}
+
 func requireScreenshotPathUnderDir(t *testing.T, path, dir string) {
 	t.Helper()
 	canonicalPath, err := filepath.EvalSymlinks(path)

--- a/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
+++ b/tests/cli_e2e/slides/slides_screenshot_workflow_test.go
@@ -216,9 +216,9 @@ func TestSlidesScreenshotOverviewLiveE2E(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "png", overviewFormat, overviewResult.Stdout)
 	require.Equal(t, 1360, overviewConfig.Width, overviewResult.Stdout)
-	require.Equal(t, 236, overviewConfig.Height, overviewResult.Stdout)
+	require.Equal(t, 212, overviewConfig.Height, overviewResult.Stdout)
 	require.Equal(t, int64(1360), overview.Get("image_size.width").Int(), overviewResult.Stdout)
-	require.Equal(t, int64(236), overview.Get("image_size.height").Int(), overviewResult.Stdout)
+	require.Equal(t, int64(212), overview.Get("image_size.height").Int(), overviewResult.Stdout)
 
 }
 


### PR DESCRIPTION
## Summary

- add `slides +screenshot --overview` to generate an indexed overview PNG for the current presentation
- support `--overview-page` pagination for presentations with more than 20 slides
- return overview image metadata, page state, and slide-to-grid mappings
- document overview parameters and output fields

## Tests

- `GOTOOLCHAIN=go1.23.0 go test ./shortcuts/slides -run 'TestSlidesScreenshotOverview' -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added overview mode for generating indexed PNG images of presentation slides.
  - Added pagination support for large presentations with configurable overview pages.
  - Added dry-run previews showing slide-number retrieval batches and output paths.
  - Preserved slide numbers and metadata in overview results.

- **Bug Fixes**
  - Added validation for page ranges, response ordering, pagination consistency, and supported output formats.
  - Improved overview thumbnails with consistent sizing, centering, backgrounds, and borders.

- **Documentation**
  - Updated screenshot command guidance with overview modes, pagination, output rules, and option restrictions.

- **Tests**
  - Expanded unit and end-to-end coverage for retrieval, layout, ordering, validation, metadata, and PNG output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->