### PR TITLE
feat: words replace and minutes fix

### DIFF
--- a/affordance/minutes.md
+++ b/affordance/minutes.md
@@ -34,13 +34,53 @@
 - lark-meeting/references/lark-minutes-speaker-replace.md
 
 ## +word-replace
+Batch-replace exact keywords in a minute transcript.
+
+### Prerequisites
+- `minute_token` from [[+search]], a minutes URL, or VC recording
+
+### Tips
+- Replace straight away — the response reports every `source_word`'s outcome, so reading the transcript before or after only slows the run down
+
+### Examples
+
+**Replace several keywords in one call**
+```bash
+lark-cli minutes +word-replace --minute-token obcnxxxxxxxxxxxxxxxxxxxx --replace-words '[{"source_word":"旧词","target_word":"新词"},{"source_word":"Foo","target_word":"Bar"}]' --as user
+```
 
 ## +summary
+Replace the minute's AI summary text in full.
+
+### Prerequisites
+- Prefer reading the current summary via [[+detail]] with `--summary` before overwriting
+
+### Examples
+
+**Replace the AI summary**
+```bash
+lark-cli minutes +summary --minute-token obcnxxxxxxxxxxxxxxxxxxxx --summary "**会议结论**\n- 方案 A 通过\n- 下周跟进排期" --as user
+```
 
 ### Skills
 - lark-meeting/references/lark-minutes-summary.md
 
 ## +todo
+Write AI todos that live inside a minute — not Lark Task list items.
+
+### Avoid when
+- Personal or shared Task lists → use the task domain (`lark-cli task`), not this shortcut
+
+### Prerequisites
+- `minute_token` from [[+search]], a minutes URL, or VC recording
+- For update/delete: `todo_id` from [[+detail]] with `--todo`
+
+### Examples
+
+**Add one unfinished todo**
+```bash
+lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add --todo "跟进预算审批" --is-done=false --as user
+```
 
 ### Skills
 - lark-meeting/references/lark-minutes-todo.md

--- a/internal/affordance/minutes_source_test.go
+++ b/internal/affordance/minutes_source_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package affordance
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/meta"
+)
+
+func TestMinutesAffordanceExamples(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	tests := []struct {
+		method  string
+		command string
+	}{
+		{
+			method:  "+todo",
+			command: `lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add --todo "跟进预算审批" --is-done=false --as user`,
+		},
+		{
+			method:  "+word-replace",
+			command: `lark-cli minutes +word-replace --minute-token obcnxxxxxxxxxxxxxxxxxxxx --replace-words '[{"source_word":"旧词","target_word":"新词"},{"source_word":"Foo","target_word":"Bar"}]' --as user`,
+		},
+		{
+			method:  "+summary",
+			command: `lark-cli minutes +summary --minute-token obcnxxxxxxxxxxxxxxxxxxxx --summary "**会议结论**\n- 方案 A 通过\n- 下周跟进排期" --as user`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			raw, ok := For("minutes", tt.method)
+			if !ok {
+				t.Fatalf("For(minutes, %s) ok=false", tt.method)
+			}
+			a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+			if !ok {
+				t.Fatalf("minutes %s affordance did not parse", tt.method)
+			}
+			if len(a.Examples) != 1 || a.Examples[0].Command != tt.command {
+				t.Fatalf("examples = %#v, want one command %q", a.Examples, tt.command)
+			}
+		})
+	}
+}
+
+func TestMinutesAffordanceDoesNotDuplicateRuntimeRecovery(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	for _, method := range []string{"+todo", "+word-replace", "+summary"} {
+		raw, ok := For("minutes", method)
+		if !ok {
+			t.Fatalf("For(minutes, %s) ok=false", method)
+		}
+		for _, forbidden := range []string{"auth login", "missing_scopes", "console_url"} {
+			if strings.Contains(string(raw), forbidden) {
+				t.Errorf("%s affordance duplicates runtime recovery %q: %s", method, forbidden, raw)
+			}
+		}
+	}
+}
+
+// The transcript is large, so requiring a read before or after a replace makes
+// every keyword edit slow. Per-word outcomes come back in the response instead.
+func TestMinutesWordReplaceAffordanceDoesNotRequireTranscriptRead(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	raw, ok := For("minutes", "+word-replace")
+	if !ok {
+		t.Fatal("For(minutes, +word-replace) ok=false")
+	}
+	a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+	if !ok {
+		t.Fatal("minutes +word-replace affordance did not parse")
+	}
+	for _, prereq := range a.Prerequisites {
+		if strings.Contains(prereq, "--transcript") || strings.Contains(prereq, "+detail") {
+			t.Errorf("+word-replace must not require a transcript read first, got prerequisite: %s", prereq)
+		}
+	}
+	if !containsItem(a.Prerequisites, "minute_token") {
+		t.Errorf("+word-replace should state where minute_token comes from, got: %v", a.Prerequisites)
+	}
+}
+
+func TestMinutesTodoAffordanceRoutesAwayFromTask(t *testing.T) {
+	prev := mdSource
+	t.Cleanup(func() { SetSource(prev) })
+	SetSource(os.DirFS("../../affordance"))
+
+	raw, ok := For("minutes", "+todo")
+	if !ok {
+		t.Fatal("For(minutes, +todo) ok=false")
+	}
+	a, ok := (meta.Method{Affordance: raw}).ParsedAffordance()
+	if !ok {
+		t.Fatal("minutes +todo affordance did not parse")
+	}
+	if !containsItem(a.AvoidWhen, "task") {
+		t.Fatalf("+todo must steer Task-list work away from minutes: %v", a.AvoidWhen)
+	}
+}

--- a/shortcuts/minutes/minutes_summary.go
+++ b/shortcuts/minutes/minutes_summary.go
@@ -16,6 +16,8 @@ import (
 
 const minutesSummaryMarkdownTip = "Summary accepts any text; unsupported Markdown is saved but may display as literal raw text in Minutes. For best rendering, prefer plain text, line breaks, headings (#, ##, ###), bold (**text**), and lists (-, *, or 1.)."
 
+const minutesSummaryASRQuotaNotEnough = 2091008
+
 // MinutesSummary replaces the AI summary of a minute.
 var MinutesSummary = common.Shortcut{
 	Service:     "minutes",
@@ -61,7 +63,7 @@ var MinutesSummary = common.Shortcut{
 			"summary": summary,
 		}
 		if _, err := runtime.CallAPITyped(http.MethodPut, path, nil, body); err != nil {
-			return err
+			return minutesSummaryError(err, minuteToken)
 		}
 
 		runtime.OutFormat(map[string]interface{}{
@@ -70,4 +72,15 @@ var MinutesSummary = common.Shortcut{
 		}, nil, nil)
 		return nil
 	},
+}
+
+func minutesSummaryError(err error, minuteToken string) error {
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Code != minutesSummaryASRQuotaNotEnough {
+		return err
+	}
+	p.Subtype = errs.SubtypeQuotaExceeded
+	p.Message = fmt.Sprintf("ASR/AI quota not enough: cannot replace summary on minute %q.", minuteToken)
+	p.Hint = minutesASRQuotaNotEnoughHint
+	return err
 }

--- a/shortcuts/minutes/minutes_summary_todo_test.go
+++ b/shortcuts/minutes/minutes_summary_todo_test.go
@@ -373,7 +373,10 @@ func TestMinutesTodo_NoEditPermission(t *testing.T) {
 		Method: http.MethodPost,
 		URL:    "/open-apis/minutes/v1/minutes/" + minutesSummaryTodoTestToken + "/todo",
 		Body: map[string]interface{}{
-			"code": minutesTodoNoEditPermissionCode,
+			// Literal wire code, never the constant: feeding a constant back
+			// into the stub would pass no matter which value it holds, which is
+			// how the internal 4xxxx codes went unnoticed.
+			"code": 2091005,
 			"msg":  "permission deny",
 		},
 	})
@@ -402,6 +405,81 @@ func TestMinutesTodo_NoEditPermission(t *testing.T) {
 	}
 	if !strings.Contains(p.Hint, "+apply-permission") {
 		t.Errorf("hint should mention apply-permission, got: %s", p.Hint)
+	}
+}
+
+func TestMinutesSummary_ASRQuotaNotEnough(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPut,
+		URL:    "/open-apis/minutes/v1/minutes/" + minutesSummaryTodoTestToken + "/summary",
+		Body: map[string]interface{}{
+			"code": 2091008,
+			"msg":  "asr/ai quota not enough",
+		},
+	})
+
+	err := mountAndRun(t, MinutesSummary, []string{
+		"+summary",
+		"--minute-token", minutesSummaryTodoTestToken,
+		"--summary", "weekly sync",
+		"--format", "json", "--as", "user",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected ASR/AI quota error, got nil")
+	}
+
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("want typed errs.*, got %T: %v", err, err)
+	}
+	if p.Subtype != errs.SubtypeQuotaExceeded {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeQuotaExceeded)
+	}
+	if !strings.Contains(p.Message, minutesSummaryTodoTestToken) {
+		t.Errorf("message should name the minute, got: %s", p.Message)
+	}
+	if !strings.Contains(p.Hint, "detail page") {
+		t.Errorf("hint should point to the minute detail page, got: %s", p.Hint)
+	}
+}
+
+func TestMinutesTodo_ASRQuotaNotEnough(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/minutes/v1/minutes/" + minutesSummaryTodoTestToken + "/todo",
+		Body: map[string]interface{}{
+			"code": 2091008,
+			"msg":  "asr/ai quota not enough",
+		},
+	})
+
+	err := mountAndRun(t, MinutesTodo, []string{
+		"+todo", "--minute-token", minutesSummaryTodoTestToken,
+		"--operation", "add",
+		"--todo", "finish deck", "--is-done=false", "--as", "user",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected ASR/AI quota error, got nil")
+	}
+
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("want typed errs.*, got %T: %v", err, err)
+	}
+	if p.Subtype != errs.SubtypeQuotaExceeded {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeQuotaExceeded)
+	}
+	if !strings.Contains(p.Message, minutesSummaryTodoTestToken) {
+		t.Errorf("message should name the minute, got: %s", p.Message)
+	}
+	if !strings.Contains(p.Hint, "detail page") {
+		t.Errorf("hint should point to the minute detail page, got: %s", p.Hint)
 	}
 }
 

--- a/shortcuts/minutes/minutes_todo.go
+++ b/shortcuts/minutes/minutes_todo.go
@@ -15,7 +15,10 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-const minutesTodoNoEditPermissionCode = 40005
+const (
+	minutesTodoNoEditPermissionCode = 2091005
+	minutesTodoASRQuotaNotEnough    = 2091008
+)
 
 // minuteTodoOp describes a resolved todo_items entry derived from flags or JSON.
 type minuteTodoOp struct {
@@ -283,11 +286,18 @@ func buildMinuteTodoItem(spec minuteTodoSpec) (map[string]interface{}, error) {
 
 func minutesTodoError(err error, minuteToken string) error {
 	p, ok := errs.ProblemOf(err)
-	if !ok || p.Code != minutesTodoNoEditPermissionCode {
+	if !ok {
 		return err
 	}
-	p.Subtype = errs.SubtypePermissionDenied
-	p.Message = fmt.Sprintf("No edit permission for minute %q: cannot update todos.", minuteToken)
-	p.Hint = fmt.Sprintf("Ask the user before running: minutes +apply-permission --minute-token %s --perm edit", minuteToken)
+	switch p.Code {
+	case minutesTodoNoEditPermissionCode:
+		p.Subtype = errs.SubtypePermissionDenied
+		p.Message = fmt.Sprintf("No edit permission for minute %q: cannot update todos.", minuteToken)
+		p.Hint = fmt.Sprintf("Ask the user before running: minutes +apply-permission --minute-token %s --perm edit", minuteToken)
+	case minutesTodoASRQuotaNotEnough:
+		p.Subtype = errs.SubtypeQuotaExceeded
+		p.Message = fmt.Sprintf("ASR/AI quota not enough: cannot update todos on minute %q.", minuteToken)
+		p.Hint = minutesASRQuotaNotEnoughHint
+	}
 	return err
 }

--- a/shortcuts/minutes/minutes_upload.go
+++ b/shortcuts/minutes/minutes_upload.go
@@ -16,6 +16,7 @@ import (
 const (
 	minutesUploadSupportedFormatsTip = "Supported audio formats: wav, mp3, m4a, aac, ogg, wma, amr; supported video formats: avi, wmv, mov, mp4, m4v, mpeg, ogg, flv."
 	minutesUploadLimitsTip           = "The original uploaded media must be no larger than 6GB and no longer than 6 hours."
+	minutesUploadASRQuotaNotEnough   = 2091008
 )
 
 // MinutesUpload uploads a media file token to generate a minute.
@@ -59,7 +60,7 @@ var MinutesUpload = common.Shortcut{
 
 		data, err := runtime.CallAPITyped("POST", "/open-apis/minutes/v1/minutes/upload", nil, body)
 		if err != nil {
-			return err
+			return minutesUploadError(err)
 		}
 
 		minuteURL := common.GetString(data, "minute_url")
@@ -74,6 +75,17 @@ var MinutesUpload = common.Shortcut{
 		runtime.OutFormat(outData, nil, nil)
 		return nil
 	},
+}
+
+func minutesUploadError(err error) error {
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Code != minutesUploadASRQuotaNotEnough {
+		return err
+	}
+	p.Subtype = errs.SubtypeQuotaExceeded
+	p.Message = "ASR/AI quota not enough: cannot generate a minute from this upload."
+	p.Hint = minutesASRQuotaNotEnoughHint
+	return err
 }
 
 func extractUploadedMinuteToken(minuteURL string) string {

--- a/shortcuts/minutes/minutes_upload_test.go
+++ b/shortcuts/minutes/minutes_upload_test.go
@@ -148,6 +148,42 @@ func TestMinutesUpload_Execute(t *testing.T) {
 	}
 }
 
+func TestMinutesUpload_ASRQuotaNotEnough(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    "/open-apis/minutes/v1/minutes/upload",
+		Body: map[string]interface{}{
+			// Literal wire code, never the constant: feeding a constant back
+			// into the stub would pass no matter which value it holds, which is
+			// how the internal 4xxxx codes went unnoticed.
+			"code": 2091008,
+			"msg":  "asr/ai quota not enough",
+		},
+	})
+
+	err := mountAndRun(t, MinutesUpload, []string{"+upload", "--file-token", "boxcn123456", "--format", "json", "--as", "user"}, f, stdout)
+	if err == nil {
+		t.Fatal("expected ASR/AI quota error, got nil")
+	}
+
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("want typed errs.*, got %T: %v", err, err)
+	}
+	if p.Subtype != errs.SubtypeQuotaExceeded {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeQuotaExceeded)
+	}
+	if !strings.Contains(p.Message, "quota") {
+		t.Errorf("message should explain the quota is exhausted, got: %s", p.Message)
+	}
+	if !strings.Contains(p.Hint, "detail page") {
+		t.Errorf("hint should point to the minute detail page, got: %s", p.Hint)
+	}
+}
+
 func TestExtractUploadedMinuteToken(t *testing.T) {
 	tests := []struct {
 		name string

--- a/shortcuts/minutes/minutes_word_replace.go
+++ b/shortcuts/minutes/minutes_word_replace.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -16,10 +17,15 @@ import (
 )
 
 const (
-	minutesWordReplaceNoEditPermission = 40005
-	minutesWordReplaceOthersEditing    = 40110
-	minutesWordReplaceInvalidParams    = 40001
+	minutesWordReplaceNoEditPermission  = 2091005
+	minutesWordReplaceOthersEditing     = 2091110
+	minutesWordReplaceWordsNotFound     = 2091013
+	minutesWordReplaceASRQuotaNotEnough = 2091008
 )
+
+const minutesWordReplaceDoNotRetrySucceeded = "Do not reprocess words that already succeeded."
+
+const minutesWordReplaceNotFoundHint = "Report the unmatched source_word values and confirm their exact spelling, case and spacing with the user, then retry only those words"
 
 type transcriptWordReplace struct {
 	SourceWord string `json:"source_word"`
@@ -79,20 +85,14 @@ var MinutesWordReplace = common.Shortcut{
 			"replace_words": replaceWords,
 		}
 
-		_, err = runtime.CallAPITyped(http.MethodPut,
+		data, err := runtime.CallAPITyped(http.MethodPut,
 			fmt.Sprintf("/open-apis/minutes/v1/minutes/%s/transcript/word", validate.EncodePathSegment(minuteToken)),
 			nil, body)
 		if err != nil {
 			return minutesWordReplaceError(err, minuteToken)
 		}
 
-		outData := map[string]interface{}{
-			"minute_token":  minuteToken,
-			"replace_words": replaceWords,
-		}
-
-		runtime.OutFormat(outData, nil, nil)
-		return nil
+		return emitWordReplaceResult(runtime, minuteToken, replaceWords, data)
 	},
 }
 
@@ -129,6 +129,143 @@ func parseReplaceWords(raw string) ([]map[string]string, error) {
 	return replaceWords, nil
 }
 
+func emitWordReplaceResult(runtime *common.RuntimeContext, minuteToken string, replaceWords []map[string]string, data map[string]interface{}) error {
+	counts, hasCounts := parseReplaceWordCounts(data)
+	if !hasCounts {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"Replace request returned success, but the server did not include replace_word_counts, so per-word outcomes cannot be reported.").
+			WithHint("Check the transcript with `minutes +detail --minute-tokens %s --transcript` before retrying. %s",
+				minuteToken, minutesWordReplaceDoNotRetrySucceeded)
+	}
+
+	succeeded, failed := splitWordReplaceResults(replaceWords, counts)
+	if len(succeeded) == 0 {
+		return minutesWordReplaceAllFailed(minuteToken, failed)
+	}
+
+	runtime.OutFormat(map[string]interface{}{
+		"minute_token": minuteToken,
+		"message":      formatWordReplaceMessage(succeeded, failed),
+	}, nil, nil)
+	return nil
+}
+
+func formatWordReplaceMessage(succeeded, failed []string) string {
+	var b strings.Builder
+	b.WriteString("Succeeded: ")
+	if len(succeeded) == 0 {
+		b.WriteString("none")
+	} else {
+		b.WriteString(strings.Join(succeeded, ", "))
+	}
+	b.WriteString("; Failed: ")
+	if len(failed) == 0 {
+		b.WriteString("none")
+	} else {
+		b.WriteString(strings.Join(failed, ", "))
+	}
+	b.WriteString(". ")
+	b.WriteString(minutesWordReplaceDoNotRetrySucceeded)
+	return b.String()
+}
+
+// minutesWordReplaceAllFailed reports an all-zero replace_word_counts response.
+// The call itself succeeded, so there is no upstream code to carry here.
+func minutesWordReplaceAllFailed(minuteToken string, failed []string) error {
+	msg := fmt.Sprintf("None of the source words were found in minute %q transcript; nothing was replaced.", minuteToken)
+	if len(failed) > 0 {
+		msg = fmt.Sprintf("Succeeded: none; Failed: %s. %s", strings.Join(failed, ", "), msg)
+	}
+	return errs.NewAPIError(errs.SubtypeNotFound, "%s", msg).
+		WithHint("%s", minutesWordReplaceNotFoundHint)
+}
+
+func parseReplaceWordCounts(data map[string]interface{}) (map[string]int64, bool) {
+	if data == nil {
+		return nil, false
+	}
+	raw, ok := data["replace_word_counts"]
+	if !ok || raw == nil {
+		return nil, false
+	}
+
+	items, ok := asObjectSlice(raw)
+	if !ok {
+		return nil, false
+	}
+
+	out := make(map[string]int64, len(items))
+	for _, m := range items {
+		source := strings.TrimSpace(asString(m["source_word"]))
+		if source == "" {
+			continue
+		}
+		out[source] = toInt64(m["replace_count"])
+	}
+	return out, true
+}
+
+func asObjectSlice(v interface{}) ([]map[string]interface{}, bool) {
+	switch items := v.(type) {
+	case []interface{}:
+		out := make([]map[string]interface{}, 0, len(items))
+		for _, item := range items {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				return nil, false
+			}
+			out = append(out, m)
+		}
+		return out, true
+	case []map[string]interface{}:
+		return items, true
+	default:
+		return nil, false
+	}
+}
+
+func asString(v interface{}) string {
+	s, _ := v.(string)
+	return s
+}
+
+func toInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case float64:
+		return int64(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	case string:
+		i, err := strconv.ParseInt(strings.TrimSpace(n), 10, 64)
+		if err != nil {
+			return 0
+		}
+		return i
+	default:
+		return 0
+	}
+}
+
+func splitWordReplaceResults(replaceWords []map[string]string, counts map[string]int64) (succeeded, failed []string) {
+	succeeded = make([]string, 0, len(replaceWords))
+	failed = make([]string, 0)
+	for _, item := range replaceWords {
+		source := item["source_word"]
+		count, ok := counts[source]
+		if !ok || count <= 0 {
+			failed = append(failed, source)
+			continue
+		}
+		succeeded = append(succeeded, source)
+	}
+	return succeeded, failed
+}
+
 func minutesWordReplaceError(err error, minuteToken string) error {
 	p, ok := errs.ProblemOf(err)
 	if !ok {
@@ -144,12 +281,14 @@ func minutesWordReplaceError(err error, minuteToken string) error {
 		p.Subtype = errs.SubtypeConflict
 		p.Message = fmt.Sprintf("Minute %q transcript is being edited by someone else.", minuteToken)
 		p.Hint = "Wait until the other editor finishes, then retry"
-	case minutesWordReplaceInvalidParams:
-		if strings.Contains(strings.ToLower(p.Message), "not found in transcript") {
-			p.Subtype = errs.SubtypeNotFound
-			p.Message = fmt.Sprintf("None of the source words were found in minute %q transcript; nothing was replaced.", minuteToken)
-			p.Hint = "Verify each source_word's exact spelling and case against the current transcript (use `minutes +detail --minute-tokens <token> --transcript` to read it), then retry"
-		}
+	case minutesWordReplaceWordsNotFound:
+		p.Subtype = errs.SubtypeNotFound
+		p.Message = fmt.Sprintf("None of the source words were found in minute %q transcript; nothing was replaced.", minuteToken)
+		p.Hint = minutesWordReplaceNotFoundHint
+	case minutesWordReplaceASRQuotaNotEnough:
+		p.Subtype = errs.SubtypeQuotaExceeded
+		p.Message = fmt.Sprintf("ASR/AI quota not enough: cannot replace transcript words on minute %q.", minuteToken)
+		p.Hint = minutesASRQuotaNotEnoughHint
 	}
 
 	return err

--- a/shortcuts/minutes/minutes_word_replace_test.go
+++ b/shortcuts/minutes/minutes_word_replace_test.go
@@ -108,7 +108,11 @@ func TestMinutesWordReplace_Execute(t *testing.T) {
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "ok",
-			"data": map[string]interface{}{},
+			"data": map[string]interface{}{
+				"replace_word_counts": []map[string]interface{}{
+					{"source_word": "foo", "replace_count": "2"},
+				},
+			},
 		},
 	})
 
@@ -123,23 +127,160 @@ func TestMinutesWordReplace_Execute(t *testing.T) {
 	}
 
 	var envelope struct {
+		OK   bool `json:"ok"`
 		Data struct {
-			MinuteToken  string `json:"minute_token"`
-			ReplaceWords []struct {
-				SourceWord string `json:"source_word"`
-				TargetWord string `json:"target_word"`
-			} `json:"replace_words"`
+			MinuteToken string `json:"minute_token"`
+			Message     string `json:"message"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
 		t.Fatalf("unmarshal stdout: %v", err)
 	}
+	if !envelope.OK {
+		t.Fatalf("ok = false, want true; stdout=%s", stdout.String())
+	}
 	if envelope.Data.MinuteToken != minutesWordReplaceTestToken {
 		t.Errorf("data.minute_token = %q, want %q", envelope.Data.MinuteToken, minutesWordReplaceTestToken)
 	}
-	if len(envelope.Data.ReplaceWords) != 1 || envelope.Data.ReplaceWords[0].SourceWord != "foo" || envelope.Data.ReplaceWords[0].TargetWord != "bar" {
-		t.Errorf("data.replace_words = %#v, want foo->bar", envelope.Data.ReplaceWords)
+	wantMsg := "Succeeded: foo; Failed: none. " + minutesWordReplaceDoNotRetrySucceeded
+	if envelope.Data.Message != wantMsg {
+		t.Errorf("message = %q, want %q", envelope.Data.Message, wantMsg)
 	}
+}
+
+func TestMinutesWordReplace_PartialSuccess(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPut,
+		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"replace_word_counts": []map[string]interface{}{
+					{"source_word": "missing", "replace_count": "0"},
+					{"source_word": "hello", "replace_count": "1"},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, MinutesWordReplace, []string{
+		"+word-replace",
+		"--minute-token", minutesWordReplaceTestToken,
+		"--replace-words", `[{"source_word":"missing","target_word":"Lark"},{"source_word":"hello","target_word":"hi"}]`,
+		"--format", "json", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Message string `json:"message"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nraw=%s", err, stdout.String())
+	}
+	if !envelope.OK {
+		t.Fatalf("ok = false, want true for partial success (aligned with OAPI); stdout=%s", stdout.String())
+	}
+	wantMsg := "Succeeded: hello; Failed: missing. " + minutesWordReplaceDoNotRetrySucceeded
+	if envelope.Data.Message != wantMsg {
+		t.Errorf("message = %q, want %q", envelope.Data.Message, wantMsg)
+	}
+}
+
+func TestMinutesWordReplace_MissingCountsIsNotAllSuccess(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	// Server returns code=0 without replace_word_counts (old / incomplete deploy).
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPut,
+		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := mountAndRun(t, MinutesWordReplace, []string{
+		"+word-replace",
+		"--minute-token", minutesWordReplaceTestToken,
+		"--replace-words", `[{"source_word":"hello","target_word":"hi"},{"source_word":"missing","target_word":"x"}]`,
+		"--format", "json", "--as", "user",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected failed_precondition when replace_word_counts is missing, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("want typed errs.*, got %T: %v", err, err)
+	}
+	if p.Subtype != errs.SubtypeFailedPrecondition {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeFailedPrecondition)
+	}
+	if strings.Contains(stdout.String(), "Failed: none") {
+		t.Fatalf("must not invent all-success message, stdout=%s", stdout.String())
+	}
+}
+
+func TestMinutesWordReplace_AllCountsZero(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPut,
+		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"replace_word_counts": []map[string]interface{}{
+					{"source_word": "foo", "replace_count": "0"},
+					{"source_word": "bar", "replace_count": "0"},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, MinutesWordReplace, []string{
+		"+word-replace",
+		"--minute-token", minutesWordReplaceTestToken,
+		"--replace-words", `[{"source_word":"foo","target_word":"x"},{"source_word":"bar","target_word":"y"}]`,
+		"--format", "json", "--as", "user",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected failure exit signal, got nil")
+	}
+
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("want typed errs.*, got %T: %v", err, err)
+	}
+	if p.Subtype != errs.SubtypeNotFound {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeNotFound)
+	}
+	// The call itself succeeded, so no upstream code may be attributed to it.
+	if p.Code != 0 {
+		t.Errorf("code = %d, want 0 for a locally derived failure", p.Code)
+	}
+	if !strings.Contains(p.Message, "Failed: foo, bar") {
+		t.Errorf("message should list failed words, got: %s", p.Message)
+	}
+	if !strings.Contains(p.Message, "nothing was replaced") {
+		t.Errorf("message should state nothing was replaced, got: %s", p.Message)
+	}
+	assertNotFoundHintKeepsRecoveryWithUser(t, p.Hint)
 }
 
 func TestMinutesWordReplace_NoEditPermission(t *testing.T) {
@@ -151,7 +292,11 @@ func TestMinutesWordReplace_NoEditPermission(t *testing.T) {
 		Method: http.MethodPut,
 		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
 		Body: map[string]interface{}{
-			"code": minutesWordReplaceNoEditPermission,
+			// Literal wire codes throughout this file, never the constants:
+			// feeding a constant back into the stub would pass no matter which
+			// value it holds, which is how the internal 4xxxx codes went
+			// unnoticed.
+			"code": 2091005,
 			"msg":  "permission deny",
 		},
 	})
@@ -173,6 +318,15 @@ func TestMinutesWordReplace_NoEditPermission(t *testing.T) {
 	if p.Subtype != errs.SubtypePermissionDenied {
 		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypePermissionDenied)
 	}
+	// Subtype alone does not prove the rewrite ran: errclass already classifies
+	// 2091005 as permission_denied. Only the message and hint are this
+	// command's own.
+	if !strings.Contains(p.Message, "No edit permission") || !strings.Contains(p.Message, minutesWordReplaceTestToken) {
+		t.Errorf("message should name the minute and the missing permission, got: %s", p.Message)
+	}
+	if !strings.Contains(p.Hint, "+apply-permission") {
+		t.Errorf("hint should mention apply-permission, got: %s", p.Hint)
+	}
 }
 
 func TestMinutesWordReplace_OthersAreEditing(t *testing.T) {
@@ -184,7 +338,7 @@ func TestMinutesWordReplace_OthersAreEditing(t *testing.T) {
 		Method: http.MethodPut,
 		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
 		Body: map[string]interface{}{
-			"code": minutesWordReplaceOthersEditing,
+			"code": 2091110,
 			"msg":  "others are editing",
 		},
 	})
@@ -206,8 +360,14 @@ func TestMinutesWordReplace_OthersAreEditing(t *testing.T) {
 	if p.Subtype != errs.SubtypeConflict {
 		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeConflict)
 	}
+	if !strings.Contains(p.Message, minutesWordReplaceTestToken) {
+		t.Errorf("message should name the minute being edited, got: %s", p.Message)
+	}
 }
 
+// The gateway maps internal 40013 onto 2091013. The stub uses that wire
+// code as a literal so a constant pointed at a value the gateway never
+// sends fails this test instead of passing vacuously.
 func TestMinutesWordReplace_WordsNotFound(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
@@ -217,7 +377,7 @@ func TestMinutesWordReplace_WordsNotFound(t *testing.T) {
 		Method: http.MethodPut,
 		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
 		Body: map[string]interface{}{
-			"code": minutesWordReplaceInvalidParams,
+			"code": 2091013,
 			"msg":  "replace words not found in transcript",
 		},
 	})
@@ -239,16 +399,71 @@ func TestMinutesWordReplace_WordsNotFound(t *testing.T) {
 	if p.Subtype != errs.SubtypeNotFound {
 		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeNotFound)
 	}
+	if p.Code != 2091013 {
+		t.Errorf("code = %d, want 2091013", p.Code)
+	}
 	if !strings.Contains(p.Message, minutesWordReplaceTestToken) {
 		t.Errorf("message should include minute token, got: %s", p.Message)
 	}
-	if !strings.Contains(p.Hint, "source_word") {
-		t.Errorf("hint should mention source_word, got: %s", p.Hint)
+	if !strings.Contains(p.Message, "nothing was replaced") {
+		t.Errorf("message should state nothing was replaced, got: %s", p.Message)
+	}
+	assertNotFoundHintKeepsRecoveryWithUser(t, p.Hint)
+}
+
+// Recovery is a wording question for the user; sending the agent back into the
+// transcript makes every miss pay for a full transcript read.
+func assertNotFoundHintKeepsRecoveryWithUser(t *testing.T, hint string) {
+	t.Helper()
+	if !strings.Contains(hint, "source_word") {
+		t.Errorf("hint should point at source_word, got: %s", hint)
+	}
+	if strings.Contains(hint, "--transcript") || strings.Contains(hint, "+detail") {
+		t.Errorf("hint must not send the agent to read the transcript, got: %s", hint)
 	}
 }
 
-// A generic 40001 without the transcript marker must NOT be rewritten as
-// words_not_found; it should surface as the original invalid-params error.
+func TestMinutesWordReplace_ASRQuotaNotEnough(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	warmTokenCache(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPut,
+		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
+		Body: map[string]interface{}{
+			"code": 2091008,
+			"msg":  "asr/ai quota not enough",
+		},
+	})
+
+	err := mountAndRun(t, MinutesWordReplace, []string{
+		"+word-replace",
+		"--minute-token", minutesWordReplaceTestToken,
+		"--replace-words", `[{"source_word":"foo","target_word":"bar"}]`,
+		"--format", "json", "--as", "user",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected ASR/AI quota error, got nil")
+	}
+
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("want typed errs.*, got %T: %v", err, err)
+	}
+	if p.Subtype != errs.SubtypeQuotaExceeded {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeQuotaExceeded)
+	}
+	if !strings.Contains(p.Message, minutesWordReplaceTestToken) {
+		t.Errorf("message should name the minute, got: %s", p.Message)
+	}
+	if !strings.Contains(p.Hint, "detail page") {
+		t.Errorf("hint should point to the minute detail page, got: %s", p.Hint)
+	}
+}
+
+// 2091001 is only generic invalid-params now. Even the old words-not-found
+// message must not be rewritten; that failure has its own wire code.
 func TestMinutesWordReplace_GenericInvalidParamsNotRewritten(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
@@ -258,8 +473,8 @@ func TestMinutesWordReplace_GenericInvalidParamsNotRewritten(t *testing.T) {
 		Method: http.MethodPut,
 		URL:    "/open-apis/minutes/v1/minutes/" + minutesWordReplaceTestToken + "/transcript/word",
 		Body: map[string]interface{}{
-			"code": minutesWordReplaceInvalidParams,
-			"msg":  "Invalid Params",
+			"code": 2091001,
+			"msg":  "replace words not found in transcript",
 		},
 	})
 
@@ -278,6 +493,14 @@ func TestMinutesWordReplace_GenericInvalidParamsNotRewritten(t *testing.T) {
 		t.Fatalf("want typed errs.*, got %T: %v", err, err)
 	}
 	if p.Subtype == errs.SubtypeNotFound && strings.Contains(p.Message, "None of the source words were found") {
-		t.Fatalf("generic 40001 must not be rewritten as not_found, got subtype=%q message=%q", p.Subtype, p.Message)
+		t.Fatalf("2091001 must not be rewritten as not_found after the dedicated 2091013 mapping, got subtype=%q message=%q", p.Subtype, p.Message)
+	}
+}
+
+func TestFormatWordReplaceMessage(t *testing.T) {
+	got := formatWordReplaceMessage([]string{"hello"}, []string{"missing"})
+	want := "Succeeded: hello; Failed: missing. " + minutesWordReplaceDoNotRetrySucceeded
+	if got != want {
+		t.Fatalf("formatWordReplaceMessage() = %q, want %q", got, want)
 	}
 }

--- a/shortcuts/minutes/shortcuts.go
+++ b/shortcuts/minutes/shortcuts.go
@@ -5,6 +5,8 @@ package minutes
 
 import "github.com/larksuite/cli/shortcuts/common"
 
+const minutesASRQuotaNotEnoughHint = "The ASR/AI quota was exhausted while generating this minute; check the minute's detail page for details."
+
 // Shortcuts returns all minutes shortcuts.
 func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{

--- a/shortcuts/note/note_test.go
+++ b/shortcuts/note/note_test.go
@@ -152,9 +152,12 @@ func TestMapNoteError_NoReadPermission(t *testing.T) {
 		Problem: errs.Problem{
 			Category: errs.CategoryAuthorization,
 			Subtype:  errs.SubtypePermissionDenied,
-			Code:     NoNoteReadPermissionCode,
-			Message:  "upstream permission denied",
-			LogID:    "log_1",
+			// Literal wire code, not the constant: feeding the constant back in
+			// would pass whatever value it holds, hiding a drift to the vc
+			// service's internal 10005.
+			Code:    121005,
+			Message: "upstream permission denied",
+			LogID:   "log_1",
 		},
 		MissingScopes: []string{"vc:note:read"},
 		Identity:      "user",
@@ -198,7 +201,7 @@ func TestMapNoteError_NormalizesNonPermissionTypedError(t *testing.T) {
 		Problem: errs.Problem{
 			Category: errs.CategoryAPI,
 			Subtype:  errs.SubtypeUnknown,
-			Code:     NoNoteReadPermissionCode,
+			Code:     121005,
 			Message:  "upstream api error",
 			LogID:    "log_2",
 		},

--- a/shortcuts/vc/vc_notes_test.go
+++ b/shortcuts/vc/vc_notes_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/larksuite/cli/internal/recovery"
 	"github.com/larksuite/cli/internal/surface"
 	"github.com/larksuite/cli/shortcuts/common"
-	"github.com/larksuite/cli/shortcuts/note"
 )
 
 func TestNotes_UserMissingScopeProjectsInlineHintWithoutChangingExit(t *testing.T) {
@@ -1294,7 +1293,10 @@ func minuteGetErrStub(token string, code int, msg string) *httpmock.Stub {
 func TestMinutesReadError_ProblemOf_EnrichesMessage(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
-	reg.Register(minuteGetErrStub("tokperm", minutesNoReadPermissionCode, "no permission"))
+	// Literal wire code, not the constant: feeding the constant back in would
+	// pass whatever value it holds, hiding a drift to the minutes service's
+	// internal 40005.
+	reg.Register(minuteGetErrStub("tokperm", 2091005, "no permission"))
 	// artifactsStub not needed: we never reach it on error
 
 	// A single minute-token that fails on a no-read-permission code still
@@ -1335,7 +1337,7 @@ func TestFetchNoteDetail_NoteNoPermission_ProblemOf(t *testing.T) {
 
 	// meeting.get returns note_id, note detail returns 121005
 	reg.Register(meetingGetStub("m_noteperm2", "note_perm2"))
-	reg.Register(noteDetailErrStub("note_perm2", note.NoNoteReadPermissionCode, "no permission"))
+	reg.Register(noteDetailErrStub("note_perm2", 121005, "no permission"))
 	reg.Register(recordingOKStub("m_noteperm2", "https://meetings.feishu.cn/minutes/obcpermtest"))
 
 	// note fails but minute_token succeeds → partial success (hasNotesPayload=true)

--- a/skills/lark-meeting/references/lark-minutes-summary.md
+++ b/skills/lark-meeting/references/lark-minutes-summary.md
@@ -112,6 +112,7 @@ lark-cli minutes +summary --minute-token obcnxxxxxxxxxxxxxxxxxxxx --summary @sum
 | 总结展示为原始 Markdown 文本 | — | 总结含链接、四级标题等妙记端无法渲染的语法 | 改用标题（#～###）、加粗、列表等可展示格式；接口不会因此报错 |
 | 参数无效 | — | `minute_token` 缺失或格式错误 | 检查 token 是否完整 |
 | 权限不足 | — | 缺少 `minutes:minutes:update` | 运行 `auth login --scope "minutes:minutes:update"` |
+| `error.subtype` = `quota_exceeded` | 2091008 | 该妙记生成时 ASR/AI 额度已用尽，AI 总结未完整生成，替换无法落库 | 让用户去该妙记详情页查看额度详细信息；CLI 无法补充额度，重试不会成功 |
 
 ## 相关场景
 - [生成和修改妙记](../scenes/create-and-edit-minutes.md)

--- a/skills/lark-meeting/references/lark-minutes-todo.md
+++ b/skills/lark-meeting/references/lark-minutes-todo.md
@@ -38,6 +38,9 @@ lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation delet
 
 # 预览
 lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add --todo "新待办" --is-done --dry-run --as user
+
+# 新增待办并指定负责人（负责人以内联 @ 提及写进 --todo 内容，这是妙记待办表示归属的既定写法）
+lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add --todo "跟进预算审批 @张三" --is-done=false --as user
 ```
 
 ## 参数
@@ -94,7 +97,41 @@ lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add -
 
 `content` **不是 Markdown**，请直接传入待办描述文字。
 
-### 3. 所需权限
+### 3. 负责人 / `@` 提及（既定写法，必读）
+
+用户说"负责人是某某"时，既定写法是把负责人以内联 `@某某` 追加进 `--todo` 内容：
+
+- 用户已经直接给出姓名时（例如"负责人是张三"），**不做任何查找**，原文原样拼进 `--todo` 内容，写成纯文本 `@张三`（`--todo "xxx @张三"`）。
+- 用户说"负责人是我"时，**必须**先取当前登录用户的真实姓名再拼接，禁止直接写成字面的 `@我`：
+  - 执行 `lark-cli contact +get-user --as user`，取返回中的姓名字段作为真实姓名，拼成 `--todo "xxx @<真实姓名>"`。
+  - 如果这一步失败或取不到姓名（无权限、报错等），**不要**写任何 `@` 提及占位——直接用不带负责人后缀的原始待办文本创建（`--todo "xxx"`），不要保留字面的 `@我`。
+- **不要**因为要处理负责人而改路由到 [lark-task](../../lark-task/SKILL.md) 或做进一步的通讯录搜索——第一优先级永远是落地这条待办；姓名解析只影响追加的 `@` 文本，绝不能阻塞或取消待办创建。
+- **不要**用"创建者是谁 / 以什么身份创建"来代替 `@` 提及——创建时用的 `--as user`/`--as bot` 身份和"负责人"是两件不相关的事，即使已知当前用户真实姓名，也必须把它拼进 `content` 文本，不能只在回复里用"以你的身份创建即归属于你"这类说法搪塞。
+- 回复里**不要**主动提及或建议改用 `lark-task` 作为"想要明确负责人/可指派任务"的替代方案——用户说的负责人只是这条妙记待办里的一段文本，和 Task 完全无关，不要引入 Task 增加用户困惑。
+- 内联 `@` 是妙记待办表示负责人的既定写法。回复只陈述结果（妙记、待办内容、负责人、完成状态），**不要**出现"接口只支持 content 和 is_done""没有独立的负责人字段""所以只能把负责人写进内容里"这类实现限制说明或解释性免责。
+
+**结果示例**：
+
+```bash
+# 姓名解析成功
+lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add --todo "跟进预算审批 @王小明" --is-done=false --as user
+
+# "我"解析失败：不写 @ 提及，仅保留原始内容
+lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add --todo "跟进预算审批" --is-done=false --as user
+```
+
+```json
+{
+  "minute_token": "obcnxxxxxxxxxxxxxxxxxxxx",
+  "count": 1,
+  "updated": true,
+  "operation": "add"
+}
+```
+
+妙记里新增的这条待办的 `content` 字段就是最终拼好的文本本身（`"跟进预算审批 @王小明"` 或解析失败时的 `"跟进预算审批"`）；CLI 和这个接口都不会、也不需要把它转换成真正可点击的用户提及。
+
+### 4. 所需权限
 
 | 身份 | 所需 scope |
 |------|-----------|
@@ -120,6 +157,7 @@ lark-cli minutes +todo --minute-token obcnxxxxxxxxxxxxxxxxxxxx --operation add -
 | `--todos` 与单条 flags 冲突 | 二选一 |
 | `todos[i]` 校验失败 | 检查该条 `operation` 与字段组合 |
 | `error.subtype` = `permission_denied` | **妙记资源无编辑权**：向妙记所有者申请该妙记的编辑/协作权限；**不要**走 `auth login --scope` |
+| `error.subtype` = `quota_exceeded` | **该妙记生成时 ASR/AI 额度已用尽**，AI 待办未完整生成，改待办无法落库：让用户去该妙记详情页查看额度详细信息；CLI 无法补充额度，重试不会成功 |
 | 缺少 OAuth scope（`error.missing_scopes` 含 `minutes:minutes:update`） | `lark-cli auth login --scope "minutes:minutes:update"` |
 
 ## 相关场景

--- a/skills/lark-meeting/references/lark-minutes-upload.md
+++ b/skills/lark-meeting/references/lark-minutes-upload.md
@@ -61,5 +61,11 @@ API 会立即返回 `minute_url`，但妙记可能仍在异步生成中。`minut
 | `minute_url` | 生成的妙记访问链接 |
 | `minute_token` | 从 `minute_url` 提取出的妙记 Token，可直接传给 `minutes +detail --minute-tokens` |
 
+## 常见错误与排查
+
+| 错误现象 | 错误码 | 根本原因 | 解决方案 |
+|---------|--------|---------|---------|
+| `error.subtype` = `quota_exceeded` | 2091008 | ASR/AI 额度已用尽，不足以转写这个音视频，妙记未创建 | 让用户去妙记详情页查看额度详细信息；CLI 无法补充或提升额度，重试同一个 `--file-token` 不会成功 |
+
 ## 相关场景
 - [生成和修改妙记](../scenes/create-and-edit-minutes.md)

--- a/skills/lark-meeting/scenes/create-and-edit-minutes.md
+++ b/skills/lark-meeting/scenes/create-and-edit-minutes.md
@@ -48,7 +48,7 @@ lark-cli minutes +detail --minute-tokens <minute_token> --wait-ready --transcrip
 
 ## 增删改 AI 待办
 
-妙记 AI 待办不是飞书任务。上下文包含妙记 URL / `minute_token` 并要求修改妙记待办时，禁止改走 `lark-task`。
+妙记 AI 待办不是飞书任务。上下文包含妙记 URL / `minute_token` 并要求修改妙记待办时，禁止改走 `lark-task`；用户同时指定了负责人（包括"负责人是我"）也不改变归属。
 
 ```bash
 lark-cli minutes +todo --minute-token <token> --operation add|update|delete ... --as user
@@ -58,6 +58,18 @@ lark-cli minutes +todo --minute-token <token> --operation add|update|delete ... 
 - 更新或删除前，先执行 `minutes +detail --minute-tokens <token> --todo --as user`，按内容匹配取得精确 `todo_id`；不要用列表顺序代替 ID。
 - 待办 ID、批量结构和部分成功语义见 [`lark-minutes-todo`](../references/lark-minutes-todo.md)。
 
+### 指定负责人
+
+妙记待办表示负责人的既定写法是把 `@姓名` 作为纯文本写进待办内容，不存在独立的负责人字段：
+
+- 用户直接给出姓名时不做任何查找，原文拼成 `@姓名`。
+- 用户说"负责人是我"时，先用 `lark-cli contact +get-user --as user` 取真实姓名再拼接；取不到就不写任何 `@` 提及，不要保留字面的 `@我`。
+- 姓名解析只影响追加的 `@` 文本，绝不能阻塞或取消待办创建；不要为处理负责人改走 `lark-task` 或做进一步通讯录搜索。
+- 不要用"以你的身份创建即归属于你"代替真正的 `@` 文本拼接；`--as` 身份和负责人是两件不相关的事。
+- 回复只陈述结果（妙记、待办内容、负责人、完成状态），不要解释接口字段限制，也不要建议改用 `lark-task` 来"明确负责人"。
+
+完整规则和示例见 [`lark-minutes-todo`](../references/lark-minutes-todo.md) 的「负责人 / `@` 提及」。
+
 ## 批量替换逐字稿关键词
 
 ```bash
@@ -66,7 +78,11 @@ lark-cli minutes +word-replace --minute-token <token> --replace-words '[{"source
 
 多组替换放在同一个 JSON 数组中。具体参数运行 `lark-cli minutes +word-replace --help`。
 
-返回 `not_found` 表示 `source_word` 没有命中，是参数问题而不是权限问题；先读取当前 Transcript，核对精确写法和大小写后再决定是否重试。
+用户给出原词和目标词后直接替换：不要为了核对写法先读取 Transcript，也不要在替换成功后回读 Transcript 验证。接口逐词返回结果，按结果回报即可。
+
+只要有一个关键词命中就是成功：`data.message` 列出 Succeeded 和 Failed 关键词。重试时只提交 Failed 的词，不要重复提交已成功的词，否则会把新词再替换一遍。
+
+全部关键词都没命中才是失败（`not_found`）。这是参数问题而不是权限问题；如实告知用户哪些词没命中，请用户确认精确写法、大小写和空格后再决定是否重试，不要靠读取 Transcript 自行猜词。
 
 ## 替换逐字稿说话人
 
@@ -120,6 +136,12 @@ lark-cli minutes +apply-permission --minute-token <token> --perm view --as <sour
 
 `permission_denied` 表示对该妙记没有编辑权，不等于 OAuth scope 缺失；请所有者授权，不要误走 `auth login --scope`。
 
+## ASR/AI 额度不足
+
+`minutes +upload`、`+summary`、`+todo` 和 `+word-replace` 都可能返回 `quota_exceeded`，表示 ASR/AI 额度已耗尽。`+upload` 是额度不足以转写这个音视频，妙记根本没有创建；其余三个是该妙记生成时额度就已用尽、AI 产物未完整生成，写操作无法落库。
+
+请用户去妙记详情页查看额度详细信息，不要重试：CLI 无法补充或提升额度，重试同样的请求不会成功。这不是权限问题，也不要误走 `+apply-permission` 或 `auth login --scope`。
+
 ## 确认修改结果
 
-修改前只读取目标相关字段，修改后用 `minutes +detail` 或对应读取接口回读。批量或多步修改逐项报告写前值、写后结果和失败原因；部分成功时不要回滚已成功项，除非命令明确承诺原子回滚。
+修改前只读取目标相关字段，修改后用 `minutes +detail` 或对应读取接口回读。命令自身已逐项返回写入结果时不再回读，例如 `minutes +word-replace` 的 Succeeded / Failed 关键词。批量或多步修改逐项报告写前值、写后结果和失败原因；部分成功时不要回滚已成功项，除非命令明确承诺原子回滚。


### PR DESCRIPTION
## Summary

The `minutes` shortcuts were mapping the service's internal error codes (`40005`,
`40110`, `40001`), which the gateway never sends, so no-edit-permission,
concurrent-edit and words-not-found failures reached the caller as generic API
errors. `minutes +word-replace` also reported a blanket success without saying
which `source_word` actually matched, which pushed agents into reading the whole
transcript before and after every edit. This PR corrects the wire codes,
classifies ASR/AI quota exhaustion (`2091008`) across the four minutes write
shortcuts, reports per-word replacement outcomes from `replace_word_counts`, and
brings the minutes affordance and skill guidance in line with that behavior.

## Changes

**Error-code mapping**
- `+word-replace`: `40005` → `2091005` (no edit permission), `40110` → `2091110`
  (someone else is editing). The `40001` + "not found in transcript" message
  sniffing is replaced by the dedicated `2091013` words-not-found code, so
  generic invalid-params is no longer rewritten as `not_found`.
- `+todo`: `40005` → `2091005`.
- `2091008` now maps to `quota_exceeded` on `+upload`, `+summary`, `+todo` and
  `+word-replace`, with a shared hint stating that retrying cannot help.
- `note` / `vc` tests stub literal wire codes (`121005`, `2091005`) instead of
  feeding the production constant back into the mock — that self-referential
  stubbing is how the internal `4xxxx` codes stayed invisible. `shortcuts/vc` no
  longer imports `shortcuts/note` just to reach that constant.

**`+word-replace` per-word results**
- `replace_word_counts` from the response is parsed, and every requested
  `source_word` is reported as succeeded or failed.
- All counts zero → `not_found` (locally derived, so `code` stays `0`) instead of
  a success envelope.
- `code=0` with no `replace_word_counts` → `failed_precondition` instead of
  inventing an all-success message.
- Output shape change: `data.replace_words` (an echo of the input) is replaced by
  `data.message`, which lists the succeeded and failed words. Partial success
  keeps `ok:true` and exit `0`, following the upstream API's own success
  semantics.

**Affordance and skills**
- `affordance/minutes.md`: prerequisites, avoid-when routing and runnable
  examples for `+word-replace`, `+summary` and `+todo`. The new
  `internal/affordance/minutes_source_test.go` locks those examples, keeps
  runtime recovery (`auth login`, `missing_scopes`) out of affordance, and
  asserts `+word-replace` does not require a transcript read first.
- `lark-meeting` references and scenes: assignee handling for minute todos
  (inline `@name`, resolving "me" through `contact +get-user`), the
  partial-replacement retry rule (resubmit only the failed words), and
  quota-exhaustion troubleshooting rows for upload / summary / todo /
  word-replace.

## Test Plan
- [x] `go test ./shortcuts/minutes/... ./shortcuts/note/... ./shortcuts/vc/...`
- [x] `go test ./internal/affordance ./cmd/service ./internal/schema` (affordance content changed)
- [x] `node scripts/skill-format-check/index.js`
- [x] `gofmt` clean on the touched packages
- [x] Dry-run E2E asserts method, path and body (`TestMinutesWordReplace_DryRun`)
- [ ] `make unit-test`, `make vet`, `make fmt-check`
- [ ] `make quality-gate` with `QUALITY_GATE_CHANGED_FROM=main` (diff-scoped, run after committing)
- [ ] Live: `minutes +word-replace` on a real minute with one matching and one
      non-matching keyword; quota classification observed against a tenant with
      ASR quota exhausted

## Related Issues
- None