### PR TITLE
feat: expose reply-to message id in mail reads

### DIFF
--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -145,6 +145,7 @@ func printMessageOutputSchema(runtime *common.RuntimeContext) {
 		"_description": "Output field reference for mail +message / +messages / +thread",
 		"fields": map[string]string{
 			"message_id":                             "Email message ID",
+			"reply_to_message_id":                    "Message ID of the email this message replies to; omitted when not returned by the server",
 			"thread_id":                              "Thread ID",
 			"subject":                                "Email subject",
 			"head_from":                              "Sender object: {mail_address, name}",
@@ -1181,6 +1182,7 @@ type mailSecurityLevelOutput struct {
 // It is not the public JSON contract of `mail +message` / `mail +thread`.
 type normalizedMessageForCompose struct {
 	MessageID            string                   `json:"message_id"`
+	ReplyToMessageID     string                   `json:"reply_to_message_id,omitempty"`
 	ThreadID             string                   `json:"thread_id"`
 	SMTPMessageID        string                   `json:"smtp_message_id"`
 	Subject              string                   `json:"subject"`
@@ -1315,7 +1317,8 @@ func fetchAttachmentURLsWith(
 // auto-passed through to the public output because they are replaced by a
 // derived public shape (see buildPublicAttachments / derivedMessageFields).
 var rawMessageExcludedFields = map[string]struct{}{
-	"attachments": {},
+	"attachments":         {},
+	"reply_to_message_id": {},
 }
 
 // derivedMessageFields names the public output keys that are synthesized
@@ -1323,6 +1326,7 @@ var rawMessageExcludedFields = map[string]struct{}{
 // shouldExposeRawMessageField and by the output schema printed for agents.
 var derivedMessageFields = []string{
 	"draft_id",
+	"reply_to_message_id",
 	"body_plain_text",
 	"body_preview",
 	"body_html",
@@ -1349,6 +1353,9 @@ func buildMessageOutput(msg map[string]interface{}, html bool) map[string]interf
 
 	if draftID := derivedDraftID(msg, normalized.MessageID); draftID != "" {
 		out["draft_id"] = draftID
+	}
+	if normalized.ReplyToMessageID != "" {
+		out["reply_to_message_id"] = normalized.ReplyToMessageID
 	}
 	if normalized.ReplyTo != "" {
 		out["reply_to"] = normalized.ReplyTo
@@ -1423,17 +1430,18 @@ func derivedDraftID(msg map[string]interface{}, messageID string) string {
 //   - sanitizes body_plain_text for terminal output (strips ANSI escapes and bare CR)
 func buildMessageForCompose(msg map[string]interface{}, urlMap map[string]string, html bool) normalizedMessageForCompose {
 	out := normalizedMessageForCompose{
-		MessageID:     strVal(msg["message_id"]),
-		ThreadID:      strVal(msg["thread_id"]),
-		SMTPMessageID: strVal(msg["smtp_message_id"]),
-		Subject:       strVal(msg["subject"]),
-		From:          toAddressObject(msg["head_from"]),
-		To:            toAddressList(msg["to"]),
-		CC:            toAddressList(msg["cc"]),
-		BCC:           toAddressList(msg["bcc"]),
-		Date:          strVal(msg["date"]),
-		InReplyTo:     strVal(msg["in_reply_to"]),
-		References:    toStringList(msg["references"]),
+		MessageID:        strVal(msg["message_id"]),
+		ReplyToMessageID: strVal(msg["reply_to_message_id"]),
+		ThreadID:         strVal(msg["thread_id"]),
+		SMTPMessageID:    strVal(msg["smtp_message_id"]),
+		Subject:          strVal(msg["subject"]),
+		From:             toAddressObject(msg["head_from"]),
+		To:               toAddressList(msg["to"]),
+		CC:               toAddressList(msg["cc"]),
+		BCC:              toAddressList(msg["bcc"]),
+		Date:             strVal(msg["date"]),
+		InReplyTo:        strVal(msg["in_reply_to"]),
+		References:       toStringList(msg["references"]),
 	}
 	out.ReplyTo = strVal(msg["reply_to"])
 	out.ReplyToSMTPMessageID = strVal(msg["reply_to_smtp_message_id"])

--- a/shortcuts/mail/helpers_test.go
+++ b/shortcuts/mail/helpers_test.go
@@ -455,7 +455,7 @@ func TestPrintMessageOutputSchema(t *testing.T) {
 	out := stdout.String()
 	// Verify key fields from the schema are present
 	for _, key := range []string{
-		"body_plain_text", "body_html", "attachments", "head_from",
+		"body_plain_text", "body_html", "attachments", "head_from", "reply_to_message_id",
 		"bcc", "date", "smtp_message_id", "in_reply_to", "references",
 		"internal_date", "message_state", "message_state_text",
 		"folder_id", "label_ids", "priority_type", "priority_type_text",
@@ -1187,6 +1187,34 @@ func TestParsePriority(t *testing.T) {
 				t.Errorf("parsePriority(%q) = %q, want %q", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestBuildMessageOutput_ReplyToMessageID verifies build message output preserves reply_to_message_id.
+func TestBuildMessageOutput_ReplyToMessageID(t *testing.T) {
+	out := buildMessageOutput(map[string]interface{}{
+		"message_id":           "m1",
+		"reply_to_message_id":  "parent-message-id",
+		"reply_to":             "reply-to@example.com",
+		"body_plain_text":      base64.RawURLEncoding.EncodeToString([]byte("body")),
+		"non_string_extension": 123,
+	}, false)
+	if got := out["reply_to_message_id"]; got != "parent-message-id" {
+		t.Fatalf("reply_to_message_id = %v, want parent-message-id", got)
+	}
+	if got := out["reply_to"]; got != "reply-to@example.com" {
+		t.Fatalf("reply_to = %v, want reply-to@example.com", got)
+	}
+}
+
+// TestBuildMessageOutput_ReplyToMessageIDOmittedWhenEmpty verifies empty reply_to_message_id is omitted.
+func TestBuildMessageOutput_ReplyToMessageIDOmittedWhenEmpty(t *testing.T) {
+	out := buildMessageOutput(map[string]interface{}{
+		"message_id":          "m1",
+		"reply_to_message_id": "",
+	}, false)
+	if _, ok := out["reply_to_message_id"]; ok {
+		t.Fatalf("reply_to_message_id should be omitted when empty: %#v", out)
 	}
 }
 

--- a/shortcuts/mail/mail_messages_test.go
+++ b/shortcuts/mail/mail_messages_test.go
@@ -25,13 +25,13 @@ func TestMailMessagesExecuteChunksMoreThanTwentyIDs(t *testing.T) {
 		Method:     "POST",
 		URL:        "/user_mailboxes/me/messages/batch_get",
 		BodyFilter: requestMessageIDsEqual(ids[:20]),
-		Body:       batchGetMessagesResponse(ids[:20]),
+		Body:       batchGetMessagesResponse(ids[:20], true),
 	})
 	reg.Register(&httpmock.Stub{
 		Method:     "POST",
 		URL:        "/user_mailboxes/me/messages/batch_get",
 		BodyFilter: requestMessageIDsEqual(ids[20:]),
-		Body:       batchGetMessagesResponse(ids[20:]),
+		Body:       batchGetMessagesResponse(ids[20:], false),
 	})
 
 	err := runMountedMailShortcut(t, MailMessages, []string{
@@ -60,6 +60,13 @@ func TestMailMessagesExecuteChunksMoreThanTwentyIDs(t *testing.T) {
 		if got := msg["message_id"]; got != ids[i] {
 			t.Fatalf("messages[%d].message_id = %v, want %s", i, got, ids[i])
 		}
+		if i == 0 {
+			if got := msg["reply_to_message_id"]; got != "parent-"+ids[i] {
+				t.Fatalf("messages[%d].reply_to_message_id = %v, want %s", i, got, "parent-"+ids[i])
+			}
+		} else if _, ok := msg["reply_to_message_id"]; ok {
+			t.Fatalf("messages[%d].reply_to_message_id should be omitted when absent", i)
+		}
 	}
 }
 
@@ -75,13 +82,17 @@ func requestMessageIDsEqual(want []string) func([]byte) bool {
 	}
 }
 
-func batchGetMessagesResponse(ids []string) map[string]interface{} {
+func batchGetMessagesResponse(ids []string, includeReplyToMessageID bool) map[string]interface{} {
 	messages := make([]map[string]interface{}, 0, len(ids))
 	for _, id := range ids {
-		messages = append(messages, map[string]interface{}{
+		message := map[string]interface{}{
 			"message_id": id,
 			"subject":    id,
-		})
+		}
+		if includeReplyToMessageID && len(messages) == 0 {
+			message["reply_to_message_id"] = "parent-" + id
+		}
+		messages = append(messages, message)
 	}
 	return map[string]interface{}{
 		"code": 0,

--- a/shortcuts/mail/mail_read_help_test.go
+++ b/shortcuts/mail/mail_read_help_test.go
@@ -89,6 +89,38 @@ func TestMailMessagesDryRunMentionsBatchGetChunkingAndMerge(t *testing.T) {
 	}
 }
 
+func TestMailMessageExecuteIncludesReplyToMessageID(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	messageID := validMessageIDForTest("reply-child")
+	replyToMessageID := validMessageIDForTest("reply-parent")
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/messages/" + messageID,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"message": map[string]interface{}{
+					"message_id":          messageID,
+					"reply_to_message_id": replyToMessageID,
+					"subject":             "reply",
+				},
+			},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailMessage, []string{
+		"+message", "--message-id", messageID, "--html=false",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("message returned error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if got := data["reply_to_message_id"]; got != replyToMessageID {
+		t.Fatalf("reply_to_message_id = %v, want %s", got, replyToMessageID)
+	}
+}
+
 func TestMailTriageTableHintRoutesSingleAndMultipleReads(t *testing.T) {
 	f, stdout, stderr, reg := mailShortcutTestFactory(t)
 	registerTriageReadHintStubs(reg)

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 ## 核心概念
 
-- **邮件（Message）**：一封具体的邮件，包含发件人、收件人、主题、正文（纯文本/HTML）、附件。每封邮件有唯一 `message_id`。
+- **邮件（Message）**：一封具体的邮件，包含发件人、收件人、主题、正文（纯文本/HTML）、附件。每封邮件有唯一 `message_id`；回复邮件在服务端返回时还会带 `reply_to_message_id`，表示被回复原邮件的邮件 ID。
 - **会话（Thread）**：同一主题的邮件链，包含原始邮件和所有回复/转发。通过 `thread_id` 关联。
 - **草稿（Draft）**：未发送的邮件。所有发送类命令默认保存为草稿，加 `--confirm-send` 才实际发送。
 - **文件夹（Folder）**：邮件的组织容器。内置文件夹：`INBOX`、`SENT`、`DRAFT`、`SCHEDULED`、`TRASH`、`SPAM`、`ARCHIVED`，也可自定义。

--- a/skills/lark-mail/references/lark-mail-message.md
+++ b/skills/lark-mail/references/lark-mail-message.md
@@ -49,6 +49,7 @@ lark-cli mail +message --message-id <message-id> --dry-run
 ```json
 {
   "message_id":               "邮件 ID",
+  "reply_to_message_id":      "被回复原邮件的邮件 ID",
   "thread_id":                "会话 ID",
   "smtp_message_id":          "RFC 2822 Message-ID",
   "subject":                  "邮件主题",
@@ -107,6 +108,7 @@ lark-cli mail +message --message-id <message-id> --dry-run
 | 字段 | 说明 |
 |------|------|
 | `message_id` | 邮件 ID |
+| `reply_to_message_id` | 当前邮件回复的原邮件 ID。服务端未返回或当前邮件不是回复时省略 |
 | `thread_id` | 会话 ID |
 | `subject` | 邮件主题 |
 | `head_from` | 发件人对象：`{mail_address, name}` |

--- a/skills/lark-mail/references/lark-mail-messages.md
+++ b/skills/lark-mail/references/lark-mail-messages.md
@@ -7,6 +7,7 @@
 超过 20 个 ID 可以直接传入 CLI；CLI 会按 20 个 ID 自动拆批并合并输出，不需要手动拆批，也不要逐封循环调用 `+message`。
 
 本 shortcut 是 `mail +message` 的批量版本。每个返回的 `messages[]` 项使用与 `+message` 相同的归一化结构：安全元数据字段直接透传，正文和辅助字段由 shortcut 派生。
+当服务端返回 `reply_to_message_id` 时，每个 `messages[]` 项会保留该字段；服务端未返回或字段为空时省略。
 
 优先使用本 shortcut，因为：
 - 正文字段已 base64url 解码


### PR DESCRIPTION
## Summary\n- expose reply_to_message_id in mail +message/+messages normalized output\n- add tests for message output schemas and normalized compose payloads\n- update lark-mail skill references for the new response field\n\n## Test\n- go test ./shortcuts/mail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mail message outputs now include `reply_to_message_id` when available, identifying the original message in a reply thread.
  * The field is omitted when unavailable or empty.

* **Documentation**
  * Updated mail message schemas, examples, and references to describe the new field and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->