### PR TITLE
feat(vc): distinguish detected meeting share starts

### DIFF
--- a/shortcuts/vc/vc_meeting_events.go
+++ b/shortcuts/vc/vc_meeting_events.go
@@ -1278,9 +1278,17 @@ func magicShareStartedEntries(payload map[string]interface{}, fallbackTime time.
 		}
 		title := strings.TrimSpace(common.GetString(common.GetMap(item, "share_doc"), "title"))
 		url := strings.TrimSpace(common.GetString(common.GetMap(item, "share_doc"), "url"))
+		detected := common.GetString(item, "start_reason") == "share_detected"
 		description := "开始共享内容"
+		if detected {
+			description = "正在共享内容"
+		}
 		if title != "" {
-			description = fmt.Sprintf("开始共享「%s」", title)
+			if detected {
+				description = fmt.Sprintf("正在共享「%s」", title)
+			} else {
+				description = fmt.Sprintf("开始共享「%s」", title)
+			}
 		}
 		var details []string
 		if url != "" {
@@ -1460,6 +1468,7 @@ func needsColon(description string) bool {
 			!strings.HasPrefix(description, "被移出") &&
 			!strings.HasPrefix(description, "会议结束") &&
 			!strings.HasPrefix(description, "开始共享") &&
+			!strings.HasPrefix(description, "正在共享") &&
 			!strings.HasPrefix(description, "结束共享")
 	}
 }
@@ -1610,11 +1619,36 @@ func chatReceivedSummary(payload map[string]interface{}) string {
 func magicShareStartedSummary(payload map[string]interface{}) string {
 	items := common.GetSlice(payload, "magic_share_started_items")
 	if len(items) > 1 {
+		detectedCount := 0
+		for _, raw := range items {
+			item, _ := raw.(map[string]interface{})
+			if common.GetString(item, "start_reason") == "share_detected" {
+				detectedCount++
+			}
+		}
+		switch {
+		case detectedCount == len(items):
+			return fmt.Sprintf("%d active shares", len(items))
+		case detectedCount > 0:
+			return fmt.Sprintf("%d share events (%d started, %d active)", len(items), len(items)-detectedCount, detectedCount)
+		}
 		return fmt.Sprintf("%d share start events", len(items))
 	}
 	item := firstSliceMap(payload, "magic_share_started_items")
 	shareID := common.GetString(item, "share_id")
 	title := common.GetString(common.GetMap(item, "share_doc"), "title")
+	if common.GetString(item, "start_reason") == "share_detected" {
+		switch {
+		case shareID != "" && title != "":
+			return fmt.Sprintf("share %s active: %s", shareID, title)
+		case shareID != "":
+			return fmt.Sprintf("share %s active", shareID)
+		case title != "":
+			return fmt.Sprintf("share active: %s", title)
+		default:
+			return "share active"
+		}
+	}
 	switch {
 	case shareID != "" && title != "":
 		return fmt.Sprintf("share %s started: %s", shareID, title)

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -292,6 +292,27 @@ func magicShareStartedEvent() map[string]interface{} {
 	}
 }
 
+func magicShareDetectedEvent() map[string]interface{} {
+	event := magicShareStartedEvent()
+	item := common.GetSlice(common.GetMap(event, "payload"), "magic_share_started_items")[0].(map[string]interface{})
+	item["share_id"] = "share-1"
+	item["start_reason"] = "share_detected"
+	return event
+}
+
+func magicShareBatchEvent(startReasons ...string) map[string]interface{} {
+	items := make([]interface{}, 0, len(startReasons))
+	for _, startReason := range startReasons {
+		items = append(items, map[string]interface{}{"start_reason": startReason})
+	}
+	return map[string]interface{}{
+		"event_type": "magic_share_started",
+		"payload": map[string]interface{}{
+			"magic_share_started_items": items,
+		},
+	}
+}
+
 func documentContextChangedEvent(items []interface{}) map[string]interface{} {
 	return map[string]interface{}{
 		"event_id":   "event-document-context",
@@ -1056,6 +1077,41 @@ func TestMeetingEvents_ExecuteJSON_PrunesEmptySlices(t *testing.T) {
 	}
 	if !strings.Contains(out, `"message_type": 1`) {
 		t.Fatalf("json output should keep numeric fields: %s", out)
+	}
+}
+
+func TestMeetingEvents_ExecuteJSON_PreservesShareStartReason(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(meetingEventsStub([]interface{}{magicShareDetectedEvent()}, false, ""))
+	reg.Register(botInfoStub())
+
+	err := mountAndRun(t, VCMeetingEvents, []string{
+		"+meeting-events",
+		"--meeting-id", "7628568141510692381",
+		"--format", "json",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stdout: %v: %s", err, stdout.String())
+	}
+	events := common.GetSlice(common.GetMap(envelope, "data"), "events")
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1: %s", len(events), stdout.String())
+	}
+	event, _ := events[0].(map[string]interface{})
+	items := common.GetSlice(common.GetMap(event, "payload"), "magic_share_started_items")
+	if len(items) != 1 {
+		t.Fatalf("magic_share_started_items len = %d, want 1: %s", len(items), stdout.String())
+	}
+	item, _ := items[0].(map[string]interface{})
+	if got := common.GetString(item, "start_reason"); got != "share_detected" {
+		t.Fatalf("start_reason = %q, want share_detected: %s", got, stdout.String())
 	}
 }
 
@@ -2013,6 +2069,21 @@ func TestMeetingEventSummary(t *testing.T) {
 		want  string
 	}{
 		{
+			name:  "current share detected",
+			event: magicShareDetectedEvent(),
+			want:  "share share-1 active: 共享文档",
+		},
+		{
+			name:  "multiple current shares detected",
+			event: magicShareBatchEvent("share_detected", "share_detected"),
+			want:  "2 active shares",
+		},
+		{
+			name:  "mixed started and detected shares",
+			event: magicShareBatchEvent("share_started", "share_detected"),
+			want:  "2 share events (1 started, 1 active)",
+		},
+		{
 			name: "participant joined count",
 			event: map[string]interface{}{
 				"event_type": "participant_joined",
@@ -2057,6 +2128,23 @@ func TestMeetingEventSummary(t *testing.T) {
 				t.Fatalf("meetingEventSummary() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMagicShareDetectedEntries(t *testing.T) {
+	payload := common.GetMap(magicShareDetectedEvent(), "payload")
+	sequence := 0
+	entries := magicShareStartedEntries(payload, time.Time{}, false, &sequence)
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1", len(entries))
+	}
+	if got, want := entries[0].description, "正在共享「共享文档」"; got != want {
+		t.Fatalf("description = %q, want %q", got, want)
+	}
+
+	got := renderMeetingEventsPretty(meetingTimeline{entries: entries})
+	if want := "Bob(u2) 正在共享「共享文档」"; !strings.Contains(got, want) {
+		t.Fatalf("pretty output missing %q: %s", want, got)
 	}
 }
 

--- a/skills/lark-meeting/references/lark-vc-meeting-events.md
+++ b/skills/lark-meeting/references/lark-vc-meeting-events.md
@@ -112,7 +112,7 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token 
 - 如果上下文没有明确 `meeting_id`，先按用户当前意图选择身份：问“我/当前用户所在会议”用 `lark-cli vc +meeting-list-active --as user --format json`；问“应用机器人可见的目标用户会议”用 `lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json`。返回多个会议时先让用户选择。
 - 如果上下文只有 9 位会议号，先按当前身份执行 `+meeting-list-active` 并按 `meeting_no` 匹配；匹配到唯一会议后再查事件。不要为了总结会议而自动调用 `+meeting-join`。
 - 确认 `meeting_id` 后，沿用其来源身份执行 `lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --format pretty` 拉取最新事件流。
-- 如果事件流显示开始共享内容（JSON 事件类型为 `magic_share_started`，pretty 时间线显示“开始共享”），并包含文档标题或 URL 等线索，必须继续读取共享文档内容后再生成总结，不能只根据共享事件和文档标题概括会议内容。
+- 如果事件流显示共享内容（JSON 事件类型为 `magic_share_started`；pretty 时间线按 `start_reason` 显示“开始共享”或“正在共享”），并包含文档标题或 URL 等线索，必须继续读取共享文档内容后再生成总结，不能只根据共享事件和文档标题概括会议内容。
 - 若存在多个共享文档，按用户问题读取相关文档；处理某条文档上下文事件时必须按该 item 的 `share_id` 精确关联，不能用“最近一次共享”替代。
 - 若文档读取失败，必须明确说明“以下总结仅基于会中事件流，未成功读取共享文档内容”。
 
@@ -134,6 +134,7 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token 
 | 路径 | 含义与处理 |
 | --- | --- |
 | `payload.magic_share_started_items[].share_id/share_doc` | 建立一次共享会话与文档 URL/title 的映射。缺 `share_id` 时不建立映射。 |
+| `payload.magic_share_started_items[].start_reason` | `share_started` 或缺失表示真实开始；`share_detected` 表示开启 Agent 入会能力时发现已有共享。两者都建立共享映射。 |
 | `payload.magic_share_ended_items[].share_id` | 结束同一 `share_id` 的共享会话；不得结束其他映射。 |
 | `payload.document_context_changed_items[]` | 结构化消费按原序读取；pretty timeline 沿用统一时间排序。每项恰有一个已知 context 才生成 pretty 条目，未知/歧义项只保留 raw。 |
 | `item.operator` | 当前 item 的 actor；缺 ID/name 时不猜共享发起人。 |
@@ -249,7 +250,7 @@ lark-cli drive +list-replies \
 | `participant_left` | 有参会人离开会议 |
 | `chat_received` | 收到会中聊天消息 |
 | `transcript_received` | 收到转写文本 |
-| `magic_share_started` | 开始共享内容 / 文档 |
+| `magic_share_started` | 开始共享，或开启 Agent 入会能力时发现已有共享；由 `start_reason` 区分 |
 | `magic_share_ended` | 结束共享 |
 | `document_context_changed` | 评论聚焦、章节定位或元素预览上下文变化 |
 | `countdown_changed` | 会中倒计时被设置、延长、提前结束、关闭窗口，或自然结束、临近提醒 |


### PR DESCRIPTION
## Summary

Distinguish a real meeting share start from an already-active share detected when Agent meeting access is enabled. Preserve the new `start_reason` field in machine-readable output and make Pretty output describe detected shares as active instead of newly started.

## Changes

- Render `start_reason=share_detected` as an active share in timeline entries and summaries.
- Preserve `start_reason` in JSON output while keeping missing values and `share_started` backward compatible.
- Document the two start reasons and their shared-document correlation behavior.

## Test Plan

- [x] `go test ./shortcuts/vc -count=1`
- [x] Focused VC tests with `-race`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `node scripts/skill-format-check/index.js`
- [x] `make unit-test` — blocked locally on Go 1.26.1 darwin/arm64: the repository command combines `-race` with `-gcflags="all=-N -l"`, which causes startup SIGSEGV across unrelated packages. Each option passes independently for the affected VC tests.
- [x] Manual live OpenAPI verification

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Meeting timelines now distinguish newly started screen sharing from sharing that was already in progress.
  * Summaries clearly identify manually started shares, detected active shares, and mixed sharing activity.
  * Screen-sharing start reasons are preserved in event data and reflected in timeline displays.

* **Documentation**
  * Updated meeting event reference documentation to describe detected shares, timeline labels, and the start-reason field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->