### PR TITLE
fix: add registry mirror fallback for installs

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -60,8 +60,14 @@ function resolveReleaseAsset(version, platformName, archName) {
 // Build the ordered list of binary mirror URLs to try. Resolution rules:
 //   1. npm_config_registry     — when the user has set a non-default
 //                                registry (npmmirror clone, corp Verdaccio,
-//                                Artifactory, …), try its derived /-/binary
-//                                path and then its origin-level /mirrors path.
+//                                Artifactory, …), include its derived
+//                                /-/binary path first, then its origin-level
+//                                /mirrors path. Many of these proxies don't
+//                                actually host /-/binary, and not every custom
+//                                registry hosts /mirrors either, so we ALWAYS
+//                                append the public npmmirror as a final
+//                                fallback. This preserves the previous
+//                                "GitHub → npmmirror" behavior.
 //   2. registry.npmmirror.com  — public China mirror, always tried last.
 // The default public npmjs registry is skipped in step 1 because it does not
 // host binaries under /-/binary/...

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -60,13 +60,8 @@ function resolveReleaseAsset(version, platformName, archName) {
 // Build the ordered list of binary mirror URLs to try. Resolution rules:
 //   1. npm_config_registry     — when the user has set a non-default
 //                                registry (npmmirror clone, corp Verdaccio,
-//                                Artifactory, …), include the derived path
-//                                first. Many of these proxies don't actually
-//                                host /-/binary/<pkg>/..., so we ALWAYS
-//                                append the public npmmirror as a final
-//                                fallback so the install does not regress
-//                                from the previous behavior of "GitHub →
-//                                npmmirror".
+//                                Artifactory, …), try its derived /-/binary
+//                                path and then its origin-level /mirrors path.
 //   2. registry.npmmirror.com  — public China mirror, always tried last.
 // The default public npmjs registry is skipped in step 1 because it does not
 // host binaries under /-/binary/...
@@ -75,13 +70,18 @@ function resolveReleaseAsset(version, platformName, archName) {
 // with http-only internal registries don't have their installs broken.
 function resolveMirrorUrls(env, archive, version) {
   const binaryPath = `/-/binary/lark-cli/v${version}/${archive}`;
+  const mirrorPath = `/mirrors/lark-cli/v${version}/${archive}`;
   const defaultUrl = joinUrl(DEFAULT_MIRROR_HOST, binaryPath);
 
   const urls = [];
   const registry = (env.npm_config_registry || "").trim();
   if (registry && !isDefaultNpmjsRegistry(registry) && isValidDownloadBase(registry)) {
     const base = new URL(registry);
-    urls.push(joinUrl(base.origin + base.pathname, binaryPath));
+    const binaryUrl = joinUrl(base.origin + base.pathname, binaryPath);
+    if (binaryUrl !== defaultUrl) {
+      urls.push(binaryUrl);
+      urls.push(joinUrl(base.origin, mirrorPath));
+    }
   }
   if (!urls.includes(defaultUrl)) urls.push(defaultUrl);
   return urls;
@@ -188,6 +188,20 @@ function download(url, destPath) {
   execFileSync("curl", args, { stdio: ["ignore", "ignore", "pipe"] });
 }
 
+function downloadVerifiedArchive(urls, archivePath, expectedHash, downloadFn = download) {
+  let lastErr;
+  for (const url of urls) {
+    try {
+      downloadFn(url, archivePath);
+      verifyChecksum(archivePath, expectedHash);
+      return;
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw lastErr;
+}
+
 function extractZipWindows(archivePath, destDir) {
   const psOpts = ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"];
   const psStdio = ["ignore", "inherit", "inherit"];
@@ -234,25 +248,8 @@ function install() {
   const archivePath = path.join(tmpDir, archiveName);
 
   try {
-    // Walk the chain in order; stop at the first success. Default chain:
-    // GitHub → derived(npm_config_registry)? → npmmirror. The npmmirror
-    // tail preserves the pre-PR safety net when a corporate proxy doesn't
-    // actually host /-/binary/<pkg>/...
-    let lastErr;
-    let downloaded = false;
-    for (const url of downloadUrls) {
-      try {
-        download(url, archivePath);
-        downloaded = true;
-        break;
-      } catch (e) {
-        lastErr = e;
-      }
-    }
-    if (!downloaded) throw lastErr;
-
     const expectedHash = getExpectedChecksum(archiveName);
-    verifyChecksum(archivePath, expectedHash);
+    downloadVerifiedArchive(downloadUrls, archivePath, expectedHash);
 
     if (isWindows) {
       extractZipWindows(archivePath, tmpDir);
@@ -354,11 +351,11 @@ if (require.main === module) {
       `  # 1. Use a proxy:\n` +
       `  export https_proxy=http://your-proxy:port\n` +
       `  npm install -g @larksuite/cli\n\n` +
-      `  # 2. Point to a corporate npm mirror that proxies /-/binary/lark-cli/...:\n` +
+      `  # 2. Point to a corporate npm mirror that hosts lark-cli binaries:\n` +
       `  npm install -g @larksuite/cli --registry=https://your-corp-mirror/`
     );
     process.exit(1);
   }
 }
 
-module.exports = { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls, resolveReleaseAsset, curlSupportsSslRevokeBestEffort, isCurlVersionSupported };
+module.exports = { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls, resolveReleaseAsset, downloadVerifiedArchive, curlSupportsSslRevokeBestEffort, isCurlVersionSupported };

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -15,6 +15,7 @@ const {
   assertAllowedHost,
   resolveMirrorUrls,
   resolveReleaseAsset,
+  downloadVerifiedArchive,
   isCurlVersionSupported,
 } = require("./install.js");
 
@@ -191,6 +192,28 @@ describe("verifyChecksum", () => {
   });
 });
 
+describe("downloadVerifiedArchive", () => {
+  it("continues to the next URL when a download fails checksum verification", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "download-test-"));
+    const archivePath = path.join(dir, "archive.tar.gz");
+    const validContent = Buffer.from("valid archive content");
+    const expectedHash = crypto.createHash("sha256").update(validContent).digest("hex");
+    const urls = ["https://first.example.com/archive", "https://second.example.com/archive"];
+    const attempts = [];
+
+    downloadVerifiedArchive(urls, archivePath, expectedHash, (url, destPath) => {
+      attempts.push(url);
+      fs.writeFileSync(
+        destPath,
+        url === urls[0] ? "<html>login page</html>" : validContent
+      );
+    });
+
+    assert.deepEqual(attempts, urls);
+    assert.deepEqual(fs.readFileSync(archivePath), validContent);
+  });
+});
+
 describe("assertAllowedHost", () => {
   it("accepts github.com", () => {
     assertAllowedHost("https://github.com/larksuite/cli/releases/download/v1.0.0/archive.tar.gz");
@@ -258,12 +281,13 @@ describe("resolveMirrorUrls", () => {
     // pre-PR "GitHub → npmmirror" behavior.
     assert.deepEqual(
       resolveMirrorUrls(
-        { npm_config_registry: "https://corp.example.com/repository/npm-public/" },
+        { npm_config_registry: "https://mirror.example.com/repository/npm-public/" },
         ARCHIVE,
         VERSION
       ),
       [
-        "https://corp.example.com/repository/npm-public/-/binary/lark-cli/v1.0.0/lark-cli-1.0.0-linux-amd64.tar.gz",
+        "https://mirror.example.com/repository/npm-public/-/binary/lark-cli/v1.0.0/lark-cli-1.0.0-linux-amd64.tar.gz",
+        "https://mirror.example.com/mirrors/lark-cli/v1.0.0/lark-cli-1.0.0-linux-amd64.tar.gz",
         DEFAULT,
       ]
     );
@@ -271,13 +295,14 @@ describe("resolveMirrorUrls", () => {
 
   it("derived URL appears before the default in the chain", () => {
     const urls = resolveMirrorUrls(
-      { npm_config_registry: "https://corp.example.com/" },
+      { npm_config_registry: "https://mirror.example.com/" },
       ARCHIVE,
       VERSION
     );
-    assert.equal(urls.length, 2);
-    assert.match(urls[0], /^https:\/\/corp\.example\.com\//);
-    assert.equal(urls[1], DEFAULT);
+    assert.equal(urls.length, 3);
+    assert.match(urls[0], /^https:\/\/mirror\.example\.com\//);
+    assert.match(urls[1], /^https:\/\/mirror\.example\.com\/mirrors\//);
+    assert.equal(urls[2], DEFAULT);
   });
 
   it("does not duplicate the default if the registry already points at it", () => {
@@ -296,12 +321,13 @@ describe("resolveMirrorUrls", () => {
   it("strips trailing slashes from the registry URL", () => {
     assert.deepEqual(
       resolveMirrorUrls(
-        { npm_config_registry: "https://corp.example.com///" },
+        { npm_config_registry: "https://mirror.example.com///" },
         ARCHIVE,
         VERSION
       ),
       [
-        "https://corp.example.com/-/binary/lark-cli/v1.0.0/lark-cli-1.0.0-linux-amd64.tar.gz",
+        "https://mirror.example.com/-/binary/lark-cli/v1.0.0/lark-cli-1.0.0-linux-amd64.tar.gz",
+        "https://mirror.example.com/mirrors/lark-cli/v1.0.0/lark-cli-1.0.0-linux-amd64.tar.gz",
         DEFAULT,
       ]
     );


### PR DESCRIPTION
## Summary

Improve npm binary installation fallback behavior for custom registries while preserving the existing public fallback.

## Changes

- Try an origin-level `/mirrors/lark-cli/...` URL after a custom registry's `/-/binary/lark-cli/...` candidate fails.
- Require each downloaded candidate to pass checksum verification before stopping the fallback chain.
- Keep the public npmmirror `/-/binary` URL as the final fallback and add regression coverage for URL ordering and checksum failures.

## Test Plan

- [x] `node --test scripts/install.test.js`
- [x] `make script-test`
- [x] Independent security review and acceptance review passed

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary downloads by retrying alternate mirror locations when a download or checksum verification fails.
  * Added support for origin-level `/mirrors` fallback URLs, including consistent handling of trailing slashes.
  * Updated corporate mirror guidance to reflect the expanded mirror resolution behavior.
  * Improved installation reliability when the first available archive source is unavailable or invalid.

* **Tests**
  * Added coverage for checksum-failure fallback and multi-URL mirror ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->