### PR TITLE
docs(lark-im): add AppLink guidance

### DIFF
--- a/shortcuts/im/chat_app_link.go
+++ b/shortcuts/im/chat_app_link.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func addChatAppLinks(chats []map[string]interface{}, runtime *common.RuntimeContext) {
+	if runtime == nil || runtime.Config == nil {
+		return
+	}
+	for _, chat := range chats {
+		if link := assembleChatAppLink(chat["chat_id"], runtime.Config.Brand); link != "" {
+			chat["chat_app_link"] = link
+		}
+	}
+}
+
+func assembleChatAppLink(rawChatID interface{}, brand core.LarkBrand) string {
+	chatID, _ := rawChatID.(string)
+	chatID = strings.TrimSpace(chatID)
+	if !strings.HasPrefix(chatID, "oc_") {
+		return ""
+	}
+	domain := resolveChatAppLinkDomain(brand)
+	if domain == "" {
+		return ""
+	}
+
+	u := &url.URL{Scheme: "https", Host: domain, Path: "/client/chat/open"}
+	q := url.Values{}
+	q.Set("openChatId", chatID)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func resolveChatAppLinkDomain(brand core.LarkBrand) string {
+	appLink := core.ResolveEndpoints(brand).AppLink
+	u, err := url.Parse(appLink)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}

--- a/shortcuts/im/chat_app_link_test.go
+++ b/shortcuts/im/chat_app_link_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/core"
+)
+
+func TestAssembleChatAppLink(t *testing.T) {
+	tests := []struct {
+		name   string
+		chatID interface{}
+		brand  core.LarkBrand
+		want   string
+	}{
+		{
+			name:   "feishu open chat id",
+			chatID: "oc_a0553eda9014c201e6969b478895c230",
+			brand:  core.BrandFeishu,
+			want:   "https://applink.feishu.cn/client/chat/open?openChatId=oc_a0553eda9014c201e6969b478895c230",
+		},
+		{
+			name:   "lark open chat id",
+			chatID: "oc_a0553eda9014c201e6969b478895c230",
+			brand:  core.BrandLark,
+			want:   "https://applink.larksuite.com/client/chat/open?openChatId=oc_a0553eda9014c201e6969b478895c230",
+		},
+		{
+			name:   "numeric internal chat id omitted",
+			chatID: "7670440925243608339",
+			brand:  core.BrandFeishu,
+		},
+		{
+			name:   "non string chat id omitted",
+			chatID: 123,
+			brand:  core.BrandFeishu,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := assembleChatAppLink(tt.chatID, tt.brand); got != tt.want {
+				t.Fatalf("assembleChatAppLink() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImChatListExecuteAddsChatAppLink(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"code":0,"msg":"ok","data":{"items":[{"chat_id":"oc_g","name":"G","chat_mode":"group"}],"has_more":false,"page_token":""}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	}))
+	attachChatListCmd(t, rt, map[string]string{"types": "group"}, nil)
+
+	if err := ImChatList.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Chats []map[string]interface{} `json:"chats"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(chatListOutBuf(t, rt).Bytes(), &envelope); err != nil {
+		t.Fatalf("stdout is not JSON: %v", err)
+	}
+	if len(envelope.Data.Chats) != 1 {
+		t.Fatalf("chats length = %d, want 1", len(envelope.Data.Chats))
+	}
+	want := "https://applink.feishu.cn/client/chat/open?openChatId=oc_g"
+	if got, _ := envelope.Data.Chats[0]["chat_app_link"].(string); got != want {
+		t.Fatalf("chat_app_link = %q, want %q", got, want)
+	}
+}
+
+func TestImChatSearchExecuteOmitsChatAppLink(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"code":0,"msg":"ok","data":{"items":[{"meta_data":{"chat_id":"oc_visible","name":"Visible","chat_mode":"group"}}],"has_more":false,"page_token":""}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	}))
+	rt.Cmd = newChatSearchNoticeTestCommand(t, "Joined")
+	rt.Format = "json"
+
+	if err := ImChatSearch.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Chats []map[string]interface{} `json:"chats"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(chatListOutBuf(t, rt).Bytes(), &envelope); err != nil {
+		t.Fatalf("stdout is not JSON: %v", err)
+	}
+	if _, ok := envelope.Data.Chats[0]["chat_app_link"]; ok {
+		t.Fatalf("chat_app_link must be omitted for search results: %#v", envelope.Data.Chats[0])
+	}
+}
+
+func TestImChatSearchExecuteOmitsChatAppLinkForNonMemberResults(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"code":0,"msg":"ok","data":{"items":[{"meta_data":{"chat_id":"oc_not_joined","name":"Not Joined","chat_mode":"group"}}],"has_more":false,"page_token":""}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	}))
+	rt.Cmd = newChatSearchNoticeTestCommand(t, "Not Joined")
+	if err := rt.Cmd.Flags().Set("search-types", "public_not_joined"); err != nil {
+		t.Fatalf("Flags().Set(search-types) error = %v", err)
+	}
+	rt.Format = "json"
+
+	if err := ImChatSearch.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Chats []map[string]interface{} `json:"chats"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(chatListOutBuf(t, rt).Bytes(), &envelope); err != nil {
+		t.Fatalf("stdout is not JSON: %v", err)
+	}
+	if _, ok := envelope.Data.Chats[0]["chat_app_link"]; ok {
+		t.Fatalf("chat_app_link must be omitted for public_not_joined search results: %#v", envelope.Data.Chats[0])
+	}
+}

--- a/shortcuts/im/im_chat_create.go
+++ b/shortcuts/im/im_chat_create.go
@@ -125,6 +125,11 @@ var ImChatCreate = common.Shortcut{
 			"owner_id":  resData["owner_id"],
 			"external":  resData["external"],
 		}
+		if runtime.Config != nil {
+			if link := assembleChatAppLink(resData["chat_id"], runtime.Config.Brand); link != "" {
+				outData["chat_app_link"] = link
+			}
+		}
 
 		// Try to fetch the group share link without blocking on failure.
 		if chatID, ok := resData["chat_id"].(string); ok && chatID != "" {

--- a/shortcuts/im/im_chat_list.go
+++ b/shortcuts/im/im_chat_list.go
@@ -142,6 +142,7 @@ var ImChatList = common.Shortcut{
 		}
 		items = mfOut.Chats
 		pagination.Items = len(items)
+		addChatAppLinks(items, runtime)
 
 		// Presentation stage: business data stays backward compatible while the
 		// output layer carries the authoritative pagination outcome for every

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -35,6 +35,10 @@ Chat (oc_xxx)
 
 ## Important Notes
 
+### AppLink and Share Links
+
+Prefer CLI-returned links: use `chat_app_link` to open joined conversations, `message_app_link` to open messages, and `share_link` to invite others to groups. If manually building a joined-conversation AppLink, use `https://<applink_host>/client/chat/open?openChatId=<oc_xxx>`, never `chatId=<oc_xxx>` or `lark://...chat_id=<oc_xxx>`.
+
 ### Identity and Token Mapping
 
 - `--as user` means **user identity** and uses `user_access_token`. Calls run as the authorized end user, so permissions depend on both the app scopes and that user's own access to the target chat/message/resource.


### PR DESCRIPTION
## Summary
- Add focused lark-im AppLink guidance for chat, group share, and message links.
- Clarify that lark-cli `chat_id` values are `oc_xxx` OpenAPI chat IDs and should use `openChatId`, not `chatId`.
- Point message workflows to `message_app_link` instead of reconstructing message URLs.

## Test plan
- Documentation-only change.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat creation, listing, and search results now include clickable conversation AppLinks when available.
  * Message and thread results now provide ready-to-use links, conversation identifiers, and position metadata.
  * Sent messages and replies can now be linked through message retrieval results.

* **Documentation**
  * Added guidance for conversation, direct-chat, invitation, message, thread, and citation AppLinks.
  * Clarified Feishu and Lark host formats, `openChatId` usage, group sharing, link handling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->