### PR TITLE
fix(skills): scope markdown routing to Lark resources

### DIFF
--- a/skills/lark-markdown/SKILL.md
+++ b/skills/lark-markdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-markdown
 version: 1.2.2
-description: "飞书 Markdown：查看、创建、上传、编辑和比较 Markdown 文件。当用户需要创建或编辑 Markdown 文件、读取、修改、局部 patch 或比较差异时使用。不负责将 Markdown 导入为飞书在线文档，也不负责文件搜索、权限、评论、移动、删除等云空间管理操作。"
+description: "飞书 Markdown：查看、创建、上传、编辑和比较飞书中的原生 Markdown 文件。当用户要操作飞书 Markdown 文件，或比较其远端版本及本地草稿时使用。纯本地 Markdown 文件操作不触发本 skill。不负责将 Markdown 导入为飞书在线文档，也不负责文件搜索、权限、评论、移动、删除等云空间管理操作。"
 metadata:
   requires:
     bins: ["lark-cli"]


### PR DESCRIPTION
## Summary
Scope lark-markdown discovery to native Markdown resources in Lark, preventing pure local Markdown operations from incorrectly triggering the skill.

## Changes
- Remove the broad generic Markdown triggers from the frontmatter description.
- Explicitly exclude pure local Markdown operations from skill discovery.

## Test Plan
- [ ] Unit tests pass
- [ ] Manual local verification confirms the lark-cli flow works as expected
- [x] git diff --check passes
- [x] Final diff reviewed

Unit tests and CLI flows were not run because this is a routing guidance-only change and local execution was not requested.

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the skill handles native Markdown files within Feishu.
  * Specified that purely local Markdown file operations do not trigger the skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->