### PR TITLE
docs(skills): fix broken reference links

### DIFF
--- a/skills/lark-apps/references/lark-apps-local-dev.md
+++ b/skills/lark-apps/references/lark-apps-local-dev.md
@@ -66,7 +66,7 @@ lark-cli apps +release-get --as user --app-id app_xxx --release-id <上一步返
 
 #### 首次开发（无 app，无代码）
 
-`+create(html)` → `+init` → 加载 [`creative-design`](../creative-design/SKILL.md) skill 在 repo 根目录产出文件 → `git add .` + `git commit` → `git push origin sprint/default` → `+release-create` → `+release-get`。
+`+create(html)` → `+init` → 加载 [`creative-design`](../creative-design/creative-design.md) skill 在 repo 根目录产出文件 → `git add .` + `git commit` → `git push origin sprint/default` → `+release-create` → `+release-get`。
 
 ```bash
 lark-cli apps +create --name "活动页" --app-type html --as user

--- a/skills/lark-mail/references/lark-mail-draft-create.md
+++ b/skills/lark-mail/references/lark-mail-draft-create.md
@@ -8,7 +8,7 @@
 
 如需修改已有草稿，不要使用此命令，请使用 `lark-cli mail +draft-edit`。
 
-**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
+**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [lark-mail-html.md](lark-mail-html.md)，其中包含邮件书写规范**
 
 ## 安全约束
 

--- a/skills/lark-mail/references/lark-mail-draft-edit.md
+++ b/skills/lark-mail/references/lark-mail-draft-edit.md
@@ -12,7 +12,7 @@
 
 **正文整体替换的快捷方式：** `--body <text>` / `--body-file <path>`（二选一互斥）会自动展开为 `set_body` op。如果只想做整段正文替换且不需要保留引用区，用这两个 flag 即可，无需写 patch-file。要保留引用区或做更精细的 op 组合，仍走 `--patch-file`。两个入口与 `--patch-file` 内的 `set_body` / `set_reply_body` 互斥。
 
-**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
+**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [lark-mail-html.md](lark-mail-html.md)，其中包含邮件书写规范**
 
 ## 正文编辑：快捷 flag 与 typed op 的选择
 

--- a/skills/lark-mail/references/lark-mail-forward.md
+++ b/skills/lark-mail/references/lark-mail-forward.md
@@ -13,7 +13,7 @@
 
 ## CRITICAL — 发送工作流（必须遵循）
 
-**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
+**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [lark-mail-html.md](lark-mail-html.md)，其中包含邮件书写规范**
 
 此命令默认**只保存草稿**，不会发送邮件。转发会将原邮件内容发送给新收件人，需要发送时有两种合规方式：
 

--- a/skills/lark-mail/references/lark-mail-reply-all.md
+++ b/skills/lark-mail/references/lark-mail-reply-all.md
@@ -13,7 +13,7 @@
 
 ## CRITICAL — 发送工作流（必须遵循）
 
-**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
+**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [lark-mail-html.md](lark-mail-html.md)，其中包含邮件书写规范**
 
 此命令默认**只保存草稿**，不会发送邮件。回复全部会发送给**所有**原始收件人，需要发送时有两种合规方式：
 

--- a/skills/lark-mail/references/lark-mail-reply.md
+++ b/skills/lark-mail/references/lark-mail-reply.md
@@ -17,7 +17,7 @@
 
 ## CRITICAL — 发送工作流（必须遵循）
 
-**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
+**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [lark-mail-html.md](lark-mail-html.md)，其中包含邮件书写规范**
 
 此命令默认**只保存草稿**，不会发送邮件。需要发送时，有两种合规方式：
 

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -12,7 +12,7 @@
 
 ## CRITICAL — 发送工作流（必须遵循）
 
-**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
+**CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [lark-mail-html.md](lark-mail-html.md)，其中包含邮件书写规范**
 
 此命令默认**只保存草稿**，不会发送邮件。需要发送时，有两种合规方式：
 

--- a/skills/lark-mail/references/lark-mail-watch.md
+++ b/skills/lark-mail/references/lark-mail-watch.md
@@ -91,4 +91,4 @@ lark-cli mail +watch --print-output-schema
 
 - [lark-mail](../SKILL.md) — 邮箱域总览
 - [lark-mail-triage](lark-mail-triage.md) — 邮件摘要列表
-- [lark-event-subscribe](../../lark-event/references/lark-event-subscribe.md) — 通用事件订阅
+- [lark-event](../../lark-event/SKILL.md) — 通用事件订阅


### PR DESCRIPTION
## Summary

Repair eight relative links in shipped mail and app skill guidance so every referenced Markdown file resolves inside the installed skill tree.

## Changes

- Fix six mail-compose references that accidentally added a second `references/` segment.
- Point the local app workflow at the actual `creative-design.md` entry.
- Point mail watch at the existing generic `lark-event/SKILL.md` guidance.

## Test Plan

- [x] Resolved every local Markdown link in the eight changed files; 0 missing targets
- [x] `node scripts/skill-format-check/index.js`
- [x] `git diff --check origin/main...HEAD`
- [x] Manual local verification confirms each corrected target exists

## Related Issues

- Fixes #2480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected guidance links for HTML-based app development workflows.
  * Updated email drafting, editing, forwarding, replying, sending, and monitoring instructions to point to the appropriate local documentation.
  * Refreshed event subscription guidance to reference the current documentation.
  * Improved the reliability of required pre-task reading and workflow instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->