### PR TITLE
fix(client): surface later-page failures in --page-all runs

### DIFF
--- a/cmd/api/api_paginate_test.go
+++ b/cmd/api/api_paginate_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
@@ -392,5 +393,221 @@ func TestAPIPaginate_StreamBusinessErrorIsMarkedRaw(t *testing.T) {
 	}
 	if got := errOut.String(); got != "" {
 		t.Fatalf("stderr bytes = %q, want empty", got)
+	}
+}
+
+// firstPageHasMoreStub registers a successful page 1 that advertises a next
+// page, so the loop is guaranteed to attempt page 2.
+func firstPageHasMoreStub(reg *httpmock.Registry) {
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/test/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "first"}},
+				"has_more":   true,
+				"page_token": "next-1",
+			},
+		},
+	})
+}
+
+// The command-layer view of the first-page rule. Exactly one stub is registered,
+// so a second request would fail the run; the method is POST because the hazard
+// pinned is a replayed write.
+//
+//   - A first page that passed classification and needs no pagination is output
+//     on each format's own contract: json wraps it in the envelope, ndjson
+//     streams its records — a code-less list is still a list.
+//   - A first page that did not declare success but carries a continuation token
+//     is refused before output, with a non-zero exit, so the streaming formats —
+//     which have no envelope to carry has_more — get a machine-readable signal.
+//   - A business error dumps the raw response (json) or writes nothing
+//     (ndjson) and fails, as before.
+func TestAPIPaginate_FirstPageIsOutputOnlyIfItNeedsNoPagination(t *testing.T) {
+	page := func(code string, cursor bool) []byte {
+		data := `"data":{"items":[{"id":"first"}],"has_more":false}`
+		if cursor {
+			data = `"data":{"items":[{"id":"first"}],"has_more":true,"page_token":"next-1"}`
+		}
+		if code == "" {
+			return []byte(`{"msg":"m",` + data + `}`)
+		}
+		return []byte(`{"code":` + code + `,"msg":"m",` + data + `}`)
+	}
+	for _, tc := range []struct {
+		name          string
+		code          string
+		cursor        bool
+		format        output.Format
+		wantErrCat    errs.Category // "" = expect nil error
+		wantSubtype   errs.Subtype
+		wantStdout    []string
+		wantNotStdout []string
+		wantNotStderr string
+	}{
+		{"json, code-less list, no cursor", "", false, output.FormatJSON, "", "", []string{`"has_more": false`, `"first"`}, nil, ""},
+		{"json, missing code, cursor", "", true, output.FormatJSON, errs.CategoryInternal, errs.SubtypeInvalidResponse, nil, []string{`first`}, ""},
+		{"json, fractional code, cursor", "0.5", true, output.FormatJSON, errs.CategoryInternal, errs.SubtypeInvalidResponse, nil, []string{`first`}, ""},
+		{"json, null code, cursor", "null", true, output.FormatJSON, errs.CategoryInternal, errs.SubtypeInvalidResponse, nil, []string{`first`}, ""},
+		{"json, business error", "230027", true, output.FormatJSON, errs.CategoryAuthorization, "", []string{`"code": 230027`}, nil, ""},
+		{"ndjson, code-less list, no cursor", "", false, output.FormatNDJSON, "", "", []string{`"first"`}, []string{`has_more`}, "does not return a list"},
+		{"ndjson, missing code, cursor", "", true, output.FormatNDJSON, errs.CategoryInternal, errs.SubtypeInvalidResponse, nil, []string{`first`}, ""},
+		{"ndjson, fractional code, cursor", "0.5", true, output.FormatNDJSON, errs.CategoryInternal, errs.SubtypeInvalidResponse, nil, []string{`first`}, ""},
+		{"ndjson, business error", "230027", true, output.FormatNDJSON, errs.CategoryAuthorization, "", nil, []string{`first`}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ac, out, errOut, reg := newAPIPaginateTestHarness(t)
+			reg.Register(&httpmock.Stub{URL: "/open-apis/test/v1/items", RawBody: page(tc.code, tc.cursor), ContentType: "text/json"})
+
+			err := apiPaginate(context.Background(), ac,
+				client.RawApiRequest{Method: "POST", URL: "/open-apis/test/v1/items", As: core.AsBot},
+				tc.format, "", out, errOut, "lark-cli api POST",
+				client.PaginationOptions{PageLimit: 0, PageDelay: -1})
+
+			if tc.wantErrCat == "" {
+				if err != nil {
+					t.Fatalf("apiPaginate() error = %v, want nil (a second request would have failed the run)", err)
+				}
+			} else {
+				if got := errs.CategoryOf(err); err == nil || got != tc.wantErrCat {
+					t.Fatalf("apiPaginate() error = %v (category %q), want %q", err, got, tc.wantErrCat)
+				}
+				if tc.wantSubtype != "" {
+					p, ok := errs.ProblemOf(err)
+					if !ok || p.Subtype != tc.wantSubtype {
+						t.Fatalf("subtype = %v, want %q", err, tc.wantSubtype)
+					}
+					if tc.cursor {
+						const wantHint = "verify whether the first request changed remote state before retrying it"
+						if p.Hint != wantHint {
+							t.Errorf("Hint = %q, want %q", p.Hint, wantHint)
+						}
+					}
+				}
+			}
+			for _, want := range tc.wantStdout {
+				if !strings.Contains(out.String(), want) {
+					t.Errorf("stdout = %q, want it to contain %q", out.String(), want)
+				}
+			}
+			for _, notWant := range tc.wantNotStdout {
+				if strings.Contains(out.String(), notWant) {
+					t.Errorf("stdout = %q, want it NOT to contain %q", out.String(), notWant)
+				}
+			}
+			if tc.wantNotStderr != "" && strings.Contains(errOut.String(), tc.wantNotStderr) {
+				t.Errorf("stderr = %q, want it NOT to contain %q: the page is a list and must be streamed", errOut.String(), tc.wantNotStderr)
+			}
+		})
+	}
+}
+
+// The counterpart to the JSON cases, and the reason "a failed run writes no
+// stdout" is only true for the buffered formats. A streaming format has already
+// emitted the pages that succeeded by the time a later one fails; those lines
+// stay, by design (see apiPaginate's note that callers must use the exit code
+// to tell complete from partial output). What this change fixes is that the
+// exit code now actually says so.
+func TestAPIPaginate_LaterPageFailureKeepsStreamedStdout(t *testing.T) {
+	ac, out, errOut, reg := newAPIPaginateTestHarness(t)
+	firstPageHasMoreStub(reg)
+	reg.Register(&httpmock.Stub{
+		URL:    "/open-apis/test/v1/items",
+		Status: 502,
+		Body:   map[string]interface{}{"msg": "Bad Gateway"},
+	})
+
+	err := apiPaginate(context.Background(), ac, apiPaginateRequest(),
+		output.FormatNDJSON, "", out, errOut, "lark-cli api GET",
+		client.PaginationOptions{PageLimit: 0, PageDelay: -1})
+
+	if err == nil {
+		t.Fatal("apiPaginate() error = nil, want HTTP 502 from page 2")
+	}
+	if got := errs.CategoryOf(err); got != errs.CategoryNetwork {
+		t.Errorf("errs.CategoryOf(err) = %q, want %q", got, errs.CategoryNetwork)
+	}
+	if !bytes.Contains(out.Bytes(), []byte(`"first"`)) {
+		t.Fatalf("streamed stdout = %q, want it to keep the page-1 item it already wrote", out.Bytes())
+	}
+}
+
+// apiPaginate's return value is what determines the process exit code, so a nil
+// here means the CLI would exit 0 on a partial result — the shape #2477 reported.
+// The buffered formats must also leave stdout empty: a success envelope written
+// alongside a non-zero exit is the same lie in a different place.
+//
+// Each case asserts the classification, not merely that something failed. A 502
+// body carrying no code is also an unreadable page, so the later-page guard would
+// catch it too; only the category shows which branch actually ran.
+func TestAPIPaginate_LaterPageFailureEmitsNoStdout(t *testing.T) {
+	transportErr := errors.New("simulated transport failure")
+
+	for _, tc := range []struct {
+		name        string
+		stub        *httpmock.Stub
+		wantCat     errs.Category
+		wantSubtype errs.Subtype
+		wantCause   error
+	}{
+		{
+			name:      "transport failure",
+			stub:      &httpmock.Stub{URL: "/open-apis/test/v1/items", Error: transportErr},
+			wantCat:   errs.CategoryNetwork,
+			wantCause: transportErr,
+		},
+		{
+			name:        "business error",
+			stub:        &httpmock.Stub{URL: "/open-apis/test/v1/items", Body: map[string]interface{}{"code": 230027, "msg": "user not authorized"}},
+			wantCat:     errs.CategoryAuthorization,
+			wantSubtype: errs.SubtypeUserUnauthorized,
+		},
+		{
+			name:    "gateway 502 carrying no code",
+			stub:    &httpmock.Stub{URL: "/open-apis/test/v1/items", Status: 502, Body: map[string]interface{}{"msg": "Bad Gateway"}},
+			wantCat: errs.CategoryNetwork,
+		},
+		{
+			// The page before it promised more data; this one carries no data and
+			// a code the float decoder reads as 0. Accepting it would merge into
+			// ok:true / has_more:false over the first page alone — #2477 exactly.
+			name:        "later page did not declare success and carries no data",
+			stub:        &httpmock.Stub{URL: "/open-apis/test/v1/items", RawBody: []byte(`{"code":1e-324,"msg":"underflow"}`), ContentType: "text/json"},
+			wantCat:     errs.CategoryInternal,
+			wantSubtype: errs.SubtypeInvalidResponse,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ac, out, errOut, reg := newAPIPaginateTestHarness(t)
+			firstPageHasMoreStub(reg)
+			reg.Register(tc.stub)
+
+			err := apiPaginate(context.Background(), ac, apiPaginateRequest(),
+				output.FormatJSON, "", out, errOut, "lark-cli api GET",
+				client.PaginationOptions{PageLimit: 0, PageDelay: -1})
+
+			if err == nil {
+				t.Fatal("apiPaginate() error = nil, want the page-2 failure to reach the exit code")
+			}
+			if got := errs.CategoryOf(err); got != tc.wantCat {
+				t.Errorf("errs.CategoryOf(err) = %q, want %q", got, tc.wantCat)
+			}
+			if tc.wantSubtype != "" {
+				p, ok := errs.ProblemOf(err)
+				if !ok {
+					t.Fatalf("errs.ProblemOf(err) = _, false; want a typed problem; err = %T: %v", err, err)
+				}
+				if p.Subtype != tc.wantSubtype {
+					t.Errorf("subtype = %q, want %q", p.Subtype, tc.wantSubtype)
+				}
+			}
+			if tc.wantCause != nil && !errors.Is(err, tc.wantCause) {
+				t.Errorf("errors.Is(err, cause) = false; the cause did not survive the command layer; err = %v", err)
+			}
+			if got := out.String(); got != "" {
+				t.Fatalf("stdout bytes = %q, want empty on a failed pagination run", got)
+			}
+		})
 	}
 }

--- a/cmd/service/service_paginate_test.go
+++ b/cmd/service/service_paginate_test.go
@@ -398,3 +398,79 @@ func TestServicePaginate_StreamBusinessErrorRemainsUnmarked(t *testing.T) {
 		t.Fatalf("stderr bytes = %q, want empty", got)
 	}
 }
+
+func TestServicePaginate_LaterPageTransportErrorEmitsNoStdout(t *testing.T) {
+	ac, out, errOut, reg := newServicePaginateTestHarness(t)
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/test/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "first"}},
+				"has_more":   true,
+				"page_token": "next-1",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		URL:   "/open-apis/test/v1/items",
+		Error: errors.New("simulated transport failure"),
+	})
+
+	err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+		output.FormatJSON, "", out, errOut, "lark-cli test items list",
+		client.PaginationOptions{PageDelay: -1}, ac.CheckResponse)
+
+	if err == nil {
+		t.Fatal("servicePaginate() error = nil, want transport error from page 2")
+	}
+	if errs.IsRaw(err) {
+		t.Fatalf("errs.IsRaw(error) = true, want current servicePaginate pass-through behavior")
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("stdout bytes = %q, want empty on a failed pagination run", got)
+	}
+	if got := errOut.String(); got != "" {
+		t.Fatalf("stderr bytes = %q, want empty", got)
+	}
+}
+
+// The generated service commands share paginateLoop with `api`, so the same
+// gateway 5xx has to fail here too. The api-side cases alone would leave this
+// command layer unverified.
+func TestServicePaginate_LaterPageHTTPErrorEmitsNoStdout(t *testing.T) {
+	ac, out, errOut, reg := newServicePaginateTestHarness(t)
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/test/v1/items",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "first"}},
+				"has_more":   true,
+				"page_token": "next-1",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		URL:    "/open-apis/test/v1/items",
+		Status: 502,
+		Body:   map[string]interface{}{"msg": "Bad Gateway"},
+	})
+
+	err := servicePaginate(context.Background(), ac, servicePaginateRequest(),
+		output.FormatJSON, "", out, errOut, "lark-cli test items list",
+		client.PaginationOptions{PageDelay: -1}, ac.CheckResponse)
+
+	if err == nil {
+		t.Fatal("servicePaginate() error = nil, want HTTP 502 from page 2")
+	}
+	// The category, not merely that something failed: a 502 body with no code is
+	// also an unreadable page, so the later-page guard would catch it too. Only
+	// the status branch classifies it as a network failure.
+	if got := errs.CategoryOf(err); got != errs.CategoryNetwork {
+		t.Errorf("errs.CategoryOf(err) = %q, want %q", got, errs.CategoryNetwork)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("stdout bytes = %q, want empty on a failed pagination run", got)
+	}
+}

--- a/errs/subtypes.go
+++ b/errs/subtypes.go
@@ -86,7 +86,7 @@ const (
 // CategoryInternal subtypes
 const (
 	SubtypeSDKError        Subtype = "sdk_error"        // lark SDK Do() returned an unexpected error
-	SubtypeInvalidResponse Subtype = "invalid_response" // SDK response body not parsable as JSON
+	SubtypeInvalidResponse Subtype = "invalid_response" // response body not parsable as JSON, or a response the CLI cannot accept as the envelope it expects (e.g. a --page-all page that did not declare success)
 	SubtypeFileIO          Subtype = "file_io"          // local file I/O failure (mkdir / write / read)
 	SubtypeExternalTool    Subtype = "external_tool"    // an external tool the CLI shells out to (git, npx) failed at runtime; the tool output is in the message
 	SubtypeStorage         Subtype = "storage"          // local persistence failure (e.g. config file save)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -374,8 +374,132 @@ func (c *APIClient) CallAPI(ctx context.Context, request RawApiRequest) (interfa
 	return result, nil
 }
 
-// paginateLoop runs the core pagination loop. For each successful page (code == 0),
-// it calls onResult if non-nil. It always accumulates and returns all raw page results.
+// callPage is CallAPI plus the raw response. CallAPI drops the
+// *larkcore.ApiResp, which is why the pagination loop could not tell a 4xx/5xx
+// page from a successful one — nothing below it reads the HTTP status.
+//
+// A body that fails to parse is classified by status when the status is a
+// failure, as HandleResponse does (response.go), or --page-all would exit 5
+// where plain `api` exits 4; on a success status the parse error stands. What
+// reaches that branch is a body the SDK did not decode itself: one with no
+// Content-Type, or one typed text/json, which IsJSONContentType accepts but the
+// SDK does not. A body typed application/json that does not parse fails inside
+// DoAPI instead, with no response left to read a status from, and a body that
+// declares a non-JSON type never gets as far as the parser.
+func (c *APIClient) callPage(ctx context.Context, request RawApiRequest) (interface{}, *larkcore.ApiResp, error) {
+	resp, err := c.DoAPI(ctx, request)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Whether the body is JSON is decided by the rule HandleResponse uses, so
+	// both paths look at the same bytes the same way. A declared non-JSON body
+	// is never parsed: failed, it is classified by status; succeeded, plain `api`
+	// treats it as a download, which a paginated run has no way to be.
+	if ct := resp.Header.Get("Content-Type"); !isJSONBody(ct) {
+		if resp.StatusCode >= 400 {
+			return nil, resp, httpStatusError(resp.StatusCode, resp.RawBody)
+		}
+		return nil, resp, errs.NewInternalError(errs.SubtypeInvalidResponse,
+			"response is not JSON (Content-Type %q); --page-all needs a JSON list response", ct)
+	}
+	result, parseErr := ParseJSONResponse(resp)
+	if parseErr != nil {
+		if resp.StatusCode >= 400 {
+			return nil, resp, httpStatusError(resp.StatusCode, resp.RawBody)
+		}
+		return nil, resp, WrapJSONResponseParseError(parseErr, resp.RawBody)
+	}
+	return result, resp, nil
+}
+
+// pageDeclaresSuccess reports whether a page carries a business code that is
+// exactly 0. It decides one thing — whether the loop may treat the page as a
+// step in the pagination: follow its cursor, or accept it as the continuation
+// an earlier page promised — and is deliberately narrower than CheckResponse's
+// notion of "not an error", which is what decides whether the page is output:
+// that one reads the code as a float, under which 0.5, 1e-324 and an absent
+// field all become 0. Here a JSON number is zero only if every digit of its
+// mantissa is 0 — 0, -0, 0.0, 0e10 — which is exact, allocation-free, and
+// indifferent to how large an exponent a hostile body attaches.
+func pageDeclaresSuccess(result interface{}) bool {
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	switch n := m["code"].(type) {
+	case int:
+		return n == 0
+	case int64:
+		return n == 0
+	case float64:
+		// Reachable only from a caller that decoded without UseNumber;
+		// ParseJSONResponse never produces this.
+		return n == 0
+	case json.Number:
+		return isZeroLiteral(string(n))
+	}
+	return false
+}
+
+func isZeroLiteral(s string) bool {
+	s = strings.TrimPrefix(s, "-")
+	if e := strings.IndexAny(s, "eE"); e >= 0 {
+		s = s[:e]
+	}
+	sawDigit := false
+	for _, c := range s {
+		switch c {
+		case '0':
+			sawDigit = true
+		case '.':
+		default:
+			return false
+		}
+	}
+	return sawDigit
+}
+
+// nextPageToken is the continuation token a page carries: its page_token or
+// next_page_token when has_more is true, or "" when it carries none.
+func nextPageToken(result interface{}) string {
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	data, ok := resultMap["data"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	if hasMore, _ := data["has_more"].(bool); !hasMore {
+		return ""
+	}
+	if pt, ok := data["page_token"].(string); ok && pt != "" {
+		return pt
+	}
+	if pt, ok := data["next_page_token"].(string); ok && pt != "" {
+		return pt
+	}
+	return ""
+}
+
+func firstPageRecoveryHint(method string) string {
+	if strings.EqualFold(method, http.MethodGet) || strings.EqualFold(method, http.MethodHead) {
+		return "remove `--page-all` and `--jq`; use `--output <path>` to save the raw response"
+	}
+	// The generic api command does not confirmation-gate every write. Do not
+	// turn the automatic replay protection below into instructions for a human
+	// or agent to replay a POST, PUT, PATCH, or DELETE manually.
+	return "verify whether the first request changed remote state before retrying it"
+}
+
+// paginateLoop runs the core pagination loop. Each page accepted for output
+// calls onResult if non-nil and is accumulated after that callback succeeds.
+// Acceptance requires a business code of exactly 0, except that a first page
+// which passes classification and carries no continuation token is still output
+// for plain-api compatibility.
+// A first-page business error is handed back whole with a nil error for the
+// command layer to classify; any later failure returns the pages accumulated so
+// far together with the error.
 func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opts PaginationOptions, onResult func(interface{}) error) ([]interface{}, error) {
 	var allResults []interface{}
 	var pageToken string
@@ -383,6 +507,21 @@ func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opt
 	pageDelay := opts.PageDelay
 	if pageDelay == 0 {
 		pageDelay = 200
+	}
+
+	// This loop owns the CheckResponse call that classifies a later page's
+	// failure, so it resolves the identity that classification uses rather than
+	// trusting every caller to fill opts in. An empty identity is not neutral:
+	// errclass rewrites it to "user" (internal/errclass/classify.go) and hands a bot the
+	// user-facing recovery text. The request carries the identity it was sent
+	// with, so prefer it over guessing; AsAuto means "not resolved yet" and is
+	// treated as unset at both steps.
+	identity := opts.Identity
+	if identity == "" || identity == core.AsAuto {
+		identity = request.As
+	}
+	if identity == "" || identity == core.AsAuto {
+		identity = core.AsUser
 	}
 
 	for {
@@ -396,7 +535,7 @@ func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opt
 		}
 
 		fmt.Fprintf(c.ErrOut, "[page %d] fetching...\n", page)
-		result, err := c.CallAPI(ctx, RawApiRequest{
+		result, resp, err := c.callPage(ctx, RawApiRequest{
 			Method:    request.Method,
 			URL:       request.URL,
 			Params:    params,
@@ -405,23 +544,69 @@ func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opt
 			ExtraOpts: request.ExtraOpts,
 		})
 		if err != nil {
-			if page == 1 {
-				return nil, err
+			// Page 1 has nothing accumulated yet, so both paths return the same
+			// (nil, err); only the progress line differs. A later page must not
+			// fall through to the loop's `return allResults, nil` — that is what
+			// turned a mid-pagination failure into a successful partial result.
+			if page > 1 {
+				fmt.Fprintf(c.ErrOut, "[page %d] error, stopping pagination\n", page)
 			}
-			fmt.Fprintf(c.ErrOut, "[page %d] error, stopping pagination\n", page)
-			break
+			return allResults, err
 		}
 
-		if resultMap, ok := result.(map[string]interface{}); ok {
-			code, _ := util.ToFloat64(resultMap["code"])
-			if code != 0 {
-				allResults = append(allResults, result)
-				if page == 1 {
-					return allResults, nil
-				}
-				fmt.Fprintf(c.ErrOut, "[page %d] API error (code=%.0f), stopping pagination\n", page, code)
-				break
+		// A failed page is classified exactly as HandleResponse classifies a plain
+		// `api` response, in the same order — the business code through
+		// CheckResponse, then the HTTP status — so one response cannot exit two
+		// ways depending on a flag. A business error on page 1 is handed back
+		// whole with a nil error so the command layer can classify it and dump
+		// the raw response, the long-standing output contract; on a later page it
+		// fails the run. An HTTP failure fails the run on any page, as plain `api`
+		// fails it too. Whether a page that passes both checks is a step in the
+		// pagination at all is decided below.
+		if apiErr := c.CheckResponse(result, identity); apiErr != nil {
+			if page == 1 {
+				return append(allResults, result), nil
 			}
+			fmt.Fprintf(c.ErrOut, "[page %d] API error, stopping pagination\n", page)
+			return allResults, apiErr
+		}
+		if resp.StatusCode >= 400 {
+			if page > 1 {
+				fmt.Fprintf(c.ErrOut, "[page %d] HTTP %d, stopping pagination\n", page, resp.StatusCode)
+			}
+			return allResults, httpStatusError(resp.StatusCode, resp.RawBody)
+		}
+
+		// A page that passed both checks is a response the classifier accepts. It
+		// is output on the existing contract — unless the run must not treat it as
+		// a step in the pagination, which is decided by whether it declared
+		// success: a business code that is exactly 0. CheckResponse cannot make
+		// that call, it reads the code as a float, under which 0.5, 1e-324 and an
+		// absent field all become 0. The rule is asymmetric on purpose:
+		//   - a later page that did not declare success fails the run before it is
+		//     emitted or accumulated. The page before it promised more data, and
+		//     accepting this one — with or without a cursor of its own — would end
+		//     the run as complete over that promise, which is #2477.
+		//   - a first page that did not declare success but carries a continuation
+		//     token is refused before output. `api --page-all` is not restricted to
+		//     GET, and re-issuing the request for its cursor would replay a POST or a
+		//     DELETE against a page the loop could not read. Refusing with an
+		//     error, rather than outputting the page and stopping, is what gives
+		//     the streaming formats — which have no envelope to carry has_more — a
+		//     machine-readable signal that the run did not complete.
+		//   - a first page that did not declare success and carries no continuation
+		//     token is output on the existing contract: there is nothing to
+		//     paginate, and plain `api` would have shown the same response.
+		token := nextPageToken(result)
+		if !pageDeclaresSuccess(result) && (page > 1 || token != "") {
+			if page > 1 {
+				fmt.Fprintf(c.ErrOut, "[page %d] response did not declare success (code is missing, unreadable, or not exactly zero), stopping pagination\n", page)
+				return allResults, errs.NewInternalError(errs.SubtypeInvalidResponse,
+					"page %d of a --page-all run did not declare success (code is missing, unreadable, or not exactly zero)", page)
+			}
+			return allResults, errs.NewInternalError(errs.SubtypeInvalidResponse,
+				"the first page carries a continuation token but did not declare success (code is missing, unreadable, or not exactly zero)").
+				WithHint("%s", firstPageRecoveryHint(request.Method))
 		}
 
 		if onResult != nil {
@@ -431,20 +616,7 @@ func (c *APIClient) paginateLoop(ctx context.Context, request RawApiRequest, opt
 		}
 		allResults = append(allResults, result)
 
-		pageToken = ""
-		if resultMap, ok := result.(map[string]interface{}); ok {
-			if data, ok := resultMap["data"].(map[string]interface{}); ok {
-				hasMore, _ := data["has_more"].(bool)
-				if hasMore {
-					if pt, ok := data["page_token"].(string); ok && pt != "" {
-						pageToken = pt
-					} else if pt, ok := data["next_page_token"].(string); ok && pt != "" {
-						pageToken = pt
-					}
-				}
-			}
-		}
-
+		pageToken = token
 		if pageToken == "" {
 			break
 		}
@@ -479,9 +651,11 @@ func (c *APIClient) PaginateAll(ctx context.Context, request RawApiRequest, opts
 
 // StreamPages fetches all pages and streams each page's list items via onItems.
 // Returns the last page result (for error checking), whether any list items were found,
-// and any network error. Use this for streaming formats (ndjson, table, csv).
+// and the error that ended the run — transport, HTTP status, business code, or a page
+// that did not declare success. Use this for streaming formats (ndjson, table, csv).
 func (c *APIClient) StreamPages(ctx context.Context, request RawApiRequest, onItems func([]interface{}) error, opts PaginationOptions) (result interface{}, hasItems bool, err error) {
 	totalItems := 0
+	emittedPages := 0
 	results, loopErr := c.paginateLoop(ctx, request, opts, func(r interface{}) error {
 		resultMap, ok := r.(map[string]interface{})
 		if !ok {
@@ -499,17 +673,36 @@ func (c *APIClient) StreamPages(ctx context.Context, request RawApiRequest, onIt
 		if !ok {
 			return nil
 		}
-		totalItems += len(items)
+		// Counted only after onItems accepts them. onItems is what actually
+		// writes the page out, and it can refuse — counting first would let the
+		// failure summary claim items that never reached stdout, in precisely
+		// the run where the caller is relying on that number.
 		if err := onItems(items); err != nil {
 			return err
 		}
+		totalItems += len(items)
+		emittedPages++
 		hasItems = true
 		return nil
 	})
 	if loopErr != nil {
+		// Streaming formats have already written the pages that succeeded, so the
+		// exit code says the run is incomplete and this line says how far it got.
+		// Worded apart from the success summary so the two are never confused.
+		//
+		// emittedPages, not len(results): a page whose data carries no array
+		// field is fetched and accumulated but never offered to onItems, so it
+		// put nothing on stdout and must not be counted here.
+		if hasItems {
+			fmt.Fprintf(c.ErrOut, "[pagination] streamed %d pages, %d total items before the run failed\n", emittedPages, totalItems)
+		}
 		return nil, false, loopErr
 	}
 
+	// Deliberately still len(results): this line predates this change and reads
+	// as "the run traversed N pages", which is true. Switching it to
+	// emittedPages would alter established output outside the scope of the
+	// failure semantics being fixed here. Unifying the two is a separate call.
 	if hasItems {
 		fmt.Fprintf(c.ErrOut, "[pagination] streamed %d pages, %d total items\n", len(results), totalItems)
 	}

--- a/internal/client/pagination.go
+++ b/internal/client/pagination.go
@@ -13,9 +13,19 @@ import (
 
 // PaginationOptions contains pagination control options.
 type PaginationOptions struct {
-	PageLimit int           // max pages to fetch; 0 = unlimited (default: 10)
-	PageDelay int           // ms, default 200
-	Identity  core.Identity // identity passed to checkErr; defaults to AsUser when empty
+	PageLimit int // max pages to fetch; 0 = unlimited (default: 10)
+	// PageDelay is the pause between pages in ms. Zero means "unset" and takes
+	// the 200ms default, so a caller that wants no pause at all — tests, mostly —
+	// passes a negative value: the loop sleeps only when the resolved delay is
+	// positive.
+	PageDelay int
+	// Identity is used when a later page's non-zero code is turned into a typed
+	// error. It is optional: paginateLoop falls back to the request's own
+	// identity and finally to AsUser, treating AsAuto as unresolved, so a caller
+	// that leaves it empty still classifies a bot's failure as a bot's. Setting
+	// it is only necessary to classify as something other than the identity the
+	// request was sent with.
+	Identity core.Identity
 }
 
 func mergePagedResults(w io.Writer, results []interface{}) interface{} {

--- a/internal/client/pagination_failure_test.go
+++ b/internal/client/pagination_failure_test.go
@@ -1,0 +1,555 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/core"
+)
+
+// pageSeqTransport replays responders in order, one per request. It lets a test
+// make page 1 succeed and page 2 fail, which is the shape this file is about.
+func pageSeqTransport(responders ...func() (*http.Response, error)) http.RoundTripper {
+	i := 0
+	return roundTripFunc(func(*http.Request) (*http.Response, error) {
+		if i >= len(responders) {
+			return nil, errors.New("unexpected extra request")
+		}
+		r := responders[i]
+		i++
+		return r()
+	})
+}
+
+// firstPageHasMore is a successful page 1 that advertises a next page, so the
+// loop is guaranteed to attempt page 2.
+func firstPageHasMore() (*http.Response, error) {
+	return jsonResponse(map[string]interface{}{
+		"code": 0, "msg": "ok",
+		"data": map[string]interface{}{
+			"items":      []interface{}{map[string]interface{}{"id": "first"}},
+			"has_more":   true,
+			"page_token": "tok-2",
+		},
+	}), nil
+}
+
+// errSimulatedTransport is a stable sentinel so the tests can assert the
+// transport error is carried through the pagination loop rather than merely
+// classified as a network failure — the loop must not swallow the cause.
+var errSimulatedTransport = errors.New("simulated transport failure")
+
+func transportFailure() (*http.Response, error) {
+	return nil, errSimulatedTransport
+}
+
+func TestPaginateAll_LaterPageTransportErrorPropagates(t *testing.T) {
+	ac, _ := newTestAPIClient(t, pageSeqTransport(firstPageHasMore, transportFailure))
+
+	_, err := ac.PaginateAll(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test",
+		As:     "bot",
+	}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+
+	if err == nil {
+		t.Fatal("PaginateAll() error = nil, want transport error from page 2")
+	}
+	if got := errs.CategoryOf(err); got != errs.CategoryNetwork {
+		t.Errorf("errs.CategoryOf(err) = %q, want %q", got, errs.CategoryNetwork)
+	}
+	if !errors.Is(err, errSimulatedTransport) {
+		t.Errorf("errors.Is(err, errSimulatedTransport) = false; cause was not preserved; err = %v", err)
+	}
+}
+
+func TestStreamPages_LaterPageTransportErrorPropagates(t *testing.T) {
+	ac, _ := newTestAPIClient(t, pageSeqTransport(firstPageHasMore, transportFailure))
+
+	_, _, err := ac.StreamPages(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test",
+		As:     "bot",
+	}, func([]interface{}) error { return nil },
+		PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+
+	if err == nil {
+		t.Fatal("StreamPages() error = nil, want transport error from page 2")
+	}
+	if got := errs.CategoryOf(err); got != errs.CategoryNetwork {
+		t.Errorf("errs.CategoryOf(err) = %q, want %q", got, errs.CategoryNetwork)
+	}
+	if !errors.Is(err, errSimulatedTransport) {
+		t.Errorf("errors.Is(err, errSimulatedTransport) = false; cause was not preserved; err = %v", err)
+	}
+}
+
+// businessFailure builds a page that failed with a non-zero business code.
+// Such a page carries no data object, which is why the merged view used to
+// report has_more=false and hide the failure.
+func businessFailure(code int, msg string) func() (*http.Response, error) {
+	return func() (*http.Response, error) {
+		return jsonResponse(map[string]interface{}{"code": code, "msg": msg}), nil
+	}
+}
+
+// Unknown codes fall through errclass's codemeta table into CategoryAPI.
+func TestPaginateAll_LaterPageUnknownBusinessCodePropagates(t *testing.T) {
+	ac, _ := newTestAPIClient(t, pageSeqTransport(
+		firstPageHasMore, businessFailure(999999, "fixture unknown error")))
+
+	_, err := ac.PaginateAll(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test",
+		As:     "bot",
+	}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+
+	if err == nil {
+		t.Fatal("PaginateAll() error = nil, want business error from page 2")
+	}
+	if got := errs.CategoryOf(err); got != errs.CategoryAPI {
+		t.Errorf("errs.CategoryOf(err) = %q, want %q", got, errs.CategoryAPI)
+	}
+
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("errs.ProblemOf(err) = _, false; want a typed problem; err = %T: %v", err, err)
+	}
+	if p.Subtype != errs.SubtypeUnknown {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeUnknown)
+	}
+}
+
+// 230027 is in the codemeta table, so it classifies as authorization.
+//
+// The point of this case is the comparison in its name, so it runs both pages
+// rather than asserting a hardcoded pair and calling that "matches page 1".
+// Page 1 reaches its classification through the command layer: the loop hands
+// back (failing page, nil) and CheckResponse turns it into the typed error.
+// A later page is classified inside the loop. Both must land on the same
+// category and subtype, or --page-all would report the same API failure
+// differently depending on which page it arrived on.
+func TestPaginateAll_LaterPageKnownBusinessCodeMatchesPageOneClassification(t *testing.T) {
+	const code, msg = 230027, "user not authorized"
+	opts := PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"}
+	req := RawApiRequest{Method: "GET", URL: "/open-apis/test", As: "bot"}
+
+	laterAC, _ := newTestAPIClient(t, pageSeqTransport(firstPageHasMore, businessFailure(code, msg)))
+	_, laterErr := laterAC.PaginateAll(context.Background(), req, opts)
+	if laterErr == nil {
+		t.Fatal("PaginateAll() error = nil, want business error from page 2")
+	}
+
+	firstAC, _ := newTestAPIClient(t, pageSeqTransport(businessFailure(code, msg)))
+	firstResult, err := firstAC.PaginateAll(context.Background(), req, opts)
+	if err != nil {
+		t.Fatalf("PaginateAll() on a failing page 1 = %v, want nil so the command layer can dump the raw response", err)
+	}
+	firstErr := firstAC.CheckResponse(firstResult, opts.Identity)
+	if firstErr == nil {
+		t.Fatal("CheckResponse() on a failing page 1 = nil, want the typed error the command layer reports")
+	}
+
+	if got, want := errs.CategoryOf(laterErr), errs.CategoryOf(firstErr); got != want {
+		t.Errorf("category: later page = %q, page 1 = %q; want identical", got, want)
+	}
+	if got := errs.CategoryOf(laterErr); got != errs.CategoryAuthorization {
+		t.Errorf("errs.CategoryOf(laterErr) = %q, want %q", got, errs.CategoryAuthorization)
+	}
+
+	laterP, ok := errs.ProblemOf(laterErr)
+	if !ok {
+		t.Fatalf("errs.ProblemOf(laterErr) = _, false; want a typed problem; err = %T: %v", laterErr, laterErr)
+	}
+	firstP, ok := errs.ProblemOf(firstErr)
+	if !ok {
+		t.Fatalf("errs.ProblemOf(firstErr) = _, false; want a typed problem; err = %T: %v", firstErr, firstErr)
+	}
+	if laterP.Subtype != firstP.Subtype {
+		t.Errorf("subtype: later page = %q, page 1 = %q; want identical", laterP.Subtype, firstP.Subtype)
+	}
+	if laterP.Subtype != errs.SubtypeUserUnauthorized {
+		t.Errorf("subtype = %q, want %q", laterP.Subtype, errs.SubtypeUserUnauthorized)
+	}
+}
+
+// The streaming path already surfaced non-zero codes before this change (the
+// failing page was appended and returned as the last result, where the command
+// layer's CheckResponse caught it). This case locks that behaviour against
+// regression now that the error is built inside the loop instead.
+//
+// The "[pagination] streamed N pages" summary has its own case below; this one
+// stays scoped to the error the caller receives.
+func TestStreamPages_LaterPageKnownBusinessCodePropagates(t *testing.T) {
+	ac, _ := newTestAPIClient(t, pageSeqTransport(
+		firstPageHasMore, businessFailure(230027, "user not authorized")))
+
+	_, _, err := ac.StreamPages(context.Background(), RawApiRequest{
+		Method: "GET",
+		URL:    "/open-apis/test",
+		As:     "bot",
+	}, func([]interface{}) error { return nil },
+		PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+
+	if err == nil {
+		t.Fatal("StreamPages() error = nil, want business error from page 2")
+	}
+	if got := errs.CategoryOf(err); got != errs.CategoryAuthorization {
+		t.Errorf("errs.CategoryOf(err) = %q, want %q", got, errs.CategoryAuthorization)
+	}
+}
+
+// statusResponse builds a page with an explicit HTTP status and a raw body,
+// which jsonResponse cannot express (it hardcodes 200 and marshals a value).
+func statusResponse(status int, body string) func() (*http.Response, error) {
+	return func() (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	}
+}
+
+// The [page N] progress lines are the only place the loop treats page 1 and a
+// later page differently on the failure path, and paginateLoop's comment names
+// that guard specifically. It has to be asserted here, on the client's own
+// ErrOut: the cmd-layer harnesses point ac.ErrOut at io.Discard, so the errOut
+// assertions there check the command's output and can never fail on this.
+func TestPaginateAll_StoppingLineIsLaterPagesOnly(t *testing.T) {
+	req := RawApiRequest{Method: "GET", URL: "/open-apis/test", As: "bot"}
+	opts := PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"}
+
+	t.Run("later page reports why it stopped", func(t *testing.T) {
+		ac, errBuf := newTestAPIClient(t, pageSeqTransport(firstPageHasMore, transportFailure))
+		if _, err := ac.PaginateAll(context.Background(), req, opts); err == nil {
+			t.Fatal("PaginateAll() error = nil, want transport error from page 2")
+		}
+		if want := "[page 2] error, stopping pagination"; !strings.Contains(errBuf.String(), want) {
+			t.Errorf("ErrOut = %q, want it to contain %q", errBuf.String(), want)
+		}
+	})
+
+	t.Run("page 1 does not, having stopped nothing", func(t *testing.T) {
+		ac, errBuf := newTestAPIClient(t, pageSeqTransport(transportFailure))
+		if _, err := ac.PaginateAll(context.Background(), req, opts); err == nil {
+			t.Fatal("PaginateAll() error = nil, want transport error from page 1")
+		}
+		if strings.Contains(errBuf.String(), "stopping pagination") {
+			t.Errorf("ErrOut = %q, want no \"stopping pagination\" line for a page-1 failure", errBuf.String())
+		}
+	})
+}
+
+// A body that claims to be JSON is decoded by the SDK inside DoAPI, which fails
+// there and returns no response — so these never reach callPage's parse branch
+// and stay internal errors. Only a body whose Content-Type is not JSON gets that
+// far with its status intact; that case is covered by
+// TestPaginateAll_LaterPageHTTPErrorIsClassifiedByStatus, and the two
+// together are what separate the paths.
+//
+// The Content-Type is the whole distinction, so both fixtures here declare
+// application/json deliberately.
+func TestPaginateAll_UnparseableJSONLaterPageFailsInsideDoAPI(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"truncated JSON on 200", 200, `{"code":0,`},
+		{"HTML on 502", 502, `<html>Bad Gateway</html>`},
+		{"code is a string", 200, `{"code":"230027","msg":"user not authorized"}`},
+		{"code is an object", 200, `{"code":{},"msg":"nonsense"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ac, _ := newTestAPIClient(t, pageSeqTransport(
+				firstPageHasMore, statusResponse(tc.status, tc.body)))
+
+			_, err := ac.PaginateAll(context.Background(), RawApiRequest{
+				Method: "GET", URL: "/open-apis/test", As: "bot",
+			}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+
+			if err == nil {
+				t.Fatal("PaginateAll() error = nil, want an unparseable page 2 to fail")
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("errs.ProblemOf(err) = _, false; want a typed problem; err = %T: %v", err, err)
+			}
+			if p.Subtype != errs.SubtypeInvalidResponse {
+				t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeInvalidResponse)
+			}
+		})
+	}
+}
+
+// ctResponse builds a page with an explicit Content-Type. statusResponse always
+// says application/json, and that difference is load-bearing: the SDK decodes a
+// body only when it claims to be JSON, so the Content-Type decides whether an
+// unparseable page fails inside DoAPI or reaches callPage with its status still
+// readable. A fixture that only ever says application/json cannot see the
+// difference — which is how the misclassification below went unnoticed.
+func ctResponse(status int, contentType, body string) func() (*http.Response, error) {
+	return func() (*http.Response, error) {
+		h := http.Header{}
+		if contentType != "" {
+			h.Set("Content-Type", contentType)
+		}
+		return &http.Response{
+			StatusCode: status,
+			Header:     h,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	}
+}
+
+// The classification a later page's failure gets must match the identity the
+// request was actually sent with. An empty opts.Identity is not neutral:
+// errclass rewrites it to "user" and the bot then receives the user-facing
+// recovery text instead of the app-console scope guidance it needs.
+//
+// The command entry points happen to fill Identity today, so this asserts the
+// contract at the layer that owns CheckResponse rather than at the layer that
+// currently happens to protect it.
+func TestPaginateAll_LaterPageErrorKeepsRequestIdentityWhenOptsOmitsIt(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		optsID    core.Identity
+		requestAs core.Identity
+		want      core.Identity
+	}{
+		{"opts empty falls back to the request", "", core.AsBot, core.AsBot},
+		{"opts auto is treated as unresolved", core.AsAuto, core.AsBot, core.AsBot},
+		{"opts wins when it is a real identity", core.AsUser, core.AsBot, core.AsUser},
+		{"both unset lands on user", "", "", core.AsUser},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ac, _ := newTestAPIClient(t, pageSeqTransport(
+				firstPageHasMore, businessFailure(230027, "user not authorized")))
+
+			_, err := ac.PaginateAll(context.Background(), RawApiRequest{
+				Method: "GET", URL: "/open-apis/test", As: tc.requestAs,
+			}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: tc.optsID})
+
+			if err == nil {
+				t.Fatal("PaginateAll() error = nil, want business error from page 2")
+			}
+			var perm *errs.PermissionError
+			if !errors.As(err, &perm) {
+				t.Fatalf("error is %T, want *errs.PermissionError; err = %v", err, err)
+			}
+			if core.Identity(perm.Identity) != tc.want {
+				t.Errorf("PermissionError.Identity = %q, want %q", perm.Identity, tc.want)
+			}
+		})
+	}
+}
+
+func TestStreamPages_LaterPageErrorKeepsRequestIdentityWhenOptsOmitsIt(t *testing.T) {
+	ac, _ := newTestAPIClient(t, pageSeqTransport(
+		firstPageHasMore, businessFailure(230027, "user not authorized")))
+
+	_, _, err := ac.StreamPages(context.Background(), RawApiRequest{
+		Method: "GET", URL: "/open-apis/test", As: core.AsBot,
+	}, func([]interface{}) error { return nil },
+		PaginationOptions{PageLimit: 0, PageDelay: -1})
+
+	if err == nil {
+		t.Fatal("StreamPages() error = nil, want business error from page 2")
+	}
+	var perm *errs.PermissionError
+	if !errors.As(err, &perm) {
+		t.Fatalf("error is %T, want *errs.PermissionError; err = %v", err, err)
+	}
+	if core.Identity(perm.Identity) != core.AsBot {
+		t.Errorf("PermissionError.Identity = %q, want %q", perm.Identity, core.AsBot)
+	}
+}
+
+// The business code is consulted first and the HTTP status classifies whatever
+// it leaves behind: a 5xx carrying no code, or one whose body still says code 0.
+//
+// Content-Type decides which layer sees the failure. The SDK decodes only a body
+// it believes is JSON, so a text/html gateway page reaches the loop with its
+// status intact; reporting that as a decode failure would exit 5 where plain
+// `api` exits 4. The fixtures declare Content-Type explicitly rather than taking
+// a helper default, because that default is what once hid this.
+//
+// Which guard catches a row is itself Content-Type-dependent: the rows that
+// declare a non-JSON type are taken by callPage before it parses anything, and
+// the row with no Content-Type at all is the one that still reaches the
+// parse-failure branch. Both are asserted here because both must classify by
+// status.
+func TestPaginateAll_LaterPageHTTPErrorIsClassifiedByStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		wantCat     errs.Category
+	}{
+		{"502 JSON without a code", 502, "application/json", `{"msg":"Bad Gateway"}`, errs.CategoryNetwork},
+		{"500 JSON still saying code 0", 500, "application/json", `{"code":0,"msg":"ok"}`, errs.CategoryNetwork},
+		{"404 JSON still saying code 0", 404, "application/json", `{"code":0,"msg":"ok"}`, errs.CategoryAPI},
+		{"502 text/html", 502, "text/html", `<html>Bad Gateway</html>`, errs.CategoryNetwork},
+		{"502 text/plain", 502, "text/plain", `Bad Gateway`, errs.CategoryNetwork},
+		{"502 with no Content-Type", 502, "", `<html>Bad Gateway</html>`, errs.CategoryNetwork},
+		{"404 text/html", 404, "text/html", `<html>Not Found</html>`, errs.CategoryAPI},
+		// 504 is deliberately absent: the SDK maps it to a server timeout inside
+		// DoAPI, so it never reaches this branch and a case for it would pass
+		// whether or not the branch exists.
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ac, _ := newTestAPIClient(t, pageSeqTransport(
+				firstPageHasMore, ctResponse(tc.status, tc.contentType, tc.body)))
+
+			_, err := ac.PaginateAll(context.Background(), RawApiRequest{
+				Method: "GET", URL: "/open-apis/test", As: "bot",
+			}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+
+			if err == nil {
+				t.Fatalf("PaginateAll() error = nil, want HTTP %d from page 2", tc.status)
+			}
+			if got := errs.CategoryOf(err); got != tc.wantCat {
+				t.Errorf("errs.CategoryOf(err) = %q, want %q", got, tc.wantCat)
+			}
+		})
+	}
+}
+
+// The parity this change claims is that `api GET <url>` and the same command
+// with --page-all classify one response identically. A failed response that
+// declares a non-JSON body is where the two paths could drift: HandleResponse
+// refuses to read a business code out of it, callPage used to read one anyway,
+// and a 403 text/plain carrying 230027 then exited 3 paginated and 1 plain.
+// Asserting against HandleResponse rather than a hardcoded category pins the
+// two paths to each other, so a later change to either one fails here.
+func TestPaginateAll_NonJSONErrorPageMatchesPlainAPIClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+	}{
+		{"403 text/plain carrying a business code", 403, "text/plain", `{"code":230027,"msg":"user not authorized"}`},
+		{"502 text/html gateway page", 502, "text/html", `<html>Bad Gateway</html>`},
+		{"404 text/plain still saying code 0", 404, "text/plain", `{"code":0,"msg":"ok"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			h.Set("Content-Type", tc.contentType)
+			var out, errOut bytes.Buffer
+			plainErr := HandleResponse(&larkcore.ApiResp{
+				StatusCode: tc.status, Header: h, RawBody: []byte(tc.body),
+			}, ResponseOptions{Identity: core.AsBot, Out: &out, ErrOut: &errOut})
+			if plainErr == nil {
+				t.Fatal("HandleResponse() error = nil; the fixture must fail on both paths for the comparison to mean anything")
+			}
+
+			ac, _ := newTestAPIClient(t, pageSeqTransport(
+				firstPageHasMore, ctResponse(tc.status, tc.contentType, tc.body)))
+			_, pageErr := ac.PaginateAll(context.Background(), RawApiRequest{
+				Method: "GET", URL: "/open-apis/test", As: "bot",
+			}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+			if pageErr == nil {
+				t.Fatalf("PaginateAll() error = nil, want HTTP %d from page 2", tc.status)
+			}
+
+			if got, want := errs.CategoryOf(pageErr), errs.CategoryOf(plainErr); got != want {
+				t.Errorf("--page-all category = %q, plain api = %q; one response must not exit two ways", got, want)
+			}
+			if got, want := pageErr.Error(), plainErr.Error(); got != want {
+				t.Errorf("--page-all error = %q, plain api = %q", got, want)
+			}
+		})
+	}
+}
+
+// Streaming formats have already written the pages that succeeded, so this line
+// is the only thing that says how much of stdout is real. It counts what onItems
+// accepted, not what the loop fetched: a page the callback refused and a page
+// whose data carries no array field both put nothing on stdout.
+func TestStreamPages_FailureSummaryCountsOnlyWhatWasEmitted(t *testing.T) {
+	fiveItems := func() (*http.Response, error) {
+		items := make([]interface{}, 5)
+		for i := range items {
+			items[i] = map[string]interface{}{"id": "x"}
+		}
+		return jsonResponse(map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"items": items, "has_more": false},
+		}), nil
+	}
+	noArray := func() (*http.Response, error) {
+		return jsonResponse(map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"has_more": true, "page_token": "tok-3"},
+		}), nil
+	}
+	failing := businessFailure(230027, "user not authorized")
+
+	for _, tc := range []struct {
+		name         string
+		pages        []func() (*http.Response, error)
+		refuseOnPage int
+		wantStreamed int
+		wantLine     string
+	}{
+		{
+			name:         "page 2 fails outright",
+			pages:        []func() (*http.Response, error){firstPageHasMore, failing},
+			wantStreamed: 1,
+			wantLine:     "[pagination] streamed 1 pages, 1 total items before the run failed",
+		},
+		{
+			name:         "the writer refuses page 2's five items",
+			pages:        []func() (*http.Response, error){firstPageHasMore, fiveItems},
+			refuseOnPage: 2,
+			wantStreamed: 1,
+			wantLine:     "[pagination] streamed 1 pages, 1 total items before the run failed",
+		},
+		{
+			name:         "page 2 emits nothing, page 3 fails",
+			pages:        []func() (*http.Response, error){firstPageHasMore, noArray, failing},
+			wantStreamed: 1,
+			wantLine:     "[pagination] streamed 1 pages, 1 total items before the run failed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ac, errBuf := newTestAPIClient(t, pageSeqTransport(tc.pages...))
+			var streamed []interface{}
+			seen := 0
+			_, _, err := ac.StreamPages(context.Background(), RawApiRequest{
+				Method: "GET", URL: "/open-apis/test", As: "bot",
+			}, func(items []interface{}) error {
+				seen++
+				if seen == tc.refuseOnPage {
+					return errors.New("writer refused the page")
+				}
+				streamed = append(streamed, items...)
+				return nil
+			}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+
+			if err == nil {
+				t.Fatal("StreamPages() error = nil, want the run to fail")
+			}
+			if len(streamed) != tc.wantStreamed {
+				t.Fatalf("onItems accepted %d items, want %d; got %#v", len(streamed), tc.wantStreamed, streamed)
+			}
+			if !strings.Contains(errBuf.String(), tc.wantLine) {
+				t.Errorf("ErrOut = %q, want it to contain %q", errBuf.String(), tc.wantLine)
+			}
+		})
+	}
+}

--- a/internal/client/pagination_rules_test.go
+++ b/internal/client/pagination_rules_test.go
@@ -1,0 +1,503 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/core"
+)
+
+// countingTransport replays responders in order and counts requests. Running out
+// of responders is a transport error, so a loop that issues one request too many
+// fails loudly instead of quietly succeeding.
+func countingTransport(responders ...func() (*http.Response, error)) (http.RoundTripper, *int) {
+	i, n := 0, 0
+	return roundTripFunc(func(*http.Request) (*http.Response, error) {
+		n++
+		if i >= len(responders) {
+			return nil, errors.New("loop issued a request past the last responder")
+		}
+		r := responders[i]
+		i++
+		return r()
+	}), &n
+}
+
+// codeShape is one spelling of the business code field. `zero` is whether the
+// loop may paginate from it; whether it is a business error is not declared
+// here but read from CheckResponse itself, so the table asserts parity with the
+// classifier rather than a hardcoded answer.
+type codeShape struct {
+	name  string
+	field string // the literal placed after `"code":`, or "" for no code field
+	zero  bool
+}
+
+// The rows cover every boundary a float would blur: spellings of 0, integers at
+// 2^53 and int64, fractions, underflow, out-of-range, and non-numbers.
+var codeShapes = []codeShape{
+	{"missing", "", false},
+	{"0", "0", true},
+	{"-0", "-0", true},
+	{"0.0", "0.0", true},
+	{"0e10", "0e10", true},
+	{"230027", "230027", false},
+	{"230027.0", "230027.0", false},
+	{"230027.5", "230027.5", false},
+	{"999999", "999999", false},
+	{"2^53+1 as decimal", "9007199254740993.0", false},
+	{"int64 max", "9223372036854775807", false},
+	{"int64+1", "9223372036854775808", false},
+	{"null", "null", false},
+	{"string", `"230027"`, false},
+	{"object", "{}", false},
+	{"0.5", "0.5", false},
+	{"1e-324", "1e-324", false},
+	{"-1e-400", "-1e-400", false},
+	{"1e20", "1e20", false},
+	{"1e999", "1e999", false},
+}
+
+// pageVariants are the shapes a page's data can take, independent of its code.
+// The two cursor variants pin both supported field names; following either is
+// observable as an extra request. "terminal" is a list that ends the run;
+// "bare" has no data at all — the shape a failed later page most often has, and
+// the one a rule that only looks at cursors misses.
+var pageVariants = []string{"cursor", "next cursor", "terminal", "bare"}
+
+type shapeVariant struct {
+	shape   codeShape
+	variant string
+}
+
+// shapeVariants is the cross product of codeShapes and pageVariants.
+func shapeVariants() []shapeVariant {
+	var out []shapeVariant
+	for _, v := range pageVariants {
+		for _, sh := range codeShapes {
+			out = append(out, shapeVariant{sh, v})
+		}
+	}
+	return out
+}
+
+// body builds a page for a shape and a data variant.
+func (s codeShape) body(variant string) string {
+	var data string
+	switch variant {
+	case "cursor":
+		data = `,"data":{"items":[{"id":"x"}],"has_more":true,"page_token":"next"}`
+	case "next cursor":
+		data = `,"data":{"items":[{"id":"x"}],"has_more":true,"next_page_token":"next"}`
+	case "terminal":
+		data = `,"data":{"items":[{"id":"x"}],"has_more":false}`
+	case "bare":
+		data = ``
+	default:
+		panic("unknown variant " + variant)
+	}
+	if s.field == "" {
+		return `{"msg":"m"` + data + `}`
+	}
+	return `{"code":` + s.field + `,"msg":"m"` + data + `}`
+}
+
+// parsed decodes a terminal body the way ParseJSONResponse does.
+func (s codeShape) parsed(t *testing.T) interface{} {
+	t.Helper()
+	var v interface{}
+	dec := json.NewDecoder(strings.NewReader(s.body("terminal")))
+	dec.UseNumber()
+	if err := dec.Decode(&v); err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+// statusCategory is what httpStatusError assigns a status, read from the
+// function rather than restated here.
+func statusCategory(status int) errs.Category {
+	return errs.CategoryOf(httpStatusError(status, nil))
+}
+
+// The success check's contract: a JSON number is zero only if every mantissa
+// digit is 0. This is what separates "may paginate" from "may not", so it is
+// pinned per literal.
+func TestPageDeclaresSuccess(t *testing.T) {
+	for _, sh := range codeShapes {
+		t.Run(sh.name, func(t *testing.T) {
+			if got := pageDeclaresSuccess(sh.parsed(t)); got != sh.zero {
+				t.Errorf("pageDeclaresSuccess(code=%s) = %v, want %v", sh.field, got, sh.zero)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name string
+		v    interface{}
+		want bool
+	}{
+		{"not an object", []interface{}{}, false},
+		{"JSON null page", nil, false},
+		{"Go int 0", map[string]interface{}{"code": 0}, true},
+		{"Go int 7", map[string]interface{}{"code": 7}, false},
+		{"Go float64 0", map[string]interface{}{"code": 0.0}, true},
+		{"zero mantissa, absurd exponent", map[string]interface{}{"code": json.Number("0e1000000")}, true},
+		{"nonzero mantissa, absurd exponent", map[string]interface{}{"code": json.Number("1e1000000")}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pageDeclaresSuccess(tc.v); got != tc.want {
+				t.Errorf("pageDeclaresSuccess(%v) = %v, want %v", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+// The pagination rule as a decision table. Every cell's expected outcome is
+// derived from three facts — what CheckResponse says about the body, the HTTP
+// status, and whether the page is the first — never written per row, so the
+// test states the rule once and checks the loop follows it everywhere:
+//
+//  1. CheckResponse classifies the body first, exactly as HandleResponse does
+//     for plain `api`; a business error wins over the status.
+//  2. Otherwise an HTTP status of 400 or more classifies the page.
+//  3. Otherwise, whether the page is a step in the pagination is decided by
+//     whether its code is exactly 0 — and the rule is asymmetric on purpose:
+//     a later page that is not fails the run before it is emitted; a first
+//     page that is not and carries a continuation token is refused before output;
+//     a first page that is not and carries no continuation token is output on the
+//     existing contract, because there is nothing to paginate.
+//  4. A page that is a step is emitted, accumulated, and its cursor followed.
+//  5. Page position decides only how a failure from 1 or 2 is reported: page 1
+//     is handed back whole with a nil error for the command layer to classify;
+//     a later page fails the run.
+//
+// Every shape runs with both cursor field names, as a terminal list, and with no
+// data at all, so the table sees the failed-page-without-data case a cursor-only
+// rule misses, and the request count proves rule 4 in both directions. Both
+// entry points run the same rows.
+func TestPagination_DecisionTable(t *testing.T) {
+	req := RawApiRequest{Method: "POST", URL: "/open-apis/test", As: "bot"}
+	opts := PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"}
+
+	for _, mode := range []string{"PaginateAll", "StreamPages"} {
+		for _, first := range []bool{true, false} {
+			for _, status := range []int{200, 403, 502} {
+				for _, sv := range shapeVariants() {
+					sh, variant := sv.shape, sv.variant
+					position := "page1"
+					if !first {
+						position = "page2"
+					}
+					t.Run(fmt.Sprintf("%s/%s/%d/%s/%s", mode, position, status, variant, sh.name), func(t *testing.T) {
+						var responders []func() (*http.Response, error)
+						if !first {
+							responders = append(responders, firstPageHasMore)
+						}
+						responders = append(responders, ctResponse(status, "", sh.body(variant)))
+						responders = append(responders, ctResponse(200, "application/json",
+							`{"code":0,"data":{"items":[{"id":"after"}],"has_more":false}}`)) // reached only by following the cursor
+						rt, reqs := countingTransport(responders...)
+						ac, _ := newTestAPIClient(t, rt)
+
+						// the classifier's own verdict on this body — the oracle for step 1
+						bizErr := ac.CheckResponse(sh.parsed(t), "bot")
+
+						callbacks := 0
+						var result interface{}
+						var err error
+						if mode == "PaginateAll" {
+							result, err = ac.PaginateAll(context.Background(), req, opts)
+						} else {
+							result, _, err = ac.StreamPages(context.Background(), req,
+								func([]interface{}) error { callbacks++; return nil }, opts)
+						}
+
+						pageIndex := 1
+						if !first {
+							pageIndex = 2
+						}
+						hasCursor := variant == "cursor" || variant == "next cursor"
+						hasItems := variant != "bare"
+						classified := bizErr == nil && status < 400                // rules 1-2 passed
+						refused := classified && !sh.zero && (!first || hasCursor) // rule 3: not a step, not output
+						isOutput := classified && !refused                         // rules 3-4: output on the existing contract
+						cursorFollowed := isOutput && sh.zero && hasCursor         // rule 4
+
+						// ---- requests: only a zero page's cursor is followed ----
+						wantReqs := pageIndex
+						if cursorFollowed {
+							wantReqs++
+						}
+						if *reqs != wantReqs {
+							t.Errorf("requests = %d, want %d", *reqs, wantReqs)
+						}
+
+						// ---- callbacks: an output page with items is emitted; nothing else is ----
+						if mode == "StreamPages" {
+							wantCallbacks := pageIndex - 1 // the good first page, on page-2 rows
+							if isOutput && hasItems {
+								wantCallbacks++
+							}
+							if cursorFollowed {
+								wantCallbacks++ // the page after the cursor
+							}
+							if callbacks != wantCallbacks {
+								t.Errorf("callbacks = %d, want %d", callbacks, wantCallbacks)
+							}
+						}
+
+						// ---- outcome, by the rule ----
+						switch {
+						case bizErr != nil: // step 1: business error wins
+							if first {
+								if err != nil {
+									t.Fatalf("page 1 error = %v, want nil so the command layer can dump and classify it", err)
+								}
+								err = ac.CheckResponse(result, "bot")
+							}
+							wp, _ := errs.ProblemOf(bizErr)
+							gp, ok := errs.ProblemOf(err)
+							if !ok || gp.Category != wp.Category || gp.Code != wp.Code {
+								t.Errorf("classified as %v, want the classifier's own %s/%d", err, wp.Category, wp.Code)
+							}
+
+						case status >= 400: // step 2: status
+							if got, want := errs.CategoryOf(err), statusCategory(status); err == nil || got != want {
+								t.Errorf("error = %v (category %q), want HTTP %d as %q", err, got, status, want)
+							}
+
+						case refused: // rule 3: not a step in the pagination
+							p, ok := errs.ProblemOf(err)
+							if !ok || p.Subtype != errs.SubtypeInvalidResponse {
+								t.Fatalf("error = %v, want %s: a page that did not declare success is neither a continuation nor a page to paginate from", err, errs.SubtypeInvalidResponse)
+							}
+							// ERROR_CONTRACT: Message says what is wrong, Hint says what to do
+							// next, and the two are not merged. A refused first page is the
+							// one place the loop has a next step to offer.
+							if first {
+								if p.Hint == "" {
+									t.Errorf("Hint = %q, want a safe recovery step", p.Hint)
+								}
+							} else if p.Hint != "" {
+								t.Errorf("Hint = %q, want none for a failed later page", p.Hint)
+							}
+							if strings.Contains(strings.ToLower(p.Message), "run without") || strings.HasSuffix(p.Message, ".") {
+								t.Errorf("Message = %q, want no recovery step and no trailing period in it", p.Message)
+							}
+
+						default: // rules 3-4: output on the existing contract; the run ends without error
+							if err != nil {
+								t.Fatalf("error = %v, want nil: the page passed classification and needs no pagination", err)
+							}
+							if err := ac.CheckResponse(result, "bot"); err != nil {
+								t.Errorf("command-layer CheckResponse = %v, want nil: plain api accepts this body", err)
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+// Refusing a first page that did not declare success is a property of the page,
+// not of how many pages the caller allowed. Keep the admission check ahead of
+// the page-limit stop so --page-limit 1 cannot turn a response carrying a
+// continuation token into a successful run or expose a write request to replay
+// later.
+func TestPagination_FirstPageRefusalPrecedesPageLimit(t *testing.T) {
+	const body = `{"code":0.5,"data":{"items":[{"id":"x"}],"has_more":true,"page_token":"next"}}`
+	for _, mode := range []string{"PaginateAll", "StreamPages"} {
+		t.Run(mode, func(t *testing.T) {
+			rt, reqs := countingTransport(ctResponse(200, "", body))
+			ac, _ := newTestAPIClient(t, rt)
+			req := RawApiRequest{Method: "POST", URL: "/open-apis/test", As: "bot"}
+			opts := PaginationOptions{PageLimit: 1, PageDelay: -1, Identity: "bot"}
+
+			callbacks := 0
+			var err error
+			if mode == "PaginateAll" {
+				_, err = ac.PaginateAll(context.Background(), req, opts)
+			} else {
+				_, _, err = ac.StreamPages(context.Background(), req, func([]interface{}) error {
+					callbacks++
+					return nil
+				}, opts)
+			}
+
+			p, ok := errs.ProblemOf(err)
+			if !ok || p.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("error = %v, want %s", err, errs.SubtypeInvalidResponse)
+			}
+			if *reqs != 1 {
+				t.Errorf("requests = %d, want 1", *reqs)
+			}
+			if callbacks != 0 {
+				t.Errorf("callbacks = %d, want 0", callbacks)
+			}
+		})
+	}
+}
+
+func TestFirstPageRecoveryHint(t *testing.T) {
+	tests := []struct {
+		method string
+		want   string
+	}{
+		{http.MethodGet, "remove `--page-all` and `--jq`; use `--output <path>` to save the raw response"},
+		{"get", "remove `--page-all` and `--jq`; use `--output <path>` to save the raw response"},
+		{http.MethodHead, "remove `--page-all` and `--jq`; use `--output <path>` to save the raw response"},
+		{http.MethodPost, "verify whether the first request changed remote state before retrying it"},
+		{http.MethodPut, "verify whether the first request changed remote state before retrying it"},
+		{http.MethodPatch, "verify whether the first request changed remote state before retrying it"},
+		{http.MethodDelete, "verify whether the first request changed remote state before retrying it"},
+		{"CUSTOM", "verify whether the first request changed remote state before retrying it"},
+		{"", "verify whether the first request changed remote state before retrying it"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.method, func(t *testing.T) {
+			if got := firstPageRecoveryHint(tc.method); got != tc.want {
+				t.Errorf("firstPageRecoveryHint(%q) = %q, want %q", tc.method, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNextPageTokenReturnsAlternateCursor(t *testing.T) {
+	result := map[string]interface{}{
+		"data": map[string]interface{}{
+			"has_more":        true,
+			"next_page_token": "next",
+		},
+	}
+	if got := nextPageToken(result); got != "next" {
+		t.Errorf("nextPageToken() = %q, want %q", got, "next")
+	}
+}
+
+// A body that declares a non-JSON Content-Type is not a page, whatever its
+// bytes say, because that is the rule HandleResponse applies: plain `api` saves
+// such a body as a download and never reads a code out of it. The loop must not
+// read one either — not to classify, and not to find a cursor and re-issue a
+// write for it.
+func TestPaginateAll_DeclaredNonJSONBodyIsNotAPage(t *testing.T) {
+	for _, body := range []string{
+		`{"code":0,"data":{"items":[{"id":"x"}],"has_more":true,"page_token":"next"}}`,
+		`{"code":230027,"msg":"user not authorized"}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			rt, reqs := countingTransport(ctResponse(200, "text/plain", body))
+			ac, _ := newTestAPIClient(t, rt)
+			_, err := ac.PaginateAll(context.Background(), RawApiRequest{
+				Method: "POST", URL: "/open-apis/test", As: "bot",
+			}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+			p, ok := errs.ProblemOf(err)
+			if !ok || p.Subtype != errs.SubtypeInvalidResponse {
+				t.Errorf("error = %v, want %s", err, errs.SubtypeInvalidResponse)
+			}
+			if *reqs != 1 {
+				t.Errorf("requests = %d, want 1: a non-JSON body must not yield a cursor", *reqs)
+			}
+		})
+	}
+}
+
+// The shared parser accepts one JSON value and nothing else. Trailing
+// whitespace is fine; a second value or garbage after the first is not, because
+// accepting the first value would let a truncated or concatenated body pass for
+// a complete page — cursor included.
+func TestParseJSONResponse_AcceptsExactlyOneValue(t *testing.T) {
+	const page = `{"code":0,"data":{"items":[],"has_more":true,"page_token":"next"}}`
+	for _, tc := range []struct {
+		name string
+		body string
+		ok   bool
+	}{
+		{"one value", page, true},
+		{"trailing newline", page + "\n", true},
+		{"trailing whitespace", page + " \t\r\n", true},
+		{"trailing garbage", page + "garbage", false},
+		{"second value", page + ` {"code":230027}`, false},
+		{"second value, no space", page + `{"code":230027}`, false},
+		{"truncated", `{"code":0,`, false},
+		{"empty", ``, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseJSONResponse(&larkcore.ApiResp{StatusCode: 200, Header: http.Header{}, RawBody: []byte(tc.body)})
+			if (err == nil) != tc.ok {
+				t.Errorf("ParseJSONResponse(%q) error = %v, want ok=%v", tc.body, err, tc.ok)
+			}
+		})
+	}
+}
+
+// The exit criterion stated directly: one response classifies the same way
+// through plain `api` and through `--page-all`. HandleResponse is the plain
+// path; a first page is the paginated one, followed by the CheckResponse call
+// apiPaginate makes on it. Success, category and error.code must all agree.
+//
+// The fixtures carry no Content-Type so that the SDK does not decode them inside
+// DoAPI (which would fail identically on both paths and prove nothing) and so
+// that callPage's non-JSON guard stays out of the way; the Content-Type
+// dimension has its own test.
+func TestPagination_FirstPageMatchesPlainAPI(t *testing.T) {
+	bodies := []string{
+		`null`, `[]`, `<html>Bad Gateway</html>`, `{"code":0,`,
+		`{"code":0,"data":{"items":[],"has_more":true,"page_token":"next"}}garbage`,
+		`{"code":0,"data":{"items":[],"has_more":true,"page_token":"next"}} {"code":230027}`,
+		"{\"code\":0,\"data\":{\"items\":[],\"has_more\":false}}\n",
+	}
+	for _, sh := range codeShapes {
+		// Parity is about one response, so the terminal and bare variants are
+		// compared: a page with a cursor is the decision table's business.
+		bodies = append(bodies, sh.body("terminal"), sh.body("bare"))
+	}
+	for _, status := range []int{200, 403, 502} {
+		for _, body := range bodies {
+			t.Run(fmt.Sprintf("%d/%s", status, body), func(t *testing.T) {
+				var out, errOut bytes.Buffer
+				plainErr := HandleResponse(&larkcore.ApiResp{
+					StatusCode: status, Header: http.Header{}, RawBody: []byte(body),
+				}, ResponseOptions{Identity: core.AsBot, Out: &out, ErrOut: &errOut})
+
+				ac, _ := newTestAPIClient(t, pageSeqTransport(ctResponse(status, "", body)))
+				result, pageErr := ac.PaginateAll(context.Background(), RawApiRequest{
+					Method: "GET", URL: "/open-apis/test", As: "bot",
+				}, PaginationOptions{PageLimit: 0, PageDelay: -1, Identity: "bot"})
+				if pageErr == nil {
+					pageErr = ac.CheckResponse(result, core.AsBot)
+				}
+
+				if (plainErr == nil) != (pageErr == nil) {
+					t.Fatalf("plain api error = %v, --page-all error = %v; one must not succeed where the other fails", plainErr, pageErr)
+				}
+				if plainErr == nil {
+					return
+				}
+				pp, pok := errs.ProblemOf(plainErr)
+				gp, gok := errs.ProblemOf(pageErr)
+				if !pok || !gok {
+					if plainErr.Error() != pageErr.Error() {
+						t.Errorf("plain api = %q, --page-all = %q", plainErr, pageErr)
+					}
+					return
+				}
+				if pp.Category != gp.Category || pp.Code != gp.Code {
+					t.Errorf("plain api = %s/%d, --page-all = %s/%d", pp.Category, pp.Code, gp.Category, gp.Code)
+				}
+			})
+		}
+	}
+}

--- a/internal/client/response.go
+++ b/internal/client/response.go
@@ -84,12 +84,12 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 
 	// Non-JSON error responses (e.g. 404 text/plain from gateway): return error
 	// directly instead of falling through to the binary-save path.
-	if resp.StatusCode >= 400 && !IsJSONContentType(ct) && ct != "" {
+	if resp.StatusCode >= 400 && !isJSONBody(ct) {
 		return httpStatusError(resp.StatusCode, resp.RawBody)
 	}
 
 	// JSON responses: always check for business errors before saving.
-	if IsJSONContentType(ct) || ct == "" {
+	if isJSONBody(ct) {
 		result, err := ParseJSONResponse(resp)
 		if err != nil {
 			// An unparseable / empty body on an HTTP error (common with a
@@ -184,6 +184,15 @@ func classifySaveErr(err error) error {
 
 // ── JSON helpers ──
 
+// isJSONBody is the one rule HandleResponse and the pagination loop share for
+// deciding whether a body is JSON at all: a declared non-JSON Content-Type is
+// not, whatever the bytes look like; a JSON Content-Type, or none, is. Both
+// paths must ask this question the same way, or one of them ends up reading a
+// business code out of a body the other treats as a download.
+func isJSONBody(ct string) bool {
+	return IsJSONContentType(ct) || ct == ""
+}
+
 // IsJSONContentType reports whether the Content-Type header indicates a JSON response.
 func IsJSONContentType(ct string) bool {
 	return strings.Contains(ct, "application/json") || strings.Contains(ct, "text/json")
@@ -196,6 +205,17 @@ func ParseJSONResponse(resp *larkcore.ApiResp) (interface{}, error) {
 	dec := json.NewDecoder(bytes.NewReader(resp.RawBody))
 	dec.UseNumber()
 	if err := dec.Decode(&result); err != nil {
+		return nil, fmt.Errorf("response parse error: %w (body: %s)", err, util.TruncateStr(string(resp.RawBody), 500))
+	}
+	// A body is one JSON value. Anything after it other than whitespace is not
+	// part of the response — a truncated stream, a second value concatenated on
+	// — and accepting the first value would let such a body pass for a complete
+	// one, cursor and all.
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("unexpected content after the JSON value")
+		}
 		return nil, fmt.Errorf("response parse error: %w (body: %s)", err, util.TruncateStr(string(resp.RawBody), 500))
 	}
 	return result, nil


### PR DESCRIPTION
## Summary

`--page-all` stopped paginating when a page after the first failed, but returned the pages it already had as a complete, successful result: exit code `0` and an `ok: true` envelope. With a non-zero business `code` the merged result also reported `has_more: false`, so the output actively asserted completeness and callers had no signal at all that data was missing. Export, sync and reconciliation jobs silently consumed truncated data as if it were whole.

The loop folded "I stopped" and "I finished" into the same shape — both returned a `nil` error — and it recognised only two failure signals: a transport error, or a JSON object whose `code` read as a non-zero float. A page that failed without one, most commonly a gateway 5xx, was accumulated as a normal page. A page whose `code` could not be read at all — absent, `null`, a string, `0.5`, `1e-324` — read as `0` through the float, and the loop paginated from it, re-issuing the request for its cursor. `api --page-all` is not restricted to `GET`, so that re-issued a `POST` or `DELETE`.

This aligns the loop with semantics the project already uses. A failed page is classified exactly as `HandleResponse` classifies a plain `api` response, in the same order. Whether a page is a step in the pagination — a continuation an earlier page promised, or a page to paginate from — is decided by one strict check: its business `code` is exactly `0`. That check is asymmetric by page position on purpose, and it is the one decision that was missing.

## Changes

All production changes are in `internal/client/client.go` unless noted.

- Fail the run on a later page's transport error instead of breaking out and returning a `nil` error
- Classify a failed page in the order `HandleResponse` uses for plain `api`: `CheckResponse` first, so a readable business `code` wins over the HTTP status (a `403` carrying `230027` is an authorization error), then an HTTP status of 400 or more. Because the paginated path now runs the same `CheckResponse` call and the same status check the plain path does, a business or HTTP failure classifies the same way — same category, same `error.code` — whether or not `--page-all` is set. Page 1 keeps its output contract: it is handed back whole with a `nil` error so the command layer classifies it and dumps the raw response
- Treat a page as a step in the pagination only if its business `code` is exactly `0`, as decided by `pageDeclaresSuccess`, which reads a JSON number as zero only if every digit of its mantissa is `0`. `CheckResponse` cannot make that call: it reads the code as a float, under which `0.5`, `1e-324` and an absent field all become `0`. The rule is asymmetric by page position, deliberately. A **later** page that did not declare success fails the run before it is emitted or accumulated — the page before it promised more data, and accepting this one, with or without a cursor and data of its own, would end the run as complete over that promise. A **first** page that did not declare success but carries a usable continuation token is refused before output with a non-zero exit. For `GET`/`HEAD`, the `hint` explains how to remove pagination/filtering and save the raw response with `--output`; for other methods it tells the caller to verify whether the first request changed remote state before retrying. `api --page-all` is not restricted to `GET`, so re-issuing the request for its cursor could replay a write, and an error rather than a stopped run is what gives the streaming formats, which have no envelope to carry `has_more`, a machine-readable signal. A first page that did not declare success and carries no usable continuation token is output on the existing contract: there is nothing to paginate, a code-less list is still a list, and plain `api` would have shown the same response
- **Deliberate change:** `main` paginated from a page whose `code` was absent or unreadable, re-issuing the request for its cursor and then reporting `has_more: false` over the merged result; it also accepted such a page as a later page. Both now fail with `invalid_response`. The one first-page case that still outputs — no cursor, so nothing to paginate — is where `main` special-cased a non-zero float (`0.5`, `1e999`) and withheld it from the streaming formats; such a page passes `CheckResponse` and the status check like any other, so it is now streamed like any other
- Add `callPage`, which keeps the `*larkcore.ApiResp` that `CallAPI` drops — nothing else in the loop can read an HTTP status — and decides whether the body is JSON by the same rule `HandleResponse` uses, now shared as `isJSONBody`. A body that declares a non-JSON Content-Type is never parsed: on a 4xx/5xx it is classified by status (a `text/html` gateway page exits `4` as plain `api` does, not `5`); on a 2xx it is reported as not a page, because plain `api` treats it as a download and a paginated run cannot. `main` parsed such a body anyway and followed the cursor it found in it
- Make `ParseJSONResponse` (`internal/client/response.go`) accept exactly one JSON value. It is shared by `HandleResponse`, `CallAPI`, `callPage`, the shortcut runner's `ClassifyAPIResponseWith` — so every shortcut's response classification — and the event runtime, and the stricter parse applies on each of those paths. It decoded the first value and ignored the rest, so `{...}garbage` and `{...} {"code":230027}` both passed as the first object, cursor included. Trailing whitespace is still accepted
- Resolve the identity the classification uses inside the loop — `opts.Identity`, then the request's own `As`, then `AsUser`, treating `AsAuto` as unresolved — because an empty identity is rewritten to `user` by `errclass` and hands a bot the wrong recovery text
- Report in `StreamPages` how much a streaming run emitted before it failed, counting only pages the output callback accepted
- Correct the `PaginationOptions` field comments in `internal/client/pagination.go`, and widen the `SubtypeInvalidResponse` comment in `errs/subtypes.go` to cover a response the CLI cannot accept as the envelope it expects (comments only)
- Tests: `internal/client/pagination_rules_test.go` states the rule once as a decision table — code shape × HTTP status × first/later page × `PaginateAll`/`StreamPages` — with every cell's expectation derived from `CheckResponse`'s own verdict, the status, and the page position, and asserts request count, callback count, category and `error.code`. Every shape runs with both supported cursor fields (`page_token` and `next_page_token`), as a terminal list, and with no data at all — the last being the shape a failed later page most often has — and a page beyond the cursor is always available, so the table proves the rule in both directions: a zero page's cursor is followed, any other page is refused or, on a first page that needs no pagination, output; the code shapes cover absent, every spelling of `0`, integers at 2^53 and `int64`, fractions, underflow, out-of-range and non-numbers. A parity test asserts that every one of those responses, plus bodies with trailing garbage or a second value, classifies identically through `HandleResponse` and through a first page; a declared non-JSON 2xx body is pinned as not a page; and the parser's one-value contract is pinned directly. `pagination_failure_test.go` keeps the Content-Type, identity, transport and stream-summary cases; `cmd/api/api_paginate_test.go` and `cmd/service/service_paginate_test.go` pin stdout — empty for a buffered format on a later-page failure, the pages already written for a streaming one, a first page that needs no pagination on each format's own contract — a code-less list streams as a list — a first page that carries a usable continuation token but did not declare success being refused with a non-zero exit and nothing on stdout, and a later page without data that did not declare success failing the run instead of merging as complete

Deliberately left to a follow-up: the business code is still read by `CheckResponse` and `errclass.intFromAny` through `float64`, so `230027.5` classifies as `230027` and `9007199254740993.0` reports `error.code` `9007199254740992`. Plain `api` and `--page-all` now behave identically there, which is this change's contract; making the decode exact means changing every command's classification and belongs in its own change with its own compatibility review. Also unchanged is the loop's continuation metadata — a non-boolean `has_more`, a `has_more` without a token, a repeating token — which is pre-existing behaviour on the success path.

Exit codes follow the existing `errclass` classification and add no new mapping: a transport failure or a `5xx` exits `4`, an unparseable or non-JSON page exits `5`, and a business error exits by its category. A page that passes `CheckResponse` and the status check but not the exact-zero gate exits `5` — unless it is a first page carrying no usable continuation token, in which case it is output as plain `api` would output it. The refusal does not consult `--page-limit`: a first page that carries a continuation token but did not declare success is refused even under `--page-limit 1`, where the loop would not have followed the token — the rule is about the page, not about how far the run was allowed to go.

## Test Plan

- [x] `make unit-test`, `make vet`, `make fmt-check` passed
- [x] `go test ./internal/client/ ./cmd/api/ ./cmd/service/` passed
- [x] Decision table: 20 code shapes × 3 statuses × 2 page positions × 2 entry points × 4 data variants (`page_token`, `next_page_token`, terminal list, no data) = 960 cells, with expectations derived from the rule rather than written per cell; parity test over the same shapes plus non-object, unparseable and trailing-content bodies against `HandleResponse`
- [x] Control-flow regressions: `--page-limit 1` still refuses an invalid first-page cursor before output; both cursor field names participate in the same rule; recovery hints are safe by default for unknown/write methods
- [x] Differential against `main`: a 462-case matrix (page position × HTTP status × Content-Type × 18 body shapes) compiled against both `main` and this branch for `PaginateAll` and `StreamPages`. No case issues more requests than `main`; no case succeeds where `main` failed; every difference is `main` accepting a failed page, following a cursor it should not have, or classifying a failure wrongly
- [x] Mutation-checked: reverting the transport return, exact-zero gate, page-position asymmetry, Content-Type handling, one-value parser, or float-free zero check makes the rule-specific tests fail. Additional control-flow mutations — dropping `next_page_token`, moving the page-limit stop before page admission, or giving write methods the `GET`/`HEAD` retry hint — also fail the new tests
- [x] Live check against a test tenant: a multi-page `--page-all` run still ends in an `ok: true` envelope with exit `0`, and a first-page business error still writes the raw response to stdout

## Related Issues

Closes #2477


