### PR TITLE
feat(sheets): expose OOXML chart snapshot fields

### DIFF
--- a/shortcuts/sheets/chart_examples.go
+++ b/shortcuts/sheets/chart_examples.go
@@ -44,7 +44,7 @@ var chartExampleTemplates = map[string]string{
         "aggregate": false,
         "showNegativeSize": false,
         "opacityGradientStyle": "linear",
-        "idLabel": {"visible": true}
+        "idLabel": {"bold": true}
       }}
     }},
     "data": {

--- a/shortcuts/sheets/chart_examples_test.go
+++ b/shortcuts/sheets/chart_examples_test.go
@@ -102,7 +102,7 @@ func TestChartExampleTemplates_MeetQualityMinimumSizes(t *testing.T) {
 func TestChartExampleTemplates_SpecialChartContracts(t *testing.T) {
 	t.Parallel()
 	tests := map[string][]string{
-		"bubble":    {`"role": "x"`, `"role": "y"`, `"role": "group"`, `"role": "size"`},
+		"bubble":    {`"role": "x"`, `"role": "y"`, `"role": "group"`, `"role": "size"`, `"idLabel": {"bold": true}`},
 		"waterfall": {`"firstValueAsTotal"`, `"lastValueAsSubtotal"`, `"connectorLine"`},
 		"pareto":    {`"aggregateType": "sum"`, `"index": 1`, `"index": 2`, `"percentage": true`},
 	}
@@ -115,6 +115,9 @@ func TestChartExampleTemplates_SpecialChartContracts(t *testing.T) {
 			if !strings.Contains(tmpl, marker) {
 				t.Errorf("%s template missing %s", typ, marker)
 			}
+		}
+		if typ == "bubble" && strings.Contains(tmpl, `"visible"`) {
+			t.Error("bubble template must not expose unsupported idLabel.visible")
 		}
 	}
 }

--- a/shortcuts/sheets/data/flag-schemas.json
+++ b/shortcuts/sheets/data/flag-schemas.json
@@ -1087,6 +1087,46 @@
                       "color": {
                         "type": "string",
                         "description": "字体颜色，格式为 #RRGGBB"
+                      },
+                      "overlay": {
+                        "type": "boolean",
+                        "description": "是否允许标题覆盖图表绘图区"
+                      },
+                      "layout": {
+                        "type": "object",
+                        "description": "标题在图表区内的手动布局，坐标为 0-1 归一化比例",
+                        "properties": {
+                          "xMode": {
+                            "type": "string",
+                            "enum": [
+                              "edge"
+                            ],
+                            "description": "横向布局模式"
+                          },
+                          "x": {
+                            "type": "number",
+                            "description": "横向位置，取值 0-1"
+                          },
+                          "yMode": {
+                            "type": "string",
+                            "enum": [
+                              "edge"
+                            ],
+                            "description": "纵向布局模式"
+                          },
+                          "y": {
+                            "type": "number",
+                            "description": "纵向位置，取值 0-1"
+                          }
+                        }
+                      },
+                      "background": {
+                        "type": "string",
+                        "description": "标题背景颜色"
+                      },
+                      "border": {
+                        "type": "object",
+                        "description": "标题边框配置，支持 color、width、style、dash、gradient 和 radius，字段含义同 style.border"
                       }
                     },
                     "required": [
@@ -1153,6 +1193,82 @@
                           }
                         }
                       },
+                      "backgroundGradient": {
+                        "type": "object",
+                        "description": "图表区背景渐变，包含 type、归一化坐标、gradientMethod 和至少两个 stops",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "linear",
+                              "radial"
+                            ],
+                            "description": "渐变类型"
+                          },
+                          "x0": {
+                            "type": "number",
+                            "description": "起点 x，0-1 归一化坐标"
+                          },
+                          "y0": {
+                            "type": "number",
+                            "description": "起点 y，0-1 归一化坐标"
+                          },
+                          "x1": {
+                            "type": "number",
+                            "description": "终点 x，0-1 归一化坐标"
+                          },
+                          "y1": {
+                            "type": "number",
+                            "description": "终点 y，0-1 归一化坐标"
+                          },
+                          "r0": {
+                            "type": "number",
+                            "description": "径向渐变起点半径"
+                          },
+                          "r1": {
+                            "type": "number",
+                            "description": "径向渐变终点半径"
+                          },
+                          "gradientMethod": {
+                            "type": "string",
+                            "description": "渐变插值方法"
+                          },
+                          "stops": {
+                            "type": "array",
+                            "description": "渐变色标数组，至少 2 个",
+                            "minItems": 2,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "offset": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1,
+                                  "description": "色标位置 0-1"
+                                },
+                                "color": {
+                                  "type": "string",
+                                  "description": "色标颜色"
+                                },
+                                "opacity": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1,
+                                  "description": "色标透明度 0-1"
+                                }
+                              },
+                              "required": [
+                                "offset",
+                                "color"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "stops"
+                        ]
+                      },
                       "font": {
                         "type": "object",
                         "description": "字体配置",
@@ -1188,9 +1304,182 @@
                               "dotted"
                             ]
                           },
+                          "dash": {
+                            "type": "array",
+                            "description": "OOXML 原始虚线图案数组",
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          "gradient": {
+                            "type": "object",
+                            "description": "边框渐变，包含 type、归一化坐标、gradientMethod 和至少两个 stops",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "linear",
+                                  "radial"
+                                ],
+                                "description": "渐变类型"
+                              },
+                              "x0": {
+                                "type": "number",
+                                "description": "起点 x，0-1 归一化坐标"
+                              },
+                              "y0": {
+                                "type": "number",
+                                "description": "起点 y，0-1 归一化坐标"
+                              },
+                              "x1": {
+                                "type": "number",
+                                "description": "终点 x，0-1 归一化坐标"
+                              },
+                              "y1": {
+                                "type": "number",
+                                "description": "终点 y，0-1 归一化坐标"
+                              },
+                              "r0": {
+                                "type": "number",
+                                "description": "径向渐变起点半径"
+                              },
+                              "r1": {
+                                "type": "number",
+                                "description": "径向渐变终点半径"
+                              },
+                              "gradientMethod": {
+                                "type": "string",
+                                "description": "渐变插值方法"
+                              },
+                              "stops": {
+                                "type": "array",
+                                "description": "渐变色标数组，至少 2 个",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "offset": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标位置 0-1"
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "description": "色标颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标透明度 0-1"
+                                    }
+                                  },
+                                  "required": [
+                                    "offset",
+                                    "color"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "stops"
+                            ]
+                          },
                           "radius": {
                             "type": "number",
                             "description": "边框圆角"
+                          }
+                        }
+                      },
+                      "region": {
+                        "type": "object",
+                        "description": "完整绘图区样式",
+                        "properties": {
+                          "background": {
+                            "type": "string",
+                            "description": "绘图区背景颜色"
+                          },
+                          "backgroundGradient": {
+                            "type": "object",
+                            "description": "绘图区背景渐变，结构同 style.backgroundGradient",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "linear",
+                                  "radial"
+                                ],
+                                "description": "渐变类型"
+                              },
+                              "x0": {
+                                "type": "number",
+                                "description": "起点 x，0-1 归一化坐标"
+                              },
+                              "y0": {
+                                "type": "number",
+                                "description": "起点 y，0-1 归一化坐标"
+                              },
+                              "x1": {
+                                "type": "number",
+                                "description": "终点 x，0-1 归一化坐标"
+                              },
+                              "y1": {
+                                "type": "number",
+                                "description": "终点 y，0-1 归一化坐标"
+                              },
+                              "r0": {
+                                "type": "number",
+                                "description": "径向渐变起点半径"
+                              },
+                              "r1": {
+                                "type": "number",
+                                "description": "径向渐变终点半径"
+                              },
+                              "gradientMethod": {
+                                "type": "string",
+                                "description": "渐变插值方法"
+                              },
+                              "stops": {
+                                "type": "array",
+                                "description": "渐变色标数组，至少 2 个",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "offset": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标位置 0-1"
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "description": "色标颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标透明度 0-1"
+                                    }
+                                  },
+                                  "required": [
+                                    "offset",
+                                    "color"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "stops"
+                            ]
+                          },
+                          "border": {
+                            "type": "object",
+                            "description": "绘图区边框配置，字段含义同 style.border"
                           }
                         }
                       },
@@ -1872,6 +2161,82 @@
                                       "type": "number",
                                       "description": "大小"
                                     },
+                                    "labels": {
+                                      "type": "object",
+                                      "description": "单点数据标签配置，仅折线图、面积图、雷达图及组合图中的线性系列生效。labels 对象的存在性即开关；显示最后一点的值时传 {\"value\": true}。",
+                                      "properties": {
+                                        "position": {
+                                          "type": "string",
+                                          "description": "标签位置",
+                                          "enum": [
+                                            "auto",
+                                            "top",
+                                            "bottom",
+                                            "left",
+                                            "right",
+                                            "center",
+                                            "inside",
+                                            "outside"
+                                          ]
+                                        },
+                                        "series": {
+                                          "type": "boolean",
+                                          "description": "是否显示系列名"
+                                        },
+                                        "category": {
+                                          "type": "boolean",
+                                          "description": "是否显示类别名"
+                                        },
+                                        "value": {
+                                          "type": "boolean",
+                                          "description": "是否显示值"
+                                        },
+                                        "percentage": {
+                                          "type": "boolean",
+                                          "description": "是否显示百分比"
+                                        },
+                                        "separator": {
+                                          "type": "string",
+                                          "description": "单点标签中多个内容项之间的分隔符"
+                                        },
+                                        "legendKey": {
+                                          "type": "boolean",
+                                          "description": "是否在单点标签前显示图例项标示"
+                                        },
+                                        "showGuidLine": {
+                                          "type": "boolean",
+                                          "description": "是否显示单点标签引导线"
+                                        },
+                                        "format": {
+                                          "type": "string",
+                                          "description": "标签数字格式"
+                                        },
+                                        "fontSize": {
+                                          "type": "number",
+                                          "description": "字体大小"
+                                        },
+                                        "bold": {
+                                          "type": "boolean",
+                                          "description": "是否加粗"
+                                        },
+                                        "italic": {
+                                          "type": "boolean",
+                                          "description": "是否斜体"
+                                        },
+                                        "underline": {
+                                          "type": "boolean",
+                                          "description": "是否下划线"
+                                        },
+                                        "strikethrough": {
+                                          "type": "boolean",
+                                          "description": "是否删除线"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "description": "字体颜色"
+                                        }
+                                      }
+                                    },
                                     "fillGradient": {
                                       "type": "object",
                                       "description": "单个数据点填充渐变配置",
@@ -2171,6 +2536,14 @@
                                 "type": "number",
                                 "description": "柱子间距比例，0-1之间"
                               },
+                              "overlap": {
+                                "type": "number",
+                                "description": "同一类别内系列柱的重叠比例，取值 -100 到 100"
+                              },
+                              "gapWidth": {
+                                "type": "number",
+                                "description": "相邻类别柱组间距，取值 0 到 500"
+                              },
                               "backgroundColor": {
                                 "type": "string",
                                 "description": "背景颜色"
@@ -2460,6 +2833,25 @@
                                 "type": "boolean",
                                 "description": "是否显示百分比"
                               },
+                              "separator": {
+                                "type": "string",
+                                "description": "标签中多个内容项之间的分隔符"
+                              },
+                              "legendKey": {
+                                "type": "boolean",
+                                "description": "是否在标签前显示图例项标示"
+                              },
+                              "showGuidLine": {
+                                "type": "boolean",
+                                "description": "是否显示标签引导线"
+                              },
+                              "anchorMode": {
+                                "type": "string",
+                                "enum": [
+                                  "ooxml"
+                                ],
+                                "description": "饼图外侧标签使用 OOXML 八向贴靠布局"
+                              },
                               "fontSize": {
                                 "type": "number",
                                 "description": "字体大小"
@@ -2533,7 +2925,11 @@
                                 },
                                 "labels": {
                                   "type": "object",
-                                  "description": "数据标签配置（覆盖单系列，配置项同 plotArea.plot.labels）。不覆盖该系列数据标签时省略整个 labels 字段；一旦传入 labels（即便显示开关全部置为 false），该系列仍会显示数据标签。"
+                                  "description": "数据标签配置（覆盖单系列，配置项同 plotArea.plot.labels，包括 separator、legendKey 和 showGuidLine）。不覆盖该系列数据标签时省略整个 labels 字段；一旦传入 labels（即便显示开关全部置为 false），该系列仍会显示数据标签。"
+                                },
+                                "invertIfNegative": {
+                                  "type": "string",
+                                  "description": "负值数据点使用的反色填充颜色"
                                 },
                                 "waterfall": {
                                   "type": "object",
@@ -2906,6 +3302,105 @@
                                 "linear"
                               ]
                             },
+                            "orientation": {
+                              "type": "string",
+                              "description": "坐标轴方向，minMax 为未逆序，maxMin 为逆序",
+                              "enum": [
+                                "minMax",
+                                "maxMin"
+                              ]
+                            },
+                            "domainGradient": {
+                              "type": "object",
+                              "description": "轴线渐变，包含 type、归一化坐标、gradientMethod 和至少两个 stops",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "linear",
+                                    "radial"
+                                  ],
+                                  "description": "渐变类型"
+                                },
+                                "x0": {
+                                  "type": "number",
+                                  "description": "起点 x，0-1 归一化坐标"
+                                },
+                                "y0": {
+                                  "type": "number",
+                                  "description": "起点 y，0-1 归一化坐标"
+                                },
+                                "x1": {
+                                  "type": "number",
+                                  "description": "终点 x，0-1 归一化坐标"
+                                },
+                                "y1": {
+                                  "type": "number",
+                                  "description": "终点 y，0-1 归一化坐标"
+                                },
+                                "r0": {
+                                  "type": "number",
+                                  "description": "径向渐变起点半径"
+                                },
+                                "r1": {
+                                  "type": "number",
+                                  "description": "径向渐变终点半径"
+                                },
+                                "gradientMethod": {
+                                  "type": "string",
+                                  "description": "渐变插值方法"
+                                },
+                                "stops": {
+                                  "type": "array",
+                                  "description": "渐变色标数组，至少 2 个",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "offset": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "maximum": 1,
+                                        "description": "色标位置 0-1"
+                                      },
+                                      "color": {
+                                        "type": "string",
+                                        "description": "色标颜色"
+                                      },
+                                      "opacity": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "maximum": 1,
+                                        "description": "色标透明度 0-1"
+                                      }
+                                    },
+                                    "required": [
+                                      "offset",
+                                      "color"
+                                    ]
+                                  }
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "stops"
+                              ]
+                            },
+                            "domainColor": {
+                              "type": "string",
+                              "description": "轴线颜色"
+                            },
+                            "domainWidth": {
+                              "type": "number",
+                              "description": "轴线宽度"
+                            },
+                            "domainDash": {
+                              "type": "array",
+                              "description": "轴线虚线图案数组",
+                              "items": {
+                                "type": "number"
+                              }
+                            },
                             "title": {
                               "type": "object",
                               "description": "坐标轴标题配置",
@@ -2994,12 +3489,48 @@
                                     "color": {
                                       "type": "string",
                                       "description": "网格线颜色"
+                                    },
+                                    "dash": {
+                                      "type": "array",
+                                      "description": "网格线虚线图案数组",
+                                      "items": {
+                                        "type": "number"
+                                      }
                                     }
                                   }
                                 },
                                 {
                                   "type": "boolean",
                                   "description": "false 表示隐藏网格线"
+                                }
+                              ]
+                            },
+                            "minorGridLine": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "次网格线配置",
+                                  "properties": {
+                                    "width": {
+                                      "type": "number",
+                                      "description": "次网格线宽度"
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "description": "次网格线颜色"
+                                    },
+                                    "dash": {
+                                      "type": "array",
+                                      "description": "次网格线虚线图案数组",
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "boolean",
+                                  "description": "false 表示隐藏次网格线"
                                 }
                               ]
                             }
@@ -3322,6 +3853,46 @@
                       "color": {
                         "type": "string",
                         "description": "字体颜色，格式为 #RRGGBB"
+                      },
+                      "overlay": {
+                        "type": "boolean",
+                        "description": "是否允许标题覆盖图表绘图区"
+                      },
+                      "layout": {
+                        "type": "object",
+                        "description": "标题在图表区内的手动布局，坐标为 0-1 归一化比例",
+                        "properties": {
+                          "xMode": {
+                            "type": "string",
+                            "enum": [
+                              "edge"
+                            ],
+                            "description": "横向布局模式"
+                          },
+                          "x": {
+                            "type": "number",
+                            "description": "横向位置，取值 0-1"
+                          },
+                          "yMode": {
+                            "type": "string",
+                            "enum": [
+                              "edge"
+                            ],
+                            "description": "纵向布局模式"
+                          },
+                          "y": {
+                            "type": "number",
+                            "description": "纵向位置，取值 0-1"
+                          }
+                        }
+                      },
+                      "background": {
+                        "type": "string",
+                        "description": "标题背景颜色"
+                      },
+                      "border": {
+                        "type": "object",
+                        "description": "标题边框配置，支持 color、width、style、dash、gradient 和 radius，字段含义同 style.border"
                       }
                     },
                     "required": [
@@ -3388,6 +3959,82 @@
                           }
                         }
                       },
+                      "backgroundGradient": {
+                        "type": "object",
+                        "description": "图表区背景渐变，包含 type、归一化坐标、gradientMethod 和至少两个 stops",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "linear",
+                              "radial"
+                            ],
+                            "description": "渐变类型"
+                          },
+                          "x0": {
+                            "type": "number",
+                            "description": "起点 x，0-1 归一化坐标"
+                          },
+                          "y0": {
+                            "type": "number",
+                            "description": "起点 y，0-1 归一化坐标"
+                          },
+                          "x1": {
+                            "type": "number",
+                            "description": "终点 x，0-1 归一化坐标"
+                          },
+                          "y1": {
+                            "type": "number",
+                            "description": "终点 y，0-1 归一化坐标"
+                          },
+                          "r0": {
+                            "type": "number",
+                            "description": "径向渐变起点半径"
+                          },
+                          "r1": {
+                            "type": "number",
+                            "description": "径向渐变终点半径"
+                          },
+                          "gradientMethod": {
+                            "type": "string",
+                            "description": "渐变插值方法"
+                          },
+                          "stops": {
+                            "type": "array",
+                            "description": "渐变色标数组，至少 2 个",
+                            "minItems": 2,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "offset": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1,
+                                  "description": "色标位置 0-1"
+                                },
+                                "color": {
+                                  "type": "string",
+                                  "description": "色标颜色"
+                                },
+                                "opacity": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "maximum": 1,
+                                  "description": "色标透明度 0-1"
+                                }
+                              },
+                              "required": [
+                                "offset",
+                                "color"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "stops"
+                        ]
+                      },
                       "font": {
                         "type": "object",
                         "description": "字体配置",
@@ -3423,9 +4070,182 @@
                               "dotted"
                             ]
                           },
+                          "dash": {
+                            "type": "array",
+                            "description": "OOXML 原始虚线图案数组",
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          "gradient": {
+                            "type": "object",
+                            "description": "边框渐变，包含 type、归一化坐标、gradientMethod 和至少两个 stops",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "linear",
+                                  "radial"
+                                ],
+                                "description": "渐变类型"
+                              },
+                              "x0": {
+                                "type": "number",
+                                "description": "起点 x，0-1 归一化坐标"
+                              },
+                              "y0": {
+                                "type": "number",
+                                "description": "起点 y，0-1 归一化坐标"
+                              },
+                              "x1": {
+                                "type": "number",
+                                "description": "终点 x，0-1 归一化坐标"
+                              },
+                              "y1": {
+                                "type": "number",
+                                "description": "终点 y，0-1 归一化坐标"
+                              },
+                              "r0": {
+                                "type": "number",
+                                "description": "径向渐变起点半径"
+                              },
+                              "r1": {
+                                "type": "number",
+                                "description": "径向渐变终点半径"
+                              },
+                              "gradientMethod": {
+                                "type": "string",
+                                "description": "渐变插值方法"
+                              },
+                              "stops": {
+                                "type": "array",
+                                "description": "渐变色标数组，至少 2 个",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "offset": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标位置 0-1"
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "description": "色标颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标透明度 0-1"
+                                    }
+                                  },
+                                  "required": [
+                                    "offset",
+                                    "color"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "stops"
+                            ]
+                          },
                           "radius": {
                             "type": "number",
                             "description": "边框圆角"
+                          }
+                        }
+                      },
+                      "region": {
+                        "type": "object",
+                        "description": "完整绘图区样式",
+                        "properties": {
+                          "background": {
+                            "type": "string",
+                            "description": "绘图区背景颜色"
+                          },
+                          "backgroundGradient": {
+                            "type": "object",
+                            "description": "绘图区背景渐变，结构同 style.backgroundGradient",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "linear",
+                                  "radial"
+                                ],
+                                "description": "渐变类型"
+                              },
+                              "x0": {
+                                "type": "number",
+                                "description": "起点 x，0-1 归一化坐标"
+                              },
+                              "y0": {
+                                "type": "number",
+                                "description": "起点 y，0-1 归一化坐标"
+                              },
+                              "x1": {
+                                "type": "number",
+                                "description": "终点 x，0-1 归一化坐标"
+                              },
+                              "y1": {
+                                "type": "number",
+                                "description": "终点 y，0-1 归一化坐标"
+                              },
+                              "r0": {
+                                "type": "number",
+                                "description": "径向渐变起点半径"
+                              },
+                              "r1": {
+                                "type": "number",
+                                "description": "径向渐变终点半径"
+                              },
+                              "gradientMethod": {
+                                "type": "string",
+                                "description": "渐变插值方法"
+                              },
+                              "stops": {
+                                "type": "array",
+                                "description": "渐变色标数组，至少 2 个",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "offset": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标位置 0-1"
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "description": "色标颜色"
+                                    },
+                                    "opacity": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "色标透明度 0-1"
+                                    }
+                                  },
+                                  "required": [
+                                    "offset",
+                                    "color"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "stops"
+                            ]
+                          },
+                          "border": {
+                            "type": "object",
+                            "description": "绘图区边框配置，字段含义同 style.border"
                           }
                         }
                       },
@@ -4107,6 +4927,82 @@
                                       "type": "number",
                                       "description": "大小"
                                     },
+                                    "labels": {
+                                      "type": "object",
+                                      "description": "单点数据标签配置，仅折线图、面积图、雷达图及组合图中的线性系列生效。labels 对象的存在性即开关；显示最后一点的值时传 {\"value\": true}。",
+                                      "properties": {
+                                        "position": {
+                                          "type": "string",
+                                          "description": "标签位置",
+                                          "enum": [
+                                            "auto",
+                                            "top",
+                                            "bottom",
+                                            "left",
+                                            "right",
+                                            "center",
+                                            "inside",
+                                            "outside"
+                                          ]
+                                        },
+                                        "series": {
+                                          "type": "boolean",
+                                          "description": "是否显示系列名"
+                                        },
+                                        "category": {
+                                          "type": "boolean",
+                                          "description": "是否显示类别名"
+                                        },
+                                        "value": {
+                                          "type": "boolean",
+                                          "description": "是否显示值"
+                                        },
+                                        "percentage": {
+                                          "type": "boolean",
+                                          "description": "是否显示百分比"
+                                        },
+                                        "separator": {
+                                          "type": "string",
+                                          "description": "单点标签中多个内容项之间的分隔符"
+                                        },
+                                        "legendKey": {
+                                          "type": "boolean",
+                                          "description": "是否在单点标签前显示图例项标示"
+                                        },
+                                        "showGuidLine": {
+                                          "type": "boolean",
+                                          "description": "是否显示单点标签引导线"
+                                        },
+                                        "format": {
+                                          "type": "string",
+                                          "description": "标签数字格式"
+                                        },
+                                        "fontSize": {
+                                          "type": "number",
+                                          "description": "字体大小"
+                                        },
+                                        "bold": {
+                                          "type": "boolean",
+                                          "description": "是否加粗"
+                                        },
+                                        "italic": {
+                                          "type": "boolean",
+                                          "description": "是否斜体"
+                                        },
+                                        "underline": {
+                                          "type": "boolean",
+                                          "description": "是否下划线"
+                                        },
+                                        "strikethrough": {
+                                          "type": "boolean",
+                                          "description": "是否删除线"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "description": "字体颜色"
+                                        }
+                                      }
+                                    },
                                     "fillGradient": {
                                       "type": "object",
                                       "description": "单个数据点填充渐变配置",
@@ -4406,6 +5302,14 @@
                                 "type": "number",
                                 "description": "柱子间距比例，0-1之间"
                               },
+                              "overlap": {
+                                "type": "number",
+                                "description": "同一类别内系列柱的重叠比例，取值 -100 到 100"
+                              },
+                              "gapWidth": {
+                                "type": "number",
+                                "description": "相邻类别柱组间距，取值 0 到 500"
+                              },
                               "backgroundColor": {
                                 "type": "string",
                                 "description": "背景颜色"
@@ -4695,6 +5599,25 @@
                                 "type": "boolean",
                                 "description": "是否显示百分比"
                               },
+                              "separator": {
+                                "type": "string",
+                                "description": "标签中多个内容项之间的分隔符"
+                              },
+                              "legendKey": {
+                                "type": "boolean",
+                                "description": "是否在标签前显示图例项标示"
+                              },
+                              "showGuidLine": {
+                                "type": "boolean",
+                                "description": "是否显示标签引导线"
+                              },
+                              "anchorMode": {
+                                "type": "string",
+                                "enum": [
+                                  "ooxml"
+                                ],
+                                "description": "饼图外侧标签使用 OOXML 八向贴靠布局"
+                              },
                               "fontSize": {
                                 "type": "number",
                                 "description": "字体大小"
@@ -4768,7 +5691,11 @@
                                 },
                                 "labels": {
                                   "type": "object",
-                                  "description": "数据标签配置（覆盖单系列，配置项同 plotArea.plot.labels）。不覆盖该系列数据标签时省略整个 labels 字段；一旦传入 labels（即便显示开关全部置为 false），该系列仍会显示数据标签。"
+                                  "description": "数据标签配置（覆盖单系列，配置项同 plotArea.plot.labels，包括 separator、legendKey 和 showGuidLine）。不覆盖该系列数据标签时省略整个 labels 字段；一旦传入 labels（即便显示开关全部置为 false），该系列仍会显示数据标签。"
+                                },
+                                "invertIfNegative": {
+                                  "type": "string",
+                                  "description": "负值数据点使用的反色填充颜色"
                                 },
                                 "waterfall": {
                                   "type": "object",
@@ -5141,6 +6068,105 @@
                                 "linear"
                               ]
                             },
+                            "orientation": {
+                              "type": "string",
+                              "description": "坐标轴方向，minMax 为未逆序，maxMin 为逆序",
+                              "enum": [
+                                "minMax",
+                                "maxMin"
+                              ]
+                            },
+                            "domainGradient": {
+                              "type": "object",
+                              "description": "轴线渐变，包含 type、归一化坐标、gradientMethod 和至少两个 stops",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "linear",
+                                    "radial"
+                                  ],
+                                  "description": "渐变类型"
+                                },
+                                "x0": {
+                                  "type": "number",
+                                  "description": "起点 x，0-1 归一化坐标"
+                                },
+                                "y0": {
+                                  "type": "number",
+                                  "description": "起点 y，0-1 归一化坐标"
+                                },
+                                "x1": {
+                                  "type": "number",
+                                  "description": "终点 x，0-1 归一化坐标"
+                                },
+                                "y1": {
+                                  "type": "number",
+                                  "description": "终点 y，0-1 归一化坐标"
+                                },
+                                "r0": {
+                                  "type": "number",
+                                  "description": "径向渐变起点半径"
+                                },
+                                "r1": {
+                                  "type": "number",
+                                  "description": "径向渐变终点半径"
+                                },
+                                "gradientMethod": {
+                                  "type": "string",
+                                  "description": "渐变插值方法"
+                                },
+                                "stops": {
+                                  "type": "array",
+                                  "description": "渐变色标数组，至少 2 个",
+                                  "minItems": 2,
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "offset": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "maximum": 1,
+                                        "description": "色标位置 0-1"
+                                      },
+                                      "color": {
+                                        "type": "string",
+                                        "description": "色标颜色"
+                                      },
+                                      "opacity": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "maximum": 1,
+                                        "description": "色标透明度 0-1"
+                                      }
+                                    },
+                                    "required": [
+                                      "offset",
+                                      "color"
+                                    ]
+                                  }
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "stops"
+                              ]
+                            },
+                            "domainColor": {
+                              "type": "string",
+                              "description": "轴线颜色"
+                            },
+                            "domainWidth": {
+                              "type": "number",
+                              "description": "轴线宽度"
+                            },
+                            "domainDash": {
+                              "type": "array",
+                              "description": "轴线虚线图案数组",
+                              "items": {
+                                "type": "number"
+                              }
+                            },
                             "title": {
                               "type": "object",
                               "description": "坐标轴标题配置",
@@ -5229,12 +6255,48 @@
                                     "color": {
                                       "type": "string",
                                       "description": "网格线颜色"
+                                    },
+                                    "dash": {
+                                      "type": "array",
+                                      "description": "网格线虚线图案数组",
+                                      "items": {
+                                        "type": "number"
+                                      }
                                     }
                                   }
                                 },
                                 {
                                   "type": "boolean",
                                   "description": "false 表示隐藏网格线"
+                                }
+                              ]
+                            },
+                            "minorGridLine": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "次网格线配置",
+                                  "properties": {
+                                    "width": {
+                                      "type": "number",
+                                      "description": "次网格线宽度"
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "description": "次网格线颜色"
+                                    },
+                                    "dash": {
+                                      "type": "array",
+                                      "description": "次网格线虚线图案数组",
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "boolean",
+                                  "description": "false 表示隐藏次网格线"
                                 }
                               ]
                             }

--- a/shortcuts/sheets/flag_schema_test.go
+++ b/shortcuts/sheets/flag_schema_test.go
@@ -115,6 +115,44 @@ func TestPrintFlagSchema_ChartUpdateIsRecursivePartial(t *testing.T) {
 	}
 }
 
+func TestFlagSchemas_ChartGradientsValidateStructure(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{
+		"properties.snapshot.style.backgroundGradient",
+		"properties.snapshot.style.border.gradient",
+		"properties.snapshot.style.region.backgroundGradient",
+		"properties.snapshot.plotArea.axes.items.domainGradient",
+	}
+	for _, command := range []string{"+chart-create", "+chart-update"} {
+		command := command
+		for _, path := range paths {
+			path := path
+			t.Run(command+"/"+path, func(t *testing.T) {
+				t.Parallel()
+				raw, err := printFlagSchemaFor(command)(path)
+				if err != nil {
+					t.Fatalf("print %s %s: %v", command, path, err)
+				}
+				var schema schemaProperty
+				if err := json.Unmarshal(raw, &schema); err != nil {
+					t.Fatalf("schema is not JSON: %v\n%s", err, raw)
+				}
+				valid := parseValue(t, `{"type":"linear","stops":[{"offset":0,"color":"rgb(0,0,0)"},{"offset":1,"color":"rgb(255,255,255)"}]}`)
+				if err := validateAgainstSchema(valid, &schema, path); err != nil {
+					t.Fatalf("valid gradient rejected: %v", err)
+				}
+				tooFewStops := parseValue(t, `{"type":"linear","stops":[{"offset":0,"color":"rgb(0,0,0)"}]}`)
+				if err := validateAgainstSchema(tooFewStops, &schema, path); err == nil {
+					t.Fatal("gradient with one stop must be rejected")
+				} else if !strings.Contains(err.Error(), "minimum is 2") {
+					t.Fatalf("want minItems error, got: %v", err)
+				}
+			})
+		}
+	}
+}
+
 // TestPrintFlagSchema_UnknownFlagListsAvailable confirms the error
 // message tells the caller which flags exist for the shortcut.
 func TestPrintFlagSchema_UnknownFlagListsAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
- expose OOXML chart snapshot fields in generated high-threshold flag schemas
- keep the fields limited to +chart-create and +chart-update
- align with sheet-skill-spec MR https://code.byted.org/ee/sheet-skill-spec/merge_requests/105

## Testing
- go test ./shortcuts/sheets/...
- generated flag schema matches sheet-skill-spec output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded chart customization for creation and updates, including scatter series and richer title styling and positioning.
  * Added background, border, region, and axis gradients, plus axis orientation and domain styling.
  * Added enhanced point and data labels, negative-value series colors, bar overlap and gap width controls, and dashed or minor grid lines.
  * Chart labels can now be left unset during updates.

* **Bug Fixes**
  * Corrected bubble chart labels to use bold styling instead of visibility controls.
  * Removed the legacy last-point label option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Cancelled axis arrow field

Removed `domainArrow` from the generated advanced chart-create and chart-update schemas. No new shortcut flags, runtime changes, or unrelated documentation updates.

Validation: focused schema/flag tests passed (`go test ./shortcuts/sheets -run 'Schema|Flag' -count=1`); generated schema inspection and diff checks passed.