### PR TITLE
fix(client): propagate later pagination errors

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -375,7 +375,8 @@ func (c *APIClient) CallAPI(ctx context.Context, request RawApiRequest) (interfa
 }
 
 // paginateLoop runs the core pagination loop. For each successful page (code == 0),
-// it calls onResult if non-nil. It always accumulates and returns all raw page results.
+// it calls onResult if non-nil. It accumulates successful page results and returns
+// an error when a later page fails so callers cannot treat partial results as complete.
 func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opts PaginationOptions, onResult func(interface{}) error) ([]interface{}, error) {
 	var allResults []interface{}
 	var pageToken string
@@ -409,7 +410,7 @@ func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opt
 				return nil, err
 			}
 			fmt.Fprintf(c.ErrOut, "[page %d] error, stopping pagination\n", page)
-			break
+			return allResults, err
 		}
 
 		if resultMap, ok := result.(map[string]interface{}); ok {
@@ -420,7 +421,7 @@ func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opt
 					return allResults, nil
 				}
 				fmt.Fprintf(c.ErrOut, "[page %d] API error (code=%.0f), stopping pagination\n", page, code)
-				break
+				return allResults, c.CheckResponse(result, request.As)
 			}
 		}
 
@@ -479,7 +480,7 @@ func (c *APIClient) PaginateAll(ctx context.Context, request RawApiRequest, opts
 
 // StreamPages fetches all pages and streams each page's list items via onItems.
 // Returns the last page result (for error checking), whether any list items were found,
-// and any network error. Use this for streaming formats (ndjson, table, csv).
+// and any pagination error. Use this for streaming formats (ndjson, table, csv).
 func (c *APIClient) StreamPages(ctx context.Context, request RawApiRequest, onItems func([]interface{}) error, opts PaginationOptions) (result interface{}, hasItems bool, err error) {
 	totalItems := 0
 	results, loopErr := c.paginateLoop(ctx, request, opts, func(r interface{}) error {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -288,6 +288,128 @@ func TestPaginateAll_PageLimitStopsPagination(t *testing.T) {
 	}
 }
 
+func TestPaginateAll_LaterPageTransportErrorIsReturned(t *testing.T) {
+	apiCalls := 0
+	sentinel := errors.New("page two transport failed")
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		apiCalls++
+		if apiCalls == 1 {
+			return jsonResponse(map[string]interface{}{
+				"code": 0, "msg": "ok",
+				"data": map[string]interface{}{
+					"items":      []interface{}{map[string]interface{}{"id": "first"}},
+					"has_more":   true,
+					"page_token": "next",
+				},
+			}), nil
+		}
+		return nil, sentinel
+	})
+
+	ac, _ := newTestAPIClient(t, rt)
+	result, err := ac.PaginateAll(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test/v1/items",
+		As:     "bot",
+	}, PaginationOptions{PageLimit: 10, PageDelay: -1})
+
+	if result != nil {
+		t.Fatalf("result = %#v, want nil when a later page fails", result)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want page-two transport error", err)
+	}
+	if apiCalls != 2 {
+		t.Fatalf("apiCalls = %d, want 2", apiCalls)
+	}
+}
+
+func TestPaginateAll_LaterPageAPIErrorIsReturned(t *testing.T) {
+	apiCalls := 0
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		apiCalls++
+		if apiCalls == 1 {
+			return jsonResponse(map[string]interface{}{
+				"code": 0, "msg": "ok",
+				"data": map[string]interface{}{
+					"items":      []interface{}{map[string]interface{}{"id": "first"}},
+					"has_more":   true,
+					"page_token": "next",
+				},
+			}), nil
+		}
+		return jsonResponse(map[string]interface{}{
+			"code": 123456,
+			"msg":  "page two business failure",
+			"data": map[string]interface{}{"detail": "page two failed"},
+		}), nil
+	})
+
+	ac, _ := newTestAPIClient(t, rt)
+	result, err := ac.PaginateAll(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test/v1/items",
+		As:     "bot",
+	}, PaginationOptions{PageLimit: 10, PageDelay: -1})
+
+	if result != nil {
+		t.Fatalf("result = %#v, want nil when a later page fails", result)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Code != 123456 || problem.Message != "page two business failure" {
+		t.Fatalf("problem = %#v, %v; want typed page-two API error", problem, ok)
+	}
+	if apiCalls != 2 {
+		t.Fatalf("apiCalls = %d, want 2", apiCalls)
+	}
+}
+
+func TestStreamPages_LaterPageErrorPreservesEarlierItems(t *testing.T) {
+	apiCalls := 0
+	sentinel := errors.New("page two transport failed")
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		apiCalls++
+		if apiCalls == 1 {
+			return jsonResponse(map[string]interface{}{
+				"code": 0, "msg": "ok",
+				"data": map[string]interface{}{
+					"items":      []interface{}{map[string]interface{}{"id": "first"}},
+					"has_more":   true,
+					"page_token": "next",
+				},
+			}), nil
+		}
+		return nil, sentinel
+	})
+
+	ac, _ := newTestAPIClient(t, rt)
+	var streamedItems []interface{}
+	result, hasItems, err := ac.StreamPages(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test/v1/items",
+		As:     "bot",
+	}, func(items []interface{}) error {
+		streamedItems = append(streamedItems, items...)
+		return nil
+	}, PaginationOptions{PageLimit: 10, PageDelay: -1})
+
+	if result != nil {
+		t.Fatalf("result = %#v, want nil when a later page fails", result)
+	}
+	if hasItems {
+		t.Fatal("hasItems = true, want false when pagination returns an error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want page-two transport error", err)
+	}
+	if len(streamedItems) != 1 {
+		t.Fatalf("streamedItems = %d, want one item from the successful first page", len(streamedItems))
+	}
+	if apiCalls != 2 {
+		t.Fatalf("apiCalls = %d, want 2", apiCalls)
+	}
+}
+
 func TestPaginateAll_NaturalEndClearsPageToken(t *testing.T) {
 	apiCalls := 0
 	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -410,6 +410,56 @@ func TestStreamPages_LaterPageErrorPreservesEarlierItems(t *testing.T) {
 	}
 }
 
+func TestStreamPages_LaterPageAPIErrorPreservesEarlierItems(t *testing.T) {
+	apiCalls := 0
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		apiCalls++
+		if apiCalls == 1 {
+			return jsonResponse(map[string]interface{}{
+				"code": 0, "msg": "ok",
+				"data": map[string]interface{}{
+					"items":      []interface{}{map[string]interface{}{"id": "first"}},
+					"has_more":   true,
+					"page_token": "next",
+				},
+			}), nil
+		}
+		return jsonResponse(map[string]interface{}{
+			"code": 654321,
+			"msg":  "page two business failure",
+			"data": map[string]interface{}{"detail": "page two failed"},
+		}), nil
+	})
+
+	ac, _ := newTestAPIClient(t, rt)
+	var streamedItems []interface{}
+	result, hasItems, err := ac.StreamPages(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test/v1/items",
+		As:     "bot",
+	}, func(items []interface{}) error {
+		streamedItems = append(streamedItems, items...)
+		return nil
+	}, PaginationOptions{PageLimit: 10, PageDelay: -1})
+
+	if result != nil {
+		t.Fatalf("result = %#v, want nil when a later page fails", result)
+	}
+	if hasItems {
+		t.Fatal("hasItems = true, want false when pagination returns an error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Code != 654321 || problem.Message != "page two business failure" {
+		t.Fatalf("problem = %#v, %v; want typed page-two API error", problem, ok)
+	}
+	if len(streamedItems) != 1 {
+		t.Fatalf("streamedItems = %d, want one item from the successful first page", len(streamedItems))
+	}
+	if apiCalls != 2 {
+		t.Fatalf("apiCalls = %d, want 2", apiCalls)
+	}
+}
+
 func TestPaginateAll_NaturalEndClearsPageToken(t *testing.T) {
 	apiCalls := 0
 	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary
When `--page-all` succeeds on the first page but a later page fails, the CLI must return a failure instead of treating partial data as a complete successful result.

## Changes
- Propagate later-page transport errors from `paginateLoop`.
- Propagate later-page non-zero API responses through the existing typed error path.
- Preserve already-streamed items while returning a failure status for incomplete pagination.
- Add regression tests for later-page transport errors, API errors, and streaming behavior.

## Test Plan
- [x] `make build`
- [x] `make fmt-check`
- [x] `make vet`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `go test ./internal/client ./cmd/api ./cmd/service`
- [x] `make quality-gate` with `origin/main` as the base
- [x] Diff-scoped golangci-lint, source-contract lint, lint tests, and go-licenses checks
- [x] Live read-only verification: `wiki spaces list --as user --page-all --page-size 1` fetched two real pages and exited successfully; no data was returned and no Feishu data was modified
- [x] Existing local Feishu auth and read-only CLI lookup verified
- [ ] Full local `make unit-test`: unrelated URL policy fixture failures remain in `shortcuts/im` and `shortcuts/minutes`

## Related Issues
- Fixes #2477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination now reports transport and API errors encountered on later pages instead of treating partial results as successful.
  * Streaming pagination preserves items received from earlier pages while clearly reporting subsequent-page failures.
* **Documentation**
  * Updated pagination guidance to cover API and pagination errors, in addition to network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->