### PR TITLE
fix(cmdutil): echo user_open_id in dry-run context only for user identity

### DIFF
--- a/internal/cmdutil/dryrun.go
+++ b/internal/cmdutil/dryrun.go
@@ -41,8 +41,11 @@ type DryRunAPICall struct {
 }
 
 // DryRunContext is the execution context shared by every dry-run preview:
-// which app would make the call and, when known, as which user. The identity
-// itself lives at the envelope top level, not here.
+// which app would make the call and, when the call would run as a user, as
+// which user. The identity itself lives at the envelope top level, not here.
+// user_open_id is recorded only for user-identity previews: a bot call uses
+// the tenant token and never acts as a user, so echoing a user_open_id there
+// would misreport what the real request carries.
 type DryRunContext struct {
 	AppID      string `json:"app_id,omitempty"`
 	UserOpenID string `json:"user_open_id,omitempty"`
@@ -246,20 +249,27 @@ func encodeParams(params map[string]interface{}) string {
 
 // buildDryRunPreview assembles the shared preview skeleton: HTTP method, URL,
 // query params, and the app/user context common to every dry-run.
-func buildDryRunPreview(request client.RawApiRequest, config *core.CliConfig) *DryRunAPI {
+// user_open_id is included only when identity is user; a bot-identity call
+// executes with the tenant token, so the preview must not claim a user
+// context the real request never carries.
+func buildDryRunPreview(request client.RawApiRequest, config *core.CliConfig, identity core.Identity) *DryRunAPI {
 	dr := NewDryRunAPI().call(request.Method, request.URL)
 	if len(request.Params) > 0 {
 		dr.Params(request.Params)
 	}
 	// Identity is reported at the envelope top level, not duplicated here.
-	dr.Context(config.AppID, config.UserOpenId)
+	userOpenID := ""
+	if identity == core.AsUser {
+		userOpenID = config.UserOpenId
+	}
+	dr.Context(config.AppID, userOpenID)
 	return dr
 }
 
 // PrintDryRunWithFile outputs a dry-run summary for file upload requests.
 // Instead of serializing the Formdata body, it shows file metadata.
 func PrintDryRunWithFile(request client.RawApiRequest, config *core.CliConfig, opts DryRunOutputOptions, file FileUploadMeta) error {
-	dr := buildDryRunPreview(request, config)
+	dr := buildDryRunPreview(request, config, opts.Identity)
 	filePathDisplay := file.FilePath
 	if filePathDisplay == "" {
 		filePathDisplay = "<stdin>"
@@ -278,7 +288,7 @@ func PrintDryRunWithFile(request client.RawApiRequest, config *core.CliConfig, o
 // PrintDryRun outputs a standardised dry-run summary using DryRunAPI.
 // When format is "pretty", outputs human-readable text; otherwise JSON.
 func PrintDryRun(request client.RawApiRequest, config *core.CliConfig, opts DryRunOutputOptions) error {
-	dr := buildDryRunPreview(request, config)
+	dr := buildDryRunPreview(request, config, opts.Identity)
 	if !util.IsNil(request.Data) {
 		dr.Body(request.Data)
 	}

--- a/internal/cmdutil/dryrun_test.go
+++ b/internal/cmdutil/dryrun_test.go
@@ -277,8 +277,11 @@ func TestPrintDryRunWithFile_JSONEnvelope(t *testing.T) {
 		t.Fatalf("file body = %#v", body)
 	}
 	dctx, ok := data["context"].(map[string]interface{})
-	if !ok || dctx["app_id"] != "app123" || dctx["user_open_id"] != "ou_tester" {
+	if !ok || dctx["app_id"] != "app123" {
 		t.Fatalf("unexpected data.context: %#v", data["context"])
+	}
+	if _, exists := dctx["user_open_id"]; exists {
+		t.Fatalf("bot-identity dry-run must not echo user_open_id (no user token is sent): %#v", data["context"])
 	}
 	for _, legacy := range []string{"as", "appId", "userOpenId"} {
 		if _, exists := data[legacy]; exists {
@@ -333,6 +336,62 @@ func TestPrintDryRun_EmptyConfigOmitsContext(t *testing.T) {
 	if _, exists := data["context"]; exists {
 		t.Fatalf("empty app/user context must be omitted entirely, got: %#v", data["context"])
 	}
+}
+
+// TestPrintDryRun_UserOpenIDFollowsIdentity is the contract test for
+// data.context.user_open_id: it appears only when the previewed call would
+// execute as that user. A bot-identity preview must not echo it, because the
+// real request uses the tenant token and never carries user identity.
+func TestPrintDryRun_UserOpenIDFollowsIdentity(t *testing.T) {
+	newOpts := func(identity core.Identity, buf *bytes.Buffer) DryRunOutputOptions {
+		return DryRunOutputOptions{Format: "json", Identity: identity, Out: buf, ErrOut: io.Discard}
+	}
+	readContext := func(t *testing.T, buf *bytes.Buffer) map[string]interface{} {
+		t.Helper()
+		var env map[string]interface{}
+		if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+			t.Fatalf("dry-run stdout is not JSON: %v\n%s", err, buf.String())
+		}
+		dctx, ok := env["data"].(map[string]interface{})["context"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected data.context, got: %#v", env["data"])
+		}
+		return dctx
+	}
+
+	t.Run("user identity includes user_open_id", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := PrintDryRun(client.RawApiRequest{
+			Method: "GET",
+			URL:    "/open-apis/test",
+			As:     "user",
+		}, &core.CliConfig{AppID: "app123", UserOpenId: "ou_tester"}, newOpts(core.AsUser, &buf))
+		if err != nil {
+			t.Fatalf("PrintDryRun failed: %v", err)
+		}
+		if got := readContext(t, &buf)["user_open_id"]; got != "ou_tester" {
+			t.Fatalf("user-identity dry-run must echo user_open_id, got: %#v", got)
+		}
+	})
+
+	t.Run("bot identity omits user_open_id", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := PrintDryRun(client.RawApiRequest{
+			Method: "GET",
+			URL:    "/open-apis/test",
+			As:     "bot",
+		}, &core.CliConfig{AppID: "app123", UserOpenId: "ou_tester"}, newOpts(core.AsBot, &buf))
+		if err != nil {
+			t.Fatalf("PrintDryRun failed: %v", err)
+		}
+		dctx := readContext(t, &buf)
+		if dctx["app_id"] != "app123" {
+			t.Fatalf("app_id must still be echoed for bot identity, got: %#v", dctx)
+		}
+		if _, exists := dctx["user_open_id"]; exists {
+			t.Fatalf("bot-identity dry-run must not echo user_open_id, got: %#v", dctx)
+		}
+	})
 }
 
 func TestWriteDryRun_NilPreviewIsInternalError(t *testing.T) {

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -1264,8 +1264,13 @@ func handleShortcutDryRun(f *cmdutil.Factory, rctx *RuntimeContext, s *Shortcut)
 	}
 	dryResult := s.DryRun(rctx.ctx, rctx)
 	if dryResult != nil {
-		// Same data.context contract as the service/api dry-run paths.
-		dryResult.Context(rctx.Config.AppID, rctx.UserOpenId())
+		// Same data.context contract as the service/api dry-run paths:
+		// user_open_id only when the call would execute as that user.
+		userOpenID := ""
+		if rctx.As() == core.AsUser {
+			userOpenID = rctx.UserOpenId()
+		}
+		dryResult.Context(rctx.Config.AppID, userOpenID)
 	}
 	return cmdutil.WriteDryRun(dryResult, cmdutil.DryRunOutputOptions{
 		Format:      rctx.Format,


### PR DESCRIPTION
## Summary
A bot-identity call executes with the tenant token and never acts as a user; the dry-run preview must not claim a user context the real request never carries. This applies to `api`/`service` dry-run and the shortcut dry-run path.

## Changes
- `internal/cmdutil/dryrun.go`: only populate `user_open_id` in the dry-run context when the caller is using a user identity.
- `internal/cmdutil/dryrun_test.go`: add coverage for user vs. bot identity dry-run context.
- `shortcuts/common/runner.go`: pass identity context through so the dry-run preview matches the actual execution path.

## Test Plan
- [x] Unit tests pass (`go test ./internal/cmdutil/ ./shortcuts/common/`)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dry-run previews now show user identity details only when running with user identity.
  * Bot-identity previews retain the app identity without exposing user context.
  * File uploads and standard dry-run actions now consistently reflect the selected identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->