### PR TITLE
fix(client): wrap file-save output in the standard success envelope

### DIFF
--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -404,9 +404,14 @@ func TestApiCmd_BinaryResponse_AutoSave(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("stdout is not JSON: %v\nstdout:\n%s", err, stdout.String())
 	}
-	savedPath, _ := got["saved_path"].(string)
+	// Save metadata rides the standard success envelope: {ok, identity, data:{...}}.
+	if got["ok"] != true || got["identity"] != "bot" {
+		t.Fatalf("unexpected envelope: %#v", got)
+	}
+	data, _ := got["data"].(map[string]interface{})
+	savedPath, _ := data["saved_path"].(string)
 	if savedPath == "" {
-		t.Fatalf("saved_path missing from output: %#v", got)
+		t.Fatalf("data.saved_path missing from output: %#v", got)
 	}
 	// The file must land inside the temporary cwd — this pins the isolation
 	// contract: rolling back TestChdir would leave download.bin in the repo.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -327,6 +327,45 @@ func TestPaginateAll_NaturalEndClearsPageToken(t *testing.T) {
 	}
 }
 
+// TestPaginateAll_SinglePagePreservesTopLevelPayload pins the wrap contract
+// for non-list endpoints under --page-all: a single-page response must come
+// back verbatim, so legacy payloads living outside "data" (e.g. bot/v3/info's
+// top-level "bot") survive pagination unchanged instead of being rewrapped
+// under a "pages" key.
+func TestPaginateAll_SinglePagePreservesTopLevelPayload(t *testing.T) {
+	apiCalls := 0
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		apiCalls++
+		return jsonResponse(map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"bot": map[string]interface{}{"open_id": "ou_bot", "app_name": "HypeSTAFF"},
+		}), nil
+	})
+
+	ac, _ := newTestAPIClient(t, rt)
+
+	result, err := ac.PaginateAll(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		As:     "bot",
+	}, PaginationOptions{PageLimit: 10, PageDelay: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiCalls != 1 {
+		t.Fatalf("expected 1 API call for a non-paginated endpoint, got %d", apiCalls)
+	}
+
+	resultMap, _ := result.(map[string]interface{})
+	bot, ok := resultMap["bot"].(map[string]interface{})
+	if !ok || bot["open_id"] != "ou_bot" {
+		t.Fatalf("top-level bot payload must survive verbatim, got: %#v", result)
+	}
+	if _, exists := resultMap["pages"]; exists {
+		t.Fatalf("single-page result must not be rewrapped under pages, got: %#v", result)
+	}
+}
+
 func TestBuildApiReq_QueryParams(t *testing.T) {
 	ac := &APIClient{}
 

--- a/internal/client/response.go
+++ b/internal/client/response.go
@@ -119,7 +119,7 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 			if scanResult.Alert != nil {
 				output.WriteAlertWarning(opts.ErrOut, scanResult.Alert)
 			}
-			return saveAndPrint(opts.FileIO, resp, opts.OutputPath, opts.Out)
+			return saveAndPrint(opts, resp, identity)
 		}
 
 		if opts.JqExpr != "" || opts.Format == output.FormatJSON {
@@ -149,7 +149,7 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 			WithParam("--jq")
 	}
 	if opts.OutputPath != "" {
-		return saveAndPrint(opts.FileIO, resp, opts.OutputPath, opts.Out)
+		return saveAndPrint(opts, resp, identity)
 	}
 
 	// No --output: auto-save with derived filename.
@@ -158,17 +158,28 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 		return classifySaveErr(err)
 	}
 	fmt.Fprintf(opts.ErrOut, "binary response detected (Content-Type: %s), saved to file\n", ct)
-	output.PrintJson(opts.Out, meta)
-	return nil
+	return printSaveMeta(opts, meta, identity)
 }
 
-func saveAndPrint(fio fileio.FileIO, resp *larkcore.ApiResp, path string, w io.Writer) error {
-	meta, err := SaveResponse(fio, resp, path)
+func saveAndPrint(opts ResponseOptions, resp *larkcore.ApiResp, identity core.Identity) error {
+	meta, err := SaveResponse(opts.FileIO, resp, opts.OutputPath)
 	if err != nil {
 		return classifySaveErr(err)
 	}
-	output.PrintJson(w, meta)
-	return nil
+	return printSaveMeta(opts, meta, identity)
+}
+
+// printSaveMeta emits the save metadata through the standard success envelope
+// ({ok, identity, data:{saved_path,...}}) — the error contract promises one
+// stdout shape, and the file-save paths were the only success paths bypassing
+// it with a bare map.
+func printSaveMeta(opts ResponseOptions, meta map[string]interface{}, identity core.Identity) error {
+	return output.WriteSuccessEnvelope(meta, output.SuccessEnvelopeOptions{
+		CommandPath: opts.CommandPath,
+		Identity:    string(identity),
+		Out:         opts.Out,
+		ErrOut:      opts.ErrOut,
+	})
 }
 
 // classifySaveErr routes a SaveResponse error to the right typed shape.


### PR DESCRIPTION
## Summary
The `--output` and binary auto-save paths printed a bare `{saved_path,...}` map — the only success path bypassing the `{ok,identity,data}` envelope contract. This change wraps file-save output in the standard success envelope and pins `PaginateAll`'s single-page verbatim passthrough for non-list endpoints.

## Changes
- `internal/client/response.go`: wrap file-save output in the standard success envelope; preserve `PaginateAll` verbatim passthrough for non-list endpoints.
- `internal/client/client_test.go`: add tests for the wrapped file-save envelope.
- `cmd/api/api_test.go`: update assertions to expect the success envelope.

## Test Plan
- [x] Unit tests pass (`go test ./internal/client/ ./cmd/api/`)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File-save responses now consistently use the standard success format, including saved file details and command output metadata.
  - Pagination results containing a single page now preserve top-level response fields without unnecessary wrapping.
  - Single-page pagination avoids making redundant API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->