### PR TITLE
fix(cmd): select workspace before startup config reads

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/larksuite/cli/internal/cmdmeta"
 	"github.com/larksuite/cli/internal/cmdpolicy"
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/deprecation"
 	"github.com/larksuite/cli/internal/flagalias"
 	"github.com/larksuite/cli/internal/hook"
@@ -71,6 +72,12 @@ func executeWithOptions(opts []BuildOption) int {
 	if cfg.streams == nil {
 		WithIO(os.Stdin, os.Stdout, os.Stderr)(cfg)
 	}
+	// Workspace selection must precede every config read below
+	// (isSingleAppMode, ResolveStartupBrand): both load config.json from the
+	// workspace-scoped dir, and the workspace was previously only set inside
+	// NewDefault — after those reads. Detection is env-only and deterministic;
+	// NewDefault re-sets the same value when it runs.
+	core.SetCurrentWorkspace(core.DetectWorkspaceFromEnv(os.Getenv))
 	if !cfg.hideProfileSet {
 		HideProfile(isSingleAppMode())(cfg)
 	}

--- a/cmd/startup_brand_test.go
+++ b/cmd/startup_brand_test.go
@@ -112,6 +112,51 @@ func TestStartupBrandReachesRegistry_RealStartupOrder(t *testing.T) {
 	}
 }
 
+// TestStartupBrandWorkspaceSelectedBeforeConfigRead pins the startup ordering
+// contract: workspace selection must run before brand resolution (and before
+// isSingleAppMode), otherwise a hermes/openclaw invocation reads the local
+// base config and locks the wrong brand. Runs in a subprocess because both
+// the workspace and the registry are process-global.
+func TestStartupBrandWorkspaceSelectedBeforeConfigRead(t *testing.T) {
+	if isStartupBrandHelper() {
+		// Helper: replicate executeWithOptions' startup order exactly —
+		// workspace selection first, then brand resolution.
+		core.SetCurrentWorkspace(core.DetectWorkspaceFromEnv(os.Getenv))
+		fmt.Printf("CONFIGURED_BRAND=%s\n", ResolveStartupBrand(""))
+		os.Exit(0)
+	}
+
+	tmp := t.TempDir()
+	base := `{"apps":[{"appId":"cli_f","appSecret":"test-secret","brand":"feishu","users":[]}]}`
+	if err := os.WriteFile(filepath.Join(tmp, "config.json"), []byte(base), 0600); err != nil {
+		t.Fatal(err)
+	}
+	hermesDir := filepath.Join(tmp, "hermes")
+	if err := os.MkdirAll(hermesDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	ws := `{"apps":[{"appId":"cli_l","appSecret":"test-secret","brand":"lark","users":[]}]}`
+	if err := os.WriteFile(filepath.Join(hermesDir, "config.json"), []byte(ws), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := uuid.NewString()
+	t.Setenv(startupBrandHelperEnv, nonce)
+	cmd := exec.Command(os.Args[0], "-test.run", "TestStartupBrandWorkspaceSelectedBeforeConfigRead")
+	cmd.Args = append(cmd.Args, "-startup-brand-helper="+nonce)
+	cmd.Env = append(os.Environ(),
+		"LARKSUITE_CLI_CONFIG_DIR="+tmp,
+		"HERMES_HOME="+t.TempDir(), // workspace signal: routes config reads to <tmp>/hermes
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "CONFIGURED_BRAND=lark") {
+		t.Errorf("workspace-scoped startup brand = %s, want lark (hermes config)", out)
+	}
+}
+
 func TestStartupBrandHelperRequiresMatchingCommandNonce(t *testing.T) {
 	for _, tt := range []struct {
 		name     string


### PR DESCRIPTION
## Summary
`isSingleAppMode` and `ResolveStartupBrand` ran before `NewDefault` set the workspace, so OpenClaw/Hermes invocations read the local base config: wrong startup brand and wrongly hidden `--profile`. Detection is env-only and deterministic; `NewDefault` re-sets the same value.

## Changes
- `cmd/root.go`: select the workspace earlier in startup so subsequent config reads see the correct workspace.
- `cmd/startup_brand_test.go`: add regression tests for workspace ordering and startup brand resolution.

## Test Plan
- [x] Unit tests pass (`go test ./cmd/`)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now selects the active workspace before loading configuration-dependent settings.
  * Workspace-specific branding is correctly applied during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->