### PR TITLE
fix(wiki): keep node-get stderr machine-readable

### DIFF
--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -98,8 +98,6 @@ var WikiNodeGet = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Fetching wiki node %s...\n", common.MaskToken(spec.Token))
-
 		data, err := runtime.CallAPITyped("GET", "/open-apis/wiki/v2/spaces/get_node", spec.RequestParams(), nil)
 		if err != nil {
 			return wikiNodeGetProblem(err)

--- a/shortcuts/wiki/wiki_node_get_test.go
+++ b/shortcuts/wiki/wiki_node_get_test.go
@@ -404,8 +404,8 @@ func TestWikiNodeGetMountedExecuteParsesURLAndFormatsOutput(t *testing.T) {
 	if _, ok := data["url"]; ok {
 		t.Fatalf("did not expect a url field in +node-get output, got %#v", data["url"])
 	}
-	if got := stderr.String(); !strings.Contains(got, "Fetching wiki node") {
-		t.Fatalf("stderr = %q, want fetching message", got)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no progress output", stderr.String())
 	}
 }
 
@@ -444,7 +444,7 @@ func TestWikiNodeGetMountedClassifiesTerminalBusinessErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 
-			factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+			factory, stdout, stderr, reg := cmdutil.TestFactory(t, wikiTestConfig())
 			reg.Register(&httpmock.Stub{
 				Method: "GET",
 				URL:    "/open-apis/wiki/v2/spaces/get_node",
@@ -482,6 +482,9 @@ func TestWikiNodeGetMountedClassifiesTerminalBusinessErrors(t *testing.T) {
 			}
 			if stdout.Len() != 0 {
 				t.Fatalf("stdout = %q, want no success envelope", stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want no output before the root error envelope", stderr.String())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Remove the unconditional `Fetching wiki node ...` progress line from `wiki +node-get`. Normal successful calls no longer emit that progress text, and API failures no longer have that shortcut progress line before root error rendering.

This PR intentionally leaves existing conditional warnings and the deprecated `--token` compatibility warning unchanged.

## Changes
- Stop writing the unconditional progress line before the `get_node` API request.
- Assert that the normal successful path emits no progress output.
- Assert that covered API failure paths emit no shortcut progress text before root error rendering.

## Test Plan
- [x] `go test ./shortcuts/wiki/... -count=1`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `go mod tidy -diff`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [ ] `make unit-test` (the changed `shortcuts/wiki` package passes; the full target is blocked by existing local service-catalog/metadata mismatches in `cmd/schema`, `internal/schema`, and `internal/affordance`)

## Scope
- The hidden deprecated `--token` alias and its existing pflag warning are unchanged.
- The conditional `--space-id` verification warning is unchanged.
- Broader stderr notice/deprecation policy is outside this focused fix.

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary error message displayed during wiki node retrieval.
  * Successful requests and terminal business errors now complete without unexpected terminal output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->