### PR TITLE
fix(drive): continue downloads on permission scope errors

### DIFF
--- a/shortcuts/drive/drive_download.go
+++ b/shortcuts/drive/drive_download.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -105,17 +106,33 @@ func driveDownloadShouldFailOnMetadataTitleError(ctx context.Context, err error)
 	return false
 }
 
+func driveDownloadIsPermissionAuthScopeError(err error) bool {
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryAuthorization {
+		return false
+	}
+	switch problem.Code {
+	case output.LarkErrAppScopeNotEnabled,
+		output.LarkErrTokenNoPermission,
+		output.LarkErrUserScopeInsufficient:
+		return true
+	default:
+		return false
+	}
+}
+
 var DriveDownload = common.Shortcut{
 	Service:     "drive",
 	Command:     "+download",
 	Description: "Download a file from Drive to local",
 	Risk:        "read",
-	Scopes:      []string{"drive:file:download", common.DrivePermissionMemberAuthScope},
+	Scopes:      []string{"drive:file:download"},
 	// Metadata is only required when --output is omitted and the CLI needs the
 	// remote title as the pre-download fallback filename. The wiki scope is only
 	// required when the caller passes a wiki node (--wiki-token or a /wiki/ URL)
-	// that must be resolved to the underlying file token.
-	ConditionalScopes: []string{driveMetadataReadScope, driveWikiNodeRetrieveScope},
+	// that must be resolved to the underlying file token. Permission auth scope
+	// failures are non-blocking so they do not prevent the download API call.
+	ConditionalScopes: []string{common.DrivePermissionMemberAuthScope, driveMetadataReadScope, driveWikiNodeRetrieveScope},
 	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "file-token", Desc: "Drive file token"},
@@ -226,9 +243,12 @@ var DriveDownload = common.Shortcut{
 
 		allowed, err := common.CheckDriveFileExportPermission(runtime, fileToken)
 		if err != nil {
-			return withDriveDownloadRecoveryHint(err, fileToken)
-		}
-		if !allowed {
+			if driveDownloadIsPermissionAuthScopeError(err) {
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: export permission check failed; continuing with download: %v\n", err)
+			} else {
+				return withDriveDownloadRecoveryHint(err, fileToken)
+			}
+		} else if !allowed {
 			return driveDownloadPermissionDeniedError()
 		}
 

--- a/shortcuts/drive/drive_io_test.go
+++ b/shortcuts/drive/drive_io_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2084,16 +2085,68 @@ func TestDriveDownloadOmittedOutputRequiresMetadataScope(t *testing.T) {
 	}
 }
 
-func TestDriveDownloadDeclaresPermissionMemberAuthScope(t *testing.T) {
-	found := false
+func TestDriveDownloadTreatsPermissionMemberAuthScopeAsNonBlocking(t *testing.T) {
 	for _, scope := range DriveDownload.Scopes {
 		if scope == common.DrivePermissionMemberAuthScope {
-			found = true
-			break
+			t.Fatalf("DriveDownload.Scopes = %v, permission auth scope must not be an unconditional preflight", DriveDownload.Scopes)
 		}
 	}
-	if !found {
-		t.Fatalf("DriveDownload.Scopes = %v, want %q", DriveDownload.Scopes, common.DrivePermissionMemberAuthScope)
+	if !slices.Contains(DriveDownload.ConditionalScopes, common.DrivePermissionMemberAuthScope) {
+		t.Fatalf("DriveDownload.ConditionalScopes = %v, want best-effort scope %q", DriveDownload.ConditionalScopes, common.DrivePermissionMemberAuthScope)
+	}
+}
+
+func TestDriveDownloadPermissionAuthScopeErrorsWarnAndContinue(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		msg  string
+	}{
+		{name: "app_scope_not_applied", code: 99991672, msg: "app scope not applied"},
+		{name: "token_scope_insufficient", code: 99991676, msg: "token scope insufficient"},
+		{name: "missing_scope", code: 99991679, msg: "missing scope"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, _, stderr, reg := cmdutil.TestFactory(t, driveTestConfig())
+			f.Credential = credential.NewCredentialProvider(nil, nil, &driveStatusScopedTokenResolver{scopes: "drive:file:download"}, nil)
+			fileToken := "file_" + tt.name
+			reg.Register(&httpmock.Stub{
+				Method: http.MethodGet,
+				URL:    "/open-apis/drive/v1/permissions/" + fileToken + "/members/auth",
+				Body: map[string]interface{}{
+					"code": tt.code,
+					"msg":  tt.msg,
+				},
+			})
+			reg.Register(&httpmock.Stub{
+				Method:  http.MethodGet,
+				URL:     "/open-apis/drive/v1/files/" + fileToken + "/download",
+				Status:  http.StatusOK,
+				RawBody: []byte("downloaded without permission auth scope"),
+				Headers: http.Header{"Content-Type": []string{"application/octet-stream"}},
+			})
+
+			tmpDir := t.TempDir()
+			withDriveWorkingDir(t, tmpDir)
+			err := mountAndRunDrive(t, DriveDownload, []string{
+				"+download",
+				"--file-token", fileToken,
+				"--output", "downloaded.bin",
+				"--as", "bot",
+			}, f, nil)
+			if err != nil {
+				t.Fatalf("download error = %v, want permission auth scope error %d to be non-blocking", err, tt.code)
+			}
+			if !strings.Contains(stderr.String(), "warning: export permission check failed; continuing with download:") {
+				t.Fatalf("stderr=%q, want permission scope warning", stderr.String())
+			}
+			data, readErr := os.ReadFile(filepath.Join(tmpDir, "downloaded.bin"))
+			if readErr != nil || string(data) != "downloaded without permission auth scope" {
+				t.Fatalf("downloaded content = %q, err=%v", string(data), readErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Allow `drive +download` to continue when the export-permission precheck fails only because the permission auth scope is unavailable. Other precheck failures and explicit `auth_result=false` responses remain blocking.

## Changes
- Treat `docs:permission.member:auth` as a conditional scope for `drive +download`.
- Warn and continue only for Lark error codes `99991672`, `99991676`, and `99991679`.
- Add regression coverage for scope declarations, all three non-blocking codes, and successful download continuation.

## Test Plan
- [x] `go test ./shortcuts/drive -run ^'TestDriveDownload' -count=1`\n- [x] `make build`\n- [x] Manual bot and user downloads both emitted the expected warning and produced byte-identical files.\n\n## Related Issues\n- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drive downloads now continue when permission checks encounter recognized authorization-scope issues.
  * These non-blocking permission issues generate a warning instead of stopping the download.
  * Other permission-related errors remain blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->