### PR TITLE
fix(slides): avoid PID variable in examples

### DIFF
--- a/skills/lark-slides/references/cli/lark-slides-add-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-add-slide.md
@@ -11,20 +11,20 @@
 ```bash
 # 追加到末尾（XML 直接作为参数）
 lark-cli slides +add-slide --as user \
-  --presentation "$PID" \
+  --presentation "$PRES_ID" \
   --slide '<slide xmlns="https://www.larkoffice.com/sml/2.0"><data></data></slide>'
 
 # XML 从文件读（推荐：避免 shell 转义和长参数截断）
 lark-cli slides +add-slide --as user \
-  --presentation "$PID" \
+  --presentation "$PRES_ID" \
   --slide @page3.xml
 
 # XML 从 stdin 读
-cat page3.xml | lark-cli slides +add-slide --as user --presentation "$PID" --slide -
+cat page3.xml | lark-cli slides +add-slide --as user --presentation "$PRES_ID" --slide -
 
 # 插到某页之前
 lark-cli slides +add-slide --as user \
-  --presentation "$PID" \
+  --presentation "$PRES_ID" \
   --slide @cover.xml \
   --before-slide-id "$SID"
 
@@ -34,7 +34,7 @@ lark-cli slides +add-slide --as user \
   --slide @page3.xml
 
 # 预览请求，不实际写入
-lark-cli slides +add-slide --presentation "$PID" --slide @page3.xml --dry-run
+lark-cli slides +add-slide --presentation "$PRES_ID" --slide @page3.xml --dry-run
 ```
 
 ## 参数
@@ -57,7 +57,7 @@ XML 里写 `<img src="@./chart.png" .../>`，CLI 会：先把每个不重复的�
 
 ```bash
 lark-cli slides +add-slide --as user \
-  --presentation "$PID" \
+  --presentation "$PRES_ID" \
   --slide '<slide xmlns="https://www.larkoffice.com/sml/2.0"><data><img src="@./chart.png" topLeftX="100" topLeftY="100" width="320" height="180"/></data></slide>'
 ```
 

--- a/skills/lark-slides/references/cli/lark-slides-delete-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-delete-slide.md
@@ -11,7 +11,7 @@
 ```bash
 # 直接传 xml_presentation_id
 lark-cli slides +delete-slide --as user \
-  --presentation "$PID" \
+  --presentation "$PRES_ID" \
   --slide-id "$SID"
 
 # slides URL / wiki URL 都可以（wiki 会自动解析并校验 obj_type=slides）
@@ -20,7 +20,7 @@ lark-cli slides +delete-slide --as user \
   --slide-id "$SID"
 
 # 删之前先确认打到哪份 PPT、哪一页
-lark-cli slides +delete-slide --presentation "$PID" --slide-id "$SID" --dry-run
+lark-cli slides +delete-slide --presentation "$PRES_ID" --slide-id "$SID" --dry-run
 ```
 
 ## 参数
@@ -48,7 +48,7 @@ lark-cli slides +delete-slide --presentation "$PID" --slide-id "$SID" --dry-run
 `slide_id` 是服务端短 ID，**不能从 XML 里推导**。两个来源：
 
 1. `+create` / `+add-slide` 的返回值里存下来；
-2. 事后回读：`slides +xml-get --presentation "$PID" --output .lark-slides/plan/<deck>/readback.xml`。
+2. 事后回读：`slides +xml-get --presentation "$PRES_ID" --output .lark-slides/plan/<deck>/readback.xml`。
 
 删错页的代价高于多跑一次回读 —— 不确定就先回读 + `+screenshot` 看一眼再删。
 

--- a/skills/lark-slides/references/cli/lark-slides-replace-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-replace-slide.md
@@ -28,9 +28,9 @@ lark-cli slides +replace-slide --as user \
 
 # 大 --parts 走文件或 stdin（auto-gen 命令不支持 @file，但 shortcut 支持）
 lark-cli slides +replace-slide --as user \
-  --presentation $PID --slide-id $SID --parts @parts.json
+  --presentation $PRES_ID --slide-id $SID --parts @parts.json
 cat parts.json | lark-cli slides +replace-slide --as user \
-  --presentation $PID --slide-id $SID --parts -
+  --presentation $PRES_ID --slide-id $SID --parts -
 
 # wiki URL 直接传（CLI 自动 get_node → 拿真实 xml_presentation_id）
 lark-cli slides +replace-slide --as user \
@@ -39,7 +39,7 @@ lark-cli slides +replace-slide --as user \
 
 # 预览（不实际调用）
 lark-cli slides +replace-slide --as user \
-  --presentation $PID --slide-id $SID --parts "$PARTS" --dry-run
+  --presentation $PRES_ID --slide-id $SID --parts "$PARTS" --dry-run
 ```
 
 ## 参数
@@ -180,16 +180,16 @@ lark-cli slides +replace-slide --as user \
 ### 给已有页加图（典型场景）
 
 ```bash
-PID=xxx
+PRES_ID=xxx
 SID=yyy
 
 # 1) 上传图片
 TOKEN=$(lark-cli slides +media-upload --as user \
-  --file ./pic.png --presentation "$PID" --jq '.data.file_token')
+  --file ./pic.png --presentation "$PRES_ID" --jq '.data.file_token')
 
 # 2) block_insert 到页末
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" \
+  --presentation "$PRES_ID" --slide-id "$SID" \
   --parts "$(jq -n --arg token "$TOKEN" \
     '[{action:"block_insert",insertion:("<img src=\""+$token+"\" topLeftX=\"500\" topLeftY=\"100\" width=\"200\" height=\"150\"/>")}]')"
 ```
@@ -199,11 +199,11 @@ lark-cli slides +replace-slide --as user \
 ```bash
 # 先拿原页 XML，从里面找到标题块的 3 位 short id（如 bUn）
 lark-cli slides xml_presentation.slide get --as user \
-  --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}"
+  --params "{\"xml_presentation_id\":\"$PRES_ID\",\"slide_id\":\"$SID\"}"
 
 # block_replace 换掉整个标题块（id 自动注入）
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" \
+  --presentation "$PRES_ID" --slide-id "$SID" \
   --parts '[{"action":"block_replace","block_id":"bUn","replacement":"<shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>新标题</p></content></shape>"}]'
 ```
 
@@ -213,7 +213,7 @@ lark-cli slides +replace-slide --as user \
 
 ```bash
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" \
+  --presentation "$PRES_ID" --slide-id "$SID" \
   --parts '[
     {"action":"block_replace","block_id":"bab","replacement":"<shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>新标题</p></content></shape>"},
     {"action":"block_insert","insertion":"<img src=\"<file_token>\" topLeftX=\"700\" topLeftY=\"400\" width=\"180\" height=\"100\"/>"}
@@ -225,12 +225,12 @@ lark-cli slides +replace-slide --as user \
 ```bash
 # 读时记录 revision_id
 REV=$(lark-cli slides xml_presentation.slide get --as user \
-  --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}" \
+  --params "{\"xml_presentation_id\":\"$PRES_ID\",\"slide_id\":\"$SID\"}" \
   --jq '.data.revision_id')
 
 # 写时传 --revision-id；传不存在的版本号（超过当前 revision）返回 3350002
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" --revision-id "$REV" \
+  --presentation "$PRES_ID" --slide-id "$SID" --revision-id "$REV" \
   --parts "$PARTS"
 ```
 

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-get.md
@@ -98,7 +98,7 @@ lark-cli slides xml_presentation.slide get --as user --params '{
 
    ```bash
    lark-cli slides xml_presentation.slide get --as user \
-     --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}" \
+     --params "{\"xml_presentation_id\":\"$PRES_ID\",\"slide_id\":\"$SID\"}" \
      --jq '.data.slide.content' | grep -oE 'id="[^"]+"' | sed 's/id="//;s/"//'
    ```
 

--- a/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-replace.md
+++ b/skills/lark-slides/references/cli/lark-slides-xml-presentation-slide-replace.md
@@ -95,10 +95,10 @@ lark-cli slides xml_presentation.slide replace --as user --params '{
 
 ```bash
 # 先拿 file_token
-TOKEN=$(lark-cli slides +media-upload --file ./pic.png --presentation "$PID" --as user --jq '.data.file_token')
+TOKEN=$(lark-cli slides +media-upload --file ./pic.png --presentation "$PRES_ID" --as user --jq '.data.file_token')
 
 lark-cli slides xml_presentation.slide replace --as user --params "{
-  \"xml_presentation_id\": \"$PID\",
+  \"xml_presentation_id\": \"$PRES_ID\",
   \"slide_id\": \"$SID\"
 }" --data "$(jq -n --arg token "$TOKEN" '{
   parts: [

--- a/skills/lark-slides/references/workflow/slides-editing.md
+++ b/skills/lark-slides/references/workflow/slides-editing.md
@@ -18,16 +18,16 @@
 ## 最小读-改-写闭环
 
 ```bash
-PID="xml_presentation_id_here"
+PRES_ID="xml_presentation_id_here"
 SID="slide_id_here"
 
 # 1. 读原页，从 XML 里挑出要改的块的 3 位 short id（如 bUn / bab）
 lark-cli slides xml_presentation.slide get --as user \
-  --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}"
+  --params "{\"xml_presentation_id\":\"$PRES_ID\",\"slide_id\":\"$SID\"}"
 
 # 2. 用 +replace-slide 直接改那个块（不需要搬原 XML）
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" \
+  --presentation "$PRES_ID" --slide-id "$SID" \
   --parts '[{"action":"block_replace","block_id":"bUn","replacement":"<shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>新标题</p></content></shape>"}]'
 ```
 
@@ -42,12 +42,12 @@ lark-cli slides +replace-slide --as user \
 ```bash
 # 读时拿当前 revision_id
 REV=$(lark-cli slides xml_presentation.slide get --as user \
-  --params "{\"xml_presentation_id\":\"$PID\",\"slide_id\":\"$SID\"}" \
+  --params "{\"xml_presentation_id\":\"$PRES_ID\",\"slide_id\":\"$SID\"}" \
   --jq '.data.revision_id')
 
 # 写时传该版本号，服务端以此为 base
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" --revision-id "$REV" \
+  --presentation "$PRES_ID" --slide-id "$SID" --revision-id "$REV" \
   --parts '[{"action":"block_replace","block_id":"bUn","replacement":"<shape type=\"rect\" topLeftX=\"100\" topLeftY=\"100\" width=\"200\" height=\"100\"/>"}]'
 ```
 
@@ -65,7 +65,7 @@ lark-cli slides +replace-slide --as user \
 
 ```bash
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" \
+  --presentation "$PRES_ID" --slide-id "$SID" \
   --parts '[{"action":"block_replace","block_id":"bab","replacement":"<shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>新标题</p></content></shape>"}]'
 ```
 
@@ -83,7 +83,7 @@ lark-cli slides +replace-slide --as user \
 
 ```bash
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" \
+  --presentation "$PRES_ID" --slide-id "$SID" \
   --parts "$(jq -n --arg token "$FILE_TOKEN" \
     '[{action:"block_insert",insertion:("<img src=\""+$token+"\" topLeftX=\"500\" topLeftY=\"100\" width=\"200\" height=\"150\"/>"),insert_before_block_id:"baa"}]')"
 ```
@@ -96,7 +96,7 @@ lark-cli slides +replace-slide --as user \
 | `insertion` | 是 | 要插入的完整 XML 片段 |
 | `insert_before_block_id` | 否 | 插到这个块之前；省略（不提供此字段）则追加到页面末尾 |
 
-> **`<img>` 必须用 `file_token`**，不能用外链 URL——先 `slides +media-upload --file ./pic.png --presentation $PID` 拿 token。
+> **`<img>` 必须用 `file_token`**，不能用外链 URL——先 `slides +media-upload --file ./pic.png --presentation $PRES_ID` 拿 token。
 
 ### 批量 parts
 
@@ -104,7 +104,7 @@ lark-cli slides +replace-slide --as user \
 
 ```bash
 lark-cli slides +replace-slide --as user \
-  --presentation "$PID" --slide-id "$SID" \
+  --presentation "$PRES_ID" --slide-id "$SID" \
   --parts '[{"action":"block_replace","block_id":"bab","replacement":"<shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>新标题</p></content></shape>"},{"action":"block_insert","insertion":"<img src=\"<file_token>\" topLeftX=\"700\" topLeftY=\"400\" width=\"180\" height=\"100\"/>"}]'
 ```
 
@@ -116,11 +116,11 @@ lark-cli slides +replace-slide --as user \
 
 ```bash
 # 从文件读
-lark-cli slides +replace-slide --as user --presentation "$PID" --slide-id "$SID" \
+lark-cli slides +replace-slide --as user --presentation "$PRES_ID" --slide-id "$SID" \
   --parts @parts.json
 
 # 从 stdin 读
-cat parts.json | lark-cli slides +replace-slide --as user --presentation "$PID" --slide-id "$SID" \
+cat parts.json | lark-cli slides +replace-slide --as user --presentation "$PRES_ID" --slide-id "$SID" \
   --parts -
 ```
 


### PR DESCRIPTION
## Summary

- Rename the `PID` shell variable to `PRES_ID` across Slides command examples.
- Align the examples with the existing presentation ID naming used by other Slides references.

## Why

PowerShell reserves `$PID` as a read-only automatic variable containing the current process ID. Using it for `xml_presentation_id` can cause copied or adapted examples to pass the wrong value.

This is a documentation-only change and does not alter CLI behavior.

## Testing

- `node scripts/skill-format-check/index.js`
- `make quality-gate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized presentation ID examples to use the consistent `$PRES_ID` variable across Lark Slides CLI and workflow documentation.
  * Updated command examples covering slide creation, deletion, replacement, media uploads, and XML presentation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->