### PR TITLE
fix(event): preserve UTF-8 in truncated diagnostics

### DIFF
--- a/cmd/event/appmeta_err.go
+++ b/cmd/event/appmeta_err.go
@@ -6,6 +6,8 @@ package event
 import (
 	"fmt"
 	"regexp"
+
+	eventlib "github.com/larksuite/cli/internal/event"
 )
 
 // authURLPattern matches the grant-scope URL embedded in 99991672 errors; widen the host alternation when adding brands.
@@ -18,8 +20,5 @@ func describeAppMetaErr(err error) string {
 		return fmt.Sprintf("bot is missing scopes needed for app-version metadata; grant at: %s", url)
 	}
 	const maxErrLen = 200
-	if len(msg) > maxErrLen {
-		return msg[:maxErrLen] + "…"
-	}
-	return msg
+	return eventlib.TruncateDiagnostic(msg, maxErrLen, "…")
 }

--- a/cmd/event/appmeta_err_test.go
+++ b/cmd/event/appmeta_err_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 const realisticPermError = `API GET /open-apis/application/v6/applications/cli_XXXXXXXXXXXXXXXX/app_versions?lang=zh_cn&page_size=2 returned 400: {"code":99991672,"msg":"Access denied. One of the following scopes is required: [application:application:self_manage, application:application.app_version:readonly].应用尚未开通所需的应用身份权限：[application:application:self_manage, application:application.app_version:readonly]，点击链接申请并开通任一权限即可：https://open.feishu.cn/app/cli_XXXXXXXXXXXXXXXX/auth?q=application:application:self_manage,application:application.app_version:readonly&op_from=openapi&token_type=tenant","error":{"message":"Refer to the documentation...","log_id":"20260421101203E2A5F141245B6F43B3A6"}}`
@@ -35,6 +36,19 @@ func TestDescribeAppMetaErr_UnknownErrorTruncated(t *testing.T) {
 	got := describeAppMetaErr(errors.New(long))
 	if len(got) > 220 {
 		t.Errorf("unknown error not truncated, len=%d", len(got))
+	}
+}
+
+func TestDescribeAppMetaErr_TruncationPreservesUTF8(t *testing.T) {
+	got := describeAppMetaErr(errors.New(strings.Repeat("x", 199) + "界tail"))
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated summary is not valid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("truncated summary suffix = %q, want ellipsis", got)
+	}
+	if prefix := strings.TrimSuffix(got, "…"); len(prefix) > 200 {
+		t.Fatalf("truncated prefix is %d bytes, want at most 200", len(prefix))
 	}
 }
 

--- a/cmd/event/runtime.go
+++ b/cmd/event/runtime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/core"
+	eventlib "github.com/larksuite/cli/internal/event"
 )
 
 // consumeRuntime routes event.APIClient calls through the shared client.APIClient with a pinned identity.
@@ -37,9 +38,7 @@ func (r *consumeRuntime) CallAPI(ctx context.Context, method, path string, body 
 	if resp.StatusCode >= 400 && !client.IsJSONContentType(ct) && ct != "" {
 		const maxBodyEcho = 256
 		body := string(resp.RawBody)
-		if len(body) > maxBodyEcho {
-			body = body[:maxBodyEcho] + "…(truncated)"
-		}
+		body = eventlib.TruncateDiagnostic(body, maxBodyEcho, "…(truncated)")
 		if resp.StatusCode >= 500 {
 			return nil, errs.NewNetworkError(errs.SubtypeNetworkServer,
 				"api %s %s returned %d: %s", method, path, resp.StatusCode, body).WithRetryable()

--- a/cmd/event/runtime_test.go
+++ b/cmd/event/runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -96,6 +97,19 @@ func TestConsumeRuntimeCallAPI_NonJSONHTTPErrorTruncatesLongBody(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "…(truncated)") {
 		t.Errorf("long body should be truncated in the message, got: %v", err)
+	}
+}
+
+func TestConsumeRuntimeCallAPI_NonJSONHTTPErrorTruncationPreservesUTF8(t *testing.T) {
+	body := strings.Repeat("x", 255) + "界tail"
+	r := newTestConsumeRuntime(stubRoundTripper{respond: stubResponse(http.StatusBadGateway, "text/html", body)})
+	_, err := r.CallAPI(context.Background(), "GET", "/open-apis/event/v1/connection", nil)
+	requireCallAPIProblem(t, err, errs.CategoryNetwork, errs.SubtypeNetworkServer)
+	if !utf8.ValidString(err.Error()) {
+		t.Fatalf("truncated error is not valid UTF-8: %q", err)
+	}
+	if !strings.Contains(err.Error(), "…(truncated)") {
+		t.Fatalf("truncated error missing suffix: %v", err)
 	}
 }
 

--- a/internal/event/adapter/lark/websocket/feishu.go
+++ b/internal/event/adapter/lark/websocket/feishu.go
@@ -88,10 +88,7 @@ func (s *FeishuSource) buildRawHandler(emit func(*event.RawEvent)) func(context.
 		}
 		if err := json.Unmarshal(e.Body, &envelope); err != nil {
 			if s.Logger != nil {
-				preview := string(e.Body)
-				if len(preview) > 200 {
-					preview = preview[:200] + "...(truncated)"
-				}
+				preview := event.TruncateDiagnostic(string(e.Body), 200, "...(truncated)")
 				s.Logger.Printf("[feishu] drop malformed event: unmarshal error: %v body=%s", err, preview)
 			}
 			return nil

--- a/internal/event/adapter/lark/websocket/feishu_log_test.go
+++ b/internal/event/adapter/lark/websocket/feishu_log_test.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
 
@@ -35,6 +36,25 @@ func TestRawHandlerLogsMalformedJSON(t *testing.T) {
 	}
 	if !strings.Contains(out, "not-json") {
 		t.Errorf("expected log to include body preview, got: %s", out)
+	}
+}
+
+func TestRawHandlerMalformedJSONPreviewPreservesUTF8(t *testing.T) {
+	var buf bytes.Buffer
+	s := &FeishuSource{Logger: log.New(&buf, "", 0)}
+	handler := s.buildRawHandler(func(_ *event.RawEvent) {})
+
+	body := []byte(strings.Repeat("x", 199) + "界tail")
+	if err := handler(context.Background(), &larkevent.EventReq{Body: body}); err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+
+	out := buf.String()
+	if !utf8.ValidString(out) {
+		t.Fatalf("malformed event log is not valid UTF-8: %q", out)
+	}
+	if !strings.Contains(out, "...(truncated)") {
+		t.Fatalf("malformed event log missing truncation suffix: %q", out)
 	}
 }
 

--- a/internal/event/consume/loop.go
+++ b/internal/event/consume/loop.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
-	"unicode/utf8"
 
 	"github.com/itchyny/gojq"
 	"github.com/larksuite/cli/internal/event"
@@ -206,18 +205,8 @@ func consumeLoop(ctx context.Context, conn net.Conn, br *bufio.Reader, keyDef *e
 // prefix of them.
 const diagnosticErrMaxLen = 200
 
-// truncateDiagnostic bounds s to diagnosticErrMaxLen bytes, backing off to
-// the previous rune boundary so the cut never emits invalid UTF-8, and marks
-// the cut explicitly.
 func truncateDiagnostic(s string) string {
-	if len(s) <= diagnosticErrMaxLen {
-		return s
-	}
-	cut := diagnosticErrMaxLen
-	for cut > 0 && !utf8.RuneStart(s[cut]) {
-		cut--
-	}
-	return s[:cut] + "...(truncated)"
+	return event.TruncateDiagnostic(s, diagnosticErrMaxLen, "...(truncated)")
 }
 
 // processAndOutput returns (wrote, err); err non-nil only for sink.Write failures.

--- a/internal/event/consume/remote_preflight.go
+++ b/internal/event/consume/remote_preflight.go
@@ -39,10 +39,7 @@ func CheckRemoteConnections(ctx context.Context, client APIClient) (int, error) 
 // truncateForError bounds length and collapses control chars to defang log injection.
 func truncateForError(b []byte) string {
 	const max = 256
-	s := string(b)
-	if len(s) > max {
-		s = s[:max] + "…(truncated)"
-	}
+	s := event.TruncateDiagnostic(string(b), max, "…(truncated)")
 	out := make([]byte, 0, len(s))
 	for _, r := range s {
 		if r == '\n' || r == '\r' || r == '\t' {

--- a/internal/event/consume/remote_preflight_test.go
+++ b/internal/event/consume/remote_preflight_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/larksuite/cli/internal/event/testutil"
 )
@@ -51,6 +52,24 @@ func TestCheckRemoteConnections_MalformedJSON(t *testing.T) {
 	_, err := CheckRemoteConnections(context.Background(), c)
 	if err == nil {
 		t.Fatal("expected decode error")
+	}
+}
+
+func TestCheckRemoteConnections_MalformedJSONTruncationPreservesUTF8(t *testing.T) {
+	body := strings.Repeat("x", 255) + "界tail"
+	c := &testutil.StubAPIClient{Body: body}
+	_, err := CheckRemoteConnections(context.Background(), c)
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if !utf8.ValidString(err.Error()) {
+		t.Fatalf("truncated error is not valid UTF-8: %q", err)
+	}
+	if strings.Contains(err.Error(), "\uFFFD") {
+		t.Fatalf("truncation replaced a split rune instead of preserving its boundary: %q", err)
+	}
+	if !strings.Contains(err.Error(), "…(truncated)") {
+		t.Fatalf("truncated error missing suffix: %v", err)
 	}
 }
 

--- a/internal/event/consume/remote_preflight_test.go
+++ b/internal/event/consume/remote_preflight_test.go
@@ -5,6 +5,7 @@ package consume
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -61,6 +62,10 @@ func TestCheckRemoteConnections_MalformedJSONTruncationPreservesUTF8(t *testing.
 	_, err := CheckRemoteConnections(context.Background(), c)
 	if err == nil {
 		t.Fatal("expected decode error")
+	}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("error does not preserve JSON decode cause: %v", err)
 	}
 	if !utf8.ValidString(err.Error()) {
 		t.Fatalf("truncated error is not valid UTF-8: %q", err)

--- a/internal/event/diagnostic.go
+++ b/internal/event/diagnostic.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import "unicode/utf8"
+
+// TruncateDiagnostic bounds the retained prefix of s to maxBytes, backing off
+// to the previous rune boundary so truncating valid UTF-8 keeps it valid.
+func TruncateDiagnostic(s string, maxBytes int, suffix string) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + suffix
+}

--- a/internal/event/diagnostic_test.go
+++ b/internal/event/diagnostic_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateDiagnostic(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxBytes int
+		suffix   string
+		want     string
+	}{
+		{name: "short", input: "short", maxBytes: 5, suffix: "...", want: "short"},
+		{name: "ASCII boundary", input: "abcdef", maxBytes: 5, suffix: "...", want: "abcde..."},
+		{name: "rune boundary", input: strings.Repeat("x", 4) + "界tail", maxBytes: 5, suffix: "…", want: "xxxx…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TruncateDiagnostic(tt.input, tt.maxBytes, tt.suffix)
+			if got != tt.want {
+				t.Fatalf("TruncateDiagnostic() = %q, want %q", got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("TruncateDiagnostic() returned invalid UTF-8: %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Keep event error summaries and malformed-event previews valid UTF-8 when their byte limit falls inside a multi-byte character. The change preserves each path's existing retained-byte limit and truncation suffix.

## Changes

- Add one shared rune-boundary-aware helper for byte-bounded event diagnostics.
- Use it for app metadata errors, non-JSON event API errors, remote preflight decode errors, WebSocket malformed-event previews, and process-error diagnostics.
- Add regression coverage at the 200-byte and 256-byte boundaries.

## Test Plan

- [x] RED: focused UTF-8 regression tests failed on all four previously unsafe paths before the implementation change.
- [x] GREEN: `go test ./internal/event ./cmd/event ./internal/event/consume ./internal/event/adapter/lark/websocket -count=1`
- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `make quality-gate` with `QUALITY_GATE_CHANGED_FROM=0d5334a0cdfdf18b0313ba051befb2848493ecda`
- [x] Diff-scoped golangci-lint and source-contract lint
- [x] Lint module tests and go-licenses check

## Related Issues

- Fixes #2534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved truncation of diagnostic and error messages across runtime, connection, and event handling.
  * Truncated messages now preserve valid UTF-8 characters, avoiding malformed text or replacement characters.
  * Added consistent truncation indicators to oversized error responses and malformed event previews.
* **Tests**
  * Added coverage for UTF-8-safe truncation across error and event-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->