### PR TITLE
feat(slides): support str_replace in +replace-slide

### DIFF
--- a/shortcuts/slides/slides_replace_slide.go
+++ b/shortcuts/slides/slides_replace_slide.go
@@ -35,13 +35,15 @@ const maxReplaceParts = 200
 //  4. On 3350001 errors it enriches the hint with context-specific guidance
 //     so AI agents can self-correct.
 //
-// `str_replace` is intentionally NOT exposed: product direction is that
-// slide edits go through structural (block-level) operations only. The backend
-// still accepts str_replace, but the CLI rejects it up front.
+// `str_replace` is also exposed. It does a literal text substitution on the
+// whole serialized slide XML — no block_id, and (unlike the block actions) no
+// id/<content/> injection, since the pattern must match the stored bytes
+// verbatim. It is the only field-level patch path: change one attribute or word
+// without rewriting the enclosing block.
 var SlidesReplaceSlide = common.Shortcut{
 	Service:     "slides",
 	Command:     "+replace-slide",
-	Description: "Replace elements on a slide via block_replace / block_insert parts (auto-injects id + <content/> on shape elements)",
+	Description: "Replace elements on a slide via block_replace / block_insert (auto-injects id + <content/> on shape elements), or patch text via str_replace",
 	Risk:        "write",
 	Scopes:      []string{"slides:presentation:update", "slides:presentation:write_only"},
 	// wiki:node:read is required only when --presentation is a wiki URL.
@@ -50,7 +52,7 @@ var SlidesReplaceSlide = common.Shortcut{
 	Flags: []common.Flag{
 		requiredPresentationRefFlag(),
 		{Name: "slide-id", Desc: "slide page identifier (slide_id)", Required: true},
-		{Name: "parts", Desc: "JSON array of replace parts; accepts replace/insert action aliases, target_id for block_id, and block/content/shape/element for the action's XML payload; max 200", Required: true, Input: []string{common.File, common.Stdin}},
+		{Name: "parts", Desc: "JSON array of replace parts; accepts replace/insert action aliases, target_id for block_id, and block/content/shape/element for the action's XML payload; str_replace uses pattern/replacement/is_multiple; max 200", Required: true, Input: []string{common.File, common.Stdin}},
 		{Name: "revision-id", Type: "int", Default: "-1", Desc: "presentation revision (-1 = latest; pass a specific number for optimistic locking)"},
 		{Name: "tid", Desc: "transaction id for concurrent-edit locking (usually empty)"},
 	},
@@ -197,6 +199,8 @@ type replacePart struct {
 	BlockID             *string
 	Insertion           *string
 	InsertBeforeBlockID *string
+	Pattern             *string
+	IsMultiple          *bool
 }
 
 // replacePartNormalization records each compatibility conversion so callers can
@@ -284,6 +288,20 @@ func parseReplacePartsWithNormalization(raw string) ([]replacePart, []replacePar
 				return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d].insert_before_block_id must be a string", i).WithParam("--parts")
 			}
 			p.InsertBeforeBlockID = &s
+		}
+		if v, ok := m["pattern"]; ok {
+			s, ok := v.(string)
+			if !ok {
+				return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d].pattern must be a string", i).WithParam("--parts")
+			}
+			p.Pattern = &s
+		}
+		if v, ok := m["is_multiple"]; ok {
+			b, ok := v.(bool)
+			if !ok {
+				return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d].is_multiple must be a boolean", i).WithParam("--parts")
+			}
+			p.IsMultiple = &b
 		}
 		out = append(out, p)
 	}
@@ -377,7 +395,7 @@ type replacePartSchema struct {
 	hint    string
 }
 
-// replacePartSchemas is the field contract of the two exposed actions. Holding
+// replacePartSchemas is the field contract of the exposed actions. Holding
 // it in one place lets the error name the exact set the caller may use, instead
 // of a generic "unknown field".
 var replacePartSchemas = map[string]replacePartSchema{
@@ -390,6 +408,11 @@ var replacePartSchemas = map[string]replacePartSchema{
 		fields:  []string{"action", "insertion", "insert_before_block_id"},
 		payload: "insertion",
 		hint:    `correct shape: {"action":"block_insert","insertion":"<shape type=\"rect\" width=\"100\" height=\"100\"/>"}`,
+	},
+	"str_replace": {
+		fields:  []string{"action", "pattern", "replacement", "is_multiple"},
+		payload: "replacement",
+		hint:    `correct shape: {"action":"str_replace","pattern":"width=\"560\"","replacement":"width=\"600\""}`,
 	},
 }
 
@@ -459,8 +482,8 @@ func checkMisspelledAction(i int, m map[string]interface{}) error {
 
 // checkReplacePartFields rejects fields that don't belong to the part's action,
 // naming the field the caller most likely meant. Actions this shortcut doesn't
-// expose ("", str_replace, unknown) are skipped so their own errors from
-// validateReplaceParts still win.
+// expose ("", unknown) are skipped so their own errors from validateReplaceParts
+// still win.
 func checkReplacePartFields(i int, m map[string]interface{}, action string) error {
 	schema, ok := replacePartSchemas[action]
 	if !ok {
@@ -538,7 +561,7 @@ func enrichSlidesReplaceError(err error) error {
 
 // validateReplaceParts enforces CLI-level invariants:
 //   - size is within [1, 200]
-//   - action is one of the exposed actions (block_replace / block_insert)
+//   - action is one of the exposed actions (block_replace / block_insert / str_replace)
 //   - per-action required fields are present
 func validateReplaceParts(parts []replacePart) error {
 	if len(parts) == 0 {
@@ -561,14 +584,20 @@ func validateReplaceParts(parts []replacePart) error {
 				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d] (block_insert) requires non-empty insertion", i).WithParam("--parts")
 			}
 		case "str_replace":
-			// Backend still accepts str_replace, but product decision is to
-			// force structural edits through the CLI. Block it up-front so
-			// users don't build tooling around an option we won't keep.
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d] action %q is not supported by this shortcut; use block_replace or block_insert", i, p.Action).WithParam("--parts")
+			// pattern must be non-empty; replacement must be present but may be
+			// the empty string (empty replacement = delete the matched text).
+			// This mirrors the backend contract (BuildReplaceCmd), so the CLI
+			// fails fast with the same rules rather than round-tripping a 4000002.
+			if p.Pattern == nil || *p.Pattern == "" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d] (str_replace) requires non-empty pattern", i).WithParam("--parts")
+			}
+			if p.Replacement == nil {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d] (str_replace) requires replacement (may be an empty string to delete the match)", i).WithParam("--parts")
+			}
 		case "replace_all":
 			return errs.NewValidationError(
 				errs.SubtypeInvalidArgument,
-				"--parts[%d] action %q is not equivalent to a block operation and cannot be normalized safely; use block_replace for each known block or block_insert for new elements",
+				"--parts[%d] action %q is not equivalent to a block operation and cannot be normalized safely; use str_replace with is_multiple:true for whole-slide text, block_replace for a known block, or block_insert for new elements",
 				i, p.Action,
 			).WithParam("--parts")
 		case "page_replace", "slide_replace":
@@ -580,7 +609,7 @@ func validateReplaceParts(parts []replacePart) error {
 		case "":
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d].action is required", i).WithParam("--parts")
 		default:
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d] unknown action %q, supported: block_replace, block_insert", i, p.Action).WithParam("--parts")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--parts[%d] unknown action %q, supported: block_replace, block_insert, str_replace", i, p.Action).WithParam("--parts")
 		}
 	}
 	return nil
@@ -610,6 +639,16 @@ func injectBlockReplaceIDs(parts []replacePart) ([]map[string]interface{}, error
 			m["insertion"] = ensureShapeHasContent(*p.Insertion)
 			if p.InsertBeforeBlockID != nil {
 				m["insert_before_block_id"] = *p.InsertBeforeBlockID
+			}
+		case "str_replace":
+			// Literal text substitution on the serialized slide XML: send
+			// pattern/replacement byte-for-byte, with no id or <content/>
+			// injection. The pattern must match the stored bytes exactly, so
+			// any CLI-side rewriting would break the match.
+			m["pattern"] = *p.Pattern
+			m["replacement"] = *p.Replacement
+			if p.IsMultiple != nil {
+				m["is_multiple"] = *p.IsMultiple
 			}
 		}
 		out = append(out, m)

--- a/shortcuts/slides/slides_replace_slide_test.go
+++ b/shortcuts/slides/slides_replace_slide_test.go
@@ -227,25 +227,134 @@ func TestReplaceSlideBlockInsertPassthrough(t *testing.T) {
 	}
 }
 
-// TestReplaceSlideRejectsStrReplace verifies str_replace is blocked at the
-// CLI even though the backend supports it (product decision).
-func TestReplaceSlideRejectsStrReplace(t *testing.T) {
+// TestReplaceSlideStrReplacePassthrough verifies str_replace parts are sent
+// byte-for-byte: pattern/replacement/is_multiple forwarded, and no block_id or
+// id/<content/> injection (the pattern must match the stored XML verbatim).
+func TestReplaceSlideStrReplacePassthrough(t *testing.T) {
 	t.Parallel()
 
-	f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
-	parts := `[{"action":"str_replace","pattern":"old","replacement":"new"}]`
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/slide/replace",
+		Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{"revision_id": 11}},
+	}
+	reg.Register(stub)
+
+	parts := `[{"action":"str_replace","pattern":"width=\"560\"","replacement":"width=\"600\"","is_multiple":true}]`
 	err := runSlidesShortcut(t, f, stdout, SlidesReplaceSlide, []string{
 		"+replace-slide",
 		"--presentation", "pres_abc",
-		"--slide-id", "s",
+		"--slide-id", "slide_xyz",
 		"--parts", parts,
 		"--as", "user",
 	})
-	if err == nil {
-		t.Fatal("expected error for str_replace action")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "str_replace") || !strings.Contains(err.Error(), "block_replace") {
-		t.Fatalf("err = %v, want mention of both str_replace and block_replace", err)
+
+	var body struct {
+		Parts []map[string]interface{} `json:"parts"`
+	}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	got := body.Parts[0]
+	if got["action"] != "str_replace" {
+		t.Fatalf("action = %v", got["action"])
+	}
+	if got["pattern"] != `width="560"` {
+		t.Fatalf("pattern mutated: %v", got["pattern"])
+	}
+	if got["replacement"] != `width="600"` {
+		t.Fatalf("replacement mutated: %v", got["replacement"])
+	}
+	if got["is_multiple"] != true {
+		t.Fatalf("is_multiple = %v, want true", got["is_multiple"])
+	}
+	if _, hasID := got["block_id"]; hasID {
+		t.Fatalf("str_replace should not carry block_id, got %v", got)
+	}
+	if _, hasContent := got["insertion"]; hasContent {
+		t.Fatalf("str_replace should not carry insertion, got %v", got)
+	}
+}
+
+// TestReplaceSlideStrReplaceEmptyReplacementDeletes verifies an empty
+// replacement is accepted (empty = delete the matched text) and forwarded,
+// while is_multiple is omitted when the caller doesn't set it.
+func TestReplaceSlideStrReplaceEmptyReplacementDeletes(t *testing.T) {
+	t.Parallel()
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/slide/replace",
+		Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{"revision_id": 12}},
+	}
+	reg.Register(stub)
+
+	parts := `[{"action":"str_replace","pattern":"<undefined/>","replacement":""}]`
+	err := runSlidesShortcut(t, f, stdout, SlidesReplaceSlide, []string{
+		"+replace-slide",
+		"--presentation", "pres_abc",
+		"--slide-id", "slide_xyz",
+		"--parts", parts,
+		"--as", "user",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var body struct {
+		Parts []map[string]interface{} `json:"parts"`
+	}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	got := body.Parts[0]
+	if got["replacement"] != "" {
+		t.Fatalf("replacement = %v, want empty string", got["replacement"])
+	}
+	if _, ok := got["is_multiple"]; ok {
+		t.Fatalf("is_multiple should be omitted when unset, got %v", got["is_multiple"])
+	}
+}
+
+// TestReplaceSlideStrReplaceMissingFields checks str_replace required-field
+// rules: pattern must be non-empty; replacement must be present (but may be "").
+func TestReplaceSlideStrReplaceMissingFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		parts   string
+		wantErr string
+	}{
+		{"missing pattern", `[{"action":"str_replace","replacement":"new"}]`, "requires non-empty pattern"},
+		{"empty pattern", `[{"action":"str_replace","pattern":"","replacement":"new"}]`, "requires non-empty pattern"},
+		{"missing replacement", `[{"action":"str_replace","pattern":"old"}]`, "requires replacement"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			err := runSlidesShortcut(t, f, stdout, SlidesReplaceSlide, []string{
+				"+replace-slide",
+				"--presentation", "pres_abc",
+				"--slide-id", "s",
+				"--parts", tt.parts,
+				"--as", "user",
+			})
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+			}
+			assertValidationProblem(t, err, "--parts", nil)
+		})
 	}
 }
 
@@ -740,7 +849,7 @@ func TestReplaceSlideValidationParam(t *testing.T) {
 		{"parts non-string field", "s", `[{"action":123}]`, "--parts"},
 		{"parts empty array", "s", `[]`, "--parts"},
 		{"parts missing required field", "s", `[{"action":"block_insert"}]`, "--parts"},
-		{"parts str_replace rejected", "s", `[{"action":"str_replace","pattern":"a","replacement":"b"}]`, "--parts"},
+		{"parts str_replace missing pattern", "s", `[{"action":"str_replace","replacement":"b"}]`, "--parts"},
 		{"parts unknown action", "s", `[{"action":"nuke","block_id":"b"}]`, "--parts"},
 		{"parts replacement without root", "s", `[{"action":"block_replace","block_id":"b","replacement":"plain text"}]`, "--parts"},
 	}
@@ -1129,7 +1238,7 @@ func TestReplaceSlideAcceptsDuplicateAliasValues(t *testing.T) {
 func TestReplaceSlideRejectsSemanticallyDifferentActions(t *testing.T) {
 	t.Parallel()
 
-	for _, action := range []string{"str_replace", "replace_all", "page_replace", "slide_replace"} {
+	for _, action := range []string{"replace_all", "page_replace", "slide_replace"} {
 		t.Run(action, func(t *testing.T) {
 			t.Parallel()
 			f, stdout, _, _ := cmdutil.TestFactory(t, slidesTestConfig(t, ""))

--- a/skills/lark-slides/references/cli/lark-slides-replace-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-replace-slide.md
@@ -1,8 +1,8 @@
-# slides +replace-slide（块级替换 / 插入）
+# slides +replace-slide（块级替换 / 插入 / 字符串替换）
 
-对指定 slide 做块级替换或插入。编辑已有 PPT 的主路径——`slide_id` 不变、页序不动、只影响被指定的块。
+对指定 slide 做块级替换、插入，或整页字符串级替换。编辑已有 PPT 的主路径——`slide_id` 不变、页序不动。
 
-> **编写 `--parts` 时只使用标准 action 和字段**：`block_replace` 使用 `block_id` + `replacement`，`block_insert` 使用 `insertion`（可选 `insert_before_block_id`）。不要根据其他 API 或自然语言猜 action、字段名；具体结构以本文表格为准。
+> **编写 `--parts` 时只使用标准 action 和字段**：`block_replace` 使用 `block_id` + `replacement`，`block_insert` 使用 `insertion`（可选 `insert_before_block_id`），`str_replace` 使用 `pattern` + `replacement`（可选 `is_multiple`）。不要根据其他 API 或自然语言猜 action、字段名；具体结构以本文表格为准。
 
 相比直接调 `xml_presentation.slide.replace`，这个 shortcut 的四个额外价值：
 
@@ -25,6 +25,13 @@ lark-cli slides +replace-slide --as user \
   --presentation slidesXXXXXXXXXXXXXXXXXXXXXX \
   --slide-id pfG \
   --parts '[{"action":"block_replace","block_id":"bUn","replacement":"<shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>新标题</p></content></shape>"}]'
+
+# str_replace：整页 XML 上的字符串级替换（改一个属性，不用重写整块）
+# pattern 必须与最新 slide.get 读回的序列化 XML 逐字一致
+lark-cli slides +replace-slide --as user \
+  --presentation slidesXXXXXXXXXXXXXXXXXXXXXX \
+  --slide-id pfG \
+  --parts '[{"action":"str_replace","pattern":"width=\"560\"","replacement":"width=\"600\""}]'
 
 # 大 --parts 走文件或 stdin（auto-gen 命令不支持 @file，但 shortcut 支持）
 lark-cli slides +replace-slide --as user \
@@ -54,7 +61,7 @@ lark-cli slides +replace-slide --as user \
 
 ## parts 元素结构
 
-> **限制**：最多 200 条；`block_replace` 和 `block_insert` 可以在同一批次混用。**其他 action（含 `str_replace`）CLI 会直接报错拒绝**。
+> **限制**：最多 200 条；`block_replace`、`block_insert`、`str_replace` 可以在同一批次混用。
 
 每条 part 按 `action` 取不同字段：
 
@@ -73,6 +80,15 @@ lark-cli slides +replace-slide --as user \
 | `action` | 是 | `"block_insert"` |
 | `insertion` | 是 | 要插入的 XML 片段 |
 | `insert_before_block_id` | 否 | 插到这个块之前；省略（不提供此字段）则追加到页末 |
+
+### action = `str_replace`
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `action` | 是 | `"str_replace"` |
+| `pattern` | 是 | 要查找的字符串，非空；须与最新 `slide.get` 读回的 XML 逐字一致 |
+| `replacement` | 是 | 替换字符串，允许空串（空串 = 删除匹配） |
+| `is_multiple` | 否 | `true` 替换所有匹配；省略只替换**第一处** |
 
 ### 错误字段名（CLI 直接拒绝）
 
@@ -220,6 +236,16 @@ lark-cli slides +replace-slide --as user \
   ]'
 ```
 
+### 微调一个属性 / 一个词（str_replace）
+
+只改块内某个属性/词、且原文能从最新读取里精确定位又唯一时用 `str_replace`；要动整块结构、或原文不唯一/不确定时用 `block_replace`。
+
+```bash
+lark-cli slides +replace-slide --as user \
+  --presentation "$PID" --slide-id "$SID" \
+  --parts '[{"action":"str_replace","pattern":"width=\"560\"","replacement":"width=\"600\""}]'
+```
+
 ### 乐观锁
 
 ```bash
@@ -241,7 +267,6 @@ lark-cli slides +replace-slide --as user \
 | 3350001 + hint "block_id not found" | `parts[i].block_id` 在当前页不存在 | 重新 `slide.get` 拿最新 XML，按里面的 short ID 再填 |
 | 3350002 not found | `--revision-id` 传了不存在的版本号（超过当前 revision） | 用 `-1` 或用 `slide.get` 拿到的有效 `revision_id` |
 | `--parts invalid JSON` | JSON 本身不完整，或被 shell 引号/转义破坏 | 将数组写入 `parts.json` 后传 `--parts @parts.json`，或通过 stdin 传给 `--parts -` |
-| `--parts[i] action "str_replace" is not supported` | CLI 不暴露 `str_replace` | 把替换需求改写成 `block_replace` / `block_insert` |
 | `--parts[i] action "page_replace" / "slide_replace" means whole-page replacement` | 把整页更新意图传给了块级 shortcut | 改用 [`slides +update-slide`](lark-slides-update-slide.md) 整页原地写回 |
 | `--parts contains N items, exceeds maximum of 200` | 一次提交 parts 太多 | 拆多次调用 |
 | `--parts[i] unknown field "xml"; did you mean "replacement"?` | XML 塞进了未支持的字段名（如 `xml` / `new_xml` / `data`） | 使用标准字段：`block_replace` 用 `replacement`，`block_insert` 用 `insertion` |


### PR DESCRIPTION
## Summary

- Add the `str_replace` action to `+replace-slide` for field-level text edits: change one attribute or word without rewriting the whole block.
- Fields: `pattern` (text to find), `replacement` (replacement text; empty string = delete the match), `is_multiple` (optional; replace all matches).
- Validation: `pattern` must be non-empty; `replacement` must be provided. The CLI errors out when a field is missing.
- Update the skill doc: add `str_replace` field descriptions, examples, and guidance on when to use `str_replace` vs `block_replace`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./shortcuts/slides/... --count=1` (all pass, including the new str_replace cases)
