### PR TITLE
Validate generated API parameter constraints

### DIFF
--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -244,9 +244,13 @@ lark-cli mail <resource> <method> --params '{...}' [--data '{...}']
 **GET — 只有 `--params`**（`parameters` 中有 path + query，无 `requestBody`）：
 
 ```bash
-# schema 中：user_mailbox_id (path, required), page_size (query, required), folder_id (query, optional)
-lark-cli mail user_mailbox.messages list \
+# schema 中：user_mailbox_id (path, required), page_size (query, required)
+# user_mailbox.threads.list 要求 folder_id / label_id 必须且只能提供一个
+lark-cli mail user_mailbox.threads list \
   --params '{"user_mailbox_id":"me","page_size":20,"folder_id":"INBOX"}'
+
+lark-cli mail user_mailbox.threads list \
+  --params '{"user_mailbox_id":"me","page_size":20,"label_id":"FLAGGED"}'
 ```
 
 **POST — `--params` + `--data`**（`parameters` 中有 path，`requestBody` 有 body 字段）：


### PR DESCRIPTION
Validate generated API parameter constraints before sending requests.

This change adds support for exactly-one parameter groups in the generated request path, updates the embedded command metadata, and documents valid usage for listing mail threads by either folder or label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer method help describing parameter constraints and recovery guidance.
  * Added validation for mutually exclusive mail thread filters: `folder_id` and `label_id`.
  * Validation errors now identify the relevant schema path and how to resolve the issue.
  * Mail thread listing examples now include separate folder and label filter usage.

* **Bug Fixes**
  * Improved handling of blank or duplicate constraint fields.
  * Prevented requests when neither or both mutually exclusive filters are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->