### PR TITLE
feat(im): support rich-text message attachment zone in send/reply/mge…

### DIFF
--- a/affordance/im.md
+++ b/affordance/im.md
@@ -110,10 +110,19 @@ lark-cli im +message-read-users --message-id om_xxx
 - `lark-im/references/lark-im-message-read-status.md`
 
 ## +messages-edit
-Use this to rewrite an already-sent message's content, including its attachment zone (files attached to a post message).
+Use this to edit an already-sent **text or rich-text (post)** message, including its attachment zone.
+
+### Avoid when
+- Editing an interactive card → use [[messages patch]].
+- Sending a corrected message as a new message → use [[+messages-send]].
 
 ### Prerequisites
-- Confirm the target message id, the new content, and that the calling identity is the original sender before editing.
+- Confirm the target message id, the new content, and that the calling identity (bot) is the original sender before editing.
+
+### Tips
+- Omit attachment flags to preserve the current attachment zone.
+- `--set-attachments` replaces the attachment set; `--clear-attachments` removes it.
+- `--content` that already carries a `files` array cannot be combined with the attachment flags.
 
 ### Examples
 

--- a/affordance/im.md
+++ b/affordance/im.md
@@ -109,6 +109,22 @@ lark-cli im +message-read-users --message-id om_xxx
 ### Skills
 - `lark-im/references/lark-im-message-read-status.md`
 
+## +messages-edit
+Use this to rewrite an already-sent message's content, including its attachment zone (files attached to a post message).
+
+### Prerequisites
+- Confirm the target message id, the new content, and that the calling identity is the original sender before editing.
+
+### Examples
+
+**Edit a message to a post with an attachment zone**
+```bash
+lark-cli im +messages-edit --as bot --message-id om_xxx --markdown "Updated content" --set-attachments file_xxx
+```
+
+### Skills
+- `lark-im/references/lark-im-messages-edit.md`
+
 ## +messages-mget
 Use this when one or more message_ids are already known and full message details are needed.
 

--- a/internal/affordance/im_source_test.go
+++ b/internal/affordance/im_source_test.go
@@ -31,6 +31,7 @@ var imAffordanceExamples = []imAffordanceExample{
 	{method: "+chat-update", command: `lark-cli im +chat-update --chat-id oc_xxx --name "New Group Name"`, source: "lark-im/references/lark-im-chat-update.md"},
 	{method: "+message-read-users", command: "lark-cli im +message-read-users --message-id om_xxx", source: "lark-im/references/lark-im-message-read-status.md"},
 	{method: "+messages-mget", command: "lark-cli im +messages-mget --message-ids om_xxx", source: "lark-im/references/lark-im-messages-mget.md"},
+	{method: "+messages-edit", command: "lark-cli im +messages-edit --as bot --message-id om_xxx --markdown \"Updated content\" --set-attachments file_xxx", source: "lark-im/references/lark-im-messages-edit.md"},
 	{
 		method:        "+messages-read-status",
 		command:       "lark-cli im +messages-read-status --as user --message-ids om_xxx,om_yyy",
@@ -77,6 +78,7 @@ var imAffordanceExamples = []imAffordanceExample{
 	},
 }
 
+// TestIMAffordanceExamplesTraceToCurrentSkill verifies affordance examples resolve to current shortcuts.
 func TestIMAffordanceExamplesTraceToCurrentSkill(t *testing.T) {
 	prev := mdSource
 	t.Cleanup(func() { SetSource(prev) })
@@ -85,7 +87,7 @@ func TestIMAffordanceExamplesTraceToCurrentSkill(t *testing.T) {
 	if got, ok := DomainSkill("im"); !ok || got != "lark-im" {
 		t.Fatalf("DomainSkill(im) = (%q, %v), want (lark-im, true)", got, ok)
 	}
-	if got, want := len(imAffordanceExamples), 35; got != want {
+	if got, want := len(imAffordanceExamples), 36; got != want {
 		t.Fatalf("audited IM example count = %d, want %d", got, want)
 	}
 	affordanceSource, err := os.ReadFile("../../affordance/im.md")
@@ -104,8 +106,8 @@ func TestIMAffordanceExamplesTraceToCurrentSkill(t *testing.T) {
 			shortcutCount++
 		}
 	}
-	if shortcutCount != 23 || len(imAffordanceExamples)-shortcutCount != 12 {
-		t.Fatalf("audited split = %d shortcuts / %d raw, want 23 / 12", shortcutCount, len(imAffordanceExamples)-shortcutCount)
+	if shortcutCount != 24 || len(imAffordanceExamples)-shortcutCount != 12 {
+		t.Fatalf("audited split = %d shortcuts / %d raw, want 24 / 12", shortcutCount, len(imAffordanceExamples)-shortcutCount)
 	}
 	for method := range parsedDomain.methods {
 		if !audited[method] {

--- a/shortcuts/im/affordance_migration_test.go
+++ b/shortcuts/im/affordance_migration_test.go
@@ -20,12 +20,13 @@ var imFrameworkFlags = map[string]bool{
 	"--as": true, "--dry-run": true, "--format": true, "--json": true, "--jq": true, "--yes": true,
 }
 
+// TestAllIMShortcutsUseAffordanceExamples verifies every IM shortcut has an affordance example.
 func TestAllIMShortcutsUseAffordanceExamples(t *testing.T) {
 	affordance.SetSource(os.DirFS("../../affordance"))
 	t.Cleanup(func() { affordance.SetSource(nil) })
 
 	shortcuts := Shortcuts()
-	if got, want := len(shortcuts), 23; got != want {
+	if got, want := len(shortcuts), 24; got != want {
 		t.Fatalf("registered IM shortcuts = %d, want audited count %d", got, want)
 	}
 

--- a/shortcuts/im/convert_lib/merge_test.go
+++ b/shortcuts/im/convert_lib/merge_test.go
@@ -51,6 +51,7 @@ func TestMergeForwardHelpers(t *testing.T) {
 	}
 }
 
+// TestMergeForwardConverterFallback covers merge-forward conversion fallbacks.
 func TestMergeForwardConverterFallback(t *testing.T) {
 	if got := (mergeForwardConverter{}).Convert(&ConvertContext{RawContent: `{"create_message_ids":["om_1","om_2"]}`}); got != "[Merged forward: 2 messages]" {
 		t.Fatalf("mergeForwardConverter.Convert(ids) = %q", got)
@@ -59,6 +60,38 @@ func TestMergeForwardConverterFallback(t *testing.T) {
 		t.Fatalf("mergeForwardConverter.Convert(default) = %q", got)
 	}
 }
+
+// TestFormatMergeForwardSubTreePostAttachmentZone verifies that a post
+// sub-message inside a merge_forward renders its attachment zone (<file> /
+// <folder> lines) through ConvertBodyContent's postConverter.
+func TestFormatMergeForwardSubTreePostAttachmentZone(t *testing.T) {
+	items := []map[string]interface{}{
+		{"message_id": "root", "create_time": "1710500000000"},
+		{
+			"message_id":       "child1",
+			"upper_message_id": "",
+			"create_time":      "1710500100000",
+			"msg_type":         "post",
+			"sender":           map[string]interface{}{"name": "Alice"},
+			"body":             map[string]interface{}{"content": `{"zh_cn":{"title":"Docs","content":[[{"tag":"text","text":"see below"}]]},"files":[{"file_key":"file_a","file_name":"report.pdf"},{"file_key":"file_b","file_name":"assets","is_folder":true}]}`},
+		},
+	}
+	children := BuildMergeForwardChildrenMap(items, "root")
+	got := FormatMergeForwardSubTree("root", children)
+	for _, want := range []string{
+		"<forwarded_messages>",
+		"Alice:",
+		"see below",
+		`<file key="file_a" name="report.pdf"/>`,
+		`<folder key="file_b" name="assets"/>`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("FormatMergeForwardSubTree() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestFetchMergeForwardSubMessages covers fetching merge-forward sub-messages.
 
 func TestFetchMergeForwardSubMessages(t *testing.T) {
 	t.Run("success", func(t *testing.T) {

--- a/shortcuts/im/convert_lib/resource_extract.go
+++ b/shortcuts/im/convert_lib/resource_extract.go
@@ -3,9 +3,11 @@
 
 package convertlib
 
-// ResourceRef is a downloadable resource reference extracted from a message
-// during formatting. Type is the download API resource type ("image" or
-// "file"); MessageID is the message id used as the download API path parameter.
+// ResourceRef is a resource reference for the --download-resources worklist:
+// the single-file resources to fetch from a message (image_key of images,
+// file_key of files/media, and attachment-zone files). Type is the download API
+// resource type ("image" or "file"); MessageID is the message id used as the
+// download API path parameter.
 // For a standalone message that is the message's own id; for a resource carried
 // inside a merge_forward it is the TOP-LEVEL container's id, because the
 // download API addresses forwarded resources by the container, not the sub-item
@@ -60,18 +62,43 @@ func extractResourceRefs(msgType, rawContent, messageID string, mergeSub map[str
 }
 
 // extractPostResourceRefs walks a post body's elements and collects img/media
-// resource refs.
+// resource refs, plus any attachment-zone file keys (top-level "files" array;
+// folder entries, is_folder=true, are excluded — see the inline comment).
+//
+// The rawContent is the message API's post content as returned by get/mget/
+// list, whose attachment zone arrives in the packed response format:
+//
+//	{"zh_cn":{...},"files":[{"file_key":"file_xxx","file_name":"a.txt"}]}
 func extractPostResourceRefs(rawContent, messageID string) []ResourceRef {
 	parsed, err := ParseJSONObject(rawContent)
 	if err != nil || parsed == nil {
 		return nil
 	}
+	var refs []ResourceRef
+	// Attachment zone: top-level files[] each carry a file_key. Only files enter
+	// the download worklist — folders (is_folder=true) are not single-file
+	// resources, and GET /messages/:id/resources/:file_key cannot return one, so
+	// fetching one would only fail. Folders are not hidden from the output:
+	// renderPostAttachments surfaces them as <folder key="..." name="..."/>.
+	if rawFiles, ok := parsed["files"].([]interface{}); ok {
+		for _, raw := range rawFiles {
+			f, _ := raw.(map[string]interface{})
+			if f == nil {
+				continue
+			}
+			if isFolder, _ := f["is_folder"].(bool); isFolder {
+				continue
+			}
+			if key, _ := f["file_key"].(string); key != "" {
+				refs = append(refs, ResourceRef{MessageID: messageID, Key: key, Type: "file"})
+			}
+		}
+	}
 	body := unwrapPostLocale(parsed)
 	if body == nil {
-		return nil
+		return refs
 	}
 	blocks, _ := body["content"].([]interface{})
-	var refs []ResourceRef
 	for _, para := range blocks {
 		elems, _ := para.([]interface{})
 		for _, el := range elems {

--- a/shortcuts/im/convert_lib/resource_extract_test.go
+++ b/shortcuts/im/convert_lib/resource_extract_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 )
 
+// TestExtractResourceRefs covers resource extraction across message types including post attachment zones.
 func TestExtractResourceRefs(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -32,6 +33,36 @@ func TestExtractResourceRefs(t *testing.T) {
 			raw:       `{"zh_cn":{"content":[[{"tag":"img","image_key":"post_img"},{"tag":"text","text":"x"}],[{"tag":"media","file_key":"post_media"}]]}}`,
 			messageID: "om_11",
 			want:      []ResourceRef{{MessageID: "om_11", Key: "post_img", Type: "image"}, {MessageID: "om_11", Key: "post_media", Type: "file"}},
+		},
+		{
+			name:      "post attachment zone files extracted (response format), folders skipped",
+			msgType:   "post",
+			raw:       `{"zh_cn":{"content":[[{"tag":"text","text":"hi"}]]},"files":[{"file_key":"file_a","file_name":"a.txt"},{"file_key":"file_b","file_name":"folder","is_folder":true}]}`,
+			messageID: "om_12",
+			want: []ResourceRef{
+				{MessageID: "om_12", Key: "file_a", Type: "file"},
+			},
+		},
+		{
+			name:      "post attachment zone folder-only not extracted",
+			msgType:   "post",
+			raw:       `{"zh_cn":{"content":[[{"tag":"text","text":"hi"}]]},"files":[{"file_key":"file_c","file_name":"assets","is_folder":true}]}`,
+			messageID: "om_14",
+			want:      nil,
+		},
+		{
+			name:      "post attachment with empty key skipped",
+			msgType:   "post",
+			raw:       `{"zh_cn":{"content":[]},"files":[{"file_name":"no key"}]}`,
+			messageID: "om_13",
+			want:      nil,
+		},
+		{
+			name:      "post attachment zone extracted without a post body (files only)",
+			msgType:   "post",
+			raw:       `{"files":[{"file_key":"file_d"}]}`,
+			messageID: "om_15",
+			want:      []ResourceRef{{MessageID: "om_15", Key: "file_d", Type: "file"}},
 		},
 	}
 

--- a/shortcuts/im/convert_lib/text.go
+++ b/shortcuts/im/convert_lib/text.go
@@ -11,6 +11,7 @@ import (
 
 type textConverter struct{}
 
+// textConverter converts a text message raw content into a human-readable line.
 func (textConverter) Convert(ctx *ConvertContext) string {
 	parsed, err := ParseJSONObject(ctx.RawContent)
 	if err != nil {
@@ -25,37 +26,87 @@ func (textConverter) Convert(ctx *ConvertContext) string {
 
 type postConverter struct{}
 
+// postConverter converts a post message raw content (locales, blocks, attachment zone) into human-readable lines.
 func (postConverter) Convert(ctx *ConvertContext) string {
 	parsed, err := ParseJSONObject(ctx.RawContent)
 	if err != nil || parsed == nil {
 		return invalidJSONPlaceholder("rich text")
 	}
 	body := unwrapPostLocale(parsed)
-	if body == nil {
-		return "[Rich text message]"
-	}
 
 	var parts []string
-	if title, _ := body["title"].(string); title != "" {
-		parts = append(parts, title)
-	}
-	// Prefer content_v2 blocks; fallback to content blocks
-	blocks := selectContentBlocks(body)
-	for _, para := range blocks {
-		elems, _ := para.([]interface{})
-		var line strings.Builder
-		for _, el := range elems {
-			elem, _ := el.(map[string]interface{})
-			line.WriteString(renderPostElem(elem))
+	if body != nil {
+		if title, _ := body["title"].(string); title != "" {
+			parts = append(parts, title)
 		}
-		parts = append(parts, line.String())
+		// Prefer content_v2 blocks; fallback to content blocks
+		blocks := selectContentBlocks(body)
+		for _, para := range blocks {
+			elems, _ := para.([]interface{})
+			var line strings.Builder
+			for _, el := range elems {
+				elem, _ := el.(map[string]interface{})
+				line.WriteString(renderPostElem(elem))
+			}
+			parts = append(parts, line.String())
+		}
 	}
 
 	result := strings.TrimSpace(strings.Join(parts, "\n"))
 	if result == "" {
-		return "[Rich text message]"
+		result = "[Rich text message]"
 	}
-	return ResolveMentionKeys(result, ctx.MentionMap)
+	result = ResolveMentionKeys(result, ctx.MentionMap)
+	// Attachment zone (top-level "files" array, sibling of the locale keys) is
+	// rendered as trailing lines so agents can see file/folder keys for download.
+	if attachments := renderPostAttachments(parsed); attachments != "" {
+		result += "\n" + attachments
+	}
+	return result
+}
+
+// renderPostAttachments renders a post message's attachment zone to
+// human-readable lines, one per attachment. It uses the same <file>/<folder>
+// tag style as standalone file/folder messages, so attachment keys render
+// consistently across the output and stay extractable.
+//
+// The input is the parsed post content JSON as returned by the message API
+// (get/mget/list/search/threads, merge_forward sub-items), e.g.:
+//
+//	"files":[{"file_key":"file_xxx","file_name":"report.pdf"},
+//	         {"file_key":"file_yyy","file_name":"assets","is_folder":true}]
+//
+// renders as:
+//
+//	<file key="file_xxx" name="report.pdf"/>
+//	<folder key="file_yyy" name="assets"/>
+func renderPostAttachments(parsed map[string]interface{}) string {
+	rawFiles, ok := parsed["files"].([]interface{})
+	if !ok || len(rawFiles) == 0 {
+		return ""
+	}
+	var lines []string
+	for _, raw := range rawFiles {
+		f, _ := raw.(map[string]interface{})
+		if f == nil {
+			continue
+		}
+		key, _ := f["file_key"].(string)
+		if key == "" {
+			continue
+		}
+		tag := "file"
+		if isFolder, _ := f["is_folder"].(bool); isFolder {
+			tag = "folder"
+		}
+		name, _ := f["file_name"].(string)
+		if name != "" {
+			lines = append(lines, fmt.Sprintf(`<%s key="%s" name="%s"/>`, tag, cardEscapeAttr(key), cardEscapeAttr(name)))
+		} else {
+			lines = append(lines, fmt.Sprintf(`<%s key="%s"/>`, tag, cardEscapeAttr(key)))
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // selectContentBlocks returns content_v2 blocks when present and non-empty;

--- a/shortcuts/im/convert_lib/text_test.go
+++ b/shortcuts/im/convert_lib/text_test.go
@@ -44,6 +44,7 @@ func TestPostConverterConvert(t *testing.T) {
 	}
 }
 
+// TestPostConverterConvertFallback covers fallback rendering for invalid post content.
 func TestPostConverterConvertFallback(t *testing.T) {
 	tests := []struct {
 		name string
@@ -63,6 +64,46 @@ func TestPostConverterConvertFallback(t *testing.T) {
 	}
 }
 
+// TestPostConverterConvertAttachmentZone covers attachment-zone rendering in both response and write formats.
+func TestPostConverterConvertAttachmentZone(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "file and folder attachments (response format)",
+			raw:  `{"zh_cn":{"title":"Docs","content":[[{"tag":"text","text":"see below"}]]},"files":[{"file_key":"file_1","file_name":"report.pdf"},{"file_key":"file_2","file_name":"assets","is_folder":true}]}`,
+			want: "Docs\nsee below\n<file key=\"file_1\" name=\"report.pdf\"/>\n<folder key=\"file_2\" name=\"assets\"/>",
+		},
+		{
+			name: "attachment without name shows key only",
+			raw:  `{"zh_cn":{"content":[[{"tag":"text","text":"hi"}]]},"files":[{"file_key":"file_3"}]}`,
+			want: "hi\n<file key=\"file_3\"/>",
+		},
+		{
+			name: "attachment with empty key skipped",
+			raw:  `{"zh_cn":{"content":[[{"tag":"text","text":"hi"}]]},"files":[{"file_name":"no key"}]}`,
+			want: "hi",
+		},
+		{
+			name: "attachment zone only (empty post body)",
+			raw:  `{"files":[{"file_key":"file_4","file_name":"a.txt"}]}`,
+			want: "[Rich text message]\n<file key=\"file_4\" name=\"a.txt\"/>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &ConvertContext{RawContent: tt.raw, MentionMap: map[string]string{}}
+			if got := (postConverter{}).Convert(ctx); got != tt.want {
+				t.Fatalf("postConverter.Convert() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnwrapPostLocale covers extracting the locale map from a post content JSON.
 func TestUnwrapPostLocale(t *testing.T) {
 	direct := map[string]interface{}{"title": "Direct"}
 	if got := unwrapPostLocale(direct); got["title"] != "Direct" {

--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -1179,7 +1179,12 @@ func replaceAttachmentsIntoPostContent(content string, items []attachmentItem) (
 		}
 	}
 	files := make([]map[string]interface{}, 0, len(items))
+	seen := make(map[string]bool)
 	for _, it := range items {
+		if seen[it.Key] {
+			continue
+		}
+		seen[it.Key] = true
 		files = append(files, map[string]interface{}{"key": it.Key})
 	}
 	parsed["files"] = files
@@ -1218,7 +1223,7 @@ func clearAttachmentsInPostContent(content string) (string, error) {
 // zone, so the effective message type must be post (via --markdown or an
 // explicit --msg-type post with --content). flagName is the caller's flag name
 // (e.g. "--attachment" or "--set-attachments") used in error messages.
-func validateAttachmentFlags(values []string, msgType, markdown, flagName string) ([]attachmentItem, error) {
+func validateAttachmentFlags(values []string, msgType, markdown, flagName string, msgTypeExplicit bool, text string) ([]attachmentItem, error) {
 	items, err := parseAttachments(values, flagName)
 	if err != nil {
 		return nil, err
@@ -1228,8 +1233,17 @@ func validateAttachmentFlags(values []string, msgType, markdown, flagName string
 			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s key must be a file/folder key (file_xxx), got %q", flagName, it.Key).WithParam(flagName)
 		}
 	}
-	if len(items) > 0 && markdown == "" && msgType != "post" {
-		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s attaches files to a post message; use --markdown, or --msg-type post with --content", flagName).WithParam(flagName)
+	// --text is a standalone text message; it cannot carry a post attachment
+	// zone (we do not wrap literal text into a post node).
+	if len(items) > 0 && text != "" {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s attaches files to a post message and cannot be combined with --text; use --markdown (or --msg-type post with --content) for the body", flagName).WithParam(flagName)
+	}
+	// Attachments imply a post message. When the caller did not explicitly set
+	// --msg-type, infer post automatically (same as --markdown); only an
+	// explicit incompatible --msg-type is a conflict. A markdown body already
+	// infers post, so it is always compatible.
+	if len(items) > 0 && markdown == "" && msgTypeExplicit && msgType != "post" {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s attaches files to a post message; --msg-type %q conflicts with the inferred post type", flagName, msgType).WithParam(flagName)
 	}
 	return items, nil
 }

--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -982,6 +982,33 @@ func resolveMarkdownImageURLs(ctx context.Context, runtime *common.RuntimeContex
 	})
 }
 
+// hasContentFiles reports whether the given content JSON carries a top-level
+// "files" array with at least one entry. Used to enforce the mutual exclusion
+// between attachment flags (--attachment/--set-attachments/--clear-attachments)
+// and a --content that already declares files: both are attachment-zone
+// sources, so combining them is rejected. Invalid JSON is treated as no files
+// (the content-JSON validity check reports it separately).
+func hasContentFiles(content string) bool {
+	if content == "" {
+		return false
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil || parsed == nil {
+		return false
+	}
+	files, ok := parsed["files"].([]interface{})
+	return ok && len(files) > 0
+}
+
+// hasAnyContentSource reports whether any non-attachment content flag is set
+// (text/markdown/content or a media flag). send/reply use it to allow
+// attachment-only posts while still enforcing every mutual-exclusion error when
+// another content source is present alongside --attachment.
+func hasAnyContentSource(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey string) bool {
+	return text != "" || markdown != "" || content != "" ||
+		imageKey != "" || fileKey != "" || videoKey != "" || videoCoverKey != "" || audioKey != ""
+}
+
 // validateContentFlags checks mutual exclusion between content flags (text/markdown/content)
 // and media flags (image/file/video/audio). Returns an error string or "".
 func validateContentFlags(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey string) string {
@@ -1030,6 +1057,7 @@ func validateContentFlags(text, markdown, content, imageKey, fileKey, videoKey, 
 	return ""
 }
 
+// validateExplicitMsgType rejects an explicitly-set --msg-type that conflicts with the inferred type from the content flags.
 func validateExplicitMsgType(cmd *cobra.Command, msgType, text, markdown, imageKey, fileKey, videoKey, audioKey string) string {
 	if cmd == nil || !cmd.Flags().Changed("msg-type") {
 		return ""
@@ -1055,6 +1083,158 @@ func validateExplicitMsgType(cmd *cobra.Command, msgType, text, markdown, imageK
 	}
 	return fmt.Sprintf("--msg-type %q conflicts with the inferred message type %q from the selected content flag", msgType, inferred)
 }
+
+// attachmentItem is one parsed --attachment value: a required file/folder key.
+// 服务端不信任客户端 name（OAPI resolveAttachmentFile 禁止透传 name/size/mime/is_folder，
+// 一律以文件服务元信息回填），故 CLI 不接收 display name，只传纯 key。
+type attachmentItem struct {
+	Key string
+}
+
+// parseAttachmentFlag parses a single attachment value: a bare "file_key".
+// flagName is the caller's flag name (e.g. "--attachment" or "--set-attachments")
+// used in error messages. 与 Slack file_ids 等竞品惯例一致（引用附件只传 id，不重复传 name）。
+func parseAttachmentFlag(value, flagName string) (attachmentItem, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return attachmentItem{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s value must not be empty", flagName).WithParam(flagName)
+	}
+	return attachmentItem{Key: value}, nil
+}
+
+// parseAttachments parses every attachment value in order. flagName is the
+// caller's flag name used in error messages.
+func parseAttachments(values []string, flagName string) ([]attachmentItem, error) {
+	items := make([]attachmentItem, 0, len(values))
+	for _, v := range values {
+		it, err := parseAttachmentFlag(v, flagName)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	return items, nil
+}
+
+// mergeAttachmentsIntoPostContent merges attachment items into a post content
+// JSON's top-level "files" array, preserving any files already present in
+// --content and deduplicating by key (send/reply --attachment semantics). Post
+// content JSON shape (OpenAPI):
+// {"zh_cn":{...},"files":[{"key":...}]}. name 等元信息由服务端文件服务回填，CLI 不传。
+func mergeAttachmentsIntoPostContent(content string, items []attachmentItem) (string, error) {
+	parsed := make(map[string]interface{})
+	if content != "" {
+		if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+			return "", err
+		}
+		// JSON "null" unmarshals into a nil map; treat it as empty content.
+		if parsed == nil {
+			parsed = make(map[string]interface{})
+		}
+	}
+	var files []map[string]interface{}
+	seen := make(map[string]bool)
+	if existing, ok := parsed["files"].([]interface{}); ok {
+		for _, e := range existing {
+			if m, ok := e.(map[string]interface{}); ok {
+				if key, _ := m["key"].(string); key != "" {
+					if seen[key] {
+						continue
+					}
+					seen[key] = true
+				}
+				files = append(files, m)
+			}
+		}
+	}
+	for _, it := range items {
+		if seen[it.Key] {
+			continue
+		}
+		seen[it.Key] = true
+		files = append(files, map[string]interface{}{"key": it.Key})
+	}
+	parsed["files"] = files
+	b, err := json.Marshal(parsed)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// replaceAttachmentsIntoPostContent sets the post content's top-level "files"
+// array to EXACTLY the given items, discarding any files already present in
+// --content. This is the "set" (replace) semantic used by +messages-edit
+// --set-attachments: the flag values are the final attachment list, never
+// merged with --content's files.
+func replaceAttachmentsIntoPostContent(content string, items []attachmentItem) (string, error) {
+	parsed := make(map[string]interface{})
+	if content != "" {
+		if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+			return "", err
+		}
+		// JSON "null" unmarshals into a nil map; treat it as empty content.
+		if parsed == nil {
+			parsed = make(map[string]interface{})
+		}
+	}
+	files := make([]map[string]interface{}, 0, len(items))
+	for _, it := range items {
+		files = append(files, map[string]interface{}{"key": it.Key})
+	}
+	parsed["files"] = files
+	b, err := json.Marshal(parsed)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// clearAttachmentsInPostContent sets the top-level "files" array of a post
+// content JSON to an empty array ([]), signaling the server to clear the
+// message's attachment zone. If content is empty, it returns a minimal post
+// content with an empty body and empty attachment zone.
+func clearAttachmentsInPostContent(content string) (string, error) {
+	parsed := make(map[string]interface{})
+	if content != "" {
+		if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+			return "", err
+		}
+		// JSON "null" unmarshals into a nil map; treat it as empty content.
+		if parsed == nil {
+			parsed = make(map[string]interface{})
+		}
+	}
+	parsed["files"] = []map[string]interface{}{}
+	b, err := json.Marshal(parsed)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// validateAttachmentFlags parses attachment values and enforces the post-only
+// message-type constraint: attachment files live in a post message's attachment
+// zone, so the effective message type must be post (via --markdown or an
+// explicit --msg-type post with --content). flagName is the caller's flag name
+// (e.g. "--attachment" or "--set-attachments") used in error messages.
+func validateAttachmentFlags(values []string, msgType, markdown, flagName string) ([]attachmentItem, error) {
+	items, err := parseAttachments(values, flagName)
+	if err != nil {
+		return nil, err
+	}
+	for _, it := range items {
+		if !strings.HasPrefix(it.Key, "file_") {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s key must be a file/folder key (file_xxx), got %q", flagName, it.Key).WithParam(flagName)
+		}
+	}
+	if len(items) > 0 && markdown == "" && msgType != "post" {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "%s attaches files to a post message; use --markdown, or --msg-type post with --content", flagName).WithParam(flagName)
+	}
+	return items, nil
+}
+
+// detectIMFileType infers a file_type from a local file extension, defaulting to "stream".
 
 func detectIMFileType(filePath string) string {
 	ext := strings.ToLower(filepath.Ext(filePath))

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -6,6 +6,7 @@ package im
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
 )
 
 func TestNormalizeAtMentions(t *testing.T) {
@@ -181,6 +183,7 @@ func TestBuildMediaContentFromKey(t *testing.T) {
 	}
 }
 
+// TestWrapMarkdownAsPostForDryRun covers markdown-to-post wrapping used by dry runs.
 func TestWrapMarkdownAsPostForDryRun(t *testing.T) {
 	content, desc := wrapMarkdownAsPostForDryRun("hello ![alt](https://example.com/a.png)")
 	if !strings.Contains(content, `![alt](img_dryrun_1)`) {
@@ -188,6 +191,156 @@ func TestWrapMarkdownAsPostForDryRun(t *testing.T) {
 	}
 	if !strings.Contains(desc, "placeholder image keys") {
 		t.Fatalf("wrapMarkdownAsPostForDryRun() desc = %q, want placeholder note", desc)
+	}
+}
+
+// TestParseAttachmentFlag covers bare key parsing and empty-value rejection.
+func TestParseAttachmentFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantKey string
+		wantErr bool
+	}{
+		{name: "key only", value: "file_123", wantKey: "file_123"},
+		{name: "whitespace trimmed", value: "  file_123  ", wantKey: "file_123"},
+		{name: "empty", value: "   ", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAttachmentFlag(tt.value, "--attachment")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseAttachmentFlag(%q) expected error, got %#v", tt.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAttachmentFlag(%q) unexpected error: %v", tt.value, err)
+			}
+			if got.Key != tt.wantKey {
+				t.Fatalf("parseAttachmentFlag(%q) = %+v, want key=%q", tt.value, got, tt.wantKey)
+			}
+		})
+	}
+}
+
+// TestParseAttachments parses repeated values in order.
+
+func TestParseAttachments(t *testing.T) {
+	got, err := parseAttachments([]string{"file_1", "file_2"}, "--attachment")
+	if err != nil {
+		t.Fatalf("parseAttachments unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0].Key != "file_1" || got[1].Key != "file_2" {
+		t.Fatalf("parseAttachments() = %+v, want 2 items with keys set", got)
+	}
+	// TestMergeAttachmentsIntoPostContent merges files into post content top-level, preserving existing files.
+}
+
+// TestMergeAttachmentsIntoPostContent merges files into post content top-level, preserving existing files.
+func TestMergeAttachmentsIntoPostContent(t *testing.T) {
+	items := []attachmentItem{{Key: "file_1"}, {Key: "file_2"}}
+	merged, err := mergeAttachmentsIntoPostContent(`{"zh_cn":{"content":[[{"tag":"text","text":"hi"}]]}}`, items)
+	if err != nil {
+		t.Fatalf("mergeAttachmentsIntoPostContent unexpected error: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(merged), &parsed); err != nil {
+		t.Fatalf("merged content is not valid JSON: %v\n%s", err, merged)
+	}
+	files, ok := parsed["files"].([]interface{})
+	if !ok || len(files) != 2 {
+		t.Fatalf("merged files = %#v, want 2 entries", parsed["files"])
+	}
+	// 不信任客户端 name：files 元素只应有 key，不应带 name 字段
+	for _, f := range files {
+		m, _ := f.(map[string]interface{})
+		if _, hasName := m["name"]; hasName {
+			t.Fatalf("merged files entry must not carry client name, got %#v", m)
+		}
+	}
+	if _, ok := parsed["zh_cn"]; !ok {
+		t.Fatalf("merged content lost the post body: %s", merged)
+	}
+
+	// Pre-existing files in --content are preserved, and --attachment appends.
+	merged2, err := mergeAttachmentsIntoPostContent(`{"files":[{"key":"existing"}]}`, items)
+	if err != nil {
+		t.Fatalf("mergeAttachmentsIntoPostContent(pre) unexpected error: %v", err)
+	}
+	var parsed2 map[string]interface{}
+	_ = json.Unmarshal([]byte(merged2), &parsed2)
+	files2, _ := parsed2["files"].([]interface{})
+	if len(files2) != 3 {
+		t.Fatalf("merged files with pre-existing = %d entries, want 3", len(files2))
+	}
+
+	// JSON "null" content must not panic: treat it as empty and attach files.
+	merged3, err := mergeAttachmentsIntoPostContent("null", items)
+	if err != nil {
+		t.Fatalf("mergeAttachmentsIntoPostContent(null) unexpected error: %v", err)
+	}
+	var parsed3 map[string]interface{}
+	_ = json.Unmarshal([]byte(merged3), &parsed3)
+	files3, _ := parsed3["files"].([]interface{})
+	if len(files3) != 2 {
+		t.Fatalf("merged files with null content = %d entries, want 2", len(files3))
+	}
+
+	// Duplicate keys are deduplicated: a key already in --content is not
+	// appended again by --attachment, and repeated --attachment values collapse.
+	merged4, err := mergeAttachmentsIntoPostContent(`{"files":[{"key":"file_1"}]}`, items)
+	if err != nil {
+		t.Fatalf("mergeAttachmentsIntoPostContent(dedup) unexpected error: %v", err)
+	}
+	var parsed4 map[string]interface{}
+	_ = json.Unmarshal([]byte(merged4), &parsed4)
+	files4, _ := parsed4["files"].([]interface{})
+	if len(files4) != 2 {
+		t.Fatalf("merged files with duplicate = %d entries, want 2 (file_1, file_2)", len(files4))
+	}
+}
+
+// TestValidateAttachmentFlags covers key prefix and post-only constraints.
+func TestValidateAttachmentFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		values   []string
+		msgType  string
+		markdown string
+		wantErr  bool
+		wantSub  errs.Subtype // expected validation subtype when wantErr
+		wantFlag string       // expected --flag in the typed error
+	}{
+		{name: "post with markdown", values: []string{"file_1"}, msgType: "text", markdown: "# hi", wantErr: false},
+		{name: "post via msg-type", values: []string{"file_1"}, msgType: "post", markdown: "", wantErr: false},
+		{name: "text message rejected", values: []string{"file_1"}, msgType: "text", markdown: "", wantErr: true, wantSub: errs.SubtypeInvalidArgument, wantFlag: "--attachment"},
+		{name: "non-file key rejected", values: []string{"img_1"}, msgType: "post", markdown: "", wantErr: true, wantSub: errs.SubtypeInvalidArgument, wantFlag: "--attachment"},
+		{name: "empty ok", values: nil, msgType: "text", markdown: "", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateAttachmentFlags(tt.values, tt.msgType, tt.markdown, "--attachment")
+			if tt.wantErr && err == nil {
+				t.Fatalf("validateAttachmentFlags() expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateAttachmentFlags() unexpected error: %v", err)
+			}
+			if tt.wantErr {
+				var ve *errs.ValidationError
+				if !errors.As(err, &ve) {
+					t.Fatalf("validateAttachmentFlags() error = %T, want *errs.ValidationError", err)
+				}
+				if tt.wantSub != "" && ve.Subtype != tt.wantSub {
+					t.Fatalf("validateAttachmentFlags() subtype = %q, want %q", ve.Subtype, tt.wantSub)
+				}
+				if tt.wantFlag != "" && ve.Param != tt.wantFlag {
+					t.Fatalf("validateAttachmentFlags() param = %q, want %q", ve.Param, tt.wantFlag)
+				}
+			}
+		})
 	}
 }
 
@@ -600,10 +753,12 @@ func TestResolveIMResourceDownloadPath(t *testing.T) {
 			if got != tt.want {
 				t.Fatalf("resolveIMResourceDownloadPath() = %q, want %q", got, tt.want)
 			}
+			// TestShortcuts verifies all IM shortcuts are registered and match expected commands.
 		})
 	}
 }
 
+// TestShortcuts verifies all IM shortcuts are registered and match expected commands.
 func TestShortcuts(t *testing.T) {
 	var commands []string
 	for _, shortcut := range Shortcuts() {
@@ -618,6 +773,7 @@ func TestShortcuts(t *testing.T) {
 		"+chat-search",
 		"+chat-update",
 		"+message-read-users",
+		"+messages-edit",
 		"+messages-mget",
 		"+messages-read-status",
 		"+messages-reply",
@@ -662,4 +818,180 @@ func TestSenderDisplay(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newSliceRuntimeContext builds a RuntimeContext supporting string and
+// string-slice flags, for validating send/reply with repeatable --attachment.
+func newSliceRuntimeContext(stringFlags map[string]string, sliceFlags map[string][]string) *common.RuntimeContext {
+	cmd := &cobra.Command{Use: "test"}
+	for name := range stringFlags {
+		cmd.Flags().String(name, "", "")
+	}
+	for name := range sliceFlags {
+		cmd.Flags().StringSlice(name, nil, "")
+	}
+	for name, val := range stringFlags {
+		_ = cmd.Flags().Set(name, val)
+	}
+	for name, vals := range sliceFlags {
+		_ = cmd.Flags().Set(name, strings.Join(vals, ","))
+	}
+	return &common.RuntimeContext{Cmd: cmd}
+}
+
+// TestSendReplyAttachmentDoesNotBypassContentValidation is the P1 regression
+// guard: --attachment must NOT swallow mutual-exclusion / media-integrity
+// errors when another content source is present (a conflicting --text or
+// --markdown was previously silently dropped).
+func TestSendReplyAttachmentDoesNotBypassContentValidation(t *testing.T) {
+	t.Run("send text+markdown+attachment rejected", func(t *testing.T) {
+		rt := newSliceRuntimeContext(map[string]string{
+			"chat-id": "oc_123", "text": "conflict", "markdown": "# wins",
+		}, map[string][]string{"attachment": {"file_1"}})
+		err := ImMessagesSend.Validate(context.Background(), rt)
+		if err == nil || !strings.Contains(err.Error(), "cannot be specified together") {
+			t.Fatalf("ImMessagesSend.Validate() = %v, want text/markdown conflict", err)
+		}
+	})
+
+	t.Run("send markdown+image+attachment rejected", func(t *testing.T) {
+		rt := newSliceRuntimeContext(map[string]string{
+			"chat-id": "oc_123", "markdown": "# wins", "image": "img_1",
+		}, map[string][]string{"attachment": {"file_1"}})
+		err := ImMessagesSend.Validate(context.Background(), rt)
+		if err == nil || !strings.Contains(err.Error(), "cannot be used with") {
+			t.Fatalf("ImMessagesSend.Validate() = %v, want media/content conflict", err)
+		}
+	})
+
+	t.Run("send attachment-only post allowed", func(t *testing.T) {
+		rt := newSliceRuntimeContext(map[string]string{
+			"chat-id": "oc_123", "msg-type": "post",
+		}, map[string][]string{"attachment": {"file_1"}})
+		if err := ImMessagesSend.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesSend.Validate() unexpected error = %v (attachment-only post must be allowed)", err)
+		}
+	})
+
+	t.Run("reply markdown+image+attachment rejected", func(t *testing.T) {
+		rt := newSliceRuntimeContext(map[string]string{
+			"message-id": "om_1", "markdown": "# wins", "image": "img_1",
+		}, map[string][]string{"attachment": {"file_1"}})
+		err := ImMessagesReply.Validate(context.Background(), rt)
+		if err == nil || !strings.Contains(err.Error(), "cannot be used with") {
+			t.Fatalf("ImMessagesReply.Validate() = %v, want media/content conflict", err)
+		}
+	})
+
+	t.Run("reply attachment-only post allowed", func(t *testing.T) {
+		rt := newSliceRuntimeContext(map[string]string{
+			"message-id": "om_1", "msg-type": "post",
+		}, map[string][]string{"attachment": {"file_1"}})
+		if err := ImMessagesReply.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesReply.Validate() unexpected error = %v (attachment-only reply must be allowed)", err)
+		}
+	})
+}
+
+// TestReplaceAttachmentsIntoPostContent verifies the edit "set" semantic: the
+// flag value becomes the FINAL files list, discarding --content's files and
+// never duplicating keys.
+func TestReplaceAttachmentsIntoPostContent(t *testing.T) {
+	t.Run("replaces content files, does not merge", func(t *testing.T) {
+		got, err := replaceAttachmentsIntoPostContent(`{"zh_cn":{"content":[]},"files":[{"key":"file_old"}]}`, []attachmentItem{{Key: "file_new"}})
+		if err != nil {
+			t.Fatalf("replaceAttachmentsIntoPostContent() error = %v", err)
+		}
+		var parsed map[string]interface{}
+		_ = json.Unmarshal([]byte(got), &parsed)
+		files, _ := parsed["files"].([]interface{})
+		if len(files) != 1 || files[0].(map[string]interface{})["key"] != "file_new" {
+			t.Fatalf("replace files = %#v, want only [file_new]", parsed["files"])
+		}
+		if _, ok := parsed["zh_cn"]; !ok {
+			t.Fatalf("replace lost the post body: %s", got)
+		}
+	})
+
+	t.Run("no duplicate when same key in content and flag", func(t *testing.T) {
+		got, err := replaceAttachmentsIntoPostContent(`{"zh_cn":{"content":[]},"files":[{"key":"file_old"}]}`, []attachmentItem{{Key: "file_old"}})
+		if err != nil {
+			t.Fatalf("replaceAttachmentsIntoPostContent() error = %v", err)
+		}
+		var parsed map[string]interface{}
+		_ = json.Unmarshal([]byte(got), &parsed)
+		files, _ := parsed["files"].([]interface{})
+		if len(files) != 1 {
+			t.Fatalf("replace files = %#v, want single file_old (no duplicate)", parsed["files"])
+		}
+	})
+
+	t.Run("multiple flag keys replace in order", func(t *testing.T) {
+		got, err := replaceAttachmentsIntoPostContent(`{"zh_cn":{"content":[]},"files":[{"key":"file_old"}]}`, []attachmentItem{{Key: "a"}, {Key: "b"}})
+		if err != nil {
+			t.Fatalf("replaceAttachmentsIntoPostContent() error = %v", err)
+		}
+		var parsed map[string]interface{}
+		_ = json.Unmarshal([]byte(got), &parsed)
+		files, _ := parsed["files"].([]interface{})
+		if len(files) != 2 || files[0].(map[string]interface{})["key"] != "a" || files[1].(map[string]interface{})["key"] != "b" {
+			t.Fatalf("replace files = %#v, want [a, b]", parsed["files"])
+		}
+	})
+}
+
+// TestAttachmentFlagsMutuallyExclusiveWithContentFiles verifies the A-plan
+// contract: --content that already declares a files array cannot be combined
+// with attachment flags (--attachment / --set-attachments / --clear-attachments).
+func TestAttachmentFlagsMutuallyExclusiveWithContentFiles(t *testing.T) {
+	contentWithFiles := `{"zh_cn":{"content":[]},"files":[{"key":"file_old"}]}`
+	contentNoFiles := `{"zh_cn":{"content":[]}}`
+
+	t.Run("send content-with-files + attachment rejected", func(t *testing.T) {
+		rt := newSliceRuntimeContext(map[string]string{
+			"chat-id": "oc_123", "msg-type": "post", "content": contentWithFiles,
+		}, map[string][]string{"attachment": {"file_new"}})
+		err := ImMessagesSend.Validate(context.Background(), rt)
+		if err == nil || !strings.Contains(err.Error(), "files array") {
+			t.Fatalf("ImMessagesSend.Validate() = %v, want files-array conflict", err)
+		}
+	})
+
+	t.Run("send content-no-files + attachment allowed", func(t *testing.T) {
+		rt := newSliceRuntimeContext(map[string]string{
+			"chat-id": "oc_123", "msg-type": "post", "content": contentNoFiles,
+		}, map[string][]string{"attachment": {"file_new"}})
+		if err := ImMessagesSend.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesSend.Validate() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("edit content-with-files + set-attachments rejected", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id": "om_1", "msg-type": "post", "content": contentWithFiles,
+		}, map[string][]string{"set-attachments": {"file_new"}})
+		err := ImMessagesEdit.Validate(context.Background(), rt)
+		if err == nil || !strings.Contains(err.Error(), "files array") {
+			t.Fatalf("ImMessagesEdit.Validate() = %v, want files-array conflict", err)
+		}
+	})
+
+	t.Run("edit content-with-files + clear-attachments rejected", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id": "om_1", "msg-type": "post", "content": contentWithFiles, "clear-attachments": "true",
+		}, nil)
+		err := ImMessagesEdit.Validate(context.Background(), rt)
+		if err == nil || !strings.Contains(err.Error(), "files array") {
+			t.Fatalf("ImMessagesEdit.Validate() = %v, want files-array conflict", err)
+		}
+	})
+
+	t.Run("edit content-no-files + set-attachments allowed", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id": "om_1", "msg-type": "post", "content": contentNoFiles,
+		}, map[string][]string{"set-attachments": {"file_new"}})
+		if err := ImMessagesEdit.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesEdit.Validate() unexpected error = %v", err)
+		}
+	})
 }

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -303,25 +303,29 @@ func TestMergeAttachmentsIntoPostContent(t *testing.T) {
 }
 
 // TestValidateAttachmentFlags covers key prefix and post-only constraints.
+// Attachments imply post: without an explicit --msg-type the type is inferred
+// as post; only an explicit incompatible --msg-type conflicts.
 func TestValidateAttachmentFlags(t *testing.T) {
 	tests := []struct {
-		name     string
-		values   []string
-		msgType  string
-		markdown string
-		wantErr  bool
-		wantSub  errs.Subtype // expected validation subtype when wantErr
-		wantFlag string       // expected --flag in the typed error
+		name            string
+		values          []string
+		msgType         string
+		markdown        string
+		msgTypeExplicit bool
+		wantErr         bool
+		wantSub         errs.Subtype // expected validation subtype when wantErr
+		wantFlag        string       // expected --flag in the typed error
 	}{
 		{name: "post with markdown", values: []string{"file_1"}, msgType: "text", markdown: "# hi", wantErr: false},
-		{name: "post via msg-type", values: []string{"file_1"}, msgType: "post", markdown: "", wantErr: false},
-		{name: "text message rejected", values: []string{"file_1"}, msgType: "text", markdown: "", wantErr: true, wantSub: errs.SubtypeInvalidArgument, wantFlag: "--attachment"},
+		{name: "post via explicit msg-type", values: []string{"file_1"}, msgType: "post", markdown: "", msgTypeExplicit: true, wantErr: false},
+		{name: "implicit msg-type infers post", values: []string{"file_1"}, msgType: "text", markdown: "", msgTypeExplicit: false, wantErr: false},
+		{name: "explicit non-post rejected", values: []string{"file_1"}, msgType: "text", markdown: "", msgTypeExplicit: true, wantErr: true, wantSub: errs.SubtypeInvalidArgument, wantFlag: "--attachment"},
 		{name: "non-file key rejected", values: []string{"img_1"}, msgType: "post", markdown: "", wantErr: true, wantSub: errs.SubtypeInvalidArgument, wantFlag: "--attachment"},
 		{name: "empty ok", values: nil, msgType: "text", markdown: "", wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := validateAttachmentFlags(tt.values, tt.msgType, tt.markdown, "--attachment")
+			_, err := validateAttachmentFlags(tt.values, tt.msgType, tt.markdown, "--attachment", tt.msgTypeExplicit, "")
 			if tt.wantErr && err == nil {
 				t.Fatalf("validateAttachmentFlags() expected error, got nil")
 			}
@@ -849,7 +853,7 @@ func TestSendReplyAttachmentDoesNotBypassContentValidation(t *testing.T) {
 			"chat-id": "oc_123", "text": "conflict", "markdown": "# wins",
 		}, map[string][]string{"attachment": {"file_1"}})
 		err := ImMessagesSend.Validate(context.Background(), rt)
-		if err == nil || !strings.Contains(err.Error(), "cannot be specified together") {
+		if err == nil || (!strings.Contains(err.Error(), "cannot be specified together") && !strings.Contains(err.Error(), "cannot be combined with --text")) {
 			t.Fatalf("ImMessagesSend.Validate() = %v, want text/markdown conflict", err)
 		}
 	})

--- a/shortcuts/im/im_messages_edit.go
+++ b/shortcuts/im/im_messages_edit.go
@@ -17,7 +17,7 @@ import (
 var ImMessagesEdit = common.Shortcut{
 	Service:     "im",
 	Command:     "+messages-edit",
-	Description: "Edit a message's content (text/post, including the attachment zone); bot only; user identity is rejected by the server (user access token not support); PUT /open-apis/im/v1/messages/:message_id",
+	Description: "Edit a sent text or rich-text message, optionally updating its attachment zone; bot only (the edit API does not accept user tokens)",
 	Risk:        "write",
 	Scopes:      []string{"im:message:send_as_bot"},
 	BotScopes:   []string{"im:message:send_as_bot"},
@@ -108,7 +108,7 @@ var ImMessagesEdit = common.Shortcut{
 			return err
 		}
 
-		attachments, err := validateAttachmentFlags(runtime.StrSlice("set-attachments"), msgType, markdown, "--set-attachments")
+		attachments, err := validateAttachmentFlags(runtime.StrSlice("set-attachments"), msgType, markdown, "--set-attachments", runtime.Cmd != nil && runtime.Cmd.Flags().Changed("msg-type"), text)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/im/im_messages_edit.go
+++ b/shortcuts/im/im_messages_edit.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var ImMessagesEdit = common.Shortcut{
+	Service:     "im",
+	Command:     "+messages-edit",
+	Description: "Edit a message's content (text/post, including the attachment zone); bot only; user identity is rejected by the server (user access token not support); PUT /open-apis/im/v1/messages/:message_id",
+	Risk:        "write",
+	Scopes:      []string{"im:message:send_as_bot"},
+	BotScopes:   []string{"im:message:send_as_bot"},
+	AuthTypes:   []string{"bot"},
+	Flags: []common.Flag{
+		{Name: "message-id", Desc: "message ID (om_xxx)", Required: true},
+		{Name: "msg-type", Default: "text", Desc: "message type for --content JSON; when using --markdown/--text the effective type is inferred automatically", Enum: []string{"text", "post"}},
+		{Name: "content", Desc: "(one of --content/--text/--markdown/--set-attachments required) message content JSON"},
+		{Name: "text", Desc: "plain text message (auto-wrapped as JSON)"},
+		{Name: "markdown", Desc: "markdown text (auto-wrapped as post format with style optimization; image URLs auto-resolved)"},
+		{Name: "set-attachments", Type: "string_slice", Desc: "file/folder key (file_xxx), repeatable; sets the post message's attachment zone (requires --markdown or --msg-type post)"},
+		{Name: "clear-attachments", Type: "bool", Desc: "clear the post message attachment zone (sets files:[]); cannot be used with --set-attachments"},
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		messageId := runtime.Str("message-id")
+		msgType := runtime.Str("msg-type")
+		content := runtime.Str("content")
+		desc := ""
+		text := runtime.Str("text")
+		markdown := runtime.Str("markdown")
+
+		clearAttachments := runtime.Bool("clear-attachments")
+
+		if markdown != "" {
+			msgType = "post"
+			content, desc = wrapMarkdownAsPostForDryRun(markdown)
+		} else if text != "" {
+			jsonBytes, _ := json.Marshal(map[string]string{"text": text})
+			content = string(jsonBytes)
+		}
+
+		// Attachment zone: merge --set-attachments files into the post content.
+		attachments := runtime.StrSlice("set-attachments")
+		if clearAttachments {
+			if len(attachments) > 0 {
+				return common.NewDryRunAPI().Set("error", errs.NewValidationError(errs.SubtypeInvalidArgument, "--clear-attachments cannot be used with --set-attachments").WithParam("--clear-attachments").Error())
+			}
+			msgType = "post"
+			if content == "" {
+				content = `{"zh_cn":{"content":[]}}`
+			}
+			if cleared, err := clearAttachmentsInPostContent(content); err == nil {
+				content = cleared
+			} else {
+				return common.NewDryRunAPI().Set("error", errs.NewValidationError(errs.SubtypeInvalidArgument, "--clear-attachments: %v", err).WithParam("--clear-attachments").Error())
+			}
+			if desc != "" {
+				desc += "; "
+			}
+			desc += "--clear-attachments sets files:[]"
+		} else if len(attachments) > 0 {
+			msgType = "post"
+			if items, err := parseAttachments(attachments, "--set-attachments"); err == nil {
+				if content == "" {
+					content = `{"zh_cn":{"content":[]}}`
+				}
+				if merged, err := replaceAttachmentsIntoPostContent(content, items); err == nil {
+					content = merged
+				}
+			}
+			if desc != "" {
+				desc += "; "
+			}
+			desc += "--set-attachments sets files in the post attachment zone"
+		}
+
+		body := map[string]interface{}{"msg_type": msgType, "content": content}
+		d := common.NewDryRunAPI()
+		if desc != "" {
+			d.Desc(desc)
+		}
+		return d.
+			PUT(fmt.Sprintf("/open-apis/im/v1/messages/%s", validate.EncodePathSegment(messageId))).
+			Body(body).
+			Set("message_id", messageId)
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		messageId := runtime.Str("message-id")
+		msgType := runtime.Str("msg-type")
+		content := runtime.Str("content")
+		text := runtime.Str("text")
+		markdown := runtime.Str("markdown")
+
+		if messageId == "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--message-id is required (om_xxx)").WithParam("--message-id")
+		}
+		if _, err := validateMessageID(messageId); err != nil {
+			return err
+		}
+
+		attachments, err := validateAttachmentFlags(runtime.StrSlice("set-attachments"), msgType, markdown, "--set-attachments")
+		if err != nil {
+			return err
+		}
+
+		clearAttachments := runtime.Bool("clear-attachments")
+		if clearAttachments && len(attachments) > 0 {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--clear-attachments cannot be used with --set-attachments").WithParam("--clear-attachments")
+		}
+		if clearAttachments && markdown == "" && msgType != "post" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--clear-attachments only applies to post messages; use --markdown or --msg-type post with --content").WithParam("--clear-attachments")
+		}
+		// Mutual exclusion: --content already declares a files array, so the
+		// attachment flags (--set-attachments / --clear-attachments) are another
+		// attachment-zone source and must not be combined with it.
+		if hasContentFiles(content) && (len(attachments) > 0 || clearAttachments) {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--set-attachments/--clear-attachments cannot be used with --content that already contains a files array; either edit files via --content or via the attachment flags, not both").WithParam("--set-attachments")
+		}
+
+		if msg := validateEditContentFlags(text, markdown, content, attachments, clearAttachments); msg != "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", msg)
+		}
+		if content != "" && !json.Valid([]byte(content)) {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--content is not valid JSON: %s\nexample: --content '{\"text\":\"hello\"}' or --text 'hello'", content).WithParam("--content")
+		}
+		if msg := validateExplicitMsgType(runtime.Cmd, msgType, text, markdown, "", "", "", ""); msg != "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", msg).WithParam("--msg-type")
+		}
+
+		return nil
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		messageId := runtime.Str("message-id")
+		msgType := runtime.Str("msg-type")
+		content := runtime.Str("content")
+		text := runtime.Str("text")
+		markdown := runtime.Str("markdown")
+
+		if markdown != "" {
+			msgType, content = "post", resolveMarkdownAsPost(ctx, runtime, markdown)
+		} else if text != "" {
+			jsonBytes, _ := json.Marshal(map[string]string{"text": text})
+			content = string(jsonBytes)
+		}
+
+		// Attachment zone: merge --set-attachments files into the post content.
+		attachments := runtime.StrSlice("set-attachments")
+		clearAttachments := runtime.Bool("clear-attachments")
+		if clearAttachments {
+			if len(attachments) > 0 {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--clear-attachments cannot be used with --set-attachments").WithParam("--clear-attachments")
+			}
+			msgType = "post"
+			if content == "" {
+				content = `{"zh_cn":{"content":[]}}`
+			}
+			cleared, err := clearAttachmentsInPostContent(content)
+			if err != nil {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--clear-attachments: %v", err).WithParam("--clear-attachments")
+			}
+			content = cleared
+		} else if items, err := parseAttachments(attachments, "--set-attachments"); err == nil && len(items) > 0 {
+			msgType = "post"
+			if content == "" {
+				content = `{"zh_cn":{"content":[]}}`
+			}
+			merged, err := replaceAttachmentsIntoPostContent(content, items)
+			if err != nil {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--set-attachments: %v", err).WithParam("--set-attachments")
+			}
+			content = merged
+		}
+
+		normalizedContent := content
+		if msgType == "text" || msgType == "post" {
+			normalizedContent = normalizeAtMentions(content)
+		}
+
+		data := map[string]interface{}{
+			"msg_type": msgType,
+			"content":  normalizedContent,
+		}
+
+		resData, err := runtime.DoAPIJSONTyped(http.MethodPut,
+			fmt.Sprintf("/open-apis/im/v1/messages/%s", validate.EncodePathSegment(messageId)),
+			nil, data)
+		if err != nil {
+			return err
+		}
+
+		runtime.Out(map[string]interface{}{
+			"message_id":  resData["message_id"],
+			"chat_id":     resData["chat_id"],
+			"update_time": common.FormatTimeWithSeconds(resData["update_time"]),
+		}, nil)
+		return nil
+	},
+}
+
+// validateEditContentFlags checks the edit content flags: text/markdown/content
+// are mutually exclusive; --set-attachments counts as a content source so a post with
+// only an attachment zone is allowed. --clear-attachments also counts as a content
+// source: a clear-only edit (no body flag) is legal — Execute falls back to an empty
+// post body and clears the attachment zone, matching the server's clear semantics.
+func validateEditContentFlags(text, markdown, content string, attachments []attachmentItem, clearAttachments bool) string {
+	contentFlags := 0
+	if text != "" {
+		contentFlags++
+	}
+	if markdown != "" {
+		contentFlags++
+	}
+	if content != "" {
+		contentFlags++
+	}
+	if contentFlags > 1 {
+		return "--text, --markdown, and --content cannot be specified together"
+	}
+	if contentFlags == 0 && len(attachments) == 0 && !clearAttachments {
+		return "specify --content <json>, --text <plain text>, --markdown <markdown text>, --set-attachments <file_key>, or --clear-attachments"
+	}
+	return ""
+}

--- a/shortcuts/im/im_messages_edit_test.go
+++ b/shortcuts/im/im_messages_edit_test.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+// newEditTestRuntimeContext builds a RuntimeContext wired with the +messages-edit
+// flag surface, including the repeatable --set-attachments string-slice flag.
+func newEditTestRuntimeContext(stringFlags map[string]string, sliceFlags map[string][]string) *common.RuntimeContext {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("message-id", "", "")
+	cmd.Flags().String("msg-type", "text", "")
+	cmd.Flags().String("content", "", "")
+	cmd.Flags().String("text", "", "")
+	cmd.Flags().String("markdown", "", "")
+	cmd.Flags().StringSlice("set-attachments", nil, "")
+	cmd.Flags().Bool("clear-attachments", false, "")
+	for name, val := range stringFlags {
+		_ = cmd.Flags().Set(name, val)
+	}
+	for name, vals := range sliceFlags {
+		_ = cmd.Flags().Set(name, strings.Join(vals, ","))
+	}
+	return &common.RuntimeContext{Cmd: cmd}
+}
+
+// TestValidateEditContentFlags covers mutual exclusivity of text/markdown/content and the attachment/clear-as-content-source rule.
+func TestValidateEditContentFlags(t *testing.T) {
+	tests := []struct {
+		name             string
+		text             string
+		markdown         string
+		content          string
+		attachments      []attachmentItem
+		clearAttachments bool
+		wantErr          string
+	}{
+		{name: "text ok", text: "hi", wantErr: ""},
+		{name: "markdown ok", markdown: "# hi", wantErr: ""},
+		{name: "content ok", content: `{"text":"hi"}`, wantErr: ""},
+		{name: "attachment only ok", attachments: []attachmentItem{{Key: "file_1"}}, wantErr: ""},
+		{name: "clear only ok", clearAttachments: true, wantErr: ""},
+		{name: "clear with markdown ok", markdown: "# hi", clearAttachments: true, wantErr: ""},
+		{name: "text and markdown conflict", text: "hi", markdown: "# hi", wantErr: "cannot be specified together"},
+		{name: "nothing specified", wantErr: "specify --content"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateEditContentFlags(tt.text, tt.markdown, tt.content, tt.attachments, tt.clearAttachments)
+			if tt.wantErr == "" {
+				if got != "" {
+					t.Fatalf("validateEditContentFlags() = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantErr) {
+				t.Fatalf("validateEditContentFlags() = %q, want substring %q", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+// assertEditValidationError asserts the error is a typed validation error with
+// the expected subtype and flag param (CodeRabbit: assert typed metadata, not
+// just message text).
+func assertEditValidationError(t *testing.T, err error, wantSub errs.Subtype, wantParam, wantMsg string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error = %T, want *errs.ValidationError: %v", err, err)
+	}
+	if wantSub != "" && ve.Subtype != wantSub {
+		t.Fatalf("subtype = %q, want %q", ve.Subtype, wantSub)
+	}
+	if wantParam != "" && ve.Param != wantParam {
+		t.Fatalf("param = %q, want %q", ve.Param, wantParam)
+	}
+	if wantMsg != "" && !strings.Contains(err.Error(), wantMsg) {
+		t.Fatalf("error = %v, want substring %q", err, wantMsg)
+	}
+}
+
+// TestImMessagesEditValidate covers message-id, post-only attachment, clear/set mutual exclusion, and content-required validation.
+
+func TestImMessagesEditValidate(t *testing.T) {
+	t.Run("markdown with attachment", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id": "om_123",
+			"markdown":   "# hi",
+		}, map[string][]string{"set-attachments": {"file_1"}})
+		if err := ImMessagesEdit.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesEdit.Validate() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("content post with attachment", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id": "om_123",
+			"msg-type":   "post",
+			"content":    `{"zh_cn":{"content":[[{"tag":"text","text":"hi"}]]}}`,
+		}, map[string][]string{"set-attachments": {"file_1"}})
+		if err := ImMessagesEdit.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesEdit.Validate() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("text with attachment rejected (post only)", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id": "om_123",
+			"text":       "hi",
+		}, map[string][]string{"set-attachments": {"file_1"}})
+		err := ImMessagesEdit.Validate(context.Background(), rt)
+		assertEditValidationError(t, err, errs.SubtypeInvalidArgument, "--set-attachments", "post message")
+	})
+
+	t.Run("missing message-id", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{"text": "hi"}, nil)
+		err := ImMessagesEdit.Validate(context.Background(), rt)
+		assertEditValidationError(t, err, errs.SubtypeInvalidArgument, "--message-id", "--message-id")
+	})
+
+	t.Run("missing content", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{"message-id": "om_123"}, nil)
+		err := ImMessagesEdit.Validate(context.Background(), rt)
+		assertEditValidationError(t, err, errs.SubtypeInvalidArgument, "", "specify --content")
+	})
+
+	t.Run("clear-attachments with markdown", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id":        "om_123",
+			"markdown":          "# hi",
+			"clear-attachments": "true",
+		}, nil)
+		if err := ImMessagesEdit.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesEdit.Validate() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("clear-attachments with attachment rejected", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id":        "om_123",
+			"markdown":          "# hi",
+			"clear-attachments": "true",
+		}, map[string][]string{"set-attachments": {"file_1"}})
+		err := ImMessagesEdit.Validate(context.Background(), rt)
+		assertEditValidationError(t, err, errs.SubtypeInvalidArgument, "--clear-attachments", "cannot be used with --set-attachments")
+	})
+
+	t.Run("clear-attachments without post type rejected", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id":        "om_123",
+			"text":              "hi",
+			"clear-attachments": "true",
+		}, nil)
+		err := ImMessagesEdit.Validate(context.Background(), rt)
+		assertEditValidationError(t, err, errs.SubtypeInvalidArgument, "--clear-attachments", "post message")
+	})
+
+	t.Run("clear-only with msg-type post ok", func(t *testing.T) {
+		rt := newEditTestRuntimeContext(map[string]string{
+			"message-id":        "om_123",
+			"msg-type":          "post",
+			"clear-attachments": "true",
+		}, nil)
+		if err := ImMessagesEdit.Validate(context.Background(), rt); err != nil {
+			t.Fatalf("ImMessagesEdit.Validate() unexpected error = %v (clear-only edit must be allowed)", err)
+		}
+	})
+}
+
+// TestImMessagesEditDryRunPUTContract verifies the DryRun output for attachment
+// set/clear flows: the HTTP method is PUT and the post body carries the files
+// array exactly as Execute would send it. This is the regression guard that
+// Validate's accepted inputs stay consistent with the actual request.
+func TestImMessagesEditDryRunPUTContract(t *testing.T) {
+	cases := []struct {
+		name        string
+		stringFlags map[string]string
+		sliceFlags  map[string][]string
+		wantMethod  string
+		wantMsgType string
+		wantFiles   string // substring expected in the content JSON
+	}{
+		{
+			name:        "clear-only post edit sets files empty array",
+			stringFlags: map[string]string{"message-id": "om_123", "msg-type": "post", "clear-attachments": "true"},
+			wantMethod:  "PUT",
+			wantMsgType: "post",
+			wantFiles:   "\"files\":[]",
+		},
+		{
+			name:        "set-attachments writes files array",
+			stringFlags: map[string]string{"message-id": "om_123", "msg-type": "post"},
+			sliceFlags:  map[string][]string{"set-attachments": {"file_1", "file_2"}},
+			wantMethod:  "PUT",
+			wantMsgType: "post",
+			wantFiles:   "\"files\":[{\"key\":\"file_1\"},{\"key\":\"file_2\"}]",
+		},
+		{
+			name:        "body-only edit has no files key",
+			stringFlags: map[string]string{"message-id": "om_123", "markdown": "# hi"},
+			wantMethod:  "PUT",
+			wantMsgType: "post",
+			wantFiles:   "", // absent: preserve semantics
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := newEditTestRuntimeContext(tt.stringFlags, tt.sliceFlags)
+			raw := mustMarshalDryRun(t, ImMessagesEdit.DryRun(context.Background(), rt))
+			var out struct {
+				API []struct {
+					Method string      `json:"method"`
+					Body   interface{} `json:"body"`
+				} `json:"api"`
+			}
+			if err := json.Unmarshal([]byte(raw), &out); err != nil {
+				t.Fatalf("unmarshal dry-run JSON: %v\n%s", err, raw)
+			}
+			if len(out.API) != 1 {
+				t.Fatalf("dry-run api calls = %d, want 1\n%s", len(out.API), raw)
+			}
+			if out.API[0].Method != tt.wantMethod {
+				t.Fatalf("dry-run method = %q, want %q", out.API[0].Method, tt.wantMethod)
+			}
+			body, ok := out.API[0].Body.(map[string]interface{})
+			if !ok {
+				t.Fatalf("dry-run body = %#v, want object", out.API[0].Body)
+			}
+			if body["msg_type"] != tt.wantMsgType {
+				t.Fatalf("dry-run msg_type = %v, want %q", body["msg_type"], tt.wantMsgType)
+			}
+			content, _ := body["content"].(string)
+			if tt.wantFiles == "" {
+				if strings.Contains(content, "\"files\"") {
+					t.Fatalf("dry-run content unexpectedly has files key: %s", content)
+				}
+				return
+			}
+			if !strings.Contains(content, tt.wantFiles) {
+				t.Fatalf("dry-run content = %s, want substring %q", content, tt.wantFiles)
+			}
+		})
+	}
+}

--- a/shortcuts/im/im_messages_reply.go
+++ b/shortcuts/im/im_messages_reply.go
@@ -34,6 +34,7 @@ var ImMessagesReply = common.Shortcut{
 		{Name: "video", Desc: "video file key (file_xxx), URL, or cwd-relative local path (absolute paths and .. are rejected); must be used together with --video-cover"},
 		{Name: "video-cover", Desc: "video cover image key (img_xxx), URL, or cwd-relative local path (absolute paths and .. are rejected); required when using --video"},
 		{Name: "audio", Desc: audioMessageInputDesc},
+		{Name: "attachment", Type: "string_slice", Desc: "file/folder key (file_xxx), repeatable; attaches to the post message's attachment zone (requires --markdown or --msg-type post)"},
 		{Name: "reply-in-thread", Type: "bool", Desc: "reply in thread (message appears in thread stream instead of main chat)"},
 		{Name: "idempotency-key", Desc: "idempotency key, max 50 characters (prevents duplicate sends)"},
 	},
@@ -58,6 +59,24 @@ var ImMessagesReply = common.Shortcut{
 		} else if mt, c, d := buildMediaContentFromKey(text, imageKey, fileKey, videoKey, videoCoverKey, audioKey); mt != "" {
 			msgType, content, desc = mt, c, d
 		}
+
+		// Attachment zone: merge --attachment files into the post content.
+		if attachments := runtime.StrSlice("attachment"); len(attachments) > 0 {
+			msgType = "post"
+			if items, err := parseAttachments(attachments, "--attachment"); err == nil {
+				if content == "" {
+					content = `{"zh_cn":{"content":[]}}`
+				}
+				if merged, err := mergeAttachmentsIntoPostContent(content, items); err == nil {
+					content = merged
+				}
+			}
+			if desc != "" {
+				desc += "; "
+			}
+			desc += "--attachment adds files to the post attachment zone"
+		}
+
 		if msgType == "text" || msgType == "post" {
 			content = normalizeAtMentions(content)
 		}
@@ -112,8 +131,24 @@ var ImMessagesReply = common.Shortcut{
 			return err
 		}
 
-		if msg := validateContentFlags(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey); msg != "" {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", msg)
+		attachments, err := validateAttachmentFlags(runtime.StrSlice("attachment"), msgType, markdown, "--attachment")
+		if err != nil {
+			return err
+		}
+
+		if hasContentFiles(content) && len(attachments) > 0 {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--attachment cannot be used with --content that already contains a files array; either declare files via --content or via --attachment, not both").WithParam("--attachment")
+		}
+		if hasAnyContentSource(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey) {
+			// With another content source present, mutual-exclusion and
+			// media-integrity errors must still fail (P1: attachments must not
+			// bypass content validation).
+			if msg := validateContentFlags(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey); msg != "" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s", msg)
+			}
+		} else if len(attachments) == 0 {
+			// No content source at all (and no attachment) — nothing to send.
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --content <json>, --text <plain text>, --markdown <markdown text>, a media flag (--image/--file/--video/--audio), or --attachment <file_key>")
 		}
 		if err := validateIdempotencyKey(idempotencyKey); err != nil {
 			return err
@@ -156,6 +191,19 @@ var ImMessagesReply = common.Shortcut{
 			return err
 		} else if mt != "" {
 			msgType, content = mt, c
+		}
+
+		// Attachment zone: merge --attachment files into the post content.
+		if items, err := parseAttachments(runtime.StrSlice("attachment"), "--attachment"); err == nil && len(items) > 0 {
+			msgType = "post"
+			if content == "" {
+				content = `{"zh_cn":{"content":[]}}`
+			}
+			merged, err := mergeAttachmentsIntoPostContent(content, items)
+			if err != nil {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--attachment: %v", err).WithParam("--attachment")
+			}
+			content = merged
 		}
 
 		normalizedContent := content

--- a/shortcuts/im/im_messages_reply.go
+++ b/shortcuts/im/im_messages_reply.go
@@ -131,7 +131,7 @@ var ImMessagesReply = common.Shortcut{
 			return err
 		}
 
-		attachments, err := validateAttachmentFlags(runtime.StrSlice("attachment"), msgType, markdown, "--attachment")
+		attachments, err := validateAttachmentFlags(runtime.StrSlice("attachment"), msgType, markdown, "--attachment", runtime.Cmd != nil && runtime.Cmd.Flags().Changed("msg-type"), text)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/im/im_messages_send.go
+++ b/shortcuts/im/im_messages_send.go
@@ -38,6 +38,7 @@ var ImMessagesSend = common.Shortcut{
 		{Name: "video", Desc: "video file key (file_xxx), URL, or cwd-relative local path (absolute paths and .. are rejected); must be used together with --video-cover"},
 		{Name: "video-cover", Desc: "video cover image key (img_xxx), URL, or cwd-relative local path (absolute paths and .. are rejected); required when using --video"},
 		{Name: "audio", Desc: audioMessageInputDesc},
+		{Name: "attachment", Type: "string_slice", Desc: "file/folder key (file_xxx), repeatable; attaches to the post message's attachment zone (requires --markdown or --msg-type post)"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		chatFlag := runtime.Str("chat-id")
@@ -59,6 +60,23 @@ var ImMessagesSend = common.Shortcut{
 			content, desc = wrapMarkdownAsPostForDryRun(markdown)
 		} else if mt, c, d := buildMediaContentFromKey(text, imageKey, fileKey, videoKey, videoCoverKey, audioKey); mt != "" {
 			msgType, content, desc = mt, c, d
+		}
+
+		// Attachment zone: merge --attachment files into the post content.
+		if attachments := runtime.StrSlice("attachment"); len(attachments) > 0 {
+			msgType = "post"
+			if items, err := parseAttachments(attachments, "--attachment"); err == nil {
+				if content == "" {
+					content = `{"zh_cn":{"content":[]}}`
+				}
+				if merged, err := mergeAttachmentsIntoPostContent(content, items); err == nil {
+					content = merged
+				}
+			}
+			if desc != "" {
+				desc += "; "
+			}
+			desc += "--attachment adds files to the post attachment zone"
 		}
 
 		receiveIdType := "chat_id"
@@ -133,8 +151,25 @@ var ImMessagesSend = common.Shortcut{
 			}
 		}
 
-		if msg := validateContentFlags(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey); msg != "" {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, msg)
+		attachments, err := validateAttachmentFlags(runtime.StrSlice("attachment"), msgType, markdown, "--attachment")
+		if err != nil {
+			return err
+		}
+
+		if hasContentFiles(content) && len(attachments) > 0 {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--attachment cannot be used with --content that already contains a files array; either declare files via --content or via --attachment, not both").WithParam("--attachment")
+		}
+		if hasAnyContentSource(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey) {
+			// When another content source is present, every mutual-exclusion and
+			// media-integrity error from validateContentFlags must still fail —
+			// --attachment must not silently swallow a conflicting --text/
+			// --markdown/--image etc. (P1: attachments bypass content validation).
+			if msg := validateContentFlags(text, markdown, content, imageKey, fileKey, videoKey, videoCoverKey, audioKey); msg != "" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, msg)
+			}
+		} else if len(attachments) == 0 {
+			// No content source at all (and no attachment) — nothing to send.
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --content <json>, --text <plain text>, --markdown <markdown text>, a media flag (--image/--file/--video/--audio), or --attachment <file_key>")
 		}
 		if err := validateIdempotencyKey(idempotencyKey); err != nil {
 			return err
@@ -177,6 +212,20 @@ var ImMessagesSend = common.Shortcut{
 			return err
 		} else if mt != "" {
 			msgType, content = mt, c
+		}
+
+		// Attachment zone: merge --attachment files into the post content.
+		// Validate has already enforced the post-only constraint.
+		if items, err := parseAttachments(runtime.StrSlice("attachment"), "--attachment"); err == nil && len(items) > 0 {
+			msgType = "post"
+			if content == "" {
+				content = `{"zh_cn":{"content":[]}}`
+			}
+			merged, err := mergeAttachmentsIntoPostContent(content, items)
+			if err != nil {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--attachment: %v", err).WithParam("--attachment")
+			}
+			content = merged
 		}
 
 		receiveIdType := "chat_id"

--- a/shortcuts/im/im_messages_send.go
+++ b/shortcuts/im/im_messages_send.go
@@ -151,7 +151,7 @@ var ImMessagesSend = common.Shortcut{
 			}
 		}
 
-		attachments, err := validateAttachmentFlags(runtime.StrSlice("attachment"), msgType, markdown, "--attachment")
+		attachments, err := validateAttachmentFlags(runtime.StrSlice("attachment"), msgType, markdown, "--attachment", runtime.Cmd != nil && runtime.Cmd.Flags().Changed("msg-type"), text)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/im/shortcuts.go
+++ b/shortcuts/im/shortcuts.go
@@ -15,6 +15,7 @@ func Shortcuts() []common.Shortcut {
 		ImChatSearch,
 		ImChatUpdate,
 		ImMessageReadUsers,
+		ImMessagesEdit,
 		ImMessagesMGet,
 		ImMessagesReadStatus,
 		ImMessagesReply,

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -114,6 +114,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。
 | [`+chat-search`](references/lark-im-chat-search.md) | Search visible group chats by --query keyword and/or --member-ids; user/bot; e.g. look up chat_id by group name; supports type filters, sorting, auto-pagination, and --exclude-muted (user identity only) |
 | [`+chat-update`](references/lark-im-chat-update.md) | Update group chat name or description; user/bot; updates a chat's name or description |
 | [`+message-read-users`](references/lark-im-message-read-status.md) | List users who read one message; user/bot; identity-specific scopes; supports bounded auto-pagination |
+| [`+messages-edit`](references/lark-im-messages-edit.md) | Edit a message's content (text/post, including the attachment zone); bot-only (user identity is rejected by the server); PUT /open-apis/im/v1/messages/:message_id |
 | [`+messages-mget`](references/lark-im-messages-mget.md) | Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies |
 | [`+messages-read-status`](references/lark-im-message-read-status.md) | Batch query whether the current user read 1–50 messages; user-only; returns readable items and invalid message IDs |
 | [`+messages-reply`](references/lark-im-messages-reply.md) | Reply to a message (supports thread replies); user/bot; supports text/markdown/post/media replies, reply-in-thread, idempotency key |

--- a/skills/lark-im/references/lark-im-messages-edit.md
+++ b/skills/lark-im/references/lark-im-messages-edit.md
@@ -2,9 +2,9 @@
 
 > **Prerequisite:** Read [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) first to understand authentication, global parameters, and safety rules.
 
-Edit an already-sent message's content. **Bot identity only** — the interface is `PUT /open-apis/im/v1/messages/:message_id`, and the server rejects user tokens (`user access token not support`). Only messages the bot sent can be edited.
+Edit an already-sent message's content. **Bot identity only** — the edit API does not accept user tokens. Only messages the bot sent can be edited.
 
-This skill maps to the shortcut: `lark-cli im +messages-edit` (internally calls `PUT /open-apis/im/v1/messages/:message_id`).
+This skill maps to the shortcut: `lark-cli im +messages-edit` (PUT on the message edit endpoint).
 
 ## Safety Constraints
 

--- a/skills/lark-im/references/lark-im-messages-edit.md
+++ b/skills/lark-im/references/lark-im-messages-edit.md
@@ -1,0 +1,89 @@
+# im +messages-edit
+
+> **Prerequisite:** Read [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) first to understand authentication, global parameters, and safety rules.
+
+Edit an already-sent message's content. **Bot identity only** — the interface is `PUT /open-apis/im/v1/messages/:message_id`, and the server rejects user tokens (`user access token not support`). Only messages the bot sent can be edited.
+
+This skill maps to the shortcut: `lark-cli im +messages-edit` (internally calls `PUT /open-apis/im/v1/messages/:message_id`).
+
+## Safety Constraints
+
+Editing rewrites a message visible to other people. Before calling it, you **must** confirm with the user:
+
+1. Which message to edit (its `message_id`)
+2. The new content
+
+The bot must be the original sender — editing another identity's message fails. Identity is always the bot: user identity is rejected server-side (`user access token not support`).
+
+**Do not** edit a message without explicit user approval.
+
+## Choose The Right Content Flag
+
+| Need | Recommended flag | Why |
+|------|------|------|
+| Edit to headings, lists, links, summaries, or Markdown-looking content | `--markdown` | Best default for lightweight formatting; converted to Feishu `post` JSON |
+| Edit to exact plain text | `--text` | Preserves literal text; no Markdown conversion |
+| Precisely control the new payload | `--content` | You provide the exact JSON for `text` / `post` |
+| Attach files/folders to the edited message's attachment zone | `--set-attachments` | Repeatable, as bare `file_key` (`file_xxx`); **replaces** the post content's `files` array (flag values are the final list, discarding any `files` in `--content`). Requires a post message (`--markdown` or `--msg-type post`). Name/metadata are filled by the server, not the client |
+| Clear the edited message's attachment zone | `--clear-attachments` | Sets `files:[]` on the post content. Requires a post message; mutually exclusive with `--set-attachments` |
+| Keep the existing attachment zone while rewriting the body | *(no attachment flag)* | **Default.** Editing with only `--markdown` / `--text` / `--content` leaves the current `files` array untouched — a body-only edit never drops attachments |
+
+## Editing the Attachment Zone
+
+`post` messages can carry an attachment zone — a top-level `files` array that renders files/folders under the rich-text body.
+
+**Default: no attachment flag preserves the attachment zone.** Editing with only `--markdown` / `--text` / `--content` (i.e. passing neither `--set-attachments` nor `--clear-attachments`) rewrites the body and keeps the existing `files` array unchanged. This is the safe default — fixing a typo must not drop the files you attached. Only pass `--set-attachments` to replace the zone, or `--clear-attachments` to remove it.
+
+To edit a message so it attaches (or re-attaches) files:
+
+```bash
+lark-cli im +messages-edit --as bot --message-id om_xxx --markdown "Updated content" --set-attachments file_xxx --set-attachments file_yyy
+```
+
+- `--set-attachments` accepts a bare file/folder key (`file_xxx`), and may be repeated.
+- **`--set-attachments` is a replace, not an append:** the flag values become the final `files` array. Send/reply's `--attachment` merges; edit's `--set-attachments` replaces.
+- **Mutually exclusive with `--content` carrying files:** when `--content` already contains a `files` array, `--set-attachments` and `--clear-attachments` are rejected — declare the attachment zone either via `--content` or via the attachment flags, not both. Use `--markdown` (which never emits a `files` array) or a `--content` without `files` together with the attachment flags.
+- The server fills name/size/mime/is_folder from file service metadata; the client does not (and cannot) override the display name.
+- When `--set-attachments` is present the effective `msg_type` is forced to `post`. Pair it with `--markdown` (or `--content` with post JSON plus `--msg-type post`); `--text` cannot carry an attachment zone.
+- The edited content replaces the whole message content, so include every file you want to keep in the new attachment zone.
+
+To **clear** the attachment zone entirely, pass `--clear-attachments` instead of `--set-attachments`:
+
+```bash
+lark-cli im +messages-edit --as bot --message-id om_xxx --markdown "Updated content" --clear-attachments
+```
+
+- `--clear-attachments` sets the post content's `files` array to `[]`, telling the server to remove all file/folder attachments.
+- It cannot be used together with `--set-attachments`.
+- Like `--set-attachments`, it forces the effective `msg_type` to `post`, so pair it with `--markdown` or `--msg-type post --content <post-json>`.
+
+## Parameters
+
+| Parameter | Required | Description |
+|------|------|------|
+| `--message-id <id>` | Yes | Message ID (`om_xxx`) to edit |
+| `--text <string>` | One content option | Plain text content |
+| `--markdown <string>` | One content option | Markdown text, converted to `post` JSON |
+| `--content <json>` | One content option | Exact message content JSON; must match the effective `--msg-type` |
+| `--set-attachments <key>` | One content option | Repeatable bare file/folder key (`file_xxx`); **replaces** the post attachment zone — the flag values become the final `files` array, discarding any `files` written in `--content`, and duplicate keys are sent once. Name/size/mime/is_folder are filled by the server |
+| `--clear-attachments` | One content option | Clear the post attachment zone by setting `files:[]` |
+| `--msg-type <type>` | No | Message type (default `text`). When `--markdown`/`--set-attachments`/`--clear-attachments` is used the effective type is inferred automatically |
+| `--as <identity>` | No | Identity type: `bot` only (user identity is rejected by the server) |
+| `--dry-run` | No | Print the request only, do not execute it |
+
+## Return Value
+
+```json
+{
+  "message_id": "om_xxx",
+  "chat_id": "oc_xxx",
+  "update_time": "1234567890"
+}
+```
+
+## Common Mistakes
+
+- Editing a message the calling identity did not send — the API rejects it.
+- Using `--set-attachments` with `--text`. The attachment zone only exists on `post` messages; use `--markdown` or `--msg-type post`.
+- Supplying only the files you want to keep, then losing the text. Editing replaces the entire content; pass the full new content (text + attachments) in one call.
+- Assuming a body-only edit clears the attachment zone. It does not — without `--set-attachments` / `--clear-attachments` the existing attachments are preserved.

--- a/skills/lark-im/references/lark-im-messages-mget.md
+++ b/skills/lark-im/references/lark-im-messages-mget.md
@@ -51,6 +51,14 @@ Each message contains:
 | `sender` | Sender information (includes `name`) |
 | `content` | Message content |
 
+For `post` messages, the attachment zone (top-level `files` array) is rendered as trailing lines in `content`, one per attachment:
+
+- `<file key="file_xxx" name="report.pdf"/>` — a file with a display name (same tag style as a standalone `file` message)
+- `<file key="file_xxx"/>` — a file with an empty display name (the server always backfills names, so this branch is rare but valid on the wire)
+- `<folder key="file_xxx" name="assets"/>` — a folder (`is_folder: true`, same tag style as a standalone `folder` message)
+
+Use `--format json` to see the full raw content, including each file's `file_key` / `file_name` / `is_folder` (the field names the API returns; the write format uses `key` / `name`). Attachment file keys are also eligible for [`+messages-resources-download`](lark-im-messages-resources-download.md) via `--download-resources`.
+
 ## Usage Scenarios
 
 ### Scenario 1: Fetch the full content of a specific message

--- a/skills/lark-im/references/lark-im-messages-mget.md
+++ b/skills/lark-im/references/lark-im-messages-mget.md
@@ -57,7 +57,7 @@ For `post` messages, the attachment zone (top-level `files` array) is rendered a
 - `<file key="file_xxx"/>` — a file with an empty display name (the server always backfills names, so this branch is rare but valid on the wire)
 - `<folder key="file_xxx" name="assets"/>` — a folder (`is_folder: true`, same tag style as a standalone `folder` message)
 
-Use `--format json` to see the full raw content, including each file's `file_key` / `file_name` / `is_folder` (the field names the API returns; the write format uses `key` / `name`). Attachment file keys are also eligible for [`+messages-resources-download`](lark-im-messages-resources-download.md) via `--download-resources`.
+Use `--format json` to see the full content without table truncation — note the content is the rendered text (including the `<file>`/`<folder>` lines above), not the raw post JSON. Attachment file keys rendered in the tags are eligible for [`+messages-resources-download`](lark-im-messages-resources-download.md) via `--download-resources`.
 
 ## Usage Scenarios
 

--- a/skills/lark-im/references/lark-im-messages-reply.md
+++ b/skills/lark-im/references/lark-im-messages-reply.md
@@ -187,6 +187,7 @@ lark-cli im +messages-reply --message-id om_xxx --msg-type interactive --content
 | `--video <path\|url\|key>` | One content option | Cwd-relative local video path, URL, or `file_key` (`file_xxx`); **must be used together with `--video-cover`**                                                                                |
 | `--video-cover <path\|url\|key>` | **Required with `--video`** | Cwd-relative local cover image path, URL, or `image_key` (`img_xxx`)                                                                                                                          |
 | `--audio <path\|url\|key>` | One content option | Voice-message audio key, URL, or cwd-relative local path. Local paths and URLs must be Opus (`.opus` or Ogg Opus `.ogg`) |
+| `--attachment <key>` | One content option | Repeatable bare file/folder key (`file_xxx`); merges into the post message's attachment zone. Requires a post message (`--markdown` or `--msg-type post`). Name/size/mime/is_folder are filled by the server from file service metadata, not taken from the client. Use this instead of `--file` when the file should render inside a rich-text message's attachment area |
 | `--reply-in-thread` | No | Reply inside the thread. The reply appears in the target message's thread instead of the main chat stream                                                                                     |
 | `--idempotency-key <key>` | No | Idempotency key, max 50 characters; the same key sends only one reply within 1 hour                                                                                                          |
 | `--as <identity>` | No | Identity type: `bot` or `user` (default `bot`)                                                                                                                                                |
@@ -206,6 +207,7 @@ lark-cli im +messages-reply --message-id om_xxx --msg-type interactive --content
 - Using `--content` without making the JSON match the effective `--msg-type`.
 - Explicitly setting `--msg-type` to something that conflicts with `--text`, `--markdown`, or media flags.
 - Mixing `--text`, `--markdown`, or `--content` with media flags in one command.
+- Using `--attachment` with `--text` or a media flag. The attachment zone only exists on `post` messages — pair `--attachment` with `--markdown` or `--msg-type post`.
 
 ## Return Value
 

--- a/skills/lark-im/references/lark-im-messages-send.md
+++ b/skills/lark-im/references/lark-im-messages-send.md
@@ -34,6 +34,7 @@ When using `--as user`, the message is sent as the authorized end user and requi
 | Send plain text exactly as written | `--text` | Preserves literal text; no Markdown conversion |
 | Precisely control the final payload | `--content` | You provide the exact JSON for `text` / `post` / `interactive` / `share_*` / media payloads |
 | Send image / file / video / audio | `--image` / `--file` / `--video` / `--audio` | Shortcut uploads URLs, or cwd-relative local files automatically |
+| Attach files/folders to a post message's attachment zone | `--attachment` | Repeatable, as bare `file_key` (`file_xxx`); merges into the post content's `files` array. Requires a post message (`--markdown` or `--msg-type post`). Name/metadata are filled by the server, not the client |
 
 ### `--text` vs `--markdown`
 
@@ -190,12 +191,13 @@ lark-cli im +messages-send --chat-id oc_xxx --msg-type interactive --content '<c
 | `--video <path\|url\|key>` | One content option | Cwd-relative local video path, URL, or `file_key` (`file_xxx`). Local paths and URLs are uploaded automatically. **Must be paired with `--video-cover`**                                      |
 | `--video-cover <path\|url\|key>` | **Required with `--video`** | Cwd-relative local cover image path, URL, or `image_key` (`img_xxx`). Local paths and URLs are uploaded automatically                                                                         |
 | `--audio <path\|url\|key>` | One content option | Voice-message audio key, URL, or cwd-relative local path. Local paths and URLs must be Opus (`.opus` or Ogg Opus `.ogg`) |
+| `--attachment <key>` | One content option | Repeatable bare file/folder key (`file_xxx`); merges into the post message's attachment zone. Requires a post message (`--markdown` or `--msg-type post`). Name/size/mime/is_folder are filled by the server from file service metadata, not taken from the client. Use this instead of `--file` when the file should render inside a rich-text message's attachment area |
 | `--msg-type <type>` | No | Message type (default `text`). If you use `--text` / `--markdown` / media flags, the effective type is inferred automatically. Explicitly setting a conflicting `--msg-type` fails validation |
 | `--idempotency-key <key>` | No | Idempotency key, max 50 characters; the same key sends only one message within 1 hour                                                                                                        |
 | `--as <identity>` | No | Identity type: `bot` or `user` (default `bot`)                                                                                                                                                |
 | `--dry-run` | No | Print the request only, do not execute it                                                                                                                                                     |
 
-> **Mutual exclusivity rule:** `--text`, `--markdown`, `--content`, and `--image`/`--file`/`--video`/`--audio` cannot be used together. Media flags are also mutually exclusive with each other.
+> **Mutual exclusivity rule:** `--text`, `--markdown`, `--content`, and `--image`/`--file`/`--video`/`--audio` cannot be used together. Media flags are also mutually exclusive with each other. `--attachment` cannot be combined with a `--content` that already contains a `files` array (the attachment zone is declared either via `--content` or via `--attachment`, not both).
 >
 > **Video cover rule:** `--video` **must** be accompanied by `--video-cover`. Omitting `--video-cover` when using `--video` will fail validation. `--video-cover` cannot be used without `--video`.
 
@@ -209,13 +211,15 @@ lark-cli im +messages-send --chat-id oc_xxx --msg-type interactive --content '<c
 - Using `--content` without making the JSON match the effective `--msg-type`.
 - Explicitly setting `--msg-type` to something that conflicts with `--text`, `--markdown`, or media flags.
 - Mixing `--text`, `--markdown`, or `--content` with media flags in one command.
+- Using `--attachment` with `--text` or a media flag. The attachment zone only exists on `post` messages — pair `--attachment` with `--markdown` or `--msg-type post`.
+- Using `--file` when the file should sit inside a rich-text message's attachment area. `--file` sends a standalone `file`-type message; use `--attachment` (with `--markdown` or post `--content`) to attach files/folders inside a post message.
 
 ## `content` Format Reference
 
 | `msg_type` | Example `content` |
 |----------|-------------|
 | `text` | `{"text":"Hello <at user_id=\"ou_xxx\">name</at>"}` |
-| `post` | `{"zh_cn":{"title":"Title","content":[[{"tag":"text","text":"Body"}]]}}` |
+| `post` | `{"zh_cn":{"title":"Title","content":[[{"tag":"text","text":"Body"}]]},"files":[{"key":"file_xxx"}]}` — the top-level `files` array is the attachment zone; each entry carries a file/folder `key` (name/metadata are backfilled by the server from file service metadata — a client-supplied `name` has no effect) |
 | `image` | `{"image_key":"img_xxx"}` |
 | `file` | `{"file_key":"file_xxx"}` |
 | `audio` | `{"file_key":"file_xxx"}` |


### PR DESCRIPTION
## Summary

Support the rich-text message **attachment zone** (the top-level `files` array of a post message) across the three CLI flows: sending, reading, and editing. This aligns the CLI with the server's three-way attachment semantics: omitting `files` preserves the old attachment zone, `files: []` clears it, and a non-empty `files` replaces it.

## Changes

- **`+messages-send` / `+messages-reply`**: repeatable `--attachment file_key` flags merged into the post content's `files` array (post-only; requires `--markdown` or `--msg-type post`).
- **`+messages-mget`**: renders attachment-zone files/folders as `<file key=... name=.../>` / `<folder .../>` tags; extracts attachment file keys for `--download-resources` (folders are skipped — they are not single-file resources).
- **`+messages-edit`** (new): `PUT /open-apis/im/v1/messages/:message_id` with `--set-attachments` (replace) and `--clear-attachments` (clear, sets `files: []`); body-only edits keep the existing attachment zone by default. Bot-only identity, matching server behavior (user token is rejected).
- **Docs & tests**: `SKILL.md`, per-command reference docs, and `affordance/im.md` updated; unit tests for validation, rendering, resource extraction, and edit flows added.

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./shortcuts/im/... ./internal/affordance/...` passes
- [x] Manual smoke on ppe_pan1 lane: send with single/multiple attachments, mget rendering, edit set/clear/keep semantics all verified

## Related Issues

- None
