### PR TITLE
feat(docs): add fetch citations

### DIFF
--- a/shortcuts/doc/docs_fetch.go
+++ b/shortcuts/doc/docs_fetch.go
@@ -6,6 +6,7 @@ package doc
 import (
 	"context"
 
+	"github.com/larksuite/cli/internal/citation"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -39,5 +40,9 @@ var DocsFetch = common.Shortcut{
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return executeFetchV2(ctx, runtime)
+	},
+	Citation: &common.CitationDefinition{
+		SourceTypes: []citation.SourceType{citation.SourceDoc},
+		Build:       docsFetchCitations,
 	},
 }

--- a/shortcuts/doc/docs_fetch_citation.go
+++ b/shortcuts/doc/docs_fetch_citation.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// docsFetchCitations builds the fetched document's citation from the final
+// response payload. The URL is server-resolved because it may carry tenant and
+// geo routing that cannot be reconstructed safely from the input token. The
+// fetch extra_param opts into that field only while citation output is enabled.
+func docsFetchCitations(_ *common.RuntimeContext, data any) []citation.Citation {
+	out, ok := data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	document, ok := out["document"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return []citation.Citation{{
+		SourceType: citation.SourceDoc,
+		URL:        common.GetString(document, "url"),
+		Title:      common.GetString(document, "title"),
+		ResourceID: common.GetString(document, "document_id"),
+	}}
+}

--- a/shortcuts/doc/docs_fetch_citation_test.go
+++ b/shortcuts/doc/docs_fetch_citation_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/larksuite/cli/internal/citation"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+func TestBuildFetchBodyRequestsURLWhenCitationsEnabled(t *testing.T) {
+	t.Setenv(envvars.CliCitation, "1")
+
+	body := buildFetchBody(newFetchBodyTestRuntime(context.Background()))
+	extraParam, ok := body["extra_param"].(string)
+	if !ok || extraParam == "" {
+		t.Fatalf("extra_param = %#v, want JSON string", body["extra_param"])
+	}
+	var got map[string]bool
+	if err := json.Unmarshal([]byte(extraParam), &got); err != nil {
+		t.Fatalf("decode extra_param %q: %v", extraParam, err)
+	}
+	if !got["return_url"] {
+		t.Fatalf("return_url = %#v, want true in %#v", got["return_url"], got)
+	}
+	if len(got) != 4 {
+		t.Fatalf("citation extra_param = %#v, want the three existing toggles plus return_url", got)
+	}
+}
+
+func TestDocsFetchCitationDryRunRequestsURL(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv(envvars.CliCitation, "1")
+
+	factory, stdout, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-citation-dry-run"))
+	if err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", "doxcnCitationDryRun",
+		"--dry-run",
+		"--as", "bot",
+	}, factory, stdout); err != nil {
+		t.Fatalf("docs +fetch --dry-run error = %v", err)
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode dry-run output: %v\nstdout=%s", err, stdout.String())
+	}
+	if envelope["ok"] != true || envelope["dry_run"] != true {
+		t.Fatalf("unexpected dry-run envelope: %#v", envelope)
+	}
+	data, ok := envelope["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("dry-run data = %#v, want object", envelope["data"])
+	}
+	api, ok := data["api"].([]interface{})
+	if !ok || len(api) != 1 {
+		t.Fatalf("dry-run api = %#v, want one call", data["api"])
+	}
+	call, ok := api[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("dry-run api[0] = %#v, want object", api[0])
+	}
+	body, ok := call["body"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("dry-run body = %#v, want object", call["body"])
+	}
+	var extraParam map[string]bool
+	if err := json.Unmarshal([]byte(body["extra_param"].(string)), &extraParam); err != nil {
+		t.Fatalf("decode dry-run extra_param: %v", err)
+	}
+	if !extraParam["return_url"] {
+		t.Fatalf("dry-run extra_param = %#v, want return_url=true", extraParam)
+	}
+}
+
+func TestDocsFetchCitations(t *testing.T) {
+	got := docsFetchCitations(nil, map[string]interface{}{
+		"document": map[string]interface{}{
+			"document_id": "doxcnCitation",
+			"url":         "https://example.feishu.cn/docx/doxcnCitation",
+			"title":       "Roadmap",
+		},
+	})
+	if len(got) != 1 {
+		t.Fatalf("docsFetchCitations() = %#v, want one entry", got)
+	}
+	if got[0].SourceType != citation.SourceDoc {
+		t.Errorf("source_type = %d, want %d", got[0].SourceType, citation.SourceDoc)
+	}
+	if got[0].URL != "https://example.feishu.cn/docx/doxcnCitation" {
+		t.Errorf("url = %q", got[0].URL)
+	}
+	if got[0].Title != "Roadmap" {
+		t.Errorf("title = %q, want Roadmap", got[0].Title)
+	}
+	if got[0].ResourceID != "doxcnCitation" {
+		t.Errorf("resource_id = %q, want doxcnCitation", got[0].ResourceID)
+	}
+}
+
+func TestDocsFetchCitationsTolerateUnexpectedPayload(t *testing.T) {
+	for _, data := range []any{
+		"not a map",
+		map[string]interface{}{},
+		map[string]interface{}{"document": "not a map"},
+	} {
+		if got := docsFetchCitations(nil, data); got != nil {
+			t.Errorf("docsFetchCitations(%#v) = %#v, want nil", data, got)
+		}
+	}
+}
+
+func TestDocsFetchMountedExecuteEmitsCitation(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv(envvars.CliCitation, "1")
+
+	const (
+		docToken = "doxcnCitationMounted"
+		docURL   = "https://example.feishu.cn/docx/doxcnCitationMounted"
+	)
+	factory, stdout, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-citation"))
+	stub := registerDocsAIStub(registry, "POST", "/open-apis/docs_ai/v1/documents/"+docToken+"/fetch", map[string]interface{}{
+		"document": map[string]interface{}{
+			"document_id": docToken,
+			"revision_id": float64(7),
+			"content":     "<title>Roadmap</title><p>Body</p>",
+			"url":         docURL,
+		},
+	})
+
+	if err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", docToken,
+		"--as", "bot",
+	}, factory, stdout); err != nil {
+		t.Fatalf("docs +fetch error = %v", err)
+	}
+
+	requestBody := decodeRequestBody(t, stub.CapturedBody)
+	var extraParam map[string]bool
+	if err := json.Unmarshal([]byte(requestBody["extra_param"].(string)), &extraParam); err != nil {
+		t.Fatalf("decode request extra_param: %v", err)
+	}
+	if !extraParam["return_url"] {
+		t.Fatalf("request extra_param = %#v, want return_url=true", extraParam)
+	}
+
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Document map[string]interface{} `json:"document"`
+		} `json:"data"`
+		Citations []citation.Citation `json:"citations"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v\nstdout=%s", err, stdout.String())
+	}
+	if !envelope.OK {
+		t.Fatalf("expected ok=true output: %s", stdout.String())
+	}
+	if got := envelope.Data.Document["url"]; got != docURL {
+		t.Fatalf("document.url = %#v, want %q", got, docURL)
+	}
+	if len(envelope.Citations) != 1 {
+		t.Fatalf("citations = %#v, want one entry", envelope.Citations)
+	}
+	got := envelope.Citations[0]
+	if got.SourceType != citation.SourceDoc || got.URL != docURL || got.ResourceID != docToken {
+		t.Fatalf("citation = %#v, want source_type=%d url=%q resource_id=%q", got, citation.SourceDoc, docURL, docToken)
+	}
+	if got.Title != "" {
+		t.Fatalf("title = %q, want empty because fetch response has no title field", got.Title)
+	}
+}
+
+func TestDocsFetchCitationPrettyOutputStaysContentOnly(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv(envvars.CliCitation, "1")
+
+	const (
+		docToken = "doxcnCitationPretty"
+		content  = "<title>Roadmap</title><p>Body</p>"
+	)
+	factory, stdout, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-citation-pretty"))
+	registerDocsAIStub(registry, "POST", "/open-apis/docs_ai/v1/documents/"+docToken+"/fetch", map[string]interface{}{
+		"document": map[string]interface{}{
+			"document_id": docToken,
+			"revision_id": float64(7),
+			"content":     content,
+			"url":         "https://example.feishu.cn/docx/" + docToken,
+		},
+	})
+
+	if err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", docToken,
+		"--format", "pretty",
+		"--as", "bot",
+	}, factory, stdout); err != nil {
+		t.Fatalf("docs +fetch --format pretty error = %v", err)
+	}
+	if got := stdout.String(); got != content+"\n" {
+		t.Fatalf("pretty output = %q, want content only", got)
+	}
+}
+
+func TestDocsFetchMountedExecuteOmitsCitationWhenDisabled(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv(envvars.CliCitation, "")
+
+	const docToken = "doxcnCitationDisabled"
+	factory, stdout, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-citation-disabled"))
+	stub := registerDocsAIStub(registry, "POST", "/open-apis/docs_ai/v1/documents/"+docToken+"/fetch", map[string]interface{}{
+		"document": map[string]interface{}{
+			"document_id": docToken,
+			"revision_id": float64(1),
+			"content":     "<title>Roadmap</title>",
+		},
+	})
+
+	if err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", docToken,
+		"--as", "bot",
+	}, factory, stdout); err != nil {
+		t.Fatalf("docs +fetch error = %v", err)
+	}
+
+	requestBody := decodeRequestBody(t, stub.CapturedBody)
+	var extraParam map[string]bool
+	if err := json.Unmarshal([]byte(requestBody["extra_param"].(string)), &extraParam); err != nil {
+		t.Fatalf("decode request extra_param: %v", err)
+	}
+	if _, ok := extraParam["return_url"]; ok {
+		t.Fatalf("request extra_param = %#v, return_url must be absent while citations are disabled", extraParam)
+	}
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v\nstdout=%s", err, stdout.String())
+	}
+	if _, ok := envelope["citations"]; ok {
+		t.Fatalf("disabled output must omit citations: %s", stdout.String())
+	}
+}

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -11,12 +11,14 @@ import (
 	"strings"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/citation"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
 const (
-	docsFetchExtraParam         = `{"enable_user_cite_reference_map":true,"return_html5_block_data":true}`
-	docsFetchCommentsExtraParam = `{"enable_user_cite_reference_map":true,"include_comments":true,"return_html5_block_data":true}`
+	docsFetchExtraParam                 = `{"enable_user_cite_reference_map":true,"return_html5_block_data":true}`
+	docsFetchCommentsExtraParam         = `{"enable_user_cite_reference_map":true,"include_comments":true,"return_html5_block_data":true}`
+	docsFetchCommentsCitationExtraParam = `{"enable_user_cite_reference_map":true,"include_comments":true,"return_html5_block_data":true,"return_url":true}`
 )
 
 // v2FetchFlags returns the flag definitions for the v2 (OpenAPI) fetch path.
@@ -95,9 +97,13 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 }
 
 func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
+	extraParam := docsFetchCommentsExtraParam
+	if citation.Enabled() {
+		extraParam = docsFetchCommentsCitationExtraParam
+	}
 	body := map[string]interface{}{
 		"format":      effectiveFetchFormat(runtime),
-		"extra_param": docsFetchCommentsExtraParam,
+		"extra_param": extraParam,
 	}
 	if v := runtime.Int("revision-id"); v > 0 {
 		body["revision_id"] = v

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
@@ -553,7 +554,7 @@ func TestAddFetchDetailDowngradeWarningNoops(t *testing.T) {
 }
 
 func TestBuildFetchBodyIncludesFetchExtraParamByDefault(t *testing.T) {
-	t.Parallel()
+	t.Setenv(envvars.CliCitation, "")
 
 	runtime := newFetchBodyTestRuntime(context.Background())
 


### PR DESCRIPTION
## Summary

Add citation output support to `docs +fetch` on the citation framework branch. The command opts into the server-resolved document URL only when `LARKSUITE_CLI_CITATION=1`, preserving the existing request and output contract while the gate is off.

## Changes

- declare `SourceDoc` citation support for `docs +fetch`
- request `extra_param.return_url=true` only while citation output is enabled
- build citations from the final `document.url`, `document_id`, and optional `title` payload fields without extra API calls
- cover enabled, disabled, dry-run, pretty-output, and unexpected-payload behavior

## Test Plan

- [x] `go test ./shortcuts/doc ./shortcuts/common ./internal/citation ./internal/output -count=1`
- [x] `make build`
- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/feat/citation-framework make quality-gate`
- [x] GolangCI, source guards, lint tests, and license checks pass
- [ ] PPE live verification after the server-side `return_url` support is available in the integration environment

## Related Issues

- None