### PR TITLE
fix(base): hide dashboard auto analysis setting

### DIFF
--- a/shortcuts/base/dashboard_share.go
+++ b/shortcuts/base/dashboard_share.go
@@ -13,7 +13,11 @@ var dashboardShareUpdateFlagNames = []string{
 	"enabled",
 	"access-scope",
 	"show-source",
-	"enable-auto-analysis",
+}
+
+type dashboardShareResponse struct {
+	data     map[string]interface{}
+	settings map[string]interface{}
 }
 
 var BaseDashboardShareGet = common.Shortcut{
@@ -40,7 +44,7 @@ var BaseDashboardShareGet = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		runtime.Out(data, nil)
+		runtime.Out(publicDashboardShareData(data), nil)
 		return nil
 	},
 }
@@ -58,10 +62,9 @@ var BaseDashboardShareUpdate = common.Shortcut{
 		{Name: "enabled", Type: "bool", Desc: "enable or disable dashboard sharing"},
 		{Name: "access-scope", Desc: "share access scope", Enum: shareAccessScopeEnums},
 		{Name: "show-source", Type: "bool", Desc: "show the entry back to the source Base"},
-		{Name: "enable-auto-analysis", Type: "bool", Desc: "enable intelligent analysis on the shared dashboard"},
 	},
 	Tips: []string{
-		"Boolean settings use PATCH semantics: pass --show-source=false or --enable-auto-analysis=false to explicitly turn them off.",
+		"Boolean settings use PATCH semantics: pass --show-source=false to explicitly turn it off.",
 		"Update exactly one field per invocation; run separate commands to change multiple share fields.",
 	},
 	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
@@ -81,7 +84,7 @@ var BaseDashboardShareUpdate = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		runtime.Out(data, nil)
+		runtime.Out(publicDashboardShareData(data), nil)
 		return nil
 	},
 }
@@ -94,11 +97,18 @@ func buildDashboardShareUpdateBody(runtime *common.RuntimeContext) map[string]in
 	if runtime.Changed("show-source") {
 		settings["show_source"] = runtime.Bool("show-source")
 	}
-	if runtime.Changed("enable-auto-analysis") {
-		settings["enable_auto_analysis"] = runtime.Bool("enable-auto-analysis")
-	}
 	if len(settings) > 0 {
 		body["settings"] = settings
 	}
 	return body
+}
+
+func publicDashboardShareData(data map[string]interface{}) map[string]interface{} {
+	response := dashboardShareResponse{data: data}
+	response.settings, _ = data["settings"].(map[string]interface{})
+
+	// Intelligent analysis remains backend-gated, so the CLI must not expose it
+	// while preserving every other dashboard share field returned by the API.
+	delete(response.settings, "enable_auto_analysis")
+	return response.data
 }

--- a/shortcuts/base/share_execute_test.go
+++ b/shortcuts/base/share_execute_test.go
@@ -22,6 +22,10 @@ func TestDashboardShareGetCallsResourceEndpoint(t *testing.T) {
 			"data": map[string]interface{}{
 				"enabled":      true,
 				"access_scope": "tenant",
+				"settings": map[string]interface{}{
+					"show_source":          true,
+					"enable_auto_analysis": true,
+				},
 			},
 		},
 	})
@@ -37,6 +41,12 @@ func TestDashboardShareGetCallsResourceEndpoint(t *testing.T) {
 	if got := stdout.String(); !strings.Contains(got, `"access_scope": "tenant"`) {
 		t.Fatalf("stdout=%s", got)
 	}
+	if got := stdout.String(); !strings.Contains(got, `"show_source": true`) {
+		t.Fatalf("stdout=%s", got)
+	}
+	if got := stdout.String(); strings.Contains(got, `enable_auto_analysis`) {
+		t.Fatalf("stdout exposes backend-gated auto analysis setting: %s", got)
+	}
 }
 
 func TestDashboardShareUpdatePreservesExplicitFalse(t *testing.T) {
@@ -49,11 +59,6 @@ func TestDashboardShareUpdatePreservesExplicitFalse(t *testing.T) {
 			name: "show source",
 			flag: "--show-source=false",
 			want: map[string]interface{}{"settings": map[string]interface{}{"show_source": false}},
-		},
-		{
-			name: "auto analysis",
-			flag: "--enable-auto-analysis=false",
-			want: map[string]interface{}{"settings": map[string]interface{}{"enable_auto_analysis": false}},
 		},
 	}
 
@@ -83,6 +88,49 @@ func TestDashboardShareUpdatePreservesExplicitFalse(t *testing.T) {
 				t.Fatalf("request body=%#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDashboardShareUpdateHidesAutoAnalysisFromResponse(t *testing.T) {
+	factory, stdout, reg := newExecuteFactory(t)
+	stub := &httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_1/share",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"enabled": true,
+				"settings": map[string]interface{}{
+					"show_source":          false,
+					"enable_auto_analysis": true,
+				},
+			},
+		},
+	}
+	reg.Register(stub)
+
+	err := runShortcut(t, BaseDashboardShareUpdate, []string{
+		"+dashboard-share-update",
+		"--base-token", "app_x",
+		"--dashboard-id", "dsh_1",
+		"--show-source=false",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("run shortcut: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, `"show_source": false`) {
+		t.Fatalf("stdout=%s", got)
+	}
+	if got := stdout.String(); strings.Contains(got, `enable_auto_analysis`) {
+		t.Fatalf("stdout exposes backend-gated auto analysis setting: %s", got)
+	}
+}
+
+func TestDashboardShareUpdateDoesNotExposeAutoAnalysisFlag(t *testing.T) {
+	for _, flag := range BaseDashboardShareUpdate.Flags {
+		if flag.Name == "enable-auto-analysis" {
+			t.Fatal("dashboard share update exposes backend-gated --enable-auto-analysis")
+		}
 	}
 }
 

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark-base
-version: 1.2.20
+version: 1.2.21
 description: "飞书多维表格（Base）操作：建表、字段、记录、视图、统计、公式/lookup、表单、仪表盘、应用模式（BaseApp/AppMode 页面与组件）、Workspace 目录、workflow、角色权限、模板中心（多维表格模板分类/列表/搜索）；遇到 Base/多维表格/bitable、BaseApp/AppMode、/base/ 或 /app/ 链接时使用。BaseApp 不走 lark-apps；文件导入/导出转 lark-drive，认证/授权转 lark-shared。"
 metadata:
   requires:
@@ -119,7 +119,7 @@ Form 依附于 Table，以 Field 作为题目，每次有效提交会创建一�
 
 Dashboard Block 是 Base Block 树中的仪表盘容器，负责承载页面主题、布局和内部组件集合，本身不表示某一项图表数据。使用 `+dashboard-list` 定位容器，`+dashboard-get` 读取容器信息，`+dashboard-update` 修改主题，`+dashboard-arrange` 统一编排内部组件布局。
 
-**管理 Dashboard 分享：** 使用 `+dashboard-share-get` / `+dashboard-share-update` 管理启停、访问范围、返回源 Base 入口和智能分析；更新前先读取现状，每次只修改一个字段，显式 `false` 会被保留。
+**管理 Dashboard 分享：** 使用 `+dashboard-share-get` / `+dashboard-share-update` 管理启停、访问范围和返回源 Base 入口；更新前先读取现状，每次只修改一个字段，显式 `false` 会被保留。
 
 容器内部的图表、指标卡和文本等组件在 Dashboard API 中也称为 Block，但不属于 Base Block 树。内部 Block 分为三条操作路径：
 

--- a/tests/cli_e2e/base/base_share_dryrun_test.go
+++ b/tests/cli_e2e/base/base_share_dryrun_test.go
@@ -34,6 +34,17 @@ func TestBaseShareDryRun(t *testing.T) {
 		assert.NotContains(t, result.Stdout, `"enable_auto_analysis":`)
 	})
 
+	t.Run("dashboard auto analysis is not exposed", func(t *testing.T) {
+		result := runBaseDryRun(t, 2,
+			"base", "+dashboard-share-update",
+			"--base-token", "app_x",
+			"--dashboard-id", "dsh_1",
+			"--enable-auto-analysis=true",
+		)
+		assert.Contains(t, result.Stderr, "unknown flag")
+		assert.Contains(t, result.Stderr, "--enable-auto-analysis")
+	})
+
 	t.Run("form get", func(t *testing.T) {
 		result := runBaseDryRun(t, 0,
 			"base", "+form-share-get",

--- a/tests/cli_e2e/base/base_share_workflow_test.go
+++ b/tests/cli_e2e/base/base_share_workflow_test.go
@@ -93,9 +93,7 @@ func TestBaseShareWorkflow(t *testing.T) {
 		runUpdate("--enabled=true")
 		runUpdate("--access-scope", "invite")
 		runUpdate("--show-source=true")
-		runUpdate("--enable-auto-analysis=true")
 		runUpdate("--show-source=false")
-		runUpdate("--enable-auto-analysis=false")
 
 		get, runErr := clie2e.RunCmd(ctx, clie2e.Request{
 			Args:      []string{"base", "+dashboard-share-get", "--base-token", baseToken, "--dashboard-id", dashboardID},
@@ -109,9 +107,6 @@ func TestBaseShareWorkflow(t *testing.T) {
 		showSource := gjson.Get(get.Stdout, "data.settings.show_source")
 		require.True(t, showSource.Exists(), get.Stdout)
 		require.False(t, showSource.Bool(), get.Stdout)
-		autoAnalysis := gjson.Get(get.Stdout, "data.settings.enable_auto_analysis")
-		require.True(t, autoAnalysis.Exists(), get.Stdout)
-		require.False(t, autoAnalysis.Bool(), get.Stdout)
 	})
 
 	t.Run("form share update and get", func(t *testing.T) {

--- a/tests/cli_e2e/base/coverage.md
+++ b/tests/cli_e2e/base/coverage.md
@@ -58,7 +58,7 @@
 | ✕ | base +dashboard-get | shortcut |  | none | dashboard workflows not covered |
 | ✕ | base +dashboard-list | shortcut |  | none | dashboard workflows not covered |
 | ✓ | base +dashboard-share-get | shortcut | base_share_dryrun_test.go::TestBaseShareDryRun/dashboard get; base_share_workflow_test.go::TestBaseShareWorkflow/dashboard share update and get | `--base-token`; `--dashboard-id`; dry-run + deployment-gated live | live requires `LARK_CLI_E2E_BASE_SHARE_READY=1` |
-| ✓ | base +dashboard-share-update | shortcut | base_share_dryrun_test.go::TestBaseShareDryRun/dashboard partial update; base_share_workflow_test.go::TestBaseShareWorkflow/dashboard share update and get | one of `--enabled`; `--access-scope=invite`; `--show-source`; `--enable-auto-analysis` per request | single-field updates, explicit false, invite-only scope, and live read-back covered |
+| ✓ | base +dashboard-share-update | shortcut | base_share_dryrun_test.go::TestBaseShareDryRun/dashboard partial update, dashboard auto analysis is not exposed; base_share_workflow_test.go::TestBaseShareWorkflow/dashboard share update and get | one of `--enabled`; `--access-scope=invite`; `--show-source` per request; unsupported auto-analysis flag | single-field updates, explicit false, invite-only scope, live read-back, and backend-gated setting exclusion covered |
 | ✕ | base +dashboard-update | shortcut |  | none | dashboard workflows not covered |
 | ✕ | base +data-query | shortcut |  | none | no data-query assertions yet |
 | ✓ | base +field-create | shortcut | base_field_dryrun_test.go::TestBaseFieldCreateDryRunArrayCompat | `--base-token`; `--table-id`; `--json`; dry-run only | request shape only |


### PR DESCRIPTION
## Summary
Hide the backend-gated intelligent analysis setting from dashboard share management while preserving the existing dashboard share commands and all stable settings.

## Changes
- Remove the `--enable-auto-analysis` update flag and request-body handling.
- Strip `settings.enable_auto_analysis` from dashboard share GET and PATCH output while preserving all other response fields.
- Update Base skill guidance, dry-run coverage, and live workflow expectations.

## Test Plan
- [x] `go test ./shortcuts/base -run TestDashboardShare -count=1`
- [x] `go test ./tests/cli_e2e/base -run TestBaseShareDryRun -count=1`
- [x] `node scripts/skill-format-check/index.js`
- [x] `QUALITY_GATE_CHANGED_FROM=upstream/main make quality-gate`
- [ ] `make test` deterministic checks, race unit tests, examples, and Base coverage passed; unrelated live integration cases failed because the local test identities lack Calendar/Contact/Drive scopes and one existing Base URL fixture no longer matches the resolver output.

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the dashboard sharing auto-analysis setting from the command-line options.
  - Dashboard sharing responses now hide the backend-controlled auto-analysis setting while preserving other settings.
  - Updated dashboard sharing documentation to reflect the supported settings.

- **Bug Fixes**
  - Added coverage confirming unsupported auto-analysis options are rejected and sensitive settings are not exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->