### PR TITLE
fix(event): acknowledge card action callbacks

### DIFF
--- a/internal/event/adapter/lark/websocket/feishu.go
+++ b/internal/event/adapter/lark/websocket/feishu.go
@@ -15,6 +15,7 @@ import (
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
 
 	"github.com/larksuite/cli/internal/event"
@@ -36,9 +37,7 @@ func (s *FeishuSource) Start(ctx context.Context, eventTypes []string, emit func
 
 	rawHandler := s.buildRawHandler(emit)
 
-	for _, et := range eventTypes {
-		d.OnCustomizedEvent(et, rawHandler)
-	}
+	s.registerHandlers(d, eventTypes, rawHandler)
 
 	opts := []larkws.ClientOption{larkws.WithEventHandler(d)}
 	if s.Domain != "" {
@@ -62,6 +61,28 @@ func (s *FeishuSource) Start(ctx context.Context, eventTypes []string, emit func
 		return ctx.Err()
 	case err := <-errCh:
 		return err
+	}
+}
+
+func (s *FeishuSource) registerHandlers(
+	d *dispatcher.EventDispatcher,
+	eventTypes []string,
+	rawHandler func(context.Context, *larkevent.EventReq) error,
+) {
+	for _, et := range eventTypes {
+		if et == "card.action.trigger" {
+			d.OnP2CardActionTrigger(func(
+				ctx context.Context,
+				event *callback.CardActionTriggerEvent,
+			) (*callback.CardActionTriggerResponse, error) {
+				if err := rawHandler(ctx, event.EventReq); err != nil {
+					return nil, err
+				}
+				return &callback.CardActionTriggerResponse{}, nil
+			})
+			continue
+		}
+		d.OnCustomizedEvent(et, rawHandler)
 	}
 }
 

--- a/internal/event/adapter/lark/websocket/feishu_ingress_test.go
+++ b/internal/event/adapter/lark/websocket/feishu_ingress_test.go
@@ -5,12 +5,49 @@ package websocket
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 
 	event "github.com/larksuite/cli/internal/event"
 )
+
+func TestCardActionUsesCallbackResponse(t *testing.T) {
+	s := &FeishuSource{}
+	d := dispatcher.NewEventDispatcher("", "")
+	var received *event.RawEvent
+	s.registerHandlers(
+		d,
+		[]string{"card.action.trigger"},
+		s.buildRawHandler(func(raw *event.RawEvent) { received = raw }),
+	)
+
+	payload := []byte(`{
+        "schema":"2.0",
+        "header":{"event_id":"evt-card","event_type":"card.action.trigger","create_time":"1"},
+        "event":{"operator":{"open_id":"ou_test"},"token":"token","action":{"tag":"select_static","option":"task"}}
+    }`)
+	response, err := d.Do(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("dispatch card action: %v", err)
+	}
+	if received == nil || received.EventID != "evt-card" {
+		t.Fatalf("card action was not emitted: %#v", received)
+	}
+	if _, ok := response.(*callback.CardActionTriggerResponse); !ok {
+		t.Fatalf("response type = %T, want *callback.CardActionTriggerResponse", response)
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if string(body) != `{}` {
+		t.Fatalf("response = %s, want {}", body)
+	}
+}
 
 // The websocket ingress is the only place that parses the envelope header;
 // every canonical fact consumers rely on must be captured here, once.


### PR DESCRIPTION
## Summary

Register `card.action.trigger` with the SDK's typed Card 2.0 callback handler so the WebSocket client returns the required `{}` acknowledgement instead of treating the callback as a generic custom event. This prevents Feishu callback error `108002` while preserving the existing raw event emission contract.

## Changes

- Route only `card.action.trigger` through `OnP2CardActionTrigger`; keep all other event types on `OnCustomizedEvent`.
- Return `CardActionTriggerResponse{}` after the existing raw handler succeeds.
- Add a regression test covering both raw event emission and the serialized callback response.

## Test Plan

- [x] `go test ./internal/event/adapter/lark/websocket`
- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [ ] Live tenant WebSocket callback verification (requires a configured Feishu app and interactive Card 2.0 click)

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Feishu card action events.
  * Card action callbacks now return an empty response after the event is processed, ensuring compatibility with expected callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->