### PR TITLE
fix(slides): relax office token length check from 28 to >=25

### DIFF
--- a/shortcuts/common/office_token.go
+++ b/shortcuts/common/office_token.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import "strings"
+
+// Legacy synthetic prefixes an imported "office" document token may carry.
+// Exported because callers legitimately need to name them — a test that spells
+// "fake_office_" itself would drift from this list the moment it changes.
+const (
+	FakeOfficeTokenPrefix  = "fake_office_"
+	LocalOfficeTokenPrefix = "local_office_"
+)
+
+// officeTokenPrefixes is the prefix set IsLocalOfficeToken checks.
+var officeTokenPrefixes = []string{FakeOfficeTokenPrefix, LocalOfficeTokenPrefix}
+
+// officeTokenMarker is the interleaved product/region marker an imported office
+// token carries.
+const officeTokenMarker = "OFL0X"
+
+// officeTokenMarkerOffsets are the byte offsets the marker occupies in an
+// interleaved token — positions 5, 10, 15, 20, and 25, 1-based. The array
+// length is tied to the marker so the two cannot drift apart silently: adding a
+// character to one without the other stops compiling.
+var officeTokenMarkerOffsets = [len(officeTokenMarker)]int{4, 9, 14, 19, 24}
+
+// officeTokenMinLen is the shortest token the marker can be read out of, one
+// past its last offset. It is a floor rather than an exact length on purpose;
+// see IsLocalOfficeToken. TestOfficeTokenMinLenMatchesMarkerOffsets pins it
+// to the offsets above.
+const officeTokenMinLen = 25
+
+// IsLocalOfficeToken reports whether token names a "local office" document —
+// one backed by an imported office file (pptx / xlsx / docx) rather than created
+// natively through the API.
+//
+// "Local office" is the whole category, not the LocalOfficeTokenPrefix case:
+// this returns true for FakeOfficeTokenPrefix and for the interleaved marker
+// too. The shared word stem is a naming coincidence, not a narrower contract.
+//
+// This lives in common because the token shape is a drive-level property, not a
+// per-domain one: an imported office file is an imported office file whether it
+// backs a spreadsheet or a deck. What differs per domain is only the drive media
+// parent_type the answer selects — "office_sheet_file" vs "office_slide_file" —
+// so that mapping stays with each domain and only the shape is shared. Every
+// copy of the shape is somewhere a format change has to be found again; #2509
+// had to be applied twice inside sheets alone, and slides was missed entirely.
+//
+// Two things are load-bearing about how the check is written.
+//
+// The marker is read at exact offsets, not by a looser strings.Contains, because
+// a false positive is the dangerous direction. The drive backend does not
+// validate that parent_node actually names an office file, so a native document
+// wrongly classified here still uploads successfully — the damage only surfaces
+// later as an image that will not render, far from its cause. A false negative
+// fails loudly at the upload instead.
+//
+// The length is a floor rather than one exact value. Because the offsets are
+// fixed, a token only has to be long enough to hold the marker; pinning the
+// total length silently reclassifies every other length as native. 28 used to be
+// pinned and is already stale — per #2509 the local-office format is "OFL0X + 21
+// random + 1 office type enum", 27 characters. Widening the length is only safe
+// because of the exact offsets: a token of the same length carrying a different
+// marker (a native "pptcn" or "shtcn" one) still fails.
+func IsLocalOfficeToken(token string) bool {
+	for _, prefix := range officeTokenPrefixes {
+		if strings.HasPrefix(token, prefix) {
+			return true
+		}
+	}
+	if len(token) < officeTokenMinLen {
+		return false
+	}
+	for i, offset := range officeTokenMarkerOffsets {
+		if token[offset] != officeTokenMarker[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/shortcuts/common/office_token_test.go
+++ b/shortcuts/common/office_token_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import "testing"
+
+// TestIsLocalOfficeToken pins the shared token shape every domain's
+// parent_type mapping now reads through.
+//
+// The negative cases carry as much weight as the positive ones. A native token
+// read as office still uploads successfully — the drive backend does not
+// validate that parent_node names an office file — so the failure only shows up
+// later as an image that will not render. The interleaved native tokens are what
+// make the length floor safe: they are long enough to be read but carry a
+// different marker, so relaxing the length must not pull them in.
+func TestIsLocalOfficeToken(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"empty token", "", false},
+		{"native token, too short to read", "pptcnABC123", false},
+
+		{"fake_office prefix", "fake_office_abc123", true},
+		{"fake_office, only the prefix", FakeOfficeTokenPrefix, true},
+		{"local_office prefix", "local_office_abc123", true},
+		{"local_office, only the prefix", LocalOfficeTokenPrefix, true},
+		{"fake_office prefix mid-string is not a prefix", "pptfake_office_abc", false},
+		{"local_office prefix mid-string is not a prefix", "pptlocal_office_abc", false},
+
+		{"interleaved OFL0X, 25 chars (marker exactly fills the token)", "aaaaOaaaaFaaaaLaaaa0aaaaX", true},
+		{"interleaved OFL0X, 27 chars (current local-office format)", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", true},
+		{"interleaved OFL0X, 28 chars (the length that used to be pinned)", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa", true},
+		{"interleaved OFL0X, 28 chars with ppt office-type enum", "ccccOccccFccccLcccc0ccccXccP", true},
+		{"interleaved OFL0X, 29 chars (longer than any known format)", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", true},
+		{"interleaved OFL0X, 24 chars (one short of holding the marker)", "aaaaOaaaaFaaaaLaaaa0aaaa", false},
+
+		{"interleaved pptcn native token", "abcdpefghpijkltmnopcqrstnuv", false},
+		{"interleaved shtcn native token", "abcdsefghhijkltmnopcqrstnuv", false},
+		{"OFL0X present but not on the offsets", "OFL0Xaaaaaaaaaaaaaaaaaaaaaaa", false},
+		{"marker off by one offset", "aaaaaOaaaaFaaaaLaaaa0aaaaX", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsLocalOfficeToken(tc.token); got != tc.want {
+				t.Fatalf("IsLocalOfficeToken(%q) = %v, want %v", tc.token, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOfficeTokenMinLenMatchesMarkerOffsets keeps the length floor derived from
+// the offsets rather than merely agreeing with them today. A floor that drifts
+// above the last offset would reject valid short tokens; one that drifts below
+// it would index out of range.
+func TestOfficeTokenMinLenMatchesMarkerOffsets(t *testing.T) {
+	t.Parallel()
+	last := officeTokenMarkerOffsets[len(officeTokenMarkerOffsets)-1]
+	if officeTokenMinLen != last+1 {
+		t.Fatalf("officeTokenMinLen = %d, want %d (one past last marker offset %d)",
+			officeTokenMinLen, last+1, last)
+	}
+}

--- a/shortcuts/sheets/backward/lark_sheets_float_images.go
+++ b/shortcuts/sheets/backward/lark_sheets_float_images.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
@@ -17,46 +16,20 @@ import (
 )
 
 // Drive media parent_type values for uploading an image into a spreadsheet.
-// Native spreadsheets use "sheet_image"; imported "office" spreadsheets use a
-// legacy synthetic-token prefix or a 28-character token whose interleaved
-// product/region marker is "OFL0X". The backend requires
-// "office_sheet_file" for those imported spreadsheets.
+// Native spreadsheets use "sheet_image"; the backend requires
+// "office_sheet_file" for a spreadsheet backed by an imported office file.
+// Recognising one is common.IsLocalOfficeToken's job — see the equivalent note
+// in shortcuts/sheets/helpers.go, whose mapping this deliberately mirrors for
+// the deprecated surface.
 const (
 	sheetImageParentType      = "sheet_image"
 	officeSheetFileParentType = "office_sheet_file"
-	fakeOfficePrefix          = "fake_office_"
-	localOfficePrefix         = "local_office_"
 )
-
-// officePrefixes are the legacy synthetic token prefixes an imported "office"
-// spreadsheet may carry.
-var officePrefixes = []string{fakeOfficePrefix, localOfficePrefix}
-
-func isOfficeSpreadsheet(spreadsheetToken string) bool {
-	for _, prefix := range officePrefixes {
-		if strings.HasPrefix(spreadsheetToken, prefix) {
-			return true
-		}
-	}
-	if len(spreadsheetToken) < 25 {
-		return false
-	}
-	// The five-character marker occupies positions 5, 10, 15, 20, and 25
-	// (1-based) in the interleaved token.
-	marker := []byte{
-		spreadsheetToken[4],
-		spreadsheetToken[9],
-		spreadsheetToken[14],
-		spreadsheetToken[19],
-		spreadsheetToken[24],
-	}
-	return string(marker) == "OFL0X"
-}
 
 // sheetMediaParentType returns the drive media parent_type to use when
 // uploading an image whose parent_node is spreadsheetToken.
 func sheetMediaParentType(spreadsheetToken string) string {
-	if isOfficeSpreadsheet(spreadsheetToken) {
+	if common.IsLocalOfficeToken(spreadsheetToken) {
 		return officeSheetFileParentType
 	}
 	return sheetImageParentType

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -52,48 +52,24 @@ func sheetsInputStatError(flag string, err error) error {
 }
 
 // Drive media parent_type values for uploading an image into a spreadsheet.
-// Native spreadsheets use "sheet_image"; imported "office" spreadsheets use a
-// legacy synthetic-token prefix or a 28-character token whose interleaved
-// product/region marker is "OFL0X". The backend requires
-// "office_sheet_file" for those imported spreadsheets.
+// Native spreadsheets use "sheet_image"; the backend requires
+// "office_sheet_file" for a spreadsheet backed by an imported office file.
+//
+// Recognising one is common.IsLocalOfficeToken's job, not this package's: the
+// token shape is a drive-level property shared with slides, while the
+// parent_type it selects is what differs per domain, so only the mapping below
+// lives here.
 const (
 	sheetImageParentType      = "sheet_image"
 	officeSheetFileParentType = "office_sheet_file"
-	fakeOfficePrefix          = "fake_office_"
-	localOfficePrefix         = "local_office_"
 )
-
-// officePrefixes are the legacy synthetic token prefixes an imported "office"
-// spreadsheet may carry.
-var officePrefixes = []string{fakeOfficePrefix, localOfficePrefix}
-
-func isOfficeSpreadsheet(spreadsheetToken string) bool {
-	for _, prefix := range officePrefixes {
-		if strings.HasPrefix(spreadsheetToken, prefix) {
-			return true
-		}
-	}
-	if len(spreadsheetToken) < 25 {
-		return false
-	}
-	// The five-character marker occupies positions 5, 10, 15, 20, and 25
-	// (1-based) in the interleaved token.
-	marker := []byte{
-		spreadsheetToken[4],
-		spreadsheetToken[9],
-		spreadsheetToken[14],
-		spreadsheetToken[19],
-		spreadsheetToken[24],
-	}
-	return string(marker) == "OFL0X"
-}
 
 // sheetMediaParentType returns the drive media parent_type to use when
 // uploading an image whose parent_node is spreadsheetToken. It is the single
 // place that maps a spreadsheet token to its parent_type so every image-upload
 // entry point (and its dry-run preview) stays consistent.
 func sheetMediaParentType(spreadsheetToken string) string {
-	if isOfficeSpreadsheet(spreadsheetToken) {
+	if common.IsLocalOfficeToken(spreadsheetToken) {
 		return officeSheetFileParentType
 	}
 	return sheetImageParentType

--- a/shortcuts/sheets/sheet_media_parent_type_test.go
+++ b/shortcuts/sheets/sheet_media_parent_type_test.go
@@ -25,9 +25,21 @@ import (
 
 // TestSheetMediaParentType pins the token→parent_type mapping that every
 // sheets image-upload entry point funnels through. Native spreadsheet tokens
-// use "sheet_image"; imported "office" spreadsheets use either a legacy
-// prefix or the interleaved "OFL0X" marker and must upload with
-// "office_sheet_file".
+// use "sheet_image"; a spreadsheet backed by an imported office file must upload
+// with "office_sheet_file".
+//
+// The token shape itself is common.IsLocalOfficeToken's contract and is pinned
+// exhaustively in TestIsLocalOfficeToken. What this test owns is the sheets
+// half: that the shared answer selects office_sheet_file and nothing else does.
+// The shape cases are kept here anyway, deliberately duplicated, because they
+// are what would catch the mapping being wired to a different predicate — or to
+// none — and a table holding only native tokens could not tell a working mapping
+// from a hardcoded sheetImageParentType.
+//
+// Four labels here used to be wrong: the row called "25 char, at boundary" held
+// a 27-character token and the three "new 27-char" rows held 28-character ones,
+// so the length floor the labels claimed to cover was never actually tested. The
+// 25/24 rows below are the real boundary.
 func TestSheetMediaParentType(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -38,19 +50,21 @@ func TestSheetMediaParentType(t *testing.T) {
 		{"native spreadsheet token", "shtcnABC123", sheetImageParentType},
 		{"empty token", "", sheetImageParentType},
 		{"fake_office imported token", "fake_office_abc123", officeSheetFileParentType},
-		{"fake_office token, only the prefix", fakeOfficePrefix, officeSheetFileParentType},
+		{"fake_office token, only the prefix", common.FakeOfficeTokenPrefix, officeSheetFileParentType},
 		{"local_office imported token", "local_office_abc123", officeSheetFileParentType},
-		{"local_office token, only the prefix", localOfficePrefix, officeSheetFileParentType},
+		{"local_office token, only the prefix", common.LocalOfficeTokenPrefix, officeSheetFileParentType},
 		{"interleaved OFL0X office token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa", officeSheetFileParentType},
 		{"interleaved exlcn token", "abcdeefghxijkllmnopcqrstnuv", sheetImageParentType},
 		{"interleaved shtcn native token", "abcdsefghhijkltmnopcqrstnuv", sheetImageParentType},
 		{"interleaved pptcn token", "abcdpefghpijkltmnopcqrstnuv", sheetImageParentType},
 		{"interleaved wodcn token", "abcdwefghoijkldmnopcqrstnuv", sheetImageParentType},
-		{"interleaved OFL0X marker with short length (25 char, at boundary)", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", officeSheetFileParentType},
-		{"interleaved OFL0X marker with long length (29 char)", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", officeSheetFileParentType},
-		{"new 27-char OFL0X excel token", "bbbbObbbbFbbbbLbbbb0bbbbXbbE", officeSheetFileParentType},
-		{"new 27-char OFL0X ppt token", "ccccOccccFccccLcccc0ccccXccP", officeSheetFileParentType},
-		{"new 27-char OFL0X word token", "ddddOddddFddddLdddd0ddddXddW", officeSheetFileParentType},
+		{"interleaved OFL0X, 25 chars (marker exactly fills the token)", "aaaaOaaaaFaaaaLaaaa0aaaaX", officeSheetFileParentType},
+		{"interleaved OFL0X, 24 chars (one short of holding the marker)", "aaaaOaaaaFaaaaLaaaa0aaaa", sheetImageParentType},
+		{"interleaved OFL0X, 27 chars (current local-office format)", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", officeSheetFileParentType},
+		{"interleaved OFL0X, 29 chars (longer than any known format)", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", officeSheetFileParentType},
+		{"interleaved OFL0X, 28 chars with xlsx office-type enum", "bbbbObbbbFbbbbLbbbb0bbbbXbbE", officeSheetFileParentType},
+		{"interleaved OFL0X, 28 chars with ppt office-type enum", "ccccOccccFccccLcccc0ccccXccP", officeSheetFileParentType},
+		{"interleaved OFL0X, 28 chars with word office-type enum", "ddddOddddFddddLdddd0ddddXddW", officeSheetFileParentType},
 		{"fake_office prefix mid-string is not matched", "shtfake_office_abc", sheetImageParentType},
 		{"local_office prefix mid-string is not matched", "shtlocal_office_abc", sheetImageParentType},
 	}

--- a/shortcuts/slides/slides_media_parent_type_test.go
+++ b/shortcuts/slides/slides_media_parent_type_test.go
@@ -20,19 +20,19 @@ import (
 // prefix or the interleaved "OFL0X" marker and must upload with
 // "office_slide_file".
 //
+// The token shape itself is common.IsLocalOfficeToken's contract and is
+// pinned exhaustively in TestIsLocalOfficeToken. What this test owns is the
+// slides half: that the shared answer selects office_slide_file and nothing else
+// does. The shape cases are kept here anyway, deliberately duplicated, because
+// they are what would catch the mapping being wired to a different predicate —
+// or to none — and a table that only held native tokens could not tell a working
+// mapping from a hardcoded slideFileParentType.
+//
 // The negative cases matter as much as the positive ones. A false positive —
 // a native token read as office — still uploads successfully, because the drive
 // backend does not validate that parent_node actually names an office file; the
 // damage only shows up later as an image that will not render, far from its
-// cause. So the marker is still read at exact positions rather than by a looser
-// "contains OFL0X" test.
-//
-// What is no longer pinned is the total length: it is a floor (>= 25, just
-// enough to hold the marker) rather than one exact value, because the
-// local-office format has already moved off 28 characters and sheets relaxed the
-// identical guard in #2509. The interleaved native tokens below are what keeps
-// that floor honest — they are long enough to be read but carry a different
-// marker, so widening the length window must not pull them in.
+// cause.
 func TestSlidesMediaParentType(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -43,9 +43,9 @@ func TestSlidesMediaParentType(t *testing.T) {
 		{"native presentation token", "pptcnABC123", slideFileParentType},
 		{"empty token", "", slideFileParentType},
 		{"fake_office imported token", "fake_office_abc123", officeSlideFileParentType},
-		{"fake_office token, only the prefix", fakeOfficePrefix, officeSlideFileParentType},
+		{"fake_office token, only the prefix", common.FakeOfficeTokenPrefix, officeSlideFileParentType},
 		{"local_office imported token", "local_office_abc123", officeSlideFileParentType},
-		{"local_office token, only the prefix", localOfficePrefix, officeSlideFileParentType},
+		{"local_office token, only the prefix", common.LocalOfficeTokenPrefix, officeSlideFileParentType},
 		{"interleaved OFL0X office token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa", officeSlideFileParentType},
 		{"interleaved pptcn native token", "abcdpefghpijkltmnopcqrstnuv", slideFileParentType},
 		{"interleaved shtcn token", "abcdsefghhijkltmnopcqrstnuv", slideFileParentType},
@@ -195,7 +195,8 @@ func TestSlidesDryRunParentType(t *testing.T) {
 // slidesMediaParentType yields slide_file, which is the right answer here — but
 // by accident, because a placeholder matches no office token shape. That leaves
 // the preview hostage to the placeholder's spelling and to every rule later added
-// to isOfficePresentation, so these cases pin the value while the production code
+// to common.IsLocalOfficeToken, so these cases pin the value while the
+// production code
 // asserts it directly instead of deriving it.
 func TestSlidesDryRunPlaceholderNodeParentType(t *testing.T) {
 	const wikiURL = "https://example.feishu.cn/wiki/wikcnDryRunProbe123"

--- a/shortcuts/slides/slides_media_parent_type_test.go
+++ b/shortcuts/slides/slides_media_parent_type_test.go
@@ -24,8 +24,15 @@ import (
 // a native token read as office — still uploads successfully, because the drive
 // backend does not validate that parent_node actually names an office file; the
 // damage only shows up later as an image that will not render, far from its
-// cause. So the marker check is pinned at its exact length and position rather
-// than left to a looser "contains OFL0X" reading.
+// cause. So the marker is still read at exact positions rather than by a looser
+// "contains OFL0X" test.
+//
+// What is no longer pinned is the total length: it is a floor (>= 25, just
+// enough to hold the marker) rather than one exact value, because the
+// local-office format has already moved off 28 characters and sheets relaxed the
+// identical guard in #2509. The interleaved native tokens below are what keeps
+// that floor honest — they are long enough to be read but carry a different
+// marker, so widening the length window must not pull them in.
 func TestSlidesMediaParentType(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -42,8 +49,11 @@ func TestSlidesMediaParentType(t *testing.T) {
 		{"interleaved OFL0X office token", "aaaaOaaaaFaaaaLaaaa0aaaaXaaa", officeSlideFileParentType},
 		{"interleaved pptcn native token", "abcdpefghpijkltmnopcqrstnuv", slideFileParentType},
 		{"interleaved shtcn token", "abcdsefghhijkltmnopcqrstnuv", slideFileParentType},
-		{"interleaved OFL0X marker with short length", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", slideFileParentType},
-		{"interleaved OFL0X marker with long length", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", slideFileParentType},
+		{"interleaved OFL0X, 27 chars (current local-office format)", "aaaaOaaaaFaaaaLaaaa0aaaaXaa", officeSlideFileParentType},
+		{"interleaved OFL0X, 29 chars (longer than any known format)", "aaaaOaaaaFaaaaLaaaa0aaaaXaaaa", officeSlideFileParentType},
+		{"interleaved OFL0X, 25 chars (marker exactly fills the token)", "aaaaOaaaaFaaaaLaaaa0aaaaX", officeSlideFileParentType},
+		{"interleaved OFL0X, 24 chars (one short of holding the marker)", "aaaaOaaaaFaaaaLaaaa0aaaa", slideFileParentType},
+		{"interleaved OFL0X, 28 chars with ppt office-type enum", "ccccOccccFccccLcccc0ccccXccP", officeSlideFileParentType},
 		{"fake_office prefix mid-string is not matched", "pptfake_office_abc", slideFileParentType},
 		{"local_office prefix mid-string is not matched", "pptlocal_office_abc", slideFileParentType},
 	}

--- a/shortcuts/slides/slides_media_upload.go
+++ b/shortcuts/slides/slides_media_upload.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -20,13 +19,12 @@ import (
 // return 1061002 params error, but `slide_file` returns a valid file_token
 // that can be used as <img src="..."> in slide XML.
 //
-// Imported "office" presentations carry either a legacy synthetic-token prefix
-// or a token whose interleaved product/region marker is "OFL0X",
-// and the drive backend requires "office_slide_file" for those — the
-// presentation counterpart of the office_sheet_file rule the sheets domain
-// already applies (shortcuts/sheets/helpers.go). The token shapes are the same
-// there: an imported office file is an imported office file whether it backs a
-// spreadsheet or a deck.
+// Imported "office" presentations must upload as "office_slide_file" instead —
+// the presentation counterpart of the office_sheet_file rule the sheets domain
+// already applies. Recognising one is common.IsLocalOfficeToken's job, not
+// this package's: the token shape is a drive-level property shared by every
+// imported office file, while the parent_type it selects is what differs per
+// domain, so only the mapping below lives here.
 //
 // NOTE: neither value is accepted by the multipart upload_prepare endpoint
 // (99992402 field validation failed), so slides image uploads stay capped at
@@ -34,39 +32,7 @@ import (
 const (
 	slideFileParentType       = "slide_file"
 	officeSlideFileParentType = "office_slide_file"
-	fakeOfficePrefix          = "fake_office_"
-	localOfficePrefix         = "local_office_"
 )
-
-// officePrefixes are the legacy synthetic token prefixes an imported "office"
-// presentation may carry.
-var officePrefixes = []string{fakeOfficePrefix, localOfficePrefix}
-
-func isOfficePresentation(presentationToken string) bool {
-	for _, prefix := range officePrefixes {
-		if strings.HasPrefix(presentationToken, prefix) {
-			return true
-		}
-	}
-	// The token only has to be long enough to hold the marker. The length is
-	// deliberately not pinned to one value: the local-office format has already
-	// moved off 28 characters (per #2509, "OFL0X + 21 random + 1 office type
-	// enum"), and sheets relaxed the identical guard for that reason. Pinning it
-	// again would silently reclassify every future length as native.
-	if len(presentationToken) < 25 {
-		return false
-	}
-	// The five-character marker occupies positions 5, 10, 15, 20, and 25
-	// (1-based) in the interleaved token.
-	marker := []byte{
-		presentationToken[4],
-		presentationToken[9],
-		presentationToken[14],
-		presentationToken[19],
-		presentationToken[24],
-	}
-	return string(marker) == "OFL0X"
-}
 
 // slidesMediaParentType returns the drive media parent_type to use when
 // uploading an image whose parent_node is presentationToken. It is the single
@@ -75,7 +41,7 @@ func isOfficePresentation(presentationToken string) bool {
 // +create / +add-slide / +update-slide) and its dry-run preview stay
 // consistent.
 func slidesMediaParentType(presentationToken string) string {
-	if isOfficePresentation(presentationToken) {
+	if common.IsLocalOfficeToken(presentationToken) {
 		return officeSlideFileParentType
 	}
 	return slideFileParentType
@@ -93,7 +59,7 @@ const unresolvedSlidesTokenPlaceholder = "<resolved_slides_token>"
 // that happens to yield the right answer — a placeholder matches no office token
 // shape, so it falls through to slideFileParentType — but by accident rather
 // than on purpose, which makes the preview hostage to the placeholder's spelling
-// and to every future rule added to isOfficePresentation.
+// and to every future rule added to common.IsLocalOfficeToken.
 //
 // A wiki ref is native by construction, not by default: resolvePresentationID
 // rejects any wiki node whose obj_type is not "slides" (helpers.go), and an

--- a/shortcuts/slides/slides_media_upload.go
+++ b/shortcuts/slides/slides_media_upload.go
@@ -21,7 +21,7 @@ import (
 // that can be used as <img src="..."> in slide XML.
 //
 // Imported "office" presentations carry either a legacy synthetic-token prefix
-// or a 28-character token whose interleaved product/region marker is "OFL0X",
+// or a token whose interleaved product/region marker is "OFL0X",
 // and the drive backend requires "office_slide_file" for those — the
 // presentation counterpart of the office_sheet_file rule the sheets domain
 // already applies (shortcuts/sheets/helpers.go). The token shapes are the same
@@ -48,7 +48,12 @@ func isOfficePresentation(presentationToken string) bool {
 			return true
 		}
 	}
-	if len(presentationToken) != 28 {
+	// The token only has to be long enough to hold the marker. The length is
+	// deliberately not pinned to one value: the local-office format has already
+	// moved off 28 characters (per #2509, "OFL0X + 21 random + 1 office type
+	// enum"), and sheets relaxed the identical guard for that reason. Pinning it
+	// again would silently reclassify every future length as native.
+	if len(presentationToken) < 25 {
 		return false
 	}
 	// The five-character marker occupies positions 5, 10, 15, 20, and 25


### PR DESCRIPTION
The interleaved "OFL0X" product/region marker is read at fixed positions (1-based 5/10/15/20/25), so a token only has to be long enough to hold it. Pinning the total length to exactly 28 silently reclassified every other length as native.

28 is already stale: per #2509 the local-office format is "OFL0X + 21 random + 1 office type enum" = 27 characters, and sheets relaxed the identical guard to >= 25 in that PR. Slides was missed, so an imported office deck at the current length uploaded with parent_type "slide_file" instead of "office_slide_file".

The marker positions are unchanged. Relaxing the length is only safe because of them: a false positive is the dangerous direction, since the drive backend does not validate that parent_node actually names an office file, so a misclassified native deck uploads successfully and only surfaces later as an image that will not render. The interleaved native token cases (same length, different marker) are what keep the floor honest.

Tests: replaced two mislabelled rows with five verified ones covering 27, 29, 25, 24 characters and a 28-character token carrying the ppt office type enum. #2509's own labels were off by one or two characters and it never covered the 25/24 boundary; this does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of office-backed slide and spreadsheet media across supported token formats.
  * Corrected handling of token length boundaries and marker positions, including legacy and local-office formats.
  * Ensured media is assigned to the appropriate office-file or native media type more consistently.
* **Reliability**
  * Expanded validation coverage for edge cases, malformed tokens, and office-type variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->