### PR TITLE
feat(sheets): relax local-office token length check from 28 to >=25

### DIFF
--- a/shortcuts/sheets/backward/lark_sheets_float_images.go
+++ b/shortcuts/sheets/backward/lark_sheets_float_images.go
@@ -38,7 +38,7 @@ func isOfficeSpreadsheet(spreadsheetToken string) bool {
 			return true
 		}
 	}
-	if len(spreadsheetToken) != 28 {
+	if len(spreadsheetToken) < 25 {
 		return false
 	}
 	// The five-character marker occupies positions 5, 10, 15, 20, and 25

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -73,7 +73,7 @@ func isOfficeSpreadsheet(spreadsheetToken string) bool {
 			return true
 		}
 	}
-	if len(spreadsheetToken) != 28 {
+	if len(spreadsheetToken) < 25 {
 		return false
 	}
 	// The five-character marker occupies positions 5, 10, 15, 20, and 25

--- a/shortcuts/sheets/sheet_media_parent_type_test.go
+++ b/shortcuts/sheets/sheet_media_parent_type_test.go
@@ -46,8 +46,11 @@ func TestSheetMediaParentType(t *testing.T) {
 		{"interleaved shtcn native token", "abcdsefghhijkltmnopcqrstnuv", sheetImageParentType},
 		{"interleaved pptcn token", "abcdpefghpijkltmnopcqrstnuv", sheetImageParentType},
 		{"interleaved wodcn token", "abcdwefghoijkldmnopcqrstnuv", sheetImageParentType},
-		{"interleaved OFL0X marker with short length", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", sheetImageParentType},
-		{"interleaved OFL0X marker with long length", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", sheetImageParentType},
+		{"interleaved OFL0X marker with short length (25 char, at boundary)", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", officeSheetFileParentType},
+		{"interleaved OFL0X marker with long length (29 char)", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", officeSheetFileParentType},
+		{"new 27-char OFL0X excel token", "bbbbObbbbFbbbbLbbbb0bbbbXbbE", officeSheetFileParentType},
+		{"new 27-char OFL0X ppt token", "ccccOccccFccccLcccc0ccccXccP", officeSheetFileParentType},
+		{"new 27-char OFL0X word token", "ddddOddddFddddLdddd0ddddXddW", officeSheetFileParentType},
 		{"fake_office prefix mid-string is not matched", "shtfake_office_abc", sheetImageParentType},
 		{"local_office prefix mid-string is not matched", "shtlocal_office_abc", sheetImageParentType},
 	}


### PR DESCRIPTION
## Summary

The local-office token format is changing from 28 to 27 characters per the new product rule (`OFL0X` + 21 random + 1 office type enum). This PR relaxes the guard from `len != 28` to `len < 25` so 27-char tokens can reach the `OFL0X` interleaved marker check.

## Changes

- `shortcuts/sheets/helpers.go`: `len != 28` → `len < 25`
- `shortcuts/sheets/backward/lark_sheets_float_images.go`: same
- `shortcuts/sheets/sheet_media_parent_type_test.go`: add test cases for 27-char tokens and 25-char boundary

## Backward compatibility

All legacy detection paths are preserved:
- `fake_office_` prefix
- `local_office_` prefix
- `OFL0X` interleaved marker extraction

Ref: https://bytedance.larkoffice.com/wiki/KvLqwjiJMiwICukfVeKcz3LTnNf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of office spreadsheet files with valid token lengths, including shorter and longer formats.
  * Correctly identifies supported Excel, PowerPoint, and Word files as office documents instead of sheet images.
  * Preserves detection of interleaved office-file markers across supported token formats.

* **Tests**
  * Expanded coverage for short, long, and 27-character office-file token formats.
  * Added validation for Excel, PowerPoint, and Word file classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->