### PR TITLE
feat: support countdown dashboard block

### DIFF
--- a/shortcuts/base/base_dashboard_execute_test.go
+++ b/shortcuts/base/base_dashboard_execute_test.go
@@ -817,6 +817,64 @@ func TestNormalizeDataConfigSortOrder(t *testing.T) {
 	})
 }
 
+func TestBaseDashboardBlockCreate_CountdownValidation(t *testing.T) {
+	t.Run("fixed mode accepts target without table source", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"block_id": "blk_countdown_fixed",
+					"name":     "发布倒计时",
+					"type":     "countdown",
+				},
+			},
+		})
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "发布倒计时", "--type", "countdown",
+			"--data-config", `{"extra_config":{"countdown":{"use_fixed_time":true,"target":"2026-08-20 19:56:12","units":["day","hour","min","sec"]}}}`,
+		}
+		if err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout); err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `"blk_countdown_fixed"`) {
+			t.Fatalf("stdout=%s", got)
+		}
+	})
+
+	t.Run("field mode requires count_all and one group", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "任务截止", "--type", "countdown",
+			"--data-config", `{"table_name":"任务表","group_by":[{"field_name":"截止时间","mode":"integrated"}],"extra_config":{"countdown":{"use_fixed_time":false,"type":"MIN"}}}`,
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for missing count_all")
+		}
+		if got := err.Error(); !strings.Contains(got, "count_all=true") || !strings.Contains(got, "data_config 校验失败") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fixed mode rejects table source fields", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "发布倒计时", "--type", "countdown",
+			"--data-config", `{"table_name":"任务表","count_all":true,"extra_config":{"countdown":{"use_fixed_time":true,"target":"2026-08-20 19:56:12"}}}`,
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for fixed mode")
+		}
+		if got := err.Error(); !strings.Contains(got, "fixed 模式不允许配置 table_name") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 // ── Text Block Tests ────────────────────────────────────────────────
 
 // TestBaseDashboardBlockExecuteCreate_TextType tests creating text blocks with markdown content.

--- a/shortcuts/base/base_dashboard_execute_test.go
+++ b/shortcuts/base/base_dashboard_execute_test.go
@@ -854,8 +854,21 @@ func TestBaseDashboardBlockCreate_CountdownValidation(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected validation error for missing count_all")
 		}
-		if got := err.Error(); !strings.Contains(got, "count_all=true") || !strings.Contains(got, "data_config 校验失败") {
-			t.Fatalf("unexpected error: %v", err)
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+		}
+		if validationErr.Subtype != errs.SubtypeInvalidArgument {
+			t.Fatalf("Subtype = %q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+		}
+		if validationErr.Param != "--data-config" {
+			t.Fatalf("Param = %q, want %q", validationErr.Param, "--data-config")
+		}
+		if validationErr.Unwrap() != nil {
+			t.Fatalf("Cause = %v, want nil", validationErr.Unwrap())
+		}
+		if got := validationErr.Message; !strings.Contains(got, "count_all=true") || !strings.Contains(got, "data_config 校验失败") {
+			t.Fatalf("unexpected validation message: %s", got)
 		}
 	})
 
@@ -869,8 +882,59 @@ func TestBaseDashboardBlockCreate_CountdownValidation(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected validation error for fixed mode")
 		}
-		if got := err.Error(); !strings.Contains(got, "fixed 模式不允许配置 table_name") {
-			t.Fatalf("unexpected error: %v", err)
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+		}
+		if validationErr.Subtype != errs.SubtypeInvalidArgument {
+			t.Fatalf("Subtype = %q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+		}
+		if validationErr.Param != "--data-config" {
+			t.Fatalf("Param = %q, want %q", validationErr.Param, "--data-config")
+		}
+		if validationErr.Unwrap() != nil {
+			t.Fatalf("Cause = %v, want nil", validationErr.Unwrap())
+		}
+		if got := validationErr.Message; !strings.Contains(got, "fixed 模式不允许配置 table_name") {
+			t.Fatalf("unexpected validation message: %s", got)
+		}
+	})
+
+	t.Run("fixed mode rejects invalid target timestamp", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "发布倒计时", "--type", "countdown",
+			"--data-config", `{"extra_config":{"countdown":{"use_fixed_time":true,"target":"tomorrow"}}}`,
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for invalid target")
+		}
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+		}
+		if got := validationErr.Message; !strings.Contains(got, "extra_config.countdown.target 必须匹配 YYYY-MM-DD HH:MM:SS") {
+			t.Fatalf("unexpected validation message: %s", got)
+		}
+	})
+
+	t.Run("field mode requires group mode", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-create", "--base-token", "app_x", "--dashboard-id", "dsh_001",
+			"--name", "任务截止", "--type", "countdown",
+			"--data-config", `{"table_name":"任务表","count_all":true,"group_by":[{"field_name":"截止时间"}],"extra_config":{"countdown":{"use_fixed_time":false,"type":"MIN"}}}`,
+		}
+		err := runShortcut(t, BaseDashboardBlockCreate, args, factory, stdout)
+		if err == nil {
+			t.Fatalf("expected validation error for missing group mode")
+		}
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+		}
+		if got := validationErr.Message; !strings.Contains(got, "group_by[0].mode 缺失") {
+			t.Fatalf("unexpected validation message: %s", got)
 		}
 	})
 }

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -764,6 +764,7 @@ func TestBaseDashboardHelpGuidesAgents(t *testing.T) {
 			shortcut: BaseDashboardBlockCreate,
 			wantTips: []string{
 				`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}'`,
+				`--type countdown --data-config '{"extra_config":{"countdown":{"use_fixed_time":true,"target":"2026-08-20 19:56:12","units":["day","hour","min","sec"]}}}'`,
 				`--type text --data-config '{"text":"# Sales Dashboard"}'`,
 				"+table-list and +field-list",
 				"not table_id or field_id",

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -764,7 +764,7 @@ func TestBaseDashboardHelpGuidesAgents(t *testing.T) {
 			shortcut: BaseDashboardBlockCreate,
 			wantTips: []string{
 				`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}'`,
-				`--type countdown --data-config '{"extra_config":{"countdown":{"use_fixed_time":true,"target":"2026-08-20 19:56:12","units":["day","hour","min","sec"]}}}'`,
+				`--type countdown --data-config '{"extra_config":{"countdown":{"use_fixed_time":true,"target":"2099-12-31 23:59:59","units":["day","hour","min","sec"]}}}'`,
 				`--type text --data-config '{"text":"# Sales Dashboard"}'`,
 				"+table-list and +field-list",
 				"not table_id or field_id",

--- a/shortcuts/base/block_data_config.go
+++ b/shortcuts/base/block_data_config.go
@@ -6,6 +6,7 @@ package base
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -21,6 +22,8 @@ var chartBlockTypes = []string{
 }
 
 var dashboardOnlyChartBlockTypes = []string{"countdown"}
+
+var countdownTargetTimePattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$`)
 
 // textBlockTypes are the text-ish block types. Dashboard blocks and BaseApp
 // page blocks share the same spelling "text" and the same data_config shape
@@ -212,8 +215,13 @@ func validateCountdownDataConfig(cfg map[string]interface{}) []string {
 	}
 
 	if useFixedTime {
-		if target, _ := countdown["target"].(string); strings.TrimSpace(target) == "" {
+		target, ok := countdown["target"].(string)
+		target = strings.TrimSpace(target)
+		switch {
+		case !ok || target == "":
 			errs = append(errs, "fixed 模式缺少必填字段 extra_config.countdown.target")
+		case !countdownTargetTimePattern.MatchString(target):
+			errs = append(errs, "extra_config.countdown.target 必须匹配 YYYY-MM-DD HH:MM:SS")
 		}
 		if _, exists := countdown["type"]; exists {
 			errs = append(errs, "fixed 模式不允许配置 extra_config.countdown.type")
@@ -262,11 +270,16 @@ func validateCountdownDataConfig(cfg map[string]interface{}) []string {
 			if fieldName, _ := group["field_name"].(string); strings.TrimSpace(fieldName) == "" {
 				errs = append(errs, "group_by[0].field_name 不能为空")
 			}
-			if modeRaw, exists := group["mode"]; exists {
-				mode, _ := modeRaw.(string)
-				if mode != "enumerated" && mode != "integrated" {
-					errs = append(errs, "group_by[0].mode 仅支持 enumerated|integrated")
-				}
+			modeRaw, exists := group["mode"]
+			mode, ok := modeRaw.(string)
+			mode = strings.TrimSpace(mode)
+			switch {
+			case !exists:
+				errs = append(errs, "group_by[0].mode 缺失")
+			case !ok || mode == "":
+				errs = append(errs, "group_by[0].mode 必须是非空字符串")
+			case mode != "enumerated" && mode != "integrated":
+				errs = append(errs, "group_by[0].mode 仅支持 enumerated|integrated")
 			}
 			if sortRaw, exists := group["sort"]; exists {
 				sort, ok := sortRaw.(map[string]interface{})

--- a/shortcuts/base/block_data_config.go
+++ b/shortcuts/base/block_data_config.go
@@ -20,6 +20,8 @@ var chartBlockTypes = []string{
 	"funnel", "wordCloud", "area", "combo", "radar", "statistics",
 }
 
+var dashboardOnlyChartBlockTypes = []string{"countdown"}
+
 // textBlockTypes are the text-ish block types. Dashboard blocks and BaseApp
 // page blocks share the same spelling "text" and the same data_config shape
 // ({"text": "..."}).
@@ -46,6 +48,10 @@ func matchesBlockType(blockType string, candidates []string) bool {
 func isTextBlockType(blockType string) bool { return matchesBlockType(blockType, textBlockTypes) }
 
 func isChartBlockType(blockType string) bool { return matchesBlockType(blockType, chartBlockTypes) }
+
+func isCountdownBlockType(blockType string) bool {
+	return matchesBlockType(blockType, dashboardOnlyChartBlockTypes)
+}
 
 // appBlockTypes are all block types accepted by the BaseApp page block
 // commands, in the order they appear in the protocol design.
@@ -130,6 +136,8 @@ func validateBlockDataConfig(blockType string, cfg map[string]interface{}) []str
 	switch {
 	case isTextBlockType(blockType):
 		return validateTextDataConfig(blockType, cfg)
+	case isCountdownBlockType(blockType):
+		return validateCountdownDataConfig(cfg)
 	default:
 		problems := validateChartDataConfig(cfg)
 		if matchesBlockType(blockType, []string{"statistics"}) {
@@ -148,6 +156,142 @@ func validateTextDataConfig(blockType string, cfg map[string]interface{}) []stri
 		problems = append(problems, fmt.Sprintf("%s 类型组件缺少必填字段 text", strings.TrimSpace(blockType)))
 	}
 	return problems
+}
+
+func validateCountdownDataConfig(cfg map[string]interface{}) []string {
+	var errs []string
+
+	for key := range cfg {
+		switch key {
+		case "table_name", "series", "count_all", "group_by", "filter", "extra_config":
+		default:
+			errs = append(errs, fmt.Sprintf("countdown 不支持字段 %s", key))
+		}
+	}
+
+	extraConfig, ok := cfg["extra_config"].(map[string]interface{})
+	if !ok {
+		return append(errs, "countdown 缺少必填字段 extra_config.countdown")
+	}
+	countdown, ok := extraConfig["countdown"].(map[string]interface{})
+	if !ok {
+		return append(errs, "countdown 缺少必填字段 extra_config.countdown")
+	}
+	for key := range extraConfig {
+		if key != "countdown" {
+			errs = append(errs, fmt.Sprintf("extra_config 不支持字段 %s", key))
+		}
+	}
+	for key := range countdown {
+		switch key {
+		case "use_fixed_time", "target", "type", "units":
+		default:
+			errs = append(errs, fmt.Sprintf("extra_config.countdown 不支持字段 %s", key))
+		}
+	}
+
+	useFixedTime, ok := countdown["use_fixed_time"].(bool)
+	if !ok {
+		return append(errs, "extra_config.countdown.use_fixed_time 必须为布尔值")
+	}
+
+	if unitsRaw, exists := countdown["units"]; exists {
+		units, ok := unitsRaw.([]interface{})
+		if !ok || len(units) == 0 {
+			errs = append(errs, "extra_config.countdown.units 必须是非空数组")
+		} else {
+			allowed := map[string]bool{"day": true, "hour": true, "min": true, "sec": true}
+			for i, unitRaw := range units {
+				unit, ok := unitRaw.(string)
+				unit = strings.TrimSpace(unit)
+				if !ok || !allowed[unit] {
+					errs = append(errs, fmt.Sprintf("extra_config.countdown.units[%d] 仅支持 day|hour|min|sec", i))
+				}
+			}
+		}
+	}
+
+	if useFixedTime {
+		if target, _ := countdown["target"].(string); strings.TrimSpace(target) == "" {
+			errs = append(errs, "fixed 模式缺少必填字段 extra_config.countdown.target")
+		}
+		if _, exists := countdown["type"]; exists {
+			errs = append(errs, "fixed 模式不允许配置 extra_config.countdown.type")
+		}
+		if _, exists := cfg["table_name"]; exists {
+			errs = append(errs, "fixed 模式不允许配置 table_name")
+		}
+		if _, exists := cfg["series"]; exists {
+			errs = append(errs, "fixed 模式不允许配置 series")
+		}
+		if _, exists := cfg["count_all"]; exists {
+			errs = append(errs, "fixed 模式不允许配置 count_all")
+		}
+		if _, exists := cfg["group_by"]; exists {
+			errs = append(errs, "fixed 模式不允许配置 group_by")
+		}
+		if _, exists := cfg["filter"]; exists {
+			errs = append(errs, "fixed 模式不允许配置 filter")
+		}
+		return errs
+	}
+
+	if tn, _ := cfg["table_name"].(string); strings.TrimSpace(tn) == "" {
+		errs = append(errs, "field 模式缺少必填字段 table_name")
+	}
+	if countAll, ok := cfg["count_all"].(bool); !ok || !countAll {
+		errs = append(errs, "field 模式要求 count_all=true")
+	}
+	if _, exists := cfg["series"]; exists {
+		errs = append(errs, "field 模式不允许配置 series")
+	}
+	if _, exists := countdown["target"]; exists {
+		errs = append(errs, "field 模式不允许配置 extra_config.countdown.target")
+	}
+	if compareType, _ := countdown["type"].(string); compareType != "MIN" && compareType != "MAX" {
+		errs = append(errs, "extra_config.countdown.type 仅支持 MIN|MAX")
+	}
+	groupBy, ok := cfg["group_by"].([]interface{})
+	if !ok || len(groupBy) != 1 {
+		errs = append(errs, "field 模式要求 group_by 恰好包含 1 个元素")
+	} else {
+		group, ok := groupBy[0].(map[string]interface{})
+		if !ok {
+			errs = append(errs, "group_by[0] 必须是对象")
+		} else {
+			if fieldName, _ := group["field_name"].(string); strings.TrimSpace(fieldName) == "" {
+				errs = append(errs, "group_by[0].field_name 不能为空")
+			}
+			if modeRaw, exists := group["mode"]; exists {
+				mode, _ := modeRaw.(string)
+				if mode != "enumerated" && mode != "integrated" {
+					errs = append(errs, "group_by[0].mode 仅支持 enumerated|integrated")
+				}
+			}
+			if sortRaw, exists := group["sort"]; exists {
+				sort, ok := sortRaw.(map[string]interface{})
+				if !ok {
+					errs = append(errs, "group_by[0].sort 必须是对象")
+				} else {
+					sortType, _ := sort["type"].(string)
+					sortType = strings.ToLower(strings.TrimSpace(sortType))
+					if sortType != "group" && sortType != "value" && sortType != "view" {
+						errs = append(errs, "group_by[0].sort.type 仅支持 group|value|view")
+					}
+					if orderRaw, exists := sort["order"]; exists {
+						order, ok := orderRaw.(string)
+						order = strings.ToLower(strings.TrimSpace(order))
+						if !ok || (order != "asc" && order != "desc") {
+							errs = append(errs, "group_by[0].sort.order 仅支持 asc|desc")
+						}
+					}
+				}
+			}
+		}
+	}
+
+	errs = append(errs, validateBlockFilter(cfg, "filter", false)...)
+	return errs
 }
 
 // validateChartDataConfig validates the chart/statistics data_config shape.

--- a/shortcuts/base/dashboard_block_create.go
+++ b/shortcuts/base/dashboard_block_create.go
@@ -33,7 +33,7 @@ var BaseDashboardBlockCreate = common.Shortcut{
 	Tips: []string{
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Revenue" --type statistics --data-config '{"table_name":"Orders","series":[{"field_name":"Amount","rollup":"SUM"}],"number_format":{"formatName":"dollar_rounded","precision":2}}'`,
-		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Launch Countdown" --type countdown --data-config '{"extra_config":{"countdown":{"use_fixed_time":true,"target":"2026-08-20 19:56:12","units":["day","hour","min","sec"]}}}'`,
+		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Launch Countdown" --type countdown --data-config '{"extra_config":{"countdown":{"use_fixed_time":true,"target":"2099-12-31 23:59:59","units":["day","hour","min","sec"]}}}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Dashboard Note" --type text --data-config '{"text":"# Sales Dashboard"}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}' --position '{"x":0,"y":0,"w":6,"h":4}'`,
 		"Before creating data-backed blocks, use +table-list and +field-list to confirm real table and field names.",

--- a/shortcuts/base/dashboard_block_create.go
+++ b/shortcuts/base/dashboard_block_create.go
@@ -24,7 +24,7 @@ var BaseDashboardBlockCreate = common.Shortcut{
 		baseTokenFlag(true),
 		dashboardIDFlag(true),
 		{Name: "name", Desc: "block name", Required: true},
-		{Name: "type", Desc: "block type: column(柱状图)|bar(条形图)|line(折线图)|pie(饼图)|ring(环形图)|area(面积图)|combo(组合图)|scatter(散点图)|funnel(漏斗图)|wordCloud(词云)|radar(雷达图)|statistics(指标卡)|text(文本). Read lark-base-dashboard-block-config.md before creating.", Required: true},
+		{Name: "type", Desc: "block type: column(柱状图)|bar(条形图)|line(折线图)|pie(饼图)|ring(环形图)|area(面积图)|combo(组合图)|scatter(散点图)|funnel(漏斗图)|wordCloud(词云)|radar(雷达图)|statistics(指标卡)|countdown(倒计时)|text(文本). Read lark-base-dashboard-block-config.md before creating.", Required: true},
 		{Name: "data-config", Desc: "data_config JSON object; read lark-base-dashboard-block-config.md for the SSOT"},
 		{Name: "position", Desc: `optional. component position+size in 12-col grid, JSON {"x","y","w","h"}; all four keys required and numeric (position is submitted whole, so a partial object cannot express a complete placement). Advisory bounds x/y>=0, 1<=w<=12 and x+w<=12, h>=1 — coordinate VALUES are not validated locally and pass through as given; the server auto-arranges out-of-range or overlapping positions. Omit for server auto-layout`},
 		{Name: "user-id-type", Desc: "user ID type for user fields in filters: open_id / union_id / user_id"},
@@ -33,6 +33,7 @@ var BaseDashboardBlockCreate = common.Shortcut{
 	Tips: []string{
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Revenue" --type statistics --data-config '{"table_name":"Orders","series":[{"field_name":"Amount","rollup":"SUM"}],"number_format":{"formatName":"dollar_rounded","precision":2}}'`,
+		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Launch Countdown" --type countdown --data-config '{"extra_config":{"countdown":{"use_fixed_time":true,"target":"2026-08-20 19:56:12","units":["day","hour","min","sec"]}}}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Dashboard Note" --type text --data-config '{"text":"# Sales Dashboard"}'`,
 		`lark-cli base +dashboard-block-create --base-token <base_token> --dashboard-id <dashboard_id> --name "Order Count" --type statistics --data-config '{"table_name":"Orders","count_all":true}' --position '{"x":0,"y":0,"w":6,"h":4}'`,
 		"Before creating data-backed blocks, use +table-list and +field-list to confirm real table and field names.",

--- a/skills/lark-base/references/lark-base-dashboard-block-config.md
+++ b/skills/lark-base/references/lark-base-dashboard-block-config.md
@@ -85,7 +85,7 @@ user / created_by / updated_by: is, isNot, isEmpty, isNotEmpty
 
 fixed 模式：
 
-- 只允许传 `extra_config.countdown.use_fixed_time=true` 和 `extra_config.countdown.target`
+- 只允许传 `extra_config.countdown.use_fixed_time=true`、`extra_config.countdown.target`，以及可选的 `extra_config.countdown.units`
 - 不允许传 `table_name`、`series`、`count_all`、`group_by`、`filter`
 
 ```json
@@ -93,7 +93,7 @@ fixed 模式：
   "extra_config": {
     "countdown": {
       "use_fixed_time": true,
-      "target": "2026-08-20 19:56:12",
+      "target": "2099-12-31 23:59:59",
       "units": ["day", "hour", "min", "sec"]
     }
   }

--- a/skills/lark-base/references/lark-base-dashboard-block-config.md
+++ b/skills/lark-base/references/lark-base-dashboard-block-config.md
@@ -18,6 +18,7 @@ Block 的 `data_config` 字段因 `type` 不同而变化。本文档是 Dashboar
 | `wordCloud` | 词云 |
 | `radar` | 雷达图 |
 | `statistics` | 指标卡 |
+| `countdown` | 倒计时 |
 | `text` | 文本（支持 Markdown） |
 
 ## 字段类型与操作符速查（AI 决策用）
@@ -70,6 +71,56 @@ user / created_by / updated_by: is, isNot, isEmpty, isNotEmpty
 | 无序列表 | `- 项目` | - 项目 |
 
 > **注意**：以上未提及的 Markdown 语法（如链接、图片、代码块、表格等）均不支持。
+
+### countdown 类型特殊结构
+
+`countdown` 是 Dashboard 专属图表类型，支持 `fixed` 和 `field` 两种互斥模式。两种模式统一通过 `extra_config.countdown` 描述，不复用通用图表的 `series` 指标协议。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `extra_config.countdown.use_fixed_time` | boolean | 必填。`true` 表示 fixed 模式，`false` 表示 field 模式 |
+| `extra_config.countdown.target` | string | fixed 模式必填。目标时间，格式 `YYYY-MM-DD HH:MM:SS` |
+| `extra_config.countdown.type` | `MIN` / `MAX` | field 模式必填。取筛选结果中日期字段的最早值或最晚值 |
+| `extra_config.countdown.units` | string[] | 可选。展示单位，支持 `day` / `hour` / `min` / `sec` |
+
+fixed 模式：
+
+- 只允许传 `extra_config.countdown.use_fixed_time=true` 和 `extra_config.countdown.target`
+- 不允许传 `table_name`、`series`、`count_all`、`group_by`、`filter`
+
+```json
+{
+  "extra_config": {
+    "countdown": {
+      "use_fixed_time": true,
+      "target": "2026-08-20 19:56:12",
+      "units": ["day", "hour", "min", "sec"]
+    }
+  }
+}
+```
+
+field 模式：
+
+- 必填：`table_name`、`count_all:true`、`group_by` 恰好 1 项、`extra_config.countdown.use_fixed_time=false`、`extra_config.countdown.type`
+- 不允许传 `series` 或 `extra_config.countdown.target`
+- `group_by[0]` 应填写日期类字段；CLI 只校验结构，字段类型由服务端最终裁定
+
+```json
+{
+  "table_name": "任务表",
+  "count_all": true,
+  "group_by": [{ "field_name": "截止时间", "mode": "integrated" }],
+  "filter": { "conjunction": "and", "conditions": [] },
+  "extra_config": {
+    "countdown": {
+      "use_fixed_time": false,
+      "type": "MIN",
+      "units": ["day", "hour", "min", "sec"]
+    }
+  }
+}
+```
 
 ## group_by 详细说明
 
@@ -202,9 +253,12 @@ user / created_by / updated_by: is, isNot, isEmpty, isNotEmpty
   - text 类型必填：`text`
   - 互斥：`series` 与 `count_all` 二选一，且至少提供其一（仅图表类型）
   - text 类型**不支持**：`series`、`count_all`、`group_by`、`filter`
+  - countdown fixed 模式**不支持**：`table_name`、`series`、`count_all`、`group_by`、`filter`
+  - countdown field 模式必填：`table_name`、`count_all:true`、`group_by` 恰好 1 项、`extra_config.countdown.type`
 - 长度/结构
   - `group_by` 最多 2 个；每项 `field_name` 必填
   - `group_by[].sort.type` 取值 `group|value|view`；`order` 取值 `asc|desc`
+  - `extra_config.countdown.units` 仅支持 `day|hour|min|sec`
 - 规范化（CLI 自动处理；`--no-validate` 时不生效，`data_config` 原样透传给后端）
   - `series[].rollup` 自动转成大写（如 `sum` → `SUM`）
   - `group_by[].sort.type/order` 自动转成小写

--- a/skills/lark-base/references/lark-base-dashboard-block-get-data.md
+++ b/skills/lark-base/references/lark-base-dashboard-block-get-data.md
@@ -43,6 +43,7 @@
 
 - 词云
 - 指标卡（statistics）
+- 倒计时（countdown）
 
 > [!CAUTION]
 > 文本组件虽然也属于 dashboard block，但它不产生可计算数据，因此不会返回本协议。
@@ -135,6 +136,37 @@ CLI 成功输出使用标准 `{ok, identity, data}` 信封：
 | 二维图表 | `dimensions` / `measures` / `main_data` | 无 |
 | 词云 | `dimensions` / `measures` / `main_data` | 无 |
 | 指标卡 | `dimensions` / `measures` / `main_data` | `comparison_data` / `trend_data` |
+| 倒计时 | `countdown` | 无 |
+
+### countdown 返回结构
+
+倒计时组件不返回二维图协议，而是返回一个专用对象：
+
+```json
+{
+  "countdown": {
+    "mode": "fixed",
+    "target_time": 1787255772000,
+    "title": "版本发布倒计时",
+    "units": ["day", "hour", "min", "sec"]
+  }
+}
+```
+
+field 模式会额外包含：
+
+```json
+{
+  "countdown": {
+    "mode": "field",
+    "target_time": 1787255772000,
+    "target_field_name": "截止时间",
+    "compare_type": "MIN",
+    "title": "任务截止倒计时",
+    "units": ["day", "hour", "min", "sec"]
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- add countdown support to dashboard block create validation and help text
- document countdown data_config and get-data response contracts
- add countdown-focused shortcut tests

## Testing
- go test ./shortcuts/base -run 'TestBaseDashboardBlockCreate_CountdownValidation|TestBaseDashboardHelpGuidesAgents'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added countdown dashboard blocks with fixed-time and field-based modes.
  - Supports configurable display units, targets, grouping, sorting, and filtering.
  - Added guidance for countdowns, button rules, and sharing.

- **Bug Fixes**
  - Strengthened validation for countdown timestamps, grouping modes, and incompatible field configurations.
  - Added validation for statistics number formats and precision settings.

- **Documentation**
  - Documented countdown configuration, validation rules, response formats, display units, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->