### PR TITLE
docs(base): fix broken in-page anchors in lark-base-workflow

### DIFF
--- a/skills/lark-base/references/lark-base-workflow.md
+++ b/skills/lark-base/references/lark-base-workflow.md
@@ -54,12 +54,12 @@
 
 | 场景 | 步骤组合 | 示例 |
 |------|---------|------|
-| 新增触发+通知 | AddRecordTrigger → LarkMessageAction | [下方](#示例1-新增记录触发--发送消息) |
+| 新增触发+通知 | AddRecordTrigger → LarkMessageAction | [下方](#示例-1-新增记录触发--发送消息) |
 | 按钮点击+调用外部接口+写入日志 | ButtonTrigger → HTTPClientAction → AddRecordAction | [下方](#示例-6-按钮触发--调用外部接口--写入同步日志) |
-| 定时+循环 | TimerTrigger → FindRecordAction → Loop → LarkMessageAction | [下方](#示例2-定时触发--查找记录--循环遍历--发送消息) |
-| 条件判断 | ... → IfElseBranch → 分支处理 | [下方](#示例3-条件分支-ifelsebranch) |
-| 多路分类 | ... → SwitchBranch → 多分支处理 | [下方](#示例4-多路分支-switchbranch) |
-| 复杂组合 | 定时+查找+循环+分支+消息 | [下方](#示例5-组合场景-定时查找循环分支消息) |
+| 定时+循环 | TimerTrigger → FindRecordAction → Loop → LarkMessageAction | [下方](#示例-2-定时触发--查找记录--循环遍历--发送消息) |
+| 条件判断 | ... → IfElseBranch → 分支处理 | [下方](#示例-3-条件分支ifelsebranch) |
+| 多路分类 | ... → SwitchBranch → 多分支处理 | [下方](#示例-4-多路分支switchbranch) |
+| 复杂组合 | 定时+查找+循环+分支+消息 | [下方](#示例-5-组合场景定时查找循环分支消息) |
 
 ---
 


### PR DESCRIPTION
## What

The scenario lookup table in `skills/lark-base/references/lark-base-workflow.md` links to the six full examples. Five of the six anchors do not match the ids GitHub generates for the headings, so those jumps land nowhere.

## Why they are wrong

Two independent mismatches:

| Link in the table | Id GitHub generates |
|---|---|
| `#示例1-新增记录触发--发送消息` | `示例-1-新增记录触发--发送消息` |
| `#示例2-定时触发--查找记录--循环遍历--发送消息` | `示例-2-…` |
| `#示例3-条件分支-ifelsebranch` | `示例-3-条件分支ifelsebranch` |
| `#示例4-多路分支-switchbranch` | `示例-4-多路分支switchbranch` |
| `#示例5-组合场景-定时查找循环分支消息` | `示例-5-组合场景定时查找循环分支消息` |
| `#示例-6-按钮触发--调用外部接口--写入同步日志` | already correct |

1. The space in `示例 N` becomes a hyphen in the id; the links omit it.
2. Full-width parentheses are dropped **without** producing a hyphen; the links add one.

Example 6 is already correct and untouched — which is what makes the other five look like typos rather than a different convention.

## How the target ids were determined

Not derived from the slug rules by hand: the ids were read from the anchors GitHub renders for this file's own headings on `main`, then compared against the links.

## Scope

Docs only, five link targets, no prose or code changes. `node scripts/skill-format-check/index.js` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected example links in the workflow quick-reference table.
  * Updated anchors to match the corresponding example headings for reliable navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->