### PR TITLE
feat: event organizer transfer bot to user

### DIFF
--- a/shortcuts/calendar/calendar_test.go
+++ b/shortcuts/calendar/calendar_test.go
@@ -2596,17 +2596,17 @@ func TestResolveStartEnd_ExplicitValues(t *testing.T) {
 // Shortcuts() registration test
 // ---------------------------------------------------------------------------
 
-func TestShortcuts_Returns10(t *testing.T) {
+func TestShortcuts_Returns11(t *testing.T) {
 	shortcuts := Shortcuts()
-	if len(shortcuts) != 10 {
-		t.Fatalf("expected 10 shortcuts, got %d", len(shortcuts))
+	if len(shortcuts) != 11 {
+		t.Fatalf("expected 11 shortcuts, got %d", len(shortcuts))
 	}
 
 	names := map[string]bool{}
 	for _, s := range shortcuts {
 		names[s.Command] = true
 	}
-	for _, want := range []string{"+agenda", "+create", "+update", "+freebusy", "+room-find", "+rsvp", "+suggestion", "+get"} {
+	for _, want := range []string{"+agenda", "+create", "+update", "+freebusy", "+room-find", "+rsvp", "+suggestion", "+get", "+transfer"} {
 		if !names[want] {
 			t.Errorf("missing shortcut %s", want)
 		}

--- a/shortcuts/calendar/calendar_transfer.go
+++ b/shortcuts/calendar/calendar_transfer.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// calendar +transfer — hand the organizer role of an event to another user or bot
+
+package calendar
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const (
+	flagTransferSeries          = "transfer-series"
+	flagRemoveOriginalOrganizer = "remove-original-organizer"
+)
+
+const sharedCalendarOrganizerNotice = "[calendar +transfer] note: original_organizer_removed is omitted because --calendar-id may name either kind of calendar. " +
+	"A shared calendar has no organizer of its own, so transferring an event that lives on one always removes the original organizer; " +
+	"on a primary calendar the original organizer stays as an attendee. Do not claim either outcome without checking the event.\n"
+
+const seriesConfirmationHint = "this transfers the ENTIRE recurring series (every occurrence and exception), not a single occurrence — " +
+	"the API cannot transfer one occurrence. Re-run with --transfer-series to confirm."
+
+var CalendarTransfer = common.Shortcut{
+	Service:           "calendar",
+	Command:           "+transfer",
+	Description:       "Transfer the organizer role of a calendar event to another user or bot",
+	Risk:              "high-risk-write",
+	Scopes:            []string{"calendar:calendar.event:transfer"},
+	ConditionalScopes: []string{"calendar:calendar.event:read"},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
+	Flags: []common.Flag{
+		{Name: "event-id", Desc: "event ID to transfer (uid_originalTime)", Required: true},
+		{Name: "to-user-id", Desc: "receiver open_id (ou_...); becomes the new organizer. May be a user or a bot", Required: true},
+		{Name: "calendar-id", Desc: "calendar ID the event lives on (default: primary)"},
+		{Name: flagRemoveOriginalOrganizer, Type: "bool", Default: "false", Desc: "remove the original organizer instead of keeping them as an attendee; the server forces this on a shared calendar, where original_organizer_removed is omitted from the result"},
+		{Name: flagTransferSeries, Type: "bool", Default: "false", Desc: "confirm transferring the entire recurring series; required for recurring events because a single occurrence cannot be transferred"},
+	},
+	Tips: []string{
+		"Transferring is irreversible and also moves meeting minutes, notes and attachments to the new organizer; pass --yes to confirm.",
+		"--as must be the event's current organizer (user or bot); --to-user-id may be a user or a bot, so all four user/bot directions are expressed by those two flags.",
+		`Example: lark-cli calendar +transfer --event-id <uid_originalTime> --to-user-id ou_xxx --yes`,
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return validateCalendarTransfer(runtime)
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return dryRunCalendarTransfer(runtime)
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return executeCalendarTransfer(ctx, runtime)
+	},
+}
+
+func validateCalendarTransfer(runtime *common.RuntimeContext) error {
+	if err := rejectCalendarAutoBotFallback(runtime); err != nil {
+		return err
+	}
+	for _, flag := range []string{"event-id", "to-user-id", "calendar-id"} {
+		if val := strings.TrimSpace(runtime.Str(flag)); val != "" {
+			if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+				return err
+			}
+		}
+	}
+	if strings.TrimSpace(runtime.Str("event-id")) == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --event-id").WithParam("--event-id")
+	}
+	toUserID := strings.TrimSpace(runtime.Str("to-user-id"))
+	if toUserID == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --to-user-id").WithParam("--to-user-id")
+	}
+	if !strings.HasPrefix(toUserID, "ou_") {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"invalid receiver id format %q: --to-user-id should be an open_id starting with 'ou_'", toUserID).WithParam("--to-user-id")
+	}
+	return nil
+}
+
+const (
+	larkErrCalendarNoAccessRole         = 191002
+	larkErrCalendarWrongCalendarType    = 191004
+	larkErrCalendarCannotInviteReceiver = 193109
+	larkErrCalendarEventNotInOrganizer  = 193110
+	larkErrCalendarCrossTenantTransfer  = 193111
+)
+
+func withCalendarTransferRecovery(err error) error {
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		return err
+	}
+	var hint string
+	switch p.Code {
+	case larkErrCalendarNoAccessRole:
+		hint = "the calling identity has no edit access to this calendar (WRITER or OWNER is required). This is not a missing OAuth scope, so do not run `lark-cli auth login`: set --as to the event's current organizer, or ask the calendar owner to grant access"
+	case larkErrCalendarWrongCalendarType:
+		hint = "only events on a primary or shared calendar can be transferred; resource, mailbox, and imported Google/Exchange calendars cannot"
+	case larkErrCalendarCannotInviteReceiver:
+		hint = "executive-mode collaboration rules block inviting this receiver. This is not a missing OAuth scope, so do not run `lark-cli auth login`: pick another receiver, or have the receiver start the transfer"
+	case larkErrCalendarEventNotInOrganizer:
+		hint = "the transfer must run against the organizer's own calendar; --calendar-id defaults to the primary calendar, so pass the organizer's calendar id explicitly when the event lives on a shared calendar"
+	case larkErrCalendarCrossTenantTransfer:
+		hint = "cross-tenant transfer is not supported; invite the receiver as an attendee instead"
+	default:
+		return err
+	}
+	return withStepContext(err, "%s", hint)
+}
+
+func calendarTransferIDs(runtime *common.RuntimeContext) (calendarID string, eventID string) {
+	calendarID = strings.TrimSpace(runtime.Str("calendar-id"))
+	if calendarID == "" {
+		calendarID = PrimaryCalendarIDStr
+	}
+	return calendarID, strings.TrimSpace(runtime.Str("event-id"))
+}
+
+func calendarTransferPath(calendarID, eventID string) string {
+	return fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s/transfer",
+		validate.EncodePathSegment(calendarID), validate.EncodePathSegment(eventID))
+}
+
+func calendarTransferBody(runtime *common.RuntimeContext) map[string]interface{} {
+	return map[string]interface{}{
+		"to_user_id":                     strings.TrimSpace(runtime.Str("to-user-id")),
+		"need_remove_original_organizer": runtime.Bool(flagRemoveOriginalOrganizer),
+	}
+}
+
+func transferOutcomeKnown(runtime *common.RuntimeContext, calendarID string) bool {
+	return runtime.Bool(flagRemoveOriginalOrganizer) || calendarID == PrimaryCalendarIDStr
+}
+
+func dryRunCalendarTransfer(runtime *common.RuntimeContext) *common.DryRunAPI {
+	calendarID, eventID := calendarTransferIDs(runtime)
+	d := common.NewDryRunAPI().Set("calendar_id", calendarID).Set("event_id", eventID)
+	steps := 0
+	if !runtime.Bool(flagTransferSeries) {
+		steps++
+		d.GET("/open-apis/calendar/v4/calendars/:calendar_id/events/:event_id").
+			Desc(fmt.Sprintf("[%d] Read the event to detect a recurring series (skipped when --%s is set)", steps, flagTransferSeries))
+	}
+	steps++
+	return d.POST("/open-apis/calendar/v4/calendars/:calendar_id/events/:event_id/transfer").
+		Desc(fmt.Sprintf("[%d] Transfer the organizer role", steps)).
+		Params(map[string]interface{}{"user_id_type": "open_id"}).
+		Body(calendarTransferBody(runtime))
+}
+
+func blockUnconfirmedSeriesTransfer(runtime *common.RuntimeContext, calendarID, eventID string) error {
+	event, err := readTransferEvent(runtime, calendarID, eventID)
+	if err != nil {
+		return err
+	}
+	if event.Recurrence == "" && event.RecurringEventID == "" {
+		return nil
+	}
+	return errs.NewValidationError(errs.SubtypeFailedPrecondition, "%s", seriesConfirmationHint).
+		WithParam("--" + flagTransferSeries).
+		WithHint("confirm the whole-series transfer with the user, then re-run with --" + flagTransferSeries)
+}
+
+func readTransferEvent(runtime *common.RuntimeContext, calendarID, eventID string) (*calendarEvent, error) {
+	data, err := runtime.CallAPITyped("GET",
+		fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s",
+			validate.EncodePathSegment(calendarID), validate.EncodePathSegment(eventID)),
+		nil, nil)
+	if err != nil {
+		return nil, withStepContext(withCalendarTransferRecovery(err),
+			"failed to read event %s while checking whether it is recurring; pass --%s to confirm a whole-series transfer and skip this check", eventID, flagTransferSeries)
+	}
+	return parseCalendarEvent(data)
+}
+
+func executeCalendarTransfer(ctx context.Context, runtime *common.RuntimeContext) error {
+	calendarID, eventID := calendarTransferIDs(runtime)
+	toUserID := strings.TrimSpace(runtime.Str("to-user-id"))
+
+	if !runtime.Bool(flagTransferSeries) {
+		if err := blockUnconfirmedSeriesTransfer(runtime, calendarID, eventID); err != nil {
+			return err
+		}
+	}
+	if _, err := runtime.CallAPITyped("POST", calendarTransferPath(calendarID, eventID),
+		map[string]interface{}{"user_id_type": "open_id"}, calendarTransferBody(runtime)); err != nil {
+		return withCalendarTransferRecovery(err)
+	}
+
+	result := map[string]interface{}{
+		"calendar_id":      calendarID,
+		"event_id":         eventID,
+		"new_organizer_id": toUserID,
+	}
+	if transferOutcomeKnown(runtime, calendarID) {
+		result["original_organizer_removed"] = runtime.Bool(flagRemoveOriginalOrganizer)
+	} else {
+		fmt.Fprint(runtime.IO().ErrOut, sharedCalendarOrganizerNotice)
+	}
+	runtime.OutFormat(result, nil, func(w io.Writer) {
+		output.PrintTable(w, []map[string]interface{}{result})
+		fmt.Fprintln(w, "\nOrganizer transferred successfully")
+	})
+	return nil
+}

--- a/shortcuts/calendar/calendar_transfer_test.go
+++ b/shortcuts/calendar/calendar_transfer_test.go
@@ -1,0 +1,416 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+const (
+	transferCalendarID = "cal_test123"
+	transferEventID    = "uid_abc_1742515200"
+	transferReceiverID = "ou_receiver"
+)
+
+func transferGetEventStub(event map[string]interface{}) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/" + transferCalendarID + "/events/" + transferEventID,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": event},
+		},
+	}
+}
+
+func transferPostStub() *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/calendars/" + transferCalendarID + "/events/" + transferEventID + "/transfer",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	}
+}
+
+func transferArgs(extra ...string) []string {
+	return append([]string{
+		"+transfer",
+		"--calendar-id", transferCalendarID,
+		"--event-id", transferEventID,
+		"--to-user-id", transferReceiverID,
+		"--as", "bot",
+		"--yes",
+	}, extra...)
+}
+
+// An explicit --calendar-id may be shared, and the transfer response says
+// nothing about the original organizer. Reporting false there is the bug: it
+// made agents claim the original organizer stayed as an attendee. The field is
+// omitted instead, and stderr explains the shared-calendar rule.
+func TestTransfer_NamedCalendar_OmitsOutcomeAndExplains(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(transferGetEventStub(map[string]interface{}{
+		"event_id": transferEventID,
+		"summary":  "One-off sync",
+	}))
+	post := transferPostStub()
+	reg.Register(post)
+
+	if err := mountAndRun(t, CalendarTransfer, transferArgs(), f, stdout); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(post.CapturedBodies) != 1 {
+		t.Fatalf("want exactly 1 transfer call, got %d", len(post.CapturedBodies))
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(post.CapturedBodies[0], &body); err != nil {
+		t.Fatalf("unmarshal transfer body: %v", err)
+	}
+	if body["to_user_id"] != transferReceiverID {
+		t.Errorf("to_user_id=%v, want %s", body["to_user_id"], transferReceiverID)
+	}
+	// The request still forwards what the caller asked for; only the report
+	// withholds an outcome the command cannot know.
+	if body["need_remove_original_organizer"] != false {
+		t.Errorf("need_remove_original_organizer=%v, want the flag value false", body["need_remove_original_organizer"])
+	}
+	out := stdout.String()
+	if !strings.Contains(out, transferReceiverID) {
+		t.Errorf("stdout should report the new organizer, got: %s", out)
+	}
+	if strings.Contains(out, "original_organizer_removed") {
+		t.Errorf("an unknown outcome must not be reported, got: %s", out)
+	}
+	if errOut := stderr.String(); !strings.Contains(errOut, "shared calendar") {
+		t.Errorf("stderr should explain the shared-calendar rule, got: %s", errOut)
+	}
+}
+
+// The primary calendar alias is a primary calendar by definition, so the server
+// never force-removes and the flag value is the truth.
+func TestTransfer_PrimaryCalendar_ReportsOrganizerKept(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/" + transferEventID,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": transferEventID}},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/transfer",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	})
+
+	err := mountAndRun(t, CalendarTransfer, []string{
+		"+transfer",
+		"--event-id", transferEventID,
+		"--to-user-id", transferReceiverID,
+		"--as", "bot",
+		"--yes",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out := stdout.String(); !strings.Contains(out, `"original_organizer_removed": false`) {
+		t.Errorf("a primary calendar keeps the original organizer, got: %s", out)
+	}
+	if errOut := stderr.String(); strings.Contains(errOut, "shared calendar") {
+		t.Errorf("a known outcome needs no shared-calendar note, got: %s", errOut)
+	}
+}
+
+// Asking for the removal settles the outcome on any calendar.
+func TestTransfer_RemoveOriginalOrganizer_ForwardsFlag(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(transferGetEventStub(map[string]interface{}{"event_id": transferEventID}))
+	post := transferPostStub()
+	reg.Register(post)
+
+	if err := mountAndRun(t, CalendarTransfer, transferArgs("--"+flagRemoveOriginalOrganizer), f, stdout); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(post.CapturedBodies[0], &body); err != nil {
+		t.Fatalf("unmarshal transfer body: %v", err)
+	}
+	if body["need_remove_original_organizer"] != true {
+		t.Errorf("need_remove_original_organizer=%v, want true", body["need_remove_original_organizer"])
+	}
+	if out := stdout.String(); !strings.Contains(out, `"original_organizer_removed": true`) {
+		t.Errorf("stdout should report the removal, got: %s", out)
+	}
+	if errOut := stderr.String(); strings.Contains(errOut, "shared calendar") {
+		t.Errorf("a known outcome needs no shared-calendar note, got: %s", errOut)
+	}
+}
+
+// A recurring event must not be transferred until the caller has acknowledged
+// that the whole series moves: the API cannot transfer a single occurrence.
+func TestTransfer_RecurringEvent_BlockedWithoutSeriesConfirmation(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(transferGetEventStub(map[string]interface{}{
+		"event_id":   transferEventID,
+		"summary":    "Daily standup",
+		"recurrence": "FREQ=DAILY;INTERVAL=1",
+	}))
+	transferred := false
+	reg.Register(&httpmock.Stub{
+		Method:   "POST",
+		URL:      "/transfer",
+		Optional: true,
+		OnMatch:  func(*http.Request) { transferred = true },
+		Body:     map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	})
+
+	err := mountAndRun(t, CalendarTransfer, transferArgs(), f, stdout)
+	if err == nil {
+		t.Fatal("want error for an unconfirmed recurring transfer")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeFailedPrecondition {
+		t.Errorf("subtype=%q, want %q", ve.Subtype, errs.SubtypeFailedPrecondition)
+	}
+	if ve.Param != "--"+flagTransferSeries {
+		t.Errorf("param=%q, want --%s", ve.Param, flagTransferSeries)
+	}
+	if !strings.Contains(ve.Hint, flagTransferSeries) {
+		t.Errorf("hint should name --%s, got %q", flagTransferSeries, ve.Hint)
+	}
+	if transferred {
+		t.Error("transfer must not be issued before the series is confirmed")
+	}
+}
+
+// An exception instance carries recurring_event_id rather than recurrence, and
+// still transfers the whole series.
+func TestTransfer_RecurringException_BlockedWithoutSeriesConfirmation(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(transferGetEventStub(map[string]interface{}{
+		"event_id":           transferEventID,
+		"is_exception":       true,
+		"recurring_event_id": "uid_abc_0",
+	}))
+
+	err := mountAndRun(t, CalendarTransfer, transferArgs(), f, stdout)
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) || ve.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("want failed_precondition validation error, got %v (%T)", err, err)
+	}
+}
+
+// --transfer-series is the caller's confirmation, so the transfer is the only
+// call the command makes.
+func TestTransfer_SeriesConfirmed_SkipsRecurrenceRead(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	eventRead := false
+	eventStub := transferGetEventStub(map[string]interface{}{
+		"event_id":   transferEventID,
+		"recurrence": "FREQ=DAILY;INTERVAL=1",
+	})
+	eventStub.Optional = true
+	eventStub.OnMatch = func(*http.Request) { eventRead = true }
+	reg.Register(eventStub)
+	post := transferPostStub()
+	reg.Register(post)
+
+	if err := mountAndRun(t, CalendarTransfer, transferArgs("--"+flagTransferSeries), f, stdout); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if eventRead {
+		t.Error("--transfer-series should skip the recurrence pre-read")
+	}
+	if len(post.CapturedBodies) != 1 {
+		t.Fatalf("want exactly 1 transfer call, got %d", len(post.CapturedBodies))
+	}
+}
+
+// The pre-read guards against a silent whole-series transfer, so a failed read
+// must block rather than fall through to the transfer.
+func TestTransfer_RecurrenceReadFailure_BlocksTransfer(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/" + transferCalendarID + "/events/" + transferEventID,
+		Body:   map[string]interface{}{"code": 193001, "msg": "event not found"},
+	})
+	transferred := false
+	reg.Register(&httpmock.Stub{
+		Method:   "POST",
+		URL:      "/transfer",
+		Optional: true,
+		OnMatch:  func(*http.Request) { transferred = true },
+		Body:     map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	})
+
+	if err := mountAndRun(t, CalendarTransfer, transferArgs(), f, stdout); err == nil {
+		t.Fatal("want error when the recurrence pre-read fails")
+	}
+	if transferred {
+		t.Error("transfer must not be issued when the recurrence check could not run")
+	}
+}
+
+func TestTransfer_InvalidReceiverID_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarTransfer, []string{
+		"+transfer",
+		"--calendar-id", transferCalendarID,
+		"--event-id", transferEventID,
+		"--to-user-id", "user@example.com",
+		"--as", "bot",
+		"--yes",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--to-user-id" {
+		t.Errorf("param=%q, want --to-user-id", ve.Param)
+	}
+}
+
+// Only the codes whose default agent reaction is wrong get a transfer-scoped
+// hint. The two 403s look like a missing OAuth scope; the rest need a next
+// action the server message does not name. Other codes stay as classified.
+func TestTransfer_UpstreamCodes_CarryScopedRecovery(t *testing.T) {
+	cases := []struct {
+		code     int
+		msg      string
+		wantHint []string
+	}{
+		{larkErrCalendarNoAccessRole, "no calendar access_role", []string{"--as", "do not run `lark-cli auth login`"}},
+		{larkErrCalendarWrongCalendarType, "invalid calendar type", []string{"primary or shared calendar"}},
+		{larkErrCalendarCannotInviteReceiver, "no permission to invite the receiver", []string{"do not run `lark-cli auth login`", "another receiver"}},
+		{larkErrCalendarEventNotInOrganizer, "the event is not in the organizer calendar", []string{"--calendar-id", "shared calendar"}},
+		{larkErrCalendarCrossTenantTransfer, "cannot transfer the event to another tenant", []string{"attendee"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.msg, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+			reg.Register(transferGetEventStub(map[string]interface{}{"event_id": transferEventID}))
+			reg.Register(&httpmock.Stub{
+				Method: "POST",
+				URL:    "/transfer",
+				Body:   map[string]interface{}{"code": tc.code, "msg": tc.msg},
+			})
+
+			err := mountAndRun(t, CalendarTransfer, transferArgs(), f, stdout)
+			if err == nil {
+				t.Fatalf("want error for code %d", tc.code)
+			}
+			var ae *errs.APIError
+			if !errors.As(err, &ae) {
+				t.Fatalf("want *errs.APIError, got %T", err)
+			}
+			if ae.Code != tc.code {
+				t.Errorf("code=%d, want the upstream code %d preserved", ae.Code, tc.code)
+			}
+			for _, want := range tc.wantHint {
+				if !strings.Contains(ae.Hint, want) {
+					t.Errorf("hint for code %d should mention %q, got %q", tc.code, want, ae.Hint)
+				}
+			}
+		})
+	}
+}
+
+// A failed pre-read is not a transfer-scoped code, so recovery stays the
+// existing step note. Agents must not treat "pass --transfer-series" as a
+// substitute for a missing event.
+func TestTransfer_PreReadFailure_KeepsStepContext(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/" + transferCalendarID + "/events/" + transferEventID,
+		Body:   map[string]interface{}{"code": 193001, "msg": "event not found"},
+	})
+
+	err := mountAndRun(t, CalendarTransfer, transferArgs(), f, stdout)
+	if err == nil {
+		t.Fatal("want error when the pre-read fails")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Code != 193001 {
+		t.Errorf("code=%d, want 193001 preserved", ae.Code)
+	}
+	if !strings.Contains(ae.Hint, "recurring") {
+		t.Errorf("hint should keep the pre-read step context, got %q", ae.Hint)
+	}
+}
+
+// 190014 already carries the server's field-level reason, which is more precise
+// than any flag this command could guess at, so the transfer recovery must leave
+// it alone.
+func TestTransfer_InvalidParamsDetail_KeepsServerReasonOnly(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(transferGetEventStub(map[string]interface{}{"event_id": transferEventID}))
+	const reason = "The value of event_id(bad_id) is invalid. Please provide a valid value for the field."
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/transfer",
+		Body: map[string]interface{}{
+			"code": 190014,
+			"msg":  "invalid request parameters. check details for more info.",
+			"error": map[string]interface{}{
+				"details": []interface{}{map[string]interface{}{"value": reason}},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarTransfer, transferArgs(), f, stdout)
+	if err == nil {
+		t.Fatal("want error for code 190014")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Hint != reason {
+		t.Errorf("hint=%q, want the server reason alone", ae.Hint)
+	}
+}
+
+func TestTransfer_DryRun_ShowsPrecheckAndTransfer(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+
+	if err := mountAndRun(t, CalendarTransfer, transferArgs("--dry-run"), f, stdout); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"GET", "POST", "/transfer", "to_user_id", transferReceiverID, "need_remove_original_organizer",
+		"/open-apis/calendar/v4/calendars/" + transferCalendarID + "/events/" + transferEventID,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run should contain %q, got: %s", want, out)
+		}
+	}
+	if strings.Contains(out, `"url": "/open-apis/calendar/v4/calendars/`+transferCalendarID+`"`) {
+		t.Errorf("dry-run should not preview a calendar read, got: %s", out)
+	}
+}

--- a/shortcuts/calendar/shortcuts.go
+++ b/shortcuts/calendar/shortcuts.go
@@ -18,5 +18,6 @@ func Shortcuts() []common.Shortcut {
 		CalendarMeeting,
 		CalendarSearchEvent,
 		CalendarGet,
+		CalendarTransfer,
 	}
 }

--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -42,6 +42,7 @@ lark-cli calendar +agenda --as bot
 | [`+room-find`](references/lark-calendar-room-find.md) | 针对一个或多个**明确的**时间块查找可用会议室（无明确时间时禁止直接调用，需先走 +suggestion） |
 | [`+rsvp`](references/lark-calendar-rsvp.md) | 回复日程（接受/拒绝/待定） |
 | [`+suggestion`](references/lark-calendar-suggestion.md) | 根据非明确时间或一段时间范围，推荐多个可用时间块方案 |
+| [`+transfer`](references/lark-calendar-transfer.md) | 把日程组织者转让给另一个用户或机器人；不可逆，需 `--yes` |
 
 ### `+get` — 单日程详情
 
@@ -136,6 +137,7 @@ lark-cli calendar +freebusy --start 2026-03-11 --end 2026-03-12 --user-id ou_xxx
 | 预约/改约日程、调整时间、添加/更换会议室、查会议室 | 先判断新建 vs 编辑，再进入 [schedule-meeting 工作流](references/lark-calendar-schedule-meeting.md) |
 | 仅编辑日程字段（标题/描述）或增删参会人（不涉及时间和会议室） | 先定位 `event_id`，再读 [+update](references/lark-calendar-update.md) 执行变更 |
 | 编辑/删除重复性日程（「改这个重复日程」「删掉后面的」「全部取消」等） | 先读 [重复性日程操作规范](references/lark-calendar-recurring.md)，确认操作范围后执行 |
+| 转让日程组织者（「把这个日程交给 XX」「组织者改成 XX」「这个会转给我」「bot 建完还给我」） | 读 [+transfer](references/lark-calendar-transfer.md)；`--as` 用**当前组织者**身份，`--to-user-id` 传接收人，用户和机器人任意互转 |
 
 ## 任务类型分流
 

--- a/skills/lark-calendar/references/lark-calendar-transfer.md
+++ b/skills/lark-calendar/references/lark-calendar-transfer.md
@@ -1,0 +1,89 @@
+# calendar +transfer
+
+把一个日程的**组织者（organizer）**转让给另一个用户或机器人。用户和机器人之间可以任意互转。
+
+## 命令
+
+```bash
+# 转让给某人（原组织者保留为参与人）
+lark-cli calendar +transfer --event-id <event_id> --to-user-id ou_xxx --yes
+
+# 转让并把原组织者从参与人中移除
+lark-cli calendar +transfer --event-id <event_id> --to-user-id ou_xxx --remove-original-organizer --yes
+
+# 指定日历
+lark-cli calendar +transfer --calendar-id <calendar_id> --event-id <event_id> --to-user-id ou_xxx --yes
+
+# 重复性日程：必须显式确认整个序列一起转让
+lark-cli calendar +transfer --event-id <event_id> --to-user-id ou_xxx --transfer-series --yes
+
+# 预览请求，不实际执行
+lark-cli calendar +transfer --event-id <event_id> --to-user-id ou_xxx --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--event-id <id>` | **是** | 日程 ID（`uid_originalTime` 形式） |
+| `--to-user-id <ou_...>` | **是** | 接收人 open_id，成为新组织者；用户和机器人都可以 |
+| `--calendar-id <id>` | 否 | 日程所在日历 ID（省略则使用主日历） |
+| `--remove-original-organizer` | 否 | 转让后把原组织者移出参与人；默认保留。日程在共享日历上时服务端一定会移除 |
+| `--transfer-series` | 否 | 确认整个重复性序列一起转让；重复性日程必填 |
+| `--yes` | **是**（非 dry-run） | 高敏写操作确认 |
+| `--dry-run` | 否 | 预览 API 调用，不执行 |
+
+## 转让方向
+
+转出方和接收方是两个**互相独立**的参数，四种组合都支持：
+
+- **转出方**由 `--as` 决定，必须是日程**当前组织者**的身份。bot 组织的日程用 `--as bot`，用户自己的日程用 `--as user`。用非组织者身份调用会返回 403。
+- **接收方**由 `--to-user-id` 决定，传谁的 open_id 就转给谁，是人还是机器人不影响命令写法。
+
+| 方向 | 命令 |
+|------|------|
+| user → user | `--as user --to-user-id <对方用户 open_id>` |
+| user → bot | `--as user --to-user-id <bot 的 open_id>` |
+| bot → user | `--as bot --to-user-id <用户 open_id>` |
+| bot → bot | `--as bot --to-user-id <另一个 bot 的 open_id>` |
+
+**取接收人 open_id**：
+
+```bash
+# 用户
+lark-cli contact +search-user --query <姓名> --as user
+# 机器人：从它所在群的成员列表里取 bots[] 中的 open_id
+lark-cli im +chat-members-list --chat-id <chat_id> --member-types bot
+```
+
+机器人的 open_id 同样是 `ou_` 开头；不要传 `cli_` 开头的 app_id，那是应用 ID，不是日程参与人身份。
+
+无论哪个方向，转让都要求转出方和接收方**同租户**，且接收方能通过高管模式的协作校验。
+
+## 重复性日程
+
+后端按 `uid` 定位日程，忽略 `original_time`，**无法只转让某一次实例**。因此传入任何一个实例或例外的 `event_id`，都会把整个序列（含所有例外）一起转让。
+
+是重复性日程且未加 `--transfer-series` 时命令直接失败（`failed_precondition`），不会发出转让请求。收到这个错误时**先向用户确认"整个重复日程都转让"**，得到确认后再带 `--transfer-series` 重跑；不要自动重试。已确认时加 `--transfer-series` 会跳过这次预读。
+
+## 返回中的 `original_organizer_removed`
+
+**共享日历不属于任何组织者，转让时服务端会强制把原组织者移出日程；主日历则会把原组织者保留为参与人。** 转让接口成功时不返回这个结果，所以命令只在能确定时才输出该字段：
+
+| 情况 | 返回 |
+|------|------|
+| 带 `--remove-original-organizer` | `original_organizer_removed: true` |
+| 省略 `--calendar-id`（主日历） | `original_organizer_removed: false` |
+| 传了 `--calendar-id` 且未传 `--remove-original-organizer` | **不返回该字段**，stderr 给一条 note 说明共享日历会强制移除 |
+
+字段缺失时**不要**告诉用户"原组织者已保留为参与人"，也不要断言已被移除。需要确认就转让后读一次日程看参与人，或一开始就显式传 `--remove-original-organizer`。
+
+## 提示
+
+- 转让不可逆，且会连同日程上的会议纪要、笔记和附件一起移交给新组织者。
+- 需要 `calendar:calendar.event:transfer` 权限；转让前的重复性预读需要 `calendar:calendar.event:read`（带 `--transfer-series` 时不读）。
+
+## 参考
+
+- [lark-calendar](../SKILL.md) -- skill 入口与路由
+- [重复性日程操作规范](lark-calendar-recurring.md)

--- a/tests/cli_e2e/calendar/calendar_transfer_dryrun_test.go
+++ b/tests/cli_e2e/calendar/calendar_transfer_dryrun_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalendar_TransferDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"calendar", "+transfer",
+			"--calendar-id", "cal_dry",
+			"--event-id", "uid_dry_1742515200",
+			"--to-user-id", "ou_receiver",
+			"--remove-original-organizer",
+			"--yes",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	// api.0 = the event pre-read; api.1 = the transfer itself. Asking for the
+	// removal settles the outcome, so no calendar type read is planned.
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String(), out)
+	require.Equal(t, "/open-apis/calendar/v4/calendars/cal_dry/events/uid_dry_1742515200",
+		clie2e.DryRunGet(out, "api.0.url").String(), out)
+	require.Equal(t, "POST", clie2e.DryRunGet(out, "api.1.method").String(), out)
+	require.Equal(t, "/open-apis/calendar/v4/calendars/cal_dry/events/uid_dry_1742515200/transfer",
+		clie2e.DryRunGet(out, "api.1.url").String(), out)
+	require.Equal(t, "open_id", clie2e.DryRunGet(out, "api.1.params.user_id_type").String(), out)
+	require.Equal(t, "ou_receiver", clie2e.DryRunGet(out, "api.1.body.to_user_id").String(), out)
+	require.True(t, clie2e.DryRunGet(out, "api.1.body.need_remove_original_organizer").Bool(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.2").Exists(), out)
+}
+
+// Keeping the original organizer is decided by the server, not by an extra
+// read: the plan is still the recurrence pre-read plus the transfer.
+func TestCalendar_TransferKeepOrganizerDryRun_ReadsNoCalendar(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"calendar", "+transfer",
+			"--calendar-id", "cal_dry",
+			"--event-id", "uid_dry_1742515200",
+			"--to-user-id", "ou_receiver",
+			"--yes",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, "/open-apis/calendar/v4/calendars/cal_dry/events/uid_dry_1742515200",
+		clie2e.DryRunGet(out, "api.0.url").String(), out)
+	require.Equal(t, "POST", clie2e.DryRunGet(out, "api.1.method").String(), out)
+	require.Equal(t, "/open-apis/calendar/v4/calendars/cal_dry/events/uid_dry_1742515200/transfer",
+		clie2e.DryRunGet(out, "api.1.url").String(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.1.body.need_remove_original_organizer").Bool(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.2").Exists(), out)
+}
+
+// --transfer-series skips the recurrence pre-read. An omitted --calendar-id
+// targets the primary calendar, which needs no calendar type read either.
+func TestCalendar_TransferSeriesDryRun_SkipsPreRead(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"calendar", "+transfer",
+			"--event-id", "uid_dry_1742515200",
+			"--to-user-id", "ou_receiver",
+			"--transfer-series",
+			"--yes",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, "POST", clie2e.DryRunGet(out, "api.0.method").String(), out)
+	require.Equal(t, "/open-apis/calendar/v4/calendars/primary/events/uid_dry_1742515200/transfer",
+		clie2e.DryRunGet(out, "api.0.url").String(), out)
+	require.False(t, clie2e.DryRunGet(out, "api.1").Exists(), out)
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `calendar +transfer` command to transfer event organizer responsibilities to another user or bot.
  * Supports individual events and recurring series, organizer removal, confirmation safeguards, and dry-run previews.
  * Added validation and clear reporting for transfer outcomes and unsupported scenarios.

* **Documentation**
  * Added command usage, options, permissions, transfer rules, and error guidance.

* **Tests**
  * Added comprehensive unit and end-to-end coverage for validation, recurring events, dry runs, and organizer outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->