### PR TITLE
feat(drive): support appid in member-remove

### DIFF
--- a/shortcuts/drive/drive_member_remove.go
+++ b/shortcuts/drive/drive_member_remove.go
@@ -16,7 +16,7 @@ import (
 
 var driveMemberRemoveIDTypes = []string{
 	"email", "openid", "openchat", "opendepartmentid",
-	"userid", "unionid", "groupid", "wikispaceid",
+	"userid", "unionid", "groupid", "appid", "wikispaceid",
 }
 
 // DriveMemberRemove removes one collaborator/member permission from a Drive resource.
@@ -31,7 +31,7 @@ var DriveMemberRemove = common.Shortcut{
 		{Name: "token", Desc: "target token or document URL; type is auto-inferred from URL path when omitted", Required: true},
 		{Name: "type", Desc: "target resource type; required when --token is a bare token"},
 		{Name: "member-id", Desc: "single collaborator ID to remove; comma-separated values are rejected", Required: true},
-		{Name: "member-type", Desc: "ID type for --member-id; supported: email|openid|openchat|opendepartmentid|userid|unionid|groupid|wikispaceid", Required: true},
+		{Name: "member-type", Desc: "ID type for --member-id; supported: email|openid|openchat|opendepartmentid|userid|unionid|groupid|appid|wikispaceid", Required: true},
 		{Name: "member-kind", Desc: "request body type when --member-type=wikispaceid; one of wiki_space_member|wiki_space_viewer|wiki_space_editor"},
 		{Name: "perm-type", Desc: "wiki permission scope; defaults to container; rejected for non-wiki types and wiki-space members"},
 	},

--- a/shortcuts/drive/drive_member_remove_test.go
+++ b/shortcuts/drive/drive_member_remove_test.go
@@ -34,7 +34,7 @@ func TestDriveMemberRemoveMetadata(t *testing.T) {
 	}
 	wantIDTypes := []string{
 		"email", "openid", "openchat", "opendepartmentid",
-		"userid", "unionid", "groupid", "wikispaceid",
+		"userid", "unionid", "groupid", "appid", "wikispaceid",
 	}
 	if !reflect.DeepEqual(driveMemberRemoveIDTypes, wantIDTypes) {
 		t.Fatalf("member types = %#v, want %#v", driveMemberRemoveIDTypes, wantIDTypes)
@@ -240,12 +240,6 @@ func TestDriveMemberRemoveValidation(t *testing.T) {
 			wantText:  "implies --member-type openchat",
 		},
 		{
-			name:      "rejects app ID",
-			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "cli_app", "--member-type", "appid"},
-			wantParam: "--member-type",
-			wantText:  `invalid value "appid"`,
-		},
-		{
 			name:      "rejects wiki-space ID outside wiki",
 			args:      []string{"--token", "doxTok", "--type", "docx", "--member-id", "space_x", "--member-type", "wikispaceid", "--member-kind", "wiki_space_member"},
 			wantParam: "--member-type",
@@ -358,6 +352,45 @@ func TestDriveMemberRemoveAcceptsUserID(t *testing.T) {
 	}
 	if got.Data.API[0].Body["type"] != "user" {
 		t.Fatalf("body = %#v", got.Data.API[0].Body)
+	}
+}
+
+func TestDriveMemberRemoveAcceptsAppID(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveMemberRemove, []string{
+		"+member-remove",
+		"--token", "doxTok",
+		"--type", "docx",
+		"--member-id", "cli_app_123",
+		"--member-type", "appid",
+		"--dry-run",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got struct {
+		Data struct {
+			API []struct {
+				Params map[string]interface{} `json:"params"`
+				Body   map[string]interface{} `json:"body"`
+			} `json:"api"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode dry-run output: %v\n%s", err, stdout.String())
+	}
+	if len(got.Data.API) != 1 {
+		t.Fatalf("api count = %d, want 1", len(got.Data.API))
+	}
+	if got.Data.API[0].Params["member_type"] != "appid" {
+		t.Fatalf("params = %#v", got.Data.API[0].Params)
+	}
+	if _, ok := got.Data.API[0].Body["type"]; ok {
+		t.Fatalf("body = %#v, want type omitted for appid", got.Data.API[0].Body)
 	}
 }
 

--- a/skills/lark-drive/references/lark-drive-member-remove.md
+++ b/skills/lark-drive/references/lark-drive-member-remove.md
@@ -20,7 +20,7 @@ lark-cli drive +member-remove \
 | `--token` | 是 | 裸 token 或完整 URL。路径支持 `/drive/folder/`、`/docx/`、`/doc/`、`/sheets/`、`/base/`、`/bitable/`、`/wiki/`、`/file/`、`/mindnotes/`、`/slides/`、`/minutes/`、`/page/`；URL 可从路径推断类型，裸 token 必须同时传 `--type`。 |
 | `--type` | 条件必填 | 资源类型：`docx` / `doc` / `sheet` / `bitable` / `file` / `folder` / `wiki` / `mindnote` / `slides` / `minutes` / `apps`。完整 URL 可省略。 |
 | `--member-id` | 是 | 要移除的单个协作者 ID。逗号分隔的多成员输入会被拒绝；批量场景应逐个调用。 |
-| `--member-type` | 是 | ID 类型：`email` / `openid` / `openchat` / `opendepartmentid` / `userid` / `unionid` / `groupid` / `wikispaceid`。 |
+| `--member-type` | 是 | ID 类型：`email` / `openid` / `openchat` / `opendepartmentid` / `userid` / `unionid` / `groupid` / `appid` / `wikispaceid`。 |
 | `--member-kind` | 条件必填 | 仅 `--member-type=wikispaceid` 使用：未启用知识库成员分组时传 `wiki_space_member`，启用后根据权限传 `wiki_space_viewer` 或 `wiki_space_editor`。 |
 | `--perm-type` | 否 | 仅 wiki 协作者使用：`container`（默认，当前页面及子页面）或 `single_page`（仅当前页面）。 |
 | `--dry-run` | 否 | 只预览 DELETE URL、query 和 body，不调用接口。 |
@@ -52,6 +52,7 @@ Wiki 普通协作者还会返回 `perm_type`；`wikispaceid` 返回所传的 `me
 ## 行为说明
 
 - **身份支持**：支持 `--as user` 和 `--as bot`。
+- **应用协作者**：使用 `--member-type=appid`，`--member-id` 传应用 ID（通常为 `cli_xxx`）。
 - **部门协作者**：`--member-type=opendepartmentid` 只能配合 `--as user`；bot 身份会在客户端提前拒绝。
 - **安全编码**：资源 token 和 member ID 都作为独立 path segment 编码。
 - **Wiki 范围**：普通 wiki 协作者默认删除 `container` 权限；只删除当前页面权限时显式传 `single_page`。

--- a/tests/cli_e2e/drive/drive_member_remove_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_member_remove_dryrun_test.go
@@ -57,6 +57,20 @@ func TestDrive_MemberRemoveDryRun(t *testing.T) {
 			wantMemberKind:   "user",
 		},
 		{
+			name: "app ID is accepted",
+			args: []string{
+				"drive", "+member-remove",
+				"--token", "doxcnRemoveAppID",
+				"--type", "docx",
+				"--member-id", "cli_app_123",
+				"--member-type", "appid",
+				"--dry-run",
+			},
+			wantURL:          "/open-apis/drive/v1/permissions/doxcnRemoveAppID/members/cli_app_123",
+			wantResourceType: "docx",
+			wantMemberType:   "appid",
+		},
+		{
 			name: "ordinary wiki member defaults container scope",
 			args: []string{
 				"drive", "+member-remove",
@@ -204,11 +218,6 @@ func TestDrive_MemberRemoveDryRunRejectsInvalidInputs(t *testing.T) {
 			name:    "wiki-space ID requires member kind",
 			args:    []string{"drive", "+member-remove", "--token", "wikcnRemove", "--type", "wiki", "--member-id", "space_member", "--member-type", "wikispaceid", "--dry-run"},
 			wantErr: "--member-kind is required",
-		},
-		{
-			name:    "app ID is rejected",
-			args:    []string{"drive", "+member-remove", "--token", "doxcnRemove", "--type", "docx", "--member-id", "cli_app", "--member-type", "appid", "--dry-run"},
-			wantErr: "allowed: email, openid, openchat, opendepartmentid, userid, unionid, groupid, wikispaceid",
 		},
 		{
 			name:    "wiki-space ID is rejected outside wiki",


### PR DESCRIPTION
## Summary

Add `appid` support to `drive +member-remove`, allowing application collaborators to be removed using `--member-type appid`.

## Changes

- Add `appid` to the accepted `--member-type` values for `drive +member-remove`.
- Preserve the expected DELETE request shape: `member_type=appid` is sent in the query without an extra body `type`.
- Add unit and CLI dry-run E2E regression coverage.
- Update the command reference documentation.

## Test Plan

- [x] Unit tests pass
- [x] Manual local verification confirms the `lark-cli drive +member-remove` flow works as expected
- [x] `gofmt` reports no formatting changes
- [x] `git diff --check` passes

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for removing application collaborators from Drive resources using application IDs (`appid`).
  * Dry-run mode now validates application collaborator removal and uses the correct member type.
* **Documentation**
  * Updated Drive member removal guidance with the new `appid` option and application ID format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->