### PR TITLE
fix(sheets): repair the build after the local-office detection move

### DIFF
--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -2225,7 +2225,7 @@ var WorkbookExport = common.Shortcut{
 }
 
 // errLocalOfficeExportUnsupported rejects an export whose target is an Office
-// workbook rather than a Lark spreadsheet (isOfficeSpreadsheet). Drive's export
+// workbook rather than a Lark spreadsheet (common.IsLocalOfficeToken). Drive's export
 // task only produces artifacts for native Lark documents, so these tokens fail
 // on the backend — late, after the create + poll round trips, with an opaque
 // message. Refuse up front and say why instead.
@@ -2241,7 +2241,7 @@ var WorkbookExport = common.Shortcut{
 //     local copy at all, so the recovery is to download the stored file, or to
 //     convert it into a real Lark spreadsheet that export does support.
 func errLocalOfficeExportUnsupported(token string) error {
-	if !isOfficeSpreadsheet(token) {
+	if !common.IsLocalOfficeToken(token) {
 		return nil
 	}
 	if isLocallyOpenedOfficeToken(token) {
@@ -2259,10 +2259,10 @@ func errLocalOfficeExportUnsupported(token string) error {
 
 // isLocallyOpenedOfficeToken reports whether the token is one of the synthetic
 // prefixes the client mints for a workbook opened from local disk, as opposed
-// to an Office file that lives in Lark. Both are "office spreadsheets" to
-// isOfficeSpreadsheet; only this class implies the caller holds the file.
+// to an Office file that lives in Lark. Both are local-office tokens to
+// common.IsLocalOfficeToken; only this class implies the caller holds the file.
 func isLocallyOpenedOfficeToken(token string) bool {
-	for _, prefix := range officePrefixes {
+	for _, prefix := range []string{common.FakeOfficeTokenPrefix, common.LocalOfficeTokenPrefix} {
 		if strings.HasPrefix(token, prefix) {
 			return true
 		}


### PR DESCRIPTION
**main does not currently compile.**

```
shortcuts/sheets/lark_sheet_workbook.go:2244:6: undefined: isOfficeSpreadsheet
shortcuts/sheets/lark_sheet_workbook.go:2265:25: undefined: officePrefixes
```

Reproduce with `go build ./...` on `decc9549`.

## How it happened

Neither PR was wrong on its own:

- #2531 (merged 10:39) moved local-office token detection into `common.IsLocalOfficeToken` and deleted the sheets-local `isOfficeSpreadsheet` / `officePrefixes`.
- #2533 (merged 12:48) added `errLocalOfficeExportUnsupported`, which calls both.

#2533's branch predated the move, so its CI was green against a base that still had the symbols. Nothing re-checked it against the updated `main` before merge, and the two together broke the build — a semantic conflict git had no reason to flag, since the two PRs touch different files.

## The fix

Repoints both references at the moved API. Behaviour is unchanged: `common.IsLocalOfficeToken` is the same predicate #2531 moved (same interleaved-marker offsets, same >= 25 floor), and `[]string{common.FakeOfficeTokenPrefix, common.LocalOfficeTokenPrefix}` is the exported form of the same two constants the deleted slice held.

That equivalence is pinned by #2533's own coverage rather than by anything new here: `TestWorkbookExport_LocalOfficeTokenRejected` exercises the `local_office_` prefix, the `fake_office_` prefix, and an interleaved OFL0X token, and `TestWorkbookExport_LocalOfficeBehindWikiNodeRejected` / `TestWorkbookExport_LocalOfficeTokenRejectedInDryRun` cover the remaining paths. All pass unchanged. No new test is added, because nothing about the behaviour is new — and a test would not have caught this anyway, since the failure was a compile error against a base CI never saw.

Local: `go build ./...`, `go vet`, `gofmt`, `go test ./shortcuts/... ./internal/...`, and `make quality-gate` all pass.

Worth considering separately: a required "branch up to date with main" merge gate would have caught this class outright.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of local Office workbook files during export.
  - Increased compatibility with supported local and simulated Office file tokens.
  - Ensured workbook exports are handled more reliably across supported Office file sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->