### PR TITLE
feat(auth): import tenant tokens into secure storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,13 @@ lark-cli auth status
 
 | Command       | Description                                                    |
 | ------------- | -------------------------------------------------------------- |
-| `auth login`  | OAuth login with interactive selection or CLI flags for scopes |
-| `auth logout` | Sign out and remove stored credentials                         |
-| `auth status` | Show current login status and granted scopes                   |
-| `auth check`  | Verify a specific scope (exit 0 = ok, 1 = missing)            |
-| `auth scopes` | List all available scopes for the app                          |
-| `auth list`   | List all authenticated users                                   |
+| `auth login`               | OAuth login with interactive selection or CLI flags for scopes |
+| `auth import-tenant-token` | Import a caller-supplied TAT into secure local storage          |
+| `auth logout`              | Sign out and remove stored user credentials                    |
+| `auth status`              | Show current login status and granted scopes                   |
+| `auth check`               | Verify a specific scope (exit 0 = ok, 1 = missing)             |
+| `auth scopes`              | List all available scopes for the app                           |
+| `auth list`                | List all authenticated users                                    |
 
 ```bash
 # Interactive login (TUI guides domain and permission level selection)
@@ -190,10 +191,36 @@ lark-cli auth login --domain calendar --no-wait
 # Resume polling later
 lark-cli auth login --device-code <DEVICE_CODE>
 
+# Import a bot tenant token without putting it in argv or a temporary file
+some-token-provider | lark-cli auth import-tenant-token \
+  --app-id cli_xxx --token-stdin
+
 # Identity switching: execute commands as user or bot
 lark-cli calendar +agenda --as user
 lark-cli im +messages-send --as bot --chat-id "oc_xxx" --text "Hello"
 ```
+
+The imported app ID must use only lowercase letters, digits, `.`, `_`, and `-`;
+this prevents key collisions on case-insensitive secure-storage backends.
+
+For an environment-selected token-only account, set `LARKSUITE_CLI_APP_ID` and
+omit `LARKSUITE_CLI_TENANT_ACCESS_TOKEN` to use the imported token. A non-empty
+`LARKSUITE_CLI_TENANT_ACCESS_TOKEN` remains the per-process override. If neither
+source is available, credential resolution fails closed; it does not switch to
+another profile or credential provider. App-secret profiles keep using the
+existing token-endpoint flow.
+
+Imported TAT lookups are cached for one CLI invocation. A new process reads the
+latest stored value. Re-importing the same app ID overwrites the value; this
+version does not provide a command to remove an imported TAT. Tenant access
+tokens are short-lived and lark-cli does not refresh an imported value. When it
+expires, obtain a new TAT from the upstream credential source and run the import
+command again; subsequent CLI processes will read the replacement.
+
+When `LARKSUITE_CLI_APP_ID` selects the environment credential provider, the
+existing external-provider policy still disables the other `auth` management
+commands. Use `lark-cli whoami` or an actual bot API call to verify the imported
+credential; `auth import-tenant-token` is the only management exception.
 
 ## Three-Layer Command System
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -167,6 +167,7 @@ lark-cli auth status
 | 命令          | 说明                                             |
 | --------------- | -------------------------------------------------- |
 | `auth login`  | OAuth 登录，支持交互式选择或命令行参数指定 scope |
+| `auth import-tenant-token` | 将外部提供的 TAT 导入本地安全存储             |
 | `auth logout` | 登出并删除已存储的凭证                           |
 | `auth status` | 查看当前登录状态和已授权的 scope                 |
 | `auth check`  | 校验指定 scope（exit 0 = 有权限，1 = 缺失）      |
@@ -191,10 +192,32 @@ lark-cli auth login --domain calendar --no-wait
 # 稍后恢复轮询
 lark-cli auth login --device-code <DEVICE_CODE>
 
+# 从 stdin 导入 bot tenant token，避免 token 出现在 argv 或临时文件中
+some-token-provider | lark-cli auth import-tenant-token \
+  --app-id cli_xxx --token-stdin
+
 # 身份切换：以用户或机器人身份执行命令
 lark-cli calendar +agenda --as user
 lark-cli im +messages-send --as bot --chat-id "oc_xxx" --text "Hello"
 ```
+
+导入时的 app ID 只允许小写字母、数字、`.`、`_` 和 `-`，避免在大小写不敏感的
+安全存储后端发生键冲突。
+
+对于由环境变量选中的 token-only 账号，设置
+`LARKSUITE_CLI_APP_ID`，并省略 `LARKSUITE_CLI_TENANT_ACCESS_TOKEN`，
+即可使用已导入的 TAT。非空的 `LARKSUITE_CLI_TENANT_ACCESS_TOKEN` 仍是
+当前进程的最高优先级覆盖；两者都不存在时，凭据解析会失败，不会切换到其他
+profile 或 credential provider。AppSecret profile 继续使用原有 Token Endpoint
+链路。
+
+导入的 TAT 在单次 CLI 调用内缓存，新进程会读取最新存储值。重复导入同一 app ID
+会覆盖旧值；当前版本不提供删除命令。TAT 是短期凭据，lark-cli 不会刷新导入值。
+过期后需从上游凭据源获取新的 TAT，再次执行导入命令，后续 CLI 进程会读取新值。
+
+当 `LARKSUITE_CLI_APP_ID` 激活 env credential provider 后，除
+`auth import-tenant-token` 外的 `auth` 管理命令仍遵循既有 external-provider
+策略。请使用 `lark-cli whoami` 或实际 bot API 调用验证导入结果。
 
 ## 三层命令调用
 

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -50,6 +50,7 @@ func newCmdAuth(f *cmdutil.Factory, projector *recovery.Projector) *cobra.Comman
 	cmdutil.DisableAuthCheck(cmd)
 
 	cmd.AddCommand(NewCmdAuthLogin(f, nil))
+	cmd.AddCommand(NewCmdAuthImportTenantToken(f, nil))
 	cmd.AddCommand(NewCmdAuthLogout(f, nil))
 	cmd.AddCommand(newCmdAuthStatus(f, nil, projector))
 	cmd.AddCommand(NewCmdAuthScopes(f, nil))

--- a/cmd/auth/import_tenant_token.go
+++ b/cmd/auth/import_tenant_token.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"bufio"
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// ImportTenantTokenOptions holds inputs for auth import-tenant-token.
+type ImportTenantTokenOptions struct {
+	Factory    *cmdutil.Factory
+	Ctx        context.Context
+	AppID      string
+	TokenStdin bool
+}
+
+// NewCmdAuthImportTenantToken creates the local TAT import command.
+func NewCmdAuthImportTenantToken(f *cmdutil.Factory, runF func(*ImportTenantTokenOptions) error) *cobra.Command {
+	opts := &ImportTenantTokenOptions{Factory: f}
+	cmd := &cobra.Command{
+		Use:   "import-tenant-token",
+		Short: "Import a tenant access token into secure local storage",
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"positional arguments are not accepted; provide the tenant access token via stdin").
+				WithHint("pipe the token to stdin and pass --token-stdin")
+		},
+		Long: `Import a caller-supplied tenant access token into lark-cli's cross-platform
+secure local storage. The token must be read from stdin so it does not appear in
+the process argument list. Existing values for the same App ID are overwritten.`,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// This command intentionally imports an external credential into local
+			// storage, so it is the sole auth child that bypasses the parent
+			// RequireBuiltinCredentialProvider guard.
+			cmd.SilenceUsage = true
+			f.CurrentCommand = cmd
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts.Ctx = cmd.Context()
+			if runF != nil {
+				return runF(opts)
+			}
+			return authImportTenantTokenRun(opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.AppID, "app-id", "", "App ID whose tenant token is being imported")
+	cmd.Flags().BoolVar(&opts.TokenStdin, "token-stdin", false, "read the tenant access token from stdin")
+	_ = cmd.MarkFlagRequired("app-id")
+	cmdutil.MarkSensitiveFlag(cmd, "token-stdin")
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+func authImportTenantTokenRun(opts *ImportTenantTokenOptions) error {
+	if opts == nil || opts.Factory == nil {
+		return errs.NewInternalError(errs.SubtypeStorage, "tenant token import is unavailable")
+	}
+	if !credential.IsSafeInjectedTenantAppID(opts.AppID) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--app-id must use only lowercase letters, digits, '.', '_', or '-'").
+			WithParam("--app-id")
+	}
+	if !opts.TokenStdin {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"tenant access token must be provided via stdin").
+			WithHint("use --token-stdin and pipe the token").
+			WithParam("--token-stdin")
+	}
+	if opts.Factory.IOStreams == nil || opts.Factory.IOStreams.In == nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"stdin is empty, expected tenant access token").
+			WithParam("--token-stdin")
+	}
+
+	scanner := bufio.NewScanner(opts.Factory.IOStreams.In)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return errs.NewValidationError(errs.SubtypeFailedPrecondition,
+				"failed to read tenant access token from stdin: %v", err).
+				WithCause(err).
+				WithParam("--token-stdin")
+		}
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"stdin is empty, expected tenant access token").
+			WithParam("--token-stdin")
+	}
+	token := scanner.Text()
+	if !isValidTenantToken(token) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"tenant access token must be one non-empty line of visible ASCII characters").
+			WithParam("--token-stdin")
+	}
+	if scanner.Scan() {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"tenant access token must be provided as exactly one line").
+			WithParam("--token-stdin")
+	}
+	if err := scanner.Err(); err != nil {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"failed to read tenant access token from stdin: %v", err).
+			WithCause(err).
+			WithParam("--token-stdin")
+	}
+
+	if err := credential.StoreInjectedTenantAccessToken(opts.Factory.Keychain, opts.AppID, token); err != nil {
+		return err
+	}
+	return output.WriteSuccessEnvelope(map[string]any{
+		"appId":  opts.AppID,
+		"stored": true,
+	}, output.SuccessEnvelopeOptions{
+		CommandPath: "lark-cli auth import-tenant-token",
+		Out:         opts.Factory.IOStreams.Out,
+		ErrOut:      opts.Factory.IOStreams.ErrOut,
+	})
+}
+
+func isValidTenantToken(token string) bool {
+	if token == "" {
+		return false
+	}
+	for i := 0; i < len(token); i++ {
+		if token[i] < 0x21 || token[i] > 0x7e {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/auth/import_tenant_token_test.go
+++ b/cmd/auth/import_tenant_token_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	extcred "github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/keychain"
+	"github.com/larksuite/cli/internal/output"
+)
+
+type importTATKeychain struct {
+	service string
+	account string
+	value   string
+	setErr  error
+}
+
+func (k *importTATKeychain) Get(string, string) (string, error) { return "", nil }
+func (k *importTATKeychain) Set(service, account, value string) error {
+	k.service = service
+	k.account = account
+	k.value = value
+	return k.setErr
+}
+func (k *importTATKeychain) Remove(string, string) error { return nil }
+
+func isolateImportTATConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+}
+
+func TestAuthImportTenantToken_StoresSecretAndPrintsEnvelope(t *testing.T) {
+	isolateImportTATConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	f.IOStreams.In = strings.NewReader("tenant-token\n")
+	kc := &importTATKeychain{}
+	f.Keychain = kc
+
+	cmd := NewCmdAuthImportTenantToken(f, nil)
+	cmd.SetArgs([]string{"--app-id", "cli_test", "--token-stdin"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if kc.service != keychain.LarkCliService || kc.account != "tat:cli_test" || kc.value != "tenant-token" {
+		t.Fatalf("stored = (%q, %q, %q), want lark-cli/tat:cli_test with original token", kc.service, kc.account, kc.value)
+	}
+
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	data, ok := envelope.Data.(map[string]any)
+	if !envelope.OK || !ok || data["appId"] != "cli_test" || data["stored"] != true {
+		t.Fatalf("envelope = %#v, want ok data appId/stored", envelope)
+	}
+	if strings.Contains(stdout.String(), "tenant-token") {
+		t.Fatalf("stdout leaked token: %s", stdout.String())
+	}
+}
+
+func TestAuthImportTenantToken_RejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		in        string
+		wantParam string
+	}{
+		{name: "missing token stdin flag", args: []string{"--app-id", "cli_test"}, wantParam: "--token-stdin"},
+		{name: "empty stdin", args: []string{"--app-id", "cli_test", "--token-stdin"}, wantParam: "--token-stdin"},
+		{name: "empty token line", args: []string{"--app-id", "cli_test", "--token-stdin"}, in: "\n", wantParam: "--token-stdin"},
+		{name: "leading token whitespace", args: []string{"--app-id", "cli_test", "--token-stdin"}, in: " tenant-token\n", wantParam: "--token-stdin"},
+		{name: "trailing token whitespace", args: []string{"--app-id", "cli_test", "--token-stdin"}, in: "tenant-token \n", wantParam: "--token-stdin"},
+		{name: "internal token whitespace", args: []string{"--app-id", "cli_test", "--token-stdin"}, in: "tenant token\n", wantParam: "--token-stdin"},
+		{name: "multi-line token", args: []string{"--app-id", "cli_test", "--token-stdin"}, in: "tenant-token\nsecond-line\n", wantParam: "--token-stdin"},
+		{name: "whitespace app id", args: []string{"--app-id", "   ", "--token-stdin"}, in: "tenant-token\n", wantParam: "--app-id"},
+		{name: "surrounding app id whitespace", args: []string{"--app-id", " cli_test", "--token-stdin"}, in: "tenant-token\n", wantParam: "--app-id"},
+		{name: "unsafe app id", args: []string{"--app-id", "cli/test", "--token-stdin"}, in: "tenant-token\n", wantParam: "--app-id"},
+		{name: "uppercase app id", args: []string{"--app-id", "cli_Test", "--token-stdin"}, in: "tenant-token\n", wantParam: "--app-id"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateImportTATConfig(t)
+			f, _, _, _ := cmdutil.TestFactory(t, nil)
+			f.IOStreams.In = strings.NewReader(tc.in)
+			cmd := NewCmdAuthImportTenantToken(f, nil)
+			cmd.SilenceErrors = true
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want validation error")
+			}
+			if got := output.ExitCodeOf(err); got != output.ExitValidation {
+				t.Fatalf("exit code = %d, want validation", got)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %T %v, want *errs.ValidationError", err, err)
+			}
+			if validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != tc.wantParam {
+				t.Fatalf("validation metadata = (subtype=%q, param=%q), want invalid_argument/%s", validationErr.Subtype, validationErr.Param, tc.wantParam)
+			}
+		})
+	}
+}
+
+func TestAuthImportTenantToken_StorageFailureIsTypedAndDoesNotLeak(t *testing.T) {
+	isolateImportTATConfig(t)
+	f, stdout, stderr, _ := cmdutil.TestFactory(t, nil)
+	f.IOStreams.In = strings.NewReader("super-secret-token\n")
+	underlying := errors.New("set failed")
+	f.Keychain = &importTATKeychain{setErr: underlying}
+
+	cmd := NewCmdAuthImportTenantToken(f, nil)
+	cmd.SetArgs([]string{"--app-id", "cli_test", "--token-stdin"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want storage error")
+	}
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) || internalErr.Subtype != errs.SubtypeStorage || !errors.Is(err, underlying) {
+		t.Fatalf("error = %T %v, want internal/storage with cause", err, err)
+	}
+	combined := stdout.String() + stderr.String() + err.Error()
+	if strings.Contains(combined, "super-secret-token") {
+		t.Fatalf("command output leaked token: %s", combined)
+	}
+}
+
+func TestAuthImportTenantToken_RejectsPositionalToken(t *testing.T) {
+	isolateImportTATConfig(t)
+	f, stdout, stderr, _ := cmdutil.TestFactory(t, nil)
+	f.IOStreams.In = strings.NewReader("stdin-token\n")
+	kc := &importTATKeychain{}
+	f.Keychain = kc
+	cmd := NewCmdAuthImportTenantToken(f, nil)
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"--app-id", "cli_test", "--token-stdin", "positional-secret"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want positional argument rejection")
+	}
+	if kc.value != "" {
+		t.Fatalf("stored token = %q, want no write", kc.value)
+	}
+	if strings.Contains(stdout.String()+stderr.String()+err.Error(), "positional-secret") {
+		t.Fatal("command output leaked rejected positional token")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "" || !strings.Contains(validationErr.Hint, "--token-stdin") {
+		t.Fatalf("error = %T %v, want positional validation with stdin hint and no flag attribution", err, err)
+	}
+}
+
+func TestAuthImportTenantToken_BypassesExternalProviderGuardOnlyForLeaf(t *testing.T) {
+	isolateImportTATConfig(t)
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	f.IOStreams.In = strings.NewReader("tenant-token\n")
+	f.Keychain = &importTATKeychain{}
+	stub := &stubExternalProvider{name: "env"}
+	f.Credential = credential.NewCredentialProvider([]extcred.Provider{stub}, nil, nil, nil)
+
+	cmd := NewCmdAuth(f)
+	cmd.SetArgs([]string{"import-tenant-token", "--app-id", "cli_test", "--token-stdin"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("import under external provider error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"stored": true`) {
+		t.Fatalf("stdout = %s, want stored success", stdout.String())
+	}
+
+	blocked := NewCmdAuth(f)
+	blocked.SetArgs([]string{"status"})
+	if err := blocked.Execute(); err == nil {
+		t.Fatal("auth status under external provider error = nil, want existing guard")
+	}
+}
+
+func TestAuthImportTenantToken_RunHookReceivesValidatedOptions(t *testing.T) {
+	isolateImportTATConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	f.IOStreams.In = strings.NewReader("ignored-by-hook\n")
+	var got *ImportTenantTokenOptions
+	cmd := NewCmdAuthImportTenantToken(f, func(opts *ImportTenantTokenOptions) error {
+		got = opts
+		return nil
+	})
+	cmd.SetArgs([]string{"--app-id", "cli_test", "--token-stdin"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got == nil || got.AppID != "cli_test" || !got.TokenStdin || got.Ctx == nil {
+		t.Fatalf("options = %#v, want populated options", got)
+	}
+}
+
+type importTATFailingReader struct {
+	err error
+}
+
+func (r importTATFailingReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestAuthImportTenantToken_StdinFailurePreservesCause(t *testing.T) {
+	isolateImportTATConfig(t)
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	underlying := io.ErrUnexpectedEOF
+	f.IOStreams.In = importTATFailingReader{err: underlying}
+	cmd := NewCmdAuthImportTenantToken(f, nil)
+	cmd.SetArgs([]string{"--app-id", "cli_test", "--token-stdin"})
+
+	err := cmd.Execute()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T %v, want *errs.ValidationError", err, err)
+	}
+	if validationErr.Subtype != errs.SubtypeFailedPrecondition || validationErr.Param != "--token-stdin" {
+		t.Fatalf("validation metadata = (subtype=%q, param=%q), want failed_precondition/--token-stdin", validationErr.Subtype, validationErr.Param)
+	}
+	if !errors.Is(err, underlying) {
+		t.Fatalf("error = %v, want stdin cause", err)
+	}
+}
+
+var _ keychain.KeychainAccess = (*importTATKeychain)(nil)

--- a/cmd/flag_suggest_test.go
+++ b/cmd/flag_suggest_test.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/cmd/auth"
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/flagalias"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -157,5 +159,50 @@ func TestFlagDidYouMean_InvalidNonAliasValueStaysGeneric(t *testing.T) {
 	}
 	if validationErr.Param != "" || len(validationErr.Params) != 0 {
 		t.Fatalf("Param=%q Params=%v, want ordinary pflag behavior unchanged", validationErr.Param, validationErr.Params)
+	}
+}
+
+func TestFlagDidYouMean_SensitiveValueDoesNotLeak(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	root := &cobra.Command{Use: "lark-cli"}
+	root.SetFlagErrorFunc(flagDidYouMean)
+	root.AddCommand(auth.NewCmdAuth(f))
+	root.SetArgs([]string{"auth", "import-tenant-token", "--app-id", "cli_test", "--token-stdin=synthetic-secret-marker"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want sensitive flag rejection")
+	}
+	if strings.Contains(err.Error(), "synthetic-secret-marker") {
+		t.Fatalf("error leaked sensitive flag value: %v", err)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--token-stdin" {
+		t.Fatalf("error = %T %v, want validation error for --token-stdin", err, err)
+	}
+}
+
+func TestFlagDidYouMean_SensitiveShorthandValueDoesNotLeak(t *testing.T) {
+	for _, args := range [][]string{
+		{"--secret=synthetic-secret-marker"},
+		{"-s=synthetic-secret-marker"},
+	} {
+		c := &cobra.Command{Use: "demo"}
+		c.Flags().BoolP("secret", "s", false, "")
+		cmdutil.MarkSensitiveFlag(c, "secret")
+		parseErr := c.ParseFlags(args)
+		if parseErr == nil {
+			t.Fatalf("ParseFlags(%v) succeeded, want invalid boolean error", args)
+		}
+
+		err := flagDidYouMean(c, parseErr)
+		if strings.Contains(err.Error(), "synthetic-secret-marker") {
+			t.Fatalf("error leaked sensitive flag value for %v: %v", args, err)
+		}
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--secret" {
+			t.Fatalf("error = %T %v, want validation error for --secret", err, err)
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -523,14 +523,37 @@ func subcommandOnlyFlagTokens(cmd *cobra.Command, rawArgs []string) []string {
 			continue
 		}
 		if flagDefinedInTree(cmd, name) {
-			misplaced = append(misplaced, a)
+			if canonical, sensitive := sensitiveFlagInSubcommands(cmd, name); sensitive {
+				misplaced = append(misplaced, "--"+canonical)
+			} else {
+				misplaced = append(misplaced, a)
+			}
 		}
 	}
 	return misplaced
 }
 
+func sensitiveFlagInSubcommands(cmd *cobra.Command, name string) (string, bool) {
+	short := len(name) == 1
+	for _, child := range cmd.Commands() {
+		var flag *pflag.Flag
+		if short {
+			flag = child.Flags().ShorthandLookup(name)
+		} else {
+			flag = child.Flags().Lookup(name)
+		}
+		if flag != nil && cmdutil.IsSensitiveFlag(child, flag.Name) {
+			return flag.Name, true
+		}
+		if canonical, sensitive := sensitiveFlagInSubcommands(child, name); sensitive {
+			return canonical, true
+		}
+	}
+	return "", false
+}
+
 // flagDefinedInTree reports whether name is defined on cmd, its inherited
-// (persistent) flags, or any direct subcommand. The subcommand case covers a
+// (persistent) flags, or any descendant subcommand. The subcommand case covers a
 // user who merely omitted the subcommand — e.g. `sheets --format json`, where
 // --format is injected on every leaf shortcut, not on the group — so only a
 // genuinely unknown flag like `sheets --badflag` is reported.
@@ -549,8 +572,8 @@ func flagDefinedInTree(cmd *cobra.Command, name string) bool {
 	if known(cmd, false) || known(cmd, true) {
 		return true
 	}
-	for _, c := range cmd.Commands() {
-		if known(c, false) {
+	for _, child := range cmd.Commands() {
+		if known(child, false) || flagDefinedInTree(child, name) {
 			return true
 		}
 	}
@@ -669,6 +692,12 @@ func isLarkDomain(c *cobra.Command) bool {
 func flagDidYouMean(c *cobra.Command, ferr error) error {
 	name, isUnknown := unknownFlagName(ferr)
 	if !isUnknown {
+		if sensitive, ok := cmdutil.SensitiveFlagFromParseError(c, ferr); ok {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"invalid value for sensitive flag %q", "--"+sensitive).
+				WithParam("--"+sensitive).
+				WithHint("run `%s --help` for valid usage", c.CommandPath())
+		}
 		// A policy-gated flag invoked bare ("flag needs an argument")
 		// never reaches its rejecting Value; it still presents as
 		// unregistered, exactly like a set one.

--- a/cmd/unknown_subcommand_test.go
+++ b/cmd/unknown_subcommand_test.go
@@ -182,6 +182,68 @@ func TestUnknownSubcommandRunE_ValidFlagWithoutSubcommandIsStructured(t *testing
 	}
 }
 
+func TestUnknownSubcommandRunE_SensitiveFlagValueIsRedacted(t *testing.T) {
+	for _, rawFlag := range []string{
+		"--secret=synthetic-secret-marker",
+		"-s=synthetic-secret-marker",
+	} {
+		_, drive, _ := newGroupTree()
+		var search *cobra.Command
+		for _, child := range drive.Commands() {
+			if child.Name() == "+search" {
+				search = child
+				break
+			}
+		}
+		if search == nil {
+			t.Fatal("+search command not found")
+		}
+		search.Flags().BoolP("secret", "s", false, "")
+		cmdutil.MarkSensitiveFlag(search, "secret")
+		installUnknownSubcommandGuard(drive.Root())
+
+		rawInvocationArgs = []string{"drive", rawFlag}
+		err := drive.RunE(drive, nil)
+		rawInvocationArgs = nil
+		if err == nil {
+			t.Fatalf("RunE(%q) error = nil, want missing-subcommand validation", rawFlag)
+		}
+		if strings.Contains(err.Error(), "synthetic-secret-marker") {
+			t.Fatalf("RunE(%q) leaked sensitive value: %v", rawFlag, err)
+		}
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || len(validationErr.Params) != 1 || validationErr.Params[0].Name != "--secret" {
+			t.Fatalf("RunE(%q) error = %T %v, want redacted --secret param", rawFlag, err, err)
+		}
+	}
+}
+
+func TestUnknownSubcommandRunE_NestedSensitiveFlagValueIsRedactedAtRoot(t *testing.T) {
+	root := &cobra.Command{Use: "lark-cli"}
+	auth := &cobra.Command{Use: "auth"}
+	importToken := &cobra.Command{Use: "import-tenant-token", RunE: func(*cobra.Command, []string) error { return nil }}
+	importToken.Flags().Bool("token-stdin", false, "")
+	cmdutil.MarkSensitiveFlag(importToken, "token-stdin")
+	auth.AddCommand(importToken)
+	root.AddCommand(auth)
+	installUnknownSubcommandGuard(root)
+
+	rawInvocationArgs = []string{"--token-stdin=synthetic-secret-marker"}
+	t.Cleanup(func() { rawInvocationArgs = nil })
+	err := root.RunE(root, nil)
+	if err == nil {
+		t.Fatal("RunE() error = nil, want missing-subcommand validation")
+	}
+	if strings.Contains(err.Error(), "synthetic-secret-marker") {
+		t.Fatalf("RunE() leaked nested sensitive value: %v", err)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument ||
+		len(validationErr.Params) != 1 || validationErr.Params[0].Name != "--token-stdin" {
+		t.Fatalf("RunE() error = %T %v, want redacted --token-stdin param", err, err)
+	}
+}
+
 // A bare group carrying only a group-valid global flag (e.g. the inherited
 // --profile) is not missing a subcommand — those flags do not belong to a
 // subcommand — so it must print help, not fail with missing_subcommand.

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -14,7 +14,20 @@ import (
 )
 
 // Provider resolves credentials from environment variables.
-type Provider struct{}
+type Provider struct {
+	tokenFallback credential.Provider
+}
+
+// WithTokenFallback returns an invocation-scoped copy that consults fallback
+// only when the requested token is absent from the environment. It is a public
+// compatibility hook for built-in CLI wiring; third-party providers are not
+// configured through it. The registered zero-value Provider remains
+// environment-only for compatibility.
+func (p *Provider) WithTokenFallback(fallback credential.Provider) credential.Provider {
+	clone := *p
+	clone.tokenFallback = fallback
+	return &clone
+}
 
 func (p *Provider) Name() string { return "env" }
 
@@ -23,6 +36,13 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 	appSecret := os.Getenv(envvars.CliAppSecret)
 	hasUAT := os.Getenv(envvars.CliUserAccessToken) != ""
 	hasTAT := os.Getenv(envvars.CliTenantAccessToken) != ""
+	if appID != "" && appSecret == "" && !hasUAT && !hasTAT {
+		tok, err := p.resolveTokenFallback(ctx, credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: appID})
+		if err != nil {
+			return nil, err
+		}
+		hasTAT = tok != nil && tok.Value != ""
+	}
 	if appID == "" && appSecret == "" {
 		switch {
 		case hasUAT:
@@ -103,10 +123,28 @@ func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (
 		return nil, nil
 	}
 	token := os.Getenv(envKey)
-	if token == "" {
+	if token != "" {
+		return &credential.Token{Value: token, Source: "env:" + envKey}, nil
+	}
+	return p.resolveTokenFallback(ctx, req)
+}
+
+func (p *Provider) resolveTokenFallback(ctx context.Context, req credential.TokenSpec) (*credential.Token, error) {
+	if p.tokenFallback == nil || req.Type != credential.TokenTypeTAT || req.AppID == "" {
 		return nil, nil
 	}
-	return &credential.Token{Value: token, Source: "env:" + envKey}, nil
+	if req.AppID != os.Getenv(envvars.CliAppID) {
+		return nil, nil
+	}
+	// Injected TATs are a fallback for APP_ID-only token contexts. Existing
+	// app-secret and user-token accounts keep their pre-existing behavior and
+	// must not become dependent on local injected-token storage.
+	if os.Getenv(envvars.CliAppSecret) != "" || os.Getenv(envvars.CliUserAccessToken) != "" {
+		return nil, nil
+	}
+	// Storage errors intentionally propagate so an APP_ID-only environment
+	// fails closed instead of silently selecting another credential source.
+	return p.tokenFallback.ResolveToken(ctx, req)
 }
 
 func init() {

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -280,3 +280,178 @@ func TestResolveAccount_InvalidDefaultAsRejected(t *testing.T) {
 		t.Fatalf("error = %v, want mention of %s", err, envvars.CliDefaultAs)
 	}
 }
+
+type envTokenFallback struct {
+	token *credential.Token
+	err   error
+	calls []credential.TokenSpec
+}
+
+func (f *envTokenFallback) Name() string { return "injected-tat" }
+
+func (f *envTokenFallback) ResolveAccount(context.Context) (*credential.Account, error) {
+	return nil, nil
+}
+
+func (f *envTokenFallback) ResolveToken(_ context.Context, req credential.TokenSpec) (*credential.Token, error) {
+	f.calls = append(f.calls, req)
+	return f.token, f.err
+}
+
+func TestResolveAccount_AppIDOnlyUsesInjectedTAT(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	fallback := &envTokenFallback{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTokenFallback(fallback)
+
+	acct, err := p.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if acct == nil || acct.AppID != "cli_test" {
+		t.Fatalf("ResolveAccount() = %#v, want cli_test account", acct)
+	}
+	if !acct.SupportedIdentities.BotOnly() || acct.DefaultAs != credential.IdentityBot {
+		t.Fatalf("account identity = (supported=%d, default=%q), want bot-only/bot", acct.SupportedIdentities, acct.DefaultAs)
+	}
+	if len(fallback.calls) != 1 || fallback.calls[0].AppID != "cli_test" || fallback.calls[0].Type != credential.TokenTypeTAT {
+		t.Fatalf("fallback calls = %+v, want one cli_test TAT lookup", fallback.calls)
+	}
+}
+
+func TestResolveAccount_AppIDOnlyInjectedTATRespectsStrictMode(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	t.Setenv(envvars.CliStrictMode, "user")
+	fallback := &envTokenFallback{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTokenFallback(fallback)
+
+	acct, err := p.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if !acct.SupportedIdentities.UserOnly() {
+		t.Fatalf("SupportedIdentities = %d, want explicit user-only strict mode", acct.SupportedIdentities)
+	}
+}
+
+func TestResolveAccount_AppIDOnlyWithoutInjectedTATStillBlocks(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	p := (&Provider{}).WithTokenFallback(&envTokenFallback{})
+
+	_, err := p.ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("ResolveAccount() error = %T %v, want BlockError", err, err)
+	}
+}
+
+func TestResolveToken_TATPrefersEnvironmentOverInjected(t *testing.T) {
+	t.Setenv(envvars.CliTenantAccessToken, "env-tat")
+	fallback := &envTokenFallback{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTokenFallback(fallback)
+
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_test"})
+	if err != nil {
+		t.Fatalf("ResolveToken() error = %v", err)
+	}
+	if tok == nil || tok.Value != "env-tat" {
+		t.Fatalf("ResolveToken() = %#v, want env-tat", tok)
+	}
+	if len(fallback.calls) != 0 {
+		t.Fatalf("fallback calls = %+v, want none while env TAT is set", fallback.calls)
+	}
+}
+
+func TestResolveToken_TATFallsBackToInjected(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	fallback := &envTokenFallback{token: &credential.Token{Value: "stored-tat", Source: "keychain:tat:cli_test"}}
+	p := (&Provider{}).WithTokenFallback(fallback)
+
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_test"})
+	if err != nil {
+		t.Fatalf("ResolveToken() error = %v", err)
+	}
+	if tok == nil || tok.Value != "stored-tat" || tok.Source != "keychain:tat:cli_test" {
+		t.Fatalf("ResolveToken() = %#v, want injected token", tok)
+	}
+}
+
+func TestResolveToken_TATFallbackRequiresSelectedAppID(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_selected")
+	fallback := &envTokenFallback{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTokenFallback(fallback)
+
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_other"})
+	if err != nil || tok != nil {
+		t.Fatalf("ResolveToken() = (%#v, %v), want nil, nil for non-selected app ID", tok, err)
+	}
+	if len(fallback.calls) != 0 {
+		t.Fatalf("fallback calls = %+v, want none for non-selected app ID", fallback.calls)
+	}
+}
+
+func TestResolveAccount_PropagatesInjectedTATStorageError(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	sentinel := errors.New("storage failed")
+	p := (&Provider{}).WithTokenFallback(&envTokenFallback{err: sentinel})
+
+	_, err := p.ResolveAccount(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("ResolveAccount() error = %v, want storage failure", err)
+	}
+}
+
+func TestResolveAccount_ExistingCredentialDoesNotConsultInjectedTAT(t *testing.T) {
+	tests := []struct {
+		name      string
+		appSecret string
+		uat       string
+	}{
+		{name: "app secret", appSecret: "app-secret"},
+		{name: "user token", uat: "user-token"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envvars.CliAppID, "cli_test")
+			t.Setenv(envvars.CliAppSecret, tc.appSecret)
+			t.Setenv(envvars.CliUserAccessToken, tc.uat)
+			fallback := &envTokenFallback{err: errors.New("must not be called")}
+			p := (&Provider{}).WithTokenFallback(fallback)
+
+			acct, err := p.ResolveAccount(context.Background())
+			if err != nil || acct == nil {
+				t.Fatalf("ResolveAccount() = (%#v, %v), want existing credential account", acct, err)
+			}
+			if len(fallback.calls) != 0 {
+				t.Fatalf("fallback calls = %+v, want none", fallback.calls)
+			}
+		})
+	}
+}
+
+func TestResolveToken_ExistingCredentialDoesNotConsultInjectedTAT(t *testing.T) {
+	tests := []struct {
+		name      string
+		appSecret string
+		uat       string
+	}{
+		{name: "app secret", appSecret: "app-secret"},
+		{name: "user token", uat: "user-token"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envvars.CliAppID, "cli_test")
+			t.Setenv(envvars.CliAppSecret, tc.appSecret)
+			t.Setenv(envvars.CliUserAccessToken, tc.uat)
+			fallback := &envTokenFallback{token: &credential.Token{Value: "stored-tat"}}
+			p := (&Provider{}).WithTokenFallback(fallback)
+
+			tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_test"})
+			if err != nil || tok != nil {
+				t.Fatalf("ResolveToken() = (%#v, %v), want existing behavior nil, nil", tok, err)
+			}
+			if len(fallback.calls) != 0 {
+				t.Fatalf("fallback calls = %+v, want none", fallback.calls)
+			}
+		})
+	}
+}

--- a/internal/cmdutil/annotations.go
+++ b/internal/cmdutil/annotations.go
@@ -4,13 +4,16 @@
 package cmdutil
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 const skipAuthCheckKey = "skipAuthCheck"
 const annotationSupportedIdentities = "lark:supportedIdentities"
+const annotationSensitiveFlags = "lark:sensitiveFlags"
 
 // SetSupportedIdentities marks which identities a command supports.
 func SetSupportedIdentities(cmd *cobra.Command, identities []string) {
@@ -45,4 +48,46 @@ func IsAuthCheckDisabled(cmd *cobra.Command) bool {
 		}
 	}
 	return false
+}
+
+// MarkSensitiveFlag marks a flag whose rejected value must never be echoed in
+// a parse error. The root flag presenter uses this annotation to replace
+// pflag's value-bearing error with a sanitized typed error.
+func MarkSensitiveFlag(cmd *cobra.Command, name string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	names := cmd.Annotations[annotationSensitiveFlags]
+	if names == "" {
+		cmd.Annotations[annotationSensitiveFlags] = name
+		return
+	}
+	cmd.Annotations[annotationSensitiveFlags] = names + "," + name
+}
+
+// IsSensitiveFlag reports whether name is marked sensitive on cmd or an
+// ancestor. Callers use it before including raw flag tokens in errors.
+func IsSensitiveFlag(cmd *cobra.Command, name string) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		for _, marked := range strings.Split(c.Annotations[annotationSensitiveFlags], ",") {
+			if marked != "" && marked == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// SensitiveFlagFromParseError returns the marked flag implicated by ferr
+// without returning the rejected value embedded in ferr.Error().
+func SensitiveFlagFromParseError(cmd *cobra.Command, ferr error) (string, bool) {
+	var invalidValue *pflag.InvalidValueError
+	if !errors.As(ferr, &invalidValue) || invalidValue == nil || invalidValue.GetFlag() == nil {
+		return "", false
+	}
+	invalidName := invalidValue.GetFlag().Name
+	if IsSensitiveFlag(cmd, invalidName) {
+		return invalidName, true
+	}
+	return "", false
 }

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -281,7 +281,8 @@ type credentialDeps struct {
 }
 
 func buildCredentialProvider(deps credentialDeps) *credential.CredentialProvider {
-	providers := extcred.Providers()
+	injectedTAT := credential.NewInjectedTenantTokenProvider(deps.Keychain)
+	providers := withInjectedTATFallback(extcred.Providers(), injectedTAT)
 	defaultAcct := credential.NewDefaultAccountProvider(deps.Keychain, deps.Profile, deps.ProfileSource)
 	defaultToken := credential.NewDefaultTokenProvider(defaultAcct, deps.HttpClient, deps.ErrOut)
 	// NOTE: Do not pass deps.ErrOut as warnOut. Credential resolution
@@ -291,4 +292,22 @@ func buildCredentialProvider(deps credentialDeps) *credential.CredentialProvider
 	// provider clears unverified identity fields), so silencing the
 	// warning is safe.
 	return credential.NewCredentialProvider(providers, defaultAcct, defaultToken, deps.HttpClient)
+}
+
+func withInjectedTATFallback(providers []extcred.Provider, injectedTAT extcred.Provider) []extcred.Provider {
+	for i, provider := range providers {
+		// Injected tenant tokens extend only the built-in environment provider.
+		// A third-party provider may expose a method with the same shape for its
+		// own purposes and must not be configured implicitly.
+		if provider.Name() != "env" {
+			continue
+		}
+		configurer, ok := provider.(interface {
+			WithTokenFallback(extcred.Provider) extcred.Provider
+		})
+		if ok {
+			providers[i] = configurer.WithTokenFallback(injectedTAT)
+		}
+	}
+	return providers
 }

--- a/internal/cmdutil/factory_default_test.go
+++ b/internal/cmdutil/factory_default_test.go
@@ -9,17 +9,77 @@ import (
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	extcred "github.com/larksuite/cli/extension/credential"
 	_ "github.com/larksuite/cli/extension/credential/env"
 	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/envvars"
+	"github.com/larksuite/cli/internal/keychain"
 	"github.com/larksuite/cli/internal/vfs/localfileio"
 )
 
 type countingFileIOProvider struct {
 	resolveCalls int
 }
+
+type fallbackConfigurableProvider struct {
+	name       string
+	configured bool
+}
+
+func (p *fallbackConfigurableProvider) Name() string { return p.name }
+func (p *fallbackConfigurableProvider) ResolveAccount(context.Context) (*extcred.Account, error) {
+	return nil, nil
+}
+func (p *fallbackConfigurableProvider) ResolveToken(context.Context, extcred.TokenSpec) (*extcred.Token, error) {
+	return nil, nil
+}
+func (p *fallbackConfigurableProvider) WithTokenFallback(extcred.Provider) extcred.Provider {
+	clone := *p
+	clone.configured = true
+	return &clone
+}
+
+type inertCredentialProvider struct{ name string }
+
+func (p *inertCredentialProvider) Name() string { return p.name }
+func (p *inertCredentialProvider) ResolveAccount(context.Context) (*extcred.Account, error) {
+	return nil, nil
+}
+func (p *inertCredentialProvider) ResolveToken(context.Context, extcred.TokenSpec) (*extcred.Token, error) {
+	return nil, nil
+}
+
+func TestWithInjectedTATFallback_ConfiguresOnlyEnvProvider(t *testing.T) {
+	envProvider := &fallbackConfigurableProvider{name: "env"}
+	thirdParty := &fallbackConfigurableProvider{name: "third-party"}
+	fallback := &inertCredentialProvider{name: "injected-tat"}
+
+	got := withInjectedTATFallback([]extcred.Provider{envProvider, thirdParty}, fallback)
+	if configured, ok := got[0].(*fallbackConfigurableProvider); !ok || !configured.configured {
+		t.Fatalf("env provider = %#v, want configured copy", got[0])
+	}
+	if got[1] != thirdParty || thirdParty.configured {
+		t.Fatalf("third-party provider = %#v, want original unconfigured provider", got[1])
+	}
+}
+
+type factoryInjectedTATKeychain struct {
+	value    string
+	getCalls int
+}
+
+func (k *factoryInjectedTATKeychain) Get(service, account string) (string, error) {
+	k.getCalls++
+	if service == keychain.LarkCliService && account == "tat:env-app" {
+		return k.value, nil
+	}
+	return "", nil
+}
+
+func (k *factoryInjectedTATKeychain) Set(string, string, string) error { return nil }
+func (k *factoryInjectedTATKeychain) Remove(string, string) error      { return nil }
 
 func (p *countingFileIOProvider) Name() string { return "counting" }
 
@@ -189,6 +249,47 @@ func TestNewDefault_ConfigUsesRuntimePlaceholderForTokenOnlyEnvAccount(t *testin
 	}
 	if credential.HasRealAppSecret(cfg.AppSecret) {
 		t.Fatalf("Config().AppSecret = %q, want token-only no-secret marker", cfg.AppSecret)
+	}
+}
+
+func TestNewDefault_EnvAppIDUsesInjectedTATFromFactoryKeychain(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "env-app")
+	t.Setenv(envvars.CliAppSecret, "")
+	t.Setenv(envvars.CliDefaultAs, "")
+	t.Setenv(envvars.CliUserAccessToken, "")
+	t.Setenv(envvars.CliTenantAccessToken, "")
+	t.Setenv(envvars.CliStrictMode, "")
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f := NewDefault(nil, InvocationContext{})
+	kc := &factoryInjectedTATKeychain{value: "stored-tenant-token"}
+	f.Keychain = kc
+
+	acct, err := f.Credential.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if acct.AppID != "env-app" || acct.DefaultAs != core.AsBot {
+		t.Fatalf("account = %#v, want env-app with bot default", acct)
+	}
+	if got := f.ResolveStrictMode(context.Background()); got != core.StrictModeBot {
+		t.Fatalf("ResolveStrictMode() = %q, want bot", got)
+	}
+	result, err := f.Credential.ResolveToken(context.Background(), credential.TokenSpec{
+		Type:  credential.TokenTypeTAT,
+		AppID: "env-app",
+	})
+	if err != nil {
+		t.Fatalf("ResolveToken() error = %v", err)
+	}
+	if result == nil || result.Token != "stored-tenant-token" {
+		t.Fatalf("ResolveToken() = %#v, want stored token", result)
+	}
+	if result.Source != core.CredentialSourceEnv {
+		t.Fatalf("credential source = %q, want env provider context", result.Source)
+	}
+	if kc.getCalls != 1 {
+		t.Fatalf("Keychain Get calls = %d, want one shared cached lookup", kc.getCalls)
 	}
 }
 

--- a/internal/credential/injected_tat.go
+++ b/internal/credential/injected_tat.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package credential
+
+import (
+	"context"
+	"sync"
+
+	"github.com/larksuite/cli/errs"
+	extcred "github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/keychain"
+)
+
+const injectedTATKeyPrefix = "tat:"
+
+func injectedTATAccountKey(appID string) string {
+	return injectedTATKeyPrefix + appID
+}
+
+// IsSafeInjectedTenantAppID reports whether appID survives every platform
+// keychain backend without filename/registry normalization. Lowercase-only
+// input also avoids collisions on case-insensitive filesystems and registries.
+func IsSafeInjectedTenantAppID(appID string) bool {
+	if appID == "" {
+		return false
+	}
+	for _, r := range appID {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// StoreInjectedTenantAccessToken persists a caller-supplied TAT under the
+// app-scoped key used by NewInjectedTenantTokenProvider.
+func StoreInjectedTenantAccessToken(kc keychain.KeychainAccess, appID, token string) error {
+	if !IsSafeInjectedTenantAppID(appID) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"injected tenant token app ID must use only lowercase letters, digits, '.', '_', or '-'").
+			WithParam("app_id")
+	}
+	if kc == nil {
+		return errs.NewInternalError(errs.SubtypeStorage, "injected tenant token storage is unavailable")
+	}
+	if err := kc.Set(keychain.LarkCliService, injectedTATAccountKey(appID), token); err != nil {
+		return injectedTATStorageError("store", appID, err)
+	}
+	return nil
+}
+
+type injectedTATCacheEntry struct {
+	value string
+	found bool
+	err   error
+}
+
+// InjectedTenantTokenProvider resolves app-scoped TATs from the injected
+// KeychainAccess. Cache state is owned by one Factory/provider assembly, not by
+// the process-global extension registry.
+type InjectedTenantTokenProvider struct {
+	keychain func() keychain.KeychainAccess
+
+	mu    sync.Mutex
+	cache map[string]injectedTATCacheEntry
+}
+
+// NewInjectedTenantTokenProvider creates a token-only extension provider. The
+// keychain closure is evaluated on first lookup so Factory.Keychain remains
+// replaceable after Factory construction in tests and embeddings.
+func NewInjectedTenantTokenProvider(kc func() keychain.KeychainAccess) *InjectedTenantTokenProvider {
+	if kc == nil {
+		kc = keychain.Default
+	}
+	return &InjectedTenantTokenProvider{
+		keychain: kc,
+		cache:    make(map[string]injectedTATCacheEntry),
+	}
+}
+
+func (p *InjectedTenantTokenProvider) Name() string { return "injected-tat" }
+
+func (p *InjectedTenantTokenProvider) ResolveAccount(context.Context) (*extcred.Account, error) {
+	return nil, nil
+}
+
+func (p *InjectedTenantTokenProvider) ResolveToken(_ context.Context, req extcred.TokenSpec) (*extcred.Token, error) {
+	if req.Type != extcred.TokenTypeTAT || req.AppID == "" {
+		return nil, nil
+	}
+	if !IsSafeInjectedTenantAppID(req.AppID) {
+		return nil, errs.NewConfigError(errs.SubtypeInvalidConfig,
+			"injected tenant token app ID %q contains unsupported characters", req.AppID)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if cached, ok := p.cache[req.AppID]; ok {
+		return injectedTATToken(cached, req.AppID)
+	}
+
+	kc := p.keychain()
+	if kc == nil {
+		entry := injectedTATCacheEntry{err: errs.NewInternalError(errs.SubtypeStorage, "injected tenant token storage is unavailable")}
+		p.cache[req.AppID] = entry
+		return nil, entry.err
+	}
+	value, err := kc.Get(keychain.LarkCliService, injectedTATAccountKey(req.AppID))
+	entry := injectedTATCacheEntry{value: value, found: value != ""}
+	if err != nil {
+		entry.err = injectedTATStorageError("read", req.AppID, err)
+	}
+	p.cache[req.AppID] = entry
+	return injectedTATToken(entry, req.AppID)
+}
+
+func injectedTATToken(entry injectedTATCacheEntry, appID string) (*extcred.Token, error) {
+	if entry.err != nil {
+		return nil, entry.err
+	}
+	if !entry.found {
+		return nil, nil
+	}
+	return &extcred.Token{
+		Value:  entry.value,
+		Source: "keychain:" + injectedTATAccountKey(appID),
+	}, nil
+}
+
+func injectedTATStorageError(op, appID string, cause error) error {
+	storageErr := errs.NewInternalError(errs.SubtypeStorage,
+		"failed to %s injected tenant token for app %s: %v", op, appID, cause).
+		WithCause(cause)
+	if problem, ok := errs.ProblemOf(cause); ok && problem.Hint != "" {
+		storageErr.WithHint("%s", problem.Hint)
+	}
+	return storageErr
+}
+
+var _ extcred.Provider = (*InjectedTenantTokenProvider)(nil)

--- a/internal/credential/injected_tat_test.go
+++ b/internal/credential/injected_tat_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package credential
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	extcred "github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/keychain"
+)
+
+type injectedTATTestKeychain struct {
+	values   map[string]string
+	getErr   error
+	setErr   error
+	getCalls []string
+	setCalls []injectedTATSetCall
+}
+
+type injectedTATSetCall struct {
+	service string
+	account string
+	value   string
+}
+
+func (k *injectedTATTestKeychain) Get(service, account string) (string, error) {
+	k.getCalls = append(k.getCalls, service+"/"+account)
+	if k.getErr != nil {
+		return "", k.getErr
+	}
+	return k.values[service+"/"+account], nil
+}
+
+func (k *injectedTATTestKeychain) Set(service, account, value string) error {
+	k.setCalls = append(k.setCalls, injectedTATSetCall{service: service, account: account, value: value})
+	if k.setErr != nil {
+		return k.setErr
+	}
+	if k.values == nil {
+		k.values = make(map[string]string)
+	}
+	k.values[service+"/"+account] = value
+	return nil
+}
+
+func (k *injectedTATTestKeychain) Remove(string, string) error { return nil }
+
+func TestStoreInjectedTenantAccessTokenUsesTypedAccountKey(t *testing.T) {
+	kc := &injectedTATTestKeychain{}
+	if err := StoreInjectedTenantAccessToken(kc, "cli_test", "tenant-token"); err != nil {
+		t.Fatalf("StoreInjectedTenantAccessToken() error = %v", err)
+	}
+	if err := StoreInjectedTenantAccessToken(kc, "cli_test", "replacement-token"); err != nil {
+		t.Fatalf("replacement StoreInjectedTenantAccessToken() error = %v", err)
+	}
+	if len(kc.setCalls) != 2 {
+		t.Fatalf("Set calls = %d, want 2", len(kc.setCalls))
+	}
+	got := kc.setCalls[1]
+	if got.service != keychain.LarkCliService || got.account != "tat:cli_test" || got.value != "replacement-token" {
+		t.Fatalf("replacement Set call = %#v, want service lark-cli, account tat:cli_test, replacement token", got)
+	}
+	if stored := kc.values[keychain.LarkCliService+"/tat:cli_test"]; stored != "replacement-token" {
+		t.Fatalf("stored value = %q, want replacement-token", stored)
+	}
+}
+
+func TestInjectedTenantTokenProviderCachesHitPerApp(t *testing.T) {
+	kc := &injectedTATTestKeychain{values: map[string]string{
+		keychain.LarkCliService + "/tat:cli_test": "tenant-token-v1",
+	}}
+	p := NewInjectedTenantTokenProvider(func() keychain.KeychainAccess { return kc })
+	req := extcred.TokenSpec{Type: extcred.TokenTypeTAT, AppID: "cli_test"}
+
+	first, err := p.ResolveToken(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first ResolveToken() error = %v", err)
+	}
+	kc.values[keychain.LarkCliService+"/tat:cli_test"] = "tenant-token-v2"
+	second, err := p.ResolveToken(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second ResolveToken() error = %v", err)
+	}
+	if first == nil || second == nil || first.Value != "tenant-token-v1" || second.Value != "tenant-token-v1" {
+		t.Fatalf("tokens = (%#v, %#v), want cached tenant-token-v1", first, second)
+	}
+	if len(kc.getCalls) != 1 {
+		t.Fatalf("Get calls = %v, want one call", kc.getCalls)
+	}
+}
+
+func TestInjectedTenantTokenProviderCachesMiss(t *testing.T) {
+	kc := &injectedTATTestKeychain{values: map[string]string{}}
+	p := NewInjectedTenantTokenProvider(func() keychain.KeychainAccess { return kc })
+	req := extcred.TokenSpec{Type: extcred.TokenTypeTAT, AppID: "cli_missing"}
+
+	for i := 0; i < 2; i++ {
+		tok, err := p.ResolveToken(context.Background(), req)
+		if err != nil || tok != nil {
+			t.Fatalf("ResolveToken() = (%#v, %v), want nil, nil", tok, err)
+		}
+	}
+	if len(kc.getCalls) != 1 {
+		t.Fatalf("Get calls = %v, want one cached miss", kc.getCalls)
+	}
+}
+
+func TestInjectedTenantTokenProviderCachesTypedStorageError(t *testing.T) {
+	underlying := errors.New("keychain unavailable")
+	kc := &injectedTATTestKeychain{getErr: underlying}
+	p := NewInjectedTenantTokenProvider(func() keychain.KeychainAccess { return kc })
+	req := extcred.TokenSpec{Type: extcred.TokenTypeTAT, AppID: "cli_test"}
+
+	for i := 0; i < 2; i++ {
+		_, err := p.ResolveToken(context.Background(), req)
+		if err == nil {
+			t.Fatal("ResolveToken() error = nil, want typed storage error")
+		}
+		var internalErr *errs.InternalError
+		if !errors.As(err, &internalErr) || internalErr.Subtype != errs.SubtypeStorage {
+			t.Fatalf("error = %T %v, want internal/storage", err, err)
+		}
+		if !errors.Is(err, underlying) {
+			t.Fatalf("error = %v, want underlying cause", err)
+		}
+	}
+	if len(kc.getCalls) != 1 {
+		t.Fatalf("Get calls = %v, want one cached failure", kc.getCalls)
+	}
+}
+
+func TestInjectedTenantTokenProviderSkipsUnsupportedOrEmptyRequests(t *testing.T) {
+	kc := &injectedTATTestKeychain{}
+	p := NewInjectedTenantTokenProvider(func() keychain.KeychainAccess { return kc })
+
+	for _, req := range []extcred.TokenSpec{
+		{Type: extcred.TokenTypeUAT, AppID: "cli_test"},
+		{Type: extcred.TokenTypeTAT, AppID: ""},
+	} {
+		tok, err := p.ResolveToken(context.Background(), req)
+		if err != nil || tok != nil {
+			t.Fatalf("ResolveToken(%+v) = (%#v, %v), want nil, nil", req, tok, err)
+		}
+	}
+	if len(kc.getCalls) != 0 {
+		t.Fatalf("Get calls = %v, want none", kc.getCalls)
+	}
+}
+
+func TestInjectedTenantTokenStorageRejectsUnsafeAppIDWithoutAccess(t *testing.T) {
+	kc := &injectedTATTestKeychain{}
+	err := StoreInjectedTenantAccessToken(kc, "cli/test", "tenant-token")
+	if err == nil {
+		t.Fatal("StoreInjectedTenantAccessToken() error = nil, want unsafe app ID rejection")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "app_id" {
+		t.Fatalf("store error = %T %v, want validation/invalid_argument for app_id", err, err)
+	}
+	if len(kc.setCalls) != 0 {
+		t.Fatalf("Set calls = %v, want none", kc.setCalls)
+	}
+
+	p := NewInjectedTenantTokenProvider(func() keychain.KeychainAccess { return kc })
+	_, err = p.ResolveToken(context.Background(), extcred.TokenSpec{Type: extcred.TokenTypeTAT, AppID: "cli/test"})
+	if err == nil {
+		t.Fatal("ResolveToken() error = nil, want unsafe app ID rejection")
+	}
+	var configErr *errs.ConfigError
+	if !errors.As(err, &configErr) || configErr.Subtype != errs.SubtypeInvalidConfig {
+		t.Fatalf("resolve error = %T %v, want config/invalid_config", err, err)
+	}
+	if len(kc.getCalls) != 0 {
+		t.Fatalf("Get calls = %v, want none", kc.getCalls)
+	}
+}
+
+func TestInjectedTenantTokenStorageRejectsUppercaseAppIDWithoutAccess(t *testing.T) {
+	kc := &injectedTATTestKeychain{}
+	err := StoreInjectedTenantAccessToken(kc, "cli_Test", "tenant-token")
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "app_id" {
+		t.Fatalf("store error = %T %v, want validation/invalid_argument for app_id", err, err)
+	}
+	p := NewInjectedTenantTokenProvider(func() keychain.KeychainAccess { return kc })
+	_, err = p.ResolveToken(context.Background(), extcred.TokenSpec{Type: extcred.TokenTypeTAT, AppID: "cli_Test"})
+	var configErr *errs.ConfigError
+	if !errors.As(err, &configErr) || configErr.Subtype != errs.SubtypeInvalidConfig {
+		t.Fatalf("resolve error = %T %v, want config/invalid_config", err, err)
+	}
+	if len(kc.setCalls) != 0 || len(kc.getCalls) != 0 {
+		t.Fatalf("keychain calls = set:%v get:%v, want none", kc.setCalls, kc.getCalls)
+	}
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -22,8 +22,9 @@ var (
 
 const (
 	// LarkCliService is the unified keychain service name for all secrets
-	// (both AppSecret and UAT). Entries are distinguished by account key format:
+	// (AppSecret, injected TAT, and UAT). Entries are distinguished by account key format:
 	//   - AppSecret: "appsecret:<appId>"
+	//   - TAT:       "tat:<appId>"
 	//   - UAT:       "<appId>:<userOpenId>"
 	LarkCliService = "lark-cli"
 )
@@ -55,7 +56,7 @@ func wrapError(op string, err error) error {
 }
 
 // KeychainAccess abstracts keychain Get/Set/Remove for dependency injection.
-// Used by AppSecret operations (ForStorage, ResolveSecretInput, RemoveSecretStore).
+// Used by AppSecret and injected-TAT operations.
 // UAT operations in token_store.go use the package-level Get/Set/Remove directly.
 type KeychainAccess interface {
 	Get(service, account string) (string, error)

--- a/internal/keychain/keychain_windows.go
+++ b/internal/keychain/keychain_windows.go
@@ -7,6 +7,7 @@ package keychain
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -109,8 +110,11 @@ func freeDataBlob(b *windows.DataBlob) {
 
 // platformGet retrieves a value from the Windows registry.
 func platformGet(service, account string) (string, error) {
-	v, ok := registryGet(service, account)
-	if !ok {
+	v, found, err := registryGet(service, account)
+	if err != nil {
+		return "", err
+	}
+	if !found {
 		return "", nil
 	}
 	return v, nil
@@ -132,28 +136,37 @@ func platformRemove(service, account string) error {
 }
 
 // registryGet retrieves a string value from the registry under the given service and account.
-func registryGet(service, account string) (string, bool) {
+func registryGet(service, account string) (string, bool, error) {
 	keyPath := registryPathForService(service)
 	k, err := registry.OpenKey(registry.CURRENT_USER, keyPath, registry.QUERY_VALUE)
 	if err != nil {
-		return "", false
+		if errors.Is(err, registry.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("registry open failed: %w", err)
 	}
 	defer k.Close()
 
 	b64, _, err := k.GetStringValue(valueNameForAccount(account))
-	if err != nil || b64 == "" {
-		return "", false
+	if err != nil {
+		if errors.Is(err, registry.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("registry read failed: %w", err)
+	}
+	if b64 == "" {
+		return "", false, errors.New("registry value is empty")
 	}
 	blob, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("registry value decode failed: %w", err)
 	}
 	entropy := dpapiEntropy(service, account)
 	plain, err := dpapiUnprotect(blob, entropy)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("dpapi unprotect failed: %w", err)
 	}
-	return string(plain), true
+	return string(plain), true, nil
 }
 
 // registrySet stores a string value in the registry under the given service and account.

--- a/internal/keychain/keychain_windows_test.go
+++ b/internal/keychain/keychain_windows_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package keychain
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func TestRegistryGetDistinguishesMissingFromCorruptValue(t *testing.T) {
+	service := "lark-cli-test-" + strings.ReplaceAll(t.Name(), "/", "-")
+	account := "tat:cli_test"
+	keyPath := registryPathForService(service)
+	_ = registry.DeleteKey(registry.CURRENT_USER, keyPath)
+	t.Cleanup(func() { _ = registry.DeleteKey(registry.CURRENT_USER, keyPath) })
+
+	value, found, err := registryGet(service, account)
+	if err != nil || found || value != "" {
+		t.Fatalf("missing registryGet() = (%q, %v, %v), want empty, false, nil", value, found, err)
+	}
+
+	k, _, err := registry.CreateKey(registry.CURRENT_USER, keyPath, registry.SET_VALUE)
+	if err != nil {
+		t.Fatalf("CreateKey() error = %v", err)
+	}
+	if err := k.SetStringValue(valueNameForAccount(account), "not-base64!"); err != nil {
+		_ = k.Close()
+		t.Fatalf("SetStringValue() error = %v", err)
+	}
+	if err := k.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if _, found, err := registryGet(service, account); err == nil || found {
+		t.Fatalf("corrupt registryGet() = (found=%v, err=%v), want false with error", found, err)
+	}
+	if _, err := platformGet(service, account); err == nil {
+		t.Fatal("platformGet() error = nil for corrupt registry value")
+	}
+}

--- a/skills/lark-shared/references/lark-shared-identity-and-permissions.md
+++ b/skills/lark-shared/references/lark-shared-identity-and-permissions.md
@@ -9,6 +9,7 @@
 | 指定单个 scope 授权 | `lark-cli auth login --scope "<scope>" --no-wait --json` |
 | 检查当前登录态、是谁登录、token 是否有效 | `lark-cli auth status --json --verify`；回答时引用 `identity`、`verified`、`identities.user.status`、`identities.user.userName`、`identities.user.openId`（用户 open id）、`identities.user.tokenStatus`、`identities.user.scope` |
 | 快速查看当前身份状态 | `lark-cli whoami`；实际生效的那一个身份 |
+| 从外部凭据源安全注入 bot TAT | 见下方“注入 bot TAT”；禁止把 token 放进 argv |
 | 退出当前机器的用户登录态 | `lark-cli auth logout --json`；`loggedOut:true` 表示注销成功 |
 | bot 缺少权限 | 不要执行 `auth login`；引导用户在开发者后台开通 bot scope，优先复用错误里的 `console_url` |
 | 取消用户对应用的全部服务端授权 | `auth logout` 只清本机登录态；服务端授权需用户在飞书授权管理页取消 |
@@ -28,6 +29,31 @@ LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1 LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1 lark-cli a
 |------|------|---------|---------|
 | user 用户身份 | `--as user` | `lark-cli auth login` 等 | 访问用户自己的资源（日历、云空间/云盘/云存储等） |
 | bot 应用身份 | `--as bot` | 自动，只需 appId + appSecret | 应用级操作,访问bot自己的资源 |
+
+### 注入 bot TAT
+
+`auth import-tenant-token` 接受任意上游凭据源通过 stdin 提供的 TAT，并按
+app ID 写入 lark-cli 的跨平台安全存储。命令只接收 stdin，不接受明文 token
+flag；不要在日志或回复中展示 token。app ID 只允许小写字母、数字、`.`、`_`
+和 `-`，避免在大小写不敏感的安全存储后端发生键冲突。
+
+使用注入 TAT 的 token-only 环境需要设置 `LARKSUITE_CLI_APP_ID`。读取顺序为：
+
+1. 非空的 `LARKSUITE_CLI_TENANT_ACCESS_TOKEN`；
+2. 当前 app ID 对应的本地注入 TAT；
+3. 两者都缺失时失败，不切换其他 profile/provider。
+
+默认 AppSecret profile 是独立链路，继续通过 Token Endpoint 换取 TAT。
+sidecar 和第三方 credential provider 继续使用各自 token source。注入值在
+同一次 CLI 调用内缓存，新进程会重新读取；重复导入同一 app ID 会覆盖旧值。
+当前版本没有删除注入 TAT 的命令。TAT 是短期凭据，CLI 不会自动刷新注入值；
+过期后需要从上游凭据源获取新 TAT 并重新执行导入命令，后续 CLI 进程会读取
+覆盖后的值。
+
+`LARKSUITE_CLI_APP_ID` 激活 env credential provider 后，除
+`auth import-tenant-token` 外的 `auth` 管理命令仍按既有 external-provider
+策略不可用。验证注入结果时使用 `lark-cli whoami` 或实际 bot API 调用，
+不要用 `auth status`。
 
 ## 身份选择原则
 


### PR DESCRIPTION
## Summary

Add a source-agnostic command for importing tenant access tokens into lark-cli's cross-platform secure storage. Environment-selected token-only accounts can use the stored TAT without exposing it through argv, while existing app-secret, UAT, sidecar, and third-party credential flows remain isolated.

## Changes

- Add `auth import-tenant-token --app-id <id> --token-stdin` with typed errors, standard JSON success output, `risk=write`, and positional-argument leak prevention.
- Add a Factory-scoped injected-TAT store/provider using the `lark-cli` / `tat:<appId>` key, including cached hit/miss/error states and exact overwrite behavior.
- Extend the built-in env provider with an invocation-scoped fallback: environment TAT first, injected TAT second, fail closed when both are missing.
- Preserve AppSecret, UAT, sidecar, and third-party provider behavior, and document precedence, lifecycle, and the existing external-provider auth guard.

## Impact

- **Public surface:** Adds `lark-cli auth import-tenant-token --app-id <id> --token-stdin`; existing commands, config schemas, and credential-provider interfaces are unchanged.
- **Credential selection:** Applies only to the built-in env provider in an APP_ID-only context. A non-empty environment TAT wins, then the injected `tat:<appId>` value is consulted; if neither exists, resolution fails closed.
- **Unchanged paths:** AppSecret token exchange, UAT, sidecar, and third-party credential providers keep their existing behavior.
- **Storage and platforms:** Reuses the existing `KeychainAccess` backends on macOS, Linux, and Windows; no config schema change or migration is required. The Windows backend now distinguishes an absent registry value from registry/Base64/DPAPI failures so injected-token resolution fails closed on storage corruption or access errors.
- **Lifecycle:** Hit, miss, and error results are cached per Factory/CLI invocation; a new process reloads storage. Re-importing the same app ID overwrites its value, and this version has no remove command. Imported TATs are short-lived and are not refreshed by the CLI; expiry recovery is to obtain a new upstream TAT and re-import it.
- **Auth management:** Only `auth import-tenant-token` bypasses the external-provider guard; other `auth` management commands remain guarded.
- **Security and errors:** Token input is stdin-only and restricted to exactly one non-empty visible-ASCII line. Sensitive flag parse errors use typed pflag attribution (including shorthand), and missing-subcommand raw-argument errors also redact marked values. App IDs are restricted to lowercase letters, digits, `.`, `_`, and `-` to avoid normalization and case-folding collisions across backends.
- **Rollout and rollback:** The behavior is additive and opt-in, with blast radius limited to the new command and built-in env APP_ID-only resolution. Reverting the change stops reading imported entries; existing versions ignore the added `tat:` keys.

## Credential Flow

```mermaid
flowchart TD
  subgraph Legend["Legend"]
    direction LR
    LegendNew["NEW added"]:::new
    LegendChanged["CHANGED modified"]:::changed
    LegendExisting["UNCHANGED existing"]:::existing
  end

  subgraph ImportPath["Import path"]
    direction LR
    Import["NEW auth import-tenant-token"]:::new --> Store["NEW injected TAT store and provider"]:::new
    Store --> AccountKey["NEW account key tat:appId"]:::new --> Keychain["UNCHANGED KeychainAccess platform backends"]:::existing
  end

  Factory["CHANGED Factory fallback injection"]:::changed --> Env["CHANGED built-in env APP_ID-only resolution"]:::changed

  subgraph Resolution["Credential precedence"]
    direction LR
    Env --> EnvCheck{"UNCHANGED environment TAT set?"}:::existing
    EnvCheck -->|yes| UseEnv["UNCHANGED use environment TAT"]:::existing
    EnvCheck -->|no| Lookup["NEW injected TAT lookup"]:::new
    Lookup --> Store
    Lookup --> StoredCheck{"NEW injected TAT found?"}:::new
    StoredCheck -->|yes| UseStored["NEW use injected TAT"]:::new
    StoredCheck -->|no| Fail["CHANGED fail closed"]:::changed
  end

  Other["UNCHANGED AppSecret, UAT, sidecar, third-party"]:::existing -. isolated .-> Existing["UNCHANGED existing credential flows"]:::existing

  classDef new fill:#dcfce7,stroke:#16a34a,color:#14532d,stroke-width:2px
  classDef changed fill:#dbeafe,stroke:#2563eb,color:#1e3a8a,stroke-width:2px
  classDef existing fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-width:1px
```

## Local E2E Results

- **Build — PASS:** `make build`; the resulting binary reports version `v1.0.89-6-g57e31e5a`.
- **Injected-TAT storage and resolution — PASS:** Using synthetic app ID `cli_codex_e2e_2467`, a synthetic token was piped through stdin to `auth import-tenant-token`; the command exited `0` with `data.stored=true`. A new process then explicitly cleared `LARKSUITE_CLI_TENANT_ACCESS_TOKEN`, `LARKSUITE_CLI_APP_SECRET`, and `LARKSUITE_CLI_USER_ACCESS_TOKEN`, set `LARKSUITE_CLI_APP_ID=cli_codex_e2e_2467`, `LARKSUITE_CLI_DEFAULT_AS=bot`, and `LARKSUITE_CLI_BRAND=feishu`, and ran `./lark-cli whoami`. It exited `0` with `identity=bot`, `available=true`, and `tokenStatus=ready`.
- **macOS storage evidence — PASS:** `~/Library/Application Support/lark-cli/tat_cli_codex_e2e_2467.enc` exists with size `50` bytes and mode `0600`. `~/Library/Application Support/lark-cli/master.key.file` does not exist. A read-only `security find-generic-password -s lark-cli -a master.key` lookup succeeded and identified `login.keychain-db`, service `lark-cli`, and account `master.key`; the command did not use `-w` and did not read the key/password value. Therefore, this run used the system Keychain master key rather than the file fallback to protect the encrypted TAT file. The token content was not read back or written into this PR. This used a synthetic token and does not validate acceptance by a real OpenAPI endpoint.
- **Full integration suite — FAIL:** `make integration-test` ran to completion but returned failure. Observed failures involved the machine's existing live fixtures, permissions, and current fixture expectations, including missing bot scopes for calendar, contact, and drive, plus Base URL output assertion drift. Many dry-run, user, and plugin E2E cases passed, while relevant live cases were skipped. The observed failures were outside the injected-TAT path and none referenced the changed packages or command; this evidence does not establish that every failure is unrelated to the change.

## Test Plan

- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- [x] `go run -C lint . --changed-from origin/main ..`
- [x] `go test -C lint ./... -count=1`
- [x] `GOOS=windows GOARCH=amd64 go test -c ./internal/keychain`
- [x] `make build` and command help/error smoke tests

Real-token API smoke testing was not run to avoid persisting a test credential in the developer's local secure store. Storage, overwrite, cache, precedence, guard, and zero-leak behavior are covered with injected Keychain fakes and the full race-enabled unit suite.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `auth import-tenant-token` to securely import tenant access tokens from stdin.
  * Tokens are stored per app, support replacement and expiration handling, and remain hidden from command arguments and output.
  * Added automatic fallback to stored tokens when environment credentials are unavailable, with caching and credential precedence.

* **Bug Fixes**
  * Improved app ID and token validation.
  * Prevented sensitive token values from appearing in errors.

* **Documentation**
  * Documented token import, credential resolution, storage behavior, restrictions, verification guidance, and logout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
