### PR TITLE
feat(config): support keychain-backed tenant access tokens

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -46,6 +46,7 @@ func newCmdConfig(f *cmdutil.Factory, projector *recovery.Projector) *cobra.Comm
 	cmd.AddCommand(NewCmdConfigPolicy(f))
 	cmd.AddCommand(NewCmdConfigPlugins(f))
 	cmd.AddCommand(NewCmdConfigKeychainDowngrade(f))
+	cmd.AddCommand(newCmdConfigTenantAccessToken(f))
 	return cmd
 }
 

--- a/cmd/config/tenant_access_token.go
+++ b/cmd/config/tenant_access_token.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"bufio"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/keychain"
+	"github.com/larksuite/cli/internal/output"
+)
+
+func newCmdConfigTenantAccessToken(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tenant-access-token",
+		Short: "Manage tenant access tokens in secure local storage",
+		// Credential provisioning must work while the env provider is active, so
+		// this group intentionally bypasses config's builtin-provider guard.
+		PersistentPreRunE: func(c *cobra.Command, _ []string) error {
+			c.SilenceUsage = true
+			f.CurrentCommand = c
+			return nil
+		},
+	}
+	cmd.AddCommand(newCmdConfigTenantAccessTokenSet(f))
+	cmd.AddCommand(newCmdConfigTenantAccessTokenRemove(f))
+	return cmd
+}
+
+func newCmdConfigTenantAccessTokenSet(f *cmdutil.Factory) *cobra.Command {
+	var appID string
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Store a tenant access token read from stdin",
+		Long: "Store a tenant access token for an App ID in secure local storage.\n" +
+			"The token is always read from stdin and is never accepted as an argument or flag.\n" +
+			"Set LARKSUITE_CLI_TENANT_ACCESS_TOKEN_SOURCE=keychain to select the stored token\n" +
+			"for bot requests in an env-selected account.",
+		Args: rejectTenantTokenPositionals,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return configTenantAccessTokenSetRun(f, appID)
+		},
+	}
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID whose tenant access token is stored")
+	_ = cmd.MarkFlagRequired("app-id")
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+func newCmdConfigTenantAccessTokenRemove(f *cmdutil.Factory) *cobra.Command {
+	var appID string
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a stored tenant access token",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return configTenantAccessTokenRemoveRun(f, appID)
+		},
+	}
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID whose stored tenant access token is removed")
+	_ = cmd.MarkFlagRequired("app-id")
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+func rejectTenantTokenPositionals(_ *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"positional arguments are not accepted; pipe the tenant access token to stdin").
+		WithHint("pipe exactly one token line to stdin")
+}
+
+func configTenantAccessTokenSetRun(f *cmdutil.Factory, appID string) error {
+	if f == nil || f.IOStreams == nil || f.IOStreams.In == nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"stdin is empty, expected tenant access token")
+	}
+	if appID == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--app-id is required").WithParam("--app-id")
+	}
+
+	scanner := bufio.NewScanner(f.IOStreams.In)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return errs.NewValidationError(errs.SubtypeFailedPrecondition,
+				"failed to read tenant access token from stdin: %v", err).WithCause(err)
+		}
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"stdin is empty, expected tenant access token")
+	}
+	token := scanner.Text()
+	if token == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"tenant access token must be provided as one non-empty line")
+	}
+	if scanner.Scan() {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"tenant access token must be provided as exactly one line")
+	}
+	if err := scanner.Err(); err != nil {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"failed to read tenant access token from stdin: %v", err).WithCause(err)
+	}
+
+	store := credential.NewTenantTokenStore(func() keychain.KeychainAccess {
+		return f.Keychain
+	})
+	if err := store.Set(appID, token); err != nil {
+		return err
+	}
+	return output.WriteSuccessEnvelope(map[string]any{
+		"appId":  appID,
+		"stored": true,
+	}, output.SuccessEnvelopeOptions{
+		CommandPath: "lark-cli config tenant-access-token set",
+		Out:         f.IOStreams.Out,
+		ErrOut:      f.IOStreams.ErrOut,
+	})
+}
+
+func configTenantAccessTokenRemoveRun(f *cmdutil.Factory, appID string) error {
+	if f == nil {
+		return errs.NewInternalError(errs.SubtypeStorage, "tenant access token storage is unavailable")
+	}
+	if appID == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--app-id is required").WithParam("--app-id")
+	}
+	store := credential.NewTenantTokenStore(func() keychain.KeychainAccess {
+		return f.Keychain
+	})
+	if err := store.Remove(appID); err != nil {
+		return err
+	}
+	return output.WriteSuccessEnvelope(map[string]any{
+		"appId":   appID,
+		"removed": true,
+	}, output.SuccessEnvelopeOptions{
+		CommandPath: "lark-cli config tenant-access-token remove",
+		Out:         f.IOStreams.Out,
+		ErrOut:      f.IOStreams.ErrOut,
+	})
+}

--- a/cmd/config/tenant_access_token.go
+++ b/cmd/config/tenant_access_token.go
@@ -39,7 +39,7 @@ func newCmdConfigTenantAccessTokenSet(f *cmdutil.Factory) *cobra.Command {
 		Short: "Store a tenant access token read from stdin",
 		Long: "Store a tenant access token for an App ID in secure local storage.\n" +
 			"The token is always read from stdin and is never accepted as an argument or flag.\n" +
-			"Set LARKSUITE_CLI_TENANT_ACCESS_TOKEN_SOURCE=keychain to select the stored token\n" +
+			"Set LARKSUITE_CLI_TENANT_ACCESS_TOKEN_SOURCE=credential-store to select the stored token\n" +
 			"for bot requests in an env-selected account.",
 		Args: rejectTenantTokenPositionals,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/config/tenant_access_token_test.go
+++ b/cmd/config/tenant_access_token_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	extcred "github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/keychain"
+	"github.com/larksuite/cli/internal/output"
+)
+
+type configTenantTokenKeychain struct {
+	values      map[string]string
+	setCalls    int
+	setValues   []string
+	removeCalls int
+}
+
+func (k *configTenantTokenKeychain) Get(service, account string) (string, error) {
+	return k.values[service+"/"+account], nil
+}
+
+func (k *configTenantTokenKeychain) Set(service, account, value string) error {
+	k.setCalls++
+	k.setValues = append(k.setValues, value)
+	if k.values == nil {
+		k.values = make(map[string]string)
+	}
+	k.values[service+"/"+account] = value
+	return nil
+}
+
+func TestConfigTenantAccessTokenSetPreservesOpaqueLine(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	token := "opaque token\t雪"
+	f.IOStreams.In = strings.NewReader(token + "\n")
+	kc := &configTenantTokenKeychain{}
+	f.Keychain = kc
+	cmd := newCmdConfigTenantAccessTokenSet(f)
+	cmd.SetArgs([]string{"--app-id", "cli_test"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(kc.setValues) != 1 || kc.setValues[0] != token {
+		t.Fatalf("stored values = %q, want opaque input preserved verbatim", kc.setValues)
+	}
+}
+
+func TestConfigTenantAccessTokenSetHelpHasNoSourceIndentation(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	cmd := newCmdConfigTenantAccessTokenSet(f)
+	if strings.Contains(cmd.Long, "\t") || !strings.Contains(cmd.Long, "\nfor bot requests") {
+		t.Fatalf("Long help contains source indentation: %q", cmd.Long)
+	}
+}
+
+func (k *configTenantTokenKeychain) Remove(service, account string) error {
+	k.removeCalls++
+	delete(k.values, service+"/"+account)
+	return nil
+}
+
+func TestConfigTenantAccessTokenSetStoresWithoutLeaking(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, stderr, _ := cmdutil.TestFactory(t, nil)
+	f.IOStreams.In = strings.NewReader("super-secret-tat\n")
+	kc := &configTenantTokenKeychain{}
+	f.Keychain = kc
+	cmd := newCmdConfigTenantAccessTokenSet(f)
+	cmd.SetArgs([]string{"--app-id", "cli_Test/opaque"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if kc.setCalls != 1 {
+		t.Fatalf("Set calls = %d, want 1", kc.setCalls)
+	}
+	if strings.Contains(stdout.String()+stderr.String(), "super-secret-tat") {
+		t.Fatalf("output leaked token: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	data, ok := envelope.Data.(map[string]any)
+	if !envelope.OK || !ok || data["appId"] != "cli_Test/opaque" || data["stored"] != true {
+		t.Fatalf("envelope = %#v, want stored success", envelope)
+	}
+}
+
+func TestConfigTenantAccessTokenSetRejectsInvalidInputBeforeStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		in   io.Reader
+		args []string
+	}{
+		{name: "empty stdin", in: strings.NewReader(""), args: []string{"--app-id", "cli_test"}},
+		{name: "empty line", in: strings.NewReader("\n"), args: []string{"--app-id", "cli_test"}},
+		{name: "multiple lines", in: strings.NewReader("token\nsecond\n"), args: []string{"--app-id", "cli_test"}},
+		{name: "positional", in: strings.NewReader("token\n"), args: []string{"--app-id", "cli_test", "secret-positional"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+			f, stdout, stderr, _ := cmdutil.TestFactory(t, nil)
+			f.IOStreams.In = tc.in
+			kc := &configTenantTokenKeychain{}
+			f.Keychain = kc
+			cmd := newCmdConfigTenantAccessTokenSet(f)
+			cmd.SilenceErrors = true
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) || kc.setCalls != 0 {
+				t.Fatalf("error=%T %v setCalls=%d, want validation before storage", err, err, kc.setCalls)
+			}
+			combined := stdout.String() + stderr.String() + err.Error()
+			if strings.Contains(combined, "secret-positional") {
+				t.Fatalf("error leaked positional value: %s", combined)
+			}
+		})
+	}
+}
+
+type failingTenantTokenReader struct{ err error }
+
+func (r failingTenantTokenReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestConfigTenantAccessTokenSetPreservesStdinFailure(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	sentinel := io.ErrUnexpectedEOF
+	f.IOStreams.In = failingTenantTokenReader{err: sentinel}
+	kc := &configTenantTokenKeychain{}
+	f.Keychain = kc
+	cmd := newCmdConfigTenantAccessTokenSet(f)
+	cmd.SetArgs([]string{"--app-id", "cli_test"})
+
+	err := cmd.Execute()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Subtype != errs.SubtypeFailedPrecondition || !errors.Is(err, sentinel) || kc.setCalls != 0 {
+		t.Fatalf("error=%T %v setCalls=%d, want failed_precondition preserving cause", err, err, kc.setCalls)
+	}
+}
+
+func TestConfigTenantAccessTokenRemoveIsIdempotent(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	kc := &configTenantTokenKeychain{}
+	f.Keychain = kc
+	cmd := newCmdConfigTenantAccessTokenRemove(f)
+	cmd.SetArgs([]string{"--app-id", "cli_test"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if kc.removeCalls != 1 || !strings.Contains(stdout.String(), `"removed": true`) {
+		t.Fatalf("removeCalls=%d stdout=%s, want idempotent removed success", kc.removeCalls, stdout.String())
+	}
+}
+
+func TestConfigTenantAccessTokenGroupBypassesExternalProviderGuard(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	f.IOStreams.In = strings.NewReader("tenant-token\n")
+	f.Keychain = &configTenantTokenKeychain{}
+	f.Credential = credential.NewCredentialProvider(
+		[]extcred.Provider{&stubConfigExtProvider{name: "env"}}, nil, nil, nil,
+	)
+	cmd := NewCmdConfig(f)
+	cmd.SetArgs([]string{"tenant-access-token", "set", "--app-id", "cli_test"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"stored": true`) {
+		t.Fatalf("stdout = %s, want stored success", stdout.String())
+	}
+}
+
+var _ keychain.KeychainAccess = (*configTenantTokenKeychain)(nil)

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -14,7 +14,7 @@ import (
 	"github.com/larksuite/cli/internal/envvars"
 )
 
-const tenantAccessTokenSourceKeychain = "keychain"
+const tenantAccessTokenSourceCredentialStore = "credential-store"
 
 // Provider resolves account selection from environment variables. A configured
 // TAT lookup is consulted only when the dedicated source variable selects it.
@@ -42,11 +42,11 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 	if err != nil {
 		return nil, err
 	}
-	storedTATSelected := tatSource == tenantAccessTokenSourceKeychain
+	storedTATSelected := tatSource == tenantAccessTokenSourceCredentialStore
 	if storedTATSelected && appID == "" {
 		return nil, &credential.BlockError{
 			Provider: "env",
-			Reason:   envvars.CliTenantAccessTokenSource + "=keychain requires " + envvars.CliAppID,
+			Reason:   envvars.CliTenantAccessTokenSource + "=credential-store requires " + envvars.CliAppID,
 		}
 	}
 	if appID == "" && appSecret == "" {
@@ -133,14 +133,14 @@ func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (
 		if err != nil {
 			return nil, err
 		}
-		if tatSource == tenantAccessTokenSourceKeychain {
+		if tatSource == tenantAccessTokenSourceCredentialStore {
 			if req.AppID == "" || req.AppID != os.Getenv(envvars.CliAppID) {
 				return nil, nil
 			}
 			if p.tenantAccessTokenLookup == nil {
 				return nil, &credential.BlockError{
 					Provider: "env",
-					Reason:   "keychain tenant access token source is unavailable in this CLI distribution",
+					Reason:   "credential-store tenant access token source is unavailable in this CLI distribution",
 				}
 			}
 			return p.tenantAccessTokenLookup(ctx, req.AppID)
@@ -159,12 +159,12 @@ func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (
 func tenantAccessTokenSource() (string, error) {
 	source := strings.ToLower(strings.TrimSpace(os.Getenv(envvars.CliTenantAccessTokenSource)))
 	switch source {
-	case "", tenantAccessTokenSourceKeychain:
+	case "", tenantAccessTokenSourceCredentialStore:
 		return source, nil
 	default:
 		return "", &credential.BlockError{
 			Provider: "env",
-			Reason: fmt.Sprintf("invalid %s %q (want keychain or empty)",
+			Reason: fmt.Sprintf("invalid %s %q (want credential-store or empty)",
 				envvars.CliTenantAccessTokenSource, source),
 		}
 	}

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -7,14 +7,29 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
 )
 
-// Provider resolves credentials from environment variables.
-type Provider struct{}
+const tenantAccessTokenSourceKeychain = "keychain"
+
+// Provider resolves account selection from environment variables. A configured
+// TAT lookup is consulted only when the dedicated source variable selects it.
+type Provider struct {
+	tenantAccessTokenLookup func(context.Context, string) (*credential.Token, error)
+}
+
+// WithTenantAccessTokenLookup returns an invocation-scoped provider copy with
+// the CLI-owned stored-TAT lookup. The narrow callback keeps account resolution
+// independent from secret storage and avoids exposing a second full Provider.
+func (p *Provider) WithTenantAccessTokenLookup(lookup func(context.Context, string) (*credential.Token, error)) credential.Provider {
+	clone := *p
+	clone.tenantAccessTokenLookup = lookup
+	return &clone
+}
 
 func (p *Provider) Name() string { return "env" }
 
@@ -23,6 +38,17 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 	appSecret := os.Getenv(envvars.CliAppSecret)
 	hasUAT := os.Getenv(envvars.CliUserAccessToken) != ""
 	hasTAT := os.Getenv(envvars.CliTenantAccessToken) != ""
+	tatSource, err := tenantAccessTokenSource()
+	if err != nil {
+		return nil, err
+	}
+	storedTATSelected := tatSource == tenantAccessTokenSourceKeychain
+	if storedTATSelected && appID == "" {
+		return nil, &credential.BlockError{
+			Provider: "env",
+			Reason:   envvars.CliTenantAccessTokenSource + "=keychain requires " + envvars.CliAppID,
+		}
+	}
 	if appID == "" && appSecret == "" {
 		switch {
 		case hasUAT:
@@ -36,7 +62,7 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 	if appID == "" {
 		return nil, &credential.BlockError{Provider: "env", Reason: envvars.CliAppSecret + " is set but " + envvars.CliAppID + " is missing"}
 	}
-	if appSecret == "" && !hasUAT && !hasTAT {
+	if appSecret == "" && !hasUAT && !hasTAT && !storedTATSelected {
 		return nil, &credential.BlockError{
 			Provider: "env",
 			Reason:   envvars.CliAppID + " is set but no app secret or access token is available",
@@ -57,8 +83,9 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 		}
 	}
 
-	// Explicit strict mode policy takes priority
-	switch strictMode := os.Getenv(envvars.CliStrictMode); strictMode {
+	// Explicit strict mode policy takes priority.
+	strictMode := os.Getenv(envvars.CliStrictMode)
+	switch strictMode {
 	case "bot":
 		acct.SupportedIdentities = credential.SupportsBot
 	case "user":
@@ -70,7 +97,7 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 		if hasUAT {
 			acct.SupportedIdentities |= credential.SupportsUser
 		}
-		if hasTAT {
+		if hasTAT || storedTATSelected {
 			acct.SupportedIdentities |= credential.SupportsBot
 		}
 	default:
@@ -82,9 +109,13 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 
 	if acct.DefaultAs == "" {
 		switch {
+		case strictMode == "user":
+			acct.DefaultAs = credential.IdentityUser
+		case strictMode == "bot":
+			acct.DefaultAs = credential.IdentityBot
 		case hasUAT:
 			acct.DefaultAs = credential.IdentityUser
-		case hasTAT:
+		case hasTAT || storedTATSelected:
 			acct.DefaultAs = credential.IdentityBot
 		}
 	}
@@ -98,6 +129,22 @@ func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (
 	case credential.TokenTypeUAT:
 		envKey = envvars.CliUserAccessToken
 	case credential.TokenTypeTAT:
+		tatSource, err := tenantAccessTokenSource()
+		if err != nil {
+			return nil, err
+		}
+		if tatSource == tenantAccessTokenSourceKeychain {
+			if req.AppID == "" || req.AppID != os.Getenv(envvars.CliAppID) {
+				return nil, nil
+			}
+			if p.tenantAccessTokenLookup == nil {
+				return nil, &credential.BlockError{
+					Provider: "env",
+					Reason:   "keychain tenant access token source is unavailable in this CLI distribution",
+				}
+			}
+			return p.tenantAccessTokenLookup(ctx, req.AppID)
+		}
 		envKey = envvars.CliTenantAccessToken
 	default:
 		return nil, nil
@@ -107,6 +154,20 @@ func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (
 		return nil, nil
 	}
 	return &credential.Token{Value: token, Source: "env:" + envKey}, nil
+}
+
+func tenantAccessTokenSource() (string, error) {
+	source := strings.ToLower(strings.TrimSpace(os.Getenv(envvars.CliTenantAccessTokenSource)))
+	switch source {
+	case "", tenantAccessTokenSourceKeychain:
+		return source, nil
+	default:
+		return "", &credential.BlockError{
+			Provider: "env",
+			Reason: fmt.Sprintf("invalid %s %q (want keychain or empty)",
+				envvars.CliTenantAccessTokenSource, source),
+		}
+	}
 }
 
 func init() {

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -6,12 +6,20 @@ package env
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/envvars"
 )
+
+func TestMain(m *testing.M) {
+	if err := os.Unsetenv(envvars.CliTenantAccessTokenSource); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
 
 func TestProvider_Name(t *testing.T) {
 	if (&Provider{}).Name() != "env" {
@@ -279,4 +287,164 @@ func TestResolveAccount_InvalidDefaultAsRejected(t *testing.T) {
 	if !strings.Contains(err.Error(), envvars.CliDefaultAs) {
 		t.Fatalf("error = %v, want mention of %s", err, envvars.CliDefaultAs)
 	}
+}
+
+type storedTATLookup struct {
+	token *credential.Token
+	err   error
+	calls []string
+}
+
+func (l *storedTATLookup) resolve(_ context.Context, appID string) (*credential.Token, error) {
+	l.calls = append(l.calls, appID)
+	return l.token, l.err
+}
+
+func TestStoredTATSourceIsExplicitAndAccountResolutionDoesNotLookup(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
+
+	acct, err := p.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if len(lookup.calls) != 0 {
+		t.Fatalf("ResolveAccount() lookup calls = %v, want none", lookup.calls)
+	}
+	if acct == nil || acct.AppID != "cli_test" || !acct.SupportedIdentities.BotOnly() || acct.DefaultAs != credential.IdentityBot {
+		t.Fatalf("ResolveAccount() = %#v, want bot-capable cli_test account", acct)
+	}
+
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_test"})
+	if err != nil || tok == nil || tok.Value != "stored-tat" {
+		t.Fatalf("ResolveToken(TAT) = (%#v, %v), want stored-tat", tok, err)
+	}
+	if len(lookup.calls) != 1 || lookup.calls[0] != "cli_test" {
+		t.Fatalf("ResolveToken(TAT) lookup calls = %v, want cli_test", lookup.calls)
+	}
+}
+
+func TestStoredTATSourceUnsetNeverUsesLookup(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	lookup := &storedTATLookup{token: &credential.Token{Value: "must-not-be-used"}}
+	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
+
+	_, err := p.ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("ResolveAccount() error = %T %v, want existing APP_ID-only BlockError", err, err)
+	}
+	if len(lookup.calls) != 0 {
+		t.Fatalf("lookup calls = %v, want none without source selector", lookup.calls)
+	}
+}
+
+func TestStoredTATSourceLeavesUserLaneIndependent(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	t.Setenv(envvars.CliUserAccessToken, "env-uat")
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	t.Setenv(envvars.CliDefaultAs, "user")
+	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
+
+	acct, err := p.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if acct.DefaultAs != credential.IdentityUser || !acct.SupportedIdentities.Has(credential.SupportsUser) || !acct.SupportedIdentities.Has(credential.SupportsBot) {
+		t.Fatalf("account = %#v, want user default with user+bot capability", acct)
+	}
+	if len(lookup.calls) != 0 {
+		t.Fatalf("ResolveAccount() lookup calls = %v, want none", lookup.calls)
+	}
+
+	uat, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT, AppID: "cli_test"})
+	if err != nil || uat == nil || uat.Value != "env-uat" {
+		t.Fatalf("ResolveToken(UAT) = (%#v, %v), want env-uat", uat, err)
+	}
+	if len(lookup.calls) != 0 {
+		t.Fatalf("UAT resolution lookup calls = %v, want none", lookup.calls)
+	}
+
+	tat, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_test"})
+	if err != nil || tat == nil || tat.Value != "stored-tat" {
+		t.Fatalf("ResolveToken(TAT) = (%#v, %v), want stored-tat", tat, err)
+	}
+}
+
+func TestStoredTATSourceStrictUserDoesNotReadStoreDuringAccountResolution(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	t.Setenv(envvars.CliStrictMode, "user")
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
+
+	acct, err := p.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if !acct.SupportedIdentities.UserOnly() || acct.DefaultAs != credential.IdentityUser {
+		t.Fatalf("account = %#v, want strict user account with user default", acct)
+	}
+	if len(lookup.calls) != 0 {
+		t.Fatalf("ResolveAccount() lookup calls = %v, want none", lookup.calls)
+	}
+	if tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT, AppID: "cli_test"}); err != nil || tok != nil {
+		t.Fatalf("ResolveToken(UAT) = (%#v, %v), want nil without touching TAT store", tok, err)
+	}
+	if len(lookup.calls) != 0 {
+		t.Fatalf("UAT resolution lookup calls = %v, want none", lookup.calls)
+	}
+}
+
+func TestStoredTATSourcePreservesExplicitUserDefault(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	t.Setenv(envvars.CliDefaultAs, "user")
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
+
+	acct, err := p.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if acct.DefaultAs != credential.IdentityUser || len(lookup.calls) != 0 {
+		t.Fatalf("account=%#v lookup=%v, want explicit user default without store read", acct, lookup.calls)
+	}
+}
+
+func TestStoredTATSourceOverridesLiteralBotTokenLane(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "cli_test")
+	t.Setenv(envvars.CliTenantAccessToken, "env-tat")
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
+	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
+
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_test"})
+	if err != nil || tok == nil || tok.Value != "stored-tat" {
+		t.Fatalf("ResolveToken(TAT) = (%#v, %v), want explicit keychain source", tok, err)
+	}
+}
+
+func TestStoredTATSourceValidatesSelectorAndAppID(t *testing.T) {
+	t.Run("invalid source", func(t *testing.T) {
+		t.Setenv(envvars.CliAppID, "cli_test")
+		t.Setenv(envvars.CliTenantAccessTokenSource, "vault")
+		_, err := (&Provider{}).ResolveAccount(context.Background())
+		var blockErr *credential.BlockError
+		if !errors.As(err, &blockErr) || !strings.Contains(err.Error(), envvars.CliTenantAccessTokenSource) {
+			t.Fatalf("error = %T %v, want source BlockError", err, err)
+		}
+	})
+
+	t.Run("missing app ID", func(t *testing.T) {
+		t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+		_, err := (&Provider{}).ResolveAccount(context.Background())
+		var blockErr *credential.BlockError
+		if !errors.As(err, &blockErr) || !strings.Contains(err.Error(), envvars.CliAppID) {
+			t.Fatalf("error = %T %v, want APP_ID BlockError", err, err)
+		}
+	})
 }

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -302,7 +302,7 @@ func (l *storedTATLookup) resolve(_ context.Context, appID string) (*credential.
 
 func TestStoredTATSourceIsExplicitAndAccountResolutionDoesNotLookup(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "cli_test")
-	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceCredentialStore)
 	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
 	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
 
@@ -344,7 +344,7 @@ func TestStoredTATSourceUnsetNeverUsesLookup(t *testing.T) {
 func TestStoredTATSourceLeavesUserLaneIndependent(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "cli_test")
 	t.Setenv(envvars.CliUserAccessToken, "env-uat")
-	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceCredentialStore)
 	t.Setenv(envvars.CliDefaultAs, "user")
 	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
 	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
@@ -377,7 +377,7 @@ func TestStoredTATSourceLeavesUserLaneIndependent(t *testing.T) {
 func TestStoredTATSourceStrictUserDoesNotReadStoreDuringAccountResolution(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "cli_test")
 	t.Setenv(envvars.CliStrictMode, "user")
-	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceCredentialStore)
 	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
 	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
 
@@ -402,7 +402,7 @@ func TestStoredTATSourceStrictUserDoesNotReadStoreDuringAccountResolution(t *tes
 func TestStoredTATSourcePreservesExplicitUserDefault(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "cli_test")
 	t.Setenv(envvars.CliDefaultAs, "user")
-	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceCredentialStore)
 	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
 	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
 
@@ -418,20 +418,20 @@ func TestStoredTATSourcePreservesExplicitUserDefault(t *testing.T) {
 func TestStoredTATSourceOverridesLiteralBotTokenLane(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "cli_test")
 	t.Setenv(envvars.CliTenantAccessToken, "env-tat")
-	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+	t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceCredentialStore)
 	lookup := &storedTATLookup{token: &credential.Token{Value: "stored-tat"}}
 	p := (&Provider{}).WithTenantAccessTokenLookup(lookup.resolve)
 
 	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "cli_test"})
 	if err != nil || tok == nil || tok.Value != "stored-tat" {
-		t.Fatalf("ResolveToken(TAT) = (%#v, %v), want explicit keychain source", tok, err)
+		t.Fatalf("ResolveToken(TAT) = (%#v, %v), want explicit credential-store source", tok, err)
 	}
 }
 
 func TestStoredTATSourceValidatesSelectorAndAppID(t *testing.T) {
 	t.Run("invalid source", func(t *testing.T) {
 		t.Setenv(envvars.CliAppID, "cli_test")
-		t.Setenv(envvars.CliTenantAccessTokenSource, "vault")
+		t.Setenv(envvars.CliTenantAccessTokenSource, "keychain")
 		_, err := (&Provider{}).ResolveAccount(context.Background())
 		var blockErr *credential.BlockError
 		if !errors.As(err, &blockErr) || !strings.Contains(err.Error(), envvars.CliTenantAccessTokenSource) {
@@ -440,7 +440,7 @@ func TestStoredTATSourceValidatesSelectorAndAppID(t *testing.T) {
 	})
 
 	t.Run("missing app ID", func(t *testing.T) {
-		t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceKeychain)
+		t.Setenv(envvars.CliTenantAccessTokenSource, tenantAccessTokenSourceCredentialStore)
 		_, err := (&Provider{}).ResolveAccount(context.Background())
 		var blockErr *credential.BlockError
 		if !errors.As(err, &blockErr) || !strings.Contains(err.Error(), envvars.CliAppID) {

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -281,7 +281,14 @@ type credentialDeps struct {
 }
 
 func buildCredentialProvider(deps credentialDeps) *credential.CredentialProvider {
-	providers := extcred.Providers()
+	store := credential.NewTenantTokenStore(deps.Keychain)
+	providers := withTenantAccessTokenLookup(extcred.Providers(), func(_ context.Context, appID string) (*extcred.Token, error) {
+		value, found, err := store.Get(appID)
+		if err != nil || !found {
+			return nil, err
+		}
+		return &extcred.Token{Value: value, Source: "keychain:tenant-access-token"}, nil
+	})
 	defaultAcct := credential.NewDefaultAccountProvider(deps.Keychain, deps.Profile, deps.ProfileSource)
 	defaultToken := credential.NewDefaultTokenProvider(defaultAcct, deps.HttpClient, deps.ErrOut)
 	// NOTE: Do not pass deps.ErrOut as warnOut. Credential resolution
@@ -291,4 +298,19 @@ func buildCredentialProvider(deps credentialDeps) *credential.CredentialProvider
 	// provider clears unverified identity fields), so silencing the
 	// warning is safe.
 	return credential.NewCredentialProvider(providers, defaultAcct, defaultToken, deps.HttpClient)
+}
+
+func withTenantAccessTokenLookup(
+	providers []extcred.Provider,
+	lookup func(context.Context, string) (*extcred.Token, error),
+) []extcred.Provider {
+	for i, provider := range providers {
+		configurer, ok := provider.(interface {
+			WithTenantAccessTokenLookup(func(context.Context, string) (*extcred.Token, error)) extcred.Provider
+		})
+		if ok {
+			providers[i] = configurer.WithTenantAccessTokenLookup(lookup)
+		}
+	}
+	return providers
 }

--- a/internal/cmdutil/factory_default_test.go
+++ b/internal/cmdutil/factory_default_test.go
@@ -9,16 +9,90 @@ import (
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	extcred "github.com/larksuite/cli/extension/credential"
 	_ "github.com/larksuite/cli/extension/credential/env"
 	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/envvars"
+	"github.com/larksuite/cli/internal/keychain"
 	"github.com/larksuite/cli/internal/vfs/localfileio"
 )
 
 type countingFileIOProvider struct {
 	resolveCalls int
+}
+
+type tenantLookupConfigurableProvider struct {
+	configured bool
+}
+
+func (p *tenantLookupConfigurableProvider) Name() string { return "custom" }
+func (p *tenantLookupConfigurableProvider) ResolveAccount(context.Context) (*extcred.Account, error) {
+	return nil, nil
+}
+func (p *tenantLookupConfigurableProvider) ResolveToken(context.Context, extcred.TokenSpec) (*extcred.Token, error) {
+	return nil, nil
+}
+func (p *tenantLookupConfigurableProvider) WithTenantAccessTokenLookup(func(context.Context, string) (*extcred.Token, error)) extcred.Provider {
+	clone := *p
+	clone.configured = true
+	return &clone
+}
+
+type factoryTenantTokenKeychain struct {
+	value    string
+	getCalls int
+}
+
+func (k *factoryTenantTokenKeychain) Get(string, string) (string, error) {
+	k.getCalls++
+	return k.value, nil
+}
+func (k *factoryTenantTokenKeychain) Set(string, string, string) error { return nil }
+func (k *factoryTenantTokenKeychain) Remove(string, string) error      { return nil }
+
+func TestWithTenantAccessTokenLookupUsesExplicitCapability(t *testing.T) {
+	provider := &tenantLookupConfigurableProvider{}
+	got := withTenantAccessTokenLookup([]extcred.Provider{provider}, func(context.Context, string) (*extcred.Token, error) {
+		return nil, nil
+	})
+	configured, ok := got[0].(*tenantLookupConfigurableProvider)
+	if !ok || !configured.configured || provider.configured {
+		t.Fatalf("configured providers = %#v, want configured copy without mutating registry instance", got)
+	}
+}
+
+func TestNewDefaultStoredTATReadsKeychainOnlyDuringBotTokenResolution(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "env-app")
+	t.Setenv(envvars.CliAppSecret, "")
+	t.Setenv(envvars.CliUserAccessToken, "")
+	t.Setenv(envvars.CliTenantAccessToken, "")
+	t.Setenv(envvars.CliTenantAccessTokenSource, "keychain")
+	t.Setenv(envvars.CliDefaultAs, "")
+	t.Setenv(envvars.CliStrictMode, "")
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f := NewDefault(nil, InvocationContext{})
+	kc := &factoryTenantTokenKeychain{value: "stored-tat"}
+	f.Keychain = kc
+
+	acct, err := f.Credential.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+	if acct.AppID != "env-app" || kc.getCalls != 0 {
+		t.Fatalf("account=%#v getCalls=%d, want env-app without keychain read", acct, kc.getCalls)
+	}
+	result, err := f.Credential.ResolveToken(context.Background(), credential.TokenSpec{
+		Type: credential.TokenTypeTAT, AppID: "env-app",
+	})
+	if err != nil {
+		t.Fatalf("ResolveToken() error = %v", err)
+	}
+	if result == nil || result.Token != "stored-tat" || result.Source != core.CredentialSourceEnv || kc.getCalls != 1 {
+		t.Fatalf("result=%#v getCalls=%d, want stored env TAT and one read", result, kc.getCalls)
+	}
 }
 
 func (p *countingFileIOProvider) Name() string { return "counting" }
@@ -27,6 +101,8 @@ func (p *countingFileIOProvider) ResolveFileIO(context.Context) fileio.FileIO {
 	p.resolveCalls++
 	return &localfileio.LocalFileIO{}
 }
+
+var _ keychain.KeychainAccess = (*factoryTenantTokenKeychain)(nil)
 
 func TestNewDefault_InvocationProfileUsedByStrictModeAndConfig(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "")

--- a/internal/cmdutil/factory_default_test.go
+++ b/internal/cmdutil/factory_default_test.go
@@ -68,7 +68,7 @@ func TestNewDefaultStoredTATReadsKeychainOnlyDuringBotTokenResolution(t *testing
 	t.Setenv(envvars.CliAppSecret, "")
 	t.Setenv(envvars.CliUserAccessToken, "")
 	t.Setenv(envvars.CliTenantAccessToken, "")
-	t.Setenv(envvars.CliTenantAccessTokenSource, "keychain")
+	t.Setenv(envvars.CliTenantAccessTokenSource, "credential-store")
 	t.Setenv(envvars.CliDefaultAs, "")
 	t.Setenv(envvars.CliStrictMode, "")
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())

--- a/internal/cmdutil/testmain_test.go
+++ b/internal/cmdutil/testmain_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/larksuite/cli/internal/envvars"
 )
 
 func TestMain(m *testing.M) {
@@ -22,6 +24,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	if err := os.Setenv("LARKSUITE_CLI_REMOTE_META", "off"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv(envvars.CliTenantAccessTokenSource, ""); err != nil {
 		panic(err)
 	}
 	code := m.Run()

--- a/internal/credential/tenant_token_store.go
+++ b/internal/credential/tenant_token_store.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package credential
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/keychain"
+)
+
+const tenantAccessTokenAccountPrefix = "tat:v1:"
+
+// TenantTokenStore owns persisted tenant access tokens. The account key hashes
+// the opaque app ID so platform-specific filename/registry normalization never
+// narrows or aliases the caller's identifier.
+type TenantTokenStore struct {
+	keychain func() keychain.KeychainAccess
+}
+
+// NewTenantTokenStore returns a store backed by the invocation's KeychainAccess.
+func NewTenantTokenStore(kc func() keychain.KeychainAccess) *TenantTokenStore {
+	if kc == nil {
+		kc = keychain.Default
+	}
+	return &TenantTokenStore{keychain: kc}
+}
+
+func tenantAccessTokenAccountKey(appID string) string {
+	sum := sha256.Sum256([]byte(appID))
+	return tenantAccessTokenAccountPrefix + hex.EncodeToString(sum[:])
+}
+
+// Set stores a TAT for appID, replacing the previous value.
+func (s *TenantTokenStore) Set(appID, token string) error {
+	if appID == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "app ID is required").WithParam("app_id")
+	}
+	if token == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "tenant access token is empty").WithParam("token")
+	}
+	kc := s.keychain()
+	if kc == nil {
+		return errs.NewInternalError(errs.SubtypeStorage, "tenant access token storage is unavailable")
+	}
+	if err := kc.Set(keychain.LarkCliService, tenantAccessTokenAccountKey(appID), token); err != nil {
+		return tenantTokenStorageError("store", appID, err)
+	}
+	return nil
+}
+
+// Get returns the stored TAT and whether it exists.
+func (s *TenantTokenStore) Get(appID string) (string, bool, error) {
+	if appID == "" {
+		return "", false, errs.NewConfigError(errs.SubtypeInvalidConfig, "tenant access token app ID is missing")
+	}
+	kc := s.keychain()
+	if kc == nil {
+		return "", false, errs.NewInternalError(errs.SubtypeStorage, "tenant access token storage is unavailable")
+	}
+	value, err := kc.Get(keychain.LarkCliService, tenantAccessTokenAccountKey(appID))
+	if err != nil {
+		return "", false, tenantTokenStorageError("read", appID, err)
+	}
+	if value == "" {
+		return "", false, nil
+	}
+	return value, true, nil
+}
+
+// Remove removes the stored TAT. Removing an absent value is successful.
+func (s *TenantTokenStore) Remove(appID string) error {
+	if appID == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "app ID is required").WithParam("app_id")
+	}
+	kc := s.keychain()
+	if kc == nil {
+		return errs.NewInternalError(errs.SubtypeStorage, "tenant access token storage is unavailable")
+	}
+	if err := kc.Remove(keychain.LarkCliService, tenantAccessTokenAccountKey(appID)); err != nil {
+		return tenantTokenStorageError("remove", appID, err)
+	}
+	return nil
+}
+
+func tenantTokenStorageError(op, appID string, cause error) error {
+	if errs.IsTyped(cause) {
+		return cause
+	}
+	storageErr := errs.NewInternalError(errs.SubtypeStorage,
+		"failed to %s tenant access token for app %s: %v", op, appID, cause).
+		WithCause(cause)
+	if problem, ok := errs.ProblemOf(cause); ok && problem.Hint != "" {
+		storageErr.WithHint("%s", problem.Hint)
+	}
+	return storageErr
+}

--- a/internal/credential/tenant_token_store_test.go
+++ b/internal/credential/tenant_token_store_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package credential
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/keychain"
+)
+
+type tenantTokenStoreKeychain struct {
+	values      map[string]string
+	getErr      error
+	setErr      error
+	removeErr   error
+	getCalls    []string
+	setCalls    []string
+	removeCalls []string
+}
+
+func (k *tenantTokenStoreKeychain) Get(service, account string) (string, error) {
+	k.getCalls = append(k.getCalls, service+"/"+account)
+	if k.getErr != nil {
+		return "", k.getErr
+	}
+	return k.values[service+"/"+account], nil
+}
+
+func (k *tenantTokenStoreKeychain) Set(service, account, value string) error {
+	k.setCalls = append(k.setCalls, service+"/"+account)
+	if k.setErr != nil {
+		return k.setErr
+	}
+	if k.values == nil {
+		k.values = make(map[string]string)
+	}
+	k.values[service+"/"+account] = value
+	return nil
+}
+
+func (k *tenantTokenStoreKeychain) Remove(service, account string) error {
+	k.removeCalls = append(k.removeCalls, service+"/"+account)
+	if k.removeErr != nil {
+		return k.removeErr
+	}
+	delete(k.values, service+"/"+account)
+	return nil
+}
+
+func TestTenantTokenStoreSetGetRemove(t *testing.T) {
+	kc := &tenantTokenStoreKeychain{}
+	store := NewTenantTokenStore(func() keychain.KeychainAccess { return kc })
+	appID := "cli_Test/opaque"
+
+	if err := store.Set(appID, "token-v1"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := store.Set(appID, "token-v2"); err != nil {
+		t.Fatalf("replacement Set() error = %v", err)
+	}
+	if len(kc.setCalls) != 2 || kc.setCalls[0] != kc.setCalls[1] {
+		t.Fatalf("Set calls = %v, want one stable account key", kc.setCalls)
+	}
+	account := strings.TrimPrefix(kc.setCalls[0], keychain.LarkCliService+"/")
+	if !strings.HasPrefix(account, tenantAccessTokenAccountPrefix) || strings.Contains(account, appID) {
+		t.Fatalf("account key = %q, want versioned opaque key", account)
+	}
+	if got, found, err := store.Get(appID); err != nil || !found || got != "token-v2" {
+		t.Fatalf("Get() = (%q, %v, %v), want token-v2, true, nil", got, found, err)
+	}
+	if err := store.Remove(appID); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if got, found, err := store.Get(appID); err != nil || found || got != "" {
+		t.Fatalf("Get() after Remove = (%q, %v, %v), want empty, false, nil", got, found, err)
+	}
+}
+
+func TestTenantTokenStoreKeysDoNotAlias(t *testing.T) {
+	left := tenantAccessTokenAccountKey("cli/a")
+	right := tenantAccessTokenAccountKey("cli_a")
+	caseVariant := tenantAccessTokenAccountKey("CLI/A")
+	if left == right || left == caseVariant || right == caseVariant {
+		t.Fatalf("account keys alias: left=%q right=%q case=%q", left, right, caseVariant)
+	}
+}
+
+func TestTenantTokenStorePreservesStorageErrors(t *testing.T) {
+	sentinel := errors.New("keychain unavailable")
+	kc := &tenantTokenStoreKeychain{getErr: sentinel, setErr: sentinel, removeErr: sentinel}
+	store := NewTenantTokenStore(func() keychain.KeychainAccess { return kc })
+
+	for name, run := range map[string]func() error{
+		"set":    func() error { return store.Set("cli_test", "token") },
+		"get":    func() error { _, _, err := store.Get("cli_test"); return err },
+		"remove": func() error { return store.Remove("cli_test") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := run()
+			var internalErr *errs.InternalError
+			if !errors.As(err, &internalErr) || internalErr.Subtype != errs.SubtypeStorage || !errors.Is(err, sentinel) {
+				t.Fatalf("error = %T %v, want internal/storage preserving cause", err, err)
+			}
+		})
+	}
+}
+
+func TestTenantTokenStorePassesTypedKeychainErrorThrough(t *testing.T) {
+	typed := errs.NewAPIError(errs.SubtypeUnknown, "keychain locked")
+	kc := &tenantTokenStoreKeychain{setErr: typed}
+	store := NewTenantTokenStore(func() keychain.KeychainAccess { return kc })
+	if err := store.Set("cli_test", "token"); err != typed {
+		t.Fatalf("Set() error = %T %v, want original typed error", err, err)
+	}
+}
+
+var _ keychain.KeychainAccess = (*tenantTokenStoreKeychain)(nil)

--- a/internal/envvars/envvars.go
+++ b/internal/envvars/envvars.go
@@ -4,14 +4,15 @@
 package envvars
 
 const (
-	CliAppID             = "LARKSUITE_CLI_APP_ID"
-	CliAppSecret         = "LARKSUITE_CLI_APP_SECRET"
-	CliBrand             = "LARKSUITE_CLI_BRAND"
-	CliUserAccessToken   = "LARKSUITE_CLI_USER_ACCESS_TOKEN"
-	CliTenantAccessToken = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN"
-	CliDefaultAs         = "LARKSUITE_CLI_DEFAULT_AS"
-	CliProfile           = "LARKSUITE_CLI_PROFILE"
-	CliStrictMode        = "LARKSUITE_CLI_STRICT_MODE"
+	CliAppID                   = "LARKSUITE_CLI_APP_ID"
+	CliAppSecret               = "LARKSUITE_CLI_APP_SECRET"
+	CliBrand                   = "LARKSUITE_CLI_BRAND"
+	CliUserAccessToken         = "LARKSUITE_CLI_USER_ACCESS_TOKEN"
+	CliTenantAccessToken       = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN"
+	CliTenantAccessTokenSource = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN_SOURCE"
+	CliDefaultAs               = "LARKSUITE_CLI_DEFAULT_AS"
+	CliProfile                 = "LARKSUITE_CLI_PROFILE"
+	CliStrictMode              = "LARKSUITE_CLI_STRICT_MODE"
 
 	// Sidecar proxy (auth proxy mode)
 	CliAuthProxy = "LARKSUITE_CLI_AUTH_PROXY" // sidecar HTTP address, e.g. "http://127.0.0.1:16384"

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -21,9 +21,10 @@ var (
 )
 
 const (
-	// LarkCliService is the unified keychain service name for all secrets
-	// (both AppSecret and UAT). Entries are distinguished by account key format:
+	// LarkCliService is the unified keychain service name for all secrets.
+	// Entries are distinguished by account key format:
 	//   - AppSecret: "appsecret:<appId>"
+	//   - Stored TAT: "tat:v1:<sha256(appId)>"
 	//   - UAT:       "<appId>:<userOpenId>"
 	LarkCliService = "lark-cli"
 )
@@ -55,7 +56,7 @@ func wrapError(op string, err error) error {
 }
 
 // KeychainAccess abstracts keychain Get/Set/Remove for dependency injection.
-// Used by AppSecret operations (ForStorage, ResolveSecretInput, RemoveSecretStore).
+// Used by AppSecret and stored-TAT operations.
 // UAT operations in token_store.go use the package-level Get/Set/Remove directly.
 type KeychainAccess interface {
 	Get(service, account string) (string, error)


### PR DESCRIPTION
## Summary
Store externally issued tenant access tokens in CLI-managed secure storage without passing the token through environment variables, command arguments, or flags. Stored tokens are selected only when LARKSUITE_CLI_TENANT_ACCESS_TOKEN_SOURCE=credential-store is explicitly configured.

## Changes
- Add config tenant-access-token set/remove with stdin-only token input and symmetric lifecycle management.
- Add a versioned, collision-safe TenantTokenStore backed by the invocation keychain.
- Keep account resolution independent from secret storage; read the stored TAT only during bot token resolution.
- Keep the user/UAT lane independent and preserve env as the external credential-source classification.
- Avoid root flag/error changes, shared skill or README guidance, speculative caches, and unrelated keychain backend changes.

## Test Plan
- [x] make unit-test
- [x] make vet
- [x] make fmt-check
- [x] make build
- [x] QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate
- [x] golangci-lint and repository source guards
- [x] lint module tests and go-licenses policy check
- [x] Linux and Windows cross-compilation for affected packages
- [x] Manual help/command-surface verification
- [ ] Live OS keychain plus real TAT API flow; not run because unit tests use an injected keychain and no live credential was provided

## Related Issues
- Alternative design for #2467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to securely store and remove tenant access tokens using an app ID.
  * Added configurable tenant access-token sourcing, including secure local credential storage.
  * Stored tokens can support credential validation, identity detection, and default selection.
* **Bug Fixes**
  * Improved validation for missing, empty, or malformed token input.
  * Added clearer handling for unavailable secure storage and invalid token-source settings.
  * Prevented token values from appearing in command output or error messages.
* **Documentation**
  * Clarified secure storage behavior and tenant-token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->