### PR TITLE
fix(shortcuts): remove non-actionable stderr progress

### DIFF
--- a/shortcuts/common/drive_media_upload.go
+++ b/shortcuts/common/drive_media_upload.go
@@ -60,9 +60,9 @@ type DriveMediaMultipartUploadConfig struct {
 	Extra      string
 	// Reader mirrors DriveMediaUploadAllConfig.Reader for chunked uploads.
 	Reader io.Reader
-	// Quiet suppresses the progress narration on ErrOut that the multipart
-	// path writes unconditionally. Callers whose success contract forbids
-	// non-empty stderr (e.g. sheets shortcuts) set this to true.
+	// Quiet is retained for source compatibility. This helper no longer emits
+	// multipart progress on stderr, so the field has no runtime effect.
+	// Deprecated: multipart uploads are silent by default.
 	Quiet bool
 }
 

--- a/shortcuts/common/drive_media_upload.go
+++ b/shortcuts/common/drive_media_upload.go
@@ -157,10 +157,6 @@ func UploadDriveMediaMultipartTyped(runtime *RuntimeContext, cfg DriveMediaMulti
 	if err != nil {
 		return "", fileevent.ReportUploadError(runtime, err, meta)
 	}
-	if !cfg.Quiet {
-		fmt.Fprintf(runtime.IO().ErrOut, "Multipart upload initialized: %d chunks x %s\n", session.BlockNum, FormatSize(session.BlockSize))
-	}
-
 	meta.APIPath = driveMediaUploadPartPath
 	if err = uploadDriveMediaMultipartPartsTyped(runtime, cfg, session); err != nil {
 		return "", fileevent.ReportUploadError(runtime, err, meta)
@@ -258,9 +254,6 @@ func uploadDriveMediaMultipartPartsTyped(runtime *RuntimeContext, cfg DriveMedia
 
 		if err := uploadDriveMediaMultipartPartTyped(runtime, session.UploadID, seq, buffer[:n]); err != nil {
 			return err
-		}
-		if !cfg.Quiet {
-			fmt.Fprintf(runtime.IO().ErrOut, "  Block %d/%d uploaded (%s)\n", seq+1, session.BlockNum, FormatSize(int64(n)))
 		}
 		remaining -= int64(n)
 	}

--- a/shortcuts/common/drive_media_upload_typed_test.go
+++ b/shortcuts/common/drive_media_upload_typed_test.go
@@ -583,6 +583,13 @@ func TestUploadDriveMediaMultipartTypedReportsFileEventOnSuccess(t *testing.T) {
 	if fileToken != "file_multi_ok" {
 		t.Fatalf("fileToken = %q, want file_multi_ok", fileToken)
 	}
+	stderr, ok := runtime.IO().ErrOut.(*bytes.Buffer)
+	if !ok {
+		t.Fatalf("stderr writer = %T, want *bytes.Buffer", runtime.IO().ErrOut)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no multipart progress", stderr.String())
+	}
 
 	tags := assertSingleReport(t, reportStub, fileevent.StatusSuccess)
 	if _, ok := tags["upload_mode"]; ok {

--- a/shortcuts/common/drive_media_upload_typed_test.go
+++ b/shortcuts/common/drive_media_upload_typed_test.go
@@ -534,9 +534,10 @@ func TestUploadDriveMediaMultipartTypedReportsFileEventOnPrepareError(t *testing
 	}
 }
 
-// TestUploadDriveMediaMultipartTypedReportsFileEventOnSuccess verifies reporting after a multipart upload succeeds.
-func TestUploadDriveMediaMultipartTypedReportsFileEventOnSuccess(t *testing.T) {
+// TestUploadDriveMediaMultipartTypedReportsFileEventAndHonorsQuietOnSuccess verifies reporting and the published Quiet contract.
+func TestUploadDriveMediaMultipartTypedReportsFileEventAndHonorsQuietOnSuccess(t *testing.T) {
 	runtime, reg := newDriveMediaUploadTestRuntime(t)
+	runtime.IO().StderrIsTerminal = true
 	withDriveMediaUploadWorkingDir(t, t.TempDir())
 	reportStub := registerDriveMediaReportStub(t, reg)
 
@@ -576,6 +577,7 @@ func TestUploadDriveMediaMultipartTypedReportsFileEventOnSuccess(t *testing.T) {
 		FileSize:   size,
 		ParentType: "docx_image",
 		ParentNode: "",
+		Quiet:      true,
 	})
 	if err != nil {
 		t.Fatalf("UploadDriveMediaMultipartTyped() error: %v", err)

--- a/shortcuts/doc/doc_errors.go
+++ b/shortcuts/doc/doc_errors.go
@@ -63,6 +63,19 @@ func appendDocRecoveryHint(problem *errs.Problem, hint string) {
 	problem.Hint = strings.TrimSpace(problem.Hint) + "\n" + hint
 }
 
+// withDocRecoveryHint preserves an existing typed error while adding recovery
+// guidance for a server-side write that completed before a later step failed.
+func withDocRecoveryHint(err error, hint string) error {
+	if err == nil {
+		return nil
+	}
+	if problem, ok := errs.ProblemOf(err); ok {
+		appendDocRecoveryHint(problem, hint)
+		return err
+	}
+	return errs.NewInternalError(errs.SubtypeSDKError, "%s", err.Error()).WithHint(hint).WithCause(err)
+}
+
 func docMediaDownloadPermissionDeniedError() error {
 	const tokenArg = "<MEDIA_TOKEN>"
 	return errs.NewPermissionError(

--- a/shortcuts/doc/doc_media_download.go
+++ b/shortcuts/doc/doc_media_download.go
@@ -91,8 +91,6 @@ var DocMediaDownload = common.Shortcut{
 			}
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Downloading: %s %s\n", mediaType, common.MaskToken(token))
-
 		// Build API URL
 		encodedToken := validate.EncodePathSegment(token)
 		var apiPath string

--- a/shortcuts/doc/doc_media_insert.go
+++ b/shortcuts/doc/doc_media_insert.go
@@ -288,6 +288,23 @@ var DocMediaInsert = common.Shortcut{
 			fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", warning)
 			return opErr
 		}
+		withBindRollbackRecovery := func(opErr error, fileToken string) error {
+			rollbackErr := rollback()
+			rollbackStatus := "succeeded"
+			if rollbackErr != nil {
+				rollbackStatus = "failed"
+			}
+			hint := fmt.Sprintf(
+				"Document media upload succeeded but binding failed: phase=bind_media, document_id=%s, upload_succeeded=true, file_token=%s, block_id=%s, replace_block_id=%s, rollback=%s.",
+				documentID, fileToken, blockId, replaceBlockID, rollbackStatus,
+			)
+			if rollbackErr != nil {
+				hint += fmt.Sprintf(" rollback_error=%q. Do not blindly retry the upload; inspect or repair the existing block first.", rollbackErr.Error())
+			} else {
+				hint += " The placeholder block was removed; retry the original command if the operation is still needed."
+			}
+			return withDocRecoveryHint(opErr, hint)
+		}
 
 		// Step 3: Upload media file.
 		// Only materialize Content when clipboard bytes exist, so the `io.Reader`
@@ -355,7 +372,7 @@ var DocMediaInsert = common.Shortcut{
 		if _, err := runtime.CallAPITyped("PATCH",
 			fmt.Sprintf("/open-apis/docx/v1/documents/%s/blocks/batch_update", validate.EncodePathSegment(documentID)),
 			nil, buildBatchUpdateData(replaceBlockID, mediaType, fileToken, alignStr, caption, finalWidth, finalHeight)); err != nil {
-			return withRollbackWarning(err)
+			return withBindRollbackRecovery(err, fileToken)
 		}
 
 		outData := map[string]interface{}{

--- a/shortcuts/doc/doc_media_insert.go
+++ b/shortcuts/doc/doc_media_insert.go
@@ -215,7 +215,6 @@ var DocMediaInsert = common.Shortcut{
 		// Clipboard path: read image bytes into memory, bypassing FileIO path validation.
 		var clipboardContent []byte
 		if runtime.Bool("from-clipboard") {
-			fmt.Fprintf(runtime.IO().ErrOut, "Reading image from clipboard...\n")
 			var err error
 			clipboardContent, err = readClipboardImage()
 			if err != nil {
@@ -246,11 +245,6 @@ var DocMediaInsert = common.Shortcut{
 			fileName = filepath.Base(filePath)
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Inserting: %s -> document %s\n", fileName, common.MaskToken(documentID))
-		if fileSize > common.MaxDriveMediaUploadSinglePartSize {
-			fmt.Fprintf(runtime.IO().ErrOut, "File exceeds 20MB, using multipart upload\n")
-		}
-
 		// Step 1: Get document root block to find where to insert
 		rootData, err := runtime.CallAPITyped("GET",
 			fmt.Sprintf("/open-apis/docx/v1/documents/%s/blocks/%s", validate.EncodePathSegment(documentID), validate.EncodePathSegment(documentID)),
@@ -263,11 +257,7 @@ var DocMediaInsert = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Root block ready: %s (%d children)\n", parentBlockID, insertIndex)
-
 		// Step 2: Create an empty block at the target position
-		fmt.Fprintf(runtime.IO().ErrOut, "Creating block at index %d\n", insertIndex)
-
 		createData, err := runtime.CallAPITyped("POST",
 			fmt.Sprintf("/open-apis/docx/v1/documents/%s/blocks/%s/children", validate.EncodePathSegment(documentID), validate.EncodePathSegment(parentBlockID)),
 			nil, buildCreateBlockData(mediaType, insertIndex, fileViewType))
@@ -281,15 +271,9 @@ var DocMediaInsert = common.Shortcut{
 			return errs.NewInternalError(errs.SubtypeInvalidResponse, "failed to create block: no block_id returned")
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Block created: %s\n", blockId)
-		if uploadParentNode != blockId || replaceBlockID != blockId {
-			fmt.Fprintf(runtime.IO().ErrOut, "Resolved file block targets: upload=%s replace=%s\n", uploadParentNode, replaceBlockID)
-		}
-
 		// The placeholder block is created before any upload starts, so failures in
 		// later steps should try to remove it instead of leaving an empty artifact.
 		rollback := func() error {
-			fmt.Fprintf(runtime.IO().ErrOut, "Rolling back: deleting block %s\n", blockId)
 			_, err := runtime.CallAPITyped("DELETE",
 				fmt.Sprintf("/open-apis/docx/v1/documents/%s/blocks/%s/children/batch_delete", validate.EncodePathSegment(documentID), validate.EncodePathSegment(parentBlockID)),
 				nil, buildDeleteBlockData(insertIndex))
@@ -348,7 +332,6 @@ var DocMediaInsert = common.Shortcut{
 				dims := computeMissingDimension(userWidth, userHeight, nativeW, nativeH)
 				finalWidth = dims.width
 				finalHeight = dims.height
-				fmt.Fprintf(runtime.IO().ErrOut, "Image dimensions: %dx%d (native: %dx%d)\n", finalWidth, finalHeight, nativeW, nativeH)
 			}
 		}
 
@@ -368,11 +351,7 @@ var DocMediaInsert = common.Shortcut{
 			return withRollbackWarning(err)
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "File uploaded: %s\n", fileToken)
-
 		// Step 4: Bind file token to block via batch_update
-		fmt.Fprintf(runtime.IO().ErrOut, "Binding uploaded media to block %s\n", replaceBlockID)
-
 		if _, err := runtime.CallAPITyped("PATCH",
 			fmt.Sprintf("/open-apis/docx/v1/documents/%s/blocks/batch_update", validate.EncodePathSegment(documentID)),
 			nil, buildBatchUpdateData(replaceBlockID, mediaType, fileToken, alignStr, caption, finalWidth, finalHeight)); err != nil {
@@ -456,7 +435,6 @@ func resolveDocxDocumentID(runtime *common.RuntimeContext, input string) (string
 	case "doc":
 		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "this document operation only supports docx documents; use a docx token/URL or a wiki URL that resolves to docx").WithParam("--doc")
 	case "wiki":
-		fmt.Fprintf(runtime.IO().ErrOut, "Resolving wiki node: %s\n", common.MaskToken(docRef.Token))
 		data, err := runtime.CallAPITyped(
 			"GET",
 			"/open-apis/wiki/v2/spaces/get_node",
@@ -477,7 +455,6 @@ func resolveDocxDocumentID(runtime *common.RuntimeContext, input string) (string
 			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but this document operation only supports docx documents", objType).WithParam("--doc")
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to docx: %s\n", common.MaskToken(objToken))
 		return objToken, nil
 	default:
 		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "this document operation only supports docx documents").WithParam("--doc")

--- a/shortcuts/doc/doc_media_preview.go
+++ b/shortcuts/doc/doc_media_preview.go
@@ -52,8 +52,6 @@ var DocMediaPreview = common.Shortcut{
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe output path: %s", err).WithParam("--output").WithCause(err)
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Previewing: media %s\n", common.MaskToken(token))
-
 		encodedToken := validate.EncodePathSegment(token)
 		apiPath := fmt.Sprintf("/open-apis/drive/v1/medias/%s/preview_download", encodedToken)
 

--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -474,6 +474,127 @@ func TestDocMediaInsertExecuteClipboardReadError(t *testing.T) {
 	}
 }
 
+func TestDocMediaInsertBindFailureReportsUploadedStateAndRollback(t *testing.T) {
+	tests := []struct {
+		name             string
+		rollbackBody     map[string]interface{}
+		wantRollback     string
+		wantRollbackText string
+	}{
+		{
+			name:         "rollback succeeds",
+			rollbackBody: map[string]interface{}{"code": 0, "msg": "ok"},
+			wantRollback: "rollback=succeeded",
+		},
+		{
+			name: "rollback fails",
+			rollbackBody: map[string]interface{}{
+				"code": 1777001,
+				"msg":  "rollback backend failure",
+			},
+			wantRollback:     "rollback=failed",
+			wantRollbackText: "rollback backend failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, stderr, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-bind-recovery-app"))
+			documentID := "doxcnBindRecovery1"
+			blockID := "blk_bind_recovery"
+			fileToken := "file_bind_recovery_token"
+
+			tmpDir := t.TempDir()
+			withDocsWorkingDir(t, tmpDir)
+			if err := os.WriteFile("image.png", []byte("png-data"), 0644); err != nil {
+				t.Fatalf("WriteFile() error: %v", err)
+			}
+
+			reg.Register(&httpmock.Stub{
+				Method: "GET",
+				URL:    "/open-apis/docx/v1/documents/" + documentID + "/blocks/" + documentID,
+				Body: map[string]interface{}{
+					"code": 0,
+					"data": map[string]interface{}{
+						"block": map[string]interface{}{
+							"block_id": documentID,
+							"children": []interface{}{},
+						},
+					},
+				},
+			})
+			reg.Register(&httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/docx/v1/documents/" + documentID + "/blocks/" + documentID + "/children",
+				Body: map[string]interface{}{
+					"code": 0,
+					"data": map[string]interface{}{
+						"children": []interface{}{map[string]interface{}{"block_id": blockID}},
+					},
+				},
+			})
+			reg.Register(&httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/drive/v1/medias/upload_all",
+				Body: map[string]interface{}{
+					"code": 0,
+					"data": map[string]interface{}{"file_token": fileToken},
+				},
+			})
+			reg.Register(&httpmock.Stub{
+				Method: "PATCH",
+				URL:    "/open-apis/docx/v1/documents/" + documentID + "/blocks/batch_update",
+				Body:   map[string]interface{}{"code": 1777000, "msg": "bind backend failure"},
+			})
+			reg.Register(&httpmock.Stub{
+				Method: "DELETE",
+				URL:    "/open-apis/docx/v1/documents/" + documentID + "/blocks/" + documentID + "/children/batch_delete",
+				Body:   tt.rollbackBody,
+			})
+
+			err := mountAndRunDocs(t, DocMediaInsert, []string{
+				"+media-insert",
+				"--doc", documentID,
+				"--file", "image.png",
+				"--width", "100",
+				"--height", "80",
+				"--as", "bot",
+			}, f, stdout)
+			if err == nil {
+				t.Fatal("expected bind failure, got nil")
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty on bind failure", stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want recovery in typed error only", stderr.String())
+			}
+
+			problem, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed error, got %T: %v", err, err)
+			}
+			if problem.Code != 1777000 {
+				t.Fatalf("code = %d, want preserved bind error code 1777000", problem.Code)
+			}
+			for _, want := range []string{
+				"phase=bind_media",
+				"document_id=" + documentID,
+				"upload_succeeded=true",
+				"file_token=" + fileToken,
+				"block_id=" + blockID,
+				"replace_block_id=" + blockID,
+				tt.wantRollback,
+				tt.wantRollbackText,
+			} {
+				if want != "" && !strings.Contains(problem.Hint, want) {
+					t.Fatalf("hint = %q, want %q", problem.Hint, want)
+				}
+			}
+		})
+	}
+}
+
 func TestDocMediaInsertExecuteResolvesWikiBeforeFileCheck(t *testing.T) {
 	f, _, stderr, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-insert-exec-app"))
 	reg.Register(&httpmock.Stub{

--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -437,12 +437,8 @@ func TestDocMediaInsertExecuteFromClipboard(t *testing.T) {
 		t.Fatalf("unexpected error: %v — stderr: %s", err, stderr.String())
 	}
 
-	// stderr should show clipboard read + file name "clipboard.png"
-	if !strings.Contains(stderr.String(), "Reading image from clipboard") {
-		t.Errorf("stderr missing clipboard-read log: %s", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "clipboard.png") {
-		t.Errorf("stderr missing clipboard.png file name: %s", stderr.String())
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want no clipboard progress", stderr.String())
 	}
 	// stdout should include the file_token
 	if !strings.Contains(stdout.String(), "file_clip_abc") {
@@ -509,8 +505,8 @@ func TestDocMediaInsertExecuteResolvesWikiBeforeFileCheck(t *testing.T) {
 	if !strings.Contains(err.Error(), "file not found") {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(stderr.String(), "Resolved wiki to docx") {
-		t.Fatalf("stderr missing wiki resolution log: %s", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no wiki resolution progress", stderr.String())
 	}
 }
 
@@ -1091,7 +1087,7 @@ func TestDocMediaPreviewRejectsHTTPErrorBeforeWrite(t *testing.T) {
 }
 
 func TestDocMediaPreviewAppendsExtensionFromRFC5987Filename(t *testing.T) {
-	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-preview-disposition-app"))
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-preview-disposition-app"))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
 		URL:    "/open-apis/drive/v1/medias/tok_123/preview_download?preview_type=" + PreviewType_SOURCE_FILE,
@@ -1120,6 +1116,9 @@ func TestDocMediaPreviewAppendsExtensionFromRFC5987Filename(t *testing.T) {
 	wantPath := mustDocSafeOutputPath(t, "preview.csv")
 	if got.Data.SavedPath != wantPath {
 		t.Fatalf("saved_path = %q, want %q", got.Data.SavedPath, wantPath)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no preview progress", stderr.String())
 	}
 	if _, err := os.Stat(wantPath); err != nil {
 		t.Fatalf("expected preview file at %q: %v", wantPath, err)

--- a/shortcuts/doc/doc_media_upload.go
+++ b/shortcuts/doc/doc_media_upload.go
@@ -91,11 +91,6 @@ var DocMediaUpload = common.Shortcut{
 		}
 
 		fileName := filepath.Base(filePath)
-		fmt.Fprintf(runtime.IO().ErrOut, "Uploading: %s (%d bytes)\n", fileName, stat.Size())
-		if stat.Size() > common.MaxDriveMediaUploadSinglePartSize {
-			fmt.Fprintf(runtime.IO().ErrOut, "File exceeds 20MB, using multipart upload\n")
-		}
-
 		fileToken, err := uploadDocMediaFile(runtime, UploadDocMediaFileConfig{
 			FilePath:   filePath,
 			FileName:   fileName,

--- a/shortcuts/doc/doc_resource_cover.go
+++ b/shortcuts/doc/doc_resource_cover.go
@@ -227,7 +227,11 @@ var DocResourceUpdate = common.Shortcut{
 			nil,
 			map[string]interface{}{"update_cover": map[string]interface{}{"cover": coverBody}},
 		); err != nil {
-			return err
+			hint := fmt.Sprintf(
+				"Document cover upload succeeded but update failed: phase=update_cover, document_id=%s, upload_succeeded=true, file_token=%s. Reuse the uploaded file_token for the remaining update instead of uploading the source again.",
+				documentID, fileToken,
+			)
+			return withDocRecoveryHint(err, hint)
 		}
 
 		runtime.Out(map[string]interface{}{

--- a/shortcuts/doc/doc_resource_cover.go
+++ b/shortcuts/doc/doc_resource_cover.go
@@ -103,7 +103,6 @@ var DocResourceDownload = common.Shortcut{
 			return errs.NewValidationError(errs.SubtypeFailedPrecondition, "document has no cover (cover is empty): %s", common.MaskToken(documentID)).WithParam("--type")
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Downloading cover: %s\n", common.MaskToken(cover.Token))
 		resp, err := runtime.DoAPIStream(ctx, &larkcore.ApiReq{
 			HttpMethod: http.MethodGet,
 			ApiPath:    fmt.Sprintf("/open-apis/drive/v1/medias/%s/download", validate.EncodePathSegment(cover.Token)),
@@ -209,11 +208,6 @@ var DocResourceUpdate = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Uploading cover image: %s (%d bytes)\n", source.FileName, source.FileSize)
-		if source.FileSize > common.MaxDriveMediaUploadSinglePartSize {
-			fmt.Fprintf(runtime.IO().ErrOut, "File exceeds 20MB, using multipart upload\n")
-		}
-
 		uploadCfg := UploadDocMediaFileConfig{
 			FilePath:   source.FilePath,
 			Reader:     source.Reader,
@@ -227,8 +221,6 @@ var DocResourceUpdate = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "File uploaded: %s\n", common.MaskToken(fileToken))
-
 		coverBody := buildDocCoverUpdateBody(fileToken, runtime)
 		if _, err := runtime.CallAPITyped("PATCH",
 			fmt.Sprintf("/open-apis/docx/v1/documents/%s", validate.EncodePathSegment(documentID)),
@@ -467,7 +459,6 @@ func getOptionalFloat(m map[string]interface{}, key string) (float64, bool) {
 
 func readDocCoverUpdateSource(ctx context.Context, runtime *common.RuntimeContext) (docCoverUpdateSource, error) {
 	if runtime.Bool("from-clipboard") {
-		fmt.Fprintf(runtime.IO().ErrOut, "Reading image from clipboard...\n")
 		content, err := readClipboardImage()
 		if err != nil {
 			return docCoverUpdateSource{}, err

--- a/shortcuts/doc/doc_resource_cover_test.go
+++ b/shortcuts/doc/doc_resource_cover_test.go
@@ -237,6 +237,68 @@ func TestDocResourceUpdateCoverUploadsFileAndReturnsFullTokenOnlyOnStdout(t *tes
 	}
 }
 
+func TestDocResourceUpdateCoverPatchFailureReportsUploadedState(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-cover-recovery-app"))
+	documentID := "doxcnCoverRecovery1"
+	fileToken := "file_cover_recovery_token"
+
+	tmpDir := t.TempDir()
+	withDocsWorkingDir(t, tmpDir)
+	if err := os.WriteFile("cover.png", []byte("png-data"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_all",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"file_token": fileToken},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/docx/v1/documents/" + documentID,
+		Body:   map[string]interface{}{"code": 1777002, "msg": "cover update failed"},
+	})
+
+	err := mountAndRunDocs(t, DocResourceUpdate, []string{
+		"+resource-update",
+		"--doc", documentID,
+		"--type", "cover",
+		"--file", "cover.png",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected cover PATCH failure, got nil")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on cover PATCH failure", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want recovery in typed error only", stderr.String())
+	}
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if problem.Code != 1777002 {
+		t.Fatalf("code = %d, want preserved cover error code 1777002", problem.Code)
+	}
+	for _, want := range []string{
+		"phase=update_cover",
+		"document_id=" + documentID,
+		"upload_succeeded=true",
+		"file_token=" + fileToken,
+		"Reuse the uploaded file_token",
+	} {
+		if !strings.Contains(problem.Hint, want) {
+			t.Fatalf("hint = %q, want %q", problem.Hint, want)
+		}
+	}
+}
+
 func TestDocResourceUpdateCoverRejectsMultipleSources(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-cover-source-validation-app"))
 

--- a/shortcuts/doc/doc_resource_cover_test.go
+++ b/shortcuts/doc/doc_resource_cover_test.go
@@ -224,8 +224,8 @@ func TestDocResourceUpdateCoverUploadsFileAndReturnsFullTokenOnlyOnStdout(t *tes
 		}
 	}
 
-	if strings.Contains(stderr.String(), fileToken) {
-		t.Fatalf("stderr leaked full file_token: %s", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no cover upload progress", stderr.String())
 	}
 	data := decodeDocResourceOutput(t, stdout).Data
 	if data["file_token"] != fileToken {

--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -362,20 +362,10 @@ var DriveAddComment = common.Shortcut{
 			return err
 		}
 
-		if mode == commentModeLocal {
-			fmt.Fprintf(runtime.IO().ErrOut, "Using explicit block ID: %s\n", blockID)
-		}
-
 		requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(target.FileToken))
 		requestBody := buildCommentCreateV2Request(target.FileType, "", "", replyElements, nil)
 		if mode == commentModeLocal {
 			requestBody = buildCommentCreateV2Request(target.FileType, blockID, "", replyElements, nil)
-		}
-
-		if mode == commentModeLocal {
-			fmt.Fprintf(runtime.IO().ErrOut, "Creating local comment in %s\n", common.MaskToken(target.FileToken))
-		} else {
-			fmt.Fprintf(runtime.IO().ErrOut, "Creating full comment in %s\n", common.MaskToken(target.FileToken))
 		}
 
 		data, err := runtime.CallAPITyped(
@@ -497,7 +487,6 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 		}, nil
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolving wiki node: %s\n", common.MaskToken(docRef.Token))
 	data, err := runtime.CallAPITyped(
 		"GET",
 		"/open-apis/wiki/v2/spaces/get_node",
@@ -521,7 +510,6 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 		if runtime.Bool("full-comment") {
 			return resolvedCommentTarget{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but --full-comment is not applicable for base(bitable) comments; use --block-id <table-id>!<record-id>!<view-id>", objType).WithParam("--full-comment")
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to base: %s\n", common.MaskToken(objToken))
 		return resolvedCommentTarget{
 			DocID:      objToken,
 			FileToken:  objToken,
@@ -532,7 +520,6 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 	}
 	if objType == "sheet" {
 		// Sheet comments are handled via the sheet fast path in Execute.
-		fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
 		return resolvedCommentTarget{
 			DocID:      objToken,
 			FileToken:  objToken,
@@ -542,7 +529,6 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 		}, nil
 	}
 	if objType == "slides" {
-		fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
 		return resolvedCommentTarget{
 			DocID:      objToken,
 			FileToken:  objToken,
@@ -555,7 +541,6 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 		if err := validateFileCommentMode(mode, objType); err != nil {
 			return resolvedCommentTarget{}, err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
 		return resolvedCommentTarget{
 			DocID:      objToken,
 			FileToken:  objToken,
@@ -571,7 +556,6 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 		return resolvedCommentTarget{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but comments only support doc/docx/file/sheet/slides/base(bitable)", objType)
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
 	return resolvedCommentTarget{
 		DocID:      objToken,
 		FileToken:  objToken,
@@ -926,9 +910,6 @@ func executeSheetComment(runtime *common.RuntimeContext, docRef commentDocRef) e
 	requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(docRef.Token))
 	requestBody := buildCommentCreateV2Request("sheet", "", "", replyElements, anchor)
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Creating sheet comment in %s (sheet=%s, col=%d, row=%d)\n",
-		common.MaskToken(docRef.Token), anchor.SheetID, anchor.Col, anchor.Row)
-
 	data, err := runtime.CallAPITyped("POST", requestPath, nil, requestBody)
 	if err != nil {
 		return err
@@ -960,9 +941,6 @@ func executeBaseComment(runtime *common.RuntimeContext, target resolvedCommentTa
 
 	requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(target.FileToken))
 	requestBody := buildBaseCommentCreateV2Request(replyElements, anchor)
-
-	fmt.Fprintf(runtime.IO().ErrOut, "Creating base(bitable) record-local comment in %s (table=%s, record=%s, view=%s)\n",
-		common.MaskToken(target.FileToken), anchor.BlockID, anchor.BaseRecordID, anchor.BaseViewID)
 
 	data, err := runtime.CallAPITyped("POST", requestPath, nil, requestBody)
 	if err != nil {
@@ -1009,8 +987,6 @@ func executeFileComment(runtime *common.RuntimeContext, target resolvedCommentTa
 	requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(target.FileToken))
 	requestBody := buildCommentCreateV2Request("file", "", "", replyElements, nil)
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Creating file comment in %s (%s)\n", common.MaskToken(target.FileToken), extension)
-
 	data, err := runtime.CallAPITyped("POST", requestPath, nil, requestBody)
 	if err != nil {
 		return err
@@ -1050,9 +1026,6 @@ func executeSlidesComment(runtime *common.RuntimeContext, docRef commentDocRef) 
 
 	requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(docRef.Token))
 	requestBody := buildCommentCreateV2Request("slides", blockID, slideBlockType, replyElements, nil)
-
-	fmt.Fprintf(runtime.IO().ErrOut, "Creating slide block comment in %s (block_id=%s, slide_block_type=%s)\n",
-		common.MaskToken(docRef.Token), blockID, slideBlockType)
 
 	data, err := runtime.CallAPITyped("POST", requestPath, nil, requestBody)
 	if err != nil {

--- a/shortcuts/drive/drive_add_reply.go
+++ b/shortcuts/drive/drive_add_reply.go
@@ -78,7 +78,6 @@ var DriveAddReply = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Adding reply to comment %s in %s...\n", spec.CommentID, common.MaskToken(target.FileToken))
 		path := fmt.Sprintf(
 			"/open-apis/drive/v1/files/%s/comments/%s/replies",
 			validate.EncodePathSegment(target.FileToken),

--- a/shortcuts/drive/drive_apply_permission.go
+++ b/shortcuts/drive/drive_apply_permission.go
@@ -191,9 +191,6 @@ var DriveApplyPermission = common.Shortcut{
 		}
 		body := buildPermApplyBody(runtime)
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Requesting %s access on %s %s...\n",
-			runtime.Str("perm"), docType, common.MaskToken(token))
-
 		data, err := runtime.CallAPITyped("POST",
 			fmt.Sprintf("/open-apis/drive/v1/permissions/%s/members/apply", validate.EncodePathSegment(token)),
 			map[string]interface{}{"type": docType},

--- a/shortcuts/drive/drive_batch_query_comments.go
+++ b/shortcuts/drive/drive_batch_query_comments.go
@@ -90,7 +90,6 @@ var DriveBatchQueryComments = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Batch querying %d comment(s) in %s...\n", len(spec.CommentIDs), common.MaskToken(target.FileToken))
 		path := fmt.Sprintf("/open-apis/drive/v1/files/%s/comments/batch_query", validate.EncodePathSegment(target.FileToken))
 		data, err := runtime.CallAPITyped(
 			"POST",

--- a/shortcuts/drive/drive_comment_common.go
+++ b/shortcuts/drive/drive_comment_common.go
@@ -177,7 +177,6 @@ func resolveDriveCommentTarget(ctx context.Context, runtime *common.RuntimeConte
 		return driveCommentTarget{FileToken: ref.Token, FileType: ref.Type}, nil
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolving wiki node: %s\n", common.MaskToken(ref.Token))
 	data, err := runtime.CallAPITyped(
 		"GET",
 		"/open-apis/wiki/v2/spaces/get_node",
@@ -203,7 +202,6 @@ func resolveDriveCommentTarget(ctx context.Context, runtime *common.RuntimeConte
 			op.targetTypeList(),
 		).WithParam(ref.SourceFlag)
 	}
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
 	return driveCommentTarget{FileToken: objToken, FileType: objType, WikiToken: ref.Token}, nil
 }
 

--- a/shortcuts/drive/drive_copy.go
+++ b/shortcuts/drive/drive_copy.go
@@ -106,9 +106,6 @@ var DriveCopy = common.Shortcut{
 			}
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Copying %s %s to folder %s...\n",
-			spec.Ref.Type, common.MaskToken(spec.Ref.Token), common.MaskToken(folderToken))
-
 		data, err := runtime.CallAPITyped(
 			"POST",
 			fmt.Sprintf("/open-apis/drive/v1/files/%s/copy", validate.EncodePathSegment(spec.Ref.Token)),
@@ -255,7 +252,6 @@ func resolveDriveCopyInput(urlInput, tokenInput, explicitType string) (driveCopy
 
 func resolveDriveCopyWikiResource(ctx context.Context, runtime *common.RuntimeContext, spec driveCopySpec) (driveCopySpec, error) {
 	wikiToken := spec.Ref.Token
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolving wiki resource: %s\n", common.MaskToken(wikiToken))
 	data, err := driveInspectCallWithRetry(ctx, func() (map[string]interface{}, error) {
 		return runtime.CallAPITyped(
 			"GET",
@@ -297,7 +293,6 @@ func resolveDriveCopyWikiResource(ctx context.Context, runtime *common.RuntimeCo
 	spec.Ref.Token = objToken
 	spec.Ref.Type = objType
 	spec.Ref.WikiToken = wikiToken
-	fmt.Fprintf(runtime.IO().ErrOut, "Wiki resource resolved to %s: %s\n", objType, common.MaskToken(objToken))
 	return spec, nil
 }
 
@@ -329,7 +324,6 @@ func resolveDriveCopyFolderToken(input string) (string, bool, error) {
 // The endpoint is absent from platform metadata; the path follows the official
 // get-root-folder-meta documentation and works for both user and bot tokens.
 func resolveDriveCopyMySpaceRoot(runtime *common.RuntimeContext) (string, error) {
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolving My Space root folder...\n")
 	data, err := runtime.CallAPITyped("GET", driveCopyRootFolderMetaPath, nil, nil)
 	if err != nil {
 		return "", err
@@ -338,7 +332,6 @@ func resolveDriveCopyMySpaceRoot(runtime *common.RuntimeContext) (string, error)
 	if token == "" {
 		return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "root folder meta returned an empty token")
 	}
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolved My Space root: %s\n", common.MaskToken(token))
 	return token, nil
 }
 

--- a/shortcuts/drive/drive_cover.go
+++ b/shortcuts/drive/drive_cover.go
@@ -84,7 +84,6 @@ var DriveCover = common.Shortcut{
 			return wrapDriveCoverUnavailable(requestedSpec)
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Downloading cover %s for file %s\n", spec.Name, common.MaskToken(fileToken))
 		result, err := downloadDrivePreviewArtifactWithParams(ctx, runtime, fileToken, buildDriveCoverDownloadParams(version, spec), outputPath, ifExists, spec.FallbackExt)
 		if err != nil {
 			return wrapDriveCoverDownloadError(err, spec.Name)

--- a/shortcuts/drive/drive_create_folder.go
+++ b/shortcuts/drive/drive_create_folder.go
@@ -5,7 +5,6 @@ package drive
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -65,12 +64,6 @@ var DriveCreateFolder = common.Shortcut{
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		spec := newDriveCreateFolderSpec(runtime)
-
-		target := "root folder"
-		if spec.FolderToken != "" {
-			target = "folder " + common.MaskToken(spec.FolderToken)
-		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Creating folder %q in %s...\n", spec.Name, target)
 
 		data, err := runtime.CallAPITyped(
 			"POST",

--- a/shortcuts/drive/drive_create_shortcut.go
+++ b/shortcuts/drive/drive_create_shortcut.go
@@ -5,7 +5,6 @@ package drive
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -75,14 +74,6 @@ var DriveCreateShortcut = common.Shortcut{
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		spec := newDriveCreateShortcutSpec(runtime)
-
-		fmt.Fprintf(
-			runtime.IO().ErrOut,
-			"Creating shortcut for %s %s in folder %s...\n",
-			spec.FileType,
-			common.MaskToken(spec.FileToken),
-			common.MaskToken(spec.FolderToken),
-		)
 
 		data, err := runtime.CallAPITyped(
 			"POST",

--- a/shortcuts/drive/drive_delete.go
+++ b/shortcuts/drive/drive_delete.go
@@ -114,7 +114,7 @@ var DriveDelete = common.Shortcut{
 			out["deleted"] = true
 		}
 		if !ready {
-			nextCommand := driveTaskCheckResultCommand(taskID, string(runtime.As()))
+			nextCommand := driveTaskCheckResultCommand(runtime, taskID)
 			out["timed_out"] = true
 			out["next_command"] = nextCommand
 		}

--- a/shortcuts/drive/drive_delete.go
+++ b/shortcuts/drive/drive_delete.go
@@ -78,8 +78,6 @@ var DriveDelete = common.Shortcut{
 			FileType:  strings.ToLower(runtime.Str("type")),
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Deleting %s %s...\n", spec.FileType, common.MaskToken(spec.FileToken))
-
 		data, err := runtime.CallAPITyped(
 			"DELETE",
 			fmt.Sprintf("/open-apis/drive/v1/files/%s", validate.EncodePathSegment(spec.FileToken)),
@@ -100,8 +98,6 @@ var DriveDelete = common.Shortcut{
 			return nil
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Delete is async, polling task %s...\n", taskID)
-
 		status, ready, err := pollDriveTaskCheck(runtime, taskID)
 		if err != nil {
 			return err
@@ -119,7 +115,6 @@ var DriveDelete = common.Shortcut{
 		}
 		if !ready {
 			nextCommand := driveTaskCheckResultCommand(taskID, string(runtime.As()))
-			fmt.Fprintf(runtime.IO().ErrOut, "Delete task is still in progress. Continue with: %s\n", nextCommand)
 			out["timed_out"] = true
 			out["next_command"] = nextCommand
 		}

--- a/shortcuts/drive/drive_delete_reply.go
+++ b/shortcuts/drive/drive_delete_reply.go
@@ -65,7 +65,6 @@ var DriveDeleteReply = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Deleting reply %s of comment %s in %s...\n", spec.ReplyID, spec.CommentID, common.MaskToken(target.FileToken))
 		path := fmt.Sprintf(
 			"/open-apis/drive/v1/files/%s/comments/%s/replies/%s",
 			validate.EncodePathSegment(target.FileToken),

--- a/shortcuts/drive/drive_delete_test.go
+++ b/shortcuts/drive/drive_delete_test.go
@@ -245,7 +245,7 @@ func TestDriveDeleteTaskCheckOutcomes(t *testing.T) {
 			wantStdout: []string{
 				`"ready": false`,
 				`"timed_out": true`,
-				`"next_command": "lark-cli drive +task_result --scenario task_check --task-id task_123 --as bot"`,
+				`"next_command": "lark-cli --profile secondary drive +task_result --scenario task_check --task-id task_123 --as bot"`,
 			},
 		},
 		{
@@ -272,7 +272,9 @@ func TestDriveDeleteTaskCheckOutcomes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+			config := driveTestConfig()
+			config.ProfileName = "secondary"
+			f, stdout, _, reg := cmdutil.TestFactory(t, config)
 			reg.Register(&httpmock.Stub{
 				Method: "DELETE",
 				URL:    "/open-apis/drive/v1/files/" + tt.fileToken,
@@ -320,7 +322,9 @@ func TestDriveDeleteTaskCheckOutcomes(t *testing.T) {
 }
 
 func TestDriveDeleteTimedOutTaskCanBeResumedWithTaskResult(t *testing.T) {
-	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	config := driveTestConfig()
+	config.ProfileName = "secondary"
+	f, stdout, _, reg := cmdutil.TestFactory(t, config)
 	reg.Register(&httpmock.Stub{
 		Method: "DELETE",
 		URL:    "/open-apis/drive/v1/files/fld_token_test",
@@ -361,7 +365,7 @@ func TestDriveDeleteTimedOutTaskCanBeResumedWithTaskResult(t *testing.T) {
 	if !bytes.Contains(stdout.Bytes(), []byte(`"ready": false`)) {
 		t.Fatalf("stdout missing ready=false: %s", stdout.String())
 	}
-	if !bytes.Contains(stdout.Bytes(), []byte(`"next_command": "lark-cli drive +task_result --scenario task_check --task-id task_resume_123 --as bot"`)) {
+	if !bytes.Contains(stdout.Bytes(), []byte(`"next_command": "lark-cli --profile secondary drive +task_result --scenario task_check --task-id task_resume_123 --as bot"`)) {
 		t.Fatalf("stdout missing next_command: %s", stdout.String())
 	}
 

--- a/shortcuts/drive/drive_download.go
+++ b/shortcuts/drive/drive_download.go
@@ -268,8 +268,6 @@ var DriveDownload = common.Shortcut{
 			}
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Downloading: %s\n", common.MaskToken(fileToken))
-
 		resp, err := runtime.DoAPIStream(ctx, &larkcore.ApiReq{
 			HttpMethod: http.MethodGet,
 			ApiPath:    fmt.Sprintf("/open-apis/drive/v1/files/%s/download", validate.EncodePathSegment(fileToken)),

--- a/shortcuts/drive/drive_errors.go
+++ b/shortcuts/drive/drive_errors.go
@@ -138,6 +138,12 @@ func appendDriveExportRecoveryHint(err error, hint string) error {
 	return errs.NewInternalError(errs.SubtypeSDKError, "%s", err.Error()).WithHint(hint).WithCause(err)
 }
 
+// appendDriveRecoveryHint keeps new non-export recovery paths explicit without
+// renaming the established export helper and touching unrelated callers.
+func appendDriveRecoveryHint(err error, hint string) error {
+	return appendDriveExportRecoveryHint(err, hint)
+}
+
 // driveExportIsRateLimit follows the same typed-error inspection pattern as
 // driveInspectShouldRetry, but export status polling uses the signal to stop.
 // Continuing to poll after a rate-limit response only amplifies the throttling.

--- a/shortcuts/drive/drive_file_source.go
+++ b/shortcuts/drive/drive_file_source.go
@@ -5,7 +5,6 @@ package drive
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -150,7 +149,6 @@ func resolveDriveFileWikiSource(ctx context.Context, runtime *common.RuntimeCont
 		param = "--wiki-token"
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolving wiki node: %s\n", common.MaskToken(wikiToken))
 	data, err := driveInspectCallWithRetry(ctx, func() (map[string]interface{}, error) {
 		return runtime.CallAPITyped(
 			"GET",
@@ -184,7 +182,6 @@ func resolveDriveFileWikiSource(ctx context.Context, runtime *common.RuntimeCont
 			WithHint("for doc/docx/sheet/bitable/slides documents, use drive +export instead")
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to file: %s\n", common.MaskToken(objToken))
 	return objToken, driveFileWikiResolution{
 		Resolved:  true,
 		WikiToken: wikiToken,

--- a/shortcuts/drive/drive_import.go
+++ b/shortcuts/drive/drive_import.go
@@ -172,7 +172,7 @@ func RunImport(ctx context.Context, runtime *common.RuntimeContext, p ImportPara
 		// artifact a caller still gets on this path.
 		return appendDriveExportRecoveryHint(err, fmt.Sprintf(
 			"the import task was already created (ticket=%s)\ncheck its result with: %s",
-			ticket, driveImportTaskResultCommand(ticket)))
+			ticket, driveImportTaskResultCommand(runtime, ticket)))
 	}
 
 	// Some intermediate responses omit the final type, so fall back to the
@@ -212,7 +212,7 @@ func RunImport(ctx context.Context, runtime *common.RuntimeContext, p ImportPara
 		// next_command in the payload is the whole resume story; the stderr copy
 		// it used to carry told a caller nothing extra.
 		out["timed_out"] = true
-		out["next_command"] = driveImportTaskResultCommand(ticket)
+		out["next_command"] = driveImportTaskResultCommand(runtime, ticket)
 	}
 	if ready {
 		if grant := common.AutoGrantCurrentUserDrivePermission(runtime, common.GetString(out, "token"), resultType); grant != nil {

--- a/shortcuts/drive/drive_import_common.go
+++ b/shortcuts/drive/drive_import_common.go
@@ -373,8 +373,9 @@ func (s driveImportStatus) StatusLabel() string {
 
 // driveImportTaskResultCommand prints the resume command returned after bounded
 // polling times out locally.
-func driveImportTaskResultCommand(ticket string) string {
-	return fmt.Sprintf("lark-cli drive +task_result --scenario import --ticket %s", ticket)
+func driveImportTaskResultCommand(runtime *common.RuntimeContext, ticket string) string {
+	prefix, identity := driveTaskResultCommandContext(runtime)
+	return fmt.Sprintf("%s drive +task_result --scenario import --ticket %s --as %s", prefix, ticket, identity)
 }
 
 // createDriveImportTask creates the server-side import task after the media

--- a/shortcuts/drive/drive_import_common_test.go
+++ b/shortcuts/drive/drive_import_common_test.go
@@ -295,7 +295,9 @@ func TestDriveImportFailureErrorLeavesOtherFailuresUnchanged(t *testing.T) {
 }
 
 func TestDriveImportTimeoutReturnsFollowUpCommand(t *testing.T) {
-	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	config := driveTestConfig()
+	config.ProfileName = "secondary"
+	f, stdout, _, reg := cmdutil.TestFactory(t, config)
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/medias/upload_all",
@@ -353,11 +355,83 @@ func TestDriveImportTimeoutReturnsFollowUpCommand(t *testing.T) {
 	if !bytes.Contains(stdout.Bytes(), []byte(`"timed_out": true`)) {
 		t.Fatalf("stdout missing timed_out=true: %s", stdout.String())
 	}
-	if !bytes.Contains(stdout.Bytes(), []byte(`"next_command": "lark-cli drive +task_result --scenario import --ticket tk_import"`)) {
+	if !bytes.Contains(stdout.Bytes(), []byte(`"next_command": "lark-cli --profile secondary drive +task_result --scenario import --ticket tk_import --as bot"`)) {
 		t.Fatalf("stdout missing follow-up command: %s", stdout.String())
 	}
 	if bytes.Contains(stdout.Bytes(), []byte(`"permission_grant"`)) {
 		t.Fatalf("stdout should not include permission_grant before import is ready: %s", stdout.String())
+	}
+}
+
+func TestDriveImportAllPollsFailPreservesTicketAndRecoveryCommand(t *testing.T) {
+	config := driveTestConfig()
+	config.ProfileName = "secondary"
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, config)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_all",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"file_token": "file_poll_failure"},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/import_tasks",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ticket": "tk_poll_failure"},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/import_tasks/tk_poll_failure",
+		Body:   map[string]interface{}{"code": 1061001, "msg": "temporary status failure"},
+	})
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.WriteFile("data.xlsx", []byte("fake-xlsx"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	prevAttempts, prevInterval := driveImportPollAttempts, driveImportPollInterval
+	driveImportPollAttempts, driveImportPollInterval = 1, 0
+	t.Cleanup(func() {
+		driveImportPollAttempts, driveImportPollInterval = prevAttempts, prevInterval
+	})
+
+	err := mountAndRunDrive(t, DriveImport, []string{
+		"+import",
+		"--file", "data.xlsx",
+		"--type", "sheet",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected persistent poll error, got nil")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on persistent poll error", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want recovery in typed error only", stderr.String())
+	}
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %T: %v", err, err)
+	}
+	if problem.Code != 1061001 {
+		t.Fatalf("code = %d, want preserved upstream code 1061001", problem.Code)
+	}
+	for _, want := range []string{
+		"ticket=tk_poll_failure",
+		"lark-cli --profile secondary drive +task_result --scenario import --ticket tk_poll_failure --as bot",
+	} {
+		if !strings.Contains(problem.Hint, want) {
+			t.Fatalf("hint = %q, want %q", problem.Hint, want)
+		}
 	}
 }
 

--- a/shortcuts/drive/drive_inspect.go
+++ b/shortcuts/drive/drive_inspect.go
@@ -95,7 +95,6 @@ var DriveInspect = common.Shortcut{
 
 		// Step 2: If type is "wiki", unwrap via get_node API.
 		if docType == "wiki" {
-			fmt.Fprintf(runtime.IO().ErrOut, "Inspecting wiki node: %s\n", common.MaskToken(docToken))
 			data, err := driveInspectCallWithRetry(
 				ctx,
 				func() (map[string]interface{}, error) {
@@ -131,7 +130,6 @@ var DriveInspect = common.Shortcut{
 			docType = objType
 			docToken = objToken
 
-			fmt.Fprintf(runtime.IO().ErrOut, "Wiki unwrapped to %s: %s\n", docType, common.MaskToken(docToken))
 		}
 
 		// Step 3: Call batch_query to verify and get title.

--- a/shortcuts/drive/drive_list_comments.go
+++ b/shortcuts/drive/drive_list_comments.go
@@ -243,7 +243,6 @@ func resolveDriveListCommentsTarget(ctx context.Context, runtime *common.Runtime
 		return driveListCommentsTarget{FileToken: ref.Token, FileType: ref.Type}, nil
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolving wiki node: %s\n", common.MaskToken(ref.Token))
 	data, err := runtime.CallAPITyped(
 		"GET",
 		"/open-apis/wiki/v2/spaces/get_node",
@@ -267,7 +266,6 @@ func resolveDriveListCommentsTarget(ctx context.Context, runtime *common.Runtime
 			objType,
 		).WithParam(ref.SourceFlag)
 	}
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
 	return driveListCommentsTarget{FileToken: objToken, FileType: objType}, nil
 }
 

--- a/shortcuts/drive/drive_list_replies.go
+++ b/shortcuts/drive/drive_list_replies.go
@@ -70,7 +70,6 @@ var DriveListReplies = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Listing replies of comment %s in %s...\n", spec.CommentID, common.MaskToken(target.FileToken))
 		path := fmt.Sprintf(
 			"/open-apis/drive/v1/files/%s/comments/%s/replies",
 			validate.EncodePathSegment(target.FileToken),

--- a/shortcuts/drive/drive_member_add.go
+++ b/shortcuts/drive/drive_member_add.go
@@ -492,9 +492,6 @@ func buildDriveMemberAddDryRun(spec driveMemberAddSpec) *common.DryRunAPI {
 
 // executeDriveMemberAddSingle calls the single-member create API.
 func executeDriveMemberAddSingle(runtime *common.RuntimeContext, spec driveMemberAddSpec) error {
-	fmt.Fprintf(runtime.IO().ErrOut, "Adding Drive member %s (type=%s, perm=%s) to %s %s...\n",
-		common.MaskToken(spec.MemberIDs[0]), spec.MemberType, spec.Perm, spec.ResourceType, common.MaskToken(spec.Token))
-
 	body := buildMemberBody(spec.MemberIDs[0], spec.MemberType, spec.MemberKind, spec.Perm, spec.PermType)
 	data, err := runtime.CallAPITyped(
 		"POST",
@@ -507,7 +504,6 @@ func executeDriveMemberAddSingle(runtime *common.RuntimeContext, spec driveMembe
 	}
 
 	out := driveMemberAddOutput(spec, spec.MemberIDs[0], common.GetMap(data, "member"))
-	fmt.Fprintf(runtime.IO().ErrOut, "Added Drive member %s\n", common.MaskToken(common.GetString(out, "member_id")))
 	runtime.Out(out, nil)
 	return nil
 }
@@ -517,9 +513,6 @@ func executeDriveMemberAddSingle(runtime *common.RuntimeContext, spec driveMembe
 // member_id, regardless of response array order.
 func executeDriveMemberAddBatch(runtime *common.RuntimeContext, spec driveMemberAddSpec) error {
 	members := buildDriveMemberAddMemberBodies(spec)
-
-	fmt.Fprintf(runtime.IO().ErrOut, "Adding %d Drive members (type=%s, perm=%s) to %s %s...\n",
-		len(spec.MemberIDs), spec.MemberType, spec.Perm, spec.ResourceType, common.MaskToken(spec.Token))
 
 	data, err := runtime.CallAPITyped(
 		"POST",
@@ -536,7 +529,6 @@ func executeDriveMemberAddBatch(runtime *common.RuntimeContext, spec driveMember
 		return runtime.OutPartialFailure(result, nil)
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Added %d Drive member(s)\n", result["succeeded_count"])
 	runtime.Out(result, nil)
 	return nil
 }

--- a/shortcuts/drive/drive_member_add_test.go
+++ b/shortcuts/drive/drive_member_add_test.go
@@ -1047,8 +1047,8 @@ func TestDriveMemberAdd_ExecuteSuccessFlattensMember(t *testing.T) {
 		data["perm"] != "view" || data["member_kind"] != "user" {
 		t.Fatalf("flattened output = %#v", data)
 	}
-	if !strings.Contains(stderr.String(), "Added Drive member") {
-		t.Fatalf("stderr = %q, want success log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no success log", stderr.String())
 	}
 }
 
@@ -1108,8 +1108,8 @@ func TestDriveMemberAdd_ExecuteBatchSuccess(t *testing.T) {
 	if first["member_id"] != "ou_a" || second["member_id"] != "ou_b" {
 		t.Fatalf("members = %#v, want request-order fallback IDs", members)
 	}
-	if !strings.Contains(stderr.String(), "Added 2 Drive member(s)") {
-		t.Fatalf("stderr = %q, want success log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no success log", stderr.String())
 	}
 	if !strings.Contains(capturedQuery, "type=bitable") {
 		t.Fatalf("captured query = %q, want type=bitable for bascn token", capturedQuery)

--- a/shortcuts/drive/drive_member_list.go
+++ b/shortcuts/drive/drive_member_list.go
@@ -273,13 +273,9 @@ var DriveMemberList = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Listing Drive members for %s %s...\n", spec.Type, common.MaskToken(spec.Token))
 		data, err := runtime.CallAPITyped("GET", spec.apiPath(), spec.params(), nil)
 		if err != nil {
 			return err
-		}
-		if items, ok := data["items"].([]interface{}); ok {
-			fmt.Fprintf(runtime.IO().ErrOut, "Found %d Drive member(s)\n", len(items))
 		}
 		runtime.OutFormat(data, nil, func(w io.Writer) {
 			renderDriveMemberListPretty(w, data)

--- a/shortcuts/drive/drive_member_list_test.go
+++ b/shortcuts/drive/drive_member_list_test.go
@@ -378,8 +378,8 @@ func TestDriveMemberListExecutePreservesRawData(t *testing.T) {
 	if item["server_future"] != "preserved" || item["external_label"] != true {
 		t.Fatalf("item future fields not preserved: %#v", item)
 	}
-	if !strings.Contains(stderr.String(), "Found 1 Drive member") {
-		t.Fatalf("stderr = %q, want count log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no count log", stderr.String())
 	}
 }
 

--- a/shortcuts/drive/drive_member_remove.go
+++ b/shortcuts/drive/drive_member_remove.go
@@ -271,15 +271,6 @@ func driveMemberRemovePath(spec driveMemberRemoveSpec) string {
 
 // executeDriveMemberRemove issues the typed DELETE request and emits the structured removal result.
 func executeDriveMemberRemove(runtime *common.RuntimeContext, spec driveMemberRemoveSpec) error {
-	fmt.Fprintf(
-		runtime.IO().ErrOut,
-		"Removing Drive member %s (type=%s) from %s %s...\n",
-		common.MaskToken(spec.MemberID),
-		spec.MemberType,
-		spec.ResourceType,
-		common.MaskToken(spec.Token),
-	)
-
 	if _, err := runtime.CallAPITyped(
 		"DELETE",
 		driveMemberRemovePath(spec),
@@ -290,8 +281,6 @@ func executeDriveMemberRemove(runtime *common.RuntimeContext, spec driveMemberRe
 	}
 
 	out := driveMemberRemoveOutput(spec)
-
-	fmt.Fprintf(runtime.IO().ErrOut, "Removed Drive member %s\n", common.MaskToken(spec.MemberID))
 	runtime.Out(out, nil)
 	return nil
 }

--- a/shortcuts/drive/drive_member_remove_test.go
+++ b/shortcuts/drive/drive_member_remove_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
-	"github.com/larksuite/cli/shortcuts/common"
 )
 
 func TestDriveMemberRemoveMetadata(t *testing.T) {
@@ -445,11 +444,8 @@ func TestDriveMemberRemoveExecuteSuccess(t *testing.T) {
 		data["member_kind"] != "user" || data["perm_type"] != "single_page" {
 		t.Fatalf("output = %#v", data)
 	}
-	if strings.Contains(stderr.String(), "wikcnSecretToken") || strings.Contains(stderr.String(), "ou_secret_member") {
-		t.Fatalf("stderr exposes unmasked identifiers: %q", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), common.MaskToken("wikcnSecretToken")) || !strings.Contains(stderr.String(), common.MaskToken("ou_secret_member")) {
-		t.Fatalf("stderr missing masked identifiers: %q", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no removal progress", stderr.String())
 	}
 }
 

--- a/shortcuts/drive/drive_move.go
+++ b/shortcuts/drive/drive_move.go
@@ -110,7 +110,7 @@ var DriveMove = common.Shortcut{
 				"ready":        ready,
 			}
 			if !ready {
-				nextCommand := driveTaskCheckResultCommand(taskID, string(runtime.As()))
+				nextCommand := driveTaskCheckResultCommand(runtime, taskID)
 				out["timed_out"] = true
 				out["next_command"] = nextCommand
 			}

--- a/shortcuts/drive/drive_move.go
+++ b/shortcuts/drive/drive_move.go
@@ -68,7 +68,6 @@ var DriveMove = common.Shortcut{
 		// Default to the caller's root folder so the command can move items
 		// without requiring an explicit destination in common cases.
 		if spec.FolderToken == "" {
-			fmt.Fprintf(runtime.IO().ErrOut, "No target folder specified, getting root folder...\n")
 			rootToken, err := getRootFolderToken(ctx, runtime)
 			if err != nil {
 				return err
@@ -78,8 +77,6 @@ var DriveMove = common.Shortcut{
 			}
 			spec.FolderToken = rootToken
 		}
-
-		fmt.Fprintf(runtime.IO().ErrOut, "Moving %s %s to folder %s...\n", spec.FileType, common.MaskToken(spec.FileToken), common.MaskToken(spec.FolderToken))
 
 		data, err := runtime.CallAPITyped(
 			"POST",
@@ -98,8 +95,6 @@ var DriveMove = common.Shortcut{
 				return errs.NewInternalError(errs.SubtypeInvalidResponse, "move folder returned no task_id")
 			}
 
-			fmt.Fprintf(runtime.IO().ErrOut, "Folder move is async, polling task %s...\n", taskID)
-
 			status, ready, err := pollDriveTaskCheck(runtime, taskID)
 			if err != nil {
 				return err
@@ -116,7 +111,6 @@ var DriveMove = common.Shortcut{
 			}
 			if !ready {
 				nextCommand := driveTaskCheckResultCommand(taskID, string(runtime.As()))
-				fmt.Fprintf(runtime.IO().ErrOut, "Folder move task is still in progress. Continue with: %s\n", nextCommand)
 				out["timed_out"] = true
 				out["next_command"] = nextCommand
 			}

--- a/shortcuts/drive/drive_move_common.go
+++ b/shortcuts/drive/drive_move_common.go
@@ -95,8 +95,9 @@ func (s driveTaskCheckStatus) StatusLabel() string {
 
 // driveTaskCheckResultCommand prints the resume command shown when bounded
 // polling ends before the backend task completes.
-func driveTaskCheckResultCommand(taskID, as string) string {
-	return fmt.Sprintf("lark-cli drive +task_result --scenario task_check --task-id %s --as %s", taskID, as)
+func driveTaskCheckResultCommand(runtime *common.RuntimeContext, taskID string) string {
+	prefix, identity := driveTaskResultCommandContext(runtime)
+	return fmt.Sprintf("%s drive +task_result --scenario task_check --task-id %s --as %s", prefix, taskID, identity)
 }
 
 // driveTaskCheckParams keeps the task_check query parameter shape in one place
@@ -166,7 +167,12 @@ func pollDriveTaskCheck(runtime *common.RuntimeContext, taskID string) (driveTas
 	}
 
 	if !seenStatus && lastErr != nil {
-		return driveTaskCheckStatus{}, false, lastErr
+		hint := fmt.Sprintf(
+			"the Drive task was created but every status poll failed (task_id=%s)\nretry status lookup with: %s",
+			taskID,
+			driveTaskCheckResultCommand(runtime, taskID),
+		)
+		return driveTaskCheckStatus{}, false, appendDriveRecoveryHint(lastErr, hint)
 	}
 
 	return lastStatus, false, nil

--- a/shortcuts/drive/drive_move_common.go
+++ b/shortcuts/drive/drive_move_common.go
@@ -151,7 +151,6 @@ func pollDriveTaskCheck(runtime *common.RuntimeContext, taskID string) (driveTas
 		status, err := getDriveTaskCheckStatus(runtime, taskID)
 		if err != nil {
 			lastErr = err
-			fmt.Fprintf(runtime.IO().ErrOut, "Error polling task %s: %s\n", taskID, err)
 			continue
 		}
 		seenStatus = true
@@ -159,7 +158,6 @@ func pollDriveTaskCheck(runtime *common.RuntimeContext, taskID string) (driveTas
 		// Success and failure are terminal backend states. Any other value is kept
 		// as pending so the caller can decide whether to continue or resume later.
 		if status.Ready() {
-			fmt.Fprintf(runtime.IO().ErrOut, "Drive task completed successfully.\n")
 			return status, true, nil
 		}
 		if status.Failed() {

--- a/shortcuts/drive/drive_move_common_test.go
+++ b/shortcuts/drive/drive_move_common_test.go
@@ -7,10 +7,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -107,6 +109,7 @@ func TestDriveMoveFolderTaskCheckOutcomes(t *testing.T) {
 		name            string
 		taskCheckBody   map[string]interface{}
 		wantErrContains string
+		wantHint        []string
 		wantStdout      []string
 	}{
 		{
@@ -129,7 +132,7 @@ func TestDriveMoveFolderTaskCheckOutcomes(t *testing.T) {
 			wantStdout: []string{
 				`"ready": false`,
 				`"timed_out": true`,
-				`"next_command": "lark-cli drive +task_result --scenario task_check --task-id task_123 --as bot"`,
+				`"next_command": "lark-cli --profile secondary drive +task_result --scenario task_check --task-id task_123 --as bot"`,
 			},
 		},
 		{
@@ -139,12 +142,18 @@ func TestDriveMoveFolderTaskCheckOutcomes(t *testing.T) {
 				"msg":  "internal error",
 			},
 			wantErrContains: "internal error",
+			wantHint: []string{
+				"task_id=task_123",
+				"lark-cli --profile secondary drive +task_result --scenario task_check --task-id task_123 --as bot",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+			config := driveTestConfig()
+			config.ProfileName = "secondary"
+			f, stdout, _, reg := cmdutil.TestFactory(t, config)
 			reg.Register(&httpmock.Stub{
 				Method: "POST",
 				URL:    "/open-apis/drive/v1/files/fld_src/move",
@@ -175,6 +184,17 @@ func TestDriveMoveFolderTaskCheckOutcomes(t *testing.T) {
 				}
 				if !bytes.Contains([]byte(err.Error()), []byte(tt.wantErrContains)) {
 					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(tt.wantHint) > 0 {
+					problem, ok := errs.ProblemOf(err)
+					if !ok {
+						t.Fatalf("expected typed error, got %T: %v", err, err)
+					}
+					for _, want := range tt.wantHint {
+						if !strings.Contains(problem.Hint, want) {
+							t.Fatalf("hint = %q, want %q", problem.Hint, want)
+						}
+					}
 				}
 				return
 			}

--- a/shortcuts/drive/drive_permission_get_setting.go
+++ b/shortcuts/drive/drive_permission_get_setting.go
@@ -254,7 +254,6 @@ var DrivePermissionGetSetting = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Getting permission settings for %s %s...\n", spec.Type, common.MaskToken(spec.Token))
 		data, err := runtime.CallAPITyped(
 			"GET",
 			spec.apiPath(),

--- a/shortcuts/drive/drive_preview.go
+++ b/shortcuts/drive/drive_preview.go
@@ -5,7 +5,6 @@ package drive
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
@@ -150,7 +149,6 @@ var DrivePreview = common.Shortcut{
 		}
 
 		if requestedType == "source_file" {
-			fmt.Fprintf(runtime.IO().ErrOut, "Downloading source file artifact: %s\n", common.MaskToken(fileToken))
 			result, err := downloadDrivePreviewArtifact(ctx, runtime, fileToken, drivePreviewTypeSourceFile, version, outputPath, ifExists, drivePreviewFallbackExt("source_file"))
 			if err != nil {
 				return err
@@ -162,7 +160,6 @@ var DrivePreview = common.Shortcut{
 			return nil
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Fetching preview candidates: %s\n", common.MaskToken(fileToken))
 		data, candidates, err := fetchDrivePreviewCandidates(runtime, fileToken, body)
 		if err != nil {
 			if runtime.Bool("list-only") {
@@ -187,7 +184,6 @@ var DrivePreview = common.Shortcut{
 		if downloadVersion == "" {
 			downloadVersion = versionString(data["version"])
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Downloading preview %s for file %s\n", candidate.Type, common.MaskToken(fileToken))
 		result, err := downloadDrivePreviewArtifact(ctx, runtime, fileToken, candidate.TypeCode, downloadVersion, outputPath, ifExists, drivePreviewFallbackExt(candidate.Type))
 		if err != nil {
 			return err

--- a/shortcuts/drive/drive_pull.go
+++ b/shortcuts/drive/drive_pull.go
@@ -162,7 +162,6 @@ var DrivePull = common.Shortcut{
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--local-dir resolves outside cwd: %s", err).WithParam("--local-dir")
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Listing Drive folder: %s\n", common.MaskToken(folderToken))
 		entries, err := listRemoteFolderEntries(ctx, runtime, folderToken, "")
 		if err != nil {
 			return err
@@ -234,7 +233,6 @@ var DrivePull = common.Shortcut{
 				downloadFailed++
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +pull after terminal %s failure: %v\n", item.Phase, err)
 					break
 				}
 				continue

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -920,7 +920,6 @@ func drivePushUploadMultipart(_ context.Context, runtime *common.RuntimeContext,
 			"upload_prepare returned invalid data: upload_id=%q, block_size=%d, block_num=%d",
 			uploadID, blockSize, blockNum)
 	}
-
 	// Open the local file ONCE for the whole multipart loop. fileio.File
 	// implements io.ReaderAt, so each block is a fresh
 	// io.NewSectionReader over a shared fd — no need to reopen N times

--- a/shortcuts/drive/drive_push.go
+++ b/shortcuts/drive/drive_push.go
@@ -205,13 +205,11 @@ var DrivePush = common.Shortcut{
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "could not resolve cwd: %s", err)
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Walking local: %s\n", localDir)
 		localFiles, localDirs, err := drivePushWalkLocal(safeRoot, cwdCanonical)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Listing Drive folder: %s\n", common.MaskToken(folderToken))
 		entries, err := listRemoteFolderEntries(ctx, runtime, folderToken, "")
 		if err != nil {
 			return err
@@ -270,7 +268,6 @@ var DrivePush = common.Shortcut{
 				uploadFailed = true
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, ensureErr)
 					break
 				}
 				continue
@@ -306,7 +303,6 @@ var DrivePush = common.Shortcut{
 					uploadFailed = true
 					if terminal {
 						aborted = true
-						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, parentErr)
 						break
 					}
 					continue
@@ -338,7 +334,6 @@ var DrivePush = common.Shortcut{
 					uploadFailed = true
 					if terminal {
 						aborted = true
-						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, upErr)
 						break
 					}
 					continue
@@ -357,7 +352,6 @@ var DrivePush = common.Shortcut{
 				uploadFailed = true
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, ensureErr)
 					break
 				}
 				continue
@@ -370,7 +364,6 @@ var DrivePush = common.Shortcut{
 				uploadFailed = true
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, upErr)
 					break
 				}
 				continue
@@ -424,7 +417,6 @@ var DrivePush = common.Shortcut{
 						failed++
 						if terminal {
 							aborted = true
-							fmt.Fprintf(runtime.IO().ErrOut, "Aborting +push after terminal %s failure: %v\n", item.Phase, err)
 							abortDelete = true
 							break
 						}
@@ -929,9 +921,6 @@ func drivePushUploadMultipart(_ context.Context, runtime *common.RuntimeContext,
 			uploadID, blockSize, blockNum)
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Multipart upload: %s, block size %s, %d block(s)\n",
-		common.FormatSize(file.Size), common.FormatSize(blockSize), blockNum)
-
 	// Open the local file ONCE for the whole multipart loop. fileio.File
 	// implements io.ReaderAt, so each block is a fresh
 	// io.NewSectionReader over a shared fd — no need to reopen N times
@@ -972,7 +961,6 @@ func drivePushUploadMultipart(_ context.Context, runtime *common.RuntimeContext,
 		if _, err := runtime.ClassifyAPIResponse(apiResp); err != nil {
 			return "", err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "  Block %d/%d uploaded (%s)\n", seq+1, blockNum, common.FormatSize(partSize))
 	}
 
 	finishResult, err := runtime.CallAPITyped("POST", "/open-apis/drive/v1/files/upload_finish", nil, map[string]interface{}{

--- a/shortcuts/drive/drive_react_reply.go
+++ b/shortcuts/drive/drive_react_reply.go
@@ -115,7 +115,6 @@ var DriveReactReply = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Reaction %s (%s) on reply %s in %s...\n", spec.Action, spec.ReactionType, spec.ReplyID, common.MaskToken(target.FileToken))
 		path := fmt.Sprintf("/open-apis/drive/v2/files/%s/comments/reaction", validate.EncodePathSegment(target.FileToken))
 		if _, err := runtime.CallAPITyped(
 			"POST",

--- a/shortcuts/drive/drive_resolve_comment.go
+++ b/shortcuts/drive/drive_resolve_comment.go
@@ -118,7 +118,6 @@ func newDriveCommentSolvedShortcut(cfg driveCommentSolvedConfig) common.Shortcut
 				return err
 			}
 
-			fmt.Fprintf(runtime.IO().ErrOut, "%s comment %s in %s...\n", cfg.Verb, spec.CommentID, common.MaskToken(target.FileToken))
 			path := fmt.Sprintf(
 				"/open-apis/drive/v1/files/%s/comments/%s",
 				validate.EncodePathSegment(target.FileToken),

--- a/shortcuts/drive/drive_status.go
+++ b/shortcuts/drive/drive_status.go
@@ -151,13 +151,11 @@ var DriveStatus = common.Shortcut{
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "could not resolve cwd: %s", err)
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Walking local: %s\n", localDir)
 		localFiles, err := walkLocalForStatus(safeRoot, cwdCanonical)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Listing Drive folder: %s\n", common.MaskToken(folderToken))
 		entries, err := listRemoteFolderEntries(ctx, runtime, folderToken, "")
 		if err != nil {
 			return err

--- a/shortcuts/drive/drive_sync.go
+++ b/shortcuts/drive/drive_sync.go
@@ -138,13 +138,11 @@ var DriveSync = common.Shortcut{
 		}
 
 		// --- Phase 1: Compute diff (same logic as +status) ---
-		fmt.Fprintf(runtime.IO().ErrOut, "Walking local: %s\n", localDir)
 		localFiles, err := walkLocalForStatus(safeRoot, cwdCanonical)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Listing Drive folder: %s\n", common.MaskToken(folderToken))
 		entries, err := listRemoteFolderEntries(ctx, runtime, folderToken, "")
 		if err != nil {
 			return err
@@ -243,9 +241,6 @@ var DriveSync = common.Shortcut{
 			detection = driveStatusDetectionQuick
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Diff: %d new_local, %d new_remote, %d modified, %d unchanged (detection=%s)\n",
-			len(newLocal), len(newRemote), len(modified), len(unchanged), detection)
-
 		conflictResolutions := make(map[string]string, len(modified))
 		if onConflict == driveSyncOnConflictAsk && len(modified) > 0 && runtime.IO().In == nil {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--on-conflict=ask requires interactive stdin when modified files exist").WithParam("--on-conflict")
@@ -299,7 +294,6 @@ var DriveSync = common.Shortcut{
 				failed++
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, ensureErr)
 					break
 				}
 				continue
@@ -325,7 +319,6 @@ var DriveSync = common.Shortcut{
 				failed++
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, err)
 					break
 				}
 				continue
@@ -353,7 +346,6 @@ var DriveSync = common.Shortcut{
 				failed++
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, ensureErr)
 					break
 				}
 				continue
@@ -365,7 +357,6 @@ var DriveSync = common.Shortcut{
 				failed++
 				if terminal {
 					aborted = true
-					fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, upErr)
 					break
 				}
 				continue
@@ -411,7 +402,6 @@ var DriveSync = common.Shortcut{
 					failed++
 					if terminal {
 						aborted = true
-						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, err)
 						break
 					}
 					continue
@@ -434,7 +424,6 @@ var DriveSync = common.Shortcut{
 					failed++
 					if terminal {
 						aborted = true
-						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, parentErr)
 						break
 					}
 					continue
@@ -455,7 +444,6 @@ var DriveSync = common.Shortcut{
 					failed++
 					if terminal {
 						aborted = true
-						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, upErr)
 						break
 					}
 					continue
@@ -524,7 +512,6 @@ var DriveSync = common.Shortcut{
 					failed++
 					if terminal {
 						aborted = true
-						fmt.Fprintf(runtime.IO().ErrOut, "Aborting +sync after terminal %s failure: %v\n", item.Phase, downloadErr)
 						break
 					}
 					continue

--- a/shortcuts/drive/drive_task_result.go
+++ b/shortcuts/drive/drive_task_result.go
@@ -22,6 +22,26 @@ const (
 	wikiMoveToDriveResultKey = "move_wiki_to_docs_result"
 )
 
+// driveTaskResultCommandContext preserves the credential context that created
+// an async task so a recovery command does not silently fall back to another
+// profile or identity.
+func driveTaskResultCommandContext(runtime *common.RuntimeContext) (prefix, identity string) {
+	prefix = "lark-cli"
+	identity = "user"
+	if runtime == nil {
+		return prefix, identity
+	}
+	if runtime.Config != nil {
+		if profile := strings.TrimSpace(runtime.Config.ProfileName); profile != "" {
+			prefix = fmt.Sprintf("lark-cli --profile %s", profile)
+		}
+	}
+	if resolved := strings.TrimSpace(string(runtime.As())); resolved != "" {
+		identity = resolved
+	}
+	return prefix, identity
+}
+
 // DriveTaskResult exposes a unified read path for the async task types produced
 // by Drive import, export, file/folder move/delete, wiki move, wiki move-to-drive,
 // and wiki delete flows.

--- a/shortcuts/drive/drive_task_result.go
+++ b/shortcuts/drive/drive_task_result.go
@@ -138,8 +138,6 @@ var DriveTaskResult = common.Shortcut{
 		taskID := runtime.Str("task-id")
 		fileToken := runtime.Str("file-token")
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Querying %s task result...\n", scenario)
-
 		var result map[string]interface{}
 		var err error
 

--- a/shortcuts/drive/drive_update_reply.go
+++ b/shortcuts/drive/drive_update_reply.go
@@ -76,7 +76,6 @@ var DriveUpdateReply = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Updating reply %s of comment %s in %s...\n", spec.ReplyID, spec.CommentID, common.MaskToken(target.FileToken))
 		path := fmt.Sprintf(
 			"/open-apis/drive/v1/files/%s/comments/%s/replies/%s",
 			validate.EncodePathSegment(target.FileToken),

--- a/shortcuts/drive/drive_update_title.go
+++ b/shortcuts/drive/drive_update_title.go
@@ -131,9 +131,6 @@ var DriveUpdateTitle = common.Shortcut{
 		}
 		spec.Title = guard.Title
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Updating %s %s title to %q...\n",
-			spec.Ref.Type, common.MaskToken(spec.Ref.Token), spec.Title)
-
 		if _, err := runtime.CallAPITyped(
 			"PATCH",
 			driveUpdateTitlePath(spec.Ref.Token),

--- a/shortcuts/drive/drive_update_title_test.go
+++ b/shortcuts/drive/drive_update_title_test.go
@@ -669,8 +669,8 @@ func TestDriveUpdateTitleExecuteDocxURL(t *testing.T) {
 	if got := mustStringField(t, data, "url", "data.url"); got != "https://www.feishu.cn/docx/docxRenameTarget" {
 		t.Fatalf("url = %q, want the built docx URL", got)
 	}
-	if progress := stderr.String(); !strings.Contains(progress, "Updating docx") {
-		t.Fatalf("stderr = %q, want a progress line naming the target type", progress)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no update progress", stderr.String())
 	}
 }
 

--- a/shortcuts/drive/drive_upload.go
+++ b/shortcuts/drive/drive_upload.go
@@ -171,11 +171,8 @@ var DriveUpload = common.Shortcut{
 		}
 		fileSize := info.Size()
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Uploading: %s (%s) -> %s\n", fileName, common.FormatSize(fileSize), target.Label())
-
 		var uploadResult driveUploadResult
 		if fileSize > common.MaxDriveMediaUploadSinglePartSize {
-			fmt.Fprintf(runtime.IO().ErrOut, "File exceeds 20MB, using multipart upload\n")
 			uploadResult, err = uploadFileMultipart(ctx, runtime, spec.FilePath, fileName, target, fileSize, spec.FileToken)
 		} else {
 			uploadResult, err = uploadFileToDrive(ctx, runtime, spec.FilePath, fileName, target, fileSize, spec.FileToken)
@@ -347,9 +344,6 @@ func uploadFileMultipart(_ context.Context, runtime *common.RuntimeContext, file
 			uploadID, blockSize, blockNum), meta)
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Multipart upload: %s, block size %s, %d block(s)\n",
-		common.FormatSize(fileSize), common.FormatSize(blockSize), blockNum)
-
 	// Step 2: Upload parts
 	meta.APIPath = driveUploadPartPath
 	for seq := 0; seq < blockNum; seq++ {
@@ -387,7 +381,6 @@ func uploadFileMultipart(_ context.Context, runtime *common.RuntimeContext, file
 			return driveUploadResult{}, fileevent.ReportUploadError(runtime, err, meta)
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "  Block %d/%d uploaded (%s)\n", seq+1, blockNum, common.FormatSize(partSize))
 	}
 
 	// Step 3: Finish

--- a/shortcuts/drive/drive_upload.go
+++ b/shortcuts/drive/drive_upload.go
@@ -343,7 +343,6 @@ func uploadFileMultipart(_ context.Context, runtime *common.RuntimeContext, file
 			"upload_prepare returned invalid data: upload_id=%q, block_size=%d, block_num=%d",
 			uploadID, blockSize, blockNum), meta)
 	}
-
 	// Step 2: Upload parts
 	meta.APIPath = driveUploadPartPath
 	for seq := 0; seq < blockNum; seq++ {

--- a/shortcuts/sheets/backward/lark_sheets_float_images.go
+++ b/shortcuts/sheets/backward/lark_sheets_float_images.go
@@ -208,7 +208,6 @@ func uploadSheetMediaFile(runtime *common.RuntimeContext, filePath, fileName str
 		FileSize:   fileSize,
 		ParentType: parentType,
 		ParentNode: parentNode,
-		Quiet:      true,
 	})
 }
 

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -136,7 +136,6 @@ func uploadSheetImage(runtime *common.RuntimeContext, spreadsheetToken, filePath
 		FileSize:   fileSize,
 		ParentType: parentType,
 		ParentNode: spreadsheetToken,
-		Quiet:      true,
 	})
 }
 

--- a/shortcuts/sheets/success_stderr_contract_test.go
+++ b/shortcuts/sheets/success_stderr_contract_test.go
@@ -35,9 +35,8 @@ import (
 //     duplicates its permission_grant result on stderr when the grant is
 //     skipped or fails
 //
-// The +media-upload over 20MB gap was closed by the Quiet flag on
-// DriveMediaMultipartUploadConfig; sheets shortcuts pass Quiet: true so the
-// chunk narration stays silent on success.
+// Multipart progress now uses the shared TTY-only spinner, so captured sheets
+// output stays silent without command-specific suppression flags.
 
 // runCapturingStderr runs a shortcut against stubs and returns stdout, stderr
 // and the error, so a test can assert on the reporting channel and not just

--- a/shortcuts/wiki/wiki_async_task.go
+++ b/shortcuts/wiki/wiki_async_task.go
@@ -120,16 +120,15 @@ func parseWikiAsyncTaskStatus(taskID string, task map[string]interface{}, result
 }
 
 // pollWikiAsyncTask runs the bounded polling loop shared by every wiki delete
-// shortcut. label is the human-readable operation name surfaced in stderr
-// progress lines ("delete-space" / "delete-node"). nextCommand is the resume
-// hint embedded into the wrapped error when every poll fails.
+// shortcut. label names the operation in typed errors; nextCommand is the
+// resume hint embedded into the wrapped error when every poll fails.
 //
 // attempts/interval are taken as parameters (instead of consts) so callers
 // can keep their per-operation tunable constants for back-compat with the
 // existing test hooks.
 func pollWikiAsyncTask(
 	ctx context.Context,
-	runtime *common.RuntimeContext,
+	_ *common.RuntimeContext,
 	taskID, label string,
 	attempts int,
 	interval time.Duration,
@@ -155,21 +154,18 @@ func pollWikiAsyncTask(
 		status, err := fetcher(ctx, taskID)
 		if err != nil {
 			lastErr = err
-			fmt.Fprintf(runtime.IO().ErrOut, "Wiki %s status attempt %d/%d failed: %v\n", label, attempt, attempts, err)
 			continue
 		}
 		lastStatus = status
 		hadSuccessfulPoll = true
 
 		if status.Ready() {
-			fmt.Fprintf(runtime.IO().ErrOut, "Wiki %s task completed successfully.\n", label)
 			return status, true, nil
 		}
 		if status.Failed() {
 			return status, false, errs.NewAPIError(errs.SubtypeServerError, "wiki %s task %s failed: %s", label, taskID, status.StatusLabel())
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Wiki %s status %d/%d: %s\n", label, attempt, attempts, status.StatusLabel())
 	}
 
 	if !hadSuccessfulPoll && lastErr != nil {

--- a/shortcuts/wiki/wiki_async_task_test.go
+++ b/shortcuts/wiki/wiki_async_task_test.go
@@ -35,8 +35,8 @@ func TestPollWikiAsyncTaskSuccessFirstPoll(t *testing.T) {
 	if !ready || !status.Ready() {
 		t.Fatalf("ready = %v, status = %+v, want ready", ready, status)
 	}
-	if !strings.Contains(stderr.String(), "delete-node task completed successfully") {
-		t.Fatalf("stderr = %q", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no progress output", stderr.String())
 	}
 }
 
@@ -113,8 +113,8 @@ func TestPollWikiAsyncTaskAllPollsFailWrapsWithResumeHint(t *testing.T) {
 		!strings.Contains(p.Hint, "lark-cli drive +task_result --task-id task_lost") {
 		t.Fatalf("hint = %q, want resume guidance naming the task", p.Hint)
 	}
-	if !strings.Contains(stderr.String(), "attempt 2/2 failed") {
-		t.Fatalf("stderr = %q, want per-attempt progress", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no per-attempt progress", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_delete.go
+++ b/shortcuts/wiki/wiki_delete.go
@@ -44,7 +44,7 @@ var WikiDeleteSpace = common.Shortcut{
 	Tips: []string{
 		"Deletion is irreversible; double-check --space-id before running.",
 		"This is a high-risk-write command; pass --yes to confirm the deletion.",
-		"If the API returns a long-running task, this command polls for a bounded window and then prints a follow-up drive +task_result command.",
+		"If the API returns a long-running task, this command polls for a bounded window and then returns a follow-up drive +task_result command.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return validateWikiDeleteSpaceSpec(readWikiDeleteSpaceSpec(runtime))
@@ -54,8 +54,6 @@ var WikiDeleteSpace = common.Shortcut{
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		spec := readWikiDeleteSpaceSpec(runtime)
-		fmt.Fprintf(runtime.IO().ErrOut, "Deleting wiki space %s...\n", spec.SpaceID)
-
 		out, err := runWikiDeleteSpace(ctx, wikiDeleteSpaceAPI{runtime: runtime}, runtime, spec)
 		if err != nil {
 			return err
@@ -170,7 +168,6 @@ func runWikiDeleteSpace(ctx context.Context, client wikiDeleteSpaceClient, runti
 		return out, nil
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Wiki space delete is async, polling task %s...\n", response.TaskID)
 	status, ready, err := pollWikiDeleteSpaceTask(ctx, client, runtime, response.TaskID)
 	if err != nil {
 		return nil, err
@@ -184,7 +181,6 @@ func runWikiDeleteSpace(ctx context.Context, client wikiDeleteSpaceClient, runti
 
 	if !ready {
 		nextCommand := wikiDeleteSpaceTaskResultCommand(response.TaskID, runtime.As())
-		fmt.Fprintf(runtime.IO().ErrOut, "Wiki delete-space task is still in progress. Continue with: %s\n", nextCommand)
 		out["timed_out"] = true
 		out["next_command"] = nextCommand
 	}

--- a/shortcuts/wiki/wiki_delete_test.go
+++ b/shortcuts/wiki/wiki_delete_test.go
@@ -207,8 +207,8 @@ func TestRunWikiDeleteSpaceAsyncReady(t *testing.T) {
 	if out["task_id"] != "task_123" || out["ready"] != true || out["failed"] != false || out["status"] != "success" {
 		t.Fatalf("unexpected async-ready output: %#v", out)
 	}
-	if !strings.Contains(stderr.String(), "async, polling task") || !strings.Contains(stderr.String(), "completed successfully") {
-		t.Fatalf("stderr = %q, want async progress logs", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no async progress logs", stderr.String())
 	}
 }
 
@@ -237,8 +237,8 @@ func TestRunWikiDeleteSpaceAsyncTimeoutReturnsNextCommand(t *testing.T) {
 	if out["status"] != "processing" || out["status_msg"] != "processing" {
 		t.Fatalf("status fields = %#v / %#v, want both processing", out["status"], out["status_msg"])
 	}
-	if !strings.Contains(stderr.String(), "Continue with") {
-		t.Fatalf("stderr = %q, want continuation hint", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want continuation in structured output only", stderr.String())
 	}
 }
 
@@ -300,8 +300,8 @@ func TestPollWikiDeleteSpaceTaskWrapsPollFailuresWithHint(t *testing.T) {
 	if p.Code != 131006 {
 		t.Fatalf("Code = %d, want 131006 preserved through poll exhaustion", p.Code)
 	}
-	if !strings.Contains(stderr.String(), "Wiki delete-space status attempt 1/1 failed") {
-		t.Fatalf("stderr = %q, want poll failure log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want poll failure only in the typed error", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -620,8 +620,8 @@ func TestRunWikiNodeCopyRetriesLockContentionThenSucceeds(t *testing.T) {
 	if common.GetString(common.GetMap(data, "node"), "node_token") != "wik_copied" {
 		t.Fatalf("data = %#v, want copied node", data)
 	}
-	if !strings.Contains(stderr.String(), "retrying (attempt 1/2)") {
-		t.Fatalf("stderr = %q, want retry progress", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no retry progress", stderr.String())
 	}
 }
 
@@ -827,8 +827,8 @@ func TestWikiNodeCopyCopiesNodeToTargetSpace(t *testing.T) {
 	if captured["title"] != "Architecture (Copy)" {
 		t.Fatalf("captured title = %v, want %q", captured["title"], "Architecture (Copy)")
 	}
-	if got := stderr.String(); !strings.Contains(got, "Copying wiki node") {
-		t.Fatalf("stderr = %q, want copy message", got)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no copy progress", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_member_add.go
+++ b/shortcuts/wiki/wiki_member_add.go
@@ -61,9 +61,6 @@ var WikiMemberAdd = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Adding wiki space member %s (type=%s, role=%s) to space %s...\n",
-			common.MaskToken(spec.MemberID), spec.MemberType, spec.MemberRole, common.MaskToken(spaceID))
-
 		path := fmt.Sprintf("/open-apis/wiki/v2/spaces/%s/members", validate.EncodePathSegment(spaceID))
 		data, err := runtime.CallAPITyped("POST", path, spec.QueryParams(), spec.RequestBody())
 		if err != nil {
@@ -83,7 +80,6 @@ var WikiMemberAdd = common.Shortcut{
 		if common.GetString(out, "member_role") == "" {
 			out["member_role"] = spec.MemberRole
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Added wiki space member %s\n", common.MaskToken(common.GetString(out, "member_id")))
 		runtime.Out(out, nil)
 		return nil
 	},

--- a/shortcuts/wiki/wiki_member_helpers.go
+++ b/shortcuts/wiki/wiki_member_helpers.go
@@ -4,8 +4,6 @@
 package wiki
 
 import (
-	"fmt"
-
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -46,7 +44,6 @@ func resolveWikiMemberSpaceID(runtime *common.RuntimeContext, spaceID string) (s
 	if err != nil {
 		return "", err
 	}
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolved my_library to space %s\n", common.MaskToken(resolved))
 	return resolved, nil
 }
 

--- a/shortcuts/wiki/wiki_member_list.go
+++ b/shortcuts/wiki/wiki_member_list.go
@@ -86,7 +86,6 @@ var WikiMemberList = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Found %d wiki space member(s)\n", len(members))
 
 		outData := map[string]interface{}{
 			"space_id":   spaceID,

--- a/shortcuts/wiki/wiki_member_remove.go
+++ b/shortcuts/wiki/wiki_member_remove.go
@@ -60,9 +60,6 @@ var WikiMemberRemove = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Removing wiki space member %s (type=%s, role=%s) from space %s...\n",
-			common.MaskToken(spec.MemberID), spec.MemberType, spec.MemberRole, common.MaskToken(spaceID))
-
 		path := fmt.Sprintf(
 			"/open-apis/wiki/v2/spaces/%s/members/%s",
 			validate.EncodePathSegment(spaceID),
@@ -89,7 +86,6 @@ var WikiMemberRemove = common.Shortcut{
 		if common.GetString(out, "member_role") == "" {
 			out["member_role"] = spec.MemberRole
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Removed wiki space member %s\n", common.MaskToken(common.GetString(out, "member_id")))
 		runtime.Out(out, nil)
 		return nil
 	},

--- a/shortcuts/wiki/wiki_member_test.go
+++ b/shortcuts/wiki/wiki_member_test.go
@@ -305,8 +305,8 @@ func TestWikiMemberAddMountedExecuteFlattensMember(t *testing.T) {
 	if !strings.Contains(capturedQuery, "need_notification=true") {
 		t.Fatalf("captured query = %q, want need_notification=true", capturedQuery)
 	}
-	if !strings.Contains(stderr.String(), "Added wiki space member") {
-		t.Fatalf("stderr = %q, want success log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no success log", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_move.go
+++ b/shortcuts/wiki/wiki_move.go
@@ -56,7 +56,7 @@ var WikiMove = common.Shortcut{
 	Tips: []string{
 		"Use --node-token to move an existing wiki node inside or across wiki spaces.",
 		"Use --obj-type and --obj-token to move a Drive document into Wiki.",
-		"If docs-to-wiki returns a long-running task, this command polls for a bounded window and then prints a follow-up drive +task_result command.",
+		"If docs-to-wiki returns a long-running task, this command polls for a bounded window and then returns a follow-up drive +task_result command.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		spec := readWikiMoveSpec(runtime)
@@ -73,8 +73,6 @@ var WikiMove = common.Shortcut{
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		spec := readWikiMoveSpec(runtime)
-		fmt.Fprintf(runtime.IO().ErrOut, "Running wiki move (%s)...\n", spec.Mode())
-
 		out, err := runWikiMove(ctx, wikiMoveAPI{runtime: runtime}, runtime, spec)
 		if err != nil {
 			return err
@@ -537,7 +535,6 @@ func runWikiDocsToWikiMove(ctx context.Context, client wikiMoveClient, runtime *
 		out["status_msg"] = "move request submitted for approval"
 		return out, nil
 	case response.TaskID != "":
-		fmt.Fprintf(runtime.IO().ErrOut, "Docs-to-wiki move is async, polling task %s...\n", response.TaskID)
 		status, ready, err := pollWikiMoveTask(ctx, client, runtime, response.TaskID)
 		if err != nil {
 			return nil, err
@@ -556,7 +553,6 @@ func runWikiDocsToWikiMove(ctx context.Context, client wikiMoveClient, runtime *
 		}
 		if !ready {
 			nextCommand := wikiMoveTaskResultCommand(response.TaskID, runtime.As())
-			fmt.Fprintf(runtime.IO().ErrOut, "Wiki move task is still in progress. Continue with: %s\n", nextCommand)
 			out["timed_out"] = true
 			out["next_command"] = nextCommand
 		}
@@ -594,21 +590,18 @@ func pollWikiMoveTask(ctx context.Context, client wikiMoveClient, runtime *commo
 		status, err := client.GetMoveTask(ctx, taskID)
 		if err != nil {
 			lastErr = err
-			fmt.Fprintf(runtime.IO().ErrOut, "Wiki move status attempt %d/%d failed: %v\n", attempt, wikiMovePollAttempts, err)
 			continue
 		}
 		lastStatus = status
 		hadSuccessfulPoll = true
 
 		if status.Ready() {
-			fmt.Fprintf(runtime.IO().ErrOut, "Wiki move task completed successfully.\n")
 			return status, true, nil
 		}
 		if status.Failed() {
 			return status, false, errs.NewAPIError(errs.SubtypeServerError, "wiki move task failed: %s", status.PrimaryStatusLabel())
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Wiki move status %d/%d: %s\n", attempt, wikiMovePollAttempts, status.PrimaryStatusLabel())
 	}
 
 	if !hadSuccessfulPoll && lastErr != nil {

--- a/shortcuts/wiki/wiki_move_test.go
+++ b/shortcuts/wiki/wiki_move_test.go
@@ -665,8 +665,8 @@ func TestRunWikiDocsToWikiMoveAsyncReady(t *testing.T) {
 	if out["wiki_token"] != "wik_done" || out["title"] != "Roadmap" || out["status_msg"] != "success" {
 		t.Fatalf("async-ready output missing flattened fields: %#v", out)
 	}
-	if !strings.Contains(stderr.String(), "Docs-to-wiki move is async") || !strings.Contains(stderr.String(), "completed successfully") {
-		t.Fatalf("stderr = %q, want async progress logs", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no async progress logs", stderr.String())
 	}
 }
 
@@ -695,8 +695,8 @@ func TestRunWikiDocsToWikiMoveAsyncTimeoutReturnsNextCommand(t *testing.T) {
 	if out["status_msg"] != "processing" {
 		t.Fatalf("status_msg = %#v, want processing", out["status_msg"])
 	}
-	if !strings.Contains(stderr.String(), "Continue with") {
-		t.Fatalf("stderr = %q, want continuation hint", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want continuation in structured output only", stderr.String())
 	}
 }
 
@@ -872,8 +872,8 @@ func TestPollWikiMoveTaskWrapsRepeatedPollFailuresWithHint(t *testing.T) {
 	if !strings.Contains(p.Hint, "retry original") || !strings.Contains(p.Hint, wikiMoveTaskResultCommand("task_123", core.AsUser)) {
 		t.Fatalf("hint = %q, want original hint and resume command", p.Hint)
 	}
-	if !strings.Contains(stderr.String(), "Wiki move status attempt 1/1 failed") {
-		t.Fatalf("stderr = %q, want poll failure log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want poll failure only in the typed error", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_move_to_drive.go
+++ b/shortcuts/wiki/wiki_move_to_drive.go
@@ -201,23 +201,11 @@ func runWikiMoveToDrive(
 	runtime *common.RuntimeContext,
 	spec wikiMoveToDriveSpec,
 ) (map[string]interface{}, error) {
-	folderLabel := "personal-space root"
-	if spec.FolderToken != "" {
-		folderLabel = common.MaskToken(spec.FolderToken)
-	}
-	fmt.Fprintf(
-		runtime.IO().ErrOut,
-		"Moving wiki node %s to Drive folder %s...\n",
-		common.MaskToken(spec.NodeToken),
-		folderLabel,
-	)
-
 	taskID, err := client.MoveWikiToDrive(ctx, spec)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Wiki move-to-drive is async, polling task %s...\n", taskID)
 	status, ready, err := pollWikiMoveToDriveTask(ctx, client, runtime, taskID)
 	if err != nil {
 		return nil, err
@@ -237,7 +225,6 @@ func runWikiMoveToDrive(
 	}
 	if !ready {
 		nextCommand := wikiMoveToDriveTaskResultCommand(taskID, runtime.As(), wikiMoveToDriveProfileName(runtime))
-		fmt.Fprintf(runtime.IO().ErrOut, "Wiki move-to-drive task is still in progress. Continue with: %s\n", nextCommand)
 		out["timed_out"] = true
 		out["next_command"] = nextCommand
 	}
@@ -276,14 +263,12 @@ func pollWikiMoveToDriveTask(
 				)
 			}
 			lastErr = err
-			fmt.Fprintf(runtime.IO().ErrOut, "Wiki move-to-drive status attempt %d/%d failed: %v\n", attempt, wikiMoveToDrivePollAttempts, err)
 			continue
 		}
 		lastStatus = status
 		hadSuccessfulPoll = true
 
 		if status.Ready() {
-			fmt.Fprintln(runtime.IO().ErrOut, "Wiki move-to-drive task completed successfully.")
 			return status, true, nil
 		}
 		if status.Failed() {
@@ -295,13 +280,6 @@ func pollWikiMoveToDriveTask(
 			)
 		}
 
-		fmt.Fprintf(
-			runtime.IO().ErrOut,
-			"Wiki move-to-drive status %d/%d: %s\n",
-			attempt,
-			wikiMoveToDrivePollAttempts,
-			status.StatusLabel(),
-		)
 	}
 
 	if err := ctx.Err(); err != nil {

--- a/shortcuts/wiki/wiki_move_to_drive_test.go
+++ b/shortcuts/wiki/wiki_move_to_drive_test.go
@@ -253,8 +253,8 @@ func TestRunWikiMoveToDriveSuccess(t *testing.T) {
 	if len(client.moveSpecs) != 1 || client.moveSpecs[0].FolderToken != "fldABC" {
 		t.Fatalf("move specs = %#v", client.moveSpecs)
 	}
-	if !strings.Contains(stderr.String(), "completed successfully") {
-		t.Fatalf("stderr = %q", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no progress output", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_copy.go
+++ b/shortcuts/wiki/wiki_node_copy.go
@@ -85,9 +85,6 @@ var WikiNodeCopy = common.Shortcut{
 		spaceID := strings.TrimSpace(runtime.Str("space-id"))
 		nodeToken := strings.TrimSpace(runtime.Str("node-token"))
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Copying wiki node %s from space %s\n",
-			common.MaskToken(nodeToken), common.MaskToken(spaceID))
-
 		apiPath := fmt.Sprintf("/open-apis/wiki/v2/spaces/%s/nodes/%s/copy",
 			validate.EncodePathSegment(spaceID),
 			validate.EncodePathSegment(nodeToken))
@@ -104,8 +101,6 @@ var WikiNodeCopy = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Copied to node %s in space %s\n",
-			common.MaskToken(node.NodeToken), common.MaskToken(node.SpaceID))
 		out := wikiNodeCopyOutput(node)
 		if u := wikiNodeURL(runtime.Config.Brand, node); u != "" {
 			out["url"] = u
@@ -117,12 +112,11 @@ var WikiNodeCopy = common.Shortcut{
 	},
 }
 
-func runWikiNodeCopyWithRetry(ctx context.Context, errOut io.Writer, baseDelay time.Duration, call func() (map[string]interface{}, error)) (map[string]interface{}, error) {
+func runWikiNodeCopyWithRetry(ctx context.Context, _ io.Writer, baseDelay time.Duration, call func() (map[string]interface{}, error)) (map[string]interface{}, error) {
 	var lastErr error
 	for attempt := 0; attempt <= wikiNodeCopyMaxRetries; attempt++ {
 		if attempt > 0 {
 			delay := baseDelay << uint(attempt-1)
-			fmt.Fprintf(errOut, "Wiki node copy encountered lock contention, retrying (attempt %d/%d) in %v...\n", attempt, wikiNodeCopyMaxRetries, delay)
 			select {
 			case <-ctx.Done():
 				return nil, wikiNodeCopyBackoffContextError(ctx.Err())

--- a/shortcuts/wiki/wiki_node_create.go
+++ b/shortcuts/wiki/wiki_node_create.go
@@ -88,13 +88,11 @@ var WikiNodeCreate = common.Shortcut{
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		spec := readWikiNodeCreateSpec(runtime)
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Creating wiki node...\n")
 		execution, err := runWikiNodeCreate(ctx, wikiNodeCreateAPI{runtime: runtime}, runtime.As(), spec, runtime.IO().ErrOut)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Created wiki node in space %s via %s.\n", execution.ResolvedSpace.SpaceID, execution.ResolvedSpace.ResolvedBy)
 		runtime.Out(augmentWikiNodeCreateOutput(runtime, execution), nil)
 		return nil
 	},
@@ -321,7 +319,7 @@ func needsMyLibraryLookup(spec wikiNodeCreateSpec) bool {
 	return spec.SpaceID == "" || spec.SpaceID == wikiMyLibrarySpaceID
 }
 
-func runWikiNodeCreate(ctx context.Context, client wikiNodeCreateClient, identity core.Identity, spec wikiNodeCreateSpec, errOut io.Writer) (*wikiNodeCreateExecution, error) {
+func runWikiNodeCreate(ctx context.Context, client wikiNodeCreateClient, identity core.Identity, spec wikiNodeCreateSpec, _ io.Writer) (*wikiNodeCreateExecution, error) {
 	resolvedSpace, err := resolveWikiNodeCreateSpace(ctx, client, identity, spec)
 	if err != nil {
 		return nil, err
@@ -334,7 +332,6 @@ func runWikiNodeCreate(ctx context.Context, client wikiNodeCreateClient, identit
 	for attempt := 0; attempt <= wikiNodeCreateMaxRetries; attempt++ {
 		if attempt > 0 {
 			delay := wikiNodeCreateRetryBaseDelay << uint(attempt-1)
-			fmt.Fprintf(errOut, "Wiki node create encountered lock contention, retrying (attempt %d/%d) in %v...\n", attempt, wikiNodeCreateMaxRetries, delay)
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()

--- a/shortcuts/wiki/wiki_node_create_test.go
+++ b/shortcuts/wiki/wiki_node_create_test.go
@@ -627,8 +627,12 @@ func TestWikiNodeCreateMountedExecuteWithExplicitSpaceID(t *testing.T) {
 	if captured["title"] != "Wiki Node" {
 		t.Fatalf("captured title = %#v, want %q", captured["title"], "Wiki Node")
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want no completed creation message", stderr.String())
+	gotStderr := stderr.String()
+	if strings.Contains(gotStderr, "Creating wiki node") || strings.Contains(gotStderr, "Created wiki node") {
+		t.Fatalf("stderr = %q, want no creation progress", gotStderr)
+	}
+	if !strings.Contains(gotStderr, "auto-grant was skipped") {
+		t.Fatalf("stderr = %q, want actionable auto-grant warning", gotStderr)
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_create_test.go
+++ b/shortcuts/wiki/wiki_node_create_test.go
@@ -627,8 +627,8 @@ func TestWikiNodeCreateMountedExecuteWithExplicitSpaceID(t *testing.T) {
 	if captured["title"] != "Wiki Node" {
 		t.Fatalf("captured title = %#v, want %q", captured["title"], "Wiki Node")
 	}
-	if got := stderr.String(); !strings.Contains(got, "Created wiki node in space space_123 via explicit_space_id.") {
-		t.Fatalf("stderr = %q, want completed creation message", got)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no completed creation message", stderr.String())
 	}
 }
 
@@ -934,14 +934,8 @@ func TestRunWikiNodeCreateRetriesOnLockContention(t *testing.T) {
 	if execution.Node.NodeToken != "wik_created" {
 		t.Fatalf("node token = %q, want %q", execution.Node.NodeToken, "wik_created")
 	}
-	if !strings.Contains(stderr.String(), "lock contention") {
-		t.Fatalf("stderr = %q, want lock contention log", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "retrying (attempt 1/") {
-		t.Fatalf("stderr = %q, want attempt 1 log", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "retrying (attempt 2/") {
-		t.Fatalf("stderr = %q, want attempt 2 log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no retry progress", stderr.String())
 	}
 }
 
@@ -1103,11 +1097,8 @@ func TestRunWikiNodeCreateRetriesOnFirstLockThenSucceeds(t *testing.T) {
 	if execution.Node.NodeToken != "wik_created" {
 		t.Fatalf("node token = %q, want %q", execution.Node.NodeToken, "wik_created")
 	}
-	if !strings.Contains(stderr.String(), "retrying (attempt 1/") {
-		t.Fatalf("stderr = %q, want attempt 1 log", stderr.String())
-	}
-	if strings.Contains(stderr.String(), "retrying (attempt 2/") {
-		t.Fatalf("stderr = %q, should not contain attempt 2 log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no retry progress", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_delete.go
+++ b/shortcuts/wiki/wiki_node_delete.go
@@ -68,7 +68,7 @@ var WikiNodeDelete = common.Shortcut{
 		"--node-token accepts a raw token (wikcnXXX, docxXXX, ...) or a Lark URL like https://feishu.cn/wiki/<token> or https://feishu.cn/docx/<token>; URL paths also imply --obj-type.",
 		"Run +node-get first to confirm space_id / obj_type when in doubt.",
 		"Auto-resolving space_id (when --space-id is omitted) also calls get_node, which needs the wiki:node:retrieve scope; pass --space-id to skip that lookup if your token only carries wiki:node:create.",
-		"Async deletes return a task_id; this command polls for a bounded window and then prints a follow-up drive +task_result command.",
+		"Async deletes return a task_id; this command polls for a bounded window and then returns a follow-up drive +task_result command.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		_, err := readWikiNodeDeleteSpec(runtime)
@@ -310,9 +310,6 @@ func runWikiNodeDelete(ctx context.Context, client wikiNodeDeleteClient, runtime
 		return nil, err
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Deleting wiki node %s in space %s (obj_type=%s, include_children=%t)...\n",
-		common.MaskToken(spec.NodeToken), common.MaskToken(spaceID), spec.ObjType, spec.IncludeChildren)
-
 	taskID, err := client.DeleteNode(ctx, spaceID, spec)
 	if err != nil {
 		return nil, err
@@ -336,7 +333,6 @@ func runWikiNodeDelete(ctx context.Context, client wikiNodeDeleteClient, runtime
 		return out, nil
 	}
 
-	fmt.Fprintf(runtime.IO().ErrOut, "Wiki node delete is async, polling task %s...\n", taskID)
 	nextCommand := wikiDeleteNodeTaskResultCommand(taskID, runtime.As())
 	status, ready, err := pollWikiAsyncTask(
 		ctx, runtime, taskID, "delete-node",
@@ -357,7 +353,6 @@ func runWikiNodeDelete(ctx context.Context, client wikiNodeDeleteClient, runtime
 	out["status_msg"] = status.StatusLabel()
 
 	if !ready {
-		fmt.Fprintf(runtime.IO().ErrOut, "Wiki delete-node task is still in progress. Continue with: %s\n", nextCommand)
 		out["timed_out"] = true
 		out["next_command"] = nextCommand
 	}
@@ -371,7 +366,6 @@ func resolveWikiNodeDeleteSpaceID(ctx context.Context, client wikiNodeDeleteClie
 	if spec.SpaceID != "" {
 		return spec.SpaceID, nil
 	}
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolving space_id via get_node for token %s...\n", common.MaskToken(spec.NodeToken))
 	node, err := client.ResolveNode(ctx, spec.NodeToken, spec.ObjType)
 	if err != nil {
 		return "", err
@@ -380,7 +374,6 @@ func resolveWikiNodeDeleteSpaceID(ctx context.Context, client wikiNodeDeleteClie
 	if err != nil {
 		return "", err
 	}
-	fmt.Fprintf(runtime.IO().ErrOut, "Resolved to space %s\n", common.MaskToken(spaceID))
 	return spaceID, nil
 }
 

--- a/shortcuts/wiki/wiki_node_delete_test.go
+++ b/shortcuts/wiki/wiki_node_delete_test.go
@@ -306,8 +306,8 @@ func TestRunWikiNodeDeleteAsyncReadyShape(t *testing.T) {
 	if out["task_id"] != "task_async_node" || out["ready"] != true || out["failed"] != false {
 		t.Fatalf("async-ready output = %#v", out)
 	}
-	if !strings.Contains(stderr.String(), "async, polling task") || !strings.Contains(stderr.String(), "delete-node task completed successfully") {
-		t.Fatalf("stderr = %q", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no async progress output", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_list.go
+++ b/shortcuts/wiki/wiki_node_list.go
@@ -102,7 +102,6 @@ var WikiNodeList = common.Shortcut{
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(runtime.IO().ErrOut, "Resolved my_library to space %s\n", common.MaskToken(resolved))
 			spaceID = resolved
 		}
 
@@ -110,7 +109,6 @@ var WikiNodeList = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Found %d node(s)\n", len(nodes))
 		outData := map[string]interface{}{
 			"nodes":      nodes,
 			"has_more":   hasMore,

--- a/shortcuts/wiki/wiki_space_create.go
+++ b/shortcuts/wiki/wiki_space_create.go
@@ -5,7 +5,6 @@ package wiki
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -58,8 +57,6 @@ var WikiSpaceCreate = common.Shortcut{
 			return err
 		}
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Creating wiki space %q...\n", spec.Name)
-
 		data, err := runtime.CallAPITyped("POST", wikiSpacesAPIPath, nil, spec.RequestBody())
 		if err != nil {
 			return err
@@ -71,7 +68,6 @@ var WikiSpaceCreate = common.Shortcut{
 		}
 
 		out := wikiSpaceCreateOutput(raw)
-		fmt.Fprintf(runtime.IO().ErrOut, "Created wiki space %s\n", common.MaskToken(common.GetString(out, "space_id")))
 		runtime.Out(out, nil)
 		return nil
 	},

--- a/shortcuts/wiki/wiki_space_create_test.go
+++ b/shortcuts/wiki/wiki_space_create_test.go
@@ -162,8 +162,8 @@ func TestWikiSpaceCreateMountedExecuteFlattensSpace(t *testing.T) {
 	if captured["name"] != "Eng Wiki" || captured["description"] != "team docs" {
 		t.Fatalf("captured request body = %#v", captured)
 	}
-	if !strings.Contains(stderr.String(), "Created wiki space") {
-		t.Fatalf("stderr = %q, want creation log", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no creation log", stderr.String())
 	}
 }
 

--- a/shortcuts/wiki/wiki_space_list.go
+++ b/shortcuts/wiki/wiki_space_list.go
@@ -68,7 +68,6 @@ var WikiSpaceList = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "Found %d wiki space(s)\n", len(spaces))
 		outData := map[string]interface{}{
 			"spaces":     spaces,
 			"has_more":   hasMore,


### PR DESCRIPTION
## Summary

Remove non-actionable progress output from successful shortcut executions so PowerShell and agent runners do not misclassify commands as failures merely because stderr is non-empty. This keeps stdout and exit-code contracts unchanged while preserving actionable warnings, fallbacks, and interactive prompts.

## Changes

- Remove lifecycle, retry, completion, count, and polling progress logs from Docs, Wiki, and Drive shortcuts.
- Remove shared multipart upload progress such as initialization and per-block completion logs.
- Keep actionable stderr output, including:
  - rollback failures
  - permission and metadata fallbacks
  - pagination integrity warnings
  - search parameter normalization
  - skipped cleanup notices
  - file extension preservation
  - conflict prompts
- Update regression assertions to require clean stderr on representative successful flows.
- Keep existing structured result fields such as `file_token`, `block_id`, `task_id`, `ready`, `next_command`, `summary`, and `items` as the authoritative operation result.
- Audit Slides shortcuts; no direct non-actionable progress output required removal.

## Test Plan

- [x] Unit tests pass
- [x] Changed Go files formatted with `gofmt`
- [x] `git diff --check` passes
- [x] Verified actionable warning and interactive stderr paths remain intact

Local compilation and tests were not run.

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy progress and status messages across Drive, Wiki, and media operations.
  * Sensitive identifiers and operational details are no longer exposed in incidental logs.
  * Added clearer recovery guidance for failed uploads, updates, imports, and asynchronous tasks.
  * Follow-up commands and status remain available through structured output and errors.

* **User Experience**
  * Replaced lengthy polling and multipart-upload logs with compact terminal spinners when supported.

* **Tests**
  * Updated coverage for quiet output, spinner behavior, and recovery details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->