### PR TITLE
fix(slides): make IconPark JSON output encoding-safe

### DIFF
--- a/skills/lark-slides/scripts/iconpark_tool.py
+++ b/skills/lark-slides/scripts/iconpark_tool.py
@@ -330,7 +330,7 @@ def print_usage() -> None:
 
 
 def write_json(value: Any) -> None:
-    print(json.dumps(value, ensure_ascii=False, indent=2))
+    print(json.dumps(value, ensure_ascii=True, indent=2))
 
 
 def run_cli(argv: list[str] | None = None) -> None:

--- a/skills/lark-slides/scripts/iconpark_tool_test.py
+++ b/skills/lark-slides/scripts/iconpark_tool_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import unittest
@@ -117,11 +118,14 @@ class IconParkToolTest(unittest.TestCase):
 
 
 class IconParkToolCLITest(unittest.TestCase):
-    def run_tool(self, *args: str) -> subprocess.CompletedProcess[str]:
+    def run_tool(
+        self, *args: str, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [sys.executable, str(SCRIPT_PATH), *args],
             capture_output=True,
             check=False,
+            env=env,
             text=True,
         )
 
@@ -135,6 +139,17 @@ class IconParkToolCLITest(unittest.TestCase):
         self.assertTrue(
             any(entry["iconType"] == "iconpark/Charts/positive-dynamics.svg" for entry in output)
         )
+
+    def test_cli_search_writes_json_with_non_utf8_stdout(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONIOENCODING"] = "cp1252"
+
+        result = self.run_tool("search", "--query", "growth", "--limit", "1", env=env)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertTrue(result.stdout.isascii())
+        self.assertTrue(json.loads(result.stdout))
 
     def test_cli_resolve_writes_json_to_stdout(self) -> None:
         result = self.run_tool("resolve", "--name", "chart-line")


### PR DESCRIPTION
## Summary

Keep IconPark's machine-readable stdout usable on non-UTF-8 Windows locales by emitting non-ASCII JSON characters as standard escape sequences. JSON consumers receive the same decoded values without depending on the console code page.

## Changes

- Serialize IconPark JSON with ASCII-safe escapes.
- Add a subprocess regression test that forces `PYTHONIOENCODING=cp1252`.

## Test Plan

- [x] `python skills/lark-slides/scripts/iconpark_tool_test.py -k non_utf8_stdout`
- [x] `PYTHONUTF8=1 python skills/lark-slides/scripts/iconpark_tool_test.py` (21 tests)
- [x] `python -m py_compile skills/lark-slides/scripts/iconpark_tool.py skills/lark-slides/scripts/iconpark_tool_test.py`
- [x] `node scripts/skill-format-check/index.js`
- [x] Manual native Windows run with `PYTHONIOENCODING=cp1252` returned parseable JSON

## Related Issues

- Fixes #2479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON output compatibility by escaping non-ASCII characters.
  * Ensured generated JSON remains valid when displayed in environments using non-UTF-8 encodings.

* **Tests**
  * Added coverage for encoding-safe command-line output.
  * Enhanced test support for custom environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->