### PR TITLE
fix(output): preserve non-"data" top-level payloads in success envelope

### DIFF
--- a/internal/output/envelope_success.go
+++ b/internal/output/envelope_success.go
@@ -16,18 +16,30 @@ type SuccessEnvelopeOptions struct {
 }
 
 // SuccessEnvelopeData extracts the business payload for the standard success
-// envelope from a Lark API response. Outer code/msg fields are transport
-// protocol details and are intentionally not exposed as business data.
+// envelope from a Lark API response.
+//
+// Most Lark APIs wrap the business payload in "data". Some legacy/special
+// APIs (e.g. /open-apis/bot/v3/info) return the payload at the top level
+// under keys like "bot". When "data" is absent, preserve the full response
+// body so those APIs are not rendered as an empty envelope. Bare code/msg
+// responses (no business payload) still return an empty object.
 func SuccessEnvelopeData(result interface{}) interface{} {
 	m, ok := result.(map[string]interface{})
 	if !ok {
+		return result
+	}
+	if data, ok := m["data"]; ok {
+		if data == nil {
+			return map[string]interface{}{}
+		}
+		return data
+	}
+	// Bare protocol envelope with no business payload.
+	if len(m) == 2 && m["code"] != nil && m["msg"] != nil {
 		return map[string]interface{}{}
 	}
-	data, ok := m["data"]
-	if !ok || data == nil {
-		return map[string]interface{}{}
-	}
-	return data
+	// Top-level payload (e.g. "bot" from /bot/v3/info).
+	return m
 }
 
 // WriteSuccessEnvelope emits the standard success envelope used by shortcuts.

--- a/internal/output/envelope_success_test.go
+++ b/internal/output/envelope_success_test.go
@@ -55,6 +55,31 @@ func TestSuccessEnvelopeData_NilDataUsesEmptyObject(t *testing.T) {
 	}
 }
 
+func TestSuccessEnvelopeData_TopLevelPayloadPreserved(t *testing.T) {
+	result := map[string]interface{}{
+		"code": float64(0),
+		"msg":  "ok",
+		"bot": map[string]interface{}{
+			"activate_status": float64(2),
+			"app_name":        "HypeSTAFF",
+			"open_id":         "ou_62277add34f7250b065b3865729ed099",
+		},
+	}
+
+	got := SuccessEnvelopeData(result)
+	m, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("business data type = %T, want map", got)
+	}
+	if m["code"] != float64(0) || m["msg"] != "ok" {
+		t.Fatalf("protocol fields missing: %#v", m)
+	}
+	bot, ok := m["bot"].(map[string]interface{})
+	if !ok || bot["open_id"] != "ou_62277add34f7250b065b3865729ed099" {
+		t.Fatalf("top-level bot payload missing: %#v", m)
+	}
+}
+
 func TestWriteSuccessEnvelope_PrintsShortcutCompatibleEnvelope(t *testing.T) {
 	var out strings.Builder
 


### PR DESCRIPTION
## Summary
`SuccessEnvelopeData` returned `{}` whenever the API response lacked a top-level `"data"` key, silently discarding legacy payloads returned under other keys — most notably `/open-apis/bot/v3/info`, which returns its payload under `"bot"`.

## Changes
- `internal/output/envelope_success.go`: return the full response map when other top-level keys exist; only fall back to `{}` for bare `{code,msg}` envelopes.
- `internal/output/envelope_success_test.go`: add `TestSuccessEnvelopeData_TopLevelPayloadPreserved`.

## Test Plan
- [x] Unit tests pass (`go test ./internal/output/`)
- [x] Manual local verification: `lark-cli api --as bot GET /open-apis/bot/v3/info` now returns the full `bot` object instead of `data: {}`.

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved top-level response fields and nested payload data when responses do not include a dedicated data field.
  * Improved handling of non-map responses and empty protocol responses.
  * Continued returning an empty object when the data field is explicitly empty.

* **Tests**
  * Added regression coverage for preserving response fields and nested payload data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->