### PR TITLE
fix(sheets): allow recursive chart update patches

### DIFF
--- a/shortcuts/sheets/flag_schema.go
+++ b/shortcuts/sheets/flag_schema.go
@@ -60,9 +60,60 @@ func loadFlagSchemas() (*flagSchemaIndex, error) {
 		if idx.Flags == nil {
 			idx.Flags = map[string]map[string]json.RawMessage{}
 		}
+		if entry := idx.Flags["+chart-update"]; entry != nil {
+			if raw := entry["properties"]; raw != nil {
+				partial, err := recursivePartialJSONSchema(raw)
+				if err != nil {
+					parseFlagErr = errs.NewInternalError(errs.SubtypeUnknown, "derive +chart-update --properties schema: %v", err).WithCause(err)
+					return
+				}
+				entry["properties"] = partial
+			}
+		}
 		parsedFlagSchemas = &idx
 	})
 	return parsedFlagSchemas, parseFlagErr
+}
+
+// recursivePartialJSONSchema derives an update schema from a full object
+// schema by removing required constraints at every nested schema node. The
+// remaining type, enum, bounds, and additionalProperties constraints still
+// reject malformed fields that are present in the patch.
+func recursivePartialJSONSchema(raw json.RawMessage) (json.RawMessage, error) {
+	var schema map[string]interface{}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return nil, err
+	}
+	makeJSONSchemaRecursivePartial(schema)
+	return json.Marshal(schema)
+}
+
+func makeJSONSchemaRecursivePartial(schema map[string]interface{}) {
+	delete(schema, "required")
+
+	for _, key := range []string{"properties", "patternProperties", "dependentSchemas", "definitions", "$defs"} {
+		children, _ := schema[key].(map[string]interface{})
+		for _, child := range children {
+			makeJSONSchemaValueRecursivePartial(child)
+		}
+	}
+	for _, key := range []string{"items", "additionalProperties", "contains", "not", "if", "then", "else", "propertyNames"} {
+		makeJSONSchemaValueRecursivePartial(schema[key])
+	}
+	for _, key := range []string{"prefixItems", "allOf", "anyOf", "oneOf"} {
+		makeJSONSchemaValueRecursivePartial(schema[key])
+	}
+}
+
+func makeJSONSchemaValueRecursivePartial(value interface{}) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		makeJSONSchemaRecursivePartial(typed)
+	case []interface{}:
+		for _, item := range typed {
+			makeJSONSchemaValueRecursivePartial(item)
+		}
+	}
 }
 
 // commandsWithFlagSchema returns the set of shortcut commands that have

--- a/shortcuts/sheets/flag_schema_test.go
+++ b/shortcuts/sheets/flag_schema_test.go
@@ -79,6 +79,41 @@ func TestPrintFlagSchema_NamedFlagReturnsSchemaSubtree(t *testing.T) {
 	}
 }
 
+// TestPrintFlagSchema_ChartUpdateIsRecursivePartial keeps introspection aligned
+// with update validation: callers may patch a deeply nested field without
+// resending required siblings from the full chart snapshot.
+func TestPrintFlagSchema_ChartUpdateIsRecursivePartial(t *testing.T) {
+	t.Parallel()
+
+	decode := func(t *testing.T, command, path string) map[string]interface{} {
+		t.Helper()
+		out, err := printFlagSchemaFor(command)(path)
+		if err != nil {
+			t.Fatalf("print %s %s: %v", command, path, err)
+		}
+		var schema map[string]interface{}
+		if err := json.Unmarshal(out, &schema); err != nil {
+			t.Fatalf("schema is not JSON: %v\n%s", err, out)
+		}
+		return schema
+	}
+
+	createPlot := decode(t, "+chart-create", "properties.snapshot.plotArea.plot")
+	if required, _ := createPlot["required"].([]interface{}); len(required) == 0 {
+		t.Fatal("chart-create plot schema must retain required fields")
+	}
+
+	updatePlot := decode(t, "+chart-update", "properties.snapshot.plotArea.plot")
+	if _, present := updatePlot["required"]; present {
+		t.Fatalf("chart-update plot schema must be partial; required=%v", updatePlot["required"])
+	}
+
+	updateSeriesItem := decode(t, "+chart-update", "properties.snapshot.data.dim2.series.items")
+	if _, present := updateSeriesItem["required"]; present {
+		t.Fatalf("chart-update array item schema must be recursively partial; required=%v", updateSeriesItem["required"])
+	}
+}
+
 // TestPrintFlagSchema_UnknownFlagListsAvailable confirms the error
 // message tells the caller which flags exist for the shortcut.
 func TestPrintFlagSchema_UnknownFlagListsAvailable(t *testing.T) {

--- a/shortcuts/sheets/flag_schema_validate_test.go
+++ b/shortcuts/sheets/flag_schema_validate_test.go
@@ -1031,23 +1031,34 @@ func TestValidateInputAgainstSchema_RealMinimum(t *testing.T) {
 // still validates the fields that are present.
 func TestValidateInputAgainstSchema_ChartUpdateRecursivePartial(t *testing.T) {
 	t.Parallel()
+	plot := map[string]interface{}{
+		"type":   "column",
+		"labels": map[string]interface{}{"value": true, "position": "top"},
+	}
 	patch := map[string]interface{}{
 		"properties": map[string]interface{}{
 			"snapshot": map[string]interface{}{
 				"plotArea": map[string]interface{}{
-					"plot": map[string]interface{}{
-						"labels": map[string]interface{}{"value": true, "position": "top"},
-					},
+					"plot": plot,
 				},
 			},
 		},
 	}
 
+	if err := validateInputAgainstSchema(mapFlagView{command: "+chart-create"}, patch); err != nil {
+		t.Fatalf("complete chart-create payload rejected: %v", err)
+	}
+	delete(plot, "type")
 	if err := validateInputAgainstSchema(mapFlagView{command: "+chart-update"}, patch); err != nil {
 		t.Fatalf("nested chart update patch rejected: %v", err)
 	}
-	if err := validateInputAgainstSchema(mapFlagView{command: "+chart-create"}, patch); err == nil {
-		t.Fatal("chart-create must retain the full nested required-field contract")
+	createErr := validateInputAgainstSchema(mapFlagView{command: "+chart-create"}, patch)
+	ve := requireValidation(t, createErr, `required property "type" is missing`)
+	if ve.Param != "--properties" {
+		t.Errorf("param = %q, want --properties", ve.Param)
+	}
+	if ve.Cause == nil {
+		t.Error("chart-create schema error must preserve its underlying cause")
 	}
 
 	invalid := map[string]interface{}{
@@ -1062,9 +1073,9 @@ func TestValidateInputAgainstSchema_ChartUpdateRecursivePartial(t *testing.T) {
 		},
 	}
 	err := validateInputAgainstSchema(mapFlagView{command: "+chart-update"}, invalid)
-	ve := requireValidation(t, err, "position")
-	if !strings.Contains(ve.Message, "not in enum") {
-		t.Errorf("error = %q, want enum validation", ve.Message)
+	invalidVE := requireValidation(t, err, "position")
+	if !strings.Contains(invalidVE.Message, "not in enum") {
+		t.Errorf("error = %q, want enum validation", invalidVE.Message)
 	}
 }
 

--- a/shortcuts/sheets/flag_schema_validate_test.go
+++ b/shortcuts/sheets/flag_schema_validate_test.go
@@ -1026,6 +1026,48 @@ func TestValidateInputAgainstSchema_RealMinimum(t *testing.T) {
 	}
 }
 
+// TestValidateInputAgainstSchema_ChartUpdateRecursivePartial verifies that
+// update accepts a deeply nested patch while create remains strict and update
+// still validates the fields that are present.
+func TestValidateInputAgainstSchema_ChartUpdateRecursivePartial(t *testing.T) {
+	t.Parallel()
+	patch := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"snapshot": map[string]interface{}{
+				"plotArea": map[string]interface{}{
+					"plot": map[string]interface{}{
+						"labels": map[string]interface{}{"value": true, "position": "top"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := validateInputAgainstSchema(mapFlagView{command: "+chart-update"}, patch); err != nil {
+		t.Fatalf("nested chart update patch rejected: %v", err)
+	}
+	if err := validateInputAgainstSchema(mapFlagView{command: "+chart-create"}, patch); err == nil {
+		t.Fatal("chart-create must retain the full nested required-field contract")
+	}
+
+	invalid := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"snapshot": map[string]interface{}{
+				"plotArea": map[string]interface{}{
+					"plot": map[string]interface{}{
+						"labels": map[string]interface{}{"position": "diagonal"},
+					},
+				},
+			},
+		},
+	}
+	err := validateInputAgainstSchema(mapFlagView{command: "+chart-update"}, invalid)
+	ve := requireValidation(t, err, "position")
+	if !strings.Contains(ve.Message, "not in enum") {
+		t.Errorf("error = %q, want enum validation", ve.Message)
+	}
+}
+
 // TestValidateInputAgainstSchema_RealAdditionalProperties pins the
 // additionalProperties: <schema> form against the real embedded
 // schema. +pivot-create properties.collapse is declared as a dynamic

--- a/shortcuts/sheets/lark_sheet_object_crud_test.go
+++ b/shortcuts/sheets/lark_sheet_object_crud_test.go
@@ -119,7 +119,7 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 		{
 			name:     "+chart-update",
 			sc:       ChartUpdate,
-			args:     []string{"--url", testURL, "--sheet-id", testSheetID, "--chart-id", "chartXYZ", "--properties", `{"type":"bar","position":{"row":0,"col":"A"},"size":{"width":400,"height":300}}`},
+			args:     []string{"--url", testURL, "--sheet-id", testSheetID, "--chart-id", "chartXYZ", "--properties", `{"snapshot":{"plotArea":{"plot":{"labels":{"value":true,"position":"top"}}}}}`},
 			toolName: "manage_chart_object",
 			wantInput: map[string]interface{}{
 				"excel_id":  testToken,
@@ -127,9 +127,13 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 				"operation": "update",
 				"chart_id":  "chartXYZ",
 				"properties": map[string]interface{}{
-					"type":     "bar",
-					"position": map[string]interface{}{"row": float64(0), "col": "A"},
-					"size":     map[string]interface{}{"width": float64(400), "height": float64(300)},
+					"snapshot": map[string]interface{}{
+						"plotArea": map[string]interface{}{
+							"plot": map[string]interface{}{
+								"labels": map[string]interface{}{"value": true, "position": "top"},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Problem

`+chart-update --properties` reused the full chart-create schema. A valid nested patch such as updating only `snapshot.plotArea.plot.labels` was rejected locally because the sibling `plot.type` field was still required.

## Changes

- derive a recursive partial schema only for `+chart-update --properties`
- remove nested `required` constraints while preserving type, enum, bounds, and additional-property validation
- expose the same partial contract through `--print-schema`
- add validation, schema introspection, and dry-run regression coverage

## Validation

- `go test -count=1 ./shortcuts/sheets/...`
- `go vet ./shortcuts/sheets/...`
- `make unit-test`
- `make vet`
- `make fmt-check`
- `go mod tidy` with no `go.mod` / `go.sum` diff
- `make build`
- `QUALITY_GATE_CHANGED_FROM=origin/feat-chart-opt-special-types-cli make quality-gate`
- rebuilt CLI accepts the labels-only `+chart-update --properties` reproduction while `+chart-create` retains its full nested required fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart updates can now omit required fields at any nesting level, including nested objects and array items.
  * Existing validation rules, such as allowed values, remain enforced for fields that are provided.
  * Chart creation continues to require all required fields.

* **Tests**
  * Added coverage for recursive partial chart-update validation and schema behavior.
  * Updated chart update dry-run scenarios to use nested snapshot label properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->