### PR TITLE
feat(base): accept --app-token as parse-time alias for --base-token

### DIFF
--- a/shortcuts/base/shortcuts.go
+++ b/shortcuts/base/shortcuts.go
@@ -7,7 +7,7 @@ import "github.com/larksuite/cli/shortcuts/common"
 
 // Shortcuts returns all base shortcuts.
 func Shortcuts() []common.Shortcut {
-	return []common.Shortcut{
+	return withAppTokenAlias([]common.Shortcut{
 		BaseURLResolve,
 		BaseTitleResolve,
 		BaseBaseBlockList,
@@ -112,5 +112,46 @@ func Shortcuts() []common.Shortcut {
 		BaseAppBlockGetData,
 		BaseAppBlockCreate,
 		BaseAppBlockUpdate,
+	})
+}
+
+// withAppTokenAlias attaches "app-token" as a parse-time alias to every
+// "base-token" flag. Lark's Bitable API names the resource app_token in its
+// URL path (/open-apis/bitable/v1/apps/{app_token}/...), so users reading the
+// vendor docs reasonably type --app-token. The alias is scoped to this domain
+// on purpose: "base-token" flags exist only here, so the synonym cannot
+// misroute another domain's flag. Aliases are hidden from human help and
+// exported in machine metadata by the shortcut framework.
+func withAppTokenAlias(shortcuts []common.Shortcut) []common.Shortcut {
+	for i := range shortcuts {
+		// Skip shortcuts that already own an --app-token flag (e.g. BaseApp
+		// operations), so the alias does not collide with a real flag.
+		hasAppToken := false
+		for _, fl := range shortcuts[i].Flags {
+			if fl.Name == "app-token" {
+				hasAppToken = true
+				break
+			}
+		}
+		if hasAppToken {
+			continue
+		}
+		for j := range shortcuts[i].Flags {
+			fl := &shortcuts[i].Flags[j]
+			if fl.Name != "base-token" {
+				continue
+			}
+			has := false
+			for _, a := range fl.Aliases {
+				if a == "app-token" {
+					has = true
+					break
+				}
+			}
+			if !has {
+				fl.Aliases = append(fl.Aliases, "app-token")
+			}
+		}
 	}
+	return shortcuts
 }

--- a/shortcuts/base/shortcuts_test.go
+++ b/shortcuts/base/shortcuts_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import "testing"
+
+// TestShortcuts_BaseTokenFlagCarriesAppTokenAlias is the contract test for the
+// domain-level alias: Lark's Bitable API names the resource app_token in its
+// URL path, so every base "base-token" flag must accept --app-token, unless the
+// shortcut already owns a real "app-token" flag (e.g. BaseApp operations). If a
+// new shortcut adds a base-token flag without going through withAppTokenAlias
+// (e.g. Shortcuts stops wrapping), this test fails.
+func TestShortcuts_BaseTokenFlagCarriesAppTokenAlias(t *testing.T) {
+	shortcuts := Shortcuts()
+	if len(shortcuts) == 0 {
+		t.Fatal("Shortcuts() returned no shortcuts")
+	}
+	seen := 0
+	for _, s := range shortcuts {
+		hasAppToken := false
+		for _, fl := range s.Flags {
+			if fl.Name == "app-token" {
+				hasAppToken = true
+				break
+			}
+		}
+		if hasAppToken {
+			continue
+		}
+		for _, fl := range s.Flags {
+			if fl.Name != "base-token" {
+				continue
+			}
+			seen++
+			found := false
+			for _, a := range fl.Aliases {
+				if a == "app-token" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("shortcut %s %s: flag base-token missing app-token alias", s.Service, s.Command)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no base-token flags found — alias wiring untestable")
+	}
+}
+
+// TestShortcuts_AliasNotDuplicated guards against running the wrapper twice
+// appending duplicate aliases.
+func TestShortcuts_AliasNotDuplicated(t *testing.T) {
+	for _, s := range Shortcuts() {
+		for _, fl := range s.Flags {
+			count := 0
+			for _, a := range fl.Aliases {
+				if a == "app-token" {
+					count++
+				}
+			}
+			if count > 1 {
+				t.Errorf("shortcut %s %s: flag %s has duplicate app-token alias", s.Service, s.Command, fl.Name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Lark's Bitable API names the resource `app_token` in its URL path (`/open-apis/bitable/v1/apps/{app_token}/...`), so users reading the vendor docs reasonably type `--app-token`. Attach `--app-token` as a parse-time alias to every base `--base-token` flag, scoped to the base domain so the synonym cannot misroute another domain's flag. Shortcuts that already own a real `--app-token` flag (BaseApp operations) are skipped to avoid flag-name collisions.

## Changes
- `shortcuts/base/shortcuts.go`: wrap `Shortcuts()` with `withAppTokenAlias`, which adds the hidden alias while skipping shortcuts that already define `--app-token`.
- `shortcuts/base/shortcuts_test.go`: add contract tests for alias presence and deduplication, accounting for shortcuts with a native `--app-token` flag.

## Test Plan
- [x] Unit tests pass (`go test ./shortcuts/base/`)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `app-token` as an alias for eligible `base-token` shortcut flags.
  - Preserved shortcuts that already define an `app-token` flag.
  - Prevented duplicate `app-token` aliases from appearing in shortcut options.

- **Tests**
  - Added coverage to verify alias availability, existing alias behavior, and duplicate prevention across shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->