### PR TITLE
fix(qualitygate): harvest skill examples past multi-line quoted flags

### DIFF
--- a/internal/qualitygate/skillscan/harvest.go
+++ b/internal/qualitygate/skillscan/harvest.go
@@ -95,7 +95,7 @@ func harvestFile(path string) ([]Example, error) {
 
 		startLine := i + 1
 		raw := trimContinuation(line)
-		for continues(line) && i+1 < len(lines) {
+		for i+1 < len(lines) && (continues(line) || hasOpenQuote(raw)) {
 			i++
 			line = strings.TrimSpace(lines[i])
 			raw += " " + trimContinuation(line)
@@ -113,6 +113,34 @@ func harvestFile(path string) ([]Example, error) {
 
 func continues(line string) bool {
 	return strings.HasSuffix(strings.TrimRight(line, " \t"), "\\")
+}
+
+// hasOpenQuote reports whether raw ends inside a quoted word. A quoted argument
+// carries a shell word across newlines without a trailing backslash, which is
+// how the skills spell multi-line JSON flags, so harvesting has to keep reading
+// until the quote closes or the fence ends.
+func hasOpenQuote(raw string) bool {
+	var quote rune
+	escaped := false
+	for _, r := range raw {
+		switch {
+		case escaped:
+			escaped = false
+		case quote == '\'':
+			if r == quote {
+				quote = 0
+			}
+		case r == '\\':
+			escaped = true
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			}
+		case r == '\'' || r == '"':
+			quote = r
+		}
+	}
+	return quote != 0
 }
 
 func trimContinuation(line string) string {

--- a/internal/qualitygate/skillscan/harvest.go
+++ b/internal/qualitygate/skillscan/harvest.go
@@ -85,7 +85,7 @@ func harvestFile(path string) ([]Example, error) {
 	inFence := false
 	for i := 0; i < len(lines); i++ {
 		line := strings.TrimSpace(lines[i])
-		if strings.HasPrefix(line, "```") {
+		if isFence(line) {
 			inFence = !inFence
 			continue
 		}
@@ -95,7 +95,9 @@ func harvestFile(path string) ([]Example, error) {
 
 		startLine := i + 1
 		raw := trimContinuation(line)
-		for i+1 < len(lines) && (continues(line) || hasOpenQuote(raw)) {
+		// The fence bounds the example. A genuinely unterminated quote must not
+		// swallow the closing fence and every later command in the file.
+		for i+1 < len(lines) && !isFence(lines[i+1]) && (continues(line) || hasOpenQuote(raw)) {
 			i++
 			line = strings.TrimSpace(lines[i])
 			raw += " " + trimContinuation(line)
@@ -109,6 +111,10 @@ func harvestFile(path string) ([]Example, error) {
 		})
 	}
 	return out, nil
+}
+
+func isFence(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "```")
 }
 
 func continues(line string) bool {

--- a/internal/qualitygate/skillscan/harvest_test.go
+++ b/internal/qualitygate/skillscan/harvest_test.go
@@ -113,3 +113,31 @@ func TestHasOpenQuote(t *testing.T) {
 		}
 	}
 }
+
+func TestHarvestStopsQuotedContinuationAtClosingFence(t *testing.T) {
+	// An example whose quote never closes is a real defect and should still be
+	// reported as unparsable, but following the quote past the fence would
+	// swallow every later command in the file and silently drop them from
+	// validation.
+	got, err := Harvest(filepath.Join("testdata", "unterminated"))
+	if err != nil {
+		t.Fatalf("Harvest() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d examples, want 3: %#v", len(got), got)
+	}
+
+	if strings.Contains(got[0].Raw, "```") || strings.Contains(got[0].Raw, "Prose") {
+		t.Errorf("broken example absorbed the fence or the prose after it: %q", got[0].Raw)
+	}
+	if !hasOpenQuote(got[0].Raw) {
+		t.Errorf("a genuinely unterminated quote should stay unterminated: %q", got[0].Raw)
+	}
+
+	if !strings.Contains(got[1].Raw, "+chat-list") {
+		t.Errorf("command after the broken fence was dropped: %#v", got)
+	}
+	if !strings.Contains(got[2].Raw, "A3Ijlater") {
+		t.Errorf("last command in the file was dropped: %#v", got)
+	}
+}

--- a/internal/qualitygate/skillscan/harvest_test.go
+++ b/internal/qualitygate/skillscan/harvest_test.go
@@ -5,6 +5,7 @@ package skillscan
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -60,6 +61,55 @@ func TestHasPlaceholderDistinguishesHTMLFromPlaceholders(t *testing.T) {
 	} {
 		if !HasPlaceholder(raw) {
 			t.Fatalf("expected placeholder for %q", raw)
+		}
+	}
+}
+
+func TestHarvestFollowsQuotedArgumentsAcrossLines(t *testing.T) {
+	// A quoted flag value continues a shell word without a trailing backslash,
+	// which is how the shipped skills spell multi-line JSON. Stopping at the
+	// first unescaped newline hands the caller a fragment with an unclosed
+	// quote, and the example goes unvalidated.
+	got, err := Harvest(filepath.Join("testdata", "multiline"))
+	if err != nil {
+		t.Fatalf("Harvest() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d examples, want 2: %#v", len(got), got)
+	}
+
+	for _, ex := range got {
+		if hasOpenQuote(ex.Raw) {
+			t.Errorf("harvested example ends inside a quote: %q", ex.Raw)
+		}
+	}
+
+	if !strings.Contains(got[0].Raw, `"shaper": {"format": "flat"}`) {
+		t.Errorf("single-quoted JSON was truncated: %q", got[0].Raw)
+	}
+	if !strings.HasSuffix(got[0].Raw, "}'") {
+		t.Errorf("single-quoted value did not close: %q", got[0].Raw)
+	}
+	if !strings.Contains(got[1].Raw, "line one line two") {
+		t.Errorf("double-quoted value was truncated: %q", got[1].Raw)
+	}
+}
+
+func TestHasOpenQuote(t *testing.T) {
+	tests := map[string]bool{
+		`lark-cli docs +fetch --doc A3Ij`:      false,
+		`lark-cli base +data-query --dsl '{`:   true,
+		`lark-cli base +data-query --dsl '{}'`: false,
+		`lark-cli docs +fetch --note "open`:    true,
+		`lark-cli docs +fetch --note "shut"`:   false,
+		// inside single quotes a backslash is literal, so the quote still closes
+		`lark-cli docs +fetch --note 'a\'`: false,
+		// outside quotes a backslash escapes the quote that follows
+		`lark-cli docs +fetch --note \'`: false,
+	}
+	for raw, want := range tests {
+		if got := hasOpenQuote(raw); got != want {
+			t.Errorf("hasOpenQuote(%q) = %v, want %v", raw, got, want)
 		}
 	}
 }

--- a/internal/qualitygate/skillscan/testdata/multiline/lark-multiline/SKILL.md
+++ b/internal/qualitygate/skillscan/testdata/multiline/lark-multiline/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: lark-multiline
+description: Fixture for quoted arguments that span lines
+---
+
+```bash
+# a quoted flag value carries the word across lines without a trailing backslash
+lark-cli base +data-query \
+  --base-token MAGObdemo \
+  --dsl '{
+    "datasource": {"type": "table", "table": {"tableId": "tbldemo"}},
+    "shaper": {"format": "flat"}
+  }'
+
+# a double-quoted value does the same
+lark-cli docs +fetch --doc A3Ijdemo --note "line one
+line two"
+```

--- a/internal/qualitygate/skillscan/testdata/unterminated/lark-unterminated/SKILL.md
+++ b/internal/qualitygate/skillscan/testdata/unterminated/lark-unterminated/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: lark-unterminated
+description: Fixture for a genuinely unterminated quote inside a fence
+---
+
+```bash
+lark-cli docs +fetch --doc A3Ijbroken --note 'oops
+```
+
+Prose between fences must not be absorbed into the broken example.
+
+```bash
+lark-cli im +chat-list --page-size 20
+lark-cli docs +fetch --doc A3Ijlater
+```


### PR DESCRIPTION
## Summary

The quality gate reports nine `skill_command_parse` warnings against the shipped skills today, all of them `cannot parse lark-cli example: unterminated quote`. The examples are valid shell; the harvester truncates them.

A quoted flag value carries a shell word across newlines without a trailing backslash, which is how the skills spell multi-line JSON:

```bash
lark-cli base +data-query \
  --base-token MAGObxxxxx \
  --dsl '{
    "datasource": {"type": "table", "table": {"tableId": "tblxxxxxxxx"}},
    "shaper": {"format": "flat"}
  }'
```

`harvestFile` only joined the next line while the current one ended in `\`. The `--dsl '{` line does not, so harvesting stopped there and handed the caller a fragment ending in an open quote:

```
line 18   raw="lark-cli base +data-query --base-token MAGObxxxxx --dsl '{"
line 28   raw="lark-cli base +data-query --base-token MAGObxxxxx --dsl '{"
line 45   raw="lark-cli base +data-query --base-token MAGObxxxxx --dsl '{"
line 54   raw="lark-cli base +data-query --base-token MAGObxxxxx --dsl '{"
```

`splitShellWords` then rejected the fragment, so the example was reported as unparsable instead of checked. The visible cost is nine warnings; the real cost is that nine documented examples were never validated against the command manifest.

## Changes

- Keep harvesting lines while a quote is still open, not only while the line ends in a backslash.
- Add `hasOpenQuote`, which tracks quote state with the same rules the consuming tokenizer uses: a backslash outside quotes escapes the next character, and inside single quotes it is literal.
- Add a fixture and regression tests for a single-quoted multi-line JSON flag and a double-quoted multi-line value.
- Bound the continuation by the closing fence. Without that, a genuinely unterminated quote absorbed the fence and every later command in the file, dropping them from validation — the same loss of coverage this change removes. Added a fixture for that case: a broken quote in one fence and two commands in a later fence.

`hasOpenQuote` does not reuse `splitShellWords` from `internal/qualitygate/rules`: that package imports `skillscan`, so calling back would be an import cycle, and the question here is narrower — whether the accumulated text ends inside a quote, not how it splits into words.

## Result

Affected examples are now harvested whole and validated. `internal/qualitygate/skillscan` before and after, same fixture:

| | before | after |
| --- | --- | --- |
| line 18 | `…--dsl '{` (52 chars, quote open) | 305 chars, quote closed |
| line 28 | `…--dsl '{` (52 chars, quote open) | 525 chars, quote closed |
| line 45 | `…--dsl '{` (52 chars, quote open) | 243 chars, quote closed |
| line 54 | `…--dsl '{` (52 chars, quote open) | 529 chars, quote closed |

`make quality-gate` on `main`, same `QUALITY_GATE_CHANGED_FROM`:

```
before:  9 [WARNING/skill_command_parse]   4 [WARNING/default_output]
after:                                     4 [WARNING/default_output]
```

The four `default_output` warnings are unrelated to this change and untouched. The newly validated examples pass — the gate reports no rejects, so these four `base +data-query` examples were already correct, just unchecked.

## Test Plan

| Check | Result |
| --- | --- |
| `go test ./internal/qualitygate/skillscan/ -count=1` | pass, 6 tests |
| `make unit-test` | pass, 130 packages, run twice |
| `make vet` | pass |
| `make fmt-check` | pass |
| `make quality-gate` | pass, no rejects |
| `go mod tidy`, then `git diff --exit-code -- go.mod go.sum` | unchanged |
| `golangci-lint run --new-from-rev=<base>` | `0 issues` |
| `go run -C lint . --changed-from <base> ..` | pass |
| `go test -C lint ./... -count=1` | pass |
| `node scripts/skill-format-check/index.js` | pass |

Both regressions were checked against the code they guard.

Restoring only the harvest loop, keeping the tests:

```
harvest_test.go:83: harvested example ends inside a quote: "lark-cli base +data-query --base-token MAGObdemo --dsl '{"
harvest_test.go:83: harvested example ends inside a quote: "lark-cli docs +fetch --doc A3Ijdemo --note \"line one"
harvest_test.go:88: single-quoted JSON was truncated
harvest_test.go:94: double-quoted value was truncated
FAIL
```

Dropping only the fence bound:

```
harvest_test.go:127: got 1 examples, want 3
  Raw:"lark-cli docs +fetch --doc A3Ijbroken --note 'oops ``` Prose between fences … lark-cli im +chat-list …"
FAIL
```

Not run: `make live-skills-test`, which needs network and `npx`. No dry-run or live E2E applies — this changes gate tooling, not command behaviour, and no shortcut or command surface is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-line command examples, including quoted arguments and JSON values.
  * Prevented commands from being truncated when quoted content spans multiple lines.
  * Ensured unterminated quoted content does not consume closing code fences, surrounding prose, or subsequent commands.

* **Tests**
  * Added coverage for single- and double-quoted multi-line arguments.
  * Added validation for unterminated quotes and fence handling.
  * Added examples validating multi-line command parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### On the empty checks column

`CI`, `PR Preview Package` and `Skill Format Check` are sitting at
`action_required` on this branch — GitHub holds workflow runs for an outside
contributor until a maintainer approves them, so no CI result has been produced
yet. The check matrix above is what I ran locally against the stated base; it is
not a substitute for CI, and I am not claiming CI passed. Happy to push again if
approving the runs surfaces anything.
