### PR TITLE
docs(base): warn against wrapping batch record payloads in fields

### DIFF
--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -965,6 +965,7 @@ func TestBaseJSONExamplesLiveInFlagDescriptions(t *testing.T) {
 			wantHelp: []string{
 				"create_records contains one field map per record",
 				`{"create_records":[{"Name":"Task A","Status":["Todo"]},{"Name":"Task B","Score":20}]}`,
+				"do not wrap a record in fields",
 			},
 		},
 		{
@@ -973,6 +974,7 @@ func TestBaseJSONExamplesLiveInFlagDescriptions(t *testing.T) {
 			wantHelp: []string{
 				"update_records maps each record ID to its field map",
 				`{"update_records":{"recA":{"Status":["Done"]},"recB":{"Score":20}}}`,
+				"do not wrap a record in fields",
 			},
 		},
 	}

--- a/shortcuts/base/record_batch_create.go
+++ b/shortcuts/base/record_batch_create.go
@@ -19,7 +19,7 @@ var BaseRecordBatchCreate = common.Shortcut{
 	Flags: []common.Flag{
 		baseTokenFlag(true),
 		tableRefFlag(true),
-		{Name: "json", Desc: `batch create JSON object; create_records contains one field map per record, e.g. {"create_records":[{"Name":"Task A","Status":["Todo"]},{"Name":"Task B","Score":20}]}`, Required: true},
+		{Name: "json", Desc: `batch create JSON object; create_records contains one field map per record, e.g. {"create_records":[{"Name":"Task A","Status":["Todo"]},{"Name":"Task B","Score":20}]}; do not wrap a record in fields`, Required: true},
 	},
 	Tips: append([]string{
 		"Happy path field: create_records is an array of independent record field maps.",

--- a/shortcuts/base/record_batch_update.go
+++ b/shortcuts/base/record_batch_update.go
@@ -19,7 +19,7 @@ var BaseRecordBatchUpdate = common.Shortcut{
 	Flags: []common.Flag{
 		baseTokenFlag(true),
 		tableRefFlag(true),
-		{Name: "json", Desc: `batch update JSON object; update_records maps each record ID to its field map, e.g. {"update_records":{"recA":{"Status":["Done"]},"recB":{"Score":20}}}`, Required: true},
+		{Name: "json", Desc: `batch update JSON object; update_records maps each record ID to its field map, e.g. {"update_records":{"recA":{"Status":["Done"]},"recB":{"Score":20}}}; do not wrap a record in fields`, Required: true},
 	},
 	Tips: append([]string{
 		"Happy path field: update_records maps each record ID to its own field map.",

--- a/skills/lark-base/references/lark-base-record-batch-create.md
+++ b/skills/lark-base/references/lark-base-record-batch-create.md
@@ -51,6 +51,7 @@ lark-cli base +record-batch-create --base-token <base_token> --table-id <table_i
 ## 坑点
 
 - 每个 `create_records` 元素都是独立的记录字段对象，只提交该记录需要写入的字段。
+- 记录对象里直接放字段名，**不要再包一层 `fields`**：`{"create_records":[{"fields":{"标题":"任务 A"}}]}` 会把 `fields` 当成字段名，返回 `800010701 Cell value does not match any supported shape`（错误路径 `create_records[0].fields`）。看到该错误路径以 `.fields` 结尾时，先去掉这层包装，再排查 CellValue。
 - 单次最多 200 条；`1254104` 表示超过单批上限，拆成多个批次。
 - `1254045` 表示字段不存在，重新 `+field-list` 后使用真实字段名或 `field_id`。
 - `1254015` 表示 CellValue 类型不匹配，按真实 Field schema 和 CellValue 规范修正。

--- a/skills/lark-base/references/lark-base-record-batch-update.md
+++ b/skills/lark-base/references/lark-base-record-batch-update.md
@@ -49,6 +49,7 @@ lark-cli base +record-batch-update --base-token <base_token> --table-id <table_i
 - `1254045` 表示字段不存在，重新 `+field-list` 后使用真实字段名或 `field_id`。
 - `1254015` 表示 CellValue 类型不匹配，按真实 Field schema 和 CellValue 规范修正。
 - 命令不会自动做字段/行映射转换，传什么就发什么。
+- 每个 record ID 直接映射到字段对象，**不要再包一层 `fields`**：`{"update_records":{"recA":{"fields":{"标题":"任务 A"}}}}` 会返回 `800010701 Cell value does not match any supported shape`（错误路径 `update_records.recA.fields`）。
 - 如果字段映射包含只读字段，返回里可能出现 `ignored_fields` / `READONLY`；移除 Formula、Lookup、系统字段和自动编号等只读字段。
 - 同一 Table 连续批量写入使用串行执行；`1254291` 表示并发写冲突，短暂等待后重试当前批次。
 


### PR DESCRIPTION
## Summary

LLM agents repeatedly send batch record writes using the Bitable OpenAPI body shape, wrapping every record in `fields`. `lark-cli` takes a flat record object, so the server reads `fields` as a field name and rejects the write with `800010701 Cell value does not match any supported shape` at path `create_records[0].fields`. Because the message talks about cell values, the usual reaction is to keep the wrapper and keep rewriting the inner value, which never recovers. `+record-upsert` already documents `do not wrap in fields` on `--json`; the batch commands did not.

## Changes

- `+record-batch-create` and `+record-batch-update`: `--json` description now states that a record is not wrapped in `fields` (parity with `+record-upsert`).
- `skills/lark-base/references/lark-base-record-batch-create.md` and `...-batch-update.md`: record the failure signature (error code and error path) plus the fix under 坑点.
- Flag-help regression tests updated for both commands.

No behavior change: help and skill text only.

## Test Plan

- [x] `go test ./shortcuts/base/...` (assertions fail if the description change is reverted)
- [x] `make vet`, `make fmt-check`
- [x] `node scripts/skill-format-check/index.js`
- [ ] `make unit-test` — not completed locally: `shortcuts/base` (`TestJSONInputHelpers`) and `internal/client` (`TestWrapDoAPIError_UnmarshalTypeError_ReturnsInternalError`) hang on my machine. Both reproduce identically on an unmodified checkout of the base commit, so they are environmental here, not caused by this change. Relying on CI for the full run.
- [x] `QUALITY_GATE_CHANGED_FROM=<base> make quality-gate`
- [x] Manual verification against a live Base, on a throwaway base created and deleted for the check:
  - `{"create_records":[{"Name":"x"}]}` succeeds; `{"create_records":[{"fields":{"Name":"x"}}]}` returns `800010701` at path `create_records[0].fields`.
  - The same wrapper on `+record-batch-update` returns `800010701` at path `update_records.<record_id>.fields`.
  - The same wrapper on `+record-upsert` returns a dedicated server message: "Record write payload must not be wrapped in `fields`."
  - A table whose real field is literally named `fields` still writes normally with a string value, so no client-side rejection was added — this PR is guidance only.

## Note for maintainers

The single-record write path already returns a dedicated "must not be wrapped in `fields`" error from the server, while the batch paths fall through to the generic cell-value message. Extending that detection to the batch endpoints would make this guidance unnecessary; happy to file that separately if this is the right repo boundary.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified batch record creation and update examples: record data must be provided directly, without an extra `fields` wrapper.
  * Added troubleshooting guidance for identifying and correcting incorrectly nested request data.
  * Updated command help text to reflect the required JSON structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->