### PR TITLE
fix(sheets): suppress multipart stderr noise and tighten e2e boundary test

### DIFF
--- a/shortcuts/common/drive_media_upload.go
+++ b/shortcuts/common/drive_media_upload.go
@@ -60,6 +60,10 @@ type DriveMediaMultipartUploadConfig struct {
 	Extra      string
 	// Reader mirrors DriveMediaUploadAllConfig.Reader for chunked uploads.
 	Reader io.Reader
+	// Quiet suppresses the progress narration on ErrOut that the multipart
+	// path writes unconditionally. Callers whose success contract forbids
+	// non-empty stderr (e.g. sheets shortcuts) set this to true.
+	Quiet bool
 }
 
 // UploadDriveMediaAllTyped uploads a file in a single request: file-open
@@ -153,7 +157,9 @@ func UploadDriveMediaMultipartTyped(runtime *RuntimeContext, cfg DriveMediaMulti
 	if err != nil {
 		return "", fileevent.ReportUploadError(runtime, err, meta)
 	}
-	fmt.Fprintf(runtime.IO().ErrOut, "Multipart upload initialized: %d chunks x %s\n", session.BlockNum, FormatSize(session.BlockSize))
+	if !cfg.Quiet {
+		fmt.Fprintf(runtime.IO().ErrOut, "Multipart upload initialized: %d chunks x %s\n", session.BlockNum, FormatSize(session.BlockSize))
+	}
 
 	meta.APIPath = driveMediaUploadPartPath
 	if err = uploadDriveMediaMultipartPartsTyped(runtime, cfg, session); err != nil {
@@ -253,7 +259,9 @@ func uploadDriveMediaMultipartPartsTyped(runtime *RuntimeContext, cfg DriveMedia
 		if err := uploadDriveMediaMultipartPartTyped(runtime, session.UploadID, seq, buffer[:n]); err != nil {
 			return err
 		}
-		fmt.Fprintf(runtime.IO().ErrOut, "  Block %d/%d uploaded (%s)\n", seq+1, session.BlockNum, FormatSize(int64(n)))
+		if !cfg.Quiet {
+			fmt.Fprintf(runtime.IO().ErrOut, "  Block %d/%d uploaded (%s)\n", seq+1, session.BlockNum, FormatSize(int64(n)))
+		}
 		remaining -= int64(n)
 	}
 

--- a/shortcuts/sheets/backward/lark_sheets_float_images.go
+++ b/shortcuts/sheets/backward/lark_sheets_float_images.go
@@ -208,6 +208,7 @@ func uploadSheetMediaFile(runtime *common.RuntimeContext, filePath, fileName str
 		FileSize:   fileSize,
 		ParentType: parentType,
 		ParentNode: parentNode,
+		Quiet:      true,
 	})
 }
 

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -136,6 +136,7 @@ func uploadSheetImage(runtime *common.RuntimeContext, spreadsheetToken, filePath
 		FileSize:   fileSize,
 		ParentType: parentType,
 		ParentNode: spreadsheetToken,
+		Quiet:      true,
 	})
 }
 

--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -2262,12 +2262,7 @@ func errLocalOfficeExportUnsupported(token string) error {
 // to an Office file that lives in Lark. Both are local-office tokens to
 // common.IsLocalOfficeToken; only this class implies the caller holds the file.
 func isLocallyOpenedOfficeToken(token string) bool {
-	for _, prefix := range []string{common.FakeOfficeTokenPrefix, common.LocalOfficeTokenPrefix} {
-		if strings.HasPrefix(token, prefix) {
-			return true
-		}
-	}
-	return false
+	return strings.HasPrefix(token, common.FakeOfficeTokenPrefix) || strings.HasPrefix(token, common.LocalOfficeTokenPrefix)
 }
 
 // workbookExportParams builds the shared drive export request for

--- a/shortcuts/sheets/success_stderr_contract_test.go
+++ b/shortcuts/sheets/success_stderr_contract_test.go
@@ -28,17 +28,16 @@ import (
 //
 // The coverage below includes the two commands that delegate to the shared
 // drive export / import cores, since those cores were cleaned up as part of
-// this change. Two paths a sheets caller can still reach are NOT covered,
-// because their output comes from shared helpers this change does not touch:
+// this change. One path a sheets caller can still reach is NOT covered,
+// because its output comes from a shared helper this change does not touch:
 //
-//   - +media-upload over 20MB → common.UploadDriveMediaMultipartTyped narrates
-//     the chunk plan and every uploaded block
 //   - any bot-identity create/import → common.AutoGrantCurrentUserDrivePermission
 //     duplicates its permission_grant result on stderr when the grant is
 //     skipped or fails
 //
-// Both are documented gaps, not oversights; the tests below run as user
-// identity and under the single-part threshold accordingly.
+// The +media-upload over 20MB gap was closed by the Quiet flag on
+// DriveMediaMultipartUploadConfig; sheets shortcuts pass Quiet: true so the
+// chunk narration stays silent on success.
 
 // runCapturingStderr runs a shortcut against stubs and returns stdout, stderr
 // and the error, so a test can assert on the reporting channel and not just

--- a/tests/cli_e2e/sheets/sheets_image_upload_dryrun_test.go
+++ b/tests/cli_e2e/sheets/sheets_image_upload_dryrun_test.go
@@ -182,7 +182,10 @@ func TestSheets_ImageUploadDryRunChunked(t *testing.T) {
 	const singlePartCeiling = 20 * 1024 * 1024
 
 	workDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(workDir, "small.png"), []byte("png-bytes"), 0o600))
+	small, err := os.Create(filepath.Join(workDir, "small.png"))
+	require.NoError(t, err)
+	require.NoError(t, small.Truncate(singlePartCeiling))
+	require.NoError(t, small.Close())
 	big, err := os.Create(filepath.Join(workDir, "big.png"))
 	require.NoError(t, err)
 	require.NoError(t, big.Truncate(singlePartCeiling+1))


### PR DESCRIPTION
Follow-up to #2537, addressing review findings:

1. **P0 — stderr pollution**: Add a `Quiet` flag to `DriveMediaMultipartUploadConfig` so sheets shortcuts can suppress the chunk-plan and per-block progress lines the multipart path writes unconditionally on success. Both `uploadSheetImage` (new shortcuts) and `uploadSheetMediaFile` (deprecated `+media-upload`) pass `Quiet: true`.

2. **P2 — simplify `isLocallyOpenedOfficeToken`**: Replace the inline prefix-slice loop with two `HasPrefix` calls, keeping the two-prefix invariant in one expression instead of letting it drift from `common.officeTokenPrefixes`.

3. **P3 — e2e boundary**: The "at the ceiling stays single-part" test case used a 9-byte `small.png`; `Truncate` it to `singlePartCeiling` (20 MB) so the boundary is actually pinned.

### Verification
- `go build ./...` passes
- `go vet` clean
- `go test ./shortcuts/sheets/... ./shortcuts/common/...` — all green
- `TestNoDirectStderrWritesInSheetsPackages` — passes (no new ErrOut writes in sheets packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to suppress multipart upload progress messages.
  - Large spreadsheet image uploads now run quietly without per-block progress output.

- **Bug Fixes**
  - Reduced unwanted output during chunked spreadsheet image uploads while preserving upload behavior.
  - Clarified boundary handling for files exactly at the single-part upload limit.

- **Refactor**
  - Simplified internal token-prefix validation without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->