### PR TITLE
fix(binding): handle trusted directories on Windows

### DIFF
--- a/internal/binding/audit.go
+++ b/internal/binding/audit.go
@@ -122,10 +122,18 @@ func requireInTrustedDirs(effectivePath string, trustedDirs []string, label stri
 	if len(trustedDirs) == 0 {
 		return nil
 	}
-	cleaned := filepath.Clean(effectivePath)
+	// Resolve parent symlinks on both sides before the lexical containment
+	// check so a path cannot appear trusted while resolving outside the root.
+	resolvedPath, err := vfs.EvalSymlinks(filepath.Clean(effectivePath))
+	if err != nil {
+		return fmt.Errorf("%s: cannot resolve path %q for trusted directory audit: %w", label, effectivePath, err)
+	}
 	for _, dir := range trustedDirs {
-		cleanDir := filepath.Clean(dir)
-		rel, err := filepath.Rel(cleanDir, cleaned)
+		resolvedDir, err := vfs.EvalSymlinks(filepath.Clean(dir))
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(resolvedDir, resolvedPath)
 		if err == nil && rel != ".." && !filepath.IsAbs(rel) &&
 			!strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return nil

--- a/internal/binding/audit.go
+++ b/internal/binding/audit.go
@@ -125,7 +125,9 @@ func requireInTrustedDirs(effectivePath string, trustedDirs []string, label stri
 	cleaned := filepath.Clean(effectivePath)
 	for _, dir := range trustedDirs {
 		cleanDir := filepath.Clean(dir)
-		if cleaned == cleanDir || strings.HasPrefix(cleaned, cleanDir+"/") {
+		rel, err := filepath.Rel(cleanDir, cleaned)
+		if err == nil && rel != ".." && !filepath.IsAbs(rel) &&
+			!strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return nil
 		}
 	}

--- a/internal/binding/audit_test.go
+++ b/internal/binding/audit_test.go
@@ -361,3 +361,14 @@ func TestAssertSecurePath_TrustedDirs(t *testing.T) {
 		t.Errorf("got %q, want %q", got, trustedFile)
 	}
 }
+
+func TestRequireInTrustedDirs_RejectsSiblingPrefix(t *testing.T) {
+	parent := t.TempDir()
+	trustedDir := filepath.Join(parent, "trusted")
+	siblingPath := filepath.Join(parent, "trusted-backup", "secret.txt")
+
+	err := requireInTrustedDirs(siblingPath, []string{trustedDir}, "test")
+	if err == nil {
+		t.Fatal("expected sibling path sharing the trusted prefix to be rejected")
+	}
+}

--- a/internal/binding/audit_test.go
+++ b/internal/binding/audit_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/larksuite/cli/internal/vfs"
 )
 
 func TestAssertSecurePath_NonAbsolutePath(t *testing.T) {
@@ -366,13 +368,13 @@ func TestRequireInTrustedDirs_RejectsSiblingPrefix(t *testing.T) {
 	parent := t.TempDir()
 	trustedDir := filepath.Join(parent, "trusted")
 	siblingPath := filepath.Join(parent, "trusted-backup", "secret.txt")
-	if err := os.MkdirAll(trustedDir, 0o700); err != nil {
+	if err := vfs.MkdirAll(trustedDir, 0o700); err != nil {
 		t.Fatalf("create trusted dir: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(siblingPath), 0o700); err != nil {
+	if err := vfs.MkdirAll(filepath.Dir(siblingPath), 0o700); err != nil {
 		t.Fatalf("create sibling dir: %v", err)
 	}
-	if err := os.WriteFile(siblingPath, []byte("data"), 0o600); err != nil {
+	if err := vfs.WriteFile(siblingPath, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write sibling file: %v", err)
 	}
 
@@ -386,17 +388,18 @@ func TestAssertSecurePath_TrustedDirs_ParentSymlinkEscapeRejected(t *testing.T) 
 	parent := t.TempDir()
 	trustedDir := filepath.Join(parent, "trusted")
 	outsideDir := filepath.Join(parent, "outside")
-	if err := os.MkdirAll(trustedDir, 0o700); err != nil {
+	if err := vfs.MkdirAll(trustedDir, 0o700); err != nil {
 		t.Fatalf("create trusted dir: %v", err)
 	}
-	if err := os.MkdirAll(outsideDir, 0o700); err != nil {
+	if err := vfs.MkdirAll(outsideDir, 0o700); err != nil {
 		t.Fatalf("create outside dir: %v", err)
 	}
 	outsideFile := filepath.Join(outsideDir, "secret.txt")
-	if err := os.WriteFile(outsideFile, []byte("data"), 0o600); err != nil {
+	if err := vfs.WriteFile(outsideFile, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write outside file: %v", err)
 	}
 	link := filepath.Join(trustedDir, "link-out")
+	// vfs has no symlink creator; both paths are bounded by parent from t.TempDir.
 	if err := os.Symlink(outsideDir, link); err != nil {
 		t.Skipf("create parent symlink: %v", err)
 	}
@@ -415,14 +418,15 @@ func TestAssertSecurePath_TrustedDirs_ParentSymlinkEscapeRejected(t *testing.T) 
 func TestAssertSecurePath_TrustedDirs_TrustedDirSymlinkAllowed(t *testing.T) {
 	parent := t.TempDir()
 	realDir := filepath.Join(parent, "real")
-	if err := os.MkdirAll(realDir, 0o700); err != nil {
+	if err := vfs.MkdirAll(realDir, 0o700); err != nil {
 		t.Fatalf("create real dir: %v", err)
 	}
 	target := filepath.Join(realDir, "secret.txt")
-	if err := os.WriteFile(target, []byte("data"), 0o600); err != nil {
+	if err := vfs.WriteFile(target, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write target file: %v", err)
 	}
 	trustedLink := filepath.Join(parent, "trusted-link")
+	// vfs has no symlink creator; both paths are bounded by parent from t.TempDir.
 	if err := os.Symlink(realDir, trustedLink); err != nil {
 		t.Skipf("create trusted-dir symlink: %v", err)
 	}

--- a/internal/binding/audit_test.go
+++ b/internal/binding/audit_test.go
@@ -366,9 +366,77 @@ func TestRequireInTrustedDirs_RejectsSiblingPrefix(t *testing.T) {
 	parent := t.TempDir()
 	trustedDir := filepath.Join(parent, "trusted")
 	siblingPath := filepath.Join(parent, "trusted-backup", "secret.txt")
+	if err := os.MkdirAll(trustedDir, 0o700); err != nil {
+		t.Fatalf("create trusted dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(siblingPath), 0o700); err != nil {
+		t.Fatalf("create sibling dir: %v", err)
+	}
+	if err := os.WriteFile(siblingPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write sibling file: %v", err)
+	}
 
 	err := requireInTrustedDirs(siblingPath, []string{trustedDir}, "test")
 	if err == nil {
 		t.Fatal("expected sibling path sharing the trusted prefix to be rejected")
+	}
+}
+
+func TestAssertSecurePath_TrustedDirs_ParentSymlinkEscapeRejected(t *testing.T) {
+	parent := t.TempDir()
+	trustedDir := filepath.Join(parent, "trusted")
+	outsideDir := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(trustedDir, 0o700); err != nil {
+		t.Fatalf("create trusted dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o700); err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	link := filepath.Join(trustedDir, "link-out")
+	if err := os.Symlink(outsideDir, link); err != nil {
+		t.Skipf("create parent symlink: %v", err)
+	}
+
+	_, err := AssertSecurePath(AuditParams{
+		TargetPath:        filepath.Join(link, "secret.txt"),
+		Label:             "test",
+		TrustedDirs:       []string{trustedDir},
+		AllowInsecurePath: true,
+	})
+	if err == nil {
+		t.Fatal("expected a path escaping through a parent symlink to be rejected")
+	}
+}
+
+func TestAssertSecurePath_TrustedDirs_TrustedDirSymlinkAllowed(t *testing.T) {
+	parent := t.TempDir()
+	realDir := filepath.Join(parent, "real")
+	if err := os.MkdirAll(realDir, 0o700); err != nil {
+		t.Fatalf("create real dir: %v", err)
+	}
+	target := filepath.Join(realDir, "secret.txt")
+	if err := os.WriteFile(target, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	trustedLink := filepath.Join(parent, "trusted-link")
+	if err := os.Symlink(realDir, trustedLink); err != nil {
+		t.Skipf("create trusted-dir symlink: %v", err)
+	}
+
+	got, err := AssertSecurePath(AuditParams{
+		TargetPath:        target,
+		Label:             "test",
+		TrustedDirs:       []string{trustedLink},
+		AllowInsecurePath: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != target {
+		t.Fatalf("got %q, want %q", got, target)
 	}
 }


### PR DESCRIPTION
## Summary

Fix Windows trusted-directory containment so files below an allowed directory pass the binding audit. Both the target and configured roots are resolved before the platform-aware relative-path check, preventing parent symlinks from escaping the trusted boundary.

## Changes

- Replace the hard-coded `/` descendant check with platform-aware relative-path containment.
- Resolve the effective path and trusted roots before comparing containment.
- Cover nested paths, sibling-name prefixes, parent-symlink escapes, and symlinked trusted roots.

## Test Plan

- [x] `go test ./internal/binding -count=1` on native Windows
- [x] `go test ./internal/binding ./internal/transport -count=1` on Linux (Go 1.25 container; includes both symlink regressions)
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- [x] `go run -C lint . --changed-from origin/main ..`
- [ ] `make unit-test` (GNU make is unavailable in the Windows audit environment; affected packages passed on Linux, and the binding package passed on Windows)

## Related Issues

- Fixes #2478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trusted-directory validation to reject similarly prefixed sibling paths.
  * Prevented access through symlinked parent paths that escape trusted directories.
  * Continued to allow valid files accessed through symlinked trusted directories.
  * Added safeguards for paths that cannot be resolved and ignored unresolved trusted-directory entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->