### PR TITLE
docs(lark-shared): document headless OAuth recovery, Windows UTF-8, and fetch assertions

### DIFF
--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -119,6 +119,14 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 
 表格默认瘦身：即使 `<table>` 本身是顶层块，也只返回表头和命中的行。读取整张表时，使用 `range --start-block-id <table-id> --end-block-id <table-id>`。如果切片覆盖全部数据行，SDK 会自动返回完整表格，不再包裹 `<excerpt>`。
 
+> [!IMPORTANT]
+> **JSON 结构解析路径与避坑说明**：
+> 使用 `docs +fetch --doc-format xml --format json` 导出正文时，XML 内容位于 `.data.document.content` 字段。
+> ❌ **常见错误**：误用 `.data.content` 会提取出 `null`，若直接将提取结果用于后续 `docs +update` 覆盖，会导致整个文档被意外覆写为字符串 `"null"`。
+>
+> **文档更新后的机检断言闭环 (Verification Loop)**：
+> 在执行大篇幅文档覆盖更新后，建议调用 `docs +fetch` 反查云端正文，对文档内的表格（`<table>`）、画板（`<whiteboard>`）、代码块（`<pre>`）、图片（`<img>`）等关键容器数量进行结构化比对断言，确保云端渲染 100% 达成预期。
+
 ## 处理文档内嵌资源
 
 |返回内容|处理方式|

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -122,10 +122,10 @@ lark-cli docs +fetch --doc Z1Fj...tnAc --scope section --start-block-id blkTitle
 > [!IMPORTANT]
 > **JSON 结构解析路径与避坑说明**：
 > 使用 `docs +fetch --doc-format xml --format json` 导出正文时，XML 内容位于 `.data.document.content` 字段。
-> ❌ **常见错误**：误用 `.data.content` 会提取出 `null`，若直接将提取结果用于后续 `docs +update` 覆盖，会导致整个文档被意外覆写为字符串 `"null"`。
+> ❌ **常见错误**：误用 `.data.content` 会提取出 `null`，若直接将提取结果用于后续 `docs +update` 覆盖，会导致整个文档被意外覆写为字符串 `"null"`。在脚本中推入 update 之前，建议加入防御性断言（如 `jq -er '.data.document.content // error("empty content")'`），非空校验通过后再行写入。
 >
 > **文档更新后的机检断言闭环 (Verification Loop)**：
-> 在执行大篇幅文档覆盖更新后，建议调用 `docs +fetch` 反查云端正文，对文档内的表格（`<table>`）、画板（`<whiteboard>`）、代码块（`<pre>`）、图片（`<img>`）等关键容器数量进行结构化比对断言，确保云端渲染 100% 达成预期。
+> 在执行大篇幅文档覆盖更新后，建议调用 `docs +fetch` 反查云端正文，对文档内的表格（`<table>`）、画板（`<whiteboard>`）、代码块（`<pre>`）、高亮框（`<callout>`）、图片（`<img>`）等关键容器数量与结构进行自动化核验断言，确保云端渲染达到预期。
 
 ## 处理文档内嵌资源
 

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -44,9 +44,7 @@ metadata:
 3. **完成授权校验闭环**：收到用户授权完成的反馈后，由 Agent 执行 `lark-cli auth login --device-code <device_code>` 完成最终校验，无缝恢复原本被阻塞的任务。
 
 ### 2. Windows 平台子进程 stdin UTF-8 字节流传输规范
-在 Windows 平台通过子进程管道（stdin）向 `lark-cli` 推送文档文本（如 `docs +update --content -`）时：
-- **陷阱**：若依赖系统默认代码页（GBK/CP936），管道传输的中文会被 CLI（按 UTF-8 解码）解析为乱码（如出现替代字符 ）。
-- **规范**：必须显式使用 UTF-8 字节流模式推送输入（例如 Python 中使用 `proc.communicate(input=text.encode('utf-8'))`），切勿使用 `text=True` 默认平台编码。
+在 Windows 平台通过子进程管道向 `lark-cli` 推送中文时，必须使用显式 UTF-8 字节流推送，避免 GBK/CP936 代码页乱码。详见 [`references/lark-shared-windows-stdin.md`](references/lark-shared-windows-stdin.md)。
 
 ## Reference 强触发索引
 

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -39,13 +39,13 @@ metadata:
 
 ### 1. 分离式 OAuth 授权恢复闭环（AI Agent 子进程必读）
 在无浏览器 GUI 或 Agent 作为非交互式子进程运行的场景下，遇到 Token 过期或缺少 scopes 时，**绝不能**因无法自动弹窗而直接中断任务，须按以下标准 3 步闭环恢复：
-1. **获取授权链接与设备码**：执行 `lark-cli auth login --domain all --no-wait --json`（或指定缺少的 scopes），从 JSON 响应中提取 `verification_url` 与 `device_code`；
+1. **获取授权链接与设备码**：执行 `lark-cli auth login --domain all --no-wait --json`（或指定缺少的 scopes）；先验证响应中 `ok == true`，再从中提取 `verification_url` 与 `device_code`（若失败则按错误信封处理，避免带空值进入下一步）；
 2. **生成并展示二维码**：执行 `lark-cli auth qrcode <verification_url>` 生成二维码，在交互中将 URL 链接与二维码一并展示给用户，并提示用户扫码授权；
 3. **完成授权校验闭环**：收到用户授权完成的反馈后，由 Agent 执行 `lark-cli auth login --device-code <device_code>` 完成最终校验，无缝恢复原本被阻塞的任务。
 
 ### 2. Windows 平台子进程 stdin UTF-8 字节流传输规范
 在 Windows 平台通过子进程管道（stdin）向 `lark-cli` 推送文档文本（如 `docs +update --content -`）时：
-- **陷阱**：若依赖系统默认代码页（GBK/CP936），管道传输的中文会被 CLI（按 UTF-8 解码）解析为乱码（）。
+- **陷阱**：若依赖系统默认代码页（GBK/CP936），管道传输的中文会被 CLI（按 UTF-8 解码）解析为乱码（如出现替代字符 ）。
 - **规范**：必须显式使用 UTF-8 字节流模式推送输入（例如 Python 中使用 `proc.communicate(input=text.encode('utf-8'))`），切勿使用 `text=True` 默认平台编码。
 
 ## Reference 强触发索引

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -40,7 +40,7 @@ metadata:
 ### 1. 分离式 OAuth 授权恢复闭环（AI Agent 子进程必读）
 在无浏览器 GUI 或 Agent 作为非交互式子进程运行的场景下，遇到 Token 过期或缺少 scopes 时，**绝不能**因无法自动弹窗而直接中断任务，须按以下标准 3 步闭环恢复：
 1. **获取授权链接与设备码**：执行 `lark-cli auth login --domain all --no-wait --json`（或指定缺少的 scopes）；先验证响应中 `ok == true`，再从中提取 `verification_url` 与 `device_code`（若失败则按错误信封处理，避免带空值进入下一步）；
-2. **向用户展示授权链接**：在对话中直接将 `verification_url` 纯文本链接展示给用户（严禁生成二维码干扰终端文本流），提示用户：“请在浏览器中打开授权链接完成授权后回复我”；
+2. **向用户展示授权信息**：在交互中向用户展示 `verification_url` 授权链接，或按需执行 `lark-cli auth qrcode <verification_url>` 渲染二维码，提示用户在浏览器中打开或扫码完成授权；
 3. **完成授权校验闭环**：收到用户授权完成的反馈后，由 Agent 执行 `lark-cli auth login --device-code <device_code>` 完成最终校验，无缝恢复原本被阻塞的任务。
 
 ### 2. Windows 平台子进程 stdin UTF-8 字节流传输规范

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -35,6 +35,19 @@ metadata:
 5. **文件路径只接受相对路径**：`--file`、`--output`、`--output-dir`、`@file` 等路径参数只接受 cwd 下的相对路径，传绝对路径会报 `unsafe file path`。数据输入（`@file`、大 JSON）优先用 stdin 传入，避免路径和转义问题。
 
 
+## AI Agent 无头环境 (Headless) 授权恢复与跨平台开发规范
+
+### 1. 分离式 OAuth 授权恢复闭环（AI Agent 子进程必读）
+在无浏览器 GUI 或 Agent 作为非交互式子进程运行的场景下，遇到 Token 过期或缺少 scopes 时，**绝不能**因无法自动弹窗而直接中断任务，须按以下标准 3 步闭环恢复：
+1. **获取授权链接与设备码**：执行 `lark-cli auth login --domain all --no-wait --json`（或指定缺少的 scopes），从 JSON 响应中提取 `verification_url` 与 `device_code`；
+2. **生成并展示二维码**：执行 `lark-cli auth qrcode <verification_url>` 生成二维码，在交互中将 URL 链接与二维码一并展示给用户，并提示用户扫码授权；
+3. **完成授权校验闭环**：收到用户授权完成的反馈后，由 Agent 执行 `lark-cli auth login --device-code <device_code>` 完成最终校验，无缝恢复原本被阻塞的任务。
+
+### 2. Windows 平台子进程 stdin UTF-8 字节流传输规范
+在 Windows 平台通过子进程管道（stdin）向 `lark-cli` 推送文档文本（如 `docs +update --content -`）时：
+- **陷阱**：若依赖系统默认代码页（GBK/CP936），管道传输的中文会被 CLI（按 UTF-8 解码）解析为乱码（）。
+- **规范**：必须显式使用 UTF-8 字节流模式推送输入（例如 Python 中使用 `proc.communicate(input=text.encode('utf-8'))`），切勿使用 `text=True` 默认平台编码。
+
 ## Reference 强触发索引
 
 命中任一触发条件时，**MUST 在执行下一步前读取对应 reference**。命中多条时按表中顺序读取，同一reference只读取一次。

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -40,7 +40,7 @@ metadata:
 ### 1. 分离式 OAuth 授权恢复闭环（AI Agent 子进程必读）
 在无浏览器 GUI 或 Agent 作为非交互式子进程运行的场景下，遇到 Token 过期或缺少 scopes 时，**绝不能**因无法自动弹窗而直接中断任务，须按以下标准 3 步闭环恢复：
 1. **获取授权链接与设备码**：执行 `lark-cli auth login --domain all --no-wait --json`（或指定缺少的 scopes）；先验证响应中 `ok == true`，再从中提取 `verification_url` 与 `device_code`（若失败则按错误信封处理，避免带空值进入下一步）；
-2. **生成并展示二维码**：执行 `lark-cli auth qrcode <verification_url>` 生成二维码，在交互中将 URL 链接与二维码一并展示给用户，并提示用户扫码授权；
+2. **向用户展示授权链接**：在对话中直接将 `verification_url` 纯文本链接展示给用户（严禁生成二维码干扰终端文本流），提示用户：“请在浏览器中打开授权链接完成授权后回复我”；
 3. **完成授权校验闭环**：收到用户授权完成的反馈后，由 Agent 执行 `lark-cli auth login --device-code <device_code>` 完成最终校验，无缝恢复原本被阻塞的任务。
 
 ### 2. Windows 平台子进程 stdin UTF-8 字节流传输规范

--- a/skills/lark-shared/references/lark-shared-windows-stdin.md
+++ b/skills/lark-shared/references/lark-shared-windows-stdin.md
@@ -1,0 +1,37 @@
+# Windows 平台子进程 stdin UTF-8 字节流传输规范
+
+在 Windows 平台通过子进程管道（stdin）向 `lark-cli` 推送文档文本（如 `docs +update --content -`）时，须遵循以下编码规范：
+
+## 核心机理与常见陷阱
+
+- **陷阱**：Windows 控制台默认代码页通常为 GBK/CP936。若在 Python 等子进程中使用 `text=True` 或依赖系统默认编码推送 stdin，管道传输的中文会被 `lark-cli`（按 UTF-8 解码）解析为乱码（如出现替代字符 ）。
+- **规范**：向 `lark-cli` stdin 传递数据时，必须显式以 UTF-8 字节流模式传输。
+
+## 编程语言标准调用示例
+
+### Python
+```python
+import subprocess
+
+# 正确做法：显式编码为 UTF-8 字节流推入 stdin
+proc = subprocess.Popen(
+    ["lark-cli", "docs", "+update", "--doc", doc_id, "--command", "overwrite", "--content", "-"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    shell=True  # Windows 下调用 .cmd 脚本需要
+)
+stdout, stderr = proc.communicate(input=xml_content.encode("utf-8"))
+
+# 错误做法（导致乱码）：
+# subprocess.run(cmd, input=xml_content, text=True)
+```
+
+### Node.js
+```javascript
+const { spawn } = require('child_process');
+
+const child = spawn('lark-cli', ['docs', '+update', '--doc', docId, '--command', 'overwrite', '--content', '-'], { shell: true });
+child.stdin.write(Buffer.from(xmlContent, 'utf-8'));
+child.stdin.end();
+```


### PR DESCRIPTION
## Summary

Documents the decoupled headless OAuth authentication flow for AI agents, cross-platform UTF-8 encoding requirements on Windows subprocess stdin, and clarifies the JSON path schema and assertion loop for `docs +fetch`.

### Key Enhancements

1. **Decoupled Headless OAuth Recovery for AI Agents (`lark-shared`)**:
   - Outlined the standard 3-step loop for CLI runtimes in headless/agent environments:
     1. `lark-cli auth login --domain all --no-wait --json` to obtain `verification_url` and `device_code` (with explicit `ok == true` pre-validation).
     2. Directly present the plain-text `verification_url` to the user in chat (or render terminal QR code via `auth qrcode` if requested).
     3. Finalize validation seamlessly via `lark-cli auth login --device-code <device_code>`.

2. **Windows Subprocess stdin UTF-8 Byte Stream Requirement (`lark-shared`)**:
   - Clarified that when piping input via stdin to CLI commands on Windows (e.g. `docs +update --content -`), data must be sent as explicit UTF-8 bytes (e.g. `proc.communicate(input=text.encode('utf-8'))`) to prevent Chinese character corruption under default GBK/CP936 code pages.

3. **Fetch JSON Path Schema & Post-Update Assertion Loop (`lark-doc-fetch`)**:
   - Emphasized that document XML resides at `.data.document.content` with fail-closed validation (preventing the common pitfall where `.data.content` evaluates to `null` and accidentally overwrites documents with `"null"`).
   - Documented automated structural verification assertions via `+fetch` to inspect rendered tables, whiteboards, code blocks, callouts, and images.

---
Validated in production automated workflows and cross-platform tests.
