### PR TITLE
feat(auth): capture union_id at login and surface it in auth status/whoami

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -64,38 +64,39 @@ type userInfoResponse struct {
 	Code int    `json:"code"`
 	Msg  string `json:"msg"`
 	Data struct {
-		OpenID string `json:"open_id"`
-		Name   string `json:"name"`
+		OpenID  string `json:"open_id"`
+		UnionID string `json:"union_id"`
+		Name    string `json:"name"`
 	} `json:"data"`
 }
 
-// getUserInfo fetches the current user's OpenID and name using the given access token.
-func getUserInfo(ctx context.Context, sdk *lark.Client, accessToken string) (openId, name string, err error) {
+// getUserInfo fetches the current user's OpenID, union_id, and name using the given access token.
+func getUserInfo(ctx context.Context, sdk *lark.Client, accessToken string) (openId, unionId, name string, err error) {
 	apiResp, err := sdk.Do(ctx, &larkcore.ApiReq{
 		HttpMethod:                http.MethodGet,
 		ApiPath:                   larkauth.PathUserInfoV1,
 		SupportedAccessTokenTypes: []larkcore.AccessTokenType{larkcore.AccessTokenTypeUser},
 	}, larkcore.WithUserAccessToken(accessToken))
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
 	var resp userInfoResponse
 	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
-		return "", "", fmt.Errorf("failed to parse user info: %w", err)
+		return "", "", "", fmt.Errorf("failed to parse user info: %w", err)
 	}
 	if resp.Code != 0 {
-		return "", "", fmt.Errorf("failed to get user info [%d]: %s", resp.Code, resp.Msg)
+		return "", "", "", fmt.Errorf("failed to get user info [%d]: %s", resp.Code, resp.Msg)
 	}
 	if resp.Data.OpenID == "" {
-		return "", "", fmt.Errorf("failed to get user info: missing open_id in response")
+		return "", "", "", fmt.Errorf("failed to get user info: missing open_id in response")
 	}
 
 	name = resp.Data.Name
 	if name == "" {
 		name = "(unknown)"
 	}
-	return resp.Data.OpenID, name, nil
+	return resp.Data.OpenID, resp.Data.UnionID, name, nil
 }
 
 // appInfo contains application information (owner, scopes).

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -348,7 +348,7 @@ func authLoginRun(opts *LoginOptions) error {
 	if err != nil {
 		return errs.NewInternalError(errs.SubtypeSDKError, "failed to get SDK: %v", err).WithCause(err)
 	}
-	openId, userName, err := getUserInfo(opts.Ctx, sdk, result.Token.AccessToken)
+	openId, unionId, userName, err := getUserInfo(opts.Ctx, sdk, result.Token.AccessToken)
 	if err != nil {
 		return errs.NewAuthenticationError(errs.SubtypeUnknown, "failed to get user info: %v", err).WithCause(err)
 	}
@@ -372,7 +372,7 @@ func authLoginRun(opts *LoginOptions) error {
 	}
 
 	// Step 8: Update config — overwrite Users to single user, clean old tokens
-	if err := syncLoginUserToProfile(config.ProfileName, config.AppID, openId, userName); err != nil {
+	if err := syncLoginUserToProfile(config.ProfileName, config.AppID, openId, unionId, userName); err != nil {
 		_ = larkauth.RemoveStoredToken(config.AppID, openId)
 		return err
 	}
@@ -431,7 +431,7 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 	if err != nil {
 		return errs.NewInternalError(errs.SubtypeSDKError, "failed to get SDK: %v", err).WithCause(err)
 	}
-	openId, userName, err := getUserInfo(opts.Ctx, sdk, result.Token.AccessToken)
+	openId, unionId, userName, err := getUserInfo(opts.Ctx, sdk, result.Token.AccessToken)
 	if err != nil {
 		return errs.NewAuthenticationError(errs.SubtypeUnknown, "failed to get user info: %v", err).WithCause(err)
 	}
@@ -455,7 +455,7 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 	}
 
 	// Update config — overwrite Users to single user, clean old tokens
-	if err := syncLoginUserToProfile(config.ProfileName, config.AppID, openId, userName); err != nil {
+	if err := syncLoginUserToProfile(config.ProfileName, config.AppID, openId, unionId, userName); err != nil {
 		_ = larkauth.RemoveStoredToken(config.AppID, openId)
 		return errs.NewInternalError(errs.SubtypeSDKError, "failed to update login profile: %v", err).WithCause(err)
 	}
@@ -469,7 +469,7 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 }
 
 // syncLoginUserToProfile persists the logged-in user info into the named profile.
-func syncLoginUserToProfile(profileName, appID, openID, userName string) error {
+func syncLoginUserToProfile(profileName, appID, openID, unionID, userName string) error {
 	multi, err := core.LoadMultiAppConfig()
 	if err != nil {
 		return errs.NewInternalError(errs.SubtypeStorage, "load config: %v", err).WithCause(err)
@@ -481,7 +481,7 @@ func syncLoginUserToProfile(profileName, appID, openID, userName string) error {
 	}
 
 	oldUsers := append([]core.AppUser(nil), app.Users...)
-	app.Users = []core.AppUser{{UserOpenId: openID, UserName: userName}}
+	app.Users = []core.AppUser{{UserOpenId: openID, UserName: userName, UserUnionId: unionID}}
 	if err := core.SaveMultiAppConfig(multi); err != nil {
 		return errs.NewInternalError(errs.SubtypeStorage, "save config: %v", err).WithCause(err)
 	}

--- a/cmd/auth/login_config_test.go
+++ b/cmd/auth/login_config_test.go
@@ -36,7 +36,7 @@ func TestSyncLoginUserToProfile_UpdatesOnlyTargetProfile(t *testing.T) {
 		t.Fatalf("SaveMultiAppConfig() error = %v", err)
 	}
 
-	if err := syncLoginUserToProfile("target", "app-target", "ou_new", "new-user"); err != nil {
+	if err := syncLoginUserToProfile("target", "app-target", "ou_new", "on_new", "new-user"); err != nil {
 		t.Fatalf("syncLoginUserToProfile() error = %v", err)
 	}
 
@@ -44,7 +44,7 @@ func TestSyncLoginUserToProfile_UpdatesOnlyTargetProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadMultiAppConfig() error = %v", err)
 	}
-	if got := saved.Apps[0].Users; len(got) != 1 || got[0].UserOpenId != "ou_new" || got[0].UserName != "new-user" {
+	if got := saved.Apps[0].Users; len(got) != 1 || got[0].UserOpenId != "ou_new" || got[0].UserName != "new-user" || got[0].UserUnionId != "on_new" {
 		t.Fatalf("target users = %#v, want replaced login user", got)
 	}
 	if got := saved.Apps[1].Users; len(got) != 1 || got[0].UserOpenId != "ou_other" {
@@ -64,7 +64,7 @@ func TestSyncLoginUserToProfile_ProfileNotFoundReturnsError(t *testing.T) {
 		t.Fatalf("SaveMultiAppConfig() error = %v", err)
 	}
 
-	err := syncLoginUserToProfile("missing", "app-default", "ou_new", "new-user")
+	err := syncLoginUserToProfile("missing", "app-default", "ou_new", "on_new", "new-user")
 	if err == nil {
 		t.Fatal("expected error for missing profile")
 	}

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -40,6 +40,7 @@ type whoamiResult struct {
 type delegatedUser struct {
 	UserName string `json:"userName,omitempty"`
 	OpenID   string `json:"openId,omitempty"`
+	UnionID  string `json:"unionId,omitempty"`
 }
 
 // Options holds inputs for the whoami command.
@@ -167,7 +168,7 @@ func buildResult(cfg *core.CliConfig, as core.Identity, source string, diag iden
 		// Set onBehalfOf only when a user is actually resolved; an unresolved
 		// user identity (not signed in) has no one to act on behalf of yet.
 		if diag.User.UserName != "" || diag.User.OpenID != "" {
-			res.OnBehalfOf = &delegatedUser{UserName: diag.User.UserName, OpenID: diag.User.OpenID}
+			res.OnBehalfOf = &delegatedUser{UserName: diag.User.UserName, OpenID: diag.User.OpenID, UnionID: diag.User.UnionID}
 		}
 		if !diag.User.Available {
 			res.Hint = diag.User.Hint

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -32,8 +32,9 @@ func (id Identity) IsBot() bool { return id == AsBot }
 
 // AppUser is a logged-in user record stored in config.
 type AppUser struct {
-	UserOpenId string `json:"userOpenId"`
-	UserName   string `json:"userName"`
+	UserOpenId  string `json:"userOpenId"`
+	UserName    string `json:"userName"`
+	UserUnionId string `json:"userUnionId,omitempty"`
 }
 
 // AppConfig is a per-app configuration entry (stored format — secrets may be unresolved).
@@ -186,6 +187,7 @@ type CliConfig struct {
 	DefaultAs           Identity // AsUser | AsBot | AsAuto | "" (from config file)
 	UserOpenId          string
 	UserName            string
+	UserUnionId         string
 	Lang                i18n.Lang
 	SupportedIdentities uint8 `json:"-"` // bitflag: 1=user, 2=bot; set by credential provider
 }
@@ -304,6 +306,7 @@ func ResolveConfigFromMulti(raw *MultiAppConfig, kc keychain.KeychainAccess, pro
 	if len(app.Users) > 0 {
 		cfg.UserOpenId = app.Users[0].UserOpenId
 		cfg.UserName = app.Users[0].UserName
+		cfg.UserUnionId = app.Users[0].UserUnionId
 	}
 	return cfg, nil
 }

--- a/internal/credential/credential_provider.go
+++ b/internal/credential/credential_provider.go
@@ -249,6 +249,7 @@ func (p *CredentialProvider) enrichUserInfo(ctx context.Context, acct *Account, 
 	}
 	acct.UserOpenId = info.OpenID
 	acct.UserName = info.Name
+	acct.UserUnionId = info.UnionID
 	return nil
 }
 

--- a/internal/credential/types.go
+++ b/internal/credential/types.go
@@ -24,6 +24,7 @@ type Account struct {
 	DefaultAs           core.Identity
 	UserOpenId          string
 	UserName            string
+	UserUnionId         string
 	Lang                i18n.Lang
 	SupportedIdentities uint8
 }
@@ -67,6 +68,7 @@ func AccountFromCliConfig(cfg *core.CliConfig) *Account {
 		DefaultAs:           cfg.DefaultAs,
 		UserOpenId:          cfg.UserOpenId,
 		UserName:            cfg.UserName,
+		UserUnionId:         cfg.UserUnionId,
 		Lang:                cfg.Lang,
 		SupportedIdentities: cfg.SupportedIdentities,
 	}
@@ -86,6 +88,7 @@ func (a *Account) ToCliConfig() *core.CliConfig {
 		DefaultAs:           a.DefaultAs,
 		UserOpenId:          a.UserOpenId,
 		UserName:            a.UserName,
+		UserUnionId:         a.UserUnionId,
 		Lang:                a.Lang,
 		SupportedIdentities: a.SupportedIdentities,
 	}

--- a/internal/credential/types_test.go
+++ b/internal/credential/types_test.go
@@ -54,6 +54,7 @@ func TestAccountFromCliConfigAndBack_ReturnCopies(t *testing.T) {
 		DefaultAs:           "user",
 		UserOpenId:          "ou_123",
 		UserName:            "alice",
+		UserUnionId:         "on_123",
 		Lang:                i18n.LangJaJP,
 		SupportedIdentities: 3,
 	}
@@ -68,6 +69,9 @@ func TestAccountFromCliConfigAndBack_ReturnCopies(t *testing.T) {
 	if acct.Lang != cfg.Lang {
 		t.Fatalf("AccountFromCliConfig().Lang = %q, want %q", acct.Lang, cfg.Lang)
 	}
+	if acct.UserUnionId != cfg.UserUnionId {
+		t.Fatalf("AccountFromCliConfig().UserUnionId = %q, want %q", acct.UserUnionId, cfg.UserUnionId)
+	}
 
 	roundtrip := acct.ToCliConfig()
 	if roundtrip == nil {
@@ -78,6 +82,9 @@ func TestAccountFromCliConfigAndBack_ReturnCopies(t *testing.T) {
 	}
 	if roundtrip.Lang != cfg.Lang {
 		t.Fatalf("ToCliConfig().Lang = %q, want %q (production Factory path reads Lang via this conversion)", roundtrip.Lang, cfg.Lang)
+	}
+	if roundtrip.UserUnionId != cfg.UserUnionId {
+		t.Fatalf("ToCliConfig().UserUnionId = %q, want %q (round-trip must preserve union id)", roundtrip.UserUnionId, cfg.UserUnionId)
 	}
 
 	roundtrip.AppID = "mutated-cli"

--- a/internal/credential/user_info.go
+++ b/internal/credential/user_info.go
@@ -13,8 +13,9 @@ import (
 )
 
 type userInfo struct {
-	OpenID string
-	Name   string
+	OpenID  string
+	UnionID string
+	Name    string
 }
 
 // fetchUserInfo calls /open-apis/authen/v1/user_info with a UAT to get the user's identity.
@@ -42,8 +43,9 @@ func fetchUserInfo(ctx context.Context, httpClient *http.Client, brand core.Lark
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
 		Data struct {
-			OpenID string `json:"open_id"`
-			Name   string `json:"name"`
+			OpenID  string `json:"open_id"`
+			UnionID string `json:"union_id"`
+			Name    string `json:"name"`
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -52,5 +54,5 @@ func fetchUserInfo(ctx context.Context, httpClient *http.Client, brand core.Lark
 	if result.Code != 0 {
 		return nil, fmt.Errorf("user_info API error: [%d] %s", result.Code, result.Msg)
 	}
-	return &userInfo{OpenID: result.Data.OpenID, Name: result.Data.Name}, nil
+	return &userInfo{OpenID: result.Data.OpenID, UnionID: result.Data.UnionID, Name: result.Data.Name}, nil
 }

--- a/internal/identitydiag/diagnostics.go
+++ b/internal/identitydiag/diagnostics.go
@@ -48,6 +48,7 @@ type Identity struct {
 	Message          string `json:"message,omitempty"`
 	Hint             string `json:"hint,omitempty"`
 	OpenID           string `json:"openId,omitempty"`
+	UnionID          string `json:"unionId,omitempty"`
 	AppName          string `json:"appName,omitempty"`
 	UserName         string `json:"userName,omitempty"`
 	TokenStatus      string `json:"tokenStatus,omitempty"`
@@ -177,6 +178,7 @@ func diagnoseExternalUser(ctx context.Context, f *cmdutil.Factory, cfg *core.Cli
 		TokenStatus: StatusReady,
 		UserName:    cfg.UserName,
 		OpenID:      cfg.UserOpenId,
+		UnionID:     cfg.UserUnionId,
 		Message:     "User identity: ready (provided by " + provider + ")",
 	}
 	if !verify {
@@ -294,6 +296,7 @@ func diagnoseUser(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, 
 	id := Identity{
 		UserName: cfg.UserName,
 		OpenID:   cfg.UserOpenId,
+		UnionID:  cfg.UserUnionId,
 	}
 	stored := larkauth.GetStoredToken(cfg.AppID, cfg.UserOpenId)
 	if stored == nil {

--- a/internal/identitydiag/diagnostics_test.go
+++ b/internal/identitydiag/diagnostics_test.go
@@ -80,11 +80,12 @@ func TestDiagnose_VerifyUserIdentity(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_DATA_DIR", t.TempDir())
 
 	cfg := &core.CliConfig{
-		AppID:      "test-app-user",
-		AppSecret:  "secret",
-		Brand:      core.BrandFeishu,
-		UserOpenId: "ou_user",
-		UserName:   "tester",
+		AppID:       "test-app-user",
+		AppSecret:   "secret",
+		Brand:       core.BrandFeishu,
+		UserOpenId:  "ou_user",
+		UserName:    "tester",
+		UserUnionId: "on_user",
 	}
 	now := time.Now()
 	if err := larkauth.SetStoredToken(&larkauth.StoredUAToken{
@@ -129,7 +130,7 @@ func TestDiagnose_VerifyUserIdentity(t *testing.T) {
 	if got.User.Verified == nil || !*got.User.Verified {
 		t.Fatalf("user verified = %v, want true", got.User.Verified)
 	}
-	if got.User.OpenID != "ou_user" || got.User.UserName != "tester" {
+	if got.User.OpenID != "ou_user" || got.User.UserName != "tester" || got.User.UnionID != "on_user" {
 		t.Fatalf("user = %#v, want user identity details", got.User)
 	}
 }
@@ -398,7 +399,7 @@ func assertExternalHint(t *testing.T, hint string) {
 }
 
 func TestDiagnose_External_UserReady(t *testing.T) {
-	cfg := &core.CliConfig{AppID: "cli_x", Brand: core.BrandFeishu, SupportedIdentities: uint8(extcred.SupportsAll), UserOpenId: "ou_x", UserName: "Alice"}
+	cfg := &core.CliConfig{AppID: "cli_x", Brand: core.BrandFeishu, SupportedIdentities: uint8(extcred.SupportsAll), UserOpenId: "ou_x", UserName: "Alice", UserUnionId: "on_x"}
 	f := externalFactory(&fakeExtProvider{name: "corp-sso", account: &extcred.Account{AppID: "cli_x"}}, cfg)
 
 	got := Diagnose(context.Background(), f, cfg, false)
@@ -408,7 +409,7 @@ func TestDiagnose_External_UserReady(t *testing.T) {
 	if !got.User.Available || got.User.Status != StatusReady || got.User.TokenStatus != StatusReady {
 		t.Fatalf("user = %#v, want ready/available", got.User)
 	}
-	if got.User.OpenID != "ou_x" || got.User.UserName != "Alice" {
+	if got.User.OpenID != "ou_x" || got.User.UserName != "Alice" || got.User.UnionID != "on_x" {
 		t.Fatalf("user identity = %#v", got.User)
 	}
 	if got.User.Hint != "" {


### PR DESCRIPTION
## Summary
`getUserInfo` parsed only `open_id` and `name` from `authen/v1/user_info`, dropping `union_id`. Thread it through `AppUser`, `CliConfig`, `credential.Account` (both directions), the extension-provider `user_info` fetch, identity diagnostics, and `whoami` `onBehalfOf`.

## Changes
- `cmd/auth/auth.go`, `cmd/auth/login.go`: capture and store `union_id` during login.
- `internal/core/config.go`: persist `union_id` in CLI config.
- `internal/credential/types.go`, `internal/credential/credential_provider.go`, `internal/credential/user_info.go`: add `union_id` to account/user info models and provider.
- `cmd/whoami/whoami.go`: display `union_id` in `whoami` output.
- `internal/identitydiag/diagnostics.go`: include `union_id` in identity diagnostics.
- Update affected tests.

## Test Plan
- [x] Unit tests pass (`go test ./cmd/auth/ ./internal/core/ ./internal/credential/ ./internal/identitydiag/ ./cmd/whoami/`)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Union ID support during login and device-code authentication.
  * User profiles now retain Union IDs alongside Open IDs and names.
  * Delegated-user details and identity diagnostics now display Union IDs.

* **Bug Fixes**
  * Preserved Union IDs when converting and synchronizing account configuration.

* **Tests**
  * Expanded coverage to verify Union ID handling across login, account conversion, and identity diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->