### PR TITLE
fix(doc): reject unsupported image src writes

### DIFF
--- a/shortcuts/doc/local_doc_resources.go
+++ b/shortcuts/doc/local_doc_resources.go
@@ -392,6 +392,9 @@ func rewriteRawLocalResourceTag(runtime *common.RuntimeContext, raw, name string
 		}
 		href, hasHref := tag.attr("href")
 		if !hasHref {
+			if tag.hasAttr("src") {
+				return "", localDocResource{}, false, common.ValidationErrorf("<img> src is not supported for document writes; use <img path=...>, <img href=...>, or block_copy_insert_after").WithParam("img")
+			}
 			return raw, localDocResource{}, false, nil
 		}
 		conflicts := []string{"src", "token", "img_key", "img-key", "url"}

--- a/shortcuts/doc/local_doc_resources_test.go
+++ b/shortcuts/doc/local_doc_resources_test.go
@@ -146,6 +146,17 @@ func TestPrepareLocalDocResourcesXMLRemoteImageDoesNotRelaxOtherAttributes(t *te
 	}
 }
 
+func TestPrepareLocalDocResourcesRejectsUnsupportedXMLImageSrc(t *testing.T) {
+	runtime := newLocalDocResourceTestRuntime(t, nil)
+	_, _, err := prepareLocalDocResources(runtime, "xml", `<p>before</p><img src="file_token"/><p>after</p>`)
+	if err == nil {
+		t.Fatal("prepareLocalDocResources() error = nil")
+	}
+	if !strings.Contains(err.Error(), "<img> src is not supported for document writes") {
+		t.Fatalf("prepareLocalDocResources() error = %v", err)
+	}
+}
+
 func TestPrepareLocalDocResourcesRemoteImageRejectsConflicts(t *testing.T) {
 	runtime := newLocalDocResourceTestRuntime(t, nil)
 	for _, content := range []string{

--- a/shortcuts/doc/local_doc_resources_test.go
+++ b/shortcuts/doc/local_doc_resources_test.go
@@ -152,6 +152,16 @@ func TestPrepareLocalDocResourcesRejectsUnsupportedXMLImageSrc(t *testing.T) {
 	if err == nil {
 		t.Fatal("prepareLocalDocResources() error = nil")
 	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("prepareLocalDocResources() error type = %T, want *errs.ValidationError", err)
+	}
+	if validationErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("validation subtype = %q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if validationErr.Param != "img" {
+		t.Fatalf("validation param = %q, want img", validationErr.Param)
+	}
 	if !strings.Contains(err.Error(), "<img> src is not supported for document writes") {
 		t.Fatalf("prepareLocalDocResources() error = %v", err)
 	}

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -11,7 +11,7 @@
 - `<latex>E = mc^2</latex>`：适用行内公式，也适用于上标、下标写法。
 - `<ol><li>第一项<ul><li>子项</li></ul></li><li>第二项</li></ol>`：子列表放在 `<li>` 内；新增列表项必须放在 `<ul>` 或 `<ol>` 内。
 - `<pre lang="go" caption="示例"><code>fmt.Println(&quot;hello&quot;)</code></pre>`：代码必须放在 `<code>` 内，禁止直接放在 `<pre>` 下；`caption` 可省略。
-- `<img path="@./photo.png"/>`：上传当前工作目录内的本地图片。也可用 `<img href="URL"/>` 上传公开 HTTP(S) 网络图片；两者任选一个，可选 `width`、`height`、`caption`、`name`。使用 `href` 时，CLI 会将远程图片转为本地资源并完成上传；响应须为 PNG、JPEG、GIF 或 WebP，单图不超过 20MiB。内部网络图片须先下载到本地再使用 `path`。写入内容中的 `<img src="token"/>` 当前不受 `docs +update` 支持，会在写入前报错；如需复用已有图片块，请使用 `docs +update --command block_copy_insert_after --src-block-ids`。
+- `<img path="@./photo.png"/>`：上传当前工作目录内的本地图片。也可用 `<img href="URL"/>` 上传公开 HTTP(S) 网络图片；两者任选一个，可选 `width`、`height`、`caption`、`name`。使用 `href` 时，CLI 会将远程图片转为本地资源并完成上传；响应须为 PNG、JPEG、GIF 或 WebP，单图不超过 20MiB。内部网络图片须先下载到本地再使用 `path`。写入内容中的 `<img src="token"/>` 当前不受 `docs +update` 支持，会在写入前报错；如需复用已有图片块，请使用 `docs +update --command block_copy_insert_after --block-id <destination-block-id> --src-block-ids <source-block-id>`。
 - `<source path="@./report.pdf" name="报告.pdf"/>`：上传本地附件；也可使用 `<source token="token" name="xx"/>` 复制已有附件。可独立使用、放入 `<p>` 作为行内附件，或写成 `<figure view-type="Card|Preview"><source/></figure>`；
 - `<checkbox done="true|false">todo</checkbox>`
 - `p, h1-h9, li, checkbox, title` 支持可选属性 `align`，可选值为 `left`、`center`、`right`，例如 `<p align="center">居中正文</p>`。

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -11,7 +11,7 @@
 - `<latex>E = mc^2</latex>`：适用行内公式，也适用于上标、下标写法。
 - `<ol><li>第一项<ul><li>子项</li></ul></li><li>第二项</li></ol>`：子列表放在 `<li>` 内；新增列表项必须放在 `<ul>` 或 `<ol>` 内。
 - `<pre lang="go" caption="示例"><code>fmt.Println(&quot;hello&quot;)</code></pre>`：代码必须放在 `<code>` 内，禁止直接放在 `<pre>` 下；`caption` 可省略。
-- `<img path="@./photo.png"/>`：上传当前工作目录内的本地图片。也可用 `<img href="URL"/>` 上传公开 HTTP(S) 网络图片，或用 `<img src="token"/>` 复制原始图片；三者任选一个，可选 `width`、`height`、`caption`、`name`。使用 `href` 时，CLI 会将远程图片转为本地资源并完成上传；响应须为 PNG、JPEG、GIF 或 WebP，单图不超过 20MiB。内部网络图片须先下载到本地再使用 `path`。
+- `<img path="@./photo.png"/>`：上传当前工作目录内的本地图片。也可用 `<img href="URL"/>` 上传公开 HTTP(S) 网络图片；两者任选一个，可选 `width`、`height`、`caption`、`name`。使用 `href` 时，CLI 会将远程图片转为本地资源并完成上传；响应须为 PNG、JPEG、GIF 或 WebP，单图不超过 20MiB。内部网络图片须先下载到本地再使用 `path`。写入内容中的 `<img src="token"/>` 当前不受 `docs +update` 支持，会在写入前报错；如需复用已有图片块，请使用 `docs +update --command block_copy_insert_after --src-block-ids`。
 - `<source path="@./report.pdf" name="报告.pdf"/>`：上传本地附件；也可使用 `<source token="token" name="xx"/>` 复制已有附件。可独立使用、放入 `<p>` 作为行内附件，或写成 `<figure view-type="Card|Preview"><source/></figure>`；
 - `<checkbox done="true|false">todo</checkbox>`
 - `p, h1-h9, li, checkbox, title` 支持可选属性 `align`，可选值为 `left`、`center`、`right`，例如 `<p align="center">居中正文</p>`。


### PR DESCRIPTION
## Summary

Prevent `docs +update` from silently sending `<img src="token"/>` to the backend, where the image is dropped while the command reports success.

## Changes

- Reject unsupported `<img src>` attributes before the document API call with a typed validation error.
- Add a regression test and update the bundled XML skill guidance to use `block_copy_insert_after` for existing image blocks.

## Test Plan

- [ ] Unit tests pass (blocked locally: the read-only environment cannot create Go build temp files)
- [x] Manual local verification: the shipped `lark-cli` binary reproduces the original dry-run request and confirms the unmodified `<img src>` payload would be forwarded.

## Related Issues

Fixes #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject unsupported XML image syntax that uses the `src` attribute without the required path or reference.
  * Errors now clearly identify the invalid image parameter and direct users to supported document-writing alternatives.

* **Documentation**
  * Clarified that reusing existing image blocks requires specifying both the source and destination block IDs in the block-copy workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->