### PR TITLE
fix(docs): continue media downloads on permission scope errors

### DIFF
--- a/shortcuts/doc/doc_media_download.go
+++ b/shortcuts/doc/doc_media_download.go
@@ -12,9 +12,25 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+func docMediaDownloadIsPermissionAuthScopeError(err error) bool {
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryAuthorization {
+		return false
+	}
+	switch problem.Code {
+	case output.LarkErrAppScopeNotEnabled,
+		output.LarkErrTokenNoPermission,
+		output.LarkErrUserScopeInsufficient:
+		return true
+	default:
+		return false
+	}
+}
 
 var DocMediaDownload = common.Shortcut{
 	Service:           "docs",
@@ -50,12 +66,6 @@ var DocMediaDownload = common.Shortcut{
 			Desc("[2] (when --type=media) Download document media file").
 			Set("token", token).Set("output", outputPath)
 	},
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if runtime.Str("type") == "whiteboard" {
-			return nil
-		}
-		return runtime.EnsureScopes([]string{common.DrivePermissionMemberAuthScope})
-	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token := runtime.Str("token")
 		outputPath := runtime.Str("output")
@@ -71,9 +81,12 @@ var DocMediaDownload = common.Shortcut{
 		if mediaType != "whiteboard" {
 			allowed, err := common.CheckDriveFileExportPermission(runtime, token)
 			if err != nil {
-				return withDocMediaDownloadRecoveryHint(err, mediaType)
-			}
-			if !allowed {
+				if docMediaDownloadIsPermissionAuthScopeError(err) {
+					fmt.Fprintf(runtime.IO().ErrOut, "warning: export permission check failed; continuing with download: %v\n", err)
+				} else {
+					return withDocMediaDownloadRecoveryHint(err, mediaType)
+				}
+			} else if !allowed {
 				return docMediaDownloadPermissionDeniedError()
 			}
 		}

--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -688,6 +688,60 @@ func TestDocMediaDownloadDeclaresConditionalPermissionMemberAuthScope(t *testing
 	}
 }
 
+func TestDocMediaDownloadPermissionAuthScopeErrorsWarnAndContinue(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		msg  string
+	}{
+		{name: "app_scope_not_applied", code: 99991672, msg: "app scope not applied"},
+		{name: "token_scope_insufficient", code: 99991676, msg: "token scope insufficient"},
+		{name: "missing_scope", code: 99991679, msg: "missing scope"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, _, stderr, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-download-"+tt.name+"-app"))
+			f.Credential = credential.NewCredentialProvider(nil, nil, &docMediaScopedTokenResolver{scopes: "docs:document.media:download"}, nil)
+			token := "media_" + tt.name
+			reg.Register(&httpmock.Stub{
+				Method: http.MethodGet,
+				URL:    "/open-apis/drive/v1/permissions/" + token + "/members/auth",
+				Body: map[string]interface{}{
+					"code": tt.code,
+					"msg":  tt.msg,
+				},
+			})
+			reg.Register(&httpmock.Stub{
+				Method:  http.MethodGet,
+				URL:     "/open-apis/drive/v1/medias/" + token + "/download",
+				Status:  http.StatusOK,
+				RawBody: []byte("downloaded without permission auth scope"),
+				Headers: http.Header{"Content-Type": []string{"application/octet-stream"}},
+			})
+
+			tmpDir := t.TempDir()
+			withDocsWorkingDir(t, tmpDir)
+			err := mountAndRunDocs(t, DocMediaDownload, []string{
+				"+media-download",
+				"--token", token,
+				"--output", "downloaded.bin",
+				"--as", "bot",
+			}, f, nil)
+			if err != nil {
+				t.Fatalf("media download error = %v, want permission auth scope error %d to be non-blocking", err, tt.code)
+			}
+			if !strings.Contains(stderr.String(), "warning: export permission check failed; continuing with download:") {
+				t.Fatalf("stderr=%q, want permission scope warning", stderr.String())
+			}
+			data, readErr := os.ReadFile(filepath.Join(tmpDir, "downloaded.bin"))
+			if readErr != nil || string(data) != "downloaded without permission auth scope" {
+				t.Fatalf("downloaded content = %q, err=%v", string(data), readErr)
+			}
+		})
+	}
+}
+
 func TestDocWhiteboardDownloadHTTP403DoesNotSuggestMediaPreview(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-whiteboard-403-app"))
 	reg.Register(&httpmock.Stub{


### PR DESCRIPTION
## Summary
Allow `docs +media-download` to continue when the export-permission precheck fails only because the permission auth scope is unavailable, matching the behavior introduced for `drive +download` in #2494. Other precheck failures and explicit `auth_result=false` responses remain blocking.

## Changes
- Remove the unconditional local preflight for `docs:permission.member:auth` while retaining it as a conditional scope.
- Warn and continue only for Lark error codes `99991672`, `99991676`, and `99991679`.
- Add regression coverage for all three non-blocking scope errors and successful media download continuation.

## Test Plan
- [x] `go test ./shortcuts/doc -run '^(TestDocMediaDownload|TestDocWhiteboardDownload)' -count=1`
- [ ] Manual local verification confirms the `lark-cli docs +media-download` flow works as expected (not run; deterministic unit coverage exercises the API boundary)

## Related Issues
- Follow-up to #2494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media downloads now continue when permission checks encounter recognized authorization or scope-related errors.
  * Users receive a warning when downloads proceed despite these permission-check issues.
  * Downloads remain blocked when permissions are explicitly denied or another error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->