### PR TITLE
fix(apps): classify the online DDL ban and the file storage quota failure

### DIFF
--- a/internal/errclass/codemeta_spark.go
+++ b/internal/errclass/codemeta_spark.go
@@ -41,6 +41,7 @@ var sparkCodeMeta = map[int]CodeMeta{
 
 	400000034: {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                   // file not found or no access
 	500000034: {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},                   // file not found or no access, pre-4xx renumber
+	400000055: {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded},              // tenant file storage quota exceeded
 	400002467: {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied}, // app administrator or developer required
 	500002761: {Category: errs.CategoryAuthorization, Subtype: errs.SubtypePermissionDenied}, // app administrator or developer required, pre-4xx renumber
 }

--- a/internal/errclass/codemeta_spark_test.go
+++ b/internal/errclass/codemeta_spark_test.go
@@ -42,6 +42,7 @@ func TestLookupCodeMetaSparkRoleCodes(t *testing.T) {
 		// the renumbering rolls out per lane.
 		{400000034, errs.CategoryAPI, errs.SubtypeNotFound},
 		{500000034, errs.CategoryAPI, errs.SubtypeNotFound},
+		{400000055, errs.CategoryAPI, errs.SubtypeQuotaExceeded},
 		{400002467, errs.CategoryAuthorization, errs.SubtypePermissionDenied},
 		{500002761, errs.CategoryAuthorization, errs.SubtypePermissionDenied},
 	}
@@ -143,5 +144,37 @@ func TestSparkTableNotFoundLeavesHintToCaller(t *testing.T) {
 	}
 	if got := output.ExitCodeOf(err); got != 1 {
 		t.Errorf("exit = %d, want 1 (unchanged: an ordinary API lookup failure)", got)
+	}
+}
+
+// TestSparkTenantStorageQuotaExceeded 钉住配额超限的完整契约。
+//
+// 登记这个码同时解决两件事：subtype 从 unknown 变成 quota_exceeded，且 classify.go 的
+// APIHint 会补上通用的「腾出配额后再试」文案 —— 未登记时 hint 是空的，调用方拿不到任何
+// 下一步。这里断言 hint 非空，是为了让「框架已有文案」这个依赖被显式记录：若哪天 APIHint
+// 去掉了 quota_exceeded 分支，这条会失败，提示需要改为域内文案。
+func TestSparkTenantStorageQuotaExceeded(t *testing.T) {
+	err := BuildAPIError(map[string]any{
+		"code": 400000055,
+		"msg":  "当前文件存储已达到上限，暂时不支持上传",
+	}, ClassifyContext{Identity: "user"})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("BuildAPIError = %#v, want typed problem", err)
+	}
+	if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeQuotaExceeded {
+		t.Fatalf("category/subtype = %s/%s, want api/quota_exceeded", p.Category, p.Subtype)
+	}
+	if p.Hint == "" {
+		t.Error("Hint is empty: the framework APIHint no longer covers quota_exceeded, so this code needs its own wording")
+	}
+	// 配额不是「改参数就能过」，故留在 CategoryAPI（exit 1）而非 Validation（exit 2）；
+	// quota_exceeded 这个 subtype 本身已经表达了「别重试」。
+	if got := output.ExitCodeOf(err); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+	// 服务端原句必须保留：它是唯一说明「租户级」而非单 app 配额的信息。
+	if p.Message != "当前文件存储已达到上限，暂时不支持上传" {
+		t.Errorf("message = %q, want the server wording verbatim", p.Message)
 	}
 }

--- a/shortcuts/apps/apps_db_execute.go
+++ b/shortcuts/apps/apps_db_execute.go
@@ -218,7 +218,21 @@ func findErrorSentinel(stmts []map[string]interface{}) (int, map[string]interfac
 	return 0, nil, false
 }
 
-// sqlStatementError 把 ERROR 哨兵升级成 typed errs.APIError（CategoryAPI → exit 1）。
+// dbOnlineDDLForbiddenCode 是「多环境应用的 online 分支禁止 DDL/DCL」的业务码。
+//
+// 服务端专用码，一码一场景：dataloom 的 ErrOnlineEnvForbidDDLDCL（"k_dl_4000001"，
+// 客户端错误 4xxxxxx 段），只由前置校验器 OnlineEnvDDLDCLValidator 抛出，触发条件是
+// env==online && 专家模式 && 多环境库。语法错误 / PG 报错走别的码（实测分别是 2 与
+// 1300002），不会撞这个号。哨兵里带的是剥掉 "k_dl_" 前缀后的数字。
+const dbOnlineDDLForbiddenCode = 4000001
+
+// dbOnlineDDLForbiddenHint 指向正规路径：dev 改完再发布。
+//
+// 不说 "fix the SQL"——SQL 本身没问题，错的是目标环境，改 SQL 只会再撞一次同样的墙。
+const dbOnlineDDLForbiddenHint = "the online branch of a multi-env app forbids DDL/DCL. No statements were applied. " +
+	"Run the DDL against dev, then publish it with `lark-cli apps +db-env-migrate --app-id <app_id>`"
+
+// sqlStatementError 把 ERROR 哨兵升级成 typed 错误。
 //
 // 多语句失败的诊断信息——第几条失败 / 共几条 / 是否整批回滚 / 前序是否落地——都写进
 // message + hint 的人类可读文案（errs.* 信封是扁平字段、不带结构化 detail 容器）。文案对齐
@@ -227,8 +241,27 @@ func findErrorSentinel(stmts []map[string]interface{}) (int, map[string]interfac
 //   - hint 由 inferRolledBack 推断（实测后端把 BEGIN/COMMIT 也作为 statement 返回）：
 //     失败仍在用户显式事务内 → 服务端整批回滚，用 miaoda 原句 "Transaction rolled back; no changes persisted."；
 //     否则前序语句已逐条 commit、未回滚（flat 信封无逐句 breakdown，故 hint 简述前序已落地 + 从失败处续跑）。
+//
+// 【online DDL 禁令单独一支】默认分支对它三处失真，实测确认：
+//   - subtype 会是 server_error，语义是「上游 5xx、可重试」，而这是产品策略禁令，重试永远不变；
+//   - hint 会说 "fix the SQL"，方向错了（该改的是环境）；
+//   - "(at statement N of M)" 是假的：服务端前置校验整批拒绝、只回一条 ERROR 哨兵，所以
+//     发 5 条语句、DDL 在第 4 位时仍渲染成 "1 of 1"。CLI 不解析 SQL、拿不到真实语句数，
+//     无法通用修复，只能对这类「批量前置拒绝」的码去掉位置后缀。
+//
+// 「整批未执行」这一句对本码是服务端行为保证（校验器遍历全部语句、命中即整批拒绝），
+// 不是 inferRolledBack 的推断——实测回查落库行数全为 0。
 func sqlStatementError(stmts []map[string]interface{}, errIdx int, errStmt map[string]interface{}) error {
 	code, msg := parseErrorSentinel(common.GetString(errStmt, "data"))
+
+	if code == dbOnlineDDLForbiddenCode {
+		// Validation → exit 2：告诉调用方「请求本身合法，但目标环境状态不允许，去改环境而非重试」。
+		// 位置后缀刻意省略，见上方注释。
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "%s", msg).
+			WithCode(code).
+			WithHint("%s", dbOnlineDDLForbiddenHint)
+	}
+
 	stmtNo := errIdx + 1 // 1-based 给人看
 	fullMsg := fmt.Sprintf("%s (at statement %d of %d)", msg, stmtNo, len(stmts))
 

--- a/shortcuts/apps/apps_db_execute_test.go
+++ b/shortcuts/apps/apps_db_execute_test.go
@@ -984,3 +984,90 @@ func TestRenderSelectRowsAsTable_Branches(t *testing.T) {
 		})
 	}
 }
+
+// TestSQLStatementError_OnlineDDLForbidden 断言 online DDL 禁令走专属分支：
+// validation/failed_precondition（exit 2）、指向 dev + 发布的 hint、且不带伪造的语句位置。
+//
+// 为什么位置后缀必须去掉：服务端前置校验整批拒绝、只回一条 ERROR 哨兵，所以 CLI 看到的
+// len(stmts) 恒为 1。实测发 5 条语句、DDL 在第 4 位时默认分支会渲染成 "at statement 1 of 1"
+// —— 一个编造的位置。CLI 不解析 SQL，拿不到真实语句数，只能对这类码省略位置。
+func TestSQLStatementError_OnlineDDLForbidden(t *testing.T) {
+	// 两种 wire 形态都覆盖：codeString 会把 "k_dl_4000001" 剥成 4000001，
+	// 所以按数值判断对带前缀的字符串同样成立。
+	for _, wire := range []string{
+		`{"code":4000001,"message":"forbid ddl/dcl operation in online env"}`,
+		`{"code":"k_dl_4000001","message":"forbid ddl/dcl operation in online env"}`,
+	} {
+		stmts := []map[string]interface{}{{"sql_type": "ERROR", "data": wire}}
+		err := sqlStatementError(stmts, 0, stmts[0])
+		p, ok := errs.ProblemOf(err)
+		if !ok {
+			t.Fatalf("wire %s: not a typed error: %T", wire, err)
+		}
+		if p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeFailedPrecondition {
+			t.Errorf("wire %s: category/subtype = %s/%s, want validation/failed_precondition", wire, p.Category, p.Subtype)
+		}
+		if p.Code != dbOnlineDDLForbiddenCode {
+			t.Errorf("wire %s: code = %d, want %d", wire, p.Code, dbOnlineDDLForbiddenCode)
+		}
+		if got := output.ExitCodeOf(err); got != 2 {
+			t.Errorf("wire %s: exit = %d, want 2 (fix the environment, do not retry)", wire, got)
+		}
+		// 位置后缀必须消失，且 message 保留服务端原句。
+		if strings.Contains(p.Message, "at statement") {
+			t.Errorf("wire %s: message keeps a fabricated statement position: %q", wire, p.Message)
+		}
+		if p.Message != "forbid ddl/dcl operation in online env" {
+			t.Errorf("wire %s: message = %q, want the server wording verbatim", wire, p.Message)
+		}
+		if p.Hint != dbOnlineDDLForbiddenHint {
+			t.Errorf("wire %s: hint = %q, want the dev+migrate hint", wire, p.Hint)
+		}
+		if strings.Contains(p.Hint, "fix the SQL") {
+			t.Errorf("wire %s: hint still tells the caller to fix the SQL", wire)
+		}
+	}
+}
+
+// 多语句时也不能出现位置后缀：DDL 在第 4 位、服务端只回一条哨兵，位置无从得知。
+func TestSQLStatementError_OnlineDDLForbidden_NoPositionEvenWhenIndexNonZero(t *testing.T) {
+	stmts := []map[string]interface{}{
+		{"sql_type": "SELECT"},
+		{"sql_type": "INSERT"},
+		{"sql_type": "ERROR", "data": `{"code":4000001,"message":"forbid ddl/dcl operation in online env"}`},
+	}
+	p, _ := errs.ProblemOf(sqlStatementError(stmts, 2, stmts[2]))
+	if strings.Contains(p.Message, "at statement") {
+		t.Errorf("message keeps a statement position: %q", p.Message)
+	}
+	// 也不该沿用 errIdx>0 那支「前序已提交」的 hint —— 本码是整批拒绝，前序并未落地。
+	if strings.Contains(p.Hint, "Earlier statements were committed") {
+		t.Errorf("hint claims earlier statements committed, but this code rejects the whole batch: %q", p.Hint)
+	}
+}
+
+// 其它码保持原行为：分类、位置后缀、回滚推断都不变（本次改动刻意不碰它们）。
+func TestSQLStatementError_OtherCodesUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		wire string
+	}{
+		{"语法错误", `{"code":2,"message":"syntax error at or near \"SELCT\""}`},
+		{"PG 报错", `{"code":"k_dl_1300002","message":"duplicate key value violates unique constraint"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts := []map[string]interface{}{{"sql_type": "ERROR", "data": tc.wire}}
+			err := sqlStatementError(stmts, 0, stmts[0])
+			p, _ := errs.ProblemOf(err)
+			if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeServerError {
+				t.Errorf("category/subtype = %s/%s, want api/server_error (unchanged)", p.Category, p.Subtype)
+			}
+			if got := output.ExitCodeOf(err); got != 1 {
+				t.Errorf("exit = %d, want 1 (unchanged)", got)
+			}
+			if !strings.Contains(p.Message, "at statement 1 of 1") {
+				t.Errorf("message lost its position suffix: %q", p.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two apps-domain failures came back as `api/unknown` or `api/server_error` with exit 1, so a caller could not tell them apart from a transient upstream fault and had no actionable next step: the online DDL/DCL ban on `+db-execute`, and the tenant file storage quota on `+file-upload`.

## Changes

- `sqlStatementError`: give code `4000001` (online DDL/DCL ban) its own arm — `validation/failed_precondition` (exit 2), a hint pointing at dev plus `+db-env-migrate`, and no statement position. Every other code keeps its current classification, wording and `(at statement N of M)` suffix.
  - The position is dropped because the server pre-validates and rejects the whole batch, returning a single ERROR sentinel: a 5-statement request with the DDL in position 4 still rendered as `at statement 1 of 1`. The CLI does not split the SQL, so it cannot detect this mismatch generally — only codes known to be batch-level rejections can drop the suffix.
  - Matching on the numeric code also covers the `k_dl_4000001` wire form, since `codeString` already strips that prefix.
- Register code `400000055` (tenant file storage quota exceeded) as `api/quota_exceeded`, which also picks up the shared `APIHint` wording. Kept in `CategoryAPI` (exit 1) rather than `Validation`: a full quota is not something a different argument fixes.

Resulting envelopes:

| Case | Before | After |
|---|---|---|
| online DDL | `api/server_error`, exit 1, hint "fix the SQL and re-run" | `validation/failed_precondition`, exit 2, hint "run it against dev, then `+db-env-migrate`" |
| upload over quota | `api/unknown`, exit 1, no hint | `api/quota_exceeded`, exit 1, shared quota hint |

## Test Plan

- [x] Unit tests pass — `shortcuts/apps`, `internal/errclass`, `internal/output`, `errs`, `cmd`; `gofmt` and `go vet` clean
- [x] New cases assert the classification, exit code, hint and the absence of a fabricated statement position, plus a reverse lock (`TestSQLStatementError_OtherCodesUnchanged`) so the other codes keep their behaviour
- [x] Each new assertion was checked to fail when the registration or the new arm is removed, not just to pass as written
- [x] Manual local verification: `lark-cli apps +db-execute --environment online` with a DDL and `lark-cli apps +file-upload` over quota return the envelopes and exit codes above

## Related Issues

- None
