### PR TITLE
fix(config): preserve workspace policy and prior brand on init/bind

### DIFF
--- a/cmd/config/bind.go
+++ b/cmd/config/bind.go
@@ -425,6 +425,17 @@ func commitBinding(
 	projector *recovery.Projector,
 ) error {
 	multi := &core.MultiAppConfig{Apps: []core.AppConfig{*appConfig}}
+	// Preserve workspace-level policy across re-bind: strict mode and risk
+	// control are workspace settings, independent of which app is bound.
+	// CurrentApp/PreviousApp are not carried over — they reference the
+	// previous binding's profiles, which this bind replaces.
+	if previousConfigBytes != nil {
+		var prev core.MultiAppConfig
+		if json.Unmarshal(previousConfigBytes, &prev) == nil {
+			multi.StrictMode = prev.StrictMode
+			multi.RiskControl = prev.RiskControl
+		}
+	}
 
 	if err := vfs.MkdirAll(core.GetConfigDir(), 0700); err != nil {
 		return errs.NewInternalError(errs.SubtypeFileIO, "failed to create workspace directory: %v", err).WithCause(err)

--- a/cmd/config/bind_test.go
+++ b/cmd/config/bind_test.go
@@ -1409,6 +1409,56 @@ func TestConfigBindRun_IdentityEscalationWithForceAllowed(t *testing.T) {
 		core.StrictModeOff, core.AsUser)
 }
 
+// TestConfigBindRun_PreservesWorkspacePolicy verifies a re-bind does not drop
+// workspace-level policy (top-level strictMode / riskControl) when replacing
+// the bound app — those settings are workspace-scoped, not app-scoped.
+func TestConfigBindRun_PreservesWorkspacePolicy(t *testing.T) {
+	saveWorkspace(t)
+	configDir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", configDir)
+
+	hermesDir := filepath.Join(configDir, "hermes")
+	if err := os.MkdirAll(hermesDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seed := `{"strictMode":"user","riskControl":false,"apps":[{"appId":"cli_old","strictMode":"bot","defaultAs":"bot"}]}`
+	if err := os.WriteFile(filepath.Join(hermesDir, "config.json"), []byte(seed), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	hermesHome := t.TempDir()
+	t.Setenv("HERMES_HOME", hermesHome)
+	if err := os.WriteFile(filepath.Join(hermesHome, ".env"),
+		[]byte("FEISHU_APP_ID=cli_new\nFEISHU_APP_SECRET=new\n"), 0600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	f2, _, _, _ := cmdutil.TestFactory(t, nil)
+	if err := configBindRun(&BindOptions{
+		Factory:  f2,
+		Source:   "hermes",
+		Identity: "user-default",
+		Force:    true,
+	}); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(hermesDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read bound config: %v", err)
+	}
+	var got core.MultiAppConfig
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("parse bound config: %v", err)
+	}
+	if got.StrictMode != core.StrictModeUser {
+		t.Errorf("workspace strictMode = %q, want %q (preserved)", got.StrictMode, core.StrictModeUser)
+	}
+	if got.RiskControl == nil || *got.RiskControl {
+		t.Errorf("workspace riskControl = %v, want explicit false (preserved)", got.RiskControl)
+	}
+}
+
 // TestConfigBindRun_AllowsRebindSameBotOnly verifies re-binding the same
 // bot-only identity is NOT blocked — only bot→user escalation is gated.
 func TestConfigBindRun_AllowsRebindSameBotOnly(t *testing.T) {

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -220,6 +220,76 @@ func TestSaveInitConfig_OmitLangPreservesPrior(t *testing.T) {
 	}
 }
 
+// TestSaveInitConfig_PreservesWorkspacePolicy guards the single-app replace
+// path: re-init without --name must not silently drop workspace-level policy
+// (strictMode, riskControl) even though it deliberately replaces the app set.
+func TestSaveInitConfig_PreservesWorkspacePolicy(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+
+	riskOff := false
+	existing := &core.MultiAppConfig{
+		StrictMode:  core.StrictModeBot,
+		RiskControl: &riskOff,
+		Apps: []core.AppConfig{
+			{AppId: "cli_x", AppSecret: core.PlainSecret("s"), Brand: core.BrandFeishu},
+		},
+	}
+	if err := core.SaveMultiAppConfig(existing); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := saveInitConfig("", existing, f, "cli_x", core.PlainSecret("s2"), core.BrandFeishu, ""); err != nil {
+		t.Fatalf("saveInitConfig: %v", err)
+	}
+
+	got, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiAppConfig: %v", err)
+	}
+	if got.StrictMode != core.StrictModeBot {
+		t.Errorf("StrictMode after re-init = %q, want %q (preserved)", got.StrictMode, core.StrictModeBot)
+	}
+	if got.RiskControl == nil || *got.RiskControl != false {
+		t.Errorf("RiskControl after re-init = %v, want explicit false (preserved)", got.RiskControl)
+	}
+	if len(got.Apps) != 1 || got.Apps[0].AppId != "cli_x" {
+		t.Errorf("Apps after re-init = %#v, want single replaced app", got.Apps)
+	}
+}
+
+// TestConfigInitRun_OmitBrandPreservesPrior guards the non-interactive re-init
+// path: --brand defaults to "feishu" at flag registration, so omitting it must
+// inherit the prior app's brand rather than silently flipping lark → feishu.
+func TestConfigInitRun_OmitBrandPreservesPrior(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+
+	existing := &core.MultiAppConfig{Apps: []core.AppConfig{
+		{AppId: "cli_x", AppSecret: core.PlainSecret("s"), Brand: core.BrandLark},
+	}}
+	if err := core.SaveMultiAppConfig(existing); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	opts := &ConfigInitOptions{
+		Factory: f, Ctx: context.Background(),
+		AppID: "cli_x", appSecret: "s2",
+		Brand: "feishu", // flag registration default; brandExplicit stays false
+	}
+	if err := configInitRun(opts); err != nil {
+		t.Fatalf("configInitRun: %v", err)
+	}
+
+	got, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiAppConfig: %v", err)
+	}
+	if app := got.CurrentAppConfig(""); app == nil || app.Brand != core.BrandLark {
+		t.Errorf("Brand after re-init = %v, want %q (preserved)", app, core.BrandLark)
+	}
+}
+
 // TestConfigInitCmd_InvalidLang verifies a non-empty --lang on config init is
 // strictly validated the same way bind validates: wrong-case / typo / removed
 // codes / hyphen form all exit with ExitValidation. (Empty is a no-op.)

--- a/cmd/config/init.go
+++ b/cmd/config/init.go
@@ -31,6 +31,7 @@ type ConfigInitOptions struct {
 	appSecret      string // internal only; populated from stdin, never from a CLI flag
 	AppSecretStdin bool   // read app-secret from stdin (avoids process list exposure)
 	Brand          string
+	brandExplicit  bool // true when --brand was explicitly passed
 	New            bool
 
 	Lang         string // raw --lang (string for cobra); normalized to canonical/"" in validateInitLang
@@ -90,6 +91,7 @@ func NewCmdConfigInit(f *cmdutil.Factory, runF func(*ConfigInitOptions) error) *
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Ctx = cmd.Context()
 			opts.langExplicit = cmd.Flags().Changed("lang")
+			opts.brandExplicit = cmd.Flags().Changed("brand")
 			if err := validateInitLang(opts); err != nil {
 				return err
 			}
@@ -198,11 +200,18 @@ func cleanupOldConfig(existing *core.MultiAppConfig, f *cmdutil.Factory, skipApp
 }
 
 // saveAsOnlyApp overwrites config.json with a single-app config.
-func saveAsOnlyApp(appId string, secret core.SecretInput, brand core.LarkBrand, lang string) error {
+// Workspace-level policies (strict mode, risk control) are independent of the
+// app set and survive the overwrite; CurrentApp/PreviousApp are dropped with
+// the apps they referenced.
+func saveAsOnlyApp(appId string, secret core.SecretInput, brand core.LarkBrand, lang string, existing *core.MultiAppConfig) error {
 	config := &core.MultiAppConfig{
 		Apps: []core.AppConfig{{
 			AppId: appId, AppSecret: secret, Brand: brand, Lang: i18n.Lang(lang), Users: []core.AppUser{},
 		}},
+	}
+	if existing != nil {
+		config.StrictMode = existing.StrictMode
+		config.RiskControl = existing.RiskControl
 	}
 	return core.SaveMultiAppConfig(config)
 }
@@ -221,7 +230,7 @@ func saveInitConfig(profileName string, existing *core.MultiAppConfig, f *cmduti
 			prior = app.Lang
 		}
 	}
-	return saveAsOnlyApp(appId, secret, brand, string(preferredLang(i18n.Lang(lang), prior)))
+	return saveAsOnlyApp(appId, secret, brand, string(preferredLang(i18n.Lang(lang), prior)), existing)
 }
 
 // wrapSaveConfigError passes an already-typed error (e.g. the --name conflict
@@ -384,6 +393,14 @@ func configInitRun(opts *ConfigInitOptions) error {
 	// Mode 1: Non-interactive
 	if opts.AppID != "" && opts.appSecret != "" {
 		brand := parseBrand(opts.Brand)
+		// --brand defaults to feishu at flag registration, so a re-init that
+		// omits it would silently flip a prior lark brand. Inherit the current
+		// app's brand unless --brand was explicitly passed (mirrors --lang).
+		if !opts.brandExplicit && existing != nil {
+			if app := existing.CurrentAppConfig(""); app != nil && app.Brand != "" {
+				brand = core.ParseBrand(string(app.Brand))
+			}
+		}
 		secret, err := core.ForStorage(opts.AppID, core.PlainSecret(opts.appSecret), f.Keychain)
 		if err != nil {
 			return errs.NewInternalError(errs.SubtypeSDKError, "%v", err).WithCause(err)


### PR DESCRIPTION
## Summary
`saveAsOnlyApp` and `commitBinding` wrote a fresh `MultiAppConfig`, silently dropping workspace-level `strictMode`/`riskControl`. `init --brand` defaulted to `feishu` at flag registration, silently flipping a prior `lark` brand on non-interactive re-init; it now inherits the current app's brand unless `--brand` is explicit (mirrors `--lang`).

## Changes
- `cmd/config/bind.go`: preserve workspace policy fields when writing the updated config during bind.
- `cmd/config/init.go`: default `--brand` from the existing config instead of hard-coding `feishu`.
- `cmd/config/bind_test.go`, `cmd/config/config_test.go`: add regression tests for policy preservation and brand inheritance.

## Test Plan
- [x] Unit tests pass (`go test ./cmd/config/`)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rebinding or reinitializing a workspace now preserves its existing strict mode and risk control settings.
  * Reinitializing without specifying a brand now retains the app’s current brand.
  * App-specific settings are correctly replaced during rebinding while workspace-wide policies remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->