### PR TITLE
fix(slides): strip stale <note> id in +update-slide to avoid backend crash

### DIFF
--- a/shortcuts/slides/slides_update_slide.go
+++ b/shortcuts/slides/slides_update_slide.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -333,8 +334,8 @@ func slideReplaceAPIPath(presentationID string) string {
 }
 
 // updateSlideContent validates --content and returns it with the root id set to
-// slideID. The caller's own bytes are preserved apart from that one attribute:
-// their formatting ends up in the page.
+// slideID, and with a stale <note> id dropped. The caller's bytes are otherwise
+// preserved, so their formatting lands in the page.
 func updateSlideContent(runtime *common.RuntimeContext, slideID string) (string, error) {
 	content := strings.TrimSpace(runtime.Str("content"))
 	if content == "" {
@@ -352,6 +353,12 @@ func updateSlideContent(runtime *common.RuntimeContext, slideID string) (string,
 			"--content root is <slide id=%q> but --slide-id is %q; pass the page you mean to replace, or drop the id",
 			rootID, slideID)
 	}
+	// Drop a carried <note id="..."> so the backend targets the page's own note
+	// block. A stale note id (XML copied from another page, or written over a
+	// re-created page) otherwise makes RewriteSlideBySXSD reject the whole page
+	// with "block is not NoteBlock". Only the note id is touched; visible elements
+	// keep their ids and are updated in place.
+	content = stripSlideNoteID(content)
 	stamped, err := ensureXMLRootID(content, slideID)
 	if err != nil {
 		// checkSlideRoot already proved there is a single <slide> root, so the only
@@ -362,6 +369,24 @@ func updateSlideContent(runtime *common.RuntimeContext, slideID string) (string,
 			" with a default xmlns if you need one").WithCause(err)
 	}
 	return stamped, nil
+}
+
+// slideNoteIDRe matches the id attribute on a <note> element's open tag.
+var slideNoteIDRe = regexp.MustCompile(`(<note\b[^>]*?)\s+id="[^"]*"`)
+
+// stripSlideNoteID drops the id from the page's <note> (speaker notes) element.
+//
+// A +update-slide carrying a <note id="..."> that is not the page's current note
+// block makes the backend reject the whole page with "block is not NoteBlock" —
+// e.g. XML copied from another page, or written over a page that was re-created
+// (add-slide reassigns ids, so the note block's id no longer matches). With no
+// id the backend targets the page's own note block and the write succeeds.
+//
+// Only <note> is touched, so nothing rendered on the slide changes: notes are
+// speaker notes, not shown on the page, and every visible element keeps its id
+// (so it is updated in place rather than rebuilt, preserving text layout).
+func stripSlideNoteID(content string) string {
+	return slideNoteIDRe.ReplaceAllString(content, "$1")
 }
 
 // checkSlideRoot walks the tokens of content and returns the root element's id

--- a/shortcuts/slides/slides_update_slide.go
+++ b/shortcuts/slides/slides_update_slide.go
@@ -371,13 +371,15 @@ func updateSlideContent(runtime *common.RuntimeContext, slideID string) (string,
 	return stamped, nil
 }
 
-// slideNoteIDRe matches the id attribute on a <note> element's open tag. It
-// accepts both quote styles and whitespace around '=' (id="x", id='x',
-// id = "x") — all are valid XML, and the backend accepts single-quoted markup,
-// so a stale id in any of these forms must be stripped too.
-var slideNoteIDRe = regexp.MustCompile(`(<note\b[^>]*?)\s+id\s*=\s*("[^"]*"|'[^']*')`)
+// noteIDAttrRe matches an id attribute — either quote style, whitespace around
+// '=' — together with its leading whitespace, so deleting the match leaves a
+// well-formed tag. It runs only against a single <note> start tag already
+// located by the XML tokenizer, never against the whole document, so it cannot
+// scan across a tag boundary or into another element.
+var noteIDAttrRe = regexp.MustCompile(`\s+id\s*=\s*(?:"[^"]*"|'[^']*')`)
 
-// stripSlideNoteID drops the id from the page's <note> (speaker notes) element.
+// stripSlideNoteID drops the id from the page's speaker-note element: the <note>
+// that is a direct child of the root <slide>.
 //
 // A +update-slide carrying a <note id="..."> that is not the page's current note
 // block makes the backend reject the whole page with "block is not NoteBlock" —
@@ -385,11 +387,51 @@ var slideNoteIDRe = regexp.MustCompile(`(<note\b[^>]*?)\s+id\s*=\s*("[^"]*"|'[^'
 // (add-slide reassigns ids, so the note block's id no longer matches). With no
 // id the backend targets the page's own note block and the write succeeds.
 //
-// Only <note> is touched, so nothing rendered on the slide changes: notes are
-// speaker notes, not shown on the page, and every visible element keeps its id
-// (so it is updated in place rather than rebuilt, preserving text layout).
+// The <note> start tag is found with the XML tokenizer rather than a raw scan,
+// so: note-like text inside comments or CDATA is never touched; only the real
+// slide-level <note> is affected (a nested <note> elsewhere, if one ever
+// existed, is left alone); and attribute values containing '>' are handled
+// correctly. The id is then removed by editing that one tag's bytes — nothing is
+// re-serialized, so quote style, attribute order, whitespace, and every other
+// element (including inline <svg> namespaces) survive untouched. Notes are not
+// rendered and visible elements keep their ids, so the page updates in place
+// with no text reflow.
 func stripSlideNoteID(content string) string {
-	return slideNoteIDRe.ReplaceAllString(content, "$1")
+	dec := xml.NewDecoder(strings.NewReader(content))
+	var stack []string      // element local-name path to the current token
+	var prev int64          // byte offset where the current token began
+	var spans [][2]int64    // byte ranges of slide-level <note> start tags
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			// EOF, or a malformed document checkSlideRoot already rejects.
+			// Apply whatever was located and leave the rest untouched.
+			break
+		}
+		cur := dec.InputOffset() // end of tok / start of the next token
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "note" && len(stack) > 0 && stack[len(stack)-1] == "slide" {
+				spans = append(spans, [2]int64{prev, cur})
+			}
+			stack = append(stack, t.Name.Local)
+		case xml.EndElement:
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+		prev = cur
+	}
+	if len(spans) == 0 {
+		return content
+	}
+	// Rewrite from the last span backwards so earlier offsets stay valid.
+	out := content
+	for i := len(spans) - 1; i >= 0; i-- {
+		s, e := spans[i][0], spans[i][1]
+		out = out[:s] + noteIDAttrRe.ReplaceAllString(out[s:e], "") + out[e:]
+	}
+	return out
 }
 
 // checkSlideRoot walks the tokens of content and returns the root element's id

--- a/shortcuts/slides/slides_update_slide.go
+++ b/shortcuts/slides/slides_update_slide.go
@@ -371,8 +371,11 @@ func updateSlideContent(runtime *common.RuntimeContext, slideID string) (string,
 	return stamped, nil
 }
 
-// slideNoteIDRe matches the id attribute on a <note> element's open tag.
-var slideNoteIDRe = regexp.MustCompile(`(<note\b[^>]*?)\s+id="[^"]*"`)
+// slideNoteIDRe matches the id attribute on a <note> element's open tag. It
+// accepts both quote styles and whitespace around '=' (id="x", id='x',
+// id = "x") — all are valid XML, and the backend accepts single-quoted markup,
+// so a stale id in any of these forms must be stripped too.
+var slideNoteIDRe = regexp.MustCompile(`(<note\b[^>]*?)\s+id\s*=\s*("[^"]*"|'[^']*')`)
 
 // stripSlideNoteID drops the id from the page's <note> (speaker notes) element.
 //

--- a/shortcuts/slides/slides_update_slide.go
+++ b/shortcuts/slides/slides_update_slide.go
@@ -398,9 +398,9 @@ var noteIDAttrRe = regexp.MustCompile(`\s+id\s*=\s*(?:"[^"]*"|'[^']*')`)
 // with no text reflow.
 func stripSlideNoteID(content string) string {
 	dec := xml.NewDecoder(strings.NewReader(content))
-	var stack []string      // element local-name path to the current token
-	var prev int64          // byte offset where the current token began
-	var spans [][2]int64    // byte ranges of slide-level <note> start tags
+	var stack []string   // element local-name path to the current token
+	var prev int64       // byte offset where the current token began
+	var spans [][2]int64 // byte ranges of slide-level <note> start tags
 	for {
 		tok, err := dec.Token()
 		if err != nil {

--- a/shortcuts/slides/slides_update_slide_stripids_test.go
+++ b/shortcuts/slides/slides_update_slide_stripids_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package slides
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripSlideNoteID(t *testing.T) {
+	in := `<slide id="p1"><style><fill id="f1"><fillColor color="rgba(1,2,3,1)"/></fill></style><data>` +
+		`<shape type="text" id="bKZ" topLeftX="80"><content textType="title"><p>x</p></content></shape>` +
+		// embed carries an SVG with an internal gradient referenced by url(#id):
+		`<embed id="bmU" width="35"><svg xmlns="http://www.w3.org/2000/svg" id="svgroot">` +
+		`<defs><linearGradient id="grad"/></defs><path id="pp" d="M0 0" fill="url(#grad)"/><use href="#pp"/></svg></embed>` +
+		`</data><note id="blw"><content><p>n</p></content></note></slide>`
+	out := stripSlideNoteID(in)
+
+	// Only the <note> id is stripped.
+	if strings.Contains(out, `id="blw"`) {
+		t.Errorf("expected note id to be stripped, got: %s", out)
+	}
+	// The note element itself and its content survive.
+	for _, kept := range []string{`<note`, `<p>n</p>`} {
+		if !strings.Contains(out, kept) {
+			t.Errorf("expected %s to survive, got: %s", kept, out)
+		}
+	}
+
+	// Every visible element keeps its id (updated in place, not rebuilt).
+	for _, kept := range []string{`id="p1"`, `id="f1"`, `id="bKZ"`, `id="bmU"`} {
+		if !strings.Contains(out, kept) {
+			t.Errorf("expected %s to be preserved, got: %s", kept, out)
+		}
+	}
+	// SVG-subtree ids and their references are untouched.
+	for _, kept := range []string{`id="svgroot"`, `id="grad"`, `id="pp"`, `fill="url(#grad)"`, `href="#pp"`} {
+		if !strings.Contains(out, kept) {
+			t.Errorf("expected %s to be preserved, got: %s", kept, out)
+		}
+	}
+	// Non-id attributes and content survive.
+	for _, kept := range []string{`type="text"`, `topLeftX="80"`, `width="35"`, `<p>x</p>`} {
+		if !strings.Contains(out, kept) {
+			t.Errorf("expected %s to survive, got: %s", kept, out)
+		}
+	}
+}
+
+// A page with no <note> is passed through unchanged.
+func TestStripSlideNoteIDNoNote(t *testing.T) {
+	in := `<slide id="p1"><data><shape type="text" id="bKZ"><content><p>x</p></content></shape></data></slide>`
+	if out := stripSlideNoteID(in); out != in {
+		t.Errorf("expected unchanged output, got: %s", out)
+	}
+}
+
+// The note id is stripped regardless of attribute order on the <note> tag.
+func TestStripSlideNoteIDAttrOrder(t *testing.T) {
+	in := `<slide id="p1"><data/><note foo="bar" id="blw" baz="qux"><content><p>n</p></content></note></slide>`
+	out := stripSlideNoteID(in)
+	if strings.Contains(out, `id="blw"`) {
+		t.Errorf("expected note id to be stripped, got: %s", out)
+	}
+	for _, kept := range []string{`foo="bar"`, `baz="qux"`} {
+		if !strings.Contains(out, kept) {
+			t.Errorf("expected %s to survive, got: %s", kept, out)
+		}
+	}
+}

--- a/shortcuts/slides/slides_update_slide_stripids_test.go
+++ b/shortcuts/slides/slides_update_slide_stripids_test.go
@@ -113,6 +113,57 @@ func TestStripSlideNoteIDQuoteVariants(t *testing.T) {
 	}
 }
 
+// Locating the <note> tag with the XML tokenizer (rather than a raw scan) means
+// note-like text in comments/CDATA, a nested <note>, and '>' inside an attribute
+// value are all handled correctly.
+func TestStripSlideNoteIDXMLAware(t *testing.T) {
+	t.Run("attr value contains >", func(t *testing.T) {
+		in := `<slide id="p1"><data/><note data=">" id="blw"><content><p>n</p></content></note></slide>`
+		out := stripSlideNoteID(in)
+		if strings.Contains(out, `id="blw"`) {
+			t.Errorf("expected note id to be stripped, got: %s", out)
+		}
+		if !strings.Contains(out, `data=">"`) {
+			t.Errorf("expected the '>'-bearing attribute to survive, got: %s", out)
+		}
+	})
+
+	t.Run("note-like text in CDATA is untouched", func(t *testing.T) {
+		in := `<slide id="p1"><data><shape type="text"><content>` +
+			`<![CDATA[see <note id="fake"> here]]>` +
+			`</content></shape></data><note id="real"><content><p>n</p></content></note></slide>`
+		out := stripSlideNoteID(in)
+		if !strings.Contains(out, `id="fake"`) {
+			t.Errorf("expected CDATA text to be preserved verbatim, got: %s", out)
+		}
+		if strings.Contains(out, `id="real"`) {
+			t.Errorf("expected the real slide-level note id to be stripped, got: %s", out)
+		}
+	})
+
+	t.Run("note-like text in a comment is untouched", func(t *testing.T) {
+		in := `<slide id="p1"><!-- <note id="cmt"> --><data/><note id="real"><content><p>n</p></content></note></slide>`
+		out := stripSlideNoteID(in)
+		if !strings.Contains(out, `id="cmt"`) {
+			t.Errorf("expected comment text to be preserved, got: %s", out)
+		}
+		if strings.Contains(out, `id="real"`) {
+			t.Errorf("expected the real note id to be stripped, got: %s", out)
+		}
+	})
+
+	t.Run("only a slide-level note is touched", func(t *testing.T) {
+		in := `<slide id="p1"><data><group><note id="deep"/></group></data><note id="top"><content><p>n</p></content></note></slide>`
+		out := stripSlideNoteID(in)
+		if !strings.Contains(out, `id="deep"`) {
+			t.Errorf("expected a non-slide-level note id to be preserved, got: %s", out)
+		}
+		if strings.Contains(out, `id="top"`) {
+			t.Errorf("expected the slide-level note id to be stripped, got: %s", out)
+		}
+	})
+}
+
 // A single-quoted id on a visible element is left alone — only <note> is touched.
 func TestStripSlideNoteIDLeavesSingleQuotedShape(t *testing.T) {
 	in := `<slide id="p1"><data><shape id='bKZ' type='text'><content><p>x</p></content></shape></data><note id='blw'><content><p>n</p></content></note></slide>`

--- a/shortcuts/slides/slides_update_slide_stripids_test.go
+++ b/shortcuts/slides/slides_update_slide_stripids_test.go
@@ -113,6 +113,50 @@ func TestStripSlideNoteIDQuoteVariants(t *testing.T) {
 	}
 }
 
+// Everything except the one note id must survive byte-for-byte: no
+// re-serialization, so svg subtrees, quote styles, attribute order, whitespace,
+// CDATA, and every other element are untouched. Asserting exact equality against
+// "the input with only that id removed" proves nothing else moved.
+func TestStripSlideNoteIDPreservesEverythingElse(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		removed string // the exact substring that must be the only change
+	}{
+		{
+			name: "full slide with inline svg",
+			in: `<slide id="p1"><style><fill id="f1"><fillColor color="rgba(1,2,3,1)"/></fill></style>` +
+				`<data><shape type="text" id="bKZ"><content textType="title"><p>x</p></content></shape>` +
+				`<embed id="bmU"><svg xmlns="http://www.w3.org/2000/svg" id="svgroot">` +
+				`<defs><linearGradient id="grad"/></defs><path id="pp" d="M0 0" fill="url(#grad)"/><use href="#pp"/></svg></embed>` +
+				`</data><note id="blw"><content><p>n</p></content></note></slide>`,
+			removed: ` id="blw"`,
+		},
+		{
+			name: "cdata and > attribute stay verbatim",
+			in: `<slide id="p1"><data><shape type="text"><content><![CDATA[<note id="fake">]]></content></shape></data>` +
+				`<note data=">" id="blw"><content><p>n</p></content></note></slide>`,
+			removed: ` id="blw"`,
+		},
+		{
+			name:    "single quotes",
+			in:      `<slide id="p1"><data/><note id='blw'><content><p>n</p></content></note></slide>`,
+			removed: ` id='blw'`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if strings.Count(c.in, c.removed) != 1 {
+				t.Fatalf("test setup: %q must appear exactly once in input", c.removed)
+			}
+			want := strings.Replace(c.in, c.removed, "", 1)
+			if got := stripSlideNoteID(c.in); got != want {
+				t.Errorf("only the note id should change.\n got: %s\nwant: %s", got, want)
+			}
+		})
+	}
+}
+
 // Locating the <note> tag with the XML tokenizer (rather than a raw scan) means
 // note-like text in comments/CDATA, a nested <note>, and '>' inside an attribute
 // value are all handled correctly.

--- a/shortcuts/slides/slides_update_slide_stripids_test.go
+++ b/shortcuts/slides/slides_update_slide_stripids_test.go
@@ -143,6 +143,21 @@ func TestStripSlideNoteIDPreservesEverythingElse(t *testing.T) {
 			in:      `<slide id="p1"><data/><note id='blw'><content><p>n</p></content></note></slide>`,
 			removed: ` id='blw'`,
 		},
+		{
+			// &#32; (a numeric char ref) decodes to a space, but InputOffset is
+			// an input-byte offset, so the note span must not drift even with
+			// several of them ahead of the note. The refs stay verbatim.
+			name: "numeric char refs before the note",
+			in: `<slide id="p1"><data><shape type="text"><content><p>a&#32;b&#32;c</p></content></shape></data>` +
+				`<note id="blw"><content><p>n</p></content></note></slide>`,
+			removed: ` id="blw"`,
+		},
+		{
+			// A char ref inside the id value itself: the whole attribute goes.
+			name:    "char ref inside note id value",
+			in:      `<slide id="p1"><data/><note id="a&#32;b"><content><p>n</p></content></note></slide>`,
+			removed: ` id="a&#32;b"`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/shortcuts/slides/slides_update_slide_stripids_test.go
+++ b/shortcuts/slides/slides_update_slide_stripids_test.go
@@ -69,3 +69,42 @@ func TestStripSlideNoteIDAttrOrder(t *testing.T) {
 		}
 	}
 }
+
+// The id is stripped across the quote styles and spacing valid XML allows and
+// the backend accepts — single quotes and whitespace around '='. A verified
+// gap: a single-quoted stale note id used to slip through and reproduce the
+// "block is not NoteBlock" crash this strip prevents.
+func TestStripSlideNoteIDQuoteVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		note string
+	}{
+		{"single-quote", `<note id='blw'><content><p>n</p></content></note>`},
+		{"space-around-eq", `<note id = "blw"><content><p>n</p></content></note>`},
+		{"single-quote-space", `<note id =  'blw'><content><p>n</p></content></note>`},
+		{"single-quote-attr-order", `<note foo='bar' id='blw'><content><p>n</p></content></note>`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := stripSlideNoteID(`<slide id="p1"><data/>` + c.note + `</slide>`)
+			if strings.Contains(out, "blw") {
+				t.Errorf("expected note id to be stripped, got: %s", out)
+			}
+			if !strings.Contains(out, "<note") || !strings.Contains(out, "<p>n</p>") {
+				t.Errorf("expected note element and content to survive, got: %s", out)
+			}
+		})
+	}
+}
+
+// A single-quoted id on a visible element is left alone — only <note> is touched.
+func TestStripSlideNoteIDLeavesSingleQuotedShape(t *testing.T) {
+	in := `<slide id="p1"><data><shape id='bKZ' type='text'><content><p>x</p></content></shape></data><note id='blw'><content><p>n</p></content></note></slide>`
+	out := stripSlideNoteID(in)
+	if strings.Contains(out, `id='blw'`) {
+		t.Errorf("expected note id to be stripped, got: %s", out)
+	}
+	if !strings.Contains(out, `id='bKZ'`) {
+		t.Errorf("expected shape id to be preserved, got: %s", out)
+	}
+}

--- a/shortcuts/slides/slides_update_slide_stripids_test.go
+++ b/shortcuts/slides/slides_update_slide_stripids_test.go
@@ -4,9 +4,25 @@
 package slides
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// noteOpenTagRe grabs the <note> opening tag; noteIDInTagRe finds an id
+// attribute (any quote style, any spacing) inside it.
+var (
+	noteOpenTagRe = regexp.MustCompile(`<note\b[^>]*>`)
+	noteIDInTagRe = regexp.MustCompile(`(?:^|\s)id\s*=`)
+)
+
+// noteTagHasID reports whether the <note> opening tag in s still carries an id
+// attribute. Asserting on the attribute itself — rather than on a specific id
+// value disappearing — catches an implementation that swaps the id for another
+// value instead of removing it.
+func noteTagHasID(s string) bool {
+	return noteIDInTagRe.MatchString(noteOpenTagRe.FindString(s))
+}
 
 func TestStripSlideNoteID(t *testing.T) {
 	in := `<slide id="p1"><style><fill id="f1"><fillColor color="rgba(1,2,3,1)"/></fill></style><data>` +
@@ -17,9 +33,9 @@ func TestStripSlideNoteID(t *testing.T) {
 		`</data><note id="blw"><content><p>n</p></content></note></slide>`
 	out := stripSlideNoteID(in)
 
-	// Only the <note> id is stripped.
-	if strings.Contains(out, `id="blw"`) {
-		t.Errorf("expected note id to be stripped, got: %s", out)
+	// The <note> tag no longer carries an id attribute at all.
+	if noteTagHasID(out) {
+		t.Errorf("expected note id attribute to be removed, got: %s", out)
 	}
 	// The note element itself and its content survive.
 	for _, kept := range []string{`<note`, `<p>n</p>`} {
@@ -60,8 +76,8 @@ func TestStripSlideNoteIDNoNote(t *testing.T) {
 func TestStripSlideNoteIDAttrOrder(t *testing.T) {
 	in := `<slide id="p1"><data/><note foo="bar" id="blw" baz="qux"><content><p>n</p></content></note></slide>`
 	out := stripSlideNoteID(in)
-	if strings.Contains(out, `id="blw"`) {
-		t.Errorf("expected note id to be stripped, got: %s", out)
+	if noteTagHasID(out) {
+		t.Errorf("expected note id attribute to be removed, got: %s", out)
 	}
 	for _, kept := range []string{`foo="bar"`, `baz="qux"`} {
 		if !strings.Contains(out, kept) {
@@ -87,8 +103,8 @@ func TestStripSlideNoteIDQuoteVariants(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			out := stripSlideNoteID(`<slide id="p1"><data/>` + c.note + `</slide>`)
-			if strings.Contains(out, "blw") {
-				t.Errorf("expected note id to be stripped, got: %s", out)
+			if noteTagHasID(out) {
+				t.Errorf("expected note id attribute to be removed, got: %s", out)
 			}
 			if !strings.Contains(out, "<note") || !strings.Contains(out, "<p>n</p>") {
 				t.Errorf("expected note element and content to survive, got: %s", out)
@@ -101,8 +117,8 @@ func TestStripSlideNoteIDQuoteVariants(t *testing.T) {
 func TestStripSlideNoteIDLeavesSingleQuotedShape(t *testing.T) {
 	in := `<slide id="p1"><data><shape id='bKZ' type='text'><content><p>x</p></content></shape></data><note id='blw'><content><p>n</p></content></note></slide>`
 	out := stripSlideNoteID(in)
-	if strings.Contains(out, `id='blw'`) {
-		t.Errorf("expected note id to be stripped, got: %s", out)
+	if noteTagHasID(out) {
+		t.Errorf("expected note id attribute to be removed, got: %s", out)
 	}
 	if !strings.Contains(out, `id='bKZ'`) {
 		t.Errorf("expected shape id to be preserved, got: %s", out)

--- a/shortcuts/slides/slides_update_slide_test.go
+++ b/shortcuts/slides/slides_update_slide_test.go
@@ -105,8 +105,9 @@ func TestUpdateSlideSendsOnePagePart(t *testing.T) {
 	if part.BlockID != "pYw" {
 		t.Fatalf("block_id = %q, want the page id pYw", part.BlockID)
 	}
-	// The caller's bytes travel through untouched apart from the injected root id,
-	// so their formatting lands in the page.
+	// The root gets the page id stamped; the caller's bytes are otherwise preserved
+	// (only a stale <note> id would be dropped, and this fixture has no <note>), so
+	// their content, formatting and visible element ids all land in the page.
 	if !strings.HasPrefix(part.Replacement, `<slide id="pYw">`) {
 		t.Fatalf("replacement root not stamped with the page id: %s", part.Replacement)
 	}


### PR DESCRIPTION
## 问题

`slides +update-slide` 提交的 XML 里如果带了一个不属于当前页的 `<note id="...">`,后端会用 `block is not NoteBlock` 拒绝整页更新

复现场景:
- XML 从别的页复制过来(带着那一页的 note id)
- 页面被重建过(`+add-slide` 会重新分配 id),原来的 note id 已经失效

后端 `RewriteSlideBySXSD` 拿这个 stale 的 note id 去定位 note block,定位到的不是 NoteBlock,于是整页更新失败。

## 修复

在发送前只去掉 `<note>` 元素上的 `id` 属性(`stripSlideNoteID`)。没有 id 时后端会定位到本页自己的 note block 并原地改写,更新成功。

**为什么只去 note 的 id、保留其他所有元素的 id:**
- note 是演讲者备注,不参与页面渲染,去掉 id 对可见效果零影响。
- 可见元素保留 id → 后端走原地更新而不是删除重建,文字布局不会重排(删所有 id 会导致确定性的文字重排)。
- 不触碰 svg 内部 `url(#id)` / `href="#..."` 这类文档内引用。

## 验证

单测:`TestStripSlideNoteID`(note id 被删,shape/embed/svg 的 id 及 `url(#grad)`/`href="#pp"` 全部保留)、无 note 直通、属性顺序三个用例。`go test ./shortcuts/slides/` 通过,`go vet` 无告警。

线上 A/B 对比,把 A 页 XML(带 stale note id)应用到 B 页:
- **基线(main):** 报 `400001 block is not NoteBlock`,复现缺陷。
- **修复后:** 更新成功;回读 B 页确认图形文字和 note 文字都正确更新,note 换成了 B 页自己的 id,shape 保持稳定 id(原地更新,无重排)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slide updates by removing stale identifiers only from direct slide notes.
  * Preserved visible element identifiers, SVG references, formatting, content, and other note attributes during slide replacement.
  * Prevented note-like text in comments or CDATA, nested notes, and attribute values containing `>` from being altered.
  * Ensured consistent handling across note markup formats and slides without notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->