### PR TITLE
feat: add employee meeting management commands

### DIFF
--- a/affordance/minutes.md
+++ b/affordance/minutes.md
@@ -49,3 +49,8 @@
 
 ### Skills
 - lark-meeting/references/lark-minutes-apply-permission.md
+
+## +share-permission
+
+### Skills
+- lark-meeting/references/lark-minutes-share-permission.md

--- a/affordance/vc.md
+++ b/affordance/vc.md
@@ -43,6 +43,54 @@
 ### Skills
 - lark-meeting/references/lark-vc-meeting-countdown.md
 
+## +meeting-end
+Use this only when the user explicitly asks to end the entire ongoing meeting. This is a high-risk write for either supported identity: preview the target with `--dry-run` and an explicit `--as user` or `--as bot`, and pass `--yes` only after explicit confirmation.
+
+### Avoid when
+- Only the application bot should leave the meeting → use [[+meeting-leave]].
+- Only specific participants should be removed → use [[+meeting-participant-kickout]].
+
+### Prerequisites
+- Obtain the exact `meeting_id` for the target ongoing meeting from [[+meeting-list-active]] or [[meeting get]].
+- Choose the endpoint deliberately: `--as user` uses `PATCH /open-apis/vc/v1/meetings/{meeting_id}/end` with `vc:meeting`; `--as bot` uses `POST /open-apis/vc/v1/bots/end` with `vc:meeting.bot.manage:write` and requires the application bot to be the current Host.
+
+### Examples
+
+**Preview the user endpoint without making the API call**
+```bash
+lark-cli vc +meeting-end --as user --meeting-id <meeting_id> --dry-run
+```
+
+**Preview the application bot endpoint without making the API call**
+```bash
+lark-cli vc +meeting-end --as bot --meeting-id <meeting_id> --dry-run
+```
+
+### Skills
+- lark-meeting/references/lark-vc-meeting-end.md
+- lark-meeting/references/lark-vc-agent-meeting-end.md
+
+## +meeting-participant-kickout
+Use this only when the user explicitly asks a host or cohost to remove specific participants. This is a user-only, high-risk write: preview uncertain targets with `--dry-run`, and pass `--yes` only after explicit confirmation.
+
+### Avoid when
+- The entire meeting should end → use [[+meeting-end]].
+- Only the application bot should leave by itself → use [[+meeting-leave]].
+
+### Prerequisites
+- Obtain the exact `meeting_id` plus each participant tuple from the target meeting's participant snapshot via [[meeting get]]; do not infer `user_type` from an ID.
+- Use the dedicated reference for tuple syntax, dry-run shape, and result interpretation instead of re-encoding that schema here.
+
+### Examples
+
+**Preview removing one participant without making the API call**
+```bash
+lark-cli vc +meeting-participant-kickout --as user --meeting-id <meeting_id> --participant '<participant_id>=<user_type>' --dry-run
+```
+
+### Skills
+- lark-meeting/references/lark-vc-meeting-participant-kickout.md
+
 ## +meeting-join
 
 ### Skills
@@ -52,11 +100,6 @@
 
 ### Skills
 - lark-meeting/references/lark-vc-agent-meeting-invite.md
-
-## +meeting-end
-
-### Skills
-- lark-meeting/references/lark-vc-agent-meeting-end.md
 
 ## +meeting-leave
 

--- a/affordance/vc.md
+++ b/affordance/vc.md
@@ -85,7 +85,7 @@ Use this only when the user explicitly asks a host or cohost to remove specific 
 
 **Preview removing one participant without making the API call**
 ```bash
-lark-cli vc +meeting-participant-kickout --as user --meeting-id <meeting_id> --participant '<participant_id>=<user_type>' --dry-run
+lark-cli vc +meeting-participant-kickout --as user --meeting-id <meeting_id> --participant '<open_id>=<user_type>' --dry-run
 ```
 
 ### Skills

--- a/cmd/meeting_management_offline_preflight.go
+++ b/cmd/meeting_management_offline_preflight.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	extcredential "github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/extension/platform"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
+	"github.com/larksuite/cli/shortcuts"
+	shortcutcommon "github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+type offlineMeetingManagementEligibilityProbes struct {
+	registeredPluginCount      func() int
+	credentialProviderSnapshot func() ([]offlineMeetingManagementCredentialProvider, bool)
+	stat                       func(string) (fs.FileInfo, error)
+	getenv                     func(string) string
+	baseConfigDir              func() string
+}
+
+type offlineMeetingManagementCredentialProvider struct {
+	name        string
+	packagePath string
+	typeName    string
+}
+
+var standardOfflineMeetingManagementCredentialProvider = offlineMeetingManagementCredentialProvider{
+	name:        "env",
+	packagePath: "github.com/larksuite/cli/extension/credential/env",
+	typeName:    "Provider",
+}
+
+func defaultOfflineMeetingManagementEligibilityProbes() offlineMeetingManagementEligibilityProbes {
+	return offlineMeetingManagementEligibilityProbes{
+		registeredPluginCount:      func() int { return len(platform.RegisteredPlugins()) },
+		credentialProviderSnapshot: snapshotOfflineMeetingManagementCredentialProviders,
+		stat:                       os.Stat,
+		getenv:                     os.Getenv,
+		baseConfigDir:              core.GetBaseConfigDir,
+	}
+}
+
+func snapshotOfflineMeetingManagementCredentialProviders() (
+	snapshot []offlineMeetingManagementCredentialProvider,
+	determinate bool,
+) {
+	determinate = false
+	defer func() {
+		if recover() != nil {
+			snapshot = nil
+			determinate = false
+		}
+	}()
+	return describeOfflineMeetingManagementCredentialProviders(extcredential.Providers())
+}
+
+func describeOfflineMeetingManagementCredentialProviders(
+	providers []extcredential.Provider,
+) ([]offlineMeetingManagementCredentialProvider, bool) {
+	snapshot := make([]offlineMeetingManagementCredentialProvider, 0, len(providers))
+	for _, provider := range providers {
+		if provider == nil {
+			return nil, false
+		}
+		value := reflect.ValueOf(provider)
+		switch value.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+			if value.IsNil() {
+				return nil, false
+			}
+		}
+
+		providerType := reflect.TypeOf(provider)
+		if providerType.Kind() == reflect.Ptr {
+			providerType = providerType.Elem()
+		}
+		snapshot = append(snapshot, offlineMeetingManagementCredentialProvider{
+			name:        provider.Name(),
+			packagePath: providerType.PkgPath(),
+			typeName:    providerType.Name(),
+		})
+	}
+	return snapshot, true
+}
+
+func hasOnlyStandardOfflineMeetingManagementCredentialProvider(
+	snapshot func() ([]offlineMeetingManagementCredentialProvider, bool),
+) (eligible bool) {
+	if snapshot == nil {
+		return false
+	}
+	defer func() {
+		if recover() != nil {
+			eligible = false
+		}
+	}()
+
+	providers, determinate := snapshot()
+	return determinate && len(providers) == 1 &&
+		providers[0] == standardOfflineMeetingManagementCredentialProvider
+}
+
+var offlineMeetingManagementEligibilityProbesForInvocation = defaultOfflineMeetingManagementEligibilityProbes
+
+var offlineMeetingManagementCredentialEnvKeys = []string{
+	envvars.CliAppID,
+	envvars.CliAppSecret,
+	envvars.CliBrand,
+	envvars.CliUserAccessToken,
+	envvars.CliTenantAccessToken,
+	envvars.CliDefaultAs,
+	envvars.CliStrictMode,
+	envvars.CliAuthProxy,
+	envvars.CliProxyKey,
+}
+
+// canRunOfflineMeetingManagementPreflight is deliberately fail closed. The
+// minimal tree cannot reproduce policy contributed by Plugin.Install, a YAML
+// policy, custom credential providers, or strict-mode stored in config/credential
+// state. If any such state may exist, the caller must use the complete command
+// tree so its authoritative enforcement and presentation paths run before an
+// observable result.
+func canRunOfflineMeetingManagementPreflight(
+	inv cmdutil.InvocationContext,
+	presentation restrictionPresentationConfig,
+	probes offlineMeetingManagementEligibilityProbes,
+) bool {
+	if presentation.enabled ||
+		inv.ProfileSource != core.ProfileFromConfig || inv.Profile != "" ||
+		probes.registeredPluginCount == nil || probes.registeredPluginCount() != 0 ||
+		!hasOnlyStandardOfflineMeetingManagementCredentialProvider(probes.credentialProviderSnapshot) ||
+		probes.stat == nil || probes.getenv == nil || probes.baseConfigDir == nil {
+		return false
+	}
+	for _, key := range offlineMeetingManagementCredentialEnvKeys {
+		if probes.getenv(key) != "" {
+			return false
+		}
+	}
+
+	baseDir := probes.baseConfigDir()
+	if baseDir == "" {
+		return false
+	}
+	runtimeDir := baseDir
+	if workspace := core.DetectWorkspaceFromEnv(probes.getenv); !workspace.IsLocal() {
+		runtimeDir = filepath.Join(baseDir, string(workspace))
+	}
+	for _, path := range []string{
+		filepath.Join(baseDir, userPolicyFileName),
+		filepath.Join(runtimeDir, "config.json"),
+	} {
+		if _, err := probes.stat(path); !errors.Is(err, os.ErrNotExist) {
+			// Both an existing file (err == nil) and an indeterminate stat error
+			// require the full tree. Absence is the only proof that permits the
+			// dependency-free fast path.
+			return false
+		}
+	}
+	return true
+}
+
+// isOfflineMeetingManagementInvocation recognizes only the two destructive VC
+// commands whose definitions explicitly opt into confirmation-before-network.
+// Help/version keep the normal command tree so presentation and plugin policy
+// remain unchanged for introspection. Local command flags are intentionally
+// accepted only after the command path; that is the canonical Cobra spelling.
+func isOfflineMeetingManagementInvocation(args []string) bool {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" || arg == "--help=true" ||
+			arg == "-v" || arg == "--version" || arg == "--version=true" {
+			return false
+		}
+	}
+
+	commandIndex := 0
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "--profile":
+			index++
+			if index >= len(args) {
+				return false
+			}
+			continue
+		case strings.HasPrefix(arg, "--profile="):
+			continue
+		case len(arg) > 0 && arg[0] == '-':
+			// Keep scanning so malformed or unknown flags on one of these
+			// invocations are rejected by the dependency-free Cobra tree.
+			continue
+		}
+
+		switch commandIndex {
+		case 0:
+			if arg != "vc" {
+				return false
+			}
+			commandIndex++
+		case 1:
+			return arg == "+meeting-end" || arg == "+meeting-participant-kickout"
+		}
+	}
+	return false
+}
+
+// runOfflineMeetingManagementPreflight executes a minimal in-memory Cobra
+// tree. terminal is true for every local outcome (validation, dry-run, or
+// confirmation-required); false means explicit --yes passed and the caller
+// must continue through the unchanged full startup/execution path.
+func runOfflineMeetingManagementPreflight(
+	ctx context.Context,
+	inv cmdutil.InvocationContext,
+	presentation restrictionPresentationConfig,
+	streams *cmdutil.IOStreams,
+	args []string,
+) (terminal bool, exitCode int) {
+	if !isOfflineMeetingManagementInvocation(args) ||
+		!canRunOfflineMeetingManagementPreflight(inv, presentation, offlineMeetingManagementEligibilityProbesForInvocation()) {
+		return false, 0
+	}
+
+	// The literal factory intentionally has no notice provider: this local
+	// preflight must neither evaluate nor leak notices from another invocation.
+	f := &cmdutil.Factory{IOStreams: streams, Invocation: inv}
+	root := &cobra.Command{Use: "lark-cli", SilenceErrors: true, SilenceUsage: true}
+	root.SetContext(ctx)
+	root.SetIn(streams.In)
+	root.SetOut(streams.Out)
+	root.SetErr(streams.ErrOut)
+	root.SetArgs(args)
+	RegisterGlobalFlags(root.PersistentFlags(), &GlobalOptions{})
+	root.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
+		f.CurrentCommand = cmd
+	}
+
+	if err := shortcuts.RegisterOfflineMeetingManagementPreflight(ctx, root, f); err != nil {
+		return true, handleRootError(f, err, nil)
+	}
+	err := root.Execute()
+	if errors.Is(err, shortcutcommon.ErrOfflinePreflightPassed) {
+		return false, 0
+	}
+	if err != nil {
+		return true, handleRootError(f, err, nil)
+	}
+	return true, 0
+}

--- a/cmd/meeting_management_offline_preflight_test.go
+++ b/cmd/meeting_management_offline_preflight_test.go
@@ -1,0 +1,479 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	extcredential "github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/hook"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/surface"
+	"github.com/spf13/cobra"
+)
+
+type offlineMeetingManagementTestCredentialProvider struct {
+	name string
+}
+
+func (p *offlineMeetingManagementTestCredentialProvider) Name() string { return p.name }
+func (p *offlineMeetingManagementTestCredentialProvider) ResolveAccount(context.Context) (*extcredential.Account, error) {
+	return nil, nil
+}
+func (p *offlineMeetingManagementTestCredentialProvider) ResolveToken(
+	context.Context,
+	extcredential.TokenSpec,
+) (*extcredential.Token, error) {
+	return nil, nil
+}
+
+func cleanOfflineMeetingManagementEligibilityProbes() offlineMeetingManagementEligibilityProbes {
+	return offlineMeetingManagementEligibilityProbes{
+		registeredPluginCount: func() int { return 0 },
+		credentialProviderSnapshot: func() ([]offlineMeetingManagementCredentialProvider, bool) {
+			return []offlineMeetingManagementCredentialProvider{standardOfflineMeetingManagementCredentialProvider}, true
+		},
+		stat:          func(string) (fs.FileInfo, error) { return nil, fs.ErrNotExist },
+		getenv:        func(string) string { return "" },
+		baseConfigDir: func() string { return "/isolated/lark-cli" },
+	}
+}
+
+func useCleanOfflineMeetingManagementEligibility(t *testing.T) {
+	t.Helper()
+	original := offlineMeetingManagementEligibilityProbesForInvocation
+	offlineMeetingManagementEligibilityProbesForInvocation = cleanOfflineMeetingManagementEligibilityProbes
+	t.Cleanup(func() { offlineMeetingManagementEligibilityProbesForInvocation = original })
+}
+
+func TestDescribeOfflineMeetingManagementCredentialProvidersFailsClosed(t *testing.T) {
+	var nilProvider *offlineMeetingManagementTestCredentialProvider
+	tests := []struct {
+		name      string
+		providers []extcredential.Provider
+	}{
+		{name: "nil provider", providers: []extcredential.Provider{nil}},
+		{name: "typed nil provider", providers: []extcredential.Provider{nilProvider}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if snapshot, determinate := describeOfflineMeetingManagementCredentialProviders(test.providers); determinate || snapshot != nil {
+				t.Fatalf("provider snapshot = %#v, determinate = %v; want nil, false", snapshot, determinate)
+			}
+		})
+	}
+}
+
+func TestOfflineMeetingManagementEligibilityFailsClosed(t *testing.T) {
+	tests := []struct {
+		name         string
+		inv          cmdutil.InvocationContext
+		presentation restrictionPresentationConfig
+		configure    func(*offlineMeetingManagementEligibilityProbes)
+		want         bool
+	}{
+		{name: "clean default process", want: true},
+		{name: "distribution concealment requires the full surface", presentation: restrictionPresentationConfig{enabled: true}},
+		{name: "environment profile", inv: cmdutil.InvocationContext{ProfileSource: core.ProfileFromEnvironment}},
+		{name: "explicit profile", inv: cmdutil.InvocationContext{Profile: "uat", ProfileSource: core.ProfileFromFlag}},
+		{name: "registered platform plugin", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.registeredPluginCount = func() int { return 1 }
+		}},
+		{name: "missing standard credential provider", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) { return nil, true }
+		}},
+		{name: "nil credential provider makes snapshot indeterminate", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) { return nil, false }
+		}},
+		{name: "credential provider snapshot panics", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) { panic("provider name unavailable") }
+		}},
+		{name: "sidecar credential provider", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) {
+				return []offlineMeetingManagementCredentialProvider{{
+					name:        "sidecar",
+					packagePath: "github.com/larksuite/cli/extension/credential/sidecar",
+					typeName:    "Provider",
+				}}, true
+			}
+		}},
+		{name: "custom provider cannot spoof env by name", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) {
+				return []offlineMeetingManagementCredentialProvider{{
+					name:        "env",
+					packagePath: "example.com/wrapper/credential",
+					typeName:    "Provider",
+				}}, true
+			}
+		}},
+		{name: "additional credential provider", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) {
+				return []offlineMeetingManagementCredentialProvider{
+					standardOfflineMeetingManagementCredentialProvider,
+					{name: "custom", packagePath: "example.com/wrapper/credential", typeName: "Provider"},
+				}, true
+			}
+		}},
+		{name: "missing credential provider snapshot probe", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = nil
+		}},
+		{name: "policy file exists", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.stat = func(path string) (fs.FileInfo, error) {
+				if strings.HasSuffix(path, "policy.yml") {
+					return nil, nil
+				}
+				return nil, fs.ErrNotExist
+			}
+		}},
+		{name: "policy stat is indeterminate", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.stat = func(string) (fs.FileInfo, error) { return nil, errors.New("permission denied") }
+		}},
+		{name: "config file exists and may carry strict mode", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.stat = func(path string) (fs.FileInfo, error) {
+				if strings.HasSuffix(path, "config.json") {
+					return nil, nil
+				}
+				return nil, fs.ErrNotExist
+			}
+		}},
+		{name: "strict mode environment signal", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.getenv = func(key string) string {
+				if key == "LARKSUITE_CLI_STRICT_MODE" {
+					return "bot"
+				}
+				return ""
+			}
+		}},
+		{name: "credential environment signal", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.getenv = func(key string) string {
+				if key == "LARKSUITE_CLI_USER_ACCESS_TOKEN" {
+					return "present"
+				}
+				return ""
+			}
+		}},
+		{name: "missing stat probe", configure: func(p *offlineMeetingManagementEligibilityProbes) { p.stat = nil }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			probes := cleanOfflineMeetingManagementEligibilityProbes()
+			if test.configure != nil {
+				test.configure(&probes)
+			}
+			if got := canRunOfflineMeetingManagementPreflight(test.inv, test.presentation, probes); got != test.want {
+				t.Fatalf("eligibility = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestOfflineMeetingManagementIneligibleRootInvocationFallsBack(t *testing.T) {
+	originalProbes := offlineMeetingManagementEligibilityProbesForInvocation
+	t.Cleanup(func() { offlineMeetingManagementEligibilityProbesForInvocation = originalProbes })
+
+	tests := []struct {
+		name         string
+		inv          cmdutil.InvocationContext
+		args         []string
+		presentation restrictionPresentationConfig
+		configure    func(*offlineMeetingManagementEligibilityProbes)
+	}{
+		{name: "distribution concealment", presentation: restrictionPresentationConfig{enabled: true}},
+		{name: "deny plugin", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.registeredPluginCount = func() int { return 1 }
+		}},
+		{name: "conceal plugin", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.registeredPluginCount = func() int { return 1 }
+		}},
+		{name: "missing standard credential provider", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) { return nil, true }
+		}},
+		{name: "nil credential provider makes snapshot indeterminate", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) { return nil, false }
+		}},
+		{name: "credential provider snapshot panic", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) { panic("provider name unavailable") }
+		}},
+		{name: "sidecar credential provider", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) {
+				return []offlineMeetingManagementCredentialProvider{{
+					name:        "sidecar",
+					packagePath: "github.com/larksuite/cli/extension/credential/sidecar",
+					typeName:    "Provider",
+				}}, true
+			}
+		}},
+		{name: "custom provider cannot spoof env by name", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) {
+				return []offlineMeetingManagementCredentialProvider{{
+					name:        "env",
+					packagePath: "example.com/wrapper/credential",
+					typeName:    "Provider",
+				}}, true
+			}
+		}},
+		{name: "additional custom credential provider", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.credentialProviderSnapshot = func() ([]offlineMeetingManagementCredentialProvider, bool) {
+				return []offlineMeetingManagementCredentialProvider{
+					standardOfflineMeetingManagementCredentialProvider,
+					{name: "wrapper", packagePath: "example.com/wrapper/credential", typeName: "Provider"},
+				}, true
+			}
+		}},
+		{name: "yaml policy", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.stat = func(path string) (fs.FileInfo, error) {
+				if strings.HasSuffix(path, "policy.yml") {
+					return nil, nil
+				}
+				return nil, fs.ErrNotExist
+			}
+		}},
+		{name: "environment profile availability", inv: cmdutil.InvocationContext{Profile: "session", ProfileSource: core.ProfileFromEnvironment}},
+		{
+			name: "explicit profile availability",
+			inv:  cmdutil.InvocationContext{Profile: "uat", ProfileSource: core.ProfileFromFlag},
+			args: []string{"--profile", "uat", "vc", "+meeting-end", "--meeting-id", "1"},
+		},
+		{name: "persisted strict mode may exist", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.stat = func(path string) (fs.FileInfo, error) {
+				if strings.HasSuffix(path, "config.json") {
+					return nil, nil
+				}
+				return nil, fs.ErrNotExist
+			}
+		}},
+		{name: "policy stat uncertainty", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.stat = func(string) (fs.FileInfo, error) { return nil, errors.New("permission denied") }
+		}},
+		{name: "strict mode environment signal", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.getenv = func(key string) string {
+				if key == "LARKSUITE_CLI_STRICT_MODE" {
+					return "user"
+				}
+				return ""
+			}
+		}},
+		{name: "credential environment signal", configure: func(p *offlineMeetingManagementEligibilityProbes) {
+			p.getenv = func(key string) string {
+				if key == "LARKSUITE_CLI_APP_ID" {
+					return "configured"
+				}
+				return ""
+			}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			probes := cleanOfflineMeetingManagementEligibilityProbes()
+			if test.configure != nil {
+				test.configure(&probes)
+			}
+			offlineMeetingManagementEligibilityProbesForInvocation = func() offlineMeetingManagementEligibilityProbes { return probes }
+
+			var stdout, stderr bytes.Buffer
+			streams := cmdutil.NewIOStreams(strings.NewReader(""), &stdout, &stderr)
+			args := test.args
+			if args == nil {
+				args = []string{"vc", "+meeting-end", "--meeting-id", "1"}
+			}
+			terminal, code := runOfflineMeetingManagementPreflight(
+				context.Background(),
+				test.inv,
+				test.presentation,
+				streams,
+				args,
+			)
+			if terminal || code != 0 || stdout.Len() != 0 || stderr.Len() != 0 {
+				t.Fatalf("ineligible root invocation must fall back untouched; terminal=%v code=%d stdout=%q stderr=%q", terminal, code, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestOfflineMeetingManagementInvocationRecognition(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "end", args: []string{"vc", "+meeting-end", "--meeting-id", "1"}, want: true},
+		{name: "kickout with root profile", args: []string{"--profile", "uat", "vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1"}, want: true},
+		{name: "profile equals after group", args: []string{"vc", "--profile=uat", "+meeting-end", "--meeting-id", "1"}, want: true},
+		{name: "help uses full presentation", args: []string{"vc", "+meeting-end", "--help"}, want: false},
+		{name: "version uses full presentation", args: []string{"--version"}, want: false},
+		{name: "other vc command", args: []string{"vc", "+detail", "--meeting-id", "1"}, want: false},
+		{name: "target text as another command value", args: []string{"im", "messages", "list", "--query", "vc", "+meeting-end"}, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isOfflineMeetingManagementInvocation(test.args); got != test.want {
+				t.Fatalf("isOfflineMeetingManagementInvocation(%q) = %v, want %v", test.args, got, test.want)
+			}
+		})
+	}
+}
+
+func TestOfflineMeetingManagementTerminalPathsSkipFullStartup(t *testing.T) {
+	useCleanOfflineMeetingManagementEligibility(t)
+
+	originalSingleApp := singleAppModeForInvocation
+	originalBrand := resolveStartupBrandForInvocation
+	originalBuild := buildFullInvocation
+	originalNotice := output.PendingNotice
+	t.Cleanup(func() {
+		singleAppModeForInvocation = originalSingleApp
+		resolveStartupBrandForInvocation = originalBrand
+		buildFullInvocation = originalBuild
+		output.PendingNotice = originalNotice
+	})
+
+	singleAppModeForInvocation = func() bool {
+		t.Fatal("offline terminal path read config through isSingleAppMode")
+		return false
+	}
+	resolveStartupBrandForInvocation = func(string) core.LarkBrand {
+		t.Fatal("offline terminal path read config through ResolveStartupBrand")
+		return ""
+	}
+	buildFullInvocation = func(context.Context, cmdutil.InvocationContext, *buildConfig) (*buildRuntime, *cobra.Command, *hook.Registry) {
+		t.Fatal("offline terminal path entered the full config/credential/plugin build")
+		return nil, nil, nil
+	}
+	output.PendingNotice = func() map[string]interface{} {
+		t.Fatal("offline terminal path evaluated a process-global notice provider")
+		return nil
+	}
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantCode    int
+		wantOutput  string
+		wantType    errs.Category
+		wantSubtype errs.Subtype
+		wantParam   string
+	}{
+		{name: "end missing required", args: []string{"vc", "+meeting-end"}, wantCode: 2, wantOutput: "required flag", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument},
+		{name: "end business validation", args: []string{"vc", "+meeting-end", "--meeting-id", "0"}, wantCode: 2, wantOutput: "positive base-10 int64", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument, wantParam: "--meeting-id"},
+		{name: "end dry run", args: []string{"vc", "+meeting-end", "--meeting-id", "1", "--dry-run", "--as", "user"}, wantCode: 0, wantOutput: "/open-apis/vc/v1/meetings/1/end"},
+		{name: "end bot dry run", args: []string{"vc", "+meeting-end", "--meeting-id", "1", "--dry-run", "--as", "bot"}, wantCode: 0, wantOutput: "/open-apis/vc/v1/bots/end"},
+		{name: "end dry run rejects unresolved omitted identity", args: []string{"vc", "+meeting-end", "--meeting-id", "1", "--dry-run"}, wantCode: 2, wantOutput: "requires explicit --as user or --as bot", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument, wantParam: "--as"},
+		{name: "end dry run rejects unresolved auto identity", args: []string{"vc", "+meeting-end", "--meeting-id", "1", "--dry-run", "--as", "auto"}, wantCode: 2, wantOutput: "requires explicit --as user or --as bot", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument, wantParam: "--as"},
+		{name: "end confirmation", args: []string{"vc", "+meeting-end", "--meeting-id", "1"}, wantCode: 10, wantOutput: "confirmation", wantType: errs.CategoryConfirmation, wantSubtype: errs.SubtypeConfirmationRequired},
+		{name: "kickout invalid identity", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1", "--as", "bot"}, wantCode: 2, wantOutput: "only supports: user"},
+		{name: "kickout validation", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", " 2=1"}, wantCode: 2, wantOutput: "surrounding whitespace"},
+		{name: "kickout dry run", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1", "--dry-run", "--as", "user"}, wantCode: 0, wantOutput: "kickout_users"},
+		{name: "kickout confirmation", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1"}, wantCode: 10, wantOutput: "confirmation"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			code, stdout, stderr := executeWithCapturedOS(t, nil, test.args...)
+			if code != test.wantCode {
+				t.Fatalf("exit code = %d, want %d; stdout=%s stderr=%s", code, test.wantCode, stdout, stderr)
+			}
+			if combined := stdout + stderr; !strings.Contains(combined, test.wantOutput) {
+				t.Fatalf("output does not contain %q; stdout=%s stderr=%s", test.wantOutput, stdout, stderr)
+			}
+			if test.wantType == "" {
+				return
+			}
+			var envelope struct {
+				Error struct {
+					Type    errs.Category `json:"type"`
+					Subtype errs.Subtype  `json:"subtype"`
+					Param   *string       `json:"param"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal([]byte(stderr), &envelope); err != nil {
+				t.Fatalf("stderr is not a typed JSON envelope: %v; stderr=%s", err, stderr)
+			}
+			if envelope.Error.Type != test.wantType || envelope.Error.Subtype != test.wantSubtype {
+				t.Fatalf("typed error = %s/%s, want %s/%s", envelope.Error.Type, envelope.Error.Subtype, test.wantType, test.wantSubtype)
+			}
+			if test.wantParam != "" && (envelope.Error.Param == nil || *envelope.Error.Param != test.wantParam) {
+				t.Fatalf("error.param = %v, want %q", envelope.Error.Param, test.wantParam)
+			}
+		})
+	}
+}
+
+func TestOfflineMeetingManagementYesContinuesToFullStartup(t *testing.T) {
+	useCleanOfflineMeetingManagementEligibility(t)
+
+	var stdout, stderr bytes.Buffer
+	streams := cmdutil.NewIOStreams(strings.NewReader(""), &stdout, &stderr)
+	terminal, code := runOfflineMeetingManagementPreflight(
+		context.Background(),
+		cmdutil.InvocationContext{},
+		restrictionPresentationConfig{},
+		streams,
+		[]string{"vc", "+meeting-end", "--meeting-id", "1", "--yes"},
+	)
+	if terminal || code != 0 {
+		t.Fatalf("offline --yes result = terminal:%v code:%d, want continuation; stdout=%s stderr=%s", terminal, code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("offline --yes preflight emitted output before full startup; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+func TestExecuteWithConcealmentFallsBackToFullStartup(t *testing.T) {
+	useCleanOfflineMeetingManagementEligibility(t)
+
+	originalSingleApp := singleAppModeForInvocation
+	originalBrand := resolveStartupBrandForInvocation
+	originalBuild := buildFullInvocation
+	originalNotice := output.PendingNotice
+	t.Cleanup(func() {
+		singleAppModeForInvocation = originalSingleApp
+		resolveStartupBrandForInvocation = originalBrand
+		buildFullInvocation = originalBuild
+		output.PendingNotice = originalNotice
+	})
+
+	singleAppModeForInvocation = func() bool { return false }
+	resolveStartupBrandForInvocation = func(string) core.LarkBrand { return core.BrandLark }
+	fullStartupCalled := false
+	buildFullInvocation = func(_ context.Context, inv cmdutil.InvocationContext, cfg *buildConfig) (*buildRuntime, *cobra.Command, *hook.Registry) {
+		fullStartupCalled = true
+		if !cfg.presentation.enabled {
+			t.Fatal("concealment option was not preserved for the full build")
+		}
+		root := &cobra.Command{
+			Use:                "lark-cli",
+			DisableFlagParsing: true,
+			RunE:               func(*cobra.Command, []string) error { return nil },
+		}
+		root.SetIn(cfg.streams.In)
+		root.SetOut(cfg.streams.Out)
+		root.SetErr(cfg.streams.ErrOut)
+		return &buildRuntime{
+			Factory: &cmdutil.Factory{IOStreams: cfg.streams, Invocation: inv},
+			surface: surface.NewPlan(map[surface.CommandID]surface.CommandState{
+				surface.CommandUpdate: surface.CommandConcealed,
+			}),
+		}, root, nil
+	}
+
+	code, stdout, stderr := executeWithCapturedOS(
+		t,
+		[]BuildOption{ConcealRestrictedCommands()},
+		"vc", "+meeting-end", "--meeting-id", "1",
+	)
+	if code != 0 || !fullStartupCalled {
+		t.Fatalf("concealed invocation code=%d fullStartupCalled=%v; stdout=%s stderr=%s", code, fullStartupCalled, stdout, stderr)
+	}
+}

--- a/cmd/meeting_management_offline_preflight_test.go
+++ b/cmd/meeting_management_offline_preflight_test.go
@@ -373,10 +373,10 @@ func TestOfflineMeetingManagementTerminalPathsSkipFullStartup(t *testing.T) {
 		{name: "end dry run rejects unresolved omitted identity", args: []string{"vc", "+meeting-end", "--meeting-id", "1", "--dry-run"}, wantCode: 2, wantOutput: "requires explicit --as user or --as bot", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument, wantParam: "--as"},
 		{name: "end dry run rejects unresolved auto identity", args: []string{"vc", "+meeting-end", "--meeting-id", "1", "--dry-run", "--as", "auto"}, wantCode: 2, wantOutput: "requires explicit --as user or --as bot", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument, wantParam: "--as"},
 		{name: "end confirmation", args: []string{"vc", "+meeting-end", "--meeting-id", "1"}, wantCode: 10, wantOutput: "confirmation", wantType: errs.CategoryConfirmation, wantSubtype: errs.SubtypeConfirmationRequired},
-		{name: "kickout invalid identity", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1", "--as", "bot"}, wantCode: 2, wantOutput: "only supports: user"},
-		{name: "kickout validation", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", " 2=1"}, wantCode: 2, wantOutput: "surrounding whitespace"},
+		{name: "kickout invalid identity", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1", "--as", "bot"}, wantCode: 2, wantOutput: "only supports: user", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument, wantParam: "--as"},
+		{name: "kickout validation", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", " 2=1"}, wantCode: 2, wantOutput: "surrounding whitespace", wantType: errs.CategoryValidation, wantSubtype: errs.SubtypeInvalidArgument, wantParam: "--participant"},
 		{name: "kickout dry run", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1", "--dry-run", "--as", "user"}, wantCode: 0, wantOutput: "kickout_users"},
-		{name: "kickout confirmation", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1"}, wantCode: 10, wantOutput: "confirmation"},
+		{name: "kickout confirmation", args: []string{"vc", "+meeting-participant-kickout", "--meeting-id", "1", "--participant", "2=1"}, wantCode: 10, wantOutput: "confirmation", wantType: errs.CategoryConfirmation, wantSubtype: errs.SubtypeConfirmationRequired},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -391,6 +391,7 @@ func TestOfflineMeetingManagementTerminalPathsSkipFullStartup(t *testing.T) {
 				return
 			}
 			var envelope struct {
+				OK    bool `json:"ok"`
 				Error struct {
 					Type    errs.Category `json:"type"`
 					Subtype errs.Subtype  `json:"subtype"`
@@ -400,11 +401,22 @@ func TestOfflineMeetingManagementTerminalPathsSkipFullStartup(t *testing.T) {
 			if err := json.Unmarshal([]byte(stderr), &envelope); err != nil {
 				t.Fatalf("stderr is not a typed JSON envelope: %v; stderr=%s", err, stderr)
 			}
-			if envelope.Error.Type != test.wantType || envelope.Error.Subtype != test.wantSubtype {
-				t.Fatalf("typed error = %s/%s, want %s/%s", envelope.Error.Type, envelope.Error.Subtype, test.wantType, test.wantSubtype)
+			if envelope.OK {
+				t.Errorf("envelope ok = true, want false")
 			}
-			if test.wantParam != "" && (envelope.Error.Param == nil || *envelope.Error.Param != test.wantParam) {
-				t.Fatalf("error.param = %v, want %q", envelope.Error.Param, test.wantParam)
+			if envelope.Error.Type != test.wantType || envelope.Error.Subtype != test.wantSubtype {
+				t.Errorf("typed error = %s/%s, want %s/%s; stderr=%s", envelope.Error.Type, envelope.Error.Subtype, test.wantType, test.wantSubtype, stderr)
+			}
+			if test.wantParam == "" {
+				if envelope.Error.Param != nil {
+					t.Errorf("error.param = %q, want field omitted", *envelope.Error.Param)
+				}
+			} else if envelope.Error.Param == nil || *envelope.Error.Param != test.wantParam {
+				got := "<omitted>"
+				if envelope.Error.Param != nil {
+					got = *envelope.Error.Param
+				}
+				t.Errorf("error.param = %q, want %q", got, test.wantParam)
 			}
 		})
 	}
@@ -432,6 +444,7 @@ func TestOfflineMeetingManagementYesContinuesToFullStartup(t *testing.T) {
 
 func TestExecuteWithConcealmentFallsBackToFullStartup(t *testing.T) {
 	useCleanOfflineMeetingManagementEligibility(t)
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 
 	originalSingleApp := singleAppModeForInvocation
 	originalBrand := resolveStartupBrandForInvocation
@@ -447,6 +460,7 @@ func TestExecuteWithConcealmentFallsBackToFullStartup(t *testing.T) {
 	singleAppModeForInvocation = func() bool { return false }
 	resolveStartupBrandForInvocation = func(string) core.LarkBrand { return core.BrandLark }
 	fullStartupCalled := false
+	config := &core.CliConfig{Brand: core.BrandLark}
 	buildFullInvocation = func(_ context.Context, inv cmdutil.InvocationContext, cfg *buildConfig) (*buildRuntime, *cobra.Command, *hook.Registry) {
 		fullStartupCalled = true
 		if !cfg.presentation.enabled {
@@ -460,8 +474,11 @@ func TestExecuteWithConcealmentFallsBackToFullStartup(t *testing.T) {
 		root.SetIn(cfg.streams.In)
 		root.SetOut(cfg.streams.Out)
 		root.SetErr(cfg.streams.ErrOut)
+		factory, _, _, _ := cmdutil.TestFactory(t, config)
+		factory.IOStreams = cfg.streams
+		factory.Invocation = inv
 		return &buildRuntime{
-			Factory: &cmdutil.Factory{IOStreams: cfg.streams, Invocation: inv},
+			Factory: factory,
 			surface: surface.NewPlan(map[surface.CommandID]surface.CommandState{
 				surface.CommandUpdate: surface.CommandConcealed,
 			}),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,12 @@ import (
 // explicit args — correct, since those don't exercise the whitelist path.
 var rawInvocationArgs []string
 
+var (
+	singleAppModeForInvocation       = isSingleAppMode
+	resolveStartupBrandForInvocation = ResolveStartupBrand
+	buildFullInvocation              = buildInternalWithConfig
+)
+
 func Execute() int {
 	return executeWithOptions(nil)
 }
@@ -71,11 +77,16 @@ func executeWithOptions(opts []BuildOption) int {
 	if cfg.streams == nil {
 		WithIO(os.Stdin, os.Stdout, os.Stderr)(cfg)
 	}
+	if terminal, code := runOfflineMeetingManagementPreflight(
+		context.Background(), inv, cfg.presentation, cfg.streams, os.Args[1:],
+	); terminal {
+		return code
+	}
 	if !cfg.hideProfileSet {
-		HideProfile(isSingleAppMode())(cfg)
+		HideProfile(singleAppModeForInvocation())(cfg)
 	}
 	if !cfg.startupBrandSet {
-		WithStartupBrand(ResolveStartupBrand(inv.Profile))(cfg)
+		WithStartupBrand(resolveStartupBrandForInvocation(inv.Profile))(cfg)
 	}
 	configureFlagCompletions(os.Args)
 
@@ -83,7 +94,7 @@ func executeWithOptions(opts []BuildOption) int {
 	if deferProfileError {
 		cfg.deferStartup = true
 	}
-	runtime, rootCmd, reg := buildInternalWithConfig(ctx, inv, cfg)
+	runtime, rootCmd, reg := buildFullInvocation(ctx, inv, cfg)
 	f := runtime.Factory
 
 	if deferProfileError {
@@ -296,7 +307,7 @@ func handleRootError(
 	// WriteTypedErrorEnvelope still returns false when err carries no
 	// Problem; in that case we fall through to the signal / plain-text paths.
 	typedExit := output.ExitCodeOf(err)
-	if output.WriteTypedErrorEnvelope(errOut, renderedErr, string(f.ResolvedIdentity)) {
+	if output.WriteTypedErrorEnvelopeWithNoticeProvider(errOut, renderedErr, string(f.ResolvedIdentity), f.NoticeProvider) {
 		return typedExit
 	}
 
@@ -331,7 +342,7 @@ func handleRootError(
 	} else {
 		fallback = errs.NewInternalError(errs.SubtypeUnknown, "%s", err.Error()).WithCause(err)
 	}
-	output.WriteTypedErrorEnvelope(errOut, fallback, string(f.ResolvedIdentity))
+	output.WriteTypedErrorEnvelopeWithNoticeProvider(errOut, fallback, string(f.ResolvedIdentity), f.NoticeProvider)
 	return output.ExitCodeOf(fallback)
 }
 

--- a/internal/cmdutil/dryrun.go
+++ b/internal/cmdutil/dryrun.go
@@ -288,6 +288,13 @@ func PrintDryRun(request client.RawApiRequest, config *core.CliConfig, opts DryR
 // WriteDryRun emits a DryRunAPI using the shared dry-run output contract.
 // Identity may be empty; the envelope omits it rather than guessing.
 func WriteDryRun(dr *DryRunAPI, opts DryRunOutputOptions) error {
+	return WriteDryRunWithNoticeProvider(dr, opts, output.GetNotice)
+}
+
+// WriteDryRunWithNoticeProvider emits a dry-run using the invocation-scoped
+// notice provider. A nil provider deliberately suppresses notices; WriteDryRun
+// retains the legacy process-global behavior.
+func WriteDryRunWithNoticeProvider(dr *DryRunAPI, opts DryRunOutputOptions, noticeProvider output.NoticeProvider) error {
 	if dr == nil {
 		return errs.NewInternalError(errs.SubtypeUnknown, "dry-run produced no request preview")
 	}
@@ -306,12 +313,12 @@ func WriteDryRun(dr *DryRunAPI, opts DryRunOutputOptions) error {
 		fmt.Fprint(opts.Out, dr.Format())
 		return nil
 	}
-	return output.WriteSuccessEnvelope(dr, output.SuccessEnvelopeOptions{
+	return output.WriteSuccessEnvelopeWithNoticeProvider(dr, output.SuccessEnvelopeOptions{
 		CommandPath: opts.CommandPath,
 		Identity:    string(opts.Identity),
 		DryRun:      true,
 		JqExpr:      opts.JqExpr,
 		Out:         opts.Out,
 		ErrOut:      opts.ErrOut,
-	})
+	}, noticeProvider)
 }

--- a/internal/cmdutil/dryrun_test.go
+++ b/internal/cmdutil/dryrun_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
 )
 
 func TestDryRunAPI_SingleGET(t *testing.T) {
@@ -343,6 +344,32 @@ func TestWriteDryRun_NilPreviewIsInternalError(t *testing.T) {
 	var internal *errs.InternalError
 	if !errors.As(err, &internal) {
 		t.Fatalf("expected *errs.InternalError, got %T: %v", err, err)
+	}
+}
+
+func TestWriteDryRunWithNoticeProvider_NilDoesNotReadGlobal(t *testing.T) {
+	original := output.PendingNotice
+	called := false
+	output.PendingNotice = func() map[string]interface{} {
+		called = true
+		return map[string]interface{}{"source": "global"}
+	}
+	t.Cleanup(func() { output.PendingNotice = original })
+
+	var out bytes.Buffer
+	err := WriteDryRunWithNoticeProvider(
+		NewDryRunAPI().GET("/open-apis/test"),
+		DryRunOutputOptions{Format: "json", Out: &out, ErrOut: io.Discard},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("WriteDryRunWithNoticeProvider() error = %v", err)
+	}
+	if called {
+		t.Fatal("nil invocation provider consulted output.PendingNotice")
+	}
+	if strings.Contains(out.String(), "_notice") {
+		t.Fatalf("nil invocation provider emitted notice: %s", out.String())
 	}
 }
 

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -21,6 +21,7 @@ import (
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/keychain"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/recovery"
 	"github.com/larksuite/cli/internal/skillref"
 	"github.com/larksuite/cli/internal/transport"
@@ -39,10 +40,11 @@ type InvocationContext struct {
 // All function fields are lazily initialized and cached after first call.
 // In tests, replace any field to stub out external dependencies.
 type Factory struct {
-	Config     func() (*core.CliConfig, error) // lazily loads app config from Credential
-	HttpClient func() (*http.Client, error)    // policy-routed HTTP client for direct requests
-	LarkClient func() (*lark.Client, error)    // Lark SDK client for all Open API calls
-	IOStreams  *IOStreams                      // stdin/stdout/stderr streams
+	Config         func() (*core.CliConfig, error) // lazily loads app config from Credential
+	HttpClient     func() (*http.Client, error)    // policy-routed HTTP client for direct requests
+	LarkClient     func() (*lark.Client, error)    // Lark SDK client for all Open API calls
+	IOStreams      *IOStreams                      // stdin/stdout/stderr streams
+	NoticeProvider output.NoticeProvider           // captured per invocation; nil suppresses notices
 
 	Invocation           InvocationContext       // Immutable call context; do not mutate after Factory construction.
 	Keychain             keychain.KeychainAccess // secret storage (real keychain in prod, mock in tests)

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -23,6 +23,7 @@ import (
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/keychain"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/registry"
 	"github.com/larksuite/cli/internal/riskcontrol"
 	_ "github.com/larksuite/cli/internal/security/contentsafety" // register content safety provider
@@ -46,9 +47,10 @@ func init() {
 func NewDefault(streams *IOStreams, inv InvocationContext) *Factory {
 	streams = normalizeStreams(streams)
 	f := &Factory{
-		Keychain:   keychain.Default(),
-		Invocation: inv,
-		IOStreams:  streams,
+		Keychain:       keychain.Default(),
+		Invocation:     inv,
+		IOStreams:      streams,
+		NoticeProvider: output.GetNotice,
 	}
 
 	// Workspace detection: determines which config subtree to use.

--- a/internal/cmdutil/identity_flag.go
+++ b/internal/cmdutil/identity_flag.go
@@ -32,6 +32,21 @@ func AddShortcutIdentityFlag(ctx context.Context, cmd *cobra.Command, f *Factory
 	})
 }
 
+// AddOfflineShortcutIdentityFlag registers --as without consulting credentials
+// or strict-mode state. It is reserved for commands that must complete local
+// validation, dry-run, and high-risk confirmation before credential resolution.
+// The execution path must call CheckStrictMode after confirmation and before
+// any scope or API operation.
+func AddOfflineShortcutIdentityFlag(cmd *cobra.Command, authTypes []string) {
+	if len(authTypes) == 0 {
+		authTypes = []string{"user"}
+	}
+	registerIdentityFlag(cmd, nil, "", "identity type: "+strings.Join(authTypes, " | "))
+	RegisterFlagCompletion(cmd, "as", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return authTypes, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
 type identityFlagConfig struct {
 	defaultValue     string
 	usage            string

--- a/internal/cmdutil/testing.go
+++ b/internal/cmdutil/testing.go
@@ -17,6 +17,7 @@ import (
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/vfs"
 )
 
@@ -69,6 +70,7 @@ func TestFactory(t *testing.T, config *core.CliConfig) (*Factory, *bytes.Buffer,
 		HttpClient:     func() (*http.Client, error) { return mockClient, nil },
 		LarkClient:     func() (*lark.Client, error) { return testLarkClient, nil },
 		IOStreams:      &IOStreams{In: nil, Out: stdoutBuf, ErrOut: stderrBuf},
+		NoticeProvider: output.GetNotice,
 		Keychain:       &noopKeychain{},
 		Credential:     testCred,
 		FileIOProvider: fileio.GetProvider(),

--- a/internal/output/emitter_legacy_compat_test.go
+++ b/internal/output/emitter_legacy_compat_test.go
@@ -393,7 +393,10 @@ func runRuntimeContextOracle(t *testing.T, data interface{}, opts runtimeOracleO
 	parent.AddCommand(cmd)
 	cmd.AddCommand(leaf)
 
-	factory := &cmdutil.Factory{IOStreams: &cmdutil.IOStreams{Out: stdout, ErrOut: stderr}}
+	factory := &cmdutil.Factory{
+		IOStreams:      &cmdutil.IOStreams{Out: stdout, ErrOut: stderr},
+		NoticeProvider: output.GetNotice,
+	}
 	runtime := common.TestNewRuntimeContextForAPI(
 		context.Background(), leaf, &core.CliConfig{Brand: core.BrandFeishu}, factory, core.AsBot,
 	)

--- a/internal/output/envelope_success.go
+++ b/internal/output/envelope_success.go
@@ -34,12 +34,20 @@ func SuccessEnvelopeData(result interface{}) interface{} {
 // JSON output carries content-safety alerts inside the envelope. When jq is
 // applied, the alert may be filtered away, so warn mode also writes stderr.
 func WriteSuccessEnvelope(data interface{}, opts SuccessEnvelopeOptions) error {
+	return WriteSuccessEnvelopeWithNoticeProvider(data, opts, GetNotice)
+}
+
+// WriteSuccessEnvelopeWithNoticeProvider emits a success envelope using the
+// invocation-scoped notice provider. A nil provider deliberately suppresses
+// notices; callers that need the legacy process-global hook should use
+// WriteSuccessEnvelope.
+func WriteSuccessEnvelopeWithNoticeProvider(data interface{}, opts SuccessEnvelopeOptions, noticeProvider NoticeProvider) error {
 	return NewEmitter(EmitterConfig{
 		Out:            opts.Out,
 		ErrOut:         opts.ErrOut,
 		CommandPath:    opts.CommandPath,
 		Identity:       opts.Identity,
-		NoticeProvider: GetNotice,
+		NoticeProvider: noticeProvider,
 	}).Success(data, EmitOptions{
 		Format:          "",
 		Raw:             false,

--- a/internal/output/envelope_success_test.go
+++ b/internal/output/envelope_success_test.go
@@ -88,6 +88,32 @@ func TestWriteSuccessEnvelope_PrintsShortcutCompatibleEnvelope(t *testing.T) {
 	}
 }
 
+func TestWriteSuccessEnvelopeWithNoticeProvider_NilDoesNotReadGlobal(t *testing.T) {
+	original := PendingNotice
+	called := false
+	PendingNotice = func() map[string]interface{} {
+		called = true
+		return map[string]interface{}{"source": "global"}
+	}
+	t.Cleanup(func() { PendingNotice = original })
+
+	var out strings.Builder
+	err := WriteSuccessEnvelopeWithNoticeProvider(
+		map[string]interface{}{"id": "1"},
+		SuccessEnvelopeOptions{Out: &out},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("WriteSuccessEnvelopeWithNoticeProvider() error = %v", err)
+	}
+	if called {
+		t.Fatal("nil invocation provider consulted PendingNotice")
+	}
+	if strings.Contains(out.String(), "_notice") {
+		t.Fatalf("nil invocation provider emitted notice: %s", out.String())
+	}
+}
+
 func TestWriteSuccessEnvelope_JqUsesEnvelope(t *testing.T) {
 	var out strings.Builder
 

--- a/internal/output/errors.go
+++ b/internal/output/errors.go
@@ -56,15 +56,26 @@ func PartialFailure(code int) *PartialFailureError {
 // Returns false only when err carries no Problem (the dispatcher then handles
 // it via its signal / usage-error branches) or when JSON encoding itself failed.
 func WriteTypedErrorEnvelope(w io.Writer, err error, identity string) bool {
+	return WriteTypedErrorEnvelopeWithNoticeProvider(w, err, identity, GetNotice)
+}
+
+// WriteTypedErrorEnvelopeWithNoticeProvider writes a typed error envelope
+// using the invocation-scoped notice provider. A nil provider deliberately
+// suppresses notices; WriteTypedErrorEnvelope retains the legacy global hook.
+func WriteTypedErrorEnvelopeWithNoticeProvider(w io.Writer, err error, identity string, noticeProvider NoticeProvider) bool {
 	typed, ok := errs.UnwrapTypedError(err)
 	if !ok {
 		return false
+	}
+	var notice map[string]interface{}
+	if noticeProvider != nil {
+		notice = noticeProvider()
 	}
 	env := typedEnvelope{
 		OK:       false,
 		Identity: identity,
 		Error:    typed,
-		Notice:   GetNotice(),
+		Notice:   notice,
 	}
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)

--- a/internal/output/errors_test.go
+++ b/internal/output/errors_test.go
@@ -5,6 +5,7 @@ package output
 
 import (
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
@@ -16,6 +17,28 @@ import (
 type failingWriter struct {
 	limit int
 	n     int
+}
+
+func TestWriteTypedErrorEnvelopeWithNoticeProvider_NilDoesNotReadGlobal(t *testing.T) {
+	original := PendingNotice
+	called := false
+	PendingNotice = func() map[string]interface{} {
+		called = true
+		return map[string]interface{}{"source": "global"}
+	}
+	t.Cleanup(func() { PendingNotice = original })
+
+	var out strings.Builder
+	err := errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid input")
+	if ok := WriteTypedErrorEnvelopeWithNoticeProvider(&out, err, "user", nil); !ok {
+		t.Fatal("typed error was not handled")
+	}
+	if called {
+		t.Fatal("nil invocation provider consulted PendingNotice")
+	}
+	if strings.Contains(out.String(), "_notice") {
+		t.Fatalf("nil invocation provider emitted notice: %s", out.String())
+	}
 }
 
 func (f *failingWriter) Write(p []byte) (int, error) {

--- a/internal/output/errors_test.go
+++ b/internal/output/errors_test.go
@@ -4,6 +4,8 @@
 package output
 
 import (
+	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -29,15 +31,67 @@ func TestWriteTypedErrorEnvelopeWithNoticeProvider_NilDoesNotReadGlobal(t *testi
 	t.Cleanup(func() { PendingNotice = original })
 
 	var out strings.Builder
-	err := errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid input")
+	cause := errors.New("invalid input sentinel")
+	err := errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid input").
+		WithParam("--meeting-id").
+		WithCause(cause)
 	if ok := WriteTypedErrorEnvelopeWithNoticeProvider(&out, err, "user", nil); !ok {
 		t.Fatal("typed error was not handled")
 	}
 	if called {
 		t.Fatal("nil invocation provider consulted PendingNotice")
 	}
-	if strings.Contains(out.String(), "_notice") {
+
+	var raw map[string]json.RawMessage
+	if decodeErr := json.Unmarshal([]byte(out.String()), &raw); decodeErr != nil {
+		t.Fatalf("decode typed envelope: %v; output=%s", decodeErr, out.String())
+	}
+	if _, ok := raw["_notice"]; ok {
 		t.Fatalf("nil invocation provider emitted notice: %s", out.String())
+	}
+
+	var envelope struct {
+		OK       bool   `json:"ok"`
+		Identity string `json:"identity"`
+		Error    struct {
+			Type    errs.Category `json:"type"`
+			Subtype errs.Subtype  `json:"subtype"`
+			Message string        `json:"message"`
+			Param   string        `json:"param"`
+		} `json:"error"`
+	}
+	if decodeErr := json.Unmarshal([]byte(out.String()), &envelope); decodeErr != nil {
+		t.Fatalf("decode typed envelope fields: %v; output=%s", decodeErr, out.String())
+	}
+	if envelope.OK || envelope.Identity != "user" {
+		t.Errorf("envelope ok=%v identity=%q, want false/user", envelope.OK, envelope.Identity)
+	}
+	if envelope.Error.Type != errs.CategoryValidation || envelope.Error.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("typed error = %s/%s, want %s/%s", envelope.Error.Type, envelope.Error.Subtype, errs.CategoryValidation, errs.SubtypeInvalidArgument)
+	}
+	if envelope.Error.Message != "invalid input" || envelope.Error.Param != "--meeting-id" {
+		t.Errorf("typed error message=%q param=%q, want invalid input/--meeting-id", envelope.Error.Message, envelope.Error.Param)
+	}
+
+	// ValidationError causes are an in-process errors.Is/errors.Unwrap contract
+	// and are intentionally excluded from the JSON envelope.
+	if !errors.Is(err, cause) {
+		t.Fatal("typed error did not preserve its cause")
+	}
+	var errorFields map[string]json.RawMessage
+	if decodeErr := json.Unmarshal(raw["error"], &errorFields); decodeErr != nil {
+		t.Fatalf("decode typed error fields: %v; output=%s", decodeErr, out.String())
+	}
+	wantErrorFields := map[string]bool{
+		"type": true, "subtype": true, "message": true, "param": true,
+	}
+	for field := range errorFields {
+		if !wantErrorFields[field] {
+			t.Fatalf("typed envelope exposed unexpected error field %q: %s", field, out.String())
+		}
+	}
+	if strings.Contains(out.String(), cause.Error()) {
+		t.Fatalf("typed envelope exposed in-process cause value: %s", out.String())
 	}
 }
 

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"slices"
@@ -34,6 +35,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+// ErrOfflinePreflightPassed tells the process entrypoint that a deliberately
+// minimal command tree completed all local checks and observed an explicit
+// --yes. The caller must now rebuild the normal command tree so config, strict
+// mode, plugin policy, scopes, and the real API execution keep their existing
+// behavior.
+var ErrOfflinePreflightPassed = errors.New("offline shortcut preflight passed")
 
 // RuntimeContext provides helpers for shortcut execution.
 type RuntimeContext struct {
@@ -749,7 +757,7 @@ func (ctx *RuntimeContext) newEmitter() *output.Emitter {
 		CommandPath:    ctx.Cmd.CommandPath(),
 		Identity:       string(ctx.As()),
 		ColorEnabled:   streams.OutIsTerminal,
-		NoticeProvider: output.GetNotice,
+		NoticeProvider: ctx.Factory.NoticeProvider,
 	})
 }
 
@@ -907,12 +915,22 @@ func (s Shortcut) Mount(parent *cobra.Command, f *cmdutil.Factory) {
 // MountWithContext registers a shortcut while preserving the caller-provided context.
 func (s Shortcut) MountWithContext(ctx context.Context, parent *cobra.Command, f *cmdutil.Factory) {
 	if s.Execute != nil {
-		s.mountDeclarative(ctx, parent, f)
+		s.mountDeclarative(ctx, parent, f, false)
+	}
+}
+
+// MountOfflinePreflightWithContext mounts only the local half of a shortcut
+// that opted into ConfirmationBeforeNetwork. It is used by the process-level
+// two-stage dispatcher; successful confirmation returns
+// ErrOfflinePreflightPassed instead of touching runtime dependencies.
+func (s Shortcut) MountOfflinePreflightWithContext(ctx context.Context, parent *cobra.Command, f *cmdutil.Factory) {
+	if s.Execute != nil {
+		s.mountDeclarative(ctx, parent, f, true)
 	}
 }
 
 // mountDeclarative builds and registers the Cobra command described by a Shortcut.
-func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f *cmdutil.Factory) {
+func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f *cmdutil.Factory, offlinePreflightOnly bool) {
 	shortcut := s
 	if len(shortcut.AuthTypes) == 0 {
 		shortcut.AuthTypes = []string{"user"}
@@ -925,6 +943,9 @@ func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f
 		Hidden: shortcut.Hidden,
 		Args:   rejectPositionalArgs(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if offlinePreflightOnly {
+				return runShortcutConfirmationBeforeNetwork(cmd, f, &shortcut, botOnly, true)
+			}
 			return runShortcut(cmd, f, &shortcut, botOnly)
 		},
 	}
@@ -965,8 +986,10 @@ func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f
 }
 
 // runShortcut is the execution pipeline for a declarative shortcut.
-// Each step is a clear phase: identity → config → scopes → runtime →
-// canonical validation → execute.
+// Each step is a clear phase: local preflight → identity/config/scopes/runtime
+// → execute. Most shortcuts use the full eager path; a small opt-in subset can
+// delay identity/config/network setup until after local validation, dry-run,
+// and high-risk confirmation.
 func runShortcut(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, botOnly bool) error {
 	// --print-schema short-circuits everything below: it's pure local
 	// introspection, no identity / scope / network needed. The flag is
@@ -991,6 +1014,9 @@ func runShortcut(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, botOnly bo
 			fmt.Fprintln(f.IOStreams.Out, string(out))
 			return nil
 		}
+	}
+	if s.ConfirmationBeforeNetwork {
+		return runShortcutConfirmationBeforeNetwork(cmd, f, s, botOnly, false)
 	}
 	as, err := resolveShortcutIdentity(cmd, f, s)
 	if err != nil {
@@ -1054,6 +1080,68 @@ func runShortcut(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, botOnly bo
 	return rctx.outputErr
 }
 
+func runShortcutConfirmationBeforeNetwork(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, botOnly bool, offlinePreflightOnly bool) error {
+	offlineAs, err := resolveShortcutIdentityOffline(cmd, s, botOnly)
+	if err != nil {
+		return err
+	}
+	f.ResolvedIdentity = offlineAs
+	rctx, err := newOfflineRuntimeContext(cmd, f, s, offlineAs, botOnly)
+	if err != nil {
+		return err
+	}
+	if err := runShortcutLocalPreflight(rctx, s); err != nil {
+		return err
+	}
+	if rctx.Bool("dry-run") {
+		// The dependency-free phase cannot observe strict mode, default-as, or
+		// credential-based auto detection. For a user-only destructive command,
+		// require the caller to make that identity explicit before rendering a
+		// plan; otherwise the dry-run envelope could claim user while the same
+		// invocation resolves to bot after confirmation.
+		if offlineAs == core.AsAuto && len(s.AuthTypes) == 1 && s.AuthTypes[0] == string(core.AsUser) {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--dry-run requires explicit --as user because offline preflight cannot resolve default or automatic identity").
+				WithParam("--as")
+		}
+		return handleShortcutDryRun(f, rctx, s)
+	}
+	if s.Risk == "high-risk-write" && !rctx.Bool("yes") {
+		return cmdutil.RequireConfirmation(s.Service + " " + s.Command)
+	}
+	if offlinePreflightOnly {
+		return ErrOfflinePreflightPassed
+	}
+
+	// Confirmation only authorizes continuing into the established runtime
+	// path. Resolve identity again here because the dependency-free preflight
+	// deliberately cannot observe strict mode, default-as, or credential-based
+	// auto detection. In particular, a user-only destructive shortcut must
+	// reject an implicit/auto bot identity instead of silently rewriting it to
+	// user after --yes.
+	as, err := resolveShortcutIdentity(cmd, f, s)
+	if err != nil {
+		return err
+	}
+	config, err := f.Config()
+	if err != nil {
+		return err
+	}
+	if err := checkShortcutScopes(f, cmd.Context(), as, config, s.ScopesForIdentity(string(as))); err != nil {
+		return err
+	}
+	liveRctx, err := newRuntimeContext(cmd, f, s, config, as, botOnly)
+	if err != nil {
+		return err
+	}
+	liveRctx.stdinConsumed = rctx.stdinConsumed
+	liveRctx.inputResolved = maps.Clone(rctx.inputResolved)
+	if err := s.Execute(liveRctx.ctx, liveRctx); err != nil {
+		return attributeAliasValidationError(liveRctx, err)
+	}
+	return liveRctx.outputErr
+}
+
 // resolveShortcutIdentity selects the effective identity for a shortcut invocation.
 func resolveShortcutIdentity(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut) (core.Identity, error) {
 	// Step 1: determine identity (--as > default-as > auto-detect).
@@ -1069,6 +1157,35 @@ func resolveShortcutIdentity(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut
 		return "", err
 	}
 	return as, nil
+}
+
+func resolveShortcutIdentityOffline(cmd *cobra.Command, s *Shortcut, botOnly bool) (core.Identity, error) {
+	asFlag, _ := cmd.Flags().GetString("as")
+	if botOnly {
+		if asFlag != "" && asFlag != string(core.AsBot) {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--as %s is not supported, this command only supports: bot", asFlag).
+				WithParam("--as")
+		}
+		return core.AsBot, nil
+	}
+	if asFlag == "" || asFlag == string(core.AsAuto) {
+		// Keep unresolved identity unresolved in the dependency-free phase.
+		// The full path resolves it from strict mode, default-as, and credentials
+		// after confirmation; projecting it to user here would make dry-run and
+		// execution describe different identities.
+		return core.AsAuto, nil
+	}
+	as := core.Identity(asFlag)
+	for _, supported := range s.AuthTypes {
+		if supported == asFlag {
+			return as, nil
+		}
+	}
+	list := strings.Join(s.AuthTypes, ", ")
+	return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"--as %s is not supported, this command only supports: %s", as, list).
+		WithParam("--as")
 }
 
 // checkShortcutScopes verifies that the selected identity satisfies the shortcut scope contract.
@@ -1117,6 +1234,53 @@ func newRuntimeContext(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, conf
 	rctx.Format = rctx.Str("format")
 	rctx.JqExpr, _ = cmd.Flags().GetString("jq")
 	return rctx, nil
+}
+
+func newOfflineRuntimeContext(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, as core.Identity, botOnly bool) (*RuntimeContext, error) {
+	ctx := cmd.Context()
+	ctx = cmdutil.ContextWithShortcut(ctx, s.Service+":"+s.Command, uuid.New().String())
+	rctx := &RuntimeContext{
+		ctx:        ctx,
+		Config:     &core.CliConfig{},
+		Cmd:        cmd,
+		botOnly:    botOnly,
+		resolvedAs: as,
+		Factory:    f,
+	}
+	rctx.declaredScopes = s.DeclaredScopesForIdentity(string(rctx.As()))
+	applyJSONShorthand(cmd, s)
+	rctx.Format = rctx.Str("format")
+	rctx.JqExpr, _ = cmd.Flags().GetString("jq")
+	return rctx, nil
+}
+
+func runShortcutLocalPreflight(rctx *RuntimeContext, s *Shortcut) error {
+	if s.Normalize != nil {
+		if err := resolveInputFlags(rctx, s.Flags); err != nil {
+			return attributeAliasValidationError(rctx, err)
+		}
+		flagContext := rctx.FlagContext()
+		if err := s.Normalize(rctx.ctx, flagContext); err != nil {
+			return attributeAliasValidationError(rctx, err)
+		}
+	}
+	if err := validateEnumFlags(rctx, s.Flags); err != nil {
+		return attributeAliasValidationError(rctx, err)
+	}
+	if s.Normalize == nil {
+		if err := resolveInputFlags(rctx, s.Flags); err != nil {
+			return attributeAliasValidationError(rctx, err)
+		}
+	}
+	if err := output.ValidateJqFlags(rctx.JqExpr, "", rctx.Format); err != nil {
+		return err
+	}
+	if s.Validate != nil {
+		if err := s.Validate(rctx.ctx, rctx); err != nil {
+			return attributeAliasValidationError(rctx, err)
+		}
+	}
+	return nil
 }
 
 // StripUTF8BOM removes a leading UTF-8 byte-order mark from content read from a
@@ -1267,14 +1431,14 @@ func handleShortcutDryRun(f *cmdutil.Factory, rctx *RuntimeContext, s *Shortcut)
 		// Same data.context contract as the service/api dry-run paths.
 		dryResult.Context(rctx.Config.AppID, rctx.UserOpenId())
 	}
-	return cmdutil.WriteDryRun(dryResult, cmdutil.DryRunOutputOptions{
+	return cmdutil.WriteDryRunWithNoticeProvider(dryResult, cmdutil.DryRunOutputOptions{
 		Format:      rctx.Format,
 		JqExpr:      rctx.JqExpr,
 		CommandPath: rctx.Cmd.CommandPath(),
 		Identity:    rctx.As(),
 		Out:         f.IOStreams.Out,
 		ErrOut:      f.IOStreams.ErrOut,
-	})
+	}, f.NoticeProvider)
 }
 
 // rejectPositionalArgs returns a cobra.PositionalArgs that rejects any
@@ -1445,5 +1609,9 @@ func registerShortcutFlagsWithContext(ctx context.Context, cmd *cobra.Command, f
 		}
 	}
 	cmd.Flags().StringP("jq", "q", "", "jq expression to filter JSON output")
-	cmdutil.AddShortcutIdentityFlag(ctx, cmd, f, s.AuthTypes)
+	if s.ConfirmationBeforeNetwork {
+		cmdutil.AddOfflineShortcutIdentityFlag(cmd, s.AuthTypes)
+	} else {
+		cmdutil.AddShortcutIdentityFlag(ctx, cmd, f, s.AuthTypes)
+	}
 }

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -41,7 +41,7 @@ import (
 // --yes. The caller must now rebuild the normal command tree so config, strict
 // mode, plugin policy, scopes, and the real API execution keep their existing
 // behavior.
-var ErrOfflinePreflightPassed = errors.New("offline shortcut preflight passed")
+var ErrOfflinePreflightPassed = errors.New("offline shortcut preflight passed") //nolint:forbidigo // internal control-flow sentinel; consumed by errors.Is before error presentation
 
 // RuntimeContext provides helpers for shortcut execution.
 type RuntimeContext struct {

--- a/shortcuts/common/runner_identity_flag_test.go
+++ b/shortcuts/common/runner_identity_flag_test.go
@@ -5,8 +5,10 @@ package common
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/spf13/cobra"
@@ -41,5 +43,64 @@ func TestShortcutMount_StrictModeHidesAsFlag(t *testing.T) {
 	}
 	if got := flag.DefValue; got != "bot" {
 		t.Fatalf("default value = %q, want %q", got, "bot")
+	}
+}
+
+func TestRunShortcutConfirmationBeforeNetworkYesPreservesFullIdentityResolution(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *core.CliConfig
+		setExplicitAs bool
+	}{
+		{
+			name: "omitted as honors default bot",
+			config: &core.CliConfig{
+				AppID: "test-app", AppSecret: "test-secret", DefaultAs: "bot", SupportedIdentities: 2,
+			},
+		},
+		{
+			name:          "explicit auto preserves bot auto detection",
+			config:        &core.CliConfig{AppID: "test-app", AppSecret: "test-secret", SupportedIdentities: 2},
+			setExplicitAs: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, _, _, _ := cmdutil.TestFactory(t, test.config)
+			executed := false
+			shortcut := &Shortcut{
+				Service:                   "vc",
+				Command:                   "+meeting-end",
+				AuthTypes:                 []string{"user"},
+				Risk:                      "high-risk-write",
+				ConfirmationBeforeNetwork: true,
+				Execute: func(context.Context, *RuntimeContext) error {
+					executed = true
+					return nil
+				},
+			}
+			cmd := newTestShortcutCmd(shortcut, f)
+			if err := cmd.Flags().Set("yes", "true"); err != nil {
+				t.Fatalf("set --yes: %v", err)
+			}
+			if test.setExplicitAs {
+				if err := cmd.Flags().Set("as", "auto"); err != nil {
+					t.Fatalf("set --as auto: %v", err)
+				}
+			}
+
+			err := runShortcut(cmd, f, shortcut, false)
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("runShortcut() error = %T %v, want typed identity validation error", err, err)
+			}
+			if f.ResolvedIdentity != core.AsBot {
+				t.Fatalf("resolved identity = %q, want bot", f.ResolvedIdentity)
+			}
+			if executed {
+				t.Fatal("user-only destructive shortcut executed with resolved bot identity")
+			}
+		})
 	}
 }

--- a/shortcuts/common/types.go
+++ b/shortcuts/common/types.go
@@ -47,6 +47,12 @@ type Shortcut struct {
 	ConditionalUserScopes []string // optional: user-identity conditional scopes
 	ConditionalBotScopes  []string // optional: bot-identity conditional scopes
 
+	// ConfirmationBeforeNetwork opts a shortcut into an offline-preflight path:
+	// Normalize/Validate/--dry-run/high-risk confirmation run before any
+	// identity auto-detection, config load, scope probe, or API client setup.
+	// Use only when those pre-execution stages are guaranteed to stay local.
+	ConfirmationBeforeNetwork bool
+
 	// Declarative fields (new framework).
 	AuthTypes []string // supported identities: "user", "bot" (default: ["user"])
 	Flags     []Flag   // flag definitions; --dry-run is auto-injected

--- a/shortcuts/minutes/bot_identity_test.go
+++ b/shortcuts/minutes/bot_identity_test.go
@@ -50,6 +50,13 @@ func TestMinutesApplyPermissionSupportsUserAndBotIdentity(t *testing.T) {
 	}
 }
 
+func TestMinutesSharePermissionSupportsUserAndBotIdentity(t *testing.T) {
+	want := []string{"user", "bot"}
+	if !reflect.DeepEqual(MinutesSharePermission.AuthTypes, want) {
+		t.Fatalf("MinutesSharePermission.AuthTypes = %v, want %v", MinutesSharePermission.AuthTypes, want)
+	}
+}
+
 func TestApplyPermission_DryRun_BotIdentity(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
 	err := mountAndRun(t, MinutesApplyPermission, []string{
@@ -64,5 +71,22 @@ func TestApplyPermission_DryRun_BotIdentity(t *testing.T) {
 	}
 	if !strings.Contains(out, `"perm": "view"`) && !strings.Contains(out, `"perm":"view"`) {
 		t.Errorf("dry-run should show perm body, got: %s", out)
+	}
+}
+
+func TestSharePermission_DryRun_BotIdentity(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, MinutesSharePermission, []string{
+		"+share-permission", "--minute-token", "obcnexampleminute", "--dry-run", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error under --as bot: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/minutes/v1/minutes/obcnexampleminute/permissions/share") {
+		t.Errorf("dry-run should show share-permission API path, got: %s", out)
+	}
+	if strings.Contains(out, `"perm"`) {
+		t.Errorf("share-permission dry-run should not show perm body, got: %s", out)
 	}
 }

--- a/shortcuts/minutes/minutes_share_permission.go
+++ b/shortcuts/minutes/minutes_share_permission.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package minutes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// MinutesSharePermission shares a minute permission with all meeting participants.
+var MinutesSharePermission = common.Shortcut{
+	Service:     "minutes",
+	Command:     "+share-permission",
+	Description: "Share a minute with all meeting participants",
+	Risk:        "write",
+	Scopes:      []string{"minutes:minutes"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "minute-token", Desc: "minute token", Required: true},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		minuteToken := strings.TrimSpace(runtime.Str("minute-token"))
+		if minuteToken == "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--minute-token is required").WithParam("--minute-token")
+		}
+		if err := validate.ResourceName(minuteToken, "--minute-token"); err != nil {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", err).WithParam("--minute-token")
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		minuteToken := strings.TrimSpace(runtime.Str("minute-token"))
+		return common.NewDryRunAPI().
+			POST(minutesSharePermissionPath(minuteToken))
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		minuteToken := strings.TrimSpace(runtime.Str("minute-token"))
+
+		_, err := runtime.CallAPITyped(http.MethodPost, minutesSharePermissionPath(minuteToken), nil, nil)
+		if err != nil {
+			return err
+		}
+
+		runtime.OutFormat(map[string]any{
+			"minute_token": minuteToken,
+			"shared":       true,
+		}, nil, nil)
+		return nil
+	},
+}
+
+func minutesSharePermissionPath(minuteToken string) string {
+	return fmt.Sprintf("/open-apis/minutes/v1/minutes/%s/permissions/share", validate.EncodePathSegment(minuteToken))
+}

--- a/shortcuts/minutes/minutes_share_permission_test.go
+++ b/shortcuts/minutes/minutes_share_permission_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package minutes
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/spf13/cobra"
+)
+
+const minutesSharePermissionTestToken = "obcnexampleminute"
+
+func TestMinutesSharePermissionScopeAndAuthTypes(t *testing.T) {
+	if want := []string{"minutes:minutes"}; !reflect.DeepEqual(MinutesSharePermission.Scopes, want) {
+		t.Fatalf("MinutesSharePermission.Scopes = %v, want %v", MinutesSharePermission.Scopes, want)
+	}
+	if want := []string{"user", "bot"}; !reflect.DeepEqual(MinutesSharePermission.AuthTypes, want) {
+		t.Fatalf("MinutesSharePermission.AuthTypes = %v, want %v", MinutesSharePermission.AuthTypes, want)
+	}
+}
+
+func TestMinutesSharePermission_Validate(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+
+	parent := &cobra.Command{Use: "minutes"}
+	MinutesSharePermission.Mount(parent, f)
+	parent.SetArgs([]string{"+share-permission", "--as", "user"})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	err := parent.Execute()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "required flag(s) \"minute-token\" not set") {
+		t.Errorf("error should mention missing minute-token, got: %s", err.Error())
+	}
+}
+
+func TestMinutesSharePermission_ValidateTypedMinuteToken(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+
+	parent := &cobra.Command{Use: "minutes"}
+	MinutesSharePermission.Mount(parent, f)
+	parent.SetArgs([]string{"+share-permission", "--minute-token", "..", "--as", "user"})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	err := parent.Execute()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--minute-token" {
+		t.Errorf("param=%q", ve.Param)
+	}
+}
+
+func TestMinutesSharePermission_DryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	err := mountAndRun(t, MinutesSharePermission, []string{
+		"+share-permission",
+		"--minute-token", minutesSharePermissionTestToken,
+		"--dry-run", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "POST") {
+		t.Errorf("expected POST method, got:\n%s", out)
+	}
+	if !strings.Contains(out, "/open-apis/minutes/v1/minutes/"+minutesSharePermissionTestToken+"/permissions/share") {
+		t.Errorf("expected share-permission endpoint, got:\n%s", out)
+	}
+	if strings.Contains(out, `"perm"`) {
+		t.Errorf("share-permission dry-run should not contain perm body, got:\n%s", out)
+	}
+}
+
+func TestMinutesSharePermission_Execute(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	stub := &httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/minutes/v1/minutes/" + minutesSharePermissionTestToken + "/permissions/share",
+		Body: map[string]any{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]any{},
+		},
+	}
+	reg.Register(stub)
+
+	err := mountAndRun(t, MinutesSharePermission, []string{
+		"+share-permission",
+		"--minute-token", minutesSharePermissionTestToken,
+		"--format", "json", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+	if len(stub.CapturedBody) != 0 {
+		t.Fatalf("request body = %q, want empty", string(stub.CapturedBody))
+	}
+
+	var envelope struct {
+		Data struct {
+			MinuteToken string `json:"minute_token"`
+			Shared      bool   `json:"shared"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stdout: %v", err)
+	}
+	if envelope.Data.MinuteToken != minutesSharePermissionTestToken {
+		t.Errorf("data.minute_token = %q, want %q", envelope.Data.MinuteToken, minutesSharePermissionTestToken)
+	}
+	if !envelope.Data.Shared {
+		t.Errorf("data.shared = false, want true")
+	}
+}

--- a/shortcuts/minutes/shortcuts.go
+++ b/shortcuts/minutes/shortcuts.go
@@ -13,6 +13,7 @@ func Shortcuts() []common.Shortcut {
 		MinutesUpload,
 		MinutesUpdate,
 		MinutesApplyPermission,
+		MinutesSharePermission,
 		MinutesSummary,
 		MinutesTodo,
 		MinutesSpeakerReplace,

--- a/shortcuts/minutes/skill_docs_test.go
+++ b/shortcuts/minutes/skill_docs_test.go
@@ -51,6 +51,7 @@ func TestMinutesBotShortcutsIdentityDocsMatchAuthTypes(t *testing.T) {
 		{"+detail", MinutesDetail.AuthTypes, "lark-minutes-detail.md"},
 		{"+download", MinutesDownload.AuthTypes, "lark-minutes-download.md"},
 		{"+apply-permission", MinutesApplyPermission.AuthTypes, "lark-minutes-apply-permission.md"},
+		{"+share-permission", MinutesSharePermission.AuthTypes, "lark-minutes-share-permission.md"},
 	} {
 		if !hasAuthType(cmd.authTypes, "bot") {
 			t.Errorf("%s AuthTypes = %v, want bot included", cmd.name, cmd.authTypes)
@@ -87,6 +88,27 @@ func TestMinutesApplyPermissionHasReference(t *testing.T) {
 	skill := readSkillDoc(t, "skills/lark-meeting/SKILL.md")
 	if !strings.Contains(skill, "references/lark-minutes-apply-permission.md") {
 		t.Error("skills/lark-meeting/SKILL.md command table must link +apply-permission to its reference doc")
+	}
+}
+
+func TestMinutesSharePermissionHasReference(t *testing.T) {
+	if !hasAuthType(MinutesSharePermission.AuthTypes, "bot") {
+		t.Fatalf("MinutesSharePermission.AuthTypes = %v, want bot included", MinutesSharePermission.AuthTypes)
+	}
+	if !hasFlag(MinutesSharePermission.Flags, "minute-token") {
+		t.Fatalf("MinutesSharePermission flags = %v, want minute-token", MinutesSharePermission.Flags)
+	}
+
+	reference := readSkillDoc(t, "skills/lark-meeting/references/lark-minutes-share-permission.md")
+	for _, must := range []string{"--as bot", "--as user", "minutes:minutes", "permissions/share", "参会人"} {
+		if !strings.Contains(reference, must) {
+			t.Errorf("lark-minutes-share-permission.md must cover %q", must)
+		}
+	}
+
+	skill := readSkillDoc(t, "skills/lark-meeting/SKILL.md")
+	if !strings.Contains(skill, "references/lark-minutes-share-permission.md") {
+		t.Error("skills/lark-meeting/SKILL.md command table must link +share-permission to its reference doc")
 	}
 }
 

--- a/shortcuts/register.go
+++ b/shortcuts/register.go
@@ -107,6 +107,47 @@ func RegisterShortcuts(program *cobra.Command, f *cmdutil.Factory) {
 	RegisterShortcutsWithContext(context.Background(), program, f)
 }
 
+var offlineMeetingManagementCommands = map[string]struct{}{
+	"+meeting-end":                 {},
+	"+meeting-participant-kickout": {},
+}
+
+// RegisterOfflineMeetingManagementPreflight mounts the two destructive VC
+// meeting-management commands into a deliberately minimal, dependency-free
+// command tree. Keep this list closed: these definitions are safe to execute
+// twice because their local preflight has no Normalize, input-file/stdin, or
+// OnInvoke side effects. The normal tree is rebuilt only after explicit
+// confirmation.
+func RegisterOfflineMeetingManagementPreflight(ctx context.Context, program *cobra.Command, f *cmdutil.Factory) error {
+	vcGroup := &cobra.Command{Use: "vc", Short: "video conference operations"}
+	cmdmeta.SetDomain(vcGroup, "vc")
+	program.AddCommand(vcGroup)
+
+	found := make(map[string]struct{}, len(offlineMeetingManagementCommands))
+	for _, shortcut := range allShortcuts {
+		if shortcut.Service != "vc" {
+			continue
+		}
+		if _, ok := offlineMeetingManagementCommands[shortcut.Command]; !ok {
+			continue
+		}
+		if !shortcut.ConfirmationBeforeNetwork || shortcut.Normalize != nil || shortcut.OnInvoke != nil {
+			return fmt.Errorf("offline preflight invariant failed for vc %s", shortcut.Command)
+		}
+		for _, flag := range shortcut.Flags {
+			if len(flag.Input) != 0 {
+				return fmt.Errorf("offline preflight input invariant failed for vc %s --%s", shortcut.Command, flag.Name)
+			}
+		}
+		shortcut.MountOfflinePreflightWithContext(ctx, vcGroup, f)
+		found[shortcut.Command] = struct{}{}
+	}
+	if len(found) != len(offlineMeetingManagementCommands) {
+		return fmt.Errorf("offline meeting-management preflight registry is incomplete")
+	}
+	return nil
+}
+
 func RegisterShortcutsWithContext(ctx context.Context, program *cobra.Command, f *cmdutil.Factory) {
 	// Factory.Config may be nil in tests that pass a zero-value factory.
 	var brand core.LarkBrand

--- a/shortcuts/register.go
+++ b/shortcuts/register.go
@@ -132,18 +132,18 @@ func RegisterOfflineMeetingManagementPreflight(ctx context.Context, program *cob
 			continue
 		}
 		if !shortcut.ConfirmationBeforeNetwork || shortcut.Normalize != nil || shortcut.OnInvoke != nil {
-			return fmt.Errorf("offline preflight invariant failed for vc %s", shortcut.Command)
+			return errs.NewInternalError(errs.SubtypeUnknown, "offline preflight invariant failed for vc %s", shortcut.Command)
 		}
 		for _, flag := range shortcut.Flags {
 			if len(flag.Input) != 0 {
-				return fmt.Errorf("offline preflight input invariant failed for vc %s --%s", shortcut.Command, flag.Name)
+				return errs.NewInternalError(errs.SubtypeUnknown, "offline preflight input invariant failed for vc %s --%s", shortcut.Command, flag.Name)
 			}
 		}
 		shortcut.MountOfflinePreflightWithContext(ctx, vcGroup, f)
 		found[shortcut.Command] = struct{}{}
 	}
 	if len(found) != len(offlineMeetingManagementCommands) {
-		return fmt.Errorf("offline meeting-management preflight registry is incomplete")
+		return errs.NewInternalError(errs.SubtypeUnknown, "offline meeting-management preflight registry is incomplete")
 	}
 	return nil
 }

--- a/shortcuts/vc/shortcuts.go
+++ b/shortcuts/vc/shortcuts.go
@@ -21,5 +21,6 @@ func Shortcuts() []common.Shortcut {
 		VCMeetingMessageSend,
 		VCMeetingScreenshot,
 		VCMeetingCountdown,
+		VCMeetingParticipantKickout,
 	}
 }

--- a/shortcuts/vc/skill_docs_test.go
+++ b/shortcuts/vc/skill_docs_test.go
@@ -84,6 +84,66 @@ func TestVCBotShortcutsIdentityDocsMatchAuthTypes(t *testing.T) {
 	}
 }
 
+func TestVCMeetingManagementDocsMatchAuthTypesAndContracts(t *testing.T) {
+	skill := readSkillDoc(t, "skills/lark-meeting/SKILL.md")
+
+	for _, cmd := range []struct {
+		name      string
+		authTypes []string
+		reference string
+		sceneNeed string
+		bot       bool
+	}{
+		{
+			name:      "+meeting-end",
+			authTypes: VCMeetingEnd.AuthTypes,
+			reference: "lark-vc-meeting-end.md",
+			sceneNeed: "vc +meeting-end",
+			bot:       true,
+		},
+		{
+			name:      "+meeting-participant-kickout",
+			authTypes: VCMeetingParticipantKickout.AuthTypes,
+			reference: "lark-vc-meeting-participant-kickout.md",
+			sceneNeed: "vc +meeting-participant-kickout",
+		},
+	} {
+		t.Run(cmd.name, func(t *testing.T) {
+			if !hasAuthType(cmd.authTypes, "user") || hasAuthType(cmd.authTypes, "bot") != cmd.bot {
+				t.Fatalf("%s AuthTypes = %v, want user support with bot=%v", cmd.name, cmd.authTypes, cmd.bot)
+			}
+			if !strings.Contains(skill, "references/"+cmd.reference) {
+				t.Fatalf("skills/lark-meeting/SKILL.md must link %s to %s", cmd.name, cmd.reference)
+			}
+
+			reference := readSkillDoc(t, "skills/lark-meeting/references/"+cmd.reference)
+			if cmd.bot {
+				if !strings.Contains(reference, "--as user") || !strings.Contains(reference, "--as bot") {
+					t.Fatalf("%s must document both identities for %s", cmd.reference, cmd.name)
+				}
+			} else if !strings.Contains(reference, "仅支持 `user` 身份") && !strings.Contains(reference, "必须显式使用 `--as user`") {
+				t.Fatalf("%s must state that %s is user-only", cmd.reference, cmd.name)
+			}
+			if !strings.Contains(reference, "--dry-run") || !strings.Contains(reference, "--yes") {
+				t.Fatalf("%s must document both --dry-run preview and --yes confirmation", cmd.reference)
+			}
+		})
+	}
+
+	scene := readSkillDoc(t, "skills/lark-meeting/scenes/live-meeting-interact.md")
+	for _, needle := range []string{
+		"vc +meeting-end",
+		"vc +meeting-participant-kickout",
+		"vc meeting get",
+		"--dry-run",
+		"--yes",
+	} {
+		if !strings.Contains(scene, needle) {
+			t.Errorf("live-meeting-interact.md must mention %q for meeting management routing", needle)
+		}
+	}
+}
+
 func TestMeetingArtifactSceneDelegatesToDomainOwners(t *testing.T) {
 	scene := readSkillDoc(t, "skills/lark-meeting/scenes/query-meeting-and-artifacts.md")
 	for _, target := range []string{

--- a/shortcuts/vc/skill_docs_test.go
+++ b/shortcuts/vc/skill_docs_test.go
@@ -88,18 +88,18 @@ func TestVCMeetingManagementDocsMatchAuthTypesAndContracts(t *testing.T) {
 	skill := readSkillDoc(t, "skills/lark-meeting/SKILL.md")
 
 	for _, cmd := range []struct {
-		name      string
-		authTypes []string
-		reference string
-		sceneNeed string
-		bot       bool
+		name         string
+		authTypes    []string
+		reference    string
+		botReference string
+		sceneNeed    string
 	}{
 		{
-			name:      "+meeting-end",
-			authTypes: VCMeetingEnd.AuthTypes,
-			reference: "lark-vc-meeting-end.md",
-			sceneNeed: "vc +meeting-end",
-			bot:       true,
+			name:         "+meeting-end",
+			authTypes:    VCMeetingEnd.AuthTypes,
+			reference:    "lark-vc-meeting-end.md",
+			botReference: "lark-vc-agent-meeting-end.md",
+			sceneNeed:    "vc +meeting-end",
 		},
 		{
 			name:      "+meeting-participant-kickout",
@@ -109,17 +109,28 @@ func TestVCMeetingManagementDocsMatchAuthTypesAndContracts(t *testing.T) {
 		},
 	} {
 		t.Run(cmd.name, func(t *testing.T) {
-			if !hasAuthType(cmd.authTypes, "user") || hasAuthType(cmd.authTypes, "bot") != cmd.bot {
-				t.Fatalf("%s AuthTypes = %v, want user support with bot=%v", cmd.name, cmd.authTypes, cmd.bot)
+			wantBot := cmd.botReference != ""
+			if !hasAuthType(cmd.authTypes, "user") || hasAuthType(cmd.authTypes, "bot") != wantBot {
+				t.Fatalf("%s AuthTypes = %v, want user support with bot=%v", cmd.name, cmd.authTypes, wantBot)
 			}
 			if !strings.Contains(skill, "references/"+cmd.reference) {
 				t.Fatalf("skills/lark-meeting/SKILL.md must link %s to %s", cmd.name, cmd.reference)
 			}
 
 			reference := readSkillDoc(t, "skills/lark-meeting/references/"+cmd.reference)
-			if cmd.bot {
-				if !strings.Contains(reference, "--as user") || !strings.Contains(reference, "--as bot") {
-					t.Fatalf("%s must document both identities for %s", cmd.reference, cmd.name)
+			if wantBot {
+				if !strings.Contains(reference, "--as user") || strings.Contains(reference, "--as bot") {
+					t.Fatalf("%s must document only the user identity for %s", cmd.reference, cmd.name)
+				}
+				if !strings.Contains(skill, "references/"+cmd.botReference) {
+					t.Fatalf("skills/lark-meeting/SKILL.md must link %s to %s", cmd.name, cmd.botReference)
+				}
+				if !strings.Contains(reference, "("+cmd.botReference+")") {
+					t.Fatalf("%s must link the bot identity reference %s", cmd.reference, cmd.botReference)
+				}
+				botReference := readSkillDoc(t, "skills/lark-meeting/references/"+cmd.botReference)
+				if !strings.Contains(botReference, "--as bot") {
+					t.Fatalf("%s must document bot identity support for %s", cmd.botReference, cmd.name)
 				}
 			} else if !strings.Contains(reference, "仅支持 `user` 身份") && !strings.Contains(reference, "必须显式使用 `--as user`") {
 				t.Fatalf("%s must state that %s is user-only", cmd.reference, cmd.name)

--- a/shortcuts/vc/vc_meeting_end.go
+++ b/shortcuts/vc/vc_meeting_end.go
@@ -8,54 +8,132 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-const meetingBotEndPath = "/open-apis/vc/v1/bots/end"
+const (
+	meetingBotEndPath      = "/open-apis/vc/v1/bots/end"
+	vcMeetingEndPathFormat = "/open-apis/vc/v1/meetings/%s/end"
+)
 
 type meetingEndRequest struct {
 	MeetingID string `json:"meeting_id"`
 }
 
-// VCMeetingEnd ends a meeting as the app bot when that bot is the current host.
+// VCMeetingEnd ends an ongoing meeting as either a user or the host app bot.
 var VCMeetingEnd = common.Shortcut{
-	Service:     "vc",
-	Command:     "+meeting-end",
-	Description: "End a meeting as the host app bot",
-	Risk:        "high-risk-write",
-	Scopes:      []string{"vc:meeting.bot.manage:write"},
-	AuthTypes:   []string{"bot"},
-	HasFormat:   true,
+	Service:                   "vc",
+	Command:                   "+meeting-end",
+	Description:               "End an ongoing meeting as a user or host app bot",
+	Risk:                      "high-risk-write",
+	Scopes:                    []string{},
+	ConditionalUserScopes:     []string{"vc:meeting"},
+	ConditionalBotScopes:      []string{"vc:meeting.bot.manage:write"},
+	ConfirmationBeforeNetwork: true,
+	AuthTypes:                 []string{"user", "bot"},
+	HasFormat:                 true,
 	Flags: []common.Flag{
 		{Name: "meeting-id", Required: true, Desc: "meeting ID to end"},
 	},
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		return validateMeetingIDFlag(runtime.Str("meeting-id"))
-	},
-	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	Validate: validateMeetingEnd,
+	DryRun:   buildMeetingEndDryRun,
+	Execute:  executeMeetingEnd,
+}
+
+func validateMeetingEnd(_ context.Context, runtime *common.RuntimeContext) error {
+	meetingID := runtime.Str("meeting-id")
+	switch runtime.As() {
+	case core.AsUser:
+		return validateMeetingManagementID(meetingID)
+	case core.AsBot:
+		return validateMeetingIDFlag(meetingID)
+	case core.AsAuto:
+		if runtime.Bool("dry-run") {
+			return explicitMeetingEndIdentityError()
+		}
+		// Offline confirmation preflight cannot observe the configured or
+		// credential-derived identity. Apply only the validation shared by both
+		// routes here; Execute validates again after full identity resolution.
+		return validateMeetingManagementID(meetingID)
+	default:
+		return explicitMeetingEndIdentityError()
+	}
+}
+
+func buildMeetingEndDryRun(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	switch runtime.As() {
+	case core.AsUser:
+		return common.NewDryRunAPI().PATCH(buildMeetingEndPath(runtime.Str("meeting-id")))
+	case core.AsBot:
 		return common.NewDryRunAPI().POST(meetingBotEndPath).Body(buildMeetingEndBody(runtime))
-	},
-	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		data, err := runtime.CallAPITyped(http.MethodPost, meetingBotEndPath, nil, buildMeetingEndBody(runtime))
-		if err != nil {
+	default:
+		// Validate rejects unresolved or unsupported identities before DryRun.
+		return common.NewDryRunAPI()
+	}
+}
+
+func executeMeetingEnd(_ context.Context, runtime *common.RuntimeContext) error {
+	meetingID := strings.TrimSpace(runtime.Str("meeting-id"))
+	switch runtime.As() {
+	case core.AsUser:
+		if err := validateMeetingManagementID(meetingID); err != nil {
 			return err
 		}
-		meetingID := strings.TrimSpace(runtime.Str("meeting-id"))
-		if data == nil {
-			data = map[string]interface{}{}
+		return executeUserMeetingEnd(runtime, meetingID)
+	case core.AsBot:
+		if err := validateMeetingIDFlag(meetingID); err != nil {
+			return err
 		}
-		output := make(map[string]interface{}, len(data)+1)
-		for key, value := range data {
-			output[key] = value
-		}
-		output["meeting_id"] = meetingID
-		runtime.OutFormat(output, nil, func(w io.Writer) {
-			fmt.Fprintf(w, "Ended meeting %s.\n", meetingID)
-		})
-		return nil
-	},
+		return executeBotMeetingEnd(runtime, meetingID)
+	default:
+		return explicitMeetingEndIdentityError()
+	}
+}
+
+func executeUserMeetingEnd(runtime *common.RuntimeContext, meetingID string) error {
+	if err := runtime.EnsureScopes([]string{"vc:meeting"}); err != nil {
+		return err
+	}
+	envelope, _, err := callMeetingManagementAPIEnvelope(runtime, http.MethodPatch, buildMeetingEndPath(meetingID), nil)
+	if err != nil {
+		return err
+	}
+	runtime.OutFormat(envelope, nil, nil)
+	return nil
+}
+
+func executeBotMeetingEnd(runtime *common.RuntimeContext, meetingID string) error {
+	if err := runtime.EnsureScopes([]string{"vc:meeting.bot.manage:write"}); err != nil {
+		return err
+	}
+	data, err := runtime.CallAPITyped(http.MethodPost, meetingBotEndPath, nil, meetingEndRequest{MeetingID: meetingID})
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		data = map[string]interface{}{}
+	}
+	output := make(map[string]interface{}, len(data)+1)
+	for key, value := range data {
+		output[key] = value
+	}
+	output["meeting_id"] = meetingID
+	runtime.OutFormat(output, nil, func(w io.Writer) {
+		fmt.Fprintf(w, "Ended meeting %s.\n", meetingID)
+	})
+	return nil
+}
+
+func explicitMeetingEndIdentityError() error {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"--dry-run for +meeting-end requires explicit --as user or --as bot because offline preflight cannot resolve default or automatic identity").
+		WithParam("--as")
 }
 
 func buildMeetingEndBody(runtime *common.RuntimeContext) meetingEndRequest {
@@ -64,4 +142,17 @@ func buildMeetingEndBody(runtime *common.RuntimeContext) meetingEndRequest {
 
 func validateMeetingIDFlag(value string) error {
 	return validateMeetingEventsMeetingID(value)
+}
+
+func validateMeetingManagementID(meetingID string) error {
+	meetingID = strings.TrimSpace(meetingID)
+	value, err := strconv.ParseInt(meetingID, 10, 64)
+	if err != nil || value <= 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--meeting-id must be a positive base-10 int64").WithParam("--meeting-id")
+	}
+	return nil
+}
+
+func buildMeetingEndPath(meetingID string) string {
+	return fmt.Sprintf(vcMeetingEndPathFormat, validate.EncodePathSegment(strings.TrimSpace(meetingID)))
 }

--- a/shortcuts/vc/vc_meeting_end.go
+++ b/shortcuts/vc/vc_meeting_end.go
@@ -100,7 +100,7 @@ func executeUserMeetingEnd(runtime *common.RuntimeContext, meetingID string) err
 	if err := runtime.EnsureScopes([]string{"vc:meeting"}); err != nil {
 		return err
 	}
-	envelope, _, err := callMeetingManagementAPIEnvelope(runtime, http.MethodPatch, buildMeetingEndPath(meetingID), nil)
+	envelope, _, err := callMeetingManagementAPIEnvelope(runtime, http.MethodPatch, buildMeetingEndPath(meetingID), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/shortcuts/vc/vc_meeting_end_test.go
+++ b/shortcuts/vc/vc_meeting_end_test.go
@@ -275,7 +275,7 @@ func TestMeetingEndDryRunDoesNotResolveScopesOrCallAPI(t *testing.T) {
 func TestMeetingEndExecuteScopePreflightRunsBeforeAPI(t *testing.T) {
 	f, accountResolver, _, reg, stdout := newMeetingManagementFactoryWithCounters(t)
 	resolver := &meetingManagementCountingTokenResolver{
-		result: &credential.TokenResult{Token: "uat-test", Scopes: ""},
+		result: &credential.TokenResult{Token: "uat-test", Scopes: "vc:record:readonly"},
 	}
 	f.Credential = credential.NewCredentialProvider(nil, accountResolver, resolver, nil)
 	apiCalls := 0

--- a/shortcuts/vc/vc_meeting_end_test.go
+++ b/shortcuts/vc/vc_meeting_end_test.go
@@ -1,0 +1,471 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestMeetingEndContract(t *testing.T) {
+	if VCMeetingEnd.Risk != "high-risk-write" {
+		t.Fatalf("Risk = %q, want high-risk-write", VCMeetingEnd.Risk)
+	}
+	if !VCMeetingEnd.ConfirmationBeforeNetwork {
+		t.Fatal("ConfirmationBeforeNetwork = false, want true")
+	}
+	if !reflect.DeepEqual(VCMeetingEnd.Scopes, []string{}) {
+		t.Fatalf("Scopes = %#v, want explicit empty slice", VCMeetingEnd.Scopes)
+	}
+	if len(VCMeetingEnd.ConditionalUserScopes) != 1 || VCMeetingEnd.ConditionalUserScopes[0] != "vc:meeting" {
+		t.Fatalf("ConditionalUserScopes = %v, want [vc:meeting]", VCMeetingEnd.ConditionalUserScopes)
+	}
+	if len(VCMeetingEnd.ConditionalBotScopes) != 1 || VCMeetingEnd.ConditionalBotScopes[0] != "vc:meeting.bot.manage:write" {
+		t.Fatalf("ConditionalBotScopes = %v, want [vc:meeting.bot.manage:write]", VCMeetingEnd.ConditionalBotScopes)
+	}
+	if got := VCMeetingEnd.DeclaredScopesForIdentity("user"); len(got) != 1 || got[0] != "vc:meeting" {
+		t.Fatalf("DeclaredScopesForIdentity(user) = %v, want [vc:meeting]", got)
+	}
+	if got := VCMeetingEnd.DeclaredScopesForIdentity("bot"); len(got) != 1 || got[0] != "vc:meeting.bot.manage:write" {
+		t.Fatalf("DeclaredScopesForIdentity(bot) = %v, want [vc:meeting.bot.manage:write]", got)
+	}
+	if !reflect.DeepEqual(VCMeetingEnd.AuthTypes, []string{"user", "bot"}) {
+		t.Fatalf("AuthTypes = %v, want [user bot]", VCMeetingEnd.AuthTypes)
+	}
+}
+
+type meetingManagementCountingTokenResolver struct {
+	requests []credential.TokenSpec
+	result   *credential.TokenResult
+	err      error
+}
+
+func (r *meetingManagementCountingTokenResolver) ResolveToken(_ context.Context, req credential.TokenSpec) (*credential.TokenResult, error) {
+	r.requests = append(r.requests, req)
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.result != nil {
+		resultCopy := *r.result
+		return &resultCopy, nil
+	}
+	return &credential.TokenResult{Token: "counting-token"}, nil
+}
+
+type meetingManagementCountingAccountResolver struct {
+	requests int
+	account  *credential.Account
+	err      error
+}
+
+func (r *meetingManagementCountingAccountResolver) ResolveAccount(_ context.Context) (*credential.Account, error) {
+	r.requests++
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.account != nil {
+		accountCopy := *r.account
+		return &accountCopy, nil
+	}
+	return credential.AccountFromCliConfig(defaultConfig()), nil
+}
+
+func newMeetingManagementFactoryWithCounters(t *testing.T) (*cmdutil.Factory, *meetingManagementCountingAccountResolver, *meetingManagementCountingTokenResolver, *httpmock.Registry, *bytes.Buffer) {
+	t.Helper()
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	accountResolver := &meetingManagementCountingAccountResolver{}
+	tokenResolver := &meetingManagementCountingTokenResolver{}
+	f.Credential = credential.NewCredentialProvider(nil, accountResolver, tokenResolver, nil)
+	return f, accountResolver, tokenResolver, reg, stdout
+}
+
+func TestMeetingEndValidateMeetingID(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "positive", value: "7651377260537433044"},
+		{name: "trimmed positive", value: " 7651377260537433044 "},
+		{name: "nine digit positive remains valid", value: "123456789"},
+		{name: "empty", value: "", wantErr: true},
+		{name: "whitespace", value: "   ", wantErr: true},
+		{name: "zero", value: "0", wantErr: true},
+		{name: "negative", value: "-1", wantErr: true},
+		{name: "non decimal", value: "0x10", wantErr: true},
+		{name: "fraction", value: "1.5", wantErr: true},
+		{name: "overflow", value: "9223372036854775808", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMeetingManagementID(tt.value)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("validateMeetingManagementID(%q) error = %v", tt.value, err)
+				}
+				return
+			}
+
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %T %v, want *errs.ValidationError", err, err)
+			}
+			if validationErr.Param != "--meeting-id" {
+				t.Fatalf("Param = %q, want --meeting-id", validationErr.Param)
+			}
+		})
+	}
+}
+
+func TestMeetingEndDryRunUsesEscapedPathWithoutAPICall(t *testing.T) {
+	tests := []struct {
+		identity string
+		method   string
+		url      string
+		wantBody map[string]interface{}
+	}{
+		{identity: "user", method: http.MethodPatch, url: "/open-apis/vc/v1/meetings/7651377260537433044/end"},
+		{identity: "bot", method: http.MethodPost, url: meetingBotEndPath, wantBody: map[string]interface{}{"meeting_id": "7651377260537433044"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.identity, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+			calls := 0
+			reg.Register(&httpmock.Stub{
+				Method:   tt.method,
+				URL:      tt.url,
+				Optional: true,
+				OnMatch: func(_ *http.Request) {
+					calls++
+				},
+			})
+
+			err := mountAndRun(t, VCMeetingEnd, []string{
+				"+meeting-end", "--meeting-id", " 7651377260537433044 ",
+				"--dry-run", "--as", tt.identity,
+			}, f, stdout)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if calls != 0 {
+				t.Fatalf("API calls = %d, want 0", calls)
+			}
+
+			var envelope struct {
+				Data struct {
+					API []struct {
+						Method string                 `json:"method"`
+						URL    string                 `json:"url"`
+						Body   map[string]interface{} `json:"body"`
+					} `json:"api"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+				t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
+			}
+			if len(envelope.Data.API) != 1 {
+				t.Fatalf("api calls = %#v, want one call", envelope.Data.API)
+			}
+			call := envelope.Data.API[0]
+			if call.Method != tt.method || call.URL != tt.url {
+				t.Fatalf("dry-run call = %#v, want %s %s", call, tt.method, tt.url)
+			}
+			if !reflect.DeepEqual(call.Body, tt.wantBody) {
+				t.Fatalf("dry-run body = %#v, want %#v", call.Body, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestMeetingEndDryRunRequiresExplicitIdentity(t *testing.T) {
+	for _, args := range [][]string{
+		{"+meeting-end", "--meeting-id", "7651377260537433044", "--dry-run"},
+		{"+meeting-end", "--meeting-id", "7651377260537433044", "--dry-run", "--as", "auto"},
+	} {
+		f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+		err := mountAndRun(t, VCMeetingEnd, args, f, stdout)
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("args %v error = %T %v, want *errs.ValidationError", args, err, err)
+		}
+		if validationErr.Param != "--as" {
+			t.Fatalf("args %v Param = %q, want --as", args, validationErr.Param)
+		}
+	}
+}
+
+func TestMeetingEndRequiresConfirmationWithoutAPICall(t *testing.T) {
+	f, accountResolver, resolver, reg, stdout := newMeetingManagementFactoryWithCounters(t)
+	calls := 0
+	reg.Register(&httpmock.Stub{
+		Method:   "PATCH",
+		URL:      "/open-apis/vc/v1/meetings/7651377260537433044/end",
+		Optional: true,
+		OnMatch: func(_ *http.Request) {
+			calls++
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingEnd, []string{
+		"+meeting-end", "--meeting-id", "7651377260537433044", "--as", "user",
+	}, f, stdout)
+	var confirmationErr *errs.ConfirmationRequiredError
+	if !errors.As(err, &confirmationErr) {
+		t.Fatalf("error = %T %v, want *errs.ConfirmationRequiredError", err, err)
+	}
+	if confirmationErr.Action != "vc +meeting-end" || confirmationErr.Risk != "high-risk-write" {
+		t.Fatalf("confirmation = %#v", confirmationErr)
+	}
+	if accountResolver.requests != 0 {
+		t.Fatalf("ResolveAccount calls = %d, want none before confirmation", accountResolver.requests)
+	}
+	if len(resolver.requests) != 0 {
+		t.Fatalf("ResolveToken calls = %v, want none before confirmation", resolver.requests)
+	}
+	if calls != 0 {
+		t.Fatalf("API calls = %d, want 0", calls)
+	}
+}
+
+func TestMeetingEndDryRunDoesNotResolveScopesOrCallAPI(t *testing.T) {
+	f, accountResolver, resolver, reg, stdout := newMeetingManagementFactoryWithCounters(t)
+	calls := 0
+	reg.Register(&httpmock.Stub{
+		Method:   "PATCH",
+		URL:      "/open-apis/vc/v1/meetings/7651377260537433044/end",
+		Optional: true,
+		OnMatch: func(_ *http.Request) {
+			calls++
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingEnd, []string{
+		"+meeting-end", "--meeting-id", "7651377260537433044",
+		"--dry-run", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if accountResolver.requests != 0 {
+		t.Fatalf("ResolveAccount calls = %d, want none during dry-run", accountResolver.requests)
+	}
+	if len(resolver.requests) != 0 {
+		t.Fatalf("ResolveToken calls = %v, want none during dry-run", resolver.requests)
+	}
+	if calls != 0 {
+		t.Fatalf("API calls = %d, want 0", calls)
+	}
+}
+
+func TestMeetingEndExecuteScopePreflightRunsBeforeAPI(t *testing.T) {
+	f, accountResolver, _, reg, stdout := newMeetingManagementFactoryWithCounters(t)
+	resolver := &meetingManagementCountingTokenResolver{
+		result: &credential.TokenResult{Token: "uat-test", Scopes: ""},
+	}
+	f.Credential = credential.NewCredentialProvider(nil, accountResolver, resolver, nil)
+	apiCalls := 0
+	reg.Register(&httpmock.Stub{
+		Method:   "PATCH",
+		URL:      "/open-apis/vc/v1/meetings/7651377260537433044/end",
+		Optional: true,
+		OnMatch: func(_ *http.Request) {
+			apiCalls++
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingEnd, []string{
+		"+meeting-end", "--meeting-id", "7651377260537433044",
+		"--yes", "--as", "user",
+	}, f, stdout)
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("error = %T %v, want *errs.PermissionError", err, err)
+	}
+	if permissionErr.Subtype != errs.SubtypeMissingScope {
+		t.Fatalf("Subtype = %q, want %q", permissionErr.Subtype, errs.SubtypeMissingScope)
+	}
+	if permissionErr.Identity != string(core.AsUser) {
+		t.Fatalf("Identity = %q, want %q", permissionErr.Identity, core.AsUser)
+	}
+	if len(permissionErr.MissingScopes) != 1 || permissionErr.MissingScopes[0] != "vc:meeting" {
+		t.Fatalf("MissingScopes = %v, want [vc:meeting]", permissionErr.MissingScopes)
+	}
+	if accountResolver.requests != 1 {
+		t.Fatalf("ResolveAccount calls = %d, want exactly one live config load", accountResolver.requests)
+	}
+	if len(resolver.requests) != 1 {
+		t.Fatalf("ResolveToken calls = %v, want exactly one scope preflight call", resolver.requests)
+	}
+	if apiCalls != 0 {
+		t.Fatalf("API calls = %d, want 0 because scope preflight must fail before HTTP", apiCalls)
+	}
+}
+
+func TestMeetingEndExecuteUsesNilBodyAndTypedAPIError(t *testing.T) {
+	tests := []struct {
+		name        string
+		response    map[string]interface{}
+		wantErr     bool
+		wantSubtype errs.Subtype
+	}{
+		{
+			name: "success",
+			response: map[string]interface{}{
+				"code":        0,
+				"msg":         "ok",
+				"log_id":      "log-meeting-end-success",
+				"server_meta": "preserved",
+				"data":        map[string]interface{}{"ended": true, "server_detail": "preserved"},
+			},
+		},
+		{
+			name:        "permission denied",
+			response:    map[string]interface{}{"code": 121005, "msg": "no permission", "log_id": "log-meeting-end"},
+			wantErr:     true,
+			wantSubtype: errs.SubtypePermissionDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+			stub := &httpmock.Stub{
+				Method: "PATCH",
+				URL:    "/open-apis/vc/v1/meetings/7651377260537433044/end",
+				Body:   tt.response,
+				OnMatch: func(req *http.Request) {
+					if req.Body == nil {
+						return
+					}
+					body, readErr := io.ReadAll(req.Body)
+					if readErr != nil {
+						t.Errorf("read request body: %v", readErr)
+					}
+					if len(body) != 0 {
+						t.Errorf("request body = %q, want empty", body)
+					}
+				},
+			}
+			reg.Register(stub)
+
+			err := mountAndRun(t, VCMeetingEnd, []string{
+				"+meeting-end", "--meeting-id", "7651377260537433044",
+				"--yes", "--as", "user",
+			}, f, stdout)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				var envelope struct {
+					OK   bool `json:"ok"`
+					Data struct {
+						Code       int    `json:"code"`
+						Msg        string `json:"msg"`
+						LogID      string `json:"log_id"`
+						ServerMeta string `json:"server_meta"`
+						Data       struct {
+							Ended        bool   `json:"ended"`
+							ServerDetail string `json:"server_detail"`
+						} `json:"data"`
+					} `json:"data"`
+				}
+				if decodeErr := json.Unmarshal(stdout.Bytes(), &envelope); decodeErr != nil {
+					t.Fatalf("decode output: %v\n%s", decodeErr, stdout.String())
+				}
+				if !envelope.OK || envelope.Data.Code != 0 || envelope.Data.Msg != "ok" ||
+					envelope.Data.LogID != "log-meeting-end-success" || envelope.Data.ServerMeta != "preserved" ||
+					!envelope.Data.Data.Ended || envelope.Data.Data.ServerDetail != "preserved" {
+					t.Fatalf("envelope = %#v, want complete server envelope and data", envelope)
+				}
+				return
+			}
+
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Subtype != tt.wantSubtype || problem.LogID != "log-meeting-end" {
+				t.Fatalf("error = %T %v, problem = %#v", err, err, problem)
+			}
+		})
+	}
+}
+
+func TestMeetingEndBotExecuteUsesPostBodyAndDataOutput(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	stub := &httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    meetingBotEndPath,
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"server_detail": "preserved",
+			},
+		},
+	}
+	reg.Register(stub)
+
+	err := mountAndRun(t, VCMeetingEnd, []string{
+		"+meeting-end", "--meeting-id", " 7628568141510692381 ",
+		"--yes", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if !reflect.DeepEqual(body, map[string]interface{}{"meeting_id": "7628568141510692381"}) {
+		t.Fatalf("request body = %#v, want meeting_id only", body)
+	}
+
+	var envelope struct {
+		OK       bool                   `json:"ok"`
+		Identity string                 `json:"identity"`
+		Data     map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	wantData := map[string]interface{}{
+		"meeting_id":    "7628568141510692381",
+		"server_detail": "preserved",
+	}
+	if !envelope.OK || envelope.Identity != "bot" || !reflect.DeepEqual(envelope.Data, wantData) {
+		t.Fatalf("envelope = %#v, want bot data output %#v", envelope, wantData)
+	}
+}
+
+func TestBuildMeetingEndPathTrimsAndEscapesMeetingID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "trim", in: " 7651377260537433044 ", want: "/open-apis/vc/v1/meetings/7651377260537433044/end"},
+		{name: "escape segment", in: "1/2", want: "/open-apis/vc/v1/meetings/1%2F2/end"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildMeetingEndPath(tt.in); got != tt.want {
+				t.Fatalf("buildMeetingEndPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -1896,7 +1896,7 @@ func TestVCShortcuts_RegistersMeetingAgentCommands(t *testing.T) {
 	for _, shortcut := range got {
 		commands = append(commands, shortcut.Command)
 	}
-	want := []string{"+search", "+notes", "+recording", "+detail", "+meeting-join", "+meeting-invite", "+meeting-end", "+meeting-leave", "+meeting-list-active", "+meeting-events", "+meeting-message-send", "+meeting-screenshot", "+meeting-countdown"}
+	want := []string{"+search", "+notes", "+recording", "+detail", "+meeting-join", "+meeting-invite", "+meeting-end", "+meeting-leave", "+meeting-list-active", "+meeting-events", "+meeting-message-send", "+meeting-screenshot", "+meeting-countdown", "+meeting-participant-kickout"}
 	if !reflect.DeepEqual(commands, want) {
 		t.Fatalf("shortcut commands = %#v, want %#v", commands, want)
 	}

--- a/shortcuts/vc/vc_meeting_management.go
+++ b/shortcuts/vc/vc_meeting_management.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// callMeetingManagementAPIEnvelope keeps the successful OpenAPI envelope for
+// the meeting-management commands while reusing the shared typed response
+// classifier. Most shortcuts intentionally expose only the server's data field;
+// these commands also expose code, msg, log_id, and future top-level fields.
+func callMeetingManagementAPIEnvelope(runtime *common.RuntimeContext, method, path string, body any) (map[string]any, map[string]any, error) {
+	req := &larkcore.ApiReq{
+		HttpMethod: method,
+		ApiPath:    path,
+	}
+	if body != nil {
+		req.Body = body
+	}
+
+	resp, err := runtime.DoAPI(req)
+	if err != nil {
+		if errs.IsTyped(err) {
+			return nil, nil, err
+		}
+		return nil, nil, errs.WrapInternal(err)
+	}
+	if resp == nil {
+		return nil, nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting management API returned a nil response")
+	}
+
+	data, err := runtime.ClassifyAPIResponse(resp)
+	if err != nil {
+		return nil, data, err
+	}
+	parsed, err := client.ParseJSONResponse(resp)
+	if err != nil {
+		return nil, nil, client.WrapJSONResponseParseError(err, resp.RawBody)
+	}
+	envelope, ok := parsed.(map[string]any)
+	if !ok {
+		return nil, nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting management API returned a non-object JSON response")
+	}
+	if _, present := envelope["log_id"]; !present {
+		if logID := resp.Header.Get("x-tt-logid"); logID != "" {
+			envelope["log_id"] = logID
+		}
+	}
+	return envelope, data, nil
+}

--- a/shortcuts/vc/vc_meeting_management.go
+++ b/shortcuts/vc/vc_meeting_management.go
@@ -4,6 +4,8 @@
 package vc
 
 import (
+	"fmt"
+
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
 	"github.com/larksuite/cli/errs"
@@ -15,10 +17,11 @@ import (
 // the meeting-management commands while reusing the shared typed response
 // classifier. Most shortcuts intentionally expose only the server's data field;
 // these commands also expose code, msg, log_id, and future top-level fields.
-func callMeetingManagementAPIEnvelope(runtime *common.RuntimeContext, method, path string, body any) (map[string]any, map[string]any, error) {
+func callMeetingManagementAPIEnvelope(runtime *common.RuntimeContext, method, path string, params map[string]interface{}, body any) (map[string]any, map[string]any, error) {
 	req := &larkcore.ApiReq{
-		HttpMethod: method,
-		ApiPath:    path,
+		HttpMethod:  method,
+		ApiPath:     path,
+		QueryParams: meetingManagementQueryParams(params),
 	}
 	if body != nil {
 		req.Body = body
@@ -53,4 +56,23 @@ func callMeetingManagementAPIEnvelope(runtime *common.RuntimeContext, method, pa
 		}
 	}
 	return envelope, data, nil
+}
+
+func meetingManagementQueryParams(params map[string]interface{}) larkcore.QueryParams {
+	queryParams := make(larkcore.QueryParams)
+	for key, value := range params {
+		switch typed := value.(type) {
+		case []string:
+			for _, item := range typed {
+				queryParams.Add(key, item)
+			}
+		case []interface{}:
+			for _, item := range typed {
+				queryParams.Add(key, fmt.Sprintf("%v", item))
+			}
+		default:
+			queryParams.Set(key, fmt.Sprintf("%v", value))
+		}
+	}
+	return queryParams
 }

--- a/shortcuts/vc/vc_meeting_management_test.go
+++ b/shortcuts/vc/vc_meeting_management_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+type meetingManagementErrorTokenResolver struct {
+	err error
+}
+
+func (r *meetingManagementErrorTokenResolver) ResolveToken(context.Context, credential.TokenSpec) (*credential.TokenResult, error) {
+	return nil, r.err
+}
+
+func TestCallMeetingManagementAPIEnvelopePreservesTypedDoAPIErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "authentication",
+			err:  errs.NewAuthenticationError(errs.SubtypeTokenExpired, "token expired"),
+		},
+		{
+			name: "network",
+			err:  errs.NewNetworkError(errs.SubtypeNetworkTransport, "network unavailable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			f, _, _, _ := cmdutil.TestFactory(t, cfg)
+			f.Credential = credential.NewCredentialProvider(nil, nil, &meetingManagementErrorTokenResolver{err: tt.err}, nil)
+			runtime := common.TestNewRuntimeContextForAPI(
+				context.Background(),
+				&cobra.Command{Use: "+meeting-end"},
+				cfg,
+				f,
+				core.AsUser,
+			)
+
+			envelope, data, gotErr := callMeetingManagementAPIEnvelope(
+				runtime,
+				http.MethodPatch,
+				"/open-apis/vc/v1/meetings/7651377260537433044/end",
+				nil,
+			)
+			if gotErr != tt.err {
+				t.Fatalf("error = %T %v, want original %T %v", gotErr, gotErr, tt.err, tt.err)
+			}
+			if envelope != nil || data != nil {
+				t.Fatalf("envelope, data = %#v, %#v, want nil, nil", envelope, data)
+			}
+		})
+	}
+}
+
+func TestCallMeetingManagementAPIEnvelopeInjectsHeaderLogIDWithoutDroppingServerFields(t *testing.T) {
+	cfg := defaultConfig()
+	f, _, _, reg := cmdutil.TestFactory(t, cfg)
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPatch,
+		URL:    "/open-apis/vc/v1/meetings/7651377260537433044/end",
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+			"X-Tt-Logid":   []string{"header-log-id"},
+		},
+		Body: map[string]any{
+			"code":        0,
+			"msg":         "ok",
+			"server_meta": "preserved",
+			"data": map[string]any{
+				"ended":         true,
+				"server_detail": "preserved",
+			},
+		},
+	})
+	runtime := common.TestNewRuntimeContextForAPI(
+		context.Background(),
+		&cobra.Command{Use: "+meeting-end"},
+		cfg,
+		f,
+		core.AsUser,
+	)
+
+	envelope, data, err := callMeetingManagementAPIEnvelope(
+		runtime,
+		http.MethodPatch,
+		"/open-apis/vc/v1/meetings/7651377260537433044/end",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envelope["log_id"] != "header-log-id" {
+		t.Fatalf("log_id = %#v, want header-log-id", envelope["log_id"])
+	}
+	if envelope["server_meta"] != "preserved" {
+		t.Fatalf("server_meta = %#v, want preserved", envelope["server_meta"])
+	}
+	if envelopeData, ok := envelope["data"].(map[string]any); !ok {
+		t.Fatalf("envelope data = %T %#v, want object", envelope["data"], envelope["data"])
+	} else if envelopeData["ended"] != true || envelopeData["server_detail"] != "preserved" {
+		t.Fatalf("envelope data = %#v, want all server fields preserved", envelopeData)
+	}
+	if data["ended"] != true || data["server_detail"] != "preserved" {
+		t.Fatalf("classified data = %#v, want all server fields preserved", data)
+	}
+}

--- a/shortcuts/vc/vc_meeting_management_test.go
+++ b/shortcuts/vc/vc_meeting_management_test.go
@@ -59,6 +59,7 @@ func TestCallMeetingManagementAPIEnvelopePreservesTypedDoAPIErrors(t *testing.T)
 				http.MethodPatch,
 				"/open-apis/vc/v1/meetings/7651377260537433044/end",
 				nil,
+				nil,
 			)
 			if gotErr != tt.err {
 				t.Fatalf("error = %T %v, want original %T %v", gotErr, gotErr, tt.err, tt.err)
@@ -102,6 +103,7 @@ func TestCallMeetingManagementAPIEnvelopeInjectsHeaderLogIDWithoutDroppingServer
 		runtime,
 		http.MethodPatch,
 		"/open-apis/vc/v1/meetings/7651377260537433044/end",
+		nil,
 		nil,
 	)
 	if err != nil {

--- a/shortcuts/vc/vc_meeting_participant_kickout.go
+++ b/shortcuts/vc/vc_meeting_participant_kickout.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const (
+	vcMeetingParticipantKickoutPathFormat = "/open-apis/vc/v1/meetings/%s/kickout"
+	minMeetingKickoutParticipants         = 1
+	maxMeetingKickoutParticipants         = 10
+	minMeetingKickoutUserType             = 1
+	maxMeetingKickoutUserType             = 7
+)
+
+type meetingParticipantKickoutUser struct {
+	ID       string `json:"id"`
+	UserType int    `json:"user_type"`
+}
+
+type meetingParticipantKickoutBody struct {
+	KickoutUsers []meetingParticipantKickoutUser `json:"kickout_users"`
+}
+
+// VCMeetingParticipantKickout removes one or more participants from an ongoing meeting.
+var VCMeetingParticipantKickout = common.Shortcut{
+	Service:                   "vc",
+	Command:                   "+meeting-participant-kickout",
+	Description:               "Remove one or more participants from an ongoing meeting",
+	Risk:                      "high-risk-write",
+	ConfirmationBeforeNetwork: true,
+	ConditionalUserScopes:     []string{"vc:meeting"},
+	AuthTypes:                 []string{"user"},
+	HasFormat:                 true,
+	Flags: []common.Flag{
+		{Name: "meeting-id", Required: true, Desc: "positive integer meeting ID"},
+		{Name: "participant", Type: "string_array", Required: true, Desc: "participant tuple <id>=<user_type>; repeat 1 to 10 times"},
+	},
+	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+		if err := validateMeetingManagementID(runtime.Str("meeting-id")); err != nil {
+			return err
+		}
+		_, err := parseMeetingParticipantKickoutUsers(runtime.StrArray("participant"))
+		return err
+	},
+	DryRun: func(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		body, err := buildMeetingParticipantKickoutBody(runtime)
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		return common.NewDryRunAPI().
+			POST(buildMeetingParticipantKickoutPath(runtime.Str("meeting-id"))).
+			Body(body)
+	},
+	Execute: func(_ context.Context, runtime *common.RuntimeContext) error {
+		body, err := buildMeetingParticipantKickoutBody(runtime)
+		if err != nil {
+			return err
+		}
+		if err := runtime.EnsureScopes([]string{"vc:meeting"}); err != nil {
+			return err
+		}
+		envelope, data, err := callMeetingManagementAPIEnvelope(
+			runtime,
+			http.MethodPost,
+			buildMeetingParticipantKickoutPath(runtime.Str("meeting-id")),
+			body,
+		)
+		if err != nil {
+			return err
+		}
+		if err := validateMeetingParticipantKickoutResponse(data, body.KickoutUsers); err != nil {
+			return err
+		}
+		// Keep the server's kickout_results fields, values, and order intact for
+		// every output format; no client-side projection or conflict resolution.
+		runtime.OutFormat(envelope, nil, nil)
+		return nil
+	},
+}
+
+func validateMeetingParticipantKickoutResponse(data map[string]interface{}, requested []meetingParticipantKickoutUser) error {
+	if data == nil {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response is missing data")
+	}
+	rawResults, ok := data["kickout_results"]
+	if !ok {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response is missing kickout_results")
+	}
+	encoded, err := json.Marshal(rawResults)
+	if err != nil {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response has invalid kickout_results").WithCause(err)
+	}
+	var results []map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &results); err != nil {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response has invalid kickout_results").WithCause(err)
+	}
+
+	want := make(map[string]struct{}, len(requested))
+	for _, participant := range requested {
+		key, ok := meetingParticipantTupleKey(participant.ID, participant.UserType)
+		if !ok {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout request contains an invalid tuple")
+		}
+		want[key] = struct{}{}
+	}
+	if len(results) != len(want) {
+		return errs.NewInternalError(
+			errs.SubtypeInvalidResponse,
+			"meeting participant kickout response returned %d result(s), want %d unique requested tuple(s)",
+			len(results),
+			len(want),
+		)
+	}
+
+	seen := make(map[string]struct{}, len(results))
+	for index, result := range results {
+		rawID, hasID := result["id"]
+		rawUserType, hasUserType := result["user_type"]
+		_, hasResult := result["result"]
+		if !hasID || !hasUserType || !hasResult {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout result %d is missing id, user_type, or result", index)
+		}
+		var userType int
+		if err := json.Unmarshal(rawUserType, &userType); err != nil || userType < minMeetingKickoutUserType || userType > maxMeetingKickoutUserType {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout result %d has invalid user_type", index)
+		}
+		key, ok := meetingParticipantResponseTupleKey(rawID, userType)
+		if !ok {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout result %d has invalid id", index)
+		}
+		if _, exists := want[key]; !exists {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response returned an unrequested tuple")
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response returned a duplicate tuple")
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+// meetingParticipantResponseTupleKey accepts the response's canonical i64 JSON
+// number and the historical string representation. It normalizes only the
+// private correlation key; the original server envelope remains untouched.
+func meetingParticipantResponseTupleKey(rawID json.RawMessage, userType int) (string, bool) {
+	if len(rawID) == 0 || string(rawID) == "null" {
+		return "", false
+	}
+	id := string(rawID)
+	if rawID[0] == '"' {
+		if err := json.Unmarshal(rawID, &id); err != nil {
+			return "", false
+		}
+	}
+	return meetingParticipantTupleKey(id, userType)
+}
+
+func meetingParticipantTupleKey(id string, userType int) (string, bool) {
+	idValue, err := strconv.ParseInt(id, 10, 64)
+	if err != nil || idValue <= 0 {
+		return "", false
+	}
+	return fmt.Sprintf("%d/%d", idValue, userType), true
+}
+
+func buildMeetingParticipantKickoutPath(meetingID string) string {
+	return fmt.Sprintf(vcMeetingParticipantKickoutPathFormat, validate.EncodePathSegment(strings.TrimSpace(meetingID)))
+}
+
+func buildMeetingParticipantKickoutBody(runtime *common.RuntimeContext) (meetingParticipantKickoutBody, error) {
+	users, err := parseMeetingParticipantKickoutUsers(runtime.StrArray("participant"))
+	if err != nil {
+		return meetingParticipantKickoutBody{}, err
+	}
+	return meetingParticipantKickoutBody{KickoutUsers: users}, nil
+}
+
+func parseMeetingParticipantKickoutUsers(values []string) ([]meetingParticipantKickoutUser, error) {
+	if len(values) < minMeetingKickoutParticipants || len(values) > maxMeetingKickoutParticipants {
+		return nil, errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--participant must be repeated between %d and %d times",
+			minMeetingKickoutParticipants,
+			maxMeetingKickoutParticipants,
+		).WithParam("--participant")
+	}
+
+	users := make([]meetingParticipantKickoutUser, 0, len(values))
+	for index, value := range values {
+		if strings.Count(value, "=") != 1 {
+			return nil, invalidMeetingParticipantTuple(index, "must contain exactly one '='")
+		}
+		parts := strings.SplitN(value, "=", 2)
+		if parts[0] == "" {
+			return nil, invalidMeetingParticipantTuple(index, "id must not be empty")
+		}
+		if strings.TrimSpace(parts[0]) != parts[0] {
+			return nil, invalidMeetingParticipantTuple(index, "id must not have surrounding whitespace")
+		}
+		idValue, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil || idValue <= 0 {
+			return nil, invalidMeetingParticipantTuple(index, "id must be a positive base-10 int64")
+		}
+		userType, err := strconv.Atoi(parts[1])
+		if err != nil || userType < minMeetingKickoutUserType || userType > maxMeetingKickoutUserType {
+			return nil, invalidMeetingParticipantTuple(index, "user_type must be an integer from 1 to 7")
+		}
+		users = append(users, meetingParticipantKickoutUser{
+			ID:       parts[0],
+			UserType: userType,
+		})
+	}
+	return users, nil
+}
+
+func invalidMeetingParticipantTuple(index int, reason string) error {
+	return errs.NewValidationError(
+		errs.SubtypeInvalidArgument,
+		"--participant value %d %s; expected <id>=<user_type>",
+		index+1,
+		reason,
+	).WithParam("--participant")
+}

--- a/shortcuts/vc/vc_meeting_participant_kickout.go
+++ b/shortcuts/vc/vc_meeting_participant_kickout.go
@@ -40,6 +40,7 @@ var VCMeetingParticipantKickout = common.Shortcut{
 	Description:               "Remove one or more participants from an ongoing meeting",
 	Risk:                      "high-risk-write",
 	ConfirmationBeforeNetwork: true,
+	Scopes:                    []string{},
 	ConditionalUserScopes:     []string{"vc:meeting"},
 	AuthTypes:                 []string{"user"},
 	HasFormat:                 true,
@@ -107,6 +108,10 @@ func validateMeetingParticipantKickoutResponse(data map[string]interface{}, requ
 		return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response has invalid kickout_results").WithCause(err)
 	}
 
+	// OpenAPI preserves the original request body but normalizes identical
+	// participant tuples to the first occurrence before executing HostManage.
+	// Correlate against that normalized tuple set so a successful destructive
+	// request is not reported as failed merely because the input had duplicates.
 	want := make(map[string]struct{}, len(requested))
 	for _, participant := range requested {
 		key, ok := meetingParticipantTupleKey(participant.ID, participant.UserType)
@@ -118,13 +123,12 @@ func validateMeetingParticipantKickoutResponse(data map[string]interface{}, requ
 	if len(results) != len(want) {
 		return errs.NewInternalError(
 			errs.SubtypeInvalidResponse,
-			"meeting participant kickout response returned %d result(s), want %d unique requested tuple(s)",
+			"meeting participant kickout response returned %d result(s), want %d normalized requested tuple(s)",
 			len(results),
 			len(want),
 		)
 	}
 
-	seen := make(map[string]struct{}, len(results))
 	for index, result := range results {
 		rawID, hasID := result["id"]
 		rawUserType, hasUserType := result["user_type"]
@@ -140,13 +144,13 @@ func validateMeetingParticipantKickoutResponse(data map[string]interface{}, requ
 		if !ok {
 			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout result %d has invalid id", index)
 		}
-		if _, exists := want[key]; !exists {
-			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response returned an unrequested tuple")
+		if _, requested := want[key]; !requested {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response returned an unrequested or excess tuple")
 		}
-		if _, duplicate := seen[key]; duplicate {
-			return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response returned a duplicate tuple")
-		}
-		seen[key] = struct{}{}
+		delete(want, key)
+	}
+	if len(want) != 0 {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "meeting participant kickout response is missing a requested tuple")
 	}
 	return nil
 }

--- a/shortcuts/vc/vc_meeting_participant_kickout.go
+++ b/shortcuts/vc/vc_meeting_participant_kickout.go
@@ -18,11 +18,14 @@ import (
 
 const (
 	vcMeetingParticipantKickoutPathFormat = "/open-apis/vc/v1/meetings/%s/kickout"
+	defaultMeetingKickoutUserIDType       = "open_id"
 	minMeetingKickoutParticipants         = 1
 	maxMeetingKickoutParticipants         = 10
 	minMeetingKickoutUserType             = 1
 	maxMeetingKickoutUserType             = 7
 )
+
+var meetingKickoutUserIDTypes = []string{"open_id", "union_id", "user_id"}
 
 type meetingParticipantKickoutUser struct {
 	ID       string `json:"id"`
@@ -46,7 +49,8 @@ var VCMeetingParticipantKickout = common.Shortcut{
 	HasFormat:                 true,
 	Flags: []common.Flag{
 		{Name: "meeting-id", Required: true, Desc: "positive integer meeting ID"},
-		{Name: "participant", Type: "string_array", Required: true, Desc: "participant tuple <id>=<user_type>; repeat 1 to 10 times"},
+		{Name: "user-id-type", Default: defaultMeetingKickoutUserIDType, Desc: "user ID type for kickout_users.id", Enum: meetingKickoutUserIDTypes},
+		{Name: "participant", Type: "string_array", Required: true, Desc: "kickout user tuple <user_id>=<user_type>; repeat 1 to 10 times"},
 	},
 	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
 		if err := validateMeetingManagementID(runtime.Str("meeting-id")); err != nil {
@@ -62,6 +66,7 @@ var VCMeetingParticipantKickout = common.Shortcut{
 		}
 		return common.NewDryRunAPI().
 			POST(buildMeetingParticipantKickoutPath(runtime.Str("meeting-id"))).
+			Params(buildMeetingParticipantKickoutParams(runtime)).
 			Body(body)
 	},
 	Execute: func(_ context.Context, runtime *common.RuntimeContext) error {
@@ -76,6 +81,7 @@ var VCMeetingParticipantKickout = common.Shortcut{
 			runtime,
 			http.MethodPost,
 			buildMeetingParticipantKickoutPath(runtime.Str("meeting-id")),
+			buildMeetingParticipantKickoutParams(runtime),
 			body,
 		)
 		if err != nil {
@@ -155,9 +161,6 @@ func validateMeetingParticipantKickoutResponse(data map[string]interface{}, requ
 	return nil
 }
 
-// meetingParticipantResponseTupleKey accepts the response's canonical i64 JSON
-// number and the historical string representation. It normalizes only the
-// private correlation key; the original server envelope remains untouched.
 func meetingParticipantResponseTupleKey(rawID json.RawMessage, userType int) (string, bool) {
 	if len(rawID) == 0 || string(rawID) == "null" {
 		return "", false
@@ -167,16 +170,20 @@ func meetingParticipantResponseTupleKey(rawID json.RawMessage, userType int) (st
 		if err := json.Unmarshal(rawID, &id); err != nil {
 			return "", false
 		}
+	} else if rawID[0] == '{' || rawID[0] == '[' {
+		return "", false
 	}
 	return meetingParticipantTupleKey(id, userType)
 }
 
 func meetingParticipantTupleKey(id string, userType int) (string, bool) {
-	idValue, err := strconv.ParseInt(id, 10, 64)
-	if err != nil || idValue <= 0 {
+	if id == "" || strings.TrimSpace(id) != id {
 		return "", false
 	}
-	return fmt.Sprintf("%d/%d", idValue, userType), true
+	if userType < minMeetingKickoutUserType || userType > maxMeetingKickoutUserType {
+		return "", false
+	}
+	return fmt.Sprintf("%s/%d", id, userType), true
 }
 
 func buildMeetingParticipantKickoutPath(meetingID string) string {
@@ -189,6 +196,14 @@ func buildMeetingParticipantKickoutBody(runtime *common.RuntimeContext) (meeting
 		return meetingParticipantKickoutBody{}, err
 	}
 	return meetingParticipantKickoutBody{KickoutUsers: users}, nil
+}
+
+func buildMeetingParticipantKickoutParams(runtime *common.RuntimeContext) map[string]interface{} {
+	userIDType := strings.TrimSpace(runtime.Str("user-id-type"))
+	if userIDType == "" {
+		userIDType = defaultMeetingKickoutUserIDType
+	}
+	return map[string]interface{}{"user_id_type": userIDType}
 }
 
 func parseMeetingParticipantKickoutUsers(values []string) ([]meetingParticipantKickoutUser, error) {
@@ -212,10 +227,6 @@ func parseMeetingParticipantKickoutUsers(values []string) ([]meetingParticipantK
 		}
 		if strings.TrimSpace(parts[0]) != parts[0] {
 			return nil, invalidMeetingParticipantTuple(index, "id must not have surrounding whitespace")
-		}
-		idValue, err := strconv.ParseInt(parts[0], 10, 64)
-		if err != nil || idValue <= 0 {
-			return nil, invalidMeetingParticipantTuple(index, "id must be a positive base-10 int64")
 		}
 		userType, err := strconv.Atoi(parts[1])
 		if err != nil || userType < minMeetingKickoutUserType || userType > maxMeetingKickoutUserType {

--- a/shortcuts/vc/vc_meeting_participant_kickout_test.go
+++ b/shortcuts/vc/vc_meeting_participant_kickout_test.go
@@ -1,0 +1,553 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestMeetingParticipantKickoutContract(t *testing.T) {
+	if VCMeetingParticipantKickout.Risk != "high-risk-write" {
+		t.Fatalf("Risk = %q, want high-risk-write", VCMeetingParticipantKickout.Risk)
+	}
+	if !VCMeetingParticipantKickout.ConfirmationBeforeNetwork {
+		t.Fatal("ConfirmationBeforeNetwork = false, want true")
+	}
+	if len(VCMeetingParticipantKickout.Scopes) != 0 {
+		t.Fatalf("Scopes = %v, want []", VCMeetingParticipantKickout.Scopes)
+	}
+	if !reflect.DeepEqual(VCMeetingParticipantKickout.ConditionalUserScopes, []string{"vc:meeting"}) {
+		t.Fatalf("ConditionalUserScopes = %v, want [vc:meeting]", VCMeetingParticipantKickout.ConditionalUserScopes)
+	}
+	if got := VCMeetingParticipantKickout.DeclaredScopesForIdentity("user"); !reflect.DeepEqual(got, []string{"vc:meeting"}) {
+		t.Fatalf("DeclaredScopesForIdentity(user) = %v, want [vc:meeting]", got)
+	}
+	if !reflect.DeepEqual(VCMeetingParticipantKickout.AuthTypes, []string{"user"}) {
+		t.Fatalf("AuthTypes = %v, want [user]", VCMeetingParticipantKickout.AuthTypes)
+	}
+	for _, flag := range VCMeetingParticipantKickout.Flags {
+		if flag.Name == "participant" {
+			if flag.Type != "string_array" || !flag.Required {
+				t.Fatalf("participant flag = %#v, want required string_array", flag)
+			}
+			return
+		}
+	}
+	t.Fatal("participant flag is not declared")
+}
+
+func TestParseMeetingParticipantKickoutUsersPreservesOrderDuplicatesAndStringIDs(t *testing.T) {
+	input := []string{"000123=1", "000123=2", "000123=1"}
+	want := []meetingParticipantKickoutUser{
+		{ID: "000123", UserType: 1},
+		{ID: "000123", UserType: 2},
+		{ID: "000123", UserType: 1},
+	}
+
+	got, err := parseMeetingParticipantKickoutUsers(input)
+	if err != nil {
+		t.Fatalf("parseMeetingParticipantKickoutUsers() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("users = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseMeetingParticipantKickoutUsersValidation(t *testing.T) {
+	validTen := []string{"1=1", "2=2", "3=3", "4=4", "5=5", "6=6", "7=7", "8=1", "9=2", "10=3"}
+	tests := []struct {
+		name   string
+		values []string
+	}{
+		{name: "missing", values: nil},
+		{name: "too many", values: append(append([]string{}, validTen...), "11=4")},
+		{name: "missing equals", values: []string{"123"}},
+		{name: "multiple equals", values: []string{"123=1=2"}},
+		{name: "empty id", values: []string{" =1"}},
+		{name: "id has leading whitespace", values: []string{" 000123=1"}},
+		{name: "id has trailing whitespace", values: []string{"000123 =1"}},
+		{name: "id zero", values: []string{"0=1"}},
+		{name: "id negative", values: []string{"-1=1"}},
+		{name: "id non decimal", values: []string{"12a=1"}},
+		{name: "id overflow", values: []string{"9223372036854775808=1"}},
+		{name: "empty user type", values: []string{"123="}},
+		{name: "non integer user type", values: []string{"123=user"}},
+		{name: "user type below range", values: []string{"123=0"}},
+		{name: "user type above range", values: []string{"123=8"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseMeetingParticipantKickoutUsers(tt.values)
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %T %v, want *errs.ValidationError", err, err)
+			}
+			if validationErr.Param != "--participant" {
+				t.Fatalf("Param = %q, want --participant", validationErr.Param)
+			}
+		})
+	}
+
+	got, err := parseMeetingParticipantKickoutUsers(validTen)
+	if err != nil || len(got) != maxMeetingKickoutParticipants {
+		t.Fatalf("ten participants = %#v, %v", got, err)
+	}
+}
+
+func TestMeetingParticipantKickoutDryRunPreservesTuplesWithoutAPICall(t *testing.T) {
+	f, accountResolver, resolver, reg, stdout := newMeetingManagementFactoryWithCounters(t)
+	calls := 0
+	reg.Register(&httpmock.Stub{
+		Method:   "POST",
+		URL:      "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+		Optional: true,
+		OnMatch: func(_ *http.Request) {
+			calls++
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+		"+meeting-participant-kickout",
+		"--meeting-id", "7651377260537433044",
+		"--participant", "000123=1",
+		"--participant", "000123=2",
+		"--participant", "000123=1",
+		"--dry-run", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("API calls = %d, want 0", calls)
+	}
+	if accountResolver.requests != 0 {
+		t.Fatalf("ResolveAccount calls = %d, want none during dry-run", accountResolver.requests)
+	}
+	if len(resolver.requests) != 0 {
+		t.Fatalf("ResolveToken calls = %v, want none during dry-run", resolver.requests)
+	}
+
+	var envelope struct {
+		Data struct {
+			API []struct {
+				Method string                        `json:"method"`
+				URL    string                        `json:"url"`
+				Body   meetingParticipantKickoutBody `json:"body"`
+			} `json:"api"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
+	}
+	if len(envelope.Data.API) != 1 {
+		t.Fatalf("api calls = %#v, want one call", envelope.Data.API)
+	}
+	call := envelope.Data.API[0]
+	if call.Method != "POST" || call.URL != "/open-apis/vc/v1/meetings/7651377260537433044/kickout" {
+		t.Fatalf("dry-run call = %#v", call)
+	}
+	wantUsers := []meetingParticipantKickoutUser{
+		{ID: "000123", UserType: 1},
+		{ID: "000123", UserType: 2},
+		{ID: "000123", UserType: 1},
+	}
+	if !reflect.DeepEqual(call.Body.KickoutUsers, wantUsers) {
+		t.Fatalf("kickout_users = %#v, want %#v", call.Body.KickoutUsers, wantUsers)
+	}
+}
+
+func TestMeetingParticipantKickoutValidationStopsBeforeAnyAPICall(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "malformed participant tuple",
+			args: []string{
+				"+meeting-participant-kickout",
+				"--meeting-id", "7651377260537433044",
+				"--participant", " 000123=1",
+				"--yes", "--as", "user",
+			},
+		},
+		{
+			name: "participant id must be positive base-10 int64",
+			args: []string{
+				"+meeting-participant-kickout",
+				"--meeting-id", "7651377260537433044",
+				"--participant", "0=1",
+				"--yes", "--as", "user",
+			},
+		},
+		{
+			name: "missing participant",
+			args: []string{
+				"+meeting-participant-kickout",
+				"--meeting-id", "7651377260537433044",
+				"--yes", "--as", "user",
+			},
+		},
+		{
+			name: "too many participants",
+			args: []string{
+				"+meeting-participant-kickout",
+				"--meeting-id", "7651377260537433044",
+				"--participant", "1=1",
+				"--participant", "2=1",
+				"--participant", "3=1",
+				"--participant", "4=1",
+				"--participant", "5=1",
+				"--participant", "6=1",
+				"--participant", "7=1",
+				"--participant", "8=1",
+				"--participant", "9=1",
+				"--participant", "10=1",
+				"--participant", "11=1",
+				"--yes", "--as", "user",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, accountResolver, resolver, reg, stdout := newMeetingManagementFactoryWithCounters(t)
+			calls := 0
+			reg.Register(&httpmock.Stub{
+				Method:   "POST",
+				URL:      "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+				Optional: true,
+				OnMatch: func(_ *http.Request) {
+					calls++
+				},
+			})
+
+			err := mountAndRun(t, VCMeetingParticipantKickout, tt.args, f, stdout)
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %T %v, want *errs.ValidationError", err, err)
+			}
+			if validationErr.Param != "--participant" {
+				t.Fatalf("Param = %q, want --participant", validationErr.Param)
+			}
+			if accountResolver.requests != 0 {
+				t.Fatalf("ResolveAccount calls = %d, want 0", accountResolver.requests)
+			}
+			if len(resolver.requests) != 0 {
+				t.Fatalf("ResolveToken calls = %v, want none", resolver.requests)
+			}
+			if calls != 0 {
+				t.Fatalf("API calls = %d, want 0", calls)
+			}
+		})
+	}
+}
+
+func TestMeetingParticipantKickoutRequiresConfirmationWithoutAPICall(t *testing.T) {
+	f, accountResolver, resolver, reg, stdout := newMeetingManagementFactoryWithCounters(t)
+	calls := 0
+	reg.Register(&httpmock.Stub{
+		Method:   "POST",
+		URL:      "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+		Optional: true,
+		OnMatch: func(_ *http.Request) {
+			calls++
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+		"+meeting-participant-kickout",
+		"--meeting-id", "7651377260537433044",
+		"--participant", "000123=1",
+		"--as", "user",
+	}, f, stdout)
+	var confirmationErr *errs.ConfirmationRequiredError
+	if !errors.As(err, &confirmationErr) {
+		t.Fatalf("error = %T %v, want *errs.ConfirmationRequiredError", err, err)
+	}
+	if confirmationErr.Action != "vc +meeting-participant-kickout" || confirmationErr.Risk != "high-risk-write" {
+		t.Fatalf("confirmation = %#v", confirmationErr)
+	}
+	if accountResolver.requests != 0 {
+		t.Fatalf("ResolveAccount calls = %d, want none before confirmation", accountResolver.requests)
+	}
+	if len(resolver.requests) != 0 {
+		t.Fatalf("ResolveToken calls = %v, want none before confirmation", resolver.requests)
+	}
+	if calls != 0 {
+		t.Fatalf("API calls = %d, want 0", calls)
+	}
+}
+
+func TestMeetingParticipantKickoutExecuteScopePreflightRunsBeforeAPI(t *testing.T) {
+	f, accountResolver, _, reg, stdout := newMeetingManagementFactoryWithCounters(t)
+	resolver := &meetingManagementCountingTokenResolver{
+		result: &credential.TokenResult{Token: "uat-test", Scopes: ""},
+	}
+	f.Credential = credential.NewCredentialProvider(nil, accountResolver, resolver, nil)
+	apiCalls := 0
+	reg.Register(&httpmock.Stub{
+		Method:   "POST",
+		URL:      "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+		Optional: true,
+		OnMatch: func(_ *http.Request) {
+			apiCalls++
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+		"+meeting-participant-kickout",
+		"--meeting-id", "7651377260537433044",
+		"--participant", "000123=1",
+		"--yes", "--as", "user",
+	}, f, stdout)
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("error = %T %v, want *errs.PermissionError", err, err)
+	}
+	if permissionErr.Subtype != errs.SubtypeMissingScope {
+		t.Fatalf("Subtype = %q, want %q", permissionErr.Subtype, errs.SubtypeMissingScope)
+	}
+	if permissionErr.Identity != string(core.AsUser) {
+		t.Fatalf("Identity = %q, want %q", permissionErr.Identity, core.AsUser)
+	}
+	if len(permissionErr.MissingScopes) != 1 || permissionErr.MissingScopes[0] != "vc:meeting" {
+		t.Fatalf("MissingScopes = %v, want [vc:meeting]", permissionErr.MissingScopes)
+	}
+	if accountResolver.requests != 1 {
+		t.Fatalf("ResolveAccount calls = %d, want exactly one live config load", accountResolver.requests)
+	}
+	if len(resolver.requests) != 1 {
+		t.Fatalf("ResolveToken calls = %v, want exactly one scope preflight call", resolver.requests)
+	}
+	if apiCalls != 0 {
+		t.Fatalf("API calls = %d, want 0 because scope preflight must fail before HTTP", apiCalls)
+	}
+}
+
+func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *testing.T) {
+	for _, format := range []string{"json", "pretty"} {
+		t.Run(format, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+			stub := &httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+				Body: map[string]interface{}{
+					"code":         0,
+					"msg":          "ok",
+					"log_id":       "log-meeting-kickout-success",
+					"server_trace": "preserved",
+					"data": map[string]interface{}{
+						"server_page": "preserved",
+						"kickout_results": []interface{}{
+							map[string]interface{}{"id": "000456", "user_type": 2, "result": 7, "server_detail": "denied"},
+							map[string]interface{}{"id": "000123", "user_type": 1, "result": 1},
+						},
+					},
+				},
+			}
+			reg.Register(stub)
+
+			err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+				"+meeting-participant-kickout",
+				"--meeting-id", "7651377260537433044",
+				"--participant", "000123=1",
+				"--participant", "000456=2",
+				"--participant", "000123=1",
+				"--yes", "--format", format, "--as", "user",
+			}, f, stdout)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var request meetingParticipantKickoutBody
+			if err := json.Unmarshal(stub.CapturedBody, &request); err != nil {
+				t.Fatalf("decode request: %v\n%s", err, stub.CapturedBody)
+			}
+			wantUsers := []meetingParticipantKickoutUser{
+				{ID: "000123", UserType: 1},
+				{ID: "000456", UserType: 2},
+				{ID: "000123", UserType: 1},
+			}
+			if !reflect.DeepEqual(request.KickoutUsers, wantUsers) {
+				t.Fatalf("request kickout_users = %#v, want %#v", request.KickoutUsers, wantUsers)
+			}
+
+			var outputEnvelope struct {
+				OK   bool `json:"ok"`
+				Data struct {
+					Code        int    `json:"code"`
+					Msg         string `json:"msg"`
+					LogID       string `json:"log_id"`
+					ServerTrace string `json:"server_trace"`
+					Data        struct {
+						ServerPage     string `json:"server_page"`
+						KickoutResults []struct {
+							ID           string `json:"id"`
+							UserType     int    `json:"user_type"`
+							Result       int    `json:"result"`
+							ServerDetail string `json:"server_detail"`
+						} `json:"kickout_results"`
+					} `json:"data"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &outputEnvelope); err != nil {
+				t.Fatalf("decode %s output: %v\n%s", format, err, stdout.String())
+			}
+			if !outputEnvelope.OK || outputEnvelope.Data.Code != 0 || outputEnvelope.Data.Msg != "ok" ||
+				outputEnvelope.Data.LogID != "log-meeting-kickout-success" || outputEnvelope.Data.ServerTrace != "preserved" ||
+				outputEnvelope.Data.Data.ServerPage != "preserved" || len(outputEnvelope.Data.Data.KickoutResults) != 2 {
+				t.Fatalf("envelope = %#v, want complete server envelope and data", outputEnvelope)
+			}
+			wantResults := []struct {
+				ID           string `json:"id"`
+				UserType     int    `json:"user_type"`
+				Result       int    `json:"result"`
+				ServerDetail string `json:"server_detail"`
+			}{
+				{ID: "000456", UserType: 2, Result: 7, ServerDetail: "denied"},
+				{ID: "000123", UserType: 1, Result: 1},
+			}
+			if !reflect.DeepEqual(outputEnvelope.Data.Data.KickoutResults, wantResults) {
+				t.Fatalf("kickout_results = %#v, want %#v", outputEnvelope.Data.Data.KickoutResults, wantResults)
+			}
+		})
+	}
+}
+
+func TestValidateMeetingParticipantKickoutResponseTreatsResultAsOpaque(t *testing.T) {
+	requested := []meetingParticipantKickoutUser{{ID: "123", UserType: 1}}
+	for _, result := range []interface{}{7, "future-result", map[string]interface{}{"code": 9}, nil} {
+		data := map[string]interface{}{
+			"kickout_results": []interface{}{
+				map[string]interface{}{"id": "123", "user_type": 1, "result": result},
+			},
+		}
+		if err := validateMeetingParticipantKickoutResponse(data, requested); err != nil {
+			t.Fatalf("result %#v was interpreted instead of treated as opaque: %v", result, err)
+		}
+	}
+}
+
+func TestMeetingParticipantKickoutExecuteReturnsTypedAPIError(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+		Body:   map[string]interface{}{"code": 121005, "msg": "no permission", "log_id": "log-meeting-kickout"},
+	})
+
+	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+		"+meeting-participant-kickout",
+		"--meeting-id", "7651377260537433044",
+		"--participant", "000123=1",
+		"--yes", "--as", "user",
+	}, f, stdout)
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Subtype != errs.SubtypePermissionDenied || problem.LogID != "log-meeting-kickout" {
+		t.Fatalf("error = %T %v, problem = %#v", err, err, problem)
+	}
+}
+
+func TestMeetingParticipantKickoutExecuteRejectsMalformedSuccessData(t *testing.T) {
+	tests := []struct {
+		name string
+		data interface{}
+	}{
+		{name: "missing data", data: nil},
+		{name: "missing results", data: map[string]interface{}{}},
+		{name: "empty results", data: map[string]interface{}{"kickout_results": []interface{}{}}},
+		{name: "missing tuple field", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "000123", "result": 1}}}},
+		{name: "missing result field", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "000123", "user_type": 1}}}},
+		{name: "unrequested tuple", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "999", "user_type": 1, "result": 1}}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+			body := map[string]interface{}{"code": 0, "msg": "ok"}
+			if tt.data != nil {
+				body["data"] = tt.data
+			}
+			reg.Register(&httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+				Body:   body,
+			})
+
+			err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+				"+meeting-participant-kickout",
+				"--meeting-id", "7651377260537433044",
+				"--participant", "000123=1",
+				"--yes", "--as", "user",
+			}, f, stdout)
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("error = %T %v, problem = %#v, want internal/invalid_response", err, err, problem)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty on malformed success data", stdout.String())
+			}
+		})
+	}
+}
+
+func TestMeetingParticipantKickoutExecuteCorrelatesCanonicalServerIDWithoutRewritingEnvelope(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"kickout_results": []interface{}{
+					map[string]interface{}{"id": int64(123), "user_type": 1, "result": 1},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+		"+meeting-participant-kickout",
+		"--meeting-id", "7651377260537433044",
+		"--participant", "000123=1",
+		"--yes", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"id": 123`) {
+		t.Fatalf("stdout = %q, want untouched numeric server id", stdout.String())
+	}
+}
+
+func TestBuildMeetingParticipantKickoutPathTrimsAndEscapesMeetingID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "trim", in: " 7651377260537433044 ", want: "/open-apis/vc/v1/meetings/7651377260537433044/kickout"},
+		{name: "escape segment", in: "1/2", want: "/open-apis/vc/v1/meetings/1%2F2/kickout"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildMeetingParticipantKickoutPath(tt.in); got != tt.want {
+				t.Fatalf("buildMeetingParticipantKickoutPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/shortcuts/vc/vc_meeting_participant_kickout_test.go
+++ b/shortcuts/vc/vc_meeting_participant_kickout_test.go
@@ -25,8 +25,8 @@ func TestMeetingParticipantKickoutContract(t *testing.T) {
 	if !VCMeetingParticipantKickout.ConfirmationBeforeNetwork {
 		t.Fatal("ConfirmationBeforeNetwork = false, want true")
 	}
-	if len(VCMeetingParticipantKickout.Scopes) != 0 {
-		t.Fatalf("Scopes = %v, want []", VCMeetingParticipantKickout.Scopes)
+	if !reflect.DeepEqual(VCMeetingParticipantKickout.Scopes, []string{}) {
+		t.Fatalf("Scopes = %#v, want explicit empty slice", VCMeetingParticipantKickout.Scopes)
 	}
 	if !reflect.DeepEqual(VCMeetingParticipantKickout.ConditionalUserScopes, []string{"vc:meeting"}) {
 		t.Fatalf("ConditionalUserScopes = %v, want [vc:meeting]", VCMeetingParticipantKickout.ConditionalUserScopes)
@@ -171,8 +171,9 @@ func TestMeetingParticipantKickoutDryRunPreservesTuplesWithoutAPICall(t *testing
 
 func TestMeetingParticipantKickoutValidationStopsBeforeAnyAPICall(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
+		name              string
+		args              []string
+		wantRequiredError bool
 	}{
 		{
 			name: "malformed participant tuple",
@@ -193,7 +194,8 @@ func TestMeetingParticipantKickoutValidationStopsBeforeAnyAPICall(t *testing.T) 
 			},
 		},
 		{
-			name: "missing participant",
+			name:              "missing participant",
+			wantRequiredError: true,
 			args: []string{
 				"+meeting-participant-kickout",
 				"--meeting-id", "7651377260537433044",
@@ -235,12 +237,18 @@ func TestMeetingParticipantKickoutValidationStopsBeforeAnyAPICall(t *testing.T) 
 			})
 
 			err := mountAndRun(t, VCMeetingParticipantKickout, tt.args, f, stdout)
-			var validationErr *errs.ValidationError
-			if !errors.As(err, &validationErr) {
-				t.Fatalf("error = %T %v, want *errs.ValidationError", err, err)
-			}
-			if validationErr.Param != "--participant" {
-				t.Fatalf("Param = %q, want --participant", validationErr.Param)
+			if tt.wantRequiredError {
+				if err == nil || err.Error() != `required flag(s) "participant" not set` {
+					t.Fatalf("error = %T %v, want Cobra required-flag error", err, err)
+				}
+			} else {
+				var validationErr *errs.ValidationError
+				if !errors.As(err, &validationErr) {
+					t.Fatalf("error = %T %v, want *errs.ValidationError", err, err)
+				}
+				if validationErr.Param != "--participant" {
+					t.Fatalf("Param = %q, want --participant", validationErr.Param)
+				}
 			}
 			if accountResolver.requests != 0 {
 				t.Fatalf("ResolveAccount calls = %d, want 0", accountResolver.requests)
@@ -294,7 +302,7 @@ func TestMeetingParticipantKickoutRequiresConfirmationWithoutAPICall(t *testing.
 func TestMeetingParticipantKickoutExecuteScopePreflightRunsBeforeAPI(t *testing.T) {
 	f, accountResolver, _, reg, stdout := newMeetingManagementFactoryWithCounters(t)
 	resolver := &meetingManagementCountingTokenResolver{
-		result: &credential.TokenResult{Token: "uat-test", Scopes: ""},
+		result: &credential.TokenResult{Token: "uat-test", Scopes: "vc:record:readonly"},
 	}
 	f.Credential = credential.NewCredentialProvider(nil, accountResolver, resolver, nil)
 	apiCalls := 0
@@ -352,8 +360,8 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 					"data": map[string]interface{}{
 						"server_page": "preserved",
 						"kickout_results": []interface{}{
-							map[string]interface{}{"id": "000456", "user_type": 2, "result": 7, "server_detail": "denied"},
-							map[string]interface{}{"id": "000123", "user_type": 1, "result": 1},
+							map[string]interface{}{"id": "000456", "user_type": 2, "result": map[string]interface{}{"future_code": 9}, "server_detail": "second-first"},
+							map[string]interface{}{"id": "000123", "user_type": 1, "result": "future-result", "server_detail": "first-second"},
 						},
 					},
 				},
@@ -395,10 +403,10 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 					Data        struct {
 						ServerPage     string `json:"server_page"`
 						KickoutResults []struct {
-							ID           string `json:"id"`
-							UserType     int    `json:"user_type"`
-							Result       int    `json:"result"`
-							ServerDetail string `json:"server_detail"`
+							ID           string      `json:"id"`
+							UserType     int         `json:"user_type"`
+							Result       interface{} `json:"result"`
+							ServerDetail string      `json:"server_detail"`
 						} `json:"kickout_results"`
 					} `json:"data"`
 				} `json:"data"`
@@ -411,17 +419,11 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 				outputEnvelope.Data.Data.ServerPage != "preserved" || len(outputEnvelope.Data.Data.KickoutResults) != 2 {
 				t.Fatalf("envelope = %#v, want complete server envelope and data", outputEnvelope)
 			}
-			wantResults := []struct {
-				ID           string `json:"id"`
-				UserType     int    `json:"user_type"`
-				Result       int    `json:"result"`
-				ServerDetail string `json:"server_detail"`
-			}{
-				{ID: "000456", UserType: 2, Result: 7, ServerDetail: "denied"},
-				{ID: "000123", UserType: 1, Result: 1},
-			}
-			if !reflect.DeepEqual(outputEnvelope.Data.Data.KickoutResults, wantResults) {
-				t.Fatalf("kickout_results = %#v, want %#v", outputEnvelope.Data.Data.KickoutResults, wantResults)
+			results := outputEnvelope.Data.Data.KickoutResults
+			if results[0].ID != "000456" || results[0].UserType != 2 || results[0].ServerDetail != "second-first" ||
+				!reflect.DeepEqual(results[0].Result, map[string]interface{}{"future_code": float64(9)}) ||
+				results[1].ID != "000123" || results[1].UserType != 1 || results[1].Result != "future-result" || results[1].ServerDetail != "first-second" {
+				t.Fatalf("kickout_results = %#v, want server order and opaque result values preserved after request deduplication", results)
 			}
 		})
 	}
@@ -438,6 +440,73 @@ func TestValidateMeetingParticipantKickoutResponseTreatsResultAsOpaque(t *testin
 		if err := validateMeetingParticipantKickoutResponse(data, requested); err != nil {
 			t.Fatalf("result %#v was interpreted instead of treated as opaque: %v", result, err)
 		}
+	}
+}
+
+func TestValidateMeetingParticipantKickoutResponseUsesNormalizedTupleBijection(t *testing.T) {
+	duplicateRequest := []meetingParticipantKickoutUser{
+		{ID: "123", UserType: 1},
+		{ID: "123", UserType: 1},
+	}
+	if err := validateMeetingParticipantKickoutResponse(
+		map[string]interface{}{"kickout_results": []interface{}{
+			map[string]interface{}{"id": "123", "user_type": 1, "result": "future-result"},
+		}},
+		duplicateRequest,
+	); err != nil {
+		t.Fatalf("duplicate request normalized to one server result was rejected: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		requested []meetingParticipantKickoutUser
+		results   []interface{}
+	}{
+		{
+			name: "distinct requests cannot be satisfied by a duplicate response",
+			requested: []meetingParticipantKickoutUser{
+				{ID: "123", UserType: 1},
+				{ID: "456", UserType: 2},
+			},
+			results: []interface{}{
+				map[string]interface{}{"id": "123", "user_type": 1, "result": "future-result"},
+				map[string]interface{}{"id": "123", "user_type": 1, "result": 7},
+			},
+		},
+		{
+			name: "duplicate normalized request cannot be satisfied by an extra response",
+			requested: []meetingParticipantKickoutUser{
+				{ID: "123", UserType: 1},
+				{ID: "123", UserType: 1},
+			},
+			results: []interface{}{
+				map[string]interface{}{"id": "123", "user_type": 1, "result": map[string]interface{}{"code": 9}},
+				map[string]interface{}{"id": "456", "user_type": 2, "result": nil},
+			},
+		},
+		{
+			name: "conflicting user types cannot be collapsed in a success response",
+			requested: []meetingParticipantKickoutUser{
+				{ID: "123", UserType: 1},
+				{ID: "123", UserType: 2},
+			},
+			results: []interface{}{
+				map[string]interface{}{"id": "123", "user_type": 1, "result": "future-result"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMeetingParticipantKickoutResponse(
+				map[string]interface{}{"kickout_results": tt.results},
+				tt.requested,
+			)
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("error = %T %v, problem = %#v, want internal/invalid_response", err, err, problem)
+			}
+		})
 	}
 }
 

--- a/shortcuts/vc/vc_meeting_participant_kickout_test.go
+++ b/shortcuts/vc/vc_meeting_participant_kickout_test.go
@@ -37,23 +37,35 @@ func TestMeetingParticipantKickoutContract(t *testing.T) {
 	if !reflect.DeepEqual(VCMeetingParticipantKickout.AuthTypes, []string{"user"}) {
 		t.Fatalf("AuthTypes = %v, want [user]", VCMeetingParticipantKickout.AuthTypes)
 	}
+	var sawParticipant, sawUserIDType bool
 	for _, flag := range VCMeetingParticipantKickout.Flags {
-		if flag.Name == "participant" {
+		switch flag.Name {
+		case "participant":
+			sawParticipant = true
 			if flag.Type != "string_array" || !flag.Required {
 				t.Fatalf("participant flag = %#v, want required string_array", flag)
 			}
-			return
+		case "user-id-type":
+			sawUserIDType = true
+			if flag.Default != "open_id" || !reflect.DeepEqual(flag.Enum, []string{"open_id", "union_id", "user_id"}) {
+				t.Fatalf("user-id-type flag = %#v, want default open_id and expected enum", flag)
+			}
 		}
 	}
-	t.Fatal("participant flag is not declared")
+	if !sawParticipant {
+		t.Fatal("participant flag is not declared")
+	}
+	if !sawUserIDType {
+		t.Fatal("user-id-type flag is not declared")
+	}
 }
 
 func TestParseMeetingParticipantKickoutUsersPreservesOrderDuplicatesAndStringIDs(t *testing.T) {
-	input := []string{"000123=1", "000123=2", "000123=1"}
+	input := []string{"ou_123=1", "ou_123=2", "ou_123=1"}
 	want := []meetingParticipantKickoutUser{
-		{ID: "000123", UserType: 1},
-		{ID: "000123", UserType: 2},
-		{ID: "000123", UserType: 1},
+		{ID: "ou_123", UserType: 1},
+		{ID: "ou_123", UserType: 2},
+		{ID: "ou_123", UserType: 1},
 	}
 
 	got, err := parseMeetingParticipantKickoutUsers(input)
@@ -66,7 +78,7 @@ func TestParseMeetingParticipantKickoutUsersPreservesOrderDuplicatesAndStringIDs
 }
 
 func TestParseMeetingParticipantKickoutUsersValidation(t *testing.T) {
-	validTen := []string{"1=1", "2=2", "3=3", "4=4", "5=5", "6=6", "7=7", "8=1", "9=2", "10=3"}
+	validTen := []string{"ou_1=1", "ou_2=2", "ou_3=3", "ou_4=4", "ou_5=5", "ou_6=6", "ou_7=7", "ou_8=1", "ou_9=2", "ou_10=3"}
 	tests := []struct {
 		name   string
 		values []string
@@ -76,12 +88,8 @@ func TestParseMeetingParticipantKickoutUsersValidation(t *testing.T) {
 		{name: "missing equals", values: []string{"123"}},
 		{name: "multiple equals", values: []string{"123=1=2"}},
 		{name: "empty id", values: []string{" =1"}},
-		{name: "id has leading whitespace", values: []string{" 000123=1"}},
-		{name: "id has trailing whitespace", values: []string{"000123 =1"}},
-		{name: "id zero", values: []string{"0=1"}},
-		{name: "id negative", values: []string{"-1=1"}},
-		{name: "id non decimal", values: []string{"12a=1"}},
-		{name: "id overflow", values: []string{"9223372036854775808=1"}},
+		{name: "id has leading whitespace", values: []string{" ou_123=1"}},
+		{name: "id has trailing whitespace", values: []string{"ou_123 =1"}},
 		{name: "empty user type", values: []string{"123="}},
 		{name: "non integer user type", values: []string{"123=user"}},
 		{name: "user type below range", values: []string{"123=0"}},
@@ -122,9 +130,9 @@ func TestMeetingParticipantKickoutDryRunPreservesTuplesWithoutAPICall(t *testing
 	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
 		"+meeting-participant-kickout",
 		"--meeting-id", "7651377260537433044",
-		"--participant", "000123=1",
-		"--participant", "000123=2",
-		"--participant", "000123=1",
+		"--participant", "ou_123=1",
+		"--participant", "ou_123=2",
+		"--participant", "ou_123=1",
 		"--dry-run", "--as", "user",
 	}, f, stdout)
 	if err != nil {
@@ -145,6 +153,7 @@ func TestMeetingParticipantKickoutDryRunPreservesTuplesWithoutAPICall(t *testing
 			API []struct {
 				Method string                        `json:"method"`
 				URL    string                        `json:"url"`
+				Params map[string]interface{}        `json:"params"`
 				Body   meetingParticipantKickoutBody `json:"body"`
 			} `json:"api"`
 		} `json:"data"`
@@ -159,10 +168,13 @@ func TestMeetingParticipantKickoutDryRunPreservesTuplesWithoutAPICall(t *testing
 	if call.Method != "POST" || call.URL != "/open-apis/vc/v1/meetings/7651377260537433044/kickout" {
 		t.Fatalf("dry-run call = %#v", call)
 	}
+	if call.Params["user_id_type"] != "open_id" {
+		t.Fatalf("dry-run params = %#v, want user_id_type=open_id", call.Params)
+	}
 	wantUsers := []meetingParticipantKickoutUser{
-		{ID: "000123", UserType: 1},
-		{ID: "000123", UserType: 2},
-		{ID: "000123", UserType: 1},
+		{ID: "ou_123", UserType: 1},
+		{ID: "ou_123", UserType: 2},
+		{ID: "ou_123", UserType: 1},
 	}
 	if !reflect.DeepEqual(call.Body.KickoutUsers, wantUsers) {
 		t.Fatalf("kickout_users = %#v, want %#v", call.Body.KickoutUsers, wantUsers)
@@ -180,16 +192,16 @@ func TestMeetingParticipantKickoutValidationStopsBeforeAnyAPICall(t *testing.T) 
 			args: []string{
 				"+meeting-participant-kickout",
 				"--meeting-id", "7651377260537433044",
-				"--participant", " 000123=1",
+				"--participant", " ou_123=1",
 				"--yes", "--as", "user",
 			},
 		},
 		{
-			name: "participant id must be positive base-10 int64",
+			name: "participant user_type must be in documented range",
 			args: []string{
 				"+meeting-participant-kickout",
 				"--meeting-id", "7651377260537433044",
-				"--participant", "0=1",
+				"--participant", "ou_123=0",
 				"--yes", "--as", "user",
 			},
 		},
@@ -207,17 +219,17 @@ func TestMeetingParticipantKickoutValidationStopsBeforeAnyAPICall(t *testing.T) 
 			args: []string{
 				"+meeting-participant-kickout",
 				"--meeting-id", "7651377260537433044",
-				"--participant", "1=1",
-				"--participant", "2=1",
-				"--participant", "3=1",
-				"--participant", "4=1",
-				"--participant", "5=1",
-				"--participant", "6=1",
-				"--participant", "7=1",
-				"--participant", "8=1",
-				"--participant", "9=1",
-				"--participant", "10=1",
-				"--participant", "11=1",
+				"--participant", "ou_1=1",
+				"--participant", "ou_2=1",
+				"--participant", "ou_3=1",
+				"--participant", "ou_4=1",
+				"--participant", "ou_5=1",
+				"--participant", "ou_6=1",
+				"--participant", "ou_7=1",
+				"--participant", "ou_8=1",
+				"--participant", "ou_9=1",
+				"--participant", "ou_10=1",
+				"--participant", "ou_11=1",
 				"--yes", "--as", "user",
 			},
 		},
@@ -278,7 +290,7 @@ func TestMeetingParticipantKickoutRequiresConfirmationWithoutAPICall(t *testing.
 	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
 		"+meeting-participant-kickout",
 		"--meeting-id", "7651377260537433044",
-		"--participant", "000123=1",
+		"--participant", "ou_123=1",
 		"--as", "user",
 	}, f, stdout)
 	var confirmationErr *errs.ConfirmationRequiredError
@@ -318,7 +330,7 @@ func TestMeetingParticipantKickoutExecuteScopePreflightRunsBeforeAPI(t *testing.
 	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
 		"+meeting-participant-kickout",
 		"--meeting-id", "7651377260537433044",
-		"--participant", "000123=1",
+		"--participant", "ou_123=1",
 		"--yes", "--as", "user",
 	}, f, stdout)
 	var permissionErr *errs.PermissionError
@@ -352,6 +364,11 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 			stub := &httpmock.Stub{
 				Method: "POST",
 				URL:    "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+				OnMatch: func(req *http.Request) {
+					if got := req.URL.Query().Get("user_id_type"); got != "open_id" {
+						t.Fatalf("user_id_type = %q, want open_id", got)
+					}
+				},
 				Body: map[string]interface{}{
 					"code":         0,
 					"msg":          "ok",
@@ -360,8 +377,8 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 					"data": map[string]interface{}{
 						"server_page": "preserved",
 						"kickout_results": []interface{}{
-							map[string]interface{}{"id": "000456", "user_type": 2, "result": map[string]interface{}{"future_code": 9}, "server_detail": "second-first"},
-							map[string]interface{}{"id": "000123", "user_type": 1, "result": "future-result", "server_detail": "first-second"},
+							map[string]interface{}{"id": "ou_456", "user_type": 2, "result": map[string]interface{}{"future_code": 9}, "server_detail": "second-first"},
+							map[string]interface{}{"id": "ou_123", "user_type": 1, "result": "future-result", "server_detail": "first-second"},
 						},
 					},
 				},
@@ -371,9 +388,9 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 			err := mountAndRun(t, VCMeetingParticipantKickout, []string{
 				"+meeting-participant-kickout",
 				"--meeting-id", "7651377260537433044",
-				"--participant", "000123=1",
-				"--participant", "000456=2",
-				"--participant", "000123=1",
+				"--participant", "ou_123=1",
+				"--participant", "ou_456=2",
+				"--participant", "ou_123=1",
 				"--yes", "--format", format, "--as", "user",
 			}, f, stdout)
 			if err != nil {
@@ -385,9 +402,9 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 				t.Fatalf("decode request: %v\n%s", err, stub.CapturedBody)
 			}
 			wantUsers := []meetingParticipantKickoutUser{
-				{ID: "000123", UserType: 1},
-				{ID: "000456", UserType: 2},
-				{ID: "000123", UserType: 1},
+				{ID: "ou_123", UserType: 1},
+				{ID: "ou_456", UserType: 2},
+				{ID: "ou_123", UserType: 1},
 			}
 			if !reflect.DeepEqual(request.KickoutUsers, wantUsers) {
 				t.Fatalf("request kickout_users = %#v, want %#v", request.KickoutUsers, wantUsers)
@@ -420,12 +437,45 @@ func TestMeetingParticipantKickoutExecutePreservesRequestAndServerResults(t *tes
 				t.Fatalf("envelope = %#v, want complete server envelope and data", outputEnvelope)
 			}
 			results := outputEnvelope.Data.Data.KickoutResults
-			if results[0].ID != "000456" || results[0].UserType != 2 || results[0].ServerDetail != "second-first" ||
+			if results[0].ID != "ou_456" || results[0].UserType != 2 || results[0].ServerDetail != "second-first" ||
 				!reflect.DeepEqual(results[0].Result, map[string]interface{}{"future_code": float64(9)}) ||
-				results[1].ID != "000123" || results[1].UserType != 1 || results[1].Result != "future-result" || results[1].ServerDetail != "first-second" {
+				results[1].ID != "ou_123" || results[1].UserType != 1 || results[1].Result != "future-result" || results[1].ServerDetail != "first-second" {
 				t.Fatalf("kickout_results = %#v, want server order and opaque result values preserved after request deduplication", results)
 			}
 		})
+	}
+}
+
+func TestMeetingParticipantKickoutExecuteSendsUserIDTypeQuery(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/vc/v1/meetings/7651377260537433044/kickout",
+		OnMatch: func(req *http.Request) {
+			if got := req.URL.Query().Get("user_id_type"); got != "union_id" {
+				t.Fatalf("user_id_type = %q, want union_id", got)
+			}
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"kickout_results": []interface{}{
+					map[string]interface{}{"id": "on_123", "user_type": 1, "result": 1},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
+		"+meeting-participant-kickout",
+		"--meeting-id", "7651377260537433044",
+		"--user-id-type", "union_id",
+		"--participant", "on_123=1",
+		"--yes", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("run: %v", err)
 	}
 }
 
@@ -521,7 +571,7 @@ func TestMeetingParticipantKickoutExecuteReturnsTypedAPIError(t *testing.T) {
 	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
 		"+meeting-participant-kickout",
 		"--meeting-id", "7651377260537433044",
-		"--participant", "000123=1",
+		"--participant", "ou_123=1",
 		"--yes", "--as", "user",
 	}, f, stdout)
 	problem, ok := errs.ProblemOf(err)
@@ -538,9 +588,9 @@ func TestMeetingParticipantKickoutExecuteRejectsMalformedSuccessData(t *testing.
 		{name: "missing data", data: nil},
 		{name: "missing results", data: map[string]interface{}{}},
 		{name: "empty results", data: map[string]interface{}{"kickout_results": []interface{}{}}},
-		{name: "missing tuple field", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "000123", "result": 1}}}},
-		{name: "missing result field", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "000123", "user_type": 1}}}},
-		{name: "unrequested tuple", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "999", "user_type": 1, "result": 1}}}},
+		{name: "missing tuple field", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "ou_123", "result": 1}}}},
+		{name: "missing result field", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "ou_123", "user_type": 1}}}},
+		{name: "unrequested tuple", data: map[string]interface{}{"kickout_results": []interface{}{map[string]interface{}{"id": "ou_999", "user_type": 1, "result": 1}}}},
 	}
 
 	for _, tt := range tests {
@@ -559,7 +609,7 @@ func TestMeetingParticipantKickoutExecuteRejectsMalformedSuccessData(t *testing.
 			err := mountAndRun(t, VCMeetingParticipantKickout, []string{
 				"+meeting-participant-kickout",
 				"--meeting-id", "7651377260537433044",
-				"--participant", "000123=1",
+				"--participant", "ou_123=1",
 				"--yes", "--as", "user",
 			}, f, stdout)
 			problem, ok := errs.ProblemOf(err)
@@ -573,7 +623,7 @@ func TestMeetingParticipantKickoutExecuteRejectsMalformedSuccessData(t *testing.
 	}
 }
 
-func TestMeetingParticipantKickoutExecuteCorrelatesCanonicalServerIDWithoutRewritingEnvelope(t *testing.T) {
+func TestMeetingParticipantKickoutExecuteAcceptsNumericServerIDWithoutRewritingEnvelope(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
@@ -592,7 +642,7 @@ func TestMeetingParticipantKickoutExecuteCorrelatesCanonicalServerIDWithoutRewri
 	err := mountAndRun(t, VCMeetingParticipantKickout, []string{
 		"+meeting-participant-kickout",
 		"--meeting-id", "7651377260537433044",
-		"--participant", "000123=1",
+		"--participant", "123=1",
 		"--yes", "--as", "user",
 	}, f, stdout)
 	if err != nil {

--- a/shortcuts/vc/vc_meeting_test.go
+++ b/shortcuts/vc/vc_meeting_test.go
@@ -1593,13 +1593,20 @@ func TestValidateMeetingIDFlag(t *testing.T) {
 }
 
 func TestMeetingEndValidateRejectsInvalidMeetingID(t *testing.T) {
-	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().String("meeting-id", "", "")
-	_ = cmd.Flags().Set("meeting-id", "invalid")
-	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
-
-	if err := VCMeetingEnd.Validate(context.Background(), runtime); err == nil || !strings.Contains(err.Error(), "--meeting-id must be a positive integer") {
-		t.Fatalf("validate error = %v", err)
+	for _, tt := range []struct {
+		identity core.Identity
+		want     string
+	}{
+		{identity: core.AsUser, want: "--meeting-id must be a positive base-10 int64"},
+		{identity: core.AsBot, want: "--meeting-id must be a positive integer"},
+	} {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("meeting-id", "", "")
+		_ = cmd.Flags().Set("meeting-id", "invalid")
+		runtime := common.TestNewRuntimeContextWithIdentity(cmd, defaultConfig(), tt.identity)
+		if err := VCMeetingEnd.Validate(context.Background(), runtime); err == nil || !strings.Contains(err.Error(), tt.want) {
+			t.Fatalf("identity %s validate error = %v, want %q", tt.identity, err, tt.want)
+		}
 	}
 }
 
@@ -1706,8 +1713,14 @@ func TestMeetingEnd_ExecuteHandlesAPIErrorAndEmptyData(t *testing.T) {
 	})
 }
 
-func TestVCMeetingEndUsesManageScope(t *testing.T) {
-	if !reflect.DeepEqual(VCMeetingEnd.Scopes, []string{"vc:meeting.bot.manage:write"}) {
-		t.Fatalf("VCMeetingEnd.Scopes = %v", VCMeetingEnd.Scopes)
+func TestVCMeetingEndUsesIdentitySpecificScopes(t *testing.T) {
+	if !reflect.DeepEqual(VCMeetingEnd.AuthTypes, []string{"user", "bot"}) {
+		t.Fatalf("VCMeetingEnd.AuthTypes = %v, want [user bot]", VCMeetingEnd.AuthTypes)
+	}
+	if !reflect.DeepEqual(VCMeetingEnd.DeclaredScopesForIdentity("user"), []string{"vc:meeting"}) {
+		t.Fatalf("user scopes = %v", VCMeetingEnd.DeclaredScopesForIdentity("user"))
+	}
+	if !reflect.DeepEqual(VCMeetingEnd.DeclaredScopesForIdentity("bot"), []string{"vc:meeting.bot.manage:write"}) {
+		t.Fatalf("bot scopes = %v", VCMeetingEnd.DeclaredScopesForIdentity("bot"))
 	}
 }

--- a/skills/lark-meeting/SKILL.md
+++ b/skills/lark-meeting/SKILL.md
@@ -141,6 +141,7 @@ lark-cli vc +meeting-events --as <source_identity> --meeting-id <meeting_id> --p
 | `minutes +summary` | 替换妙记 AI 总结 | [lark-minutes-summary](references/lark-minutes-summary.md) |
 | `minutes +todo` | 增删改妙记 AI 待办 | [lark-minutes-todo](references/lark-minutes-todo.md) |
 | `minutes +apply-permission` | 申请妙记查看或编辑权限 | [lark-minutes-apply-permission](references/lark-minutes-apply-permission.md) |
+| `minutes +share-permission` | 将妙记权限一键分享给会议参会人 | [lark-minutes-share-permission](references/lark-minutes-share-permission.md) |
 | `drive +member-list` | 查看妙记协作者及其权限 | [lark-drive-member-list](../lark-drive/references/lark-drive-member-list.md) |
 | `drive +member-add` | 给指定成员分配妙记查看或编辑权限 | [lark-drive-member-add](../lark-drive/references/lark-drive-member-add.md) |
 | `minutes +word-replace` | 批量替换妙记逐字稿关键词 | `lark-cli minutes +word-replace --help` |

--- a/skills/lark-meeting/SKILL.md
+++ b/skills/lark-meeting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-meeting
 version: 1.0.0
-description: "飞书视频会议：查询会议记录与会议产物(纪要/逐字稿/妙记)、妙记搜索/上传/下载/编辑、机器人参与会议；查询进行中的会议、实时会议内容(发言/聊天/共享文档)问答(会上/会里)、发送会中聊天/表情；基于 meeting_id、meeting_no、event_id、note_id、minute_token、vc-node-id 或妙记 URL 查询相关信息。预约会议、忙闲和会议室管理走 lark-calendar。"
+description: "飞书视频会议：查询会议记录与会议产物(纪要/逐字稿/妙记)、妙记搜索/上传/下载/编辑、机器人参与会议；查询进行中的会议、实时会议内容(发言/聊天/共享文档)问答(会上/会里)、发送会中聊天/表情，以及主持人结束会议或移出参会人；基于 meeting_id、meeting_no、event_id、note_id、minute_token、vc-node-id 或妙记 URL 查询相关信息。预约会议、忙闲和会议室管理走 lark-calendar。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -27,6 +27,8 @@ metadata:
 - 支持：显式传入并继续执行。
 - 不支持：说明限制并停止；不要为了让命令成功而替换身份。
 - 只有用户明确同意切换身份后，才以新身份重新开始一条工作流。
+
+`vc +meeting-end` 是一个支持双身份的 shortcut：`--as user` 调用用户端 PATCH 接口，`--as bot` 调用应用机器人端 POST 接口。`vc +meeting-participant-kickout` 仅支持用户身份。两者都是高风险写操作；dry-run 必须显式传入受支持的 `--as user` 或 `--as bot`，不得为了执行成功静默切换身份，也不得替用户补做确认。
 
 ## 领域模型与概念
 
@@ -77,6 +79,9 @@ Calendar 日程 ──meeting_note────────────► Doc（
 - Note 与 Minutes 分别来自 AI 总结和录制两条独立链路。一场会议可能同时有两类产物、只有其中一类，也可能都没有；不能根据 `note_id` 推断必然存在 `minute_token`，反之亦然。
 - Minutes 可以由本地音视频直接生成，因此不一定关联 `meeting_id` 或 Calendar `event_id`。
 - Calendar `meeting_note`、Note `note_id`、Minutes `minute_token` 和各类 Doc token 标识不同对象，不能互换、代入其他域的命令或从一者反推另一者。
+- `vc +meeting-end` 无论使用用户身份还是应用身份，都会结束所有参会人的整场会议，不等于 `vc +meeting-leave` 让应用机器人自行离会；只移出指定参会人时使用仅支持用户身份的 `vc +meeting-participant-kickout`。
+- 移出参会人的 `participant ID + user_type` 必须来自目标会议的参会人快照，不得根据 open_id 或其他标识猜测 `user_type`。
+- 结束会议和移出参会人都必须先确认用户的明确目标；预览使用 `--dry-run` 并显式传入对应身份，真实执行只有在确认后才传 `--yes`。
 
 ## 快速行动
 
@@ -106,7 +111,7 @@ lark-cli vc +meeting-events --as <source_identity> --meeting-id <meeting_id> --p
 - [生成和修改妙记、管理妙记权限](scenes/create-and-edit-minutes.md)：将本地音视频生成妙记、逐字稿、总结、待办或章节；修改妙记标题、总结、待办、关键词或说话人；申请妙记权限，或查看、分配妙记协作者权限。
 - [查询智能纪要及关联产物](scenes/query-note-and-artifacts.md)：已有 `note_id`、智能纪要 Docx URL/token，或需要查询纪要正文、逐字稿、妙记和共享文档等关联产物。
 - [应用机器人参会与会中互动](scenes/live-meeting-attend.md)：完整编排应用机器人的活跃会议发现、发起或加入、邀请、事件拉取、会议截图、文本/表情/倒计时互动、结束会议和明确授权后的离会。
-- [会中事件与会中互动](scenes/live-meeting-interact.md)：在不触发新的入会/离会操作时，使用用户身份或已在会中的应用身份查询活跃会议、查看发言/聊天/共享内容、按需读取当前会议画面，或发送文本/表情、操作倒计时。
+- [会中事件、互动与主持管理](scenes/live-meeting-interact.md)：在不触发新的入会/离会操作时，使用用户身份或已在会中的应用身份查询活跃会议、查看发言/聊天/共享内容、按需读取当前会议画面，或发送文本/表情、操作倒计时；用户明确要求结束会议或移出参会人时，也从这里路由到对应的高风险命令。
 
 ## 命令参考
 
@@ -121,9 +126,10 @@ lark-cli vc +meeting-events --as <source_identity> --meeting-id <meeting_id> --p
 | `vc +meeting-message-send` | 发送会中文本消息或表情 | [lark-vc-meeting-message-send](references/lark-vc-meeting-message-send.md) |
 | `vc +meeting-screenshot` | 获取视频会议截图 | [lark-vc-meeting-screenshot](references/lark-vc-meeting-screenshot.md) |
 | `vc +meeting-countdown` | 设置、延长、提前结束或关闭会中倒计时 | [lark-vc-meeting-countdown](references/lark-vc-meeting-countdown.md) |
+| `vc +meeting-end` | 以用户身份或当前 Host 应用机器人结束整场进行中的会议 | [用户身份](references/lark-vc-meeting-end.md) / [应用身份](references/lark-vc-agent-meeting-end.md) |
+| `vc +meeting-participant-kickout` | 以用户身份移出一至十个指定参会人 | [lark-vc-meeting-participant-kickout](references/lark-vc-meeting-participant-kickout.md) |
 | `vc +meeting-join` | 让应用机器人加入会议 | [lark-vc-agent-meeting-join](references/lark-vc-agent-meeting-join.md) |
 | `vc +meeting-invite` | 以应用机器人邀请指定用户或全部合格日程参会人 | [lark-vc-agent-meeting-invite](references/lark-vc-agent-meeting-invite.md) |
-| `vc +meeting-end` | 让当前 Host 应用机器人结束会议 | [lark-vc-agent-meeting-end](references/lark-vc-agent-meeting-end.md) |
 | `vc +meeting-leave` | 让应用机器人离开会议 | [lark-vc-agent-meeting-leave](references/lark-vc-agent-meeting-leave.md) |
 | `minutes +search` | 搜索妙记 | [lark-minutes-search](references/lark-minutes-search.md) |
 | `minutes minutes get` | 查询妙记基础信息 | `lark-cli minutes minutes get --help` |

--- a/skills/lark-meeting/SKILL.md
+++ b/skills/lark-meeting/SKILL.md
@@ -80,7 +80,7 @@ Calendar 日程 ──meeting_note────────────► Doc（
 - Minutes 可以由本地音视频直接生成，因此不一定关联 `meeting_id` 或 Calendar `event_id`。
 - Calendar `meeting_note`、Note `note_id`、Minutes `minute_token` 和各类 Doc token 标识不同对象，不能互换、代入其他域的命令或从一者反推另一者。
 - `vc +meeting-end` 无论使用用户身份还是应用身份，都会结束所有参会人的整场会议，不等于 `vc +meeting-leave` 让应用机器人自行离会；只移出指定参会人时使用仅支持用户身份的 `vc +meeting-participant-kickout`。
-- 移出参会人的 `participant ID + user_type` 必须来自目标会议的参会人快照，不得根据 open_id 或其他标识猜测 `user_type`。
+- 移出参会人的 `kickout_users[].id` 默认按 open_id 解释，可用 `--user-id-type union_id|user_id` 切换；`user_type` 必须来自目标会议的参会人快照，不得根据昵称或设备信息猜测。
 - 结束会议和移出参会人都必须先确认用户的明确目标；预览使用 `--dry-run` 并显式传入对应身份，真实执行只有在确认后才传 `--yes`。
 
 ## 快速行动

--- a/skills/lark-meeting/references/lark-minutes-share-permission.md
+++ b/skills/lark-meeting/references/lark-minutes-share-permission.md
@@ -1,0 +1,69 @@
+# minutes +share-permission
+
+将一条妙记的权限一键分享给会议参会人。**写操作**，只有用户明确要求“分享给参会人”“给这场会的人开放妙记权限”时才调用。
+
+本 skill 对应 shortcut：`lark-cli minutes +share-permission`（调用 `POST /open-apis/minutes/v1/minutes/{minute_token}/permissions/share`）。支持 `--as user` / `--as bot`。
+
+## 命令
+
+```bash
+# 以 user 身份将妙记权限分享给会议参会人
+lark-cli minutes +share-permission --minute-token obcnxxxxxxxxxxxxxxxxxxxx --as user
+
+# 以 bot 身份将妙记权限分享给会议参会人
+lark-cli minutes +share-permission --minute-token obcnxxxxxxxxxxxxxxxxxxxx --as bot
+
+# 预览 API 调用
+lark-cli minutes +share-permission --minute-token obcnxxxxxxxxxxxxxxxxxxxx --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--minute-token <token>` | 是 | 妙记 Token |
+| `--dry-run` | 否 | 预览 API 调用，不执行 |
+
+## 权限语义
+
+- 本命令只接收 `minute_token`。分享范围、权限含义和权限校验由服务端下游处理，CLI 不自行判断参会人范围。
+- `--as user` 表示以当前登录用户身份发起一键分享。
+- `--as bot` 表示以应用身份发起一键分享，前提是应用已具备对应能力和资源权限。
+- 给指定成员授权时不要用本命令，使用 `drive +member-add`。
+- 为当前调用身份向所有者申请查看或编辑权限时不要用本命令，使用 `minutes +apply-permission`。
+
+## 所需权限
+
+| 身份 | 所需权限 |
+|------|---------|
+| user / bot | `minutes:minutes` |
+
+## 输出结果
+
+```json
+{
+  "minute_token": "obcnxxxxxxxxxxxxxxxxxxxx",
+  "shared": true
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `minute_token` | 妙记 Token |
+| `shared` | API 调用成功后为 `true` |
+
+## 如何获取 minute_token
+
+| 来源 | 获取方式 |
+|------|---------|
+| 妙记 URL | 从 URL 末尾提取，如 `https://sample.feishu.cn/minutes/obcnxxxxxxxxxxxxxxxxxxxx` |
+| 妙记搜索 | `lark-cli minutes +search --query "关键词"` |
+| 会议产物查询 | `lark-cli vc +recording --meeting-ids <id>`，拿到 `minute_token`（沿用同一 `--as`） |
+
+## 常见错误与排查
+
+| 错误现象 | 根本原因 | 解决方案 |
+|---------|---------|---------|
+| `--minute-token` 为空或格式不合法 | 缺少有效妙记 Token | 从妙记 URL、搜索结果或会议产物里重新取 token |
+| `missing required scope(s)` | 当前身份缺少 `minutes:minutes` | user 身份用 `auth login --scope` 补权限；bot 身份去开发者后台开通 |
+| `permission_denied` | 当前身份没有操作这条妙记的资源权限 | 请妙记所有者授权；不要通过切换身份绕过 |

--- a/skills/lark-meeting/references/lark-vc-meeting-end.md
+++ b/skills/lark-meeting/references/lark-vc-meeting-end.md
@@ -1,0 +1,47 @@
+# vc +meeting-end（用户身份）
+
+结束一场正在进行中的视频会议。该命令会结束所有人的整场会议，不是让应用机器人自行离会。
+
+本 reference 描述 `lark-cli vc +meeting-end` 的用户身份路径：显式传入 `--as user` 后调用 `PATCH /open-apis/vc/v1/meetings/{meeting_id}/end`，请求体为空。同一个 shortcut 的应用身份路径见 [vc +meeting-end（应用身份）](lark-vc-agent-meeting-end.md)。
+
+## 命令
+
+```bash
+# 先预览目标请求，不结束会议
+lark-cli vc +meeting-end --as user --meeting-id <meeting_id> --dry-run
+
+# 用户明确确认后结束整场会议
+lark-cli vc +meeting-end --as user --meeting-id <meeting_id> --yes
+```
+
+## 参数与身份
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--meeting-id <id>` | 是 | 正十进制且大于 0 的 int64 会议 ID；会先去除首尾空白。9 位正整数也满足 CLI 格式校验，不要仅凭位数判断是否有效 |
+| `--dry-run` | 否 | 只预览 PATCH 路径，不发送 API 请求，也不结束会议 |
+| `--yes` | 真实执行必需 | 确认高风险写操作；只有用户明确确认目标会议后才能传入 |
+
+- 本路径仅使用用户身份；dry-run 必须显式传入 `--as user`。真实执行建议显式指定身份；省略 `--as` 时由 CLI 的完整配置与凭据解析决定身份，不会在离线预检中擅自改成用户身份。
+- 需要 `vc:meeting` scope。
+- 当前用户必须是目标会议有权限结束会议的主持人；普通参会人或联席主持人被拒绝时，不得静默更换用户身份。
+
+## 使用边界
+
+- 结束整场会议：使用本命令。
+- 只让应用机器人离开：使用 [vc +meeting-leave](lark-vc-agent-meeting-leave.md)。
+- 只移出一个或多个参会人：使用 [vc +meeting-participant-kickout](lark-vc-meeting-participant-kickout.md)。
+- `meeting_id` 不确定时，先从当前用户可见的 active meeting 或会议详情中确定唯一目标，再执行 dry-run；不要猜测默认会议。
+
+## 输出与错误
+
+- 默认输出格式仍是 JSON；`--format pretty` 也会保留相同的服务端成功信封，不额外生成本地结束提示。
+- `--format json` 返回标准 `{ok, identity, data}` 信封，其中外层 `data` 原样保留服务端成功响应的 `code`、`msg`、`log_id`、服务端 `data` 和其他附加字段。
+- 参数错误、权限拒绝和服务端错误保持为 CLI 的结构化错误；排查时保留错误码与 `log_id`。
+- dry-run 或未通过高风险确认时不会调用会议 API。
+
+## 相关场景
+
+- [会中事件、互动与主持管理](../scenes/live-meeting-interact.md)
+- [应用身份结束会议](lark-vc-agent-meeting-end.md)
+- [移出指定参会人](lark-vc-meeting-participant-kickout.md)

--- a/skills/lark-meeting/references/lark-vc-meeting-participant-kickout.md
+++ b/skills/lark-meeting/references/lark-vc-meeting-participant-kickout.md
@@ -1,0 +1,78 @@
+# vc +meeting-participant-kickout
+
+以主持人或联席主持人的用户身份，从一场正在进行中的会议移出一个或多个指定参会人。该命令不会结束整场会议。
+
+本 skill 对应 shortcut：`lark-cli vc +meeting-participant-kickout`（调用 `POST /open-apis/vc/v1/meetings/{meeting_id}/kickout`）。
+
+## 命令
+
+```bash
+# 先预览一个目标，不移出参会人
+lark-cli vc +meeting-participant-kickout \
+  --as user \
+  --meeting-id <meeting_id> \
+  --participant '<participant_id>=<user_type>' \
+  --dry-run
+
+# 用户明确确认后，可按输入顺序提交多个目标
+lark-cli vc +meeting-participant-kickout \
+  --as user \
+  --meeting-id <meeting_id> \
+  --participant '<participant_id_1>=<user_type_1>' \
+  --participant '<participant_id_2>=<user_type_2>' \
+  --yes
+```
+
+## 参数与身份
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--meeting-id <id>` | 是 | 正十进制且大于 0 的 int64 会议 ID；会先去除首尾空白 |
+| `--participant '<id>=<user_type>'` | 是 | 可重复 1 至 10 次；每项必须恰好包含一个 `=`，ID 必须非空且首尾不能有空白，`user_type` 必须是 1 至 7 的整数 |
+| `--dry-run` | 否 | 只预览 POST 路径和请求体，不发送 API 请求，也不移出参会人 |
+| `--yes` | 真实执行必需 | 确认高风险写操作；只有用户明确确认会议和目标参会人后才能传入 |
+
+- 仅支持 `user` 身份，必须显式使用 `--as user`；没有应用身份端点，不要改用应用身份重试。
+- 需要 `vc:meeting` scope。
+- 执行者必须是目标会议的主持人或具备相应权限的联席主持人；权限拒绝时不得静默更换用户身份。
+
+## participant tuple 规则
+
+1. 从目标会议的参会人快照读取精确的 participant ID 和 `user_type`。可使用：
+
+   ```bash
+   lark-cli vc meeting get --params '{"meeting_id":"<meeting_id>","with_participants":true}' --as user
+   ```
+
+2. 不要仅凭 open_id、设备 ID 或显示名猜测 `user_type`。
+3. CLI 将 ID 当作字符串原样发送，因此前导零会保留；如果 tuple 里的 ID 含首尾空白，CLI 会直接报错，不会帮你 trim 后继续执行。
+4. CLI 不去重、不排序，也不替请求做冲突消解；重复 tuple、同一 ID 的不同类型都会按输入顺序发送。先确认这正是用户意图。
+5. 不接受 JSON `--kickout-users`、CSV 或分离的 ID/type 数组；只使用可重复的 `--participant '<id>=<user_type>'`。
+
+请求体形状为：
+
+```json
+{
+  "kickout_users": [
+    {"id": "<participant_id>", "user_type": 1}
+  ]
+}
+```
+
+## 输出与 partial result
+
+- `--format json` 和其他机器可读格式都会完整保留服务端成功响应的 `code`、`msg`、`log_id`、`data` 与附加字段；`data.kickout_results` 的字段、值与顺序不会被重新映射、排序或合并。
+- 批量请求可能同时包含成功和失败的目标。逐项根据服务端返回的 `id`、`user_type` 和 `result` 判断，不要把一个目标的结果外推到其他目标，也不要由 CLI 自行解释未知结果值。
+- 请求级参数错误、权限拒绝或框架错误保持为 CLI 的结构化错误；排查时保留错误码与 `log_id`。
+- dry-run 或未通过高风险确认时不会调用会议 API。
+
+## 使用边界
+
+- 结束所有人的整场会议：使用 [vc +meeting-end](lark-vc-meeting-end.md)。
+- 只让应用机器人自行离会：使用 [vc +meeting-leave](lark-vc-agent-meeting-leave.md)。
+- participant tuple 不确定时先读取快照；不要尝试默认参会人或默认身份。
+
+## 相关场景
+
+- [会中事件、互动与主持管理](../scenes/live-meeting-interact.md)
+- [结束整场会议](lark-vc-meeting-end.md)

--- a/skills/lark-meeting/references/lark-vc-meeting-participant-kickout.md
+++ b/skills/lark-meeting/references/lark-vc-meeting-participant-kickout.md
@@ -28,7 +28,7 @@ lark-cli vc +meeting-participant-kickout \
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `--meeting-id <id>` | 是 | 正十进制且大于 0 的 int64 会议 ID；会先去除首尾空白 |
-| `--participant '<id>=<user_type>'` | 是 | 可重复 1 至 10 次；每项必须恰好包含一个 `=`，ID 必须非空且首尾不能有空白，`user_type` 必须是 1 至 7 的整数 |
+| `--participant '<id>=<user_type>'` | 是 | 可重复 1 至 10 次；每项必须恰好包含一个 `=`，ID 必须是正十进制且大于 0 的 int64 且首尾不能有空白，`user_type` 必须是 1 至 7 的整数 |
 | `--dry-run` | 否 | 只预览 POST 路径和请求体，不发送 API 请求，也不移出参会人 |
 | `--yes` | 真实执行必需 | 确认高风险写操作；只有用户明确确认会议和目标参会人后才能传入 |
 

--- a/skills/lark-meeting/references/lark-vc-meeting-participant-kickout.md
+++ b/skills/lark-meeting/references/lark-vc-meeting-participant-kickout.md
@@ -11,15 +11,16 @@
 lark-cli vc +meeting-participant-kickout \
   --as user \
   --meeting-id <meeting_id> \
-  --participant '<participant_id>=<user_type>' \
+  --participant '<open_id>=<user_type>' \
   --dry-run
 
 # 用户明确确认后，可按输入顺序提交多个目标
 lark-cli vc +meeting-participant-kickout \
   --as user \
   --meeting-id <meeting_id> \
-  --participant '<participant_id_1>=<user_type_1>' \
-  --participant '<participant_id_2>=<user_type_2>' \
+  --user-id-type open_id \
+  --participant '<open_id_1>=<user_type_1>' \
+  --participant '<open_id_2>=<user_type_2>' \
   --yes
 ```
 
@@ -28,33 +29,41 @@ lark-cli vc +meeting-participant-kickout \
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `--meeting-id <id>` | 是 | 正十进制且大于 0 的 int64 会议 ID；会先去除首尾空白 |
-| `--participant '<id>=<user_type>'` | 是 | 可重复 1 至 10 次；每项必须恰好包含一个 `=`，ID 必须是正十进制且大于 0 的 int64 且首尾不能有空白，`user_type` 必须是 1 至 7 的整数 |
+| `--user-id-type <type>` | 否 | `kickout_users[].id` 的用户 ID 类型；可选 `open_id`、`union_id`、`user_id`，默认 `open_id` |
+| `--participant '<id>=<user_type>'` | 是 | 可重复 1 至 10 次；每项必须恰好包含一个 `=`，ID 是 `--user-id-type` 指定类型的用户 ID，首尾不能有空白，`user_type` 必须是 1 至 7 的整数 |
 | `--dry-run` | 否 | 只预览 POST 路径和请求体，不发送 API 请求，也不移出参会人 |
 | `--yes` | 真实执行必需 | 确认高风险写操作；只有用户明确确认会议和目标参会人后才能传入 |
 
 - 仅支持 `user` 身份，必须显式使用 `--as user`；没有应用身份端点，不要改用应用身份重试。
 - 需要 `vc:meeting` scope。
 - 执行者必须是目标会议的主持人或具备相应权限的联席主持人；权限拒绝时不得静默更换用户身份。
+- 本命令按用户身份（UAT）调用，不走应用身份（TAT）封装。
 
 ## participant tuple 规则
 
-1. 从目标会议的参会人快照读取精确的 participant ID 和 `user_type`。可使用：
+1. 从目标会议的参会人快照读取目标用户 ID 和 `user_type`。默认使用 `open_id`；如果输入的是 `union_id` 或 `user_id`，必须显式传 `--user-id-type`。
 
    ```bash
    lark-cli vc meeting get --params '{"meeting_id":"<meeting_id>","with_participants":true}' --as user
    ```
 
-2. 不要仅凭 open_id、设备 ID 或显示名猜测 `user_type`。
+2. 不要仅凭设备 ID 或显示名猜测 `user_type`。
 3. CLI 将 ID 当作字符串原样发送，因此前导零会保留；如果 tuple 里的 ID 含首尾空白，CLI 会直接报错，不会帮你 trim 后继续执行。
 4. CLI 不去重、不排序，也不替请求做冲突消解；重复 tuple、同一 ID 的不同类型都会按输入顺序发送。先确认这正是用户意图。
 5. 不接受 JSON `--kickout-users`、CSV 或分离的 ID/type 数组；只使用可重复的 `--participant '<id>=<user_type>'`。
+
+请求 query 默认为：
+
+```json
+{"user_id_type": "open_id"}
+```
 
 请求体形状为：
 
 ```json
 {
   "kickout_users": [
-    {"id": "<participant_id>", "user_type": 1}
+    {"id": "<open_id>", "user_type": 1}
   ]
 }
 ```

--- a/skills/lark-meeting/scenes/create-and-edit-minutes.md
+++ b/skills/lark-meeting/scenes/create-and-edit-minutes.md
@@ -1,6 +1,6 @@
 # 生成和修改妙记、管理妙记权限
 
-生成妙记和修改妙记都是写操作，必须有用户明确意图。生成成功后保存 `minute_token`；修改前确认唯一 `minute_token` 和目标内容，提供 token 不等于授权修改。除 `minutes +apply-permission` 外，本场景的 Minutes 写命令仅支持用户身份；来源身份为 bot 时停止并说明限制，只有用户明确同意后，才以 `--as user` 重新开始修改流程。`minutes +apply-permission` 支持用户或应用身份，必须沿用触发权限错误时的身份。
+生成妙记和修改妙记都是写操作，必须有用户明确意图。生成成功后保存 `minute_token`；修改前确认唯一 `minute_token` 和目标内容，提供 token 不等于授权修改。除 `minutes +apply-permission` 和 `minutes +share-permission` 外，本场景的 Minutes 写命令仅支持用户身份；来源身份为 bot 时停止并说明限制，只有用户明确同意后，才以 `--as user` 重新开始修改流程。`minutes +apply-permission` 必须沿用触发权限错误时的身份，`minutes +share-permission` 按用户指定身份发起一键分享。
 
 ## 从本地音视频生成妙记
 
@@ -86,6 +86,16 @@ lark-cli drive +member-list --token "<minute_url>" --as <source_identity> --form
 ```
 
 完整妙记 URL 可自动推断资源类型为 `minutes`；裸 `minute_token` 必须显式传 `--type minutes`。需要核对指定成员时，按 `member_id` 精确匹配返回的 `items[]`，不要按姓名或列表顺序猜测。
+
+## 一键分享给会议参会人
+
+用户要求“把妙记分享给这场会的参会人”“给参会人开放妙记权限”时，使用 `minutes +share-permission`。本命令只接收 `minute_token`；分享范围、权限含义和权限校验由服务端处理，不要在 CLI 侧自行推断参会人名单。
+
+```bash
+lark-cli minutes +share-permission --minute-token <token> --as <source_identity> --format json
+```
+
+本命令支持 user 和 bot 身份。执行前确认用户确实要做一键分享；执行成功只代表服务端接受请求，不要额外承诺具体通知或事件效果。完整语义见 [`lark-minutes-share-permission`](../references/lark-minutes-share-permission.md)。
 
 ## 分配妙记权限
 

--- a/skills/lark-meeting/scenes/live-meeting-interact.md
+++ b/skills/lark-meeting/scenes/live-meeting-interact.md
@@ -1,4 +1,4 @@
-# 读取会中事件与会中互动
+# 读取会中事件、会中互动与主持管理
 
 围绕一场正在进行的会议执行只读查询或用户明确授权的会中写操作。真实入会/离会使用应用机器人入会场景；已结束会议和会后产物使用会议查询场景。
 
@@ -20,7 +20,7 @@ lark-cli vc +meeting-list-active --as bot --user-id <open_id> --format json
 - 应用身份返回空不代表目标用户没有在开会，只代表没有找到目标用户与应用机器人同时在会中的会议。
 - 返回多个会议时，展示标题、会议号和 `meeting_id` 让用户选择，不按“最近”擅选。
 - 用户只给 9 位会议号时，在活跃会议结果中按 `meeting_no` 匹配；匹配失败时不要自动入会。
-- `meeting_id` 从哪种身份取得，后续读取事件、发送消息和操作倒计时就沿用哪种身份。
+- `meeting_id` 从哪种身份取得，后续读取事件、截图、发送消息和操作倒计时就沿用哪种身份。结束会议也显式沿用选定的用户身份或应用身份；移出参会人仅支持用户身份，从应用身份流程切入时必须先以用户身份重新确认目标会议。
 
 身份可见范围和会议号匹配见 [`lark-vc-meeting-list-active`](../references/lark-vc-meeting-list-active.md)。
 
@@ -92,10 +92,33 @@ lark-cli vc +meeting-countdown --as <same_identity> --meeting-id <meeting_id> --
 
 动作、提醒点和权限规则见 [`lark-vc-meeting-countdown`](../references/lark-vc-meeting-countdown.md)。
 
+## 结束整场会议或移出参会人
+
+只有用户明确要求主持管理动作，且目标会议与目标参会人已经确认时执行：
+
+```bash
+# 以用户身份结束整场会议：先 dry-run，确认后再补 --yes
+lark-cli vc +meeting-end --as user --meeting-id <meeting_id> --dry-run
+
+# 以当前 Host 应用机器人结束整场会议：先 dry-run，确认后再补 --yes
+lark-cli vc +meeting-end --as bot --meeting-id <meeting_id> --dry-run
+
+# 移出参会人：participant tuple 必须来自 meeting get 快照
+lark-cli vc +meeting-participant-kickout --as user --meeting-id <meeting_id> \
+  --participant '<participant_id>=<user_type>' --dry-run
+```
+
+- `vc +meeting-end` 是一个命令：`--as user` 调用用户端 PATCH 接口并要求 `vc:meeting`，`--as bot` 调用应用机器人端 POST 接口并要求 `vc:meeting.bot.manage:write`；应用机器人必须是当前 Host。
+- `vc +meeting-participant-kickout` 仅支持 `--as user`，不提供应用身份端点。不要为了执行成功静默切换身份，也不要在未确认前直接补 `--yes`。
+- 以用户身份结束会议或移出参会人前，先用 `vc meeting get --params '{"meeting_id":"<meeting_id>","with_participants":true}' --as user` 核对会议与参会人快照；以应用身份结束会议时，沿用应用身份发现或入会得到的 `meeting_id` 并确认机器人是当前 Host。
+- 所有 dry-run 都必须显式传入 `--as user` 或 `--as bot`。`vc +meeting-end` 的 dry-run 只预览所选身份的请求路径；`vc +meeting-participant-kickout` 的 dry-run 会回显按输入顺序提交的 `kickout_users`。如果回显与用户意图不完全一致，停止并修正参数，不要继续执行。
+- `--participant '<id>=<user_type>'` 每次调用接受 1 到 10 个重复 flag；ID 必须来自快照且首尾不能有空白。不要根据 open_id、昵称或设备信息猜 `user_type`，也不要把多个目标塞进 CSV/JSON。
+- 结束会议的用户身份与应用身份参考分别见 [`lark-vc-meeting-end`](../references/lark-vc-meeting-end.md) 和 [`lark-vc-agent-meeting-end`](../references/lark-vc-agent-meeting-end.md)；移出参会人见 [`lark-vc-meeting-participant-kickout`](../references/lark-vc-meeting-participant-kickout.md)。
+
 ## 处理未发现会议或权限错误
 
 - 用户身份未发现活跃会议时，可以查询当天最近结束的会议；仍无结果再询问时间、主题或会议号，不自行扩大时间范围。
 - 应用身份未发现活跃会议时，只解释当前身份的空结果，不自动查询历史会议或真实入会。
 - 用户身份调用活跃会议或事件查询时，普通 scope 缺失按 CLI hint 申请 `vc:meeting.meetingevent:read`；普通 scope 缺失不表示接口不支持用户身份，只有 CLI 明确说明不支持时才切到应用身份流程。
-- 应用身份缺少权限时不要执行 `auth login`。优先按 CLI 返回的 `missing_scopes`、`hint` 和 `console_url` 处理；手工判断时按能力配置 scope：应用身份活跃会议查询需要 `vc:meeting.bot.join:write`，会中发消息需要 `vc:meeting.message:write`，会中倒计时需要 `vc:meeting.interaction:write`。随后依次检查应用发布、租户安装和“权限可访问的数据范围”；数据范围应为“按条件筛选”，条件为“会议的归属者 包含 与应用的可用范围一致”。
+- 应用身份缺少权限时不要执行 `auth login`。优先按 CLI 返回的 `missing_scopes`、`hint` 和 `console_url` 处理；手工判断时按能力配置 scope：应用身份活跃会议查询需要 `vc:meeting.bot.join:write`，会中发消息需要 `vc:meeting.message:write`，会中倒计时需要 `vc:meeting.interaction:write`，结束会议需要 `vc:meeting.bot.manage:write`。随后依次检查应用发布、租户安装和“权限可访问的数据范围”；数据范围应为“按条件筛选”，条件为“会议的归属者 包含 与应用的可用范围一致”。
 - scope、安装和数据范围都正确后仍失败时，保留 CLI 返回的错误码和 `log_id`，按服务端权限异常排查；不要反复登录或改用其他身份重试。

--- a/skills/lark-meeting/scenes/live-meeting-interact.md
+++ b/skills/lark-meeting/scenes/live-meeting-interact.md
@@ -103,16 +103,16 @@ lark-cli vc +meeting-end --as user --meeting-id <meeting_id> --dry-run
 # 以当前 Host 应用机器人结束整场会议：先 dry-run，确认后再补 --yes
 lark-cli vc +meeting-end --as bot --meeting-id <meeting_id> --dry-run
 
-# 移出参会人：participant tuple 必须来自 meeting get 快照
+# 移出参会人：默认用 open_id，user_type 必须来自 meeting get 快照
 lark-cli vc +meeting-participant-kickout --as user --meeting-id <meeting_id> \
-  --participant '<participant_id>=<user_type>' --dry-run
+  --participant '<open_id>=<user_type>' --dry-run
 ```
 
 - `vc +meeting-end` 是一个命令：`--as user` 调用用户端 PATCH 接口并要求 `vc:meeting`，`--as bot` 调用应用机器人端 POST 接口并要求 `vc:meeting.bot.manage:write`；应用机器人必须是当前 Host。
 - `vc +meeting-participant-kickout` 仅支持 `--as user`，不提供应用身份端点。不要为了执行成功静默切换身份，也不要在未确认前直接补 `--yes`。
 - 以用户身份结束会议或移出参会人前，先用 `vc meeting get --params '{"meeting_id":"<meeting_id>","with_participants":true}' --as user` 核对会议与参会人快照；以应用身份结束会议时，沿用应用身份发现或入会得到的 `meeting_id` 并确认机器人是当前 Host。
-- 所有 dry-run 都必须显式传入 `--as user` 或 `--as bot`。`vc +meeting-end` 的 dry-run 只预览所选身份的请求路径；`vc +meeting-participant-kickout` 的 dry-run 会回显按输入顺序提交的 `kickout_users`。如果回显与用户意图不完全一致，停止并修正参数，不要继续执行。
-- `--participant '<id>=<user_type>'` 每次调用接受 1 到 10 个重复 flag；ID 必须来自快照且首尾不能有空白。不要根据 open_id、昵称或设备信息猜 `user_type`，也不要把多个目标塞进 CSV/JSON。
+- 所有 dry-run 都必须显式传入 `--as user` 或 `--as bot`。`vc +meeting-end` 的 dry-run 只预览所选身份的请求路径；`vc +meeting-participant-kickout` 的 dry-run 会回显 `user_id_type` 和按输入顺序提交的 `kickout_users`。如果回显与用户意图不完全一致，停止并修正参数，不要继续执行。
+- `--participant '<id>=<user_type>'` 每次调用接受 1 到 10 个重复 flag；ID 默认按 open_id 解释，可用 `--user-id-type union_id|user_id` 切换，且首尾不能有空白。不要根据昵称或设备信息猜 `user_type`，也不要把多个目标塞进 CSV/JSON。
 - 结束会议的用户身份与应用身份参考分别见 [`lark-vc-meeting-end`](../references/lark-vc-meeting-end.md) 和 [`lark-vc-agent-meeting-end`](../references/lark-vc-agent-meeting-end.md)；移出参会人见 [`lark-vc-meeting-participant-kickout`](../references/lark-vc-meeting-participant-kickout.md)。
 
 ## 处理未发现会议或权限错误

--- a/tests/cli_e2e/minutes/minutes_share_permission_test.go
+++ b/tests/cli_e2e/minutes/minutes_share_permission_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package minutes
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinutesSharePermission_DryRun(t *testing.T) {
+	setDryRunConfigEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"minutes", "+share-permission",
+			"--minute-token", "obcnexampleminute",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	output := result.Stdout
+	assert.True(t, strings.Contains(output, "POST"), "dry-run should contain POST method, got: %s", output)
+	assert.True(t, strings.Contains(output, "/open-apis/minutes/v1/minutes/obcnexampleminute/permissions/share"), "dry-run should contain API path, got: %s", output)
+	assert.False(t, strings.Contains(output, `"perm"`), "dry-run should not contain perm body, got: %s", output)
+}
+
+func TestMinutesSharePermission_DryRun_BotIdentity(t *testing.T) {
+	setDryRunConfigEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"minutes", "+share-permission",
+			"--minute-token", "obcnexampleminute",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	output := result.Stdout
+	assert.True(t, strings.Contains(output, "POST"), "dry-run should contain POST method, got: %s", output)
+	assert.True(t, strings.Contains(output, "/open-apis/minutes/v1/minutes/obcnexampleminute/permissions/share"), "dry-run should contain API path, got: %s", output)
+	assert.False(t, strings.Contains(output, `"perm"`), "dry-run should not contain perm body, got: %s", output)
+}

--- a/tests/cli_e2e/vc/meeting_skill_embedded_test.go
+++ b/tests/cli_e2e/vc/meeting_skill_embedded_test.go
@@ -50,6 +50,16 @@ func TestMeetingSkillIsEmbeddedInBuiltCLI(t *testing.T) {
 			args: []string{"skills", "read", "lark-meeting", "references/lark-vc-detail.md"},
 			want: "# vc +detail",
 		},
+		{
+			name: "new end reference",
+			args: []string{"skills", "read", "lark-meeting", "references/lark-vc-meeting-end.md"},
+			want: "# vc +meeting-end",
+		},
+		{
+			name: "new kickout reference",
+			args: []string{"skills", "read", "lark-meeting", "references/lark-vc-meeting-participant-kickout.md"},
+			want: "# vc +meeting-participant-kickout",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/cli_e2e/vc/vc_meeting_end_test.go
+++ b/tests/cli_e2e/vc/vc_meeting_end_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type vcMeetingEndLiveFixture struct {
+	appID             string
+	brand             string
+	hostToken         string
+	cohostToken       string
+	normalToken       string
+	hostMeetingID     string
+	cohostMeetingID   string
+	normalMeetingID   string
+	isolatedConfigDir string
+}
+
+// TestVCMeetingEndDryRunE2E proves the built binary exposes the dual-identity
+// high-risk command, emits each identity's exact request, and stops at
+// confirmation when --yes is absent.
+func TestVCMeetingEndDryRunE2E(t *testing.T) {
+	setVCDryRunEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"vc", "+meeting-end", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+
+	dryRun, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+meeting-end",
+			"--meeting-id", " 123456789 ",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	dryRun.AssertExitCode(t, 0)
+	require.True(t, gjson.Get(dryRun.Stdout, "dry_run").Bool(), "stdout:\n%s", dryRun.Stdout)
+	require.Equal(t, "user", gjson.Get(dryRun.Stdout, "identity").String(), "stdout:\n%s", dryRun.Stdout)
+	require.Equal(t, int64(1), clie2e.DryRunGet(dryRun.Stdout, "api.#").Int(), "stdout:\n%s", dryRun.Stdout)
+	require.Equal(t, "PATCH", clie2e.DryRunGet(dryRun.Stdout, "api.0.method").String(), "stdout:\n%s", dryRun.Stdout)
+	require.Equal(t, "/open-apis/vc/v1/meetings/123456789/end", clie2e.DryRunGet(dryRun.Stdout, "api.0.url").String(), "stdout:\n%s", dryRun.Stdout)
+	require.False(t, clie2e.DryRunGet(dryRun.Stdout, "api.0.body").Exists(), "stdout:\n%s", dryRun.Stdout)
+
+	withoutConfirmation, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"vc", "+meeting-end", "--meeting-id", "123456789"},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	withoutConfirmation.AssertExitCode(t, 10)
+	require.Empty(t, withoutConfirmation.Stdout)
+	require.Equal(t, "confirmation", gjson.Get(withoutConfirmation.Stderr, "error.type").String(), "stderr:\n%s", withoutConfirmation.Stderr)
+	require.Equal(t, "confirmation_required", gjson.Get(withoutConfirmation.Stderr, "error.subtype").String(), "stderr:\n%s", withoutConfirmation.Stderr)
+	require.Contains(t, gjson.Get(withoutConfirmation.Stderr, "error.hint").String(), "--yes")
+
+	invalidMeetingID, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+meeting-end",
+			"--meeting-id", "0",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	invalidMeetingID.AssertExitCode(t, 2)
+	require.Empty(t, invalidMeetingID.Stdout)
+	require.Equal(t, "validation", gjson.Get(invalidMeetingID.Stderr, "error.type").String(), "stderr:\n%s", invalidMeetingID.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(invalidMeetingID.Stderr, "error.subtype").String(), "stderr:\n%s", invalidMeetingID.Stderr)
+	require.Equal(t, "--meeting-id", gjson.Get(invalidMeetingID.Stderr, "error.param").String(), "stderr:\n%s", invalidMeetingID.Stderr)
+
+	botDryRun, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+meeting-end",
+			"--meeting-id", "7628568141510692381",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	botDryRun.AssertExitCode(t, 0)
+	require.Equal(t, "bot", gjson.Get(botDryRun.Stdout, "identity").String(), "stdout:\n%s", botDryRun.Stdout)
+	require.Equal(t, "POST", clie2e.DryRunGet(botDryRun.Stdout, "api.0.method").String(), "stdout:\n%s", botDryRun.Stdout)
+	require.Equal(t, "/open-apis/vc/v1/bots/end", clie2e.DryRunGet(botDryRun.Stdout, "api.0.url").String(), "stdout:\n%s", botDryRun.Stdout)
+	require.Equal(t, "7628568141510692381", clie2e.DryRunGet(botDryRun.Stdout, "api.0.body.meeting_id").String(), "stdout:\n%s", botDryRun.Stdout)
+
+	for _, args := range [][]string{
+		{"vc", "+meeting-end", "--meeting-id", "123456789", "--dry-run"},
+		{"vc", "+meeting-end", "--meeting-id", "123456789", "--dry-run", "--as", "auto"},
+	} {
+		result, runErr := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: args,
+			Env: map[string]string{
+				"LARKSUITE_CLI_APP_ID":     "",
+				"LARKSUITE_CLI_APP_SECRET": "",
+				"LARKSUITE_CLI_BRAND":      "",
+			},
+		})
+		require.NoError(t, runErr)
+		result.AssertExitCode(t, 2)
+		require.Empty(t, result.Stdout)
+		require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), "stderr:\n%s", result.Stderr)
+		require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), "stderr:\n%s", result.Stderr)
+		require.Equal(t, "--as", gjson.Get(result.Stderr, "error.param").String(), "stderr:\n%s", result.Stderr)
+	}
+}
+
+// TestVCMeetingEndLiveE2E is destructive and default-off. The dedicated remote
+// lane must explicitly opt in; after that, missing or invalid provisioner data
+// is fatal. This test proves the command response and pre-mutation fixture
+// roles, but does not claim a post-end final-state readback.
+func TestVCMeetingEndLiveE2E(t *testing.T) {
+	requireVCMeetingManagementDestructiveOptIn(t)
+	fixture := requireVCMeetingEndProvisionFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	for _, tc := range []struct {
+		name      string
+		token     string
+		meetingID string
+	}{
+		{name: "normal user denied", token: fixture.normalToken, meetingID: fixture.normalMeetingID},
+		{name: "cohost denied", token: fixture.cohostToken, meetingID: fixture.cohostMeetingID},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := runMeetingEndLive(ctx, fixture, tc.token, tc.meetingID)
+			require.NoError(t, err)
+			assertVCMeetingManagementDenied(t, result)
+		})
+	}
+
+	t.Run("host succeeds", func(t *testing.T) {
+		result, err := runMeetingEndLive(ctx, fixture, fixture.hostToken, fixture.hostMeetingID)
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+		require.Equal(t, "user", gjson.Get(result.Stdout, "identity").String(), "stdout:\n%s", result.Stdout)
+		require.True(t, gjson.Get(result.Stdout, "data").IsObject(), "stdout:\n%s", result.Stdout)
+	})
+}
+
+func runMeetingEndLive(ctx context.Context, fixture vcMeetingEndLiveFixture, token, meetingID string) (*clie2e.Result, error) {
+	return clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"vc", "+meeting-end", "--meeting-id", meetingID},
+		DefaultAs: "user",
+		Yes:       true,
+		Env:       vcMeetingManagementUserEnv(fixture.appID, fixture.brand, fixture.isolatedConfigDir, token),
+	}, vcMeetingManagementNoRetry())
+}

--- a/tests/cli_e2e/vc/vc_meeting_end_test.go
+++ b/tests/cli_e2e/vc/vc_meeting_end_test.go
@@ -81,6 +81,7 @@ func TestVCMeetingEndDryRunE2E(t *testing.T) {
 	require.Empty(t, invalidMeetingID.Stdout)
 	require.Equal(t, "validation", gjson.Get(invalidMeetingID.Stderr, "error.type").String(), "stderr:\n%s", invalidMeetingID.Stderr)
 	require.Equal(t, "invalid_argument", gjson.Get(invalidMeetingID.Stderr, "error.subtype").String(), "stderr:\n%s", invalidMeetingID.Stderr)
+	require.Equal(t, "--meeting-id must be a positive base-10 int64", gjson.Get(invalidMeetingID.Stderr, "error.message").String(), "stderr:\n%s", invalidMeetingID.Stderr)
 	require.Equal(t, "--meeting-id", gjson.Get(invalidMeetingID.Stderr, "error.param").String(), "stderr:\n%s", invalidMeetingID.Stderr)
 
 	botDryRun, err := clie2e.RunCmd(ctx, clie2e.Request{
@@ -115,6 +116,7 @@ func TestVCMeetingEndDryRunE2E(t *testing.T) {
 		require.Empty(t, result.Stdout)
 		require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), "stderr:\n%s", result.Stderr)
 		require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), "stderr:\n%s", result.Stderr)
+		require.Equal(t, "--dry-run for +meeting-end requires explicit --as user or --as bot because offline preflight cannot resolve default or automatic identity", gjson.Get(result.Stderr, "error.message").String(), "stderr:\n%s", result.Stderr)
 		require.Equal(t, "--as", gjson.Get(result.Stderr, "error.param").String(), "stderr:\n%s", result.Stderr)
 	}
 }

--- a/tests/cli_e2e/vc/vc_meeting_management_fixture_test.go
+++ b/tests/cli_e2e/vc/vc_meeting_management_fixture_test.go
@@ -1,0 +1,1002 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/core"
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	vcMeetingManagementPermissionDeniedCode     = 10005
+	vcMeetingManagementLarkUserType             = 1
+	vcMeetingManagementDestructiveLiveEnv       = "LARK_CLI_E2E_VC_MEETING_MANAGEMENT_DESTRUCTIVE"
+	vcMeetingManagementProvisionerEnv           = "LARK_CLI_E2E_VC_MEETING_MANAGEMENT_PROVISIONER"
+	vcMeetingManagementExpectedEnvironmentEnv   = "LARK_CLI_E2E_VC_MEETING_MANAGEMENT_ENVIRONMENT"
+	vcMeetingManagementManifestSchemaVersion    = 2
+	vcMeetingManagementCreatedBy                = "vc-meeting-management-provisioner"
+	vcMeetingManagementSubjectIDSource          = "provisioner_verified_user_token_subject"
+	vcMeetingManagementProvisionerCreateTimeout = 2 * time.Minute
+	vcMeetingManagementProvisionerCleanupTimout = 90 * time.Second
+	vcMeetingManagementReadbackTimeout          = 45 * time.Second
+	vcMeetingManagementMaxCreatedAge            = 10 * time.Minute
+	vcMeetingManagementMaxFutureSkew            = 2 * time.Minute
+	vcMeetingManagementMaxTTL                   = 2 * time.Hour
+	vcMeetingManagementOnlineEnvironment        = "online"
+	vcMeetingManagementFeishuOpenAPIHost        = "https://open.feishu.cn"
+	vcMeetingManagementLarkOpenAPIHost          = "https://open.larksuite.com"
+	vcMeetingManagementMaxUserTokenLength       = 4096
+	vcMeetingManagementMinCleanupSuffixLength   = 16
+	vcMeetingManagementMaxCleanupTokenLength    = 512
+	vcMeetingManagementMaxActorOpenIDLength     = 256
+	vcMeetingManagementCleanupFailureProbeEnv   = "LARK_CLI_E2E_VC_MEETING_MANAGEMENT_CLEANUP_FAILURE_PROBE"
+)
+
+var (
+	vcMeetingManagementCleanupSuffixPattern  = regexp.MustCompile(`^[A-Za-z0-9._~-]+$`)
+	vcMeetingManagementActorOpenIDPattern    = regexp.MustCompile(`^ou_[A-Za-z0-9_-]+$`)
+	vcMeetingManagementNumericSubjectPattern = regexp.MustCompile(`^[1-9][0-9]*$`)
+)
+
+type vcParticipantTuple struct {
+	ID       string `json:"id"`
+	UserType int64  `json:"user_type"`
+}
+
+type vcMeetingManagementManifestCredential struct {
+	UserAccessToken      string `json:"user_access_token"`
+	TokenSubjectID       string `json:"token_subject_id"`
+	TokenSubjectUserType int64  `json:"token_subject_user_type"`
+	TokenSubjectOpenID   string `json:"token_subject_open_id"`
+	TokenSubjectSource   string `json:"token_subject_source"`
+}
+
+type vcMeetingManagementManifestCredentials struct {
+	Host   vcMeetingManagementManifestCredential `json:"host"`
+	Cohost vcMeetingManagementManifestCredential `json:"cohost"`
+	Normal vcMeetingManagementManifestCredential `json:"normal"`
+}
+
+type vcMeetingEndProvisionCase struct {
+	MeetingID string             `json:"meeting_id"`
+	HostUser  vcParticipantTuple `json:"host_user"`
+	Actor     vcParticipantTuple `json:"actor"`
+}
+
+type vcMeetingEndProvisionManifest struct {
+	Host   vcMeetingEndProvisionCase `json:"host"`
+	Cohost vcMeetingEndProvisionCase `json:"cohost"`
+	Normal vcMeetingEndProvisionCase `json:"normal"`
+}
+
+type vcMeetingKickoutProvisionCase struct {
+	MeetingID string             `json:"meeting_id"`
+	HostUser  vcParticipantTuple `json:"host_user"`
+	Actor     vcParticipantTuple `json:"actor"`
+	Target    vcParticipantTuple `json:"target"`
+}
+
+type vcMeetingKickoutProvisionPartialCase struct {
+	MeetingID        string             `json:"meeting_id"`
+	HostUser         vcParticipantTuple `json:"host_user"`
+	Actor            vcParticipantTuple `json:"actor"`
+	SuccessTarget    vcParticipantTuple `json:"success_target"`
+	FailedTarget     vcParticipantTuple `json:"failed_target"`
+	FailedTargetMode string             `json:"failed_target_mode"`
+}
+
+type vcMeetingKickoutProvisionManifest struct {
+	Host    vcMeetingKickoutProvisionCase        `json:"host"`
+	Cohost  vcMeetingKickoutProvisionCase        `json:"cohost"`
+	Normal  vcMeetingKickoutProvisionCase        `json:"normal"`
+	Partial vcMeetingKickoutProvisionPartialCase `json:"partial"`
+}
+
+type vcMeetingManagementProvisionManifest struct {
+	Schema       int                                    `json:"schema"`
+	Suite        string                                 `json:"suite,omitempty"`
+	RunID        string                                 `json:"run_id"`
+	CreatedBy    string                                 `json:"created_by"`
+	Environment  string                                 `json:"environment"`
+	CreatedAt    string                                 `json:"created_at"`
+	ExpiresAt    string                                 `json:"expires_at"`
+	Dedicated    bool                                   `json:"dedicated"`
+	Disposable   bool                                   `json:"disposable"`
+	Ownership    string                                 `json:"ownership"`
+	CleanupToken string                                 `json:"cleanup_token"`
+	AppID        string                                 `json:"app_id"`
+	Brand        string                                 `json:"brand"`
+	OpenAPIHost  string                                 `json:"effective_openapi_host"`
+	Credentials  vcMeetingManagementManifestCredentials `json:"credentials"`
+	End          *vcMeetingEndProvisionManifest         `json:"end,omitempty"`
+	Kickout      *vcMeetingKickoutProvisionManifest     `json:"kickout,omitempty"`
+}
+
+type vcMeetingManagementRuntime struct {
+	appID             string
+	brand             string
+	isolatedConfigDir string
+}
+
+type vcExpectedParticipantRole struct {
+	Tuple    vcParticipantTuple
+	IsHost   bool
+	IsCohost bool
+}
+
+func requireVCMeetingManagementProvisionManifest(t *testing.T, suite string) vcMeetingManagementProvisionManifest {
+	t.Helper()
+
+	executable := requireVCMeetingManagementProvisioner(t)
+
+	expectedEnvironment := os.Getenv(vcMeetingManagementExpectedEnvironmentEnv)
+	if expectedEnvironment == "" {
+		t.Fatalf(
+			"REQUIRED-LANE BLOCKER: set %s so the provisioned fixture manifest can prove which environment it belongs to",
+			vcMeetingManagementExpectedEnvironmentEnv,
+		)
+	}
+	if strings.TrimSpace(expectedEnvironment) != expectedEnvironment {
+		t.Fatalf("REQUIRED-LANE BLOCKER: %s must not contain surrounding whitespace", vcMeetingManagementExpectedEnvironmentEnv)
+	}
+	if expectedEnvironment != vcMeetingManagementOnlineEnvironment {
+		t.Fatalf("REQUIRED-LANE BLOCKER: unsupported VC fixture environment %q; only %q has a fixed OpenAPI host mapping", expectedEnvironment, vcMeetingManagementOnlineEnvironment)
+	}
+
+	runID := newVCMeetingManagementRunID(t, suite)
+	provisionerEnv := vcMeetingManagementProvisionerEnvironment(expectedEnvironment)
+	cleanupToken := newVCMeetingManagementCleanupToken(t, suite, runID)
+
+	// Arm cleanup before create because a provisioner may create only part of a
+	// fixture and then exit non-zero. Cleanup must therefore be idempotent for
+	// this known suite/run_id/cleanup_token tuple, including when nothing was
+	// created.
+	t.Cleanup(func() {
+		runVCMeetingManagementProvisionerCleanup(t, executable, provisionerEnv, suite, runID, cleanupToken)
+	})
+
+	rawManifest := runVCMeetingManagementProvisionerCreate(t, executable, provisionerEnv, suite, runID, cleanupToken)
+
+	manifest, err := decodeVCMeetingManagementManifest(rawManifest)
+	if err != nil {
+		t.Fatalf("VC fixture provisioner create returned an invalid manifest for suite %s run_id=%s", suite, runID)
+	}
+	validateVCMeetingManagementManifestBase(t, manifest, suite, runID, expectedEnvironment, cleanupToken)
+	return manifest
+}
+
+func TestVCMeetingManagementProvisionerCleanupRunsAfterPartialCreateFailure(t *testing.T) {
+	if os.Getenv(vcMeetingManagementCleanupFailureProbeEnv) == "1" {
+		requireVCMeetingManagementProvisionManifest(t, "end")
+		t.Fatal("fake provisioner create unexpectedly succeeded")
+	}
+
+	tempDir := t.TempDir()
+	provisionerPath := filepath.Join(tempDir, "fake-vc-meeting-management-provisioner")
+	const provisioner = `#!/bin/sh
+set -eu
+case "${1:-}" in
+create)
+  shift
+  printf '%s\n' "$@" > "$0.create.args"
+  cat > "$0.create.stdin"
+  : > "$0.resource"
+  exit 23
+  ;;
+cleanup)
+  shift
+  printf '%s\n' "$@" > "$0.cleanup.args"
+  cat > "$0.cleanup.stdin"
+  rm -f "$0.resource"
+  : > "$0.cleanup.marker"
+  ;;
+*)
+  exit 64
+  ;;
+esac
+`
+	require.NoError(t, os.WriteFile(provisionerPath, []byte(provisioner), 0o700))
+
+	t.Setenv(vcMeetingManagementCleanupFailureProbeEnv, "1")
+	t.Setenv(vcMeetingManagementProvisionerEnv, provisionerPath)
+	t.Setenv(vcMeetingManagementExpectedEnvironmentEnv, vcMeetingManagementOnlineEnvironment)
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestVCMeetingManagementProvisionerCleanupRunsAfterPartialCreateFailure$")
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "failure probe must observe the injected create failure")
+	require.Contains(t, string(output), "VC fixture provisioner create failed for suite end")
+
+	readArtifact := func(suffix string) []byte {
+		t.Helper()
+		content, readErr := os.ReadFile(provisionerPath + suffix)
+		require.NoError(t, readErr, "missing fake provisioner artifact %s", suffix)
+		return content
+	}
+
+	createArgs := readArtifact(".create.args")
+	cleanupArgs := readArtifact(".cleanup.args")
+	require.Equal(t, createArgs, cleanupArgs, "cleanup must target the same suite and run_id as create")
+	args := strings.Split(strings.TrimSpace(string(createArgs)), "\n")
+	require.Len(t, args, 4)
+	require.Equal(t, []string{"--suite", "end", "--run-id"}, args[:3])
+	require.True(t, strings.HasPrefix(args[3], "end-"), "unexpected run_id %q", args[3])
+
+	createPayload := readArtifact(".create.stdin")
+	cleanupPayload := readArtifact(".cleanup.stdin")
+	require.JSONEq(t, string(createPayload), string(cleanupPayload), "cleanup must use the token supplied to create")
+	var payload struct {
+		CleanupToken string `json:"cleanup_token"`
+	}
+	require.NoError(t, json.Unmarshal(cleanupPayload, &payload))
+	require.True(t, strings.HasPrefix(payload.CleanupToken, vcMeetingManagementCleanupTokenPrefix("end", args[3])))
+
+	_, statErr := os.Stat(provisionerPath + ".resource")
+	require.ErrorIs(t, statErr, os.ErrNotExist, "cleanup must remove the resource marker left before create failed")
+	readArtifact(".cleanup.marker")
+}
+
+func requireVCMeetingManagementDestructiveOptIn(t *testing.T) {
+	t.Helper()
+
+	value, present := os.LookupEnv(vcMeetingManagementDestructiveLiveEnv)
+	if !present || value == "" {
+		t.Skipf("set %s=1 in the dedicated VC management lane to run destructive live E2E tests", vcMeetingManagementDestructiveLiveEnv)
+	}
+	if value != "1" {
+		t.Fatalf("%s must be exactly 1 when destructive VC management live E2E tests are enabled", vcMeetingManagementDestructiveLiveEnv)
+	}
+}
+
+func requireVCMeetingManagementProvisioner(t *testing.T) string {
+	t.Helper()
+
+	executable := os.Getenv(vcMeetingManagementProvisionerEnv)
+	if executable == "" {
+		t.Fatalf(
+			"REQUIRED-LANE BLOCKER: set %s to an executable that supports `create --suite <suite> --run-id <id>` and `cleanup --suite <suite> --run-id <id>` with a cleanup_token JSON request for dedicated disposable VC fixtures",
+			vcMeetingManagementProvisionerEnv,
+		)
+	}
+	if strings.TrimSpace(executable) != executable {
+		t.Fatalf("REQUIRED-LANE BLOCKER: %s must not contain surrounding whitespace", vcMeetingManagementProvisionerEnv)
+	}
+	if !filepath.IsAbs(executable) || filepath.Clean(executable) != executable {
+		t.Fatalf("REQUIRED-LANE BLOCKER: %s must be a clean absolute path", vcMeetingManagementProvisionerEnv)
+	}
+	resolvedExecutable, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		t.Fatalf("REQUIRED-LANE BLOCKER: cannot resolve %s: %v", vcMeetingManagementProvisionerEnv, err)
+	}
+	if !filepath.IsAbs(resolvedExecutable) || filepath.Clean(resolvedExecutable) != resolvedExecutable {
+		t.Fatalf("REQUIRED-LANE BLOCKER: %s must resolve to a clean absolute path", vcMeetingManagementProvisionerEnv)
+	}
+	info, err := os.Stat(resolvedExecutable)
+	if err != nil {
+		t.Fatalf("REQUIRED-LANE BLOCKER: cannot inspect resolved %s: %v", vcMeetingManagementProvisionerEnv, err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("REQUIRED-LANE BLOCKER: %s must resolve to a regular executable file", vcMeetingManagementProvisionerEnv)
+	}
+	return resolvedExecutable
+}
+
+func vcMeetingManagementProvisionerEnvironment(expectedEnvironment string) []string {
+	return []string{
+		"PATH=/usr/bin:/bin",
+		"LANG=C",
+		"LC_ALL=C",
+		vcMeetingManagementExpectedEnvironmentEnv + "=" + expectedEnvironment,
+	}
+}
+
+func runVCMeetingManagementProvisionerCreate(t *testing.T, executable string, environment []string, suite, runID, cleanupToken string) []byte {
+	t.Helper()
+	payload, err := json.Marshal(struct {
+		CleanupToken string `json:"cleanup_token"`
+	}{
+		CleanupToken: cleanupToken,
+	})
+	if err != nil {
+		t.Fatalf("VC fixture create payload failed for suite %s run_id=%s", suite, runID)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), vcMeetingManagementProvisionerCreateTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, executable, "create", "--suite", suite, "--run-id", runID)
+	cmd.Stdin = bytes.NewReader(payload)
+	cmd.Env = append([]string(nil), environment...)
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("VC fixture provisioner create failed for suite %s run_id=%s (exit=%d)", suite, runID, execCommandExitCode(err))
+	}
+	return bytes.TrimSpace(stdout.Bytes())
+}
+
+func runVCMeetingManagementProvisionerCleanup(t *testing.T, executable string, environment []string, suite, runID, cleanupToken string) {
+	t.Helper()
+	payload, err := json.Marshal(struct {
+		CleanupToken string `json:"cleanup_token"`
+	}{
+		CleanupToken: cleanupToken,
+	})
+	if err != nil {
+		t.Errorf("VC fixture cleanup payload failed for suite %s run_id=%s", suite, runID)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), vcMeetingManagementProvisionerCleanupTimout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, executable, "cleanup", "--suite", suite, "--run-id", runID)
+	cmd.Stdin = bytes.NewReader(payload)
+	cmd.Env = append([]string(nil), environment...)
+
+	if err := cmd.Run(); err != nil {
+		t.Errorf("VC fixture cleanup failed for suite %s run_id=%s (exit=%d)", suite, runID, execCommandExitCode(err))
+	}
+}
+
+func decodeVCMeetingManagementManifest(raw []byte) (vcMeetingManagementProvisionManifest, error) {
+	var manifest vcMeetingManagementProvisionManifest
+
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return manifest, errors.New("empty manifest")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return manifest, err
+	}
+
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return manifest, errors.New("manifest must contain exactly one JSON value")
+		}
+		return manifest, err
+	}
+
+	return manifest, nil
+}
+
+func validateVCMeetingManagementManifestBase(t *testing.T, manifest vcMeetingManagementProvisionManifest, suite, runID, expectedEnvironment, cleanupToken string) {
+	t.Helper()
+
+	if manifest.Schema != vcMeetingManagementManifestSchemaVersion {
+		t.Fatalf("invalid VC fixture manifest schema %d: want %d", manifest.Schema, vcMeetingManagementManifestSchemaVersion)
+	}
+	if manifest.Suite != suite {
+		t.Fatalf("invalid VC fixture manifest suite %q: want %q", manifest.Suite, suite)
+	}
+	if manifest.RunID != runID {
+		t.Fatalf("invalid VC fixture manifest run_id %q: want %q", manifest.RunID, runID)
+	}
+	if manifest.CreatedBy != vcMeetingManagementCreatedBy {
+		t.Fatalf("invalid VC fixture manifest created_by %q: want %q", manifest.CreatedBy, vcMeetingManagementCreatedBy)
+	}
+	if manifest.Environment != expectedEnvironment {
+		t.Fatalf("invalid VC fixture manifest environment %q: want %q", manifest.Environment, expectedEnvironment)
+	}
+
+	createdAt, err := time.Parse(time.RFC3339, manifest.CreatedAt)
+	if err != nil {
+		t.Fatalf("invalid VC fixture manifest created_at %q: want RFC3339", manifest.CreatedAt)
+	}
+	expiresAt, err := time.Parse(time.RFC3339, manifest.ExpiresAt)
+	if err != nil {
+		t.Fatalf("invalid VC fixture manifest expires_at %q: want RFC3339", manifest.ExpiresAt)
+	}
+	now := time.Now()
+	if createdAt.After(now.Add(vcMeetingManagementMaxFutureSkew)) {
+		t.Fatalf("invalid VC fixture manifest: created_at %s is too far in the future", manifest.CreatedAt)
+	}
+	if createdAt.Before(now.Add(-vcMeetingManagementMaxCreatedAge)) {
+		t.Fatalf("invalid VC fixture manifest: created_at %s is too old", manifest.CreatedAt)
+	}
+	if !createdAt.Before(expiresAt) {
+		t.Fatalf("invalid VC fixture manifest: expires_at %s must be after created_at %s", manifest.ExpiresAt, manifest.CreatedAt)
+	}
+	if !now.Before(expiresAt) {
+		t.Fatalf("invalid VC fixture manifest: expires_at %s is not in the future", manifest.ExpiresAt)
+	}
+	if expiresAt.Sub(createdAt) > vcMeetingManagementMaxTTL {
+		t.Fatalf("invalid VC fixture manifest: ttl %s exceeds max %s", expiresAt.Sub(createdAt), vcMeetingManagementMaxTTL)
+	}
+
+	if !manifest.Dedicated {
+		t.Fatal("invalid VC fixture manifest: dedicated must be true")
+	}
+	if !manifest.Disposable {
+		t.Fatal("invalid VC fixture manifest: disposable must be true")
+	}
+	if manifest.Ownership != vcMeetingManagementOwnership(suite, runID) {
+		t.Fatalf("invalid VC fixture manifest ownership %q: want %q", manifest.Ownership, vcMeetingManagementOwnership(suite, runID))
+	}
+	validateVCMeetingManagementCleanupToken(t, manifest.CleanupToken, suite, runID)
+	if manifest.CleanupToken != cleanupToken {
+		t.Fatal("invalid VC fixture manifest: cleanup_token must echo the credential supplied to create")
+	}
+	if strings.TrimSpace(manifest.AppID) == "" {
+		t.Fatal("invalid VC fixture manifest: app_id must be non-empty")
+	}
+	switch manifest.Brand {
+	case "feishu", "lark":
+	default:
+		t.Fatalf("invalid VC fixture manifest brand %q: want feishu|lark", manifest.Brand)
+	}
+
+	expectedOpenAPIHost, ok := vcMeetingManagementOpenAPIHost(manifest.Environment, manifest.Brand)
+	if !ok {
+		t.Fatalf("invalid VC fixture manifest: unsupported environment/brand binding %q/%q", manifest.Environment, manifest.Brand)
+	}
+	if manifest.OpenAPIHost != expectedOpenAPIHost {
+		t.Fatalf("invalid VC fixture manifest effective_openapi_host %q: want %q for environment/brand %q/%q", manifest.OpenAPIHost, expectedOpenAPIHost, manifest.Environment, manifest.Brand)
+	}
+	if resolvedHost := core.ResolveOpenBaseURL(core.LarkBrand(manifest.Brand)); resolvedHost != manifest.OpenAPIHost {
+		t.Fatalf("invalid VC fixture manifest: CLI resolves brand %q to %q, not effective_openapi_host %q", manifest.Brand, resolvedHost, manifest.OpenAPIHost)
+	}
+
+	validateVCMeetingManagementCredential(t, "credentials.host", manifest.Credentials.Host)
+	validateVCMeetingManagementCredential(t, "credentials.cohost", manifest.Credentials.Cohost)
+	validateVCMeetingManagementCredential(t, "credentials.normal", manifest.Credentials.Normal)
+}
+
+func requireVCMeetingEndProvisionFixture(t *testing.T) vcMeetingEndLiveFixture {
+	t.Helper()
+
+	manifest := requireVCMeetingManagementProvisionManifest(t, "end")
+	if manifest.End == nil {
+		t.Fatal("invalid VC fixture manifest: end suite payload must be present")
+	}
+
+	for _, item := range []struct {
+		name       string
+		data       vcMeetingEndProvisionCase
+		credential vcMeetingManagementManifestCredential
+	}{
+		{name: "end.host", data: manifest.End.Host, credential: manifest.Credentials.Host},
+		{name: "end.cohost", data: manifest.End.Cohost, credential: manifest.Credentials.Cohost},
+		{name: "end.normal", data: manifest.End.Normal, credential: manifest.Credentials.Normal},
+	} {
+		requirePositiveVCMeetingID(t, item.data.MeetingID)
+		validateVCParticipantTuple(t, item.name+".host_user", item.data.HostUser)
+		validateVCActorCredentialBinding(t, item.name+".actor", item.data.Actor, item.credential)
+	}
+
+	runtime := newVCMeetingManagementRuntime(manifest, t.TempDir())
+	fixture := vcMeetingEndLiveFixture{
+		appID:             manifest.AppID,
+		brand:             manifest.Brand,
+		hostToken:         manifest.Credentials.Host.UserAccessToken,
+		cohostToken:       manifest.Credentials.Cohost.UserAccessToken,
+		normalToken:       manifest.Credentials.Normal.UserAccessToken,
+		hostMeetingID:     manifest.End.Host.MeetingID,
+		cohostMeetingID:   manifest.End.Cohost.MeetingID,
+		normalMeetingID:   manifest.End.Normal.MeetingID,
+		isolatedConfigDir: runtime.isolatedConfigDir,
+	}
+
+	requireDistinctVCFixtureValues(t, "role tokens", fixture.hostToken, fixture.cohostToken, fixture.normalToken)
+	requireDistinctVCFixtureValues(t, "role token subject IDs", manifest.Credentials.Host.TokenSubjectID, manifest.Credentials.Cohost.TokenSubjectID, manifest.Credentials.Normal.TokenSubjectID)
+	requireDistinctVCFixtureValues(t, "role token subject OpenIDs", manifest.Credentials.Host.TokenSubjectOpenID, manifest.Credentials.Cohost.TokenSubjectOpenID, manifest.Credentials.Normal.TokenSubjectOpenID)
+	requireDistinctVCFixtureValues(t, "meeting IDs", fixture.hostMeetingID, fixture.cohostMeetingID, fixture.normalMeetingID)
+
+	requireVCAuthStatusCredentialBinding(t, runtime, manifest.Credentials.Host)
+	requireVCAuthStatusCredentialBinding(t, runtime, manifest.Credentials.Cohost)
+	requireVCAuthStatusCredentialBinding(t, runtime, manifest.Credentials.Normal)
+
+	assertVCActiveMeetingSnapshot(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.hostToken, fixture.hostMeetingID),
+		fixture.hostMeetingID,
+		manifest.End.Host.HostUser,
+		vcExpectedParticipantRole{Tuple: manifest.End.Host.HostUser, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.End.Host.Actor, IsHost: true},
+	)
+	assertVCActiveMeetingSnapshot(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.cohostToken, fixture.cohostMeetingID),
+		fixture.cohostMeetingID,
+		manifest.End.Cohost.HostUser,
+		vcExpectedParticipantRole{Tuple: manifest.End.Cohost.HostUser, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.End.Cohost.Actor, IsCohost: true},
+	)
+	assertVCActiveMeetingSnapshot(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.normalToken, fixture.normalMeetingID),
+		fixture.normalMeetingID,
+		manifest.End.Normal.HostUser,
+		vcExpectedParticipantRole{Tuple: manifest.End.Normal.HostUser, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.End.Normal.Actor},
+	)
+
+	return fixture
+}
+
+func requireVCKickoutProvisionFixture(t *testing.T) vcMeetingParticipantKickoutLiveFixture {
+	t.Helper()
+
+	manifest := requireVCMeetingManagementProvisionManifest(t, "kickout")
+	if manifest.Kickout == nil {
+		t.Fatal("invalid VC fixture manifest: kickout suite payload must be present")
+	}
+
+	for _, item := range []struct {
+		name       string
+		data       vcMeetingKickoutProvisionCase
+		credential vcMeetingManagementManifestCredential
+	}{
+		{name: "kickout.host", data: manifest.Kickout.Host, credential: manifest.Credentials.Host},
+		{name: "kickout.cohost", data: manifest.Kickout.Cohost, credential: manifest.Credentials.Cohost},
+		{name: "kickout.normal", data: manifest.Kickout.Normal, credential: manifest.Credentials.Normal},
+	} {
+		requirePositiveVCMeetingID(t, item.data.MeetingID)
+		validateVCParticipantTuple(t, item.name+".host_user", item.data.HostUser)
+		validateVCActorCredentialBinding(t, item.name+".actor", item.data.Actor, item.credential)
+		validateVCParticipantTuple(t, item.name+".target", item.data.Target)
+	}
+	requirePositiveVCMeetingID(t, manifest.Kickout.Partial.MeetingID)
+	validateVCParticipantTuple(t, "kickout.partial.host_user", manifest.Kickout.Partial.HostUser)
+	validateVCActorCredentialBinding(t, "kickout.partial.actor", manifest.Kickout.Partial.Actor, manifest.Credentials.Host)
+	validateVCParticipantTuple(t, "kickout.partial.success_target", manifest.Kickout.Partial.SuccessTarget)
+	validateVCParticipantTuple(t, "kickout.partial.failed_target", manifest.Kickout.Partial.FailedTarget)
+	validateVCFailedTargetMode(t, manifest.Kickout.Partial.FailedTargetMode)
+
+	runtime := newVCMeetingManagementRuntime(manifest, t.TempDir())
+	fixture := vcMeetingParticipantKickoutLiveFixture{
+		appID:             manifest.AppID,
+		brand:             manifest.Brand,
+		hostToken:         manifest.Credentials.Host.UserAccessToken,
+		cohostToken:       manifest.Credentials.Cohost.UserAccessToken,
+		normalToken:       manifest.Credentials.Normal.UserAccessToken,
+		hostMeetingID:     manifest.Kickout.Host.MeetingID,
+		hostTarget:        vcKickoutParticipantFixture{tuple: manifest.Kickout.Host.Target.TupleString(), id: manifest.Kickout.Host.Target.ID, userType: manifest.Kickout.Host.Target.UserType},
+		cohostMeetingID:   manifest.Kickout.Cohost.MeetingID,
+		cohostTarget:      vcKickoutParticipantFixture{tuple: manifest.Kickout.Cohost.Target.TupleString(), id: manifest.Kickout.Cohost.Target.ID, userType: manifest.Kickout.Cohost.Target.UserType},
+		normalMeetingID:   manifest.Kickout.Normal.MeetingID,
+		normalTarget:      vcKickoutParticipantFixture{tuple: manifest.Kickout.Normal.Target.TupleString(), id: manifest.Kickout.Normal.Target.ID, userType: manifest.Kickout.Normal.Target.UserType},
+		partialMeetingID:  manifest.Kickout.Partial.MeetingID,
+		partialSuccess:    vcKickoutParticipantFixture{tuple: manifest.Kickout.Partial.SuccessTarget.TupleString(), id: manifest.Kickout.Partial.SuccessTarget.ID, userType: manifest.Kickout.Partial.SuccessTarget.UserType},
+		partialFailure:    vcKickoutParticipantFixture{tuple: manifest.Kickout.Partial.FailedTarget.TupleString(), id: manifest.Kickout.Partial.FailedTarget.ID, userType: manifest.Kickout.Partial.FailedTarget.UserType},
+		isolatedConfigDir: runtime.isolatedConfigDir,
+	}
+
+	requireDistinctVCFixtureValues(t, "role tokens", fixture.hostToken, fixture.cohostToken, fixture.normalToken)
+	requireDistinctVCFixtureValues(t, "role token subject IDs", manifest.Credentials.Host.TokenSubjectID, manifest.Credentials.Cohost.TokenSubjectID, manifest.Credentials.Normal.TokenSubjectID)
+	requireDistinctVCFixtureValues(t, "role token subject OpenIDs", manifest.Credentials.Host.TokenSubjectOpenID, manifest.Credentials.Cohost.TokenSubjectOpenID, manifest.Credentials.Normal.TokenSubjectOpenID)
+	requireDistinctVCFixtureValues(t, "meeting IDs", fixture.hostMeetingID, fixture.cohostMeetingID, fixture.normalMeetingID, fixture.partialMeetingID)
+	if fixture.partialSuccess.tuple == fixture.partialFailure.tuple {
+		t.Fatal("invalid VC fixture manifest: partial success and failure tuples must be distinct")
+	}
+
+	requireVCAuthStatusCredentialBinding(t, runtime, manifest.Credentials.Host)
+	requireVCAuthStatusCredentialBinding(t, runtime, manifest.Credentials.Cohost)
+	requireVCAuthStatusCredentialBinding(t, runtime, manifest.Credentials.Normal)
+
+	assertVCActiveMeetingSnapshot(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.hostToken, fixture.hostMeetingID),
+		fixture.hostMeetingID,
+		manifest.Kickout.Host.HostUser,
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Host.HostUser, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Host.Actor, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Host.Target},
+	)
+	assertVCActiveMeetingSnapshot(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.cohostToken, fixture.cohostMeetingID),
+		fixture.cohostMeetingID,
+		manifest.Kickout.Cohost.HostUser,
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Cohost.HostUser, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Cohost.Actor, IsCohost: true},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Cohost.Target},
+	)
+	assertVCActiveMeetingSnapshot(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.normalToken, fixture.normalMeetingID),
+		fixture.normalMeetingID,
+		manifest.Kickout.Normal.HostUser,
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Normal.HostUser, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Normal.Actor},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Normal.Target},
+	)
+	assertVCActiveMeetingSnapshot(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.hostToken, fixture.partialMeetingID),
+		fixture.partialMeetingID,
+		manifest.Kickout.Partial.HostUser,
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Partial.HostUser, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Partial.Actor, IsHost: true},
+		vcExpectedParticipantRole{Tuple: manifest.Kickout.Partial.SuccessTarget},
+	)
+	assertVCFailedTargetReadbackState(
+		t,
+		requireVCMeetingReadback(t, runtime, fixture.hostToken, fixture.partialMeetingID),
+		manifest.Kickout.Partial.FailedTargetMode,
+		manifest.Kickout.Partial.FailedTarget,
+	)
+
+	return fixture
+}
+
+func newVCMeetingManagementRuntime(manifest vcMeetingManagementProvisionManifest, configDir string) vcMeetingManagementRuntime {
+	return vcMeetingManagementRuntime{
+		appID:             manifest.AppID,
+		brand:             manifest.Brand,
+		isolatedConfigDir: configDir,
+	}
+}
+
+func vcMeetingManagementUserEnv(appID, brand, configDir, token string) map[string]string {
+	return map[string]string{
+		"LARKSUITE_CLI_APP_ID":              appID,
+		"LARKSUITE_CLI_APP_SECRET":          "",
+		"LARKSUITE_CLI_USER_ACCESS_TOKEN":   token,
+		"LARKSUITE_CLI_TENANT_ACCESS_TOKEN": "",
+		"LARKSUITE_CLI_BRAND":               brand,
+		"LARKSUITE_CLI_CONFIG_DIR":          configDir,
+		"LARKSUITE_CLI_DATA_DIR":            filepath.Join(configDir, "data"),
+		"LARKSUITE_CLI_LOG_DIR":             filepath.Join(configDir, "logs"),
+		"LARKSUITE_CLI_DEFAULT_AS":          "user",
+		"LARKSUITE_CLI_STRICT_MODE":         "user",
+		"LARKSUITE_CLI_REMOTE_META":         "off",
+		"LARKSUITE_CLI_NO_UPDATE_NOTIFIER":  "1",
+		"LARKSUITE_CLI_NO_SKILLS_NOTIFIER":  "1",
+
+		// The shared E2E runner inherits os.Environ. Explicitly neutralize
+		// selectors that could replace the manifest credentials, route through
+		// an ambient proxy, or switch to another workspace.
+		"LARKSUITE_CLI_PROFILE":       "",
+		"LARKSUITE_CLI_AUTH_PROXY":    "",
+		"LARKSUITE_CLI_PROXY_KEY":     "",
+		"LARKSUITE_CLI_PROXY_ENABLE":  "",
+		"LARKSUITE_CLI_PROXY_ADDRESS": "",
+		"LARKSUITE_CLI_CA_PATH":       "",
+		"LARK_CLI_NO_PROXY":           "1",
+		"HTTP_PROXY":                  "",
+		"http_proxy":                  "",
+		"HTTPS_PROXY":                 "",
+		"https_proxy":                 "",
+		"ALL_PROXY":                   "",
+		"all_proxy":                   "",
+		"OPENCLAW_CLI":                "",
+		"OPENCLAW_HOME":               "",
+		"OPENCLAW_STATE_DIR":          "",
+		"OPENCLAW_CONFIG_PATH":        "",
+		"OPENCLAW_SERVICE_MARKER":     "",
+		"OPENCLAW_SERVICE_VERSION":    "",
+		"OPENCLAW_GATEWAY_PORT":       "",
+		"OPENCLAW_SHELL":              "",
+		"HERMES_HOME":                 "",
+		"HERMES_QUIET":                "",
+		"HERMES_EXEC_ASK":             "",
+		"HERMES_GATEWAY_TOKEN":        "",
+		"HERMES_SESSION_KEY":          "",
+		"LARK_CHANNEL":                "",
+	}
+}
+
+func vcMeetingManagementNoRetry() clie2e.RetryOptions {
+	return clie2e.RetryOptions{
+		Attempts: 1,
+		ShouldRetry: func(*clie2e.Result) bool {
+			return false
+		},
+	}
+}
+
+func requireVCAuthStatusCredentialBinding(t *testing.T, runtime vcMeetingManagementRuntime, credential vcMeetingManagementManifestCredential) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), vcMeetingManagementReadbackTimeout)
+	defer cancel()
+
+	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"auth", "status", "--verify", "--json"},
+		DefaultAs: "user",
+		Env:       vcMeetingManagementUserEnv(runtime.appID, runtime.brand, runtime.isolatedConfigDir, credential.UserAccessToken),
+	}, vcMeetingManagementNoRetry())
+	if err != nil {
+		t.Fatalf("auth status --verify --json failed while binding actor for fixture role")
+	}
+	result.AssertExitCode(t, 0)
+
+	stdout := strings.TrimSpace(result.Stdout)
+	if !gjson.Valid(stdout) {
+		t.Fatal("auth status --verify --json returned non-JSON stdout for fixture role binding")
+	}
+	if gotAppID := gjson.Get(stdout, "appId").String(); gotAppID == "" || gotAppID != runtime.appID {
+		t.Fatalf("fixture role app does not match manifest app_id: got %q want %q", gotAppID, runtime.appID)
+	}
+	if gotBrand := gjson.Get(stdout, "brand").String(); gotBrand == "" || gotBrand != runtime.brand {
+		t.Fatalf("fixture role endpoint brand does not match manifest brand: got %q want %q", gotBrand, runtime.brand)
+	}
+	if verified := gjson.Get(stdout, "identities.user.verified"); !verified.Exists() || !verified.Bool() {
+		t.Fatal("auth status --verify --json did not verify the user identity for fixture role binding")
+	}
+	if openID := gjson.Get(stdout, "identities.user.openId").String(); openID == "" || openID != credential.TokenSubjectOpenID {
+		t.Fatalf("fixture role token OpenID does not match manifest token_subject_open_id: got %q want %q", openID, credential.TokenSubjectOpenID)
+	}
+}
+
+func requireVCMeetingReadback(t *testing.T, runtime vcMeetingManagementRuntime, token, meetingID string) gjson.Result {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), vcMeetingManagementReadbackTimeout)
+	defer cancel()
+
+	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"vc", "meeting", "get"},
+		DefaultAs: "user",
+		Params: map[string]any{
+			"meeting_id":        meetingID,
+			"with_participants": true,
+		},
+		Env: vcMeetingManagementUserEnv(runtime.appID, runtime.brand, runtime.isolatedConfigDir, token),
+	}, vcMeetingManagementNoRetry())
+	if err != nil {
+		t.Fatalf("vc meeting get readback failed for meeting_id=%s", meetingID)
+	}
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+
+	meeting := gjson.Get(result.Stdout, "data.meeting")
+	if !meeting.Exists() || !meeting.IsObject() {
+		t.Fatalf("vc meeting get readback for meeting_id=%s did not return data.meeting", meetingID)
+	}
+	return meeting
+}
+
+func assertVCActiveMeetingSnapshot(t *testing.T, meeting gjson.Result, meetingID string, hostUser vcParticipantTuple, expectedParticipants ...vcExpectedParticipantRole) {
+	t.Helper()
+
+	require.Equal(t, meetingID, meeting.Get("id").String(), "meeting snapshot:\n%s", meeting.Raw)
+	require.EqualValues(t, 2, meeting.Get("status").Int(), "meeting snapshot:\n%s", meeting.Raw)
+	assertVCParticipantTuple(t, "meeting.host_user", hostUser, meeting.Get("host_user"))
+
+	participants := meeting.Get("participants").Array()
+	require.NotEmpty(t, participants, "meeting snapshot:\n%s", meeting.Raw)
+	for _, expected := range expectedParticipants {
+		participant := findVCParticipant(t, participants, expected.Tuple)
+		require.EqualValues(t, 2, participant.Get("status").Int(), "expected participant must be active in meeting snapshot:\n%s", meeting.Raw)
+		require.Equal(t, expected.IsHost, participant.Get("is_host").Bool(), "meeting snapshot:\n%s", meeting.Raw)
+		require.Equal(t, expected.IsCohost, participant.Get("is_cohost").Bool(), "meeting snapshot:\n%s", meeting.Raw)
+	}
+}
+
+func assertVCFailedTargetReadbackState(t *testing.T, meeting gjson.Result, mode string, target vcParticipantTuple) {
+	t.Helper()
+	participants := meeting.Get("participants").Array()
+	switch mode {
+	case "missing":
+		assertVCParticipantAbsent(t, participants, target)
+	case "inactive":
+		participant := findVCParticipant(t, participants, target)
+		require.True(t, participant.Get("status").Exists(), "inactive failed target must expose status in meeting snapshot:\n%s", meeting.Raw)
+		require.NotEqualValues(t, 2, participant.Get("status").Int(), "failed target must not be active in partial fixture:\n%s", meeting.Raw)
+	default:
+		t.Fatalf("invalid VC fixture failed_target_mode %q", mode)
+	}
+}
+
+func assertVCParticipantAbsent(t *testing.T, participants []gjson.Result, tuple vcParticipantTuple) {
+	t.Helper()
+	for _, participant := range participants {
+		if participant.Get("id").String() == tuple.ID && participant.Get("user_type").Int() == tuple.UserType {
+			t.Fatalf("meeting snapshot unexpectedly contains missing participant tuple %s", tuple.TupleString())
+		}
+	}
+}
+
+func findVCParticipant(t *testing.T, participants []gjson.Result, tuple vcParticipantTuple) gjson.Result {
+	t.Helper()
+
+	for _, participant := range participants {
+		if participant.Get("id").String() == tuple.ID && participant.Get("user_type").Int() == tuple.UserType {
+			return participant
+		}
+	}
+	t.Fatalf("meeting snapshot missing participant tuple %s", tuple.TupleString())
+	return gjson.Result{}
+}
+
+func assertVCParticipantTuple(t *testing.T, path string, want vcParticipantTuple, got gjson.Result) {
+	t.Helper()
+	require.True(t, got.Exists(), "%s must exist", path)
+	require.Equal(t, want.ID, got.Get("id").String(), "%s.id", path)
+	require.EqualValues(t, want.UserType, got.Get("user_type").Int(), "%s.user_type", path)
+}
+
+func requireDistinctVCFixtureValues(t *testing.T, kind string, values ...string) {
+	t.Helper()
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, exists := seen[value]; exists {
+			t.Fatalf("invalid VC fixture: %s must be pairwise distinct", kind)
+		}
+		seen[value] = struct{}{}
+	}
+}
+
+func requirePositiveVCMeetingID(t *testing.T, meetingID string) {
+	t.Helper()
+	parsed, err := strconv.ParseInt(meetingID, 10, 64)
+	if err != nil || parsed <= 0 {
+		t.Fatalf("invalid VC fixture meeting ID %q: want positive base-10 int64", meetingID)
+	}
+}
+
+func validateVCParticipantTuple(t *testing.T, field string, tuple vcParticipantTuple) {
+	t.Helper()
+	if tuple.ID == "" || strings.TrimSpace(tuple.ID) != tuple.ID {
+		t.Fatalf("invalid VC fixture %s.id %q: must be non-empty and have no surrounding whitespace", field, tuple.ID)
+	}
+	parsedID, err := strconv.ParseInt(tuple.ID, 10, 64)
+	if err != nil || parsedID <= 0 {
+		t.Fatalf("invalid VC fixture %s.id %q: want positive base-10 int64", field, tuple.ID)
+	}
+	if tuple.UserType < 1 || tuple.UserType > 7 {
+		t.Fatalf("invalid VC fixture %s.user_type %d: want 1..7", field, tuple.UserType)
+	}
+}
+
+func validateVCActorCredentialBinding(t *testing.T, field string, actor vcParticipantTuple, credential vcMeetingManagementManifestCredential) {
+	t.Helper()
+	validateVCParticipantTuple(t, field, actor)
+	if actor.UserType != vcMeetingManagementLarkUserType {
+		t.Fatalf("invalid VC fixture %s.user_type %d: meeting-management actor must be LARK_USER=%d", field, actor.UserType, vcMeetingManagementLarkUserType)
+	}
+	if actor.ID != credential.TokenSubjectID || actor.UserType != credential.TokenSubjectUserType {
+		t.Fatalf("invalid VC fixture %s: actor tuple %s must exactly match credential token subject %s=%d", field, actor.TupleString(), credential.TokenSubjectID, credential.TokenSubjectUserType)
+	}
+}
+
+func validateVCActorOpenID(t *testing.T, field, openID string) {
+	t.Helper()
+	if len(openID) > vcMeetingManagementMaxActorOpenIDLength || !vcMeetingManagementActorOpenIDPattern.MatchString(openID) {
+		t.Fatalf("invalid VC fixture %s: want an ou_-prefixed OpenID of at most %d ASCII characters", field, vcMeetingManagementMaxActorOpenIDLength)
+	}
+}
+
+func validateVCMeetingManagementUserToken(t *testing.T, field, token string) {
+	t.Helper()
+	if len(token) < len("u-")+1 || len(token) > vcMeetingManagementMaxUserTokenLength || !strings.HasPrefix(token, "u-") {
+		t.Fatalf("invalid VC fixture manifest %s: want a non-empty u- prefixed bearer token of at most %d ASCII bytes", field, vcMeetingManagementMaxUserTokenLength)
+	}
+	for _, char := range []byte(token[len("u-"):]) {
+		if char < 0x21 || char > 0x7e {
+			t.Fatalf("invalid VC fixture manifest %s: bearer token must contain only printable, non-whitespace ASCII bytes", field)
+		}
+	}
+}
+
+func validateVCMeetingManagementCredential(t *testing.T, field string, credential vcMeetingManagementManifestCredential) {
+	t.Helper()
+	validateVCMeetingManagementUserToken(t, field+".user_access_token", credential.UserAccessToken)
+	if !vcMeetingManagementNumericSubjectPattern.MatchString(credential.TokenSubjectID) {
+		t.Fatalf("invalid VC fixture manifest %s.token_subject_id %q: want canonical positive base-10 int64", field, credential.TokenSubjectID)
+	}
+	if parsed, err := strconv.ParseInt(credential.TokenSubjectID, 10, 64); err != nil || parsed <= 0 {
+		t.Fatalf("invalid VC fixture manifest %s.token_subject_id %q: want canonical positive base-10 int64", field, credential.TokenSubjectID)
+	}
+	if credential.TokenSubjectUserType != vcMeetingManagementLarkUserType {
+		t.Fatalf("invalid VC fixture manifest %s.token_subject_user_type %d: want LARK_USER=%d", field, credential.TokenSubjectUserType, vcMeetingManagementLarkUserType)
+	}
+	validateVCActorOpenID(t, field+".token_subject_open_id", credential.TokenSubjectOpenID)
+	if credential.TokenSubjectSource != vcMeetingManagementSubjectIDSource {
+		t.Fatalf("invalid VC fixture manifest %s.token_subject_source %q: want %q", field, credential.TokenSubjectSource, vcMeetingManagementSubjectIDSource)
+	}
+}
+
+func validateVCMeetingManagementCleanupToken(t *testing.T, token, suite, runID string) {
+	t.Helper()
+	prefix := vcMeetingManagementCleanupTokenPrefix(suite, runID)
+	if strings.TrimSpace(token) != token || len(token) > vcMeetingManagementMaxCleanupTokenLength || !strings.HasPrefix(token, prefix) {
+		t.Fatal("invalid VC fixture manifest: cleanup_token must be bounded and bind suite and run_id")
+	}
+	suffix := strings.TrimPrefix(token, prefix)
+	if len(suffix) < vcMeetingManagementMinCleanupSuffixLength || !vcMeetingManagementCleanupSuffixPattern.MatchString(suffix) {
+		t.Fatalf("invalid VC fixture manifest: cleanup_token suffix must contain at least %d safe ASCII characters", vcMeetingManagementMinCleanupSuffixLength)
+	}
+}
+
+func vcMeetingManagementOpenAPIHost(environment, brand string) (string, bool) {
+	if environment != vcMeetingManagementOnlineEnvironment {
+		return "", false
+	}
+	switch brand {
+	case "feishu":
+		return vcMeetingManagementFeishuOpenAPIHost, true
+	case "lark":
+		return vcMeetingManagementLarkOpenAPIHost, true
+	default:
+		return "", false
+	}
+}
+
+func validateVCFailedTargetMode(t *testing.T, mode string) {
+	switch mode {
+	case "missing", "inactive":
+		return
+	default:
+		t.Fatalf("invalid VC fixture failed_target_mode %q: want missing|inactive", mode)
+	}
+}
+
+func assertVCMeetingManagementDenied(t *testing.T, result *clie2e.Result) {
+	t.Helper()
+	require.NotNil(t, result)
+	require.NotZero(t, result.ExitCode, "destructive VC management unexpectedly succeeded\nstdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
+	require.Empty(t, result.Stdout)
+	require.True(t, gjson.Valid(result.Stderr), "stderr must be a structured error envelope:\n%s", result.Stderr)
+	require.EqualValues(t, vcMeetingManagementPermissionDeniedCode, gjson.Get(result.Stderr, "error.code").Int(), "stderr:\n%s", result.Stderr)
+	require.NotEmpty(t, gjson.Get(result.Stderr, "error.type").String(), "stderr:\n%s", result.Stderr)
+	require.NotEmpty(t, gjson.Get(result.Stderr, "error.message").String(), "stderr:\n%s", result.Stderr)
+	require.Equal(t, "user", gjson.Get(result.Stderr, "identity").String(), "stderr:\n%s", result.Stderr)
+	require.False(t, gjson.Get(result.Stderr, "error.retryable").Bool(), "stderr:\n%s", result.Stderr)
+}
+
+func newVCMeetingManagementRunID(t *testing.T, suite string) string {
+	t.Helper()
+	buf := make([]byte, 12)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("failed to generate VC fixture run_id for suite %s", suite)
+	}
+	return suite + "-" + hex.EncodeToString(buf)
+}
+
+func newVCMeetingManagementCleanupToken(t *testing.T, suite, runID string) string {
+	t.Helper()
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("failed to generate VC fixture cleanup token for suite %s run_id=%s", suite, runID)
+	}
+	return vcMeetingManagementCleanupTokenPrefix(suite, runID) + hex.EncodeToString(buf)
+}
+
+func vcMeetingManagementOwnership(suite, runID string) string {
+	return fmt.Sprintf("vc-meeting-management/%s/%s", suite, runID)
+}
+
+func vcMeetingManagementCleanupTokenPrefix(suite, runID string) string {
+	return fmt.Sprintf("vc-meeting-management:%s:%s:", suite, runID)
+}
+
+func execCommandExitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func (t vcParticipantTuple) TupleString() string {
+	return fmt.Sprintf("%s=%d", t.ID, t.UserType)
+}

--- a/tests/cli_e2e/vc/vc_meeting_management_fixture_test.go
+++ b/tests/cli_e2e/vc/vc_meeting_management_fixture_test.go
@@ -858,10 +858,6 @@ func validateVCParticipantTuple(t *testing.T, field string, tuple vcParticipantT
 	if tuple.ID == "" || strings.TrimSpace(tuple.ID) != tuple.ID {
 		t.Fatalf("invalid VC fixture %s.id %q: must be non-empty and have no surrounding whitespace", field, tuple.ID)
 	}
-	parsedID, err := strconv.ParseInt(tuple.ID, 10, 64)
-	if err != nil || parsedID <= 0 {
-		t.Fatalf("invalid VC fixture %s.id %q: want positive base-10 int64", field, tuple.ID)
-	}
 	if tuple.UserType < 1 || tuple.UserType > 7 {
 		t.Fatalf("invalid VC fixture %s.user_type %d: want 1..7", field, tuple.UserType)
 	}

--- a/tests/cli_e2e/vc/vc_meeting_participant_kickout_test.go
+++ b/tests/cli_e2e/vc/vc_meeting_participant_kickout_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package vc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type vcKickoutParticipantFixture struct {
+	tuple    string
+	id       string
+	userType int64
+}
+
+type vcMeetingParticipantKickoutLiveFixture struct {
+	appID             string
+	brand             string
+	hostToken         string
+	cohostToken       string
+	normalToken       string
+	hostMeetingID     string
+	hostTarget        vcKickoutParticipantFixture
+	cohostMeetingID   string
+	cohostTarget      vcKickoutParticipantFixture
+	normalMeetingID   string
+	normalTarget      vcKickoutParticipantFixture
+	partialMeetingID  string
+	partialSuccess    vcKickoutParticipantFixture
+	partialFailure    vcKickoutParticipantFixture
+	isolatedConfigDir string
+}
+
+// TestVCMeetingParticipantKickoutDryRunE2E proves repeated tuple flags reach
+// the built command in their original order and that dry-run bypasses the
+// high-risk confirmation without making a real request.
+func TestVCMeetingParticipantKickoutDryRunE2E(t *testing.T) {
+	setVCDryRunEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"vc", "+meeting-participant-kickout", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user")
+	require.NotContains(t, helpResult.Stdout, "identity type: user | bot")
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+meeting-participant-kickout",
+			"--meeting-id", "7651377260537433044",
+			"--participant", "000123=1",
+			"--participant", "000123=2",
+			"--participant", "000123=1",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	require.True(t, gjson.Get(result.Stdout, "dry_run").Bool(), "stdout:\n%s", result.Stdout)
+	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String(), "stdout:\n%s", result.Stdout)
+	require.Equal(t, "/open-apis/vc/v1/meetings/7651377260537433044/kickout", clie2e.DryRunGet(result.Stdout, "api.0.url").String(), "stdout:\n%s", result.Stdout)
+
+	users := clie2e.DryRunGet(result.Stdout, "api.0.body.kickout_users").Array()
+	require.Len(t, users, 3, "stdout:\n%s", result.Stdout)
+	wantIDs := []string{"000123", "000123", "000123"}
+	wantTypes := []int64{1, 2, 1}
+	for index := range users {
+		require.Equal(t, wantIDs[index], users[index].Get("id").String(), "stdout:\n%s", result.Stdout)
+		require.Equal(t, wantTypes[index], users[index].Get("user_type").Int(), "stdout:\n%s", result.Stdout)
+	}
+
+	withoutConfirmation, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+meeting-participant-kickout",
+			"--meeting-id", "7651377260537433044",
+			"--participant", "000123=1",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	withoutConfirmation.AssertExitCode(t, 10)
+	require.Empty(t, withoutConfirmation.Stdout)
+	require.Equal(t, "confirmation", gjson.Get(withoutConfirmation.Stderr, "error.type").String(), "stderr:\n%s", withoutConfirmation.Stderr)
+	require.Equal(t, "confirmation_required", gjson.Get(withoutConfirmation.Stderr, "error.subtype").String(), "stderr:\n%s", withoutConfirmation.Stderr)
+	require.Contains(t, gjson.Get(withoutConfirmation.Stderr, "error.hint").String(), "--yes")
+
+	invalidParticipant, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+meeting-participant-kickout",
+			"--meeting-id", "7651377260537433044",
+			"--participant", "0=1",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	invalidParticipant.AssertExitCode(t, 2)
+	require.Empty(t, invalidParticipant.Stdout)
+	require.Equal(t, "validation", gjson.Get(invalidParticipant.Stderr, "error.type").String(), "stderr:\n%s", invalidParticipant.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(invalidParticipant.Stderr, "error.subtype").String(), "stderr:\n%s", invalidParticipant.Stderr)
+	require.Equal(t, "--participant", gjson.Get(invalidParticipant.Stderr, "error.param").String(), "stderr:\n%s", invalidParticipant.Stderr)
+
+	botIdentity, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"vc", "+meeting-participant-kickout",
+			"--meeting-id", "7651377260537433044",
+			"--participant", "000123=1",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	botIdentity.AssertExitCode(t, 2)
+	require.Empty(t, botIdentity.Stdout)
+	require.Equal(t, "validation", gjson.Get(botIdentity.Stderr, "error.type").String(), "stderr:\n%s", botIdentity.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(botIdentity.Stderr, "error.subtype").String(), "stderr:\n%s", botIdentity.Stderr)
+	require.Equal(t, "--as", gjson.Get(botIdentity.Stderr, "error.param").String(), "stderr:\n%s", botIdentity.Stderr)
+}
+
+// TestVCMeetingParticipantKickoutLiveE2E is destructive and default-off. The
+// dedicated remote lane must explicitly opt in; after that, missing or invalid
+// provisioner data is fatal. It proves tuple-correlated command results against
+// pre-mutation fixture readback, not participant removal at the final sink.
+func TestVCMeetingParticipantKickoutLiveE2E(t *testing.T) {
+	requireVCMeetingManagementDestructiveOptIn(t)
+	fixture := requireVCKickoutProvisionFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	t.Cleanup(cancel)
+
+	t.Run("host kicks ordinary participant", func(t *testing.T) {
+		result, err := runMeetingParticipantKickoutLive(ctx, fixture, fixture.hostToken, fixture.hostMeetingID, fixture.hostTarget)
+		require.NoError(t, err)
+		assertKickoutLiveResults(t, result, []vcExpectedKickoutResult{{participant: fixture.hostTarget, result: 1}})
+	})
+
+	t.Run("cohost kicks ordinary participant", func(t *testing.T) {
+		result, err := runMeetingParticipantKickoutLive(ctx, fixture, fixture.cohostToken, fixture.cohostMeetingID, fixture.cohostTarget)
+		require.NoError(t, err)
+		assertKickoutLiveResults(t, result, []vcExpectedKickoutResult{{participant: fixture.cohostTarget, result: 1}})
+	})
+
+	t.Run("normal user is denied", func(t *testing.T) {
+		result, err := runMeetingParticipantKickoutLive(ctx, fixture, fixture.normalToken, fixture.normalMeetingID, fixture.normalTarget)
+		require.NoError(t, err)
+		assertVCMeetingManagementDenied(t, result)
+	})
+
+	t.Run("host receives tuple-correlated partial results", func(t *testing.T) {
+		result, err := runMeetingParticipantKickoutLive(
+			ctx,
+			fixture,
+			fixture.hostToken,
+			fixture.partialMeetingID,
+			fixture.partialSuccess,
+			fixture.partialFailure,
+		)
+		require.NoError(t, err)
+		assertKickoutLiveResults(t, result, []vcExpectedKickoutResult{
+			{participant: fixture.partialSuccess, result: 1},
+			{participant: fixture.partialFailure, result: 2},
+		})
+	})
+}
+
+type vcExpectedKickoutResult struct {
+	participant vcKickoutParticipantFixture
+	result      int64
+}
+
+type vcKickoutParticipantResultKey struct {
+	id       string
+	userType int64
+}
+
+func assertKickoutLiveResults(t *testing.T, result *clie2e.Result, want []vcExpectedKickoutResult) {
+	t.Helper()
+	require.NotNil(t, result)
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, true)
+	require.Equal(t, "user", gjson.Get(result.Stdout, "identity").String(), "stdout:\n%s", result.Stdout)
+
+	got := gjson.Get(result.Stdout, "data.data.kickout_results").Array()
+	require.Len(t, got, len(want), "stdout:\n%s", result.Stdout)
+
+	remainingByParticipant := make(map[vcKickoutParticipantResultKey]map[int64]int, len(want))
+	for _, expected := range want {
+		key := vcKickoutParticipantResultKey{id: expected.participant.id, userType: expected.participant.userType}
+		if remainingByParticipant[key] == nil {
+			remainingByParticipant[key] = make(map[int64]int)
+		}
+		remainingByParticipant[key][expected.result]++
+	}
+
+	for index, item := range got {
+		id := item.Get("id")
+		userType := item.Get("user_type")
+		resultCode := item.Get("result")
+		require.True(t, id.Exists() && id.String() != "" && userType.Exists() && resultCode.Exists(), "participant result %d is missing id, user_type, or result; stdout:\n%s", index, result.Stdout)
+
+		key := vcKickoutParticipantResultKey{id: id.String(), userType: userType.Int()}
+		remainingResults, ok := remainingByParticipant[key]
+		require.True(t, ok, "unexpected or duplicate participant result %s/%d at index %d; stdout:\n%s", key.id, key.userType, index, result.Stdout)
+		remaining := remainingResults[resultCode.Int()]
+		require.Greater(t, remaining, 0, "unexpected result %d for participant %s/%d at index %d; stdout:\n%s", resultCode.Int(), key.id, key.userType, index, result.Stdout)
+
+		if remaining == 1 {
+			delete(remainingResults, resultCode.Int())
+		} else {
+			remainingResults[resultCode.Int()] = remaining - 1
+		}
+		if len(remainingResults) == 0 {
+			delete(remainingByParticipant, key)
+		}
+	}
+	require.Empty(t, remainingByParticipant, "missing participant result tuple(s); stdout:\n%s", result.Stdout)
+}
+
+func runMeetingParticipantKickoutLive(ctx context.Context, fixture vcMeetingParticipantKickoutLiveFixture, token, meetingID string, participants ...vcKickoutParticipantFixture) (*clie2e.Result, error) {
+	args := []string{"vc", "+meeting-participant-kickout", "--meeting-id", meetingID}
+	for _, participant := range participants {
+		args = append(args, "--participant", participant.tuple)
+	}
+	return clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      args,
+		DefaultAs: "user",
+		Yes:       true,
+		Env:       vcMeetingManagementUserEnv(fixture.appID, fixture.brand, fixture.isolatedConfigDir, token),
+	}, vcMeetingManagementNoRetry())
+}

--- a/tests/cli_e2e/vc/vc_meeting_participant_kickout_test.go
+++ b/tests/cli_e2e/vc/vc_meeting_participant_kickout_test.go
@@ -57,9 +57,9 @@ func TestVCMeetingParticipantKickoutDryRunE2E(t *testing.T) {
 		Args: []string{
 			"vc", "+meeting-participant-kickout",
 			"--meeting-id", "7651377260537433044",
-			"--participant", "000123=1",
-			"--participant", "000123=2",
-			"--participant", "000123=1",
+			"--participant", "ou_123=1",
+			"--participant", "ou_123=2",
+			"--participant", "ou_123=1",
 			"--dry-run",
 		},
 		DefaultAs: "user",
@@ -69,10 +69,11 @@ func TestVCMeetingParticipantKickoutDryRunE2E(t *testing.T) {
 	require.True(t, gjson.Get(result.Stdout, "dry_run").Bool(), "stdout:\n%s", result.Stdout)
 	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String(), "stdout:\n%s", result.Stdout)
 	require.Equal(t, "/open-apis/vc/v1/meetings/7651377260537433044/kickout", clie2e.DryRunGet(result.Stdout, "api.0.url").String(), "stdout:\n%s", result.Stdout)
+	require.Equal(t, "open_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String(), "stdout:\n%s", result.Stdout)
 
 	users := clie2e.DryRunGet(result.Stdout, "api.0.body.kickout_users").Array()
 	require.Len(t, users, 3, "stdout:\n%s", result.Stdout)
-	wantIDs := []string{"000123", "000123", "000123"}
+	wantIDs := []string{"ou_123", "ou_123", "ou_123"}
 	wantTypes := []int64{1, 2, 1}
 	for index := range users {
 		require.Equal(t, wantIDs[index], users[index].Get("id").String(), "stdout:\n%s", result.Stdout)
@@ -83,7 +84,7 @@ func TestVCMeetingParticipantKickoutDryRunE2E(t *testing.T) {
 		Args: []string{
 			"vc", "+meeting-participant-kickout",
 			"--meeting-id", "7651377260537433044",
-			"--participant", "000123=1",
+			"--participant", "ou_123=1",
 		},
 		DefaultAs: "user",
 	})
@@ -98,7 +99,7 @@ func TestVCMeetingParticipantKickoutDryRunE2E(t *testing.T) {
 		Args: []string{
 			"vc", "+meeting-participant-kickout",
 			"--meeting-id", "7651377260537433044",
-			"--participant", "0=1",
+			"--participant", "ou_123=0",
 			"--dry-run",
 		},
 		DefaultAs: "user",
@@ -114,7 +115,7 @@ func TestVCMeetingParticipantKickoutDryRunE2E(t *testing.T) {
 		Args: []string{
 			"vc", "+meeting-participant-kickout",
 			"--meeting-id", "7651377260537433044",
-			"--participant", "000123=1",
+			"--participant", "ou_123=1",
 			"--dry-run",
 		},
 		DefaultAs: "bot",

--- a/tests/cli_e2e/vc/vc_skill_routing_contract_test.go
+++ b/tests/cli_e2e/vc/vc_skill_routing_contract_test.go
@@ -33,6 +33,7 @@ func TestMeetingSkillOwnsVCReferences(t *testing.T) {
 		sharedName string
 		oldName    string
 		command    string
+		userOnly   bool
 	}{
 		{
 			sharedName: "lark-vc-meeting-list-active.md",
@@ -54,6 +55,17 @@ func TestMeetingSkillOwnsVCReferences(t *testing.T) {
 			oldName:    "lark-vc-agent-meeting-countdown.md",
 			command:    "lark-cli vc +meeting-countdown",
 		},
+		{
+			sharedName: "lark-vc-meeting-end.md",
+			oldName:    "",
+			command:    "lark-cli vc +meeting-end",
+		},
+		{
+			sharedName: "lark-vc-meeting-participant-kickout.md",
+			oldName:    "",
+			command:    "lark-cli vc +meeting-participant-kickout",
+			userOnly:   true,
+		},
 	}
 
 	for _, reference := range references {
@@ -63,11 +75,17 @@ func TestMeetingSkillOwnsVCReferences(t *testing.T) {
 			content := readVCContractFile(t, "skills", "lark-meeting", "references", reference.sharedName)
 			require.Contains(t, content, reference.command)
 			require.Contains(t, content, "--as user")
-			require.Contains(t, content, "--as bot")
+			if reference.userOnly {
+				require.NotContains(t, content, "--as bot")
+			} else {
+				require.Contains(t, content, "--as bot")
+			}
 
 			oldPaths := []string{
 				vcContractPath(t, "skills", "lark-vc", "references", reference.sharedName),
-				vcContractPath(t, "skills", "lark-vc-agent", "references", reference.oldName),
+			}
+			if reference.oldName != "" {
+				oldPaths = append(oldPaths, vcContractPath(t, "skills", "lark-vc-agent", "references", reference.oldName))
 			}
 			for _, oldPath := range oldPaths {
 				_, err := vfs.Stat(oldPath)
@@ -84,6 +102,8 @@ func TestVCSharedMeetingReferencesHaveValidMarkdownLinks(t *testing.T) {
 		"lark-vc-meeting-events.md",
 		"lark-vc-meeting-message-send.md",
 		"lark-vc-meeting-countdown.md",
+		"lark-vc-meeting-end.md",
+		"lark-vc-meeting-participant-kickout.md",
 	}
 
 	for _, reference := range references {

--- a/tests/cli_e2e/vc/vc_skill_routing_contract_test.go
+++ b/tests/cli_e2e/vc/vc_skill_routing_contract_test.go
@@ -59,6 +59,7 @@ func TestMeetingSkillOwnsVCReferences(t *testing.T) {
 			sharedName: "lark-vc-meeting-end.md",
 			oldName:    "",
 			command:    "lark-cli vc +meeting-end",
+			userOnly:   true,
 		},
 		{
 			sharedName: "lark-vc-meeting-participant-kickout.md",


### PR DESCRIPTION
Support ending meetings and removing participants through lark-cli, with UAT/TAT compatibility and offline preflight guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `vc +meeting-end` support for ending active meetings with user or bot identity.
  * Added `vc +meeting-participant-kickout` for removing selected participants with validated participant details.
  * Added dry-run previews and explicit `--yes` confirmation for high-risk actions.
* **Bug Fixes**
  * Improved offline validation, identity checks, and structured error output before network requests.
* **Documentation**
  * Added references for meeting screenshots, countdowns, invitations, meeting termination, and participant removal.
  * Updated guidance on permissions, identity selection, and safety procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->