### PR TITLE
Feat/okr comment

### DIFF
--- a/shortcuts/okr/okr_comment.go
+++ b/shortcuts/okr/okr_comment.go
@@ -417,6 +417,9 @@ func commentAction(command, suffix string) common.Shortcut {
 			if err := validateCommentStyle(runtime); err != nil {
 				return err
 			}
+			if err := validateCommentUserIDType(runtime); err != nil {
+				return err
+			}
 			return validateCommentID("--comment-id", runtime.Str("comment-id"))
 		},
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {

--- a/shortcuts/okr/okr_comment.go
+++ b/shortcuts/okr/okr_comment.go
@@ -1,0 +1,474 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package okr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var commentTargetTypes = map[string]bool{
+	"cycle": true, "progress": true, "objective": true, "key_result": true,
+}
+
+func validateCommentID(param, value string) error {
+	if value == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s is required", param).WithParam(param)
+	}
+	if id, err := strconv.ParseInt(value, 10, 64); err != nil || id <= 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "%s must be a positive int64", param).WithParam(param)
+	}
+	return nil
+}
+
+func validateCommentStyle(runtime *common.RuntimeContext) error {
+	if style := runtime.Str("style"); style != "simple" && style != "richtext" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--style must be one of: simple | richtext").WithParam("--style")
+	}
+	return nil
+}
+
+func validateCommentUserIDType(runtime *common.RuntimeContext) error {
+	switch runtime.Str("user-id-type") {
+	case "open_id", "union_id", "user_id", "user_key":
+		return nil
+	default:
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id-type must be one of: open_id | union_id | user_id | user_key").WithParam("--user-id-type")
+	}
+}
+
+func validateCommentTarget(runtime *common.RuntimeContext) error {
+	if !commentTargetTypes[runtime.Str("target-type")] {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-type must be one of: cycle | progress | objective | key_result").WithParam("--target-type")
+	}
+	return validateCommentID("--target-id", runtime.Str("target-id"))
+}
+
+func commentQuery(runtime *common.RuntimeContext) map[string]interface{} {
+	return map[string]interface{}{"user_id_type": runtime.Str("user-id-type")}
+}
+
+func parseComment(data interface{}) (*Comment, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid comment response: %s", err).WithCause(err)
+	}
+	var result Comment
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid comment response: %s", err).WithCause(err)
+	}
+	return &result, nil
+}
+
+func parseCommentContent(runtime *common.RuntimeContext) (*ContentBlock, error) {
+	value := runtime.Str("content")
+	if value == "" {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--content is required").WithParam("--content")
+	}
+	if err := common.RejectDangerousCharsTyped("--content", value); err != nil {
+		return nil, err
+	}
+	if runtime.Str("style") == "simple" {
+		var simple SemiPlainContent
+		if err := json.Unmarshal([]byte(value), &simple); err != nil {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--content must be valid semi-plain JSON: %s", err).WithParam("--content").WithCause(err)
+		}
+		if strings.TrimSpace(simple.Text) == "" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--content text is required and cannot be empty").WithParam("--content")
+		}
+		if len(simple.Docs) > 0 || len(simple.Images) > 0 {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--content docs and images are not supported in simple style input; use richtext style").WithParam("--content")
+		}
+		return simple.ToContentBlock(), nil
+	}
+	var content ContentBlock
+	if err := json.Unmarshal([]byte(value), &content); err != nil {
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--content must be valid ContentBlock JSON: %s", err).WithParam("--content").WithCause(err)
+	}
+	return &content, nil
+}
+
+func commentResponse(data map[string]interface{}) (*Comment, error) {
+	value, ok := data["comment"]
+	if !ok {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "comment response is missing comment")
+	}
+	return parseComment(value)
+}
+
+func commentListResponse(data map[string]interface{}) ([]Comment, bool, string, error) {
+	raw, _ := data["items"].([]interface{})
+	items := make([]Comment, 0, len(raw))
+	for _, item := range raw {
+		comment, err := parseComment(item)
+		if err != nil {
+			return nil, false, "", err
+		}
+		items = append(items, *comment)
+	}
+	hasMore, token := common.PaginationMeta(data)
+	return items, hasMore, token, nil
+}
+
+func commentOutput(style string, comments []Comment) []*RespComment {
+	result := make([]*RespComment, 0, len(comments))
+	for i := range comments {
+		result = append(result, comments[i].ToResp(style))
+	}
+	return result
+}
+
+func commentThreadOutput(style string, comments []Comment) [][]*RespComment {
+	return responseCommentThreads(groupCommentThreads(comments), style)
+}
+
+func commentIDFlags() []common.Flag {
+	return []common.Flag{
+		{Name: "comment-id", Desc: "comment ID (int64)", Required: true},
+		{Name: "user-id-type", Default: "open_id", Desc: "user ID type: open_id | union_id | user_id | user_key"}}
+}
+
+// OKRListComments lists one page of comments attached to an OKR entity.
+var OKRListComments = common.Shortcut{
+	Service:     "okr",
+	Command:     "+comment-list",
+	Description: "List comments attached to an OKR entity",
+	Risk:        "read",
+	Scopes:      []string{"okr:okr.comment.readonly"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "target-id", Desc: "comment target ID (int64)", Required: true},
+		{Name: "target-type", Desc: "comment target type: cycle | progress | objective | key_result", Required: true, Enum: []string{"cycle", "progress", "objective", "key_result"}},
+		{Name: "page-size", Type: "int", Default: "100", Desc: "page size, range 1-100"},
+		{Name: "page-token", Desc: "pagination token from previous response"},
+		{Name: "user-id-type", Default: "open_id", Desc: "user ID type: open_id | union_id | user_id | user_key"},
+		{Name: "style", Default: "simple", Desc: "output style: simple (semi-plain content) | richtext (ContentBlock)", Enum: []string{"simple", "richtext"}}},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateCommentTarget(runtime); err != nil {
+			return err
+		}
+		if err := validateCommentUserIDType(runtime); err != nil {
+			return err
+		}
+		if err := validateCommentStyle(runtime); err != nil {
+			return err
+		}
+		_, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 100)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		params := commentQuery(runtime)
+		params["target_type"] = runtime.Str("target-type")
+		params["target_id"] = runtime.Str("target-id")
+		params["page_size"] = runtime.Int("page-size")
+		if token := runtime.Str("page-token"); token != "" {
+			params["page_token"] = token
+		}
+		return common.NewDryRunAPI().GET("/open-apis/okr/v2/comments").Params(params).Desc("List OKR comments")
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		params := commentQuery(runtime)
+		params["target_type"] = runtime.Str("target-type")
+		params["target_id"] = runtime.Str("target-id")
+		params["page_size"] = runtime.Int("page-size")
+		if token := runtime.Str("page-token"); token != "" {
+			params["page_token"] = token
+		}
+		data, err := runtime.CallAPITyped("GET", "/open-apis/okr/v2/comments", params, nil)
+		if err != nil {
+			return err
+		}
+		comments, hasMore, token, err := commentListResponse(data)
+		if err != nil {
+			return err
+		}
+		runtime.OutFormat(map[string]interface{}{"comments": commentThreadOutput(runtime.Str("style"), comments), "has_more": hasMore, "page_token": token, "style": runtime.Str("style")}, nil, func(w io.Writer) {
+			fmt.Fprintf(w, "Found %d comment(s) in %d thread(s)\n", len(comments), len(groupCommentThreads(comments)))
+		})
+		return nil
+	},
+}
+
+// OKRGetComment gets a comment by ID.
+var OKRGetComment = common.Shortcut{
+	Service:     "okr",
+	Command:     "+comment-get",
+	Description: "Get an OKR comment by ID",
+	Risk:        "read",
+	Scopes:      []string{"okr:okr.comment.readonly"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags:       append(commentIDFlags(), common.Flag{Name: "style", Default: "simple", Desc: "output style: simple | richtext", Enum: []string{"simple", "richtext"}}),
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateCommentID("--comment-id", runtime.Str("comment-id")); err != nil {
+			return err
+		}
+		if err := validateCommentUserIDType(runtime); err != nil {
+			return err
+		}
+		return validateCommentStyle(runtime)
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return common.NewDryRunAPI().GET("/open-apis/okr/v2/comments/:comment_id").Params(commentQuery(runtime)).Set("comment_id", runtime.Str("comment-id")).Desc("Get OKR comment")
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		data, err := runtime.CallAPITyped("GET", fmt.Sprintf("/open-apis/okr/v2/comments/%s", runtime.Str("comment-id")), commentQuery(runtime), nil)
+		if err != nil {
+			return err
+		}
+		comment, err := commentResponse(data)
+		if err != nil {
+			return err
+		}
+		runtime.OutFormat(map[string]interface{}{"comment": comment.ToResp(runtime.Str("style")), "style": runtime.Str("style")}, nil, func(w io.Writer) { fmt.Fprintf(w, "Comment [%s]\n", comment.ID) })
+		return nil
+	},
+}
+
+func validateCreateSelection(runtime *common.RuntimeContext) error {
+	targetType := runtime.Str("target-type")
+	selected := runtime.Str("selected-text")
+	ref := runtime.Str("ref-comment-id")
+	all := runtime.Bool("select-all")
+	if all && selected != "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--select-all and --selected-text are mutually exclusive").WithParam("--select-all")
+	}
+	if ref != "" {
+		if err := validateCommentID("--ref-comment-id", ref); err != nil {
+			return err
+		}
+	}
+	if selected != "" {
+		if err := common.RejectDangerousCharsTyped("--selected-text", selected); err != nil {
+			return err
+		}
+	}
+	if targetType == "objective" || targetType == "key_result" {
+		if (selected == "" && !all) == (ref == "") {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "objective/key_result comments require exactly one of --selected-text, --select-all, or --ref-comment-id").WithParam("--selected-text")
+		}
+	} else if selected != "" || all {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--selected-text and --select-all are only supported for objective/key_result comments").WithParam("--selected-text")
+	}
+	return nil
+}
+
+func createCommentBody(runtime *common.RuntimeContext) (map[string]interface{}, error) {
+	body := map[string]interface{}{"target": CommentTarget{TargetType: runtime.Str("target-type"), TargetID: runtime.Str("target-id")}}
+	if runtime.Str("content") != "" {
+		content, err := parseCommentContent(runtime)
+		if err != nil {
+			return nil, err
+		}
+		body["content"] = content
+	}
+	if selected := runtime.Str("selected-text"); selected != "" {
+		body["selected_text"] = selected
+	}
+	if runtime.Bool("select-all") {
+		content, err := parseCommentContent(runtime)
+		if err != nil {
+			return nil, err
+		}
+		plain := content.ToSemiPlain()
+		if plain != nil {
+			body["selected_text"] = strings.Repeat("*", len([]rune(plain.Text)))
+		}
+	}
+	if ref := runtime.Str("ref-comment-id"); ref != "" {
+		body["ref_comment_id"] = ref
+	}
+	return body, nil
+}
+
+// OKRCreateComment creates or replies to an OKR comment.
+var OKRCreateComment = common.Shortcut{
+	Service:     "okr",
+	Command:     "+comment-create",
+	Description: "Create or reply to an OKR comment",
+	Risk:        "write", Scopes: []string{"okr:okr.comment.writeonly"},
+	AuthTypes: []string{"user"},
+	HasFormat: true,
+	Flags: []common.Flag{
+		{Name: "target-id", Desc: "comment target ID (int64)", Required: true},
+		{Name: "target-type", Desc: "comment target type: cycle | progress | objective | key_result", Required: true, Enum: []string{"cycle", "progress", "objective", "key_result"}},
+		{Name: "content", Desc: "comment content: semi-plain JSON or ContentBlock JSON according to --style", Input: []string{common.File, common.Stdin}},
+		{Name: "selected-text", Desc: "selected text for a new objective/key_result selection comment"},
+		{Name: "select-all", Type: "bool", Desc: "use wildcard selection to trigger full-text selection"},
+		{Name: "ref-comment-id", Desc: "comment ID to reply to or attach to an existing selection"},
+		{Name: "user-id-type", Default: "open_id", Desc: "user ID type: open_id | union_id | user_id | user_key"},
+		{Name: "style", Default: "simple", Desc: "input/output style: simple | richtext", Enum: []string{"simple", "richtext"}},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateCommentTarget(runtime); err != nil {
+			return err
+		}
+		if err := validateCommentStyle(runtime); err != nil {
+			return err
+		}
+		if err := validateCommentUserIDType(runtime); err != nil {
+			return err
+		}
+		if err := validateCreateSelection(runtime); err != nil {
+			return err
+		}
+		if runtime.Bool("select-all") && runtime.Str("content") == "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--select-all requires --content").WithParam("--content")
+		}
+		if runtime.Str("content") != "" {
+			_, err := parseCommentContent(runtime)
+			return err
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		body, _ := createCommentBody(runtime)
+		return common.NewDryRunAPI().POST("/open-apis/okr/v2/comments").Params(commentQuery(runtime)).Body(body).Desc("Create OKR comment")
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		body, err := createCommentBody(runtime)
+		if err != nil {
+			return err
+		}
+		data, err := runtime.CallAPITyped("POST", "/open-apis/okr/v2/comments", commentQuery(runtime), body)
+		if err != nil {
+			return err
+		}
+		runtime.OutFormat(map[string]interface{}{"comment_id": data["comment_id"], "selection_id": data["selection_id"]}, nil, func(w io.Writer) { fmt.Fprintf(w, "Created comment %v\n", data["comment_id"]) })
+		return nil
+	},
+}
+
+// OKRPatchComment updates only a comment's content.
+var OKRPatchComment = common.Shortcut{
+	Service:     "okr",
+	Command:     "+comment-patch",
+	Description: "Update an OKR comment",
+	Risk:        "write",
+	Scopes:      []string{"okr:okr.comment.writeonly"},
+	AuthTypes:   []string{"user"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "comment-id", Desc: "comment ID (int64)", Required: true},
+		{Name: "content", Desc: "new comment content: semi-plain JSON or ContentBlock JSON according to --style", Required: true, Input: []string{common.File, common.Stdin}},
+		{Name: "user-id-type", Default: "open_id", Desc: "user ID type: open_id | union_id | user_id | user_key"},
+		{Name: "style", Default: "simple", Desc: "input/output style: simple | richtext", Enum: []string{"simple", "richtext"}},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateCommentID("--comment-id", runtime.Str("comment-id")); err != nil {
+			return err
+		}
+		if err := validateCommentUserIDType(runtime); err != nil {
+			return err
+		}
+		if err := validateCommentStyle(runtime); err != nil {
+			return err
+		}
+		_, err := parseCommentContent(runtime)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		content, _ := parseCommentContent(runtime)
+		return common.NewDryRunAPI().PATCH("/open-apis/okr/v2/comments/:comment_id").Params(commentQuery(runtime)).Body(map[string]interface{}{"content": content}).Set("comment_id", runtime.Str("comment-id")).Desc("Update OKR comment")
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		content, err := parseCommentContent(runtime)
+		if err != nil {
+			return err
+		}
+		data, err := runtime.CallAPITyped("PATCH", fmt.Sprintf("/open-apis/okr/v2/comments/%s", runtime.Str("comment-id")), commentQuery(runtime), map[string]interface{}{"content": content})
+		if err != nil {
+			return err
+		}
+		comment, err := commentResponse(data)
+		if err != nil {
+			return err
+		}
+		runtime.OutFormat(map[string]interface{}{"comment": comment.ToResp(runtime.Str("style")), "style": runtime.Str("style")}, nil, func(w io.Writer) { fmt.Fprintf(w, "Updated comment [%s]\n", comment.ID) })
+		return nil
+	},
+}
+
+func commentAction(command, suffix string) common.Shortcut {
+	flags := append(commentIDFlags(), common.Flag{Name: "style", Default: "simple", Desc: "output style: simple | richtext", Enum: []string{"simple", "richtext"}})
+	description := "Solve an OKR comment"
+	if suffix == "reopen" {
+		description = "Reopen an OKR comment"
+	}
+	return common.Shortcut{
+		Service:     "okr",
+		Command:     command,
+		Description: description,
+		Risk:        "write",
+		Scopes:      []string{"okr:okr.comment.writeonly"},
+		AuthTypes:   []string{"user"},
+		HasFormat:   true,
+		Flags:       flags,
+		Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+			if err := validateCommentStyle(runtime); err != nil {
+				return err
+			}
+			return validateCommentID("--comment-id", runtime.Str("comment-id"))
+		},
+		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+			return common.NewDryRunAPI().POST("/open-apis/okr/v2/comments/:comment_id/"+suffix).Params(commentQuery(runtime)).Set("comment_id", runtime.Str("comment-id")).Desc(command)
+		},
+		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+			data, err := runtime.CallAPITyped("POST", fmt.Sprintf("/open-apis/okr/v2/comments/%s/%s", runtime.Str("comment-id"), suffix), commentQuery(runtime), nil)
+			if err != nil {
+				return err
+			}
+			raw, _ := data["affected_comments"].([]interface{})
+			comments := make([]Comment, 0, len(raw))
+			for _, item := range raw {
+				comment, e := parseComment(item)
+				if e != nil {
+					return e
+				}
+				comments = append(comments, *comment)
+			}
+			runtime.OutFormat(map[string]interface{}{"affected_comments": commentOutput(runtime.Str("style"), comments), "style": runtime.Str("style")}, nil, func(w io.Writer) { fmt.Fprintf(w, "Updated %d comment(s)\n", len(comments)) })
+			return nil
+		}}
+}
+
+// OKRSolveComment solves a comment or its selection thread.
+var OKRSolveComment = commentAction("+comment-solve", "solve")
+
+// OKRReopenComment reopens a comment or its selection thread.
+var OKRReopenComment = commentAction("+comment-reopen", "reopen")
+
+// OKRDeleteComment permanently deletes a comment.
+var OKRDeleteComment = common.Shortcut{
+	Service:     "okr",
+	Command:     "+comment-delete",
+	Description: "Delete an OKR comment permanently",
+	Risk:        "high-risk-write",
+	Scopes:      []string{"okr:okr.comment.delete"},
+	AuthTypes:   []string{"user"},
+	Flags: []common.Flag{
+		{Name: "comment-id", Desc: "comment ID (int64)", Required: true},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return validateCommentID("--comment-id", runtime.Str("comment-id"))
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return common.NewDryRunAPI().DELETE("/open-apis/okr/v2/comments/:comment_id").Set("comment_id", runtime.Str("comment-id")).Desc("Delete OKR comment")
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := runtime.CallAPITyped("DELETE", fmt.Sprintf("/open-apis/okr/v2/comments/%s", runtime.Str("comment-id")), nil, nil)
+		if err != nil {
+			return err
+		}
+		runtime.OutFormat(map[string]interface{}{"deleted": true, "comment_id": runtime.Str("comment-id")}, nil, func(w io.Writer) { fmt.Fprintf(w, "Deleted comment %s\n", runtime.Str("comment-id")) })
+		return nil
+	}}

--- a/shortcuts/okr/okr_comment.go
+++ b/shortcuts/okr/okr_comment.go
@@ -246,6 +246,9 @@ func validateCreateSelection(runtime *common.RuntimeContext) error {
 		if err := validateCommentID("--ref-comment-id", ref); err != nil {
 			return err
 		}
+		if selected != "" || all {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--ref-comment-id is mutually exclusive with --selected-text and --select-all").WithParam("--ref-comment-id")
+		}
 	}
 	if selected != "" {
 		if err := common.RejectDangerousCharsTyped("--selected-text", selected); err != nil {
@@ -264,21 +267,15 @@ func validateCreateSelection(runtime *common.RuntimeContext) error {
 
 func createCommentBody(runtime *common.RuntimeContext) (map[string]interface{}, error) {
 	body := map[string]interface{}{"target": CommentTarget{TargetType: runtime.Str("target-type"), TargetID: runtime.Str("target-id")}}
-	if runtime.Str("content") != "" {
-		content, err := parseCommentContent(runtime)
-		if err != nil {
-			return nil, err
-		}
-		body["content"] = content
+	content, err := parseCommentContent(runtime)
+	if err != nil {
+		return nil, err
 	}
+	body["content"] = content
 	if selected := runtime.Str("selected-text"); selected != "" {
 		body["selected_text"] = selected
 	}
 	if runtime.Bool("select-all") {
-		content, err := parseCommentContent(runtime)
-		if err != nil {
-			return nil, err
-		}
 		plain := content.ToSemiPlain()
 		if plain != nil {
 			body["selected_text"] = strings.Repeat("*", len([]rune(plain.Text)))
@@ -301,7 +298,7 @@ var OKRCreateComment = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "target-id", Desc: "comment target ID (int64)", Required: true},
 		{Name: "target-type", Desc: "comment target type: cycle | progress | objective | key_result", Required: true, Enum: []string{"cycle", "progress", "objective", "key_result"}},
-		{Name: "content", Desc: "comment content: semi-plain JSON or ContentBlock JSON according to --style", Input: []string{common.File, common.Stdin}},
+		{Name: "content", Desc: "comment content: semi-plain JSON or ContentBlock JSON according to --style", Required: true, Input: []string{common.File, common.Stdin}},
 		{Name: "selected-text", Desc: "selected text for a new objective/key_result selection comment"},
 		{Name: "select-all", Type: "bool", Desc: "use wildcard selection to trigger full-text selection"},
 		{Name: "ref-comment-id", Desc: "comment ID to reply to or attach to an existing selection"},
@@ -321,14 +318,8 @@ var OKRCreateComment = common.Shortcut{
 		if err := validateCreateSelection(runtime); err != nil {
 			return err
 		}
-		if runtime.Bool("select-all") && runtime.Str("content") == "" {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--select-all requires --content").WithParam("--content")
-		}
-		if runtime.Str("content") != "" {
-			_, err := parseCommentContent(runtime)
-			return err
-		}
-		return nil
+		_, err := parseCommentContent(runtime)
+		return err
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		body, _ := createCommentBody(runtime)

--- a/shortcuts/okr/okr_comment_detail.go
+++ b/shortcuts/okr/okr_comment_detail.go
@@ -10,12 +10,49 @@ import (
 	"io"
 	"sort"
 
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
 const commentDetailConcurrency = 8
+
+func commentAPIWithContext(ctx context.Context, runtime *common.RuntimeContext, method, path string, params map[string]interface{}) (map[string]interface{}, error) {
+	query := make(larkcore.QueryParams, len(params))
+	for key, value := range params {
+		query.Set(key, fmt.Sprint(value))
+	}
+	resp, err := runtime.DoAPIWithContext(ctx, &larkcore.ApiReq{
+		HttpMethod:  method,
+		ApiPath:     path,
+		QueryParams: query,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return runtime.ClassifyAPIResponse(resp)
+}
+
+type commentProgressPage struct {
+	Items *[]Progress `json:"items"`
+}
+
+func decodeCommentProgressPage(data map[string]interface{}) ([]Progress, error) {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid progress response: marshal failed: %s", err).WithCause(err)
+	}
+	var page commentProgressPage
+	if err := json.Unmarshal(payload, &page); err != nil {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid progress response: unmarshal failed: %s", err).WithCause(err)
+	}
+	if page.Items == nil {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid progress response: missing progress response items")
+	}
+	return *page.Items, nil
+}
 
 func fetchComments(ctx context.Context, runtime *common.RuntimeContext, target CommentTarget) ([]Comment, error) {
 	params := map[string]interface{}{"target_type": target.TargetType, "target_id": target.TargetID, "page_size": 100}
@@ -24,7 +61,7 @@ func fetchComments(ctx context.Context, runtime *common.RuntimeContext, target C
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		data, err := runtime.CallAPITyped("GET", "/open-apis/okr/v2/comments", params, nil)
+		data, err := commentAPIWithContext(ctx, runtime, "GET", "/open-apis/okr/v2/comments", params)
 		if err != nil {
 			return nil, err
 		}
@@ -48,22 +85,15 @@ func fetchCommentProgresses(ctx context.Context, runtime *common.RuntimeContext,
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		data, err := runtime.CallAPITyped("GET", path, params, nil)
+		data, err := commentAPIWithContext(ctx, runtime, "GET", path, params)
 		if err != nil {
 			return nil, err
 		}
-		items, _ := data["items"].([]interface{})
-		for _, raw := range items {
-			b, err := json.Marshal(raw)
-			if err != nil {
-				return nil, err
-			}
-			var p Progress
-			if err := json.Unmarshal(b, &p); err != nil {
-				return nil, err
-			}
-			progresses = append(progresses, p)
+		items, err := decodeCommentProgressPage(data)
+		if err != nil {
+			return nil, err
 		}
+		progresses = append(progresses, items...)
 		hasMore, token := common.PaginationMeta(data)
 		if !hasMore || token == "" {
 			return progresses, nil

--- a/shortcuts/okr/okr_comment_detail.go
+++ b/shortcuts/okr/okr_comment_detail.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package okr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const commentDetailConcurrency = 8
+
+func fetchComments(ctx context.Context, runtime *common.RuntimeContext, target CommentTarget) ([]Comment, error) {
+	params := map[string]interface{}{"target_type": target.TargetType, "target_id": target.TargetID, "page_size": 100}
+	var comments []Comment
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		data, err := runtime.CallAPITyped("GET", "/open-apis/okr/v2/comments", params, nil)
+		if err != nil {
+			return nil, err
+		}
+		items, hasMore, token, err := commentListResponse(data)
+		if err != nil {
+			return nil, err
+		}
+		comments = append(comments, items...)
+		if !hasMore || token == "" {
+			return comments, nil
+		}
+		params["page_token"] = token
+	}
+}
+
+func fetchCommentProgresses(ctx context.Context, runtime *common.RuntimeContext, collection, targetID string) ([]Progress, error) {
+	path := fmt.Sprintf("/open-apis/okr/v2/%s/%s/progresses", collection, targetID)
+	params := map[string]interface{}{"page_size": 100}
+	var progresses []Progress
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		data, err := runtime.CallAPITyped("GET", path, params, nil)
+		if err != nil {
+			return nil, err
+		}
+		items, _ := data["items"].([]interface{})
+		for _, raw := range items {
+			b, err := json.Marshal(raw)
+			if err != nil {
+				return nil, err
+			}
+			var p Progress
+			if err := json.Unmarshal(b, &p); err != nil {
+				return nil, err
+			}
+			progresses = append(progresses, p)
+		}
+		hasMore, token := common.PaginationMeta(data)
+		if !hasMore || token == "" {
+			return progresses, nil
+		}
+		params["page_token"] = token
+	}
+}
+
+func commentTargetSortLess(a, b Comment) bool {
+	if a.CreateTime != b.CreateTime {
+		return a.CreateTime < b.CreateTime
+	}
+	return a.ID < b.ID
+}
+
+func groupCommentThreads(comments []Comment) [][]Comment {
+	groups := make(map[string][]Comment)
+	keys := make([]string, 0)
+	for _, comment := range comments {
+		key := "comment:" + comment.ID
+		if comment.Selection != nil && comment.Selection.ID != "" {
+			key = "selection:" + comment.Selection.ID
+		}
+		if _, ok := groups[key]; !ok {
+			keys = append(keys, key)
+		}
+		groups[key] = append(groups[key], comment)
+	}
+	for _, key := range keys {
+		sort.SliceStable(groups[key], func(i, j int) bool { return commentTargetSortLess(groups[key][i], groups[key][j]) })
+	}
+	sort.SliceStable(keys, func(i, j int) bool { return commentTargetSortLess(groups[keys[i]][0], groups[keys[j]][0]) })
+	result := make([][]Comment, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, groups[key])
+	}
+	return result
+}
+
+func responseCommentThreads(threads [][]Comment, style string) [][]*RespComment {
+	result := make([][]*RespComment, 0, len(threads))
+	for _, thread := range threads {
+		converted := make([]*RespComment, 0, len(thread))
+		for i := range thread {
+			converted = append(converted, thread[i].ToResp(style))
+		}
+		result = append(result, converted)
+	}
+	return result
+}
+
+func fetchCommentDetailTargets(ctx context.Context, runtime *common.RuntimeContext, cycleID string) ([]CommentTarget, error) {
+	objectives, err := fetchObjectives(ctx, runtime, cycleID)
+	if err != nil {
+		return nil, err
+	}
+	type loadedObjective struct {
+		objective  Objective
+		keyResults []KeyResult
+	}
+	loaded := make([]loadedObjective, len(objectives))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(commentDetailConcurrency)
+	for obj := range objectives {
+		i := obj
+		g.Go(func() error {
+			krs, err := fetchKeyResults(gctx, runtime, objectives[i].ID)
+			if err != nil {
+				return err
+			}
+			loaded[i] = loadedObjective{objectives[i], krs}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	targets := []CommentTarget{{TargetType: "cycle", TargetID: cycleID}}
+	for _, item := range loaded {
+		targets = append(targets, CommentTarget{TargetType: "objective", TargetID: item.objective.ID})
+		for _, kr := range item.keyResults {
+			targets = append(targets, CommentTarget{TargetType: "key_result", TargetID: kr.ID})
+		}
+	}
+	progressTargets := make([][]CommentTarget, len(loaded))
+	g, gctx = errgroup.WithContext(ctx)
+	g.SetLimit(commentDetailConcurrency)
+	for obj := range loaded {
+		i := obj
+		g.Go(func() error {
+			var result []CommentTarget
+			progresses, err := fetchCommentProgresses(gctx, runtime, "objectives", loaded[i].objective.ID)
+			if err != nil {
+				return err
+			}
+			for _, p := range progresses {
+				result = append(result, CommentTarget{TargetType: "progress", TargetID: p.ID})
+			}
+			for _, kr := range loaded[i].keyResults {
+				progresses, err := fetchCommentProgresses(gctx, runtime, "key_results", kr.ID)
+				if err != nil {
+					return err
+				}
+				for _, p := range progresses {
+					result = append(result, CommentTarget{TargetType: "progress", TargetID: p.ID})
+				}
+			}
+			progressTargets[i] = result
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	for _, group := range progressTargets {
+		targets = append(targets, group...)
+	}
+	return targets, nil
+}
+
+// OKRCycleCommentDetail lists all comments under a cycle, grouped by target and thread.
+var OKRCycleCommentDetail = common.Shortcut{
+	Service: "okr", Command: "+comment-detail", Description: "List all comments under an OKR cycle, grouped by target and thread", Risk: "read", Scopes: []string{"okr:okr.comment.readonly", "okr:okr.content:readonly", "okr:okr.progress:readonly"}, AuthTypes: []string{"user", "bot"}, HasFormat: true,
+	Flags: []common.Flag{
+		{Name: "cycle-id", Desc: "OKR cycle ID (int64)", Required: true},
+		{Name: "style", Default: "simple", Desc: "output style: simple (semi-plain content) | richtext (ContentBlock)", Enum: []string{"simple", "richtext"}},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateCommentID("--cycle-id", runtime.Str("cycle-id")); err != nil {
+			return err
+		}
+		return validateCommentStyle(runtime)
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return common.NewDryRunAPI().GET("/open-apis/okr/v2/cycles/:cycle_id/objectives").Set("cycle_id", runtime.Str("cycle-id")).Desc("Fetch objectives, key results, progresses, then comments concurrently")
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		targets, err := fetchCommentDetailTargets(ctx, runtime, runtime.Str("cycle-id"))
+		if err != nil {
+			return err
+		}
+		comments := make([][]Comment, len(targets))
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(commentDetailConcurrency)
+		for tgt := range targets {
+			i := tgt
+			g.Go(func() error {
+				result, err := fetchComments(gctx, runtime, targets[i])
+				if err == nil {
+					comments[i] = result
+				}
+				return err
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+		byTarget := make(map[string][][]*RespComment, len(targets))
+		for i, target := range targets {
+			byTarget[target.TargetID] = responseCommentThreads(groupCommentThreads(comments[i]), runtime.Str("style"))
+		}
+		runtime.OutFormat(map[string]interface{}{"cycle_id": runtime.Str("cycle-id"), "comments": byTarget, "style": runtime.Str("style")}, nil, func(w io.Writer) {
+			fmt.Fprintf(w, "Found comments under cycle %s across %d target(s)\n", runtime.Str("cycle-id"), len(byTarget))
+		})
+		return nil
+	},
+}

--- a/shortcuts/okr/okr_comment_test.go
+++ b/shortcuts/okr/okr_comment_test.go
@@ -122,6 +122,8 @@ func TestCommentValidationBranches(t *testing.T) {
 	}
 	invalid := [][]string{
 		{"--select-all", "--selected-text", "x"},
+		{"--selected-text", "x", "--ref-comment-id", "1"},
+		{"--select-all", "--ref-comment-id", "1"},
 		{"--ref-comment-id", "bad"},
 		{"--target-type", "objective"},
 		{"--target-type", "cycle", "--selected-text", "x"},
@@ -139,23 +141,26 @@ func TestCommentValidationBranches(t *testing.T) {
 func TestCommentContentValidationBranches(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name, content, style, param string
-		wantCause                   bool
+		name, command, content, style, param string
+		shortcut                             *common.Shortcut
+		wantCause                            bool
 	}{
-		{"bad simple json", "not-json", "simple", "--content", true},
-		{"empty simple text", "{\"text\":\"  \"}", "simple", "--content", false},
-		{"simple docs", "{\"text\":\"x\",\"docs\":[{\"url\":\"u\"}]}", "simple", "--content", false},
-		{"bad richtext json", "not-json", "richtext", "--content", true},
+		{"bad simple json", "+comment-create", "not-json", "simple", "--content", &OKRCreateComment, true},
+		{"missing create content", "+comment-create", "", "simple", "--content", &OKRCreateComment, false},
+		{"missing patch content", "+comment-patch", "", "simple", "--content", &OKRPatchComment, false},
+		{"empty simple text", "+comment-create", "{\"text\":\"  \"}", "simple", "--content", &OKRCreateComment, false},
+		{"simple docs", "+comment-create", "{\"text\":\"x\",\"docs\":[{\"url\":\"u\"}]}", "simple", "--content", &OKRCreateComment, false},
+		{"bad richtext json", "+comment-create", "not-json", "richtext", "--content", &OKRCreateComment, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			shortcut := &OKRCreateComment
-			args := []string{"+comment-create", "--target-id", "1", "--target-type", "cycle", "--content", tc.content, "--style", tc.style}
-			if tc.name == "missing" {
-				shortcut = &OKRPatchComment
-				args = []string{"+comment-patch", "--comment-id", "1", "--style", tc.style}
+			args := []string{tc.command, "--content", tc.content, "--style", tc.style}
+			if tc.shortcut == &OKRCreateComment {
+				args = append(args, "--target-id", "1", "--target-type", "cycle")
+			} else {
+				args = append(args, "--comment-id", "1")
 			}
-			err, _ := runCommentShortcut(t, shortcut, args)
+			err, _ := runCommentShortcut(t, tc.shortcut, args)
 			ve := requireCommentValidationError(t, err, tc.param)
 			if tc.wantCause {
 				var syntaxErr *json.SyntaxError

--- a/shortcuts/okr/okr_comment_test.go
+++ b/shortcuts/okr/okr_comment_test.go
@@ -5,18 +5,28 @@ package okr
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	"github.com/spf13/cobra"
 )
+
+type commentTestRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f commentTestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 func commentTestConfig(t *testing.T) *core.CliConfig {
 	t.Helper()
@@ -61,27 +71,44 @@ func commentItem(id, created string) map[string]interface{} {
 	}
 }
 
+func requireCommentValidationError(t *testing.T, err error, param string) *errs.ValidationError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error = %T (%v), want *errs.ValidationError", err, err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("Subtype = %q, want %q", ve.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if ve.Param != param {
+		t.Fatalf("Param = %q, want %q", ve.Param, param)
+	}
+	return ve
+}
+
 func TestCommentValidationBranches(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name string
-		args []string
-		want string
+		name, param string
+		args        []string
 	}{
-		{"missing target id", []string{"+comment-list", "--target-type", "cycle"}, "required"},
-		{"bad target type", []string{"+comment-list", "--target-id", "1", "--target-type", "bad"}, "target-type"},
-		{"bad target id", []string{"+comment-list", "--target-id", "0", "--target-type", "cycle"}, "positive int64"},
-		{"bad user id type", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--user-id-type", "bad"}, "user-id-type"},
-		{"bad style", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--style", "bad"}, "style"},
-		{"bad page size", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--page-size", "101"}, "page-size"},
+		{"bad target type", "--target-type", []string{"+comment-list", "--target-id", "1", "--target-type", "bad"}},
+		{"bad target id", "--target-id", []string{"+comment-list", "--target-id", "0", "--target-type", "cycle"}},
+		{"bad user id type", "--user-id-type", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--user-id-type", "bad"}},
+		{"bad style", "--style", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--style", "bad"}},
+		{"bad page size", "--page-size", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--page-size", "101"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err, _ := runCommentShortcut(t, &OKRListComments, tc.args)
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("err = %v", err)
-			}
+			requireCommentValidationError(t, err, tc.param)
 		})
+	}
+	if err, _ := runCommentShortcut(t, &OKRListComments, []string{"+comment-list", "--target-type", "cycle"}); err == nil {
+		t.Fatalf("missing required target-id error = %v", err)
 	}
 	for _, target := range []string{"cycle", "progress", "objective", "key_result"} {
 		args := []string{"+comment-create", "--target-id", "1", "--target-type", target, "--content", "{\"text\":\"x\"}"}
@@ -111,12 +138,14 @@ func TestCommentValidationBranches(t *testing.T) {
 
 func TestCommentContentValidationBranches(t *testing.T) {
 	t.Parallel()
-	cases := []struct{ name, content, style, want string }{
-		{"missing", "", "simple", "required"},
-		{"bad simple json", "not-json", "simple", "semi-plain JSON"},
-		{"empty simple text", "{\"text\":\"  \"}", "simple", "cannot be empty"},
-		{"simple docs", "{\"text\":\"x\",\"docs\":[{\"url\":\"u\"}]}", "simple", "docs and images"},
-		{"bad richtext json", "not-json", "richtext", "ContentBlock JSON"},
+	cases := []struct {
+		name, content, style, param string
+		wantCause                   bool
+	}{
+		{"bad simple json", "not-json", "simple", "--content", true},
+		{"empty simple text", "{\"text\":\"  \"}", "simple", "--content", false},
+		{"simple docs", "{\"text\":\"x\",\"docs\":[{\"url\":\"u\"}]}", "simple", "--content", false},
+		{"bad richtext json", "not-json", "richtext", "--content", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -127,10 +156,17 @@ func TestCommentContentValidationBranches(t *testing.T) {
 				args = []string{"+comment-patch", "--comment-id", "1", "--style", tc.style}
 			}
 			err, _ := runCommentShortcut(t, shortcut, args)
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("err = %v", err)
+			ve := requireCommentValidationError(t, err, tc.param)
+			if tc.wantCause {
+				var syntaxErr *json.SyntaxError
+				if ve.Cause == nil || !errors.As(err, &syntaxErr) {
+					t.Fatal("expected the original JSON parse cause to be preserved through the error chain")
+				}
 			}
 		})
+	}
+	if err, _ := runCommentShortcut(t, &OKRPatchComment, []string{"+comment-patch", "--comment-id", "1", "--style", "simple"}); err == nil {
+		t.Fatalf("missing required content error = %v", err)
 	}
 }
 
@@ -225,6 +261,92 @@ func TestCommentResponseParsingErrors(t *testing.T) {
 	}
 	if _, err := commentResponse(map[string]interface{}{}); err == nil {
 		t.Fatal("commentResponse should reject a missing comment")
+	}
+}
+
+func TestDecodeCommentProgressPage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		data      map[string]interface{}
+		wantItems int
+		wantError bool
+	}{
+		{name: "items", data: map[string]interface{}{"items": []interface{}{map[string]interface{}{"id": "p1"}}}, wantItems: 1},
+		{name: "empty items", data: map[string]interface{}{"items": []interface{}{}}, wantItems: 0},
+		{name: "missing items", data: map[string]interface{}{}, wantError: true},
+		{name: "wrong items shape", data: map[string]interface{}{"items": "not-an-array"}, wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			items, err := decodeCommentProgressPage(tc.data)
+			if !tc.wantError {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(items) != tc.wantItems {
+					t.Fatalf("items = %#v, want %d items", items, tc.wantItems)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected invalid response error")
+			}
+			var internalErr *errs.InternalError
+			if !errors.As(err, &internalErr) {
+				t.Fatalf("error = %T (%v), want *errs.InternalError", err, err)
+			}
+			if internalErr.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("Subtype = %q, want %q", internalErr.Subtype, errs.SubtypeInvalidResponse)
+			}
+		})
+	}
+	if _, err := decodeCommentProgressPage(map[string]interface{}{"items": make(chan int)}); err == nil {
+		t.Fatal("expected marshal failure")
+	} else {
+		var internalErr *errs.InternalError
+		if !errors.As(err, &internalErr) || internalErr.Cause == nil {
+			t.Fatalf("marshal error = %T (%v), cause was not preserved", err, err)
+		}
+	}
+}
+
+func TestCommentAPIWithContextHonorsCancellation(t *testing.T) {
+	started := make(chan struct{})
+	cfg := commentTestConfig(t)
+	factory, _, _, _ := cmdutil.TestFactory(t, cfg)
+	factory.LarkClient = func() (*lark.Client, error) {
+		return lark.NewClient(cfg.AppID, cfg.AppSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithLogLevel(larkcore.LogLevelError),
+			lark.WithHttpClient(&http.Client{Transport: commentTestRoundTripper(func(req *http.Request) (*http.Response, error) {
+				close(started)
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			})}),
+		), nil
+	}
+	runtime := common.TestNewRuntimeContextForAPI(context.Background(), &cobra.Command{Use: "+comment-detail"}, cfg, factory, core.AsUser)
+	callCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := commentAPIWithContext(callCtx, runtime, "GET", "/open-apis/okr/v2/comments", nil)
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %T (%v), want context.Canceled cause", err, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled request did not return promptly")
 	}
 }
 
@@ -325,8 +447,23 @@ func TestCommentDetailProgressPaginationAndFailure(t *testing.T) {
 func TestCommentValidationSelectionModes(t *testing.T) {
 	args := []string{"+comment-create", "--target-id", "1", "--target-type", "objective", "--content", "{\"text\":\"x\"}"}
 	err, _ := runCommentShortcut(t, &OKRCreateComment, args)
-	if err == nil || !strings.Contains(err.Error(), "exactly one") {
-		t.Fatalf("error = %v", err)
+	requireCommentValidationError(t, err, "--selected-text")
+}
+
+func TestCommentActionValidationUserIDType(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		shortcut *common.Shortcut
+		command  string
+	}{
+		{name: "solve", shortcut: &OKRSolveComment, command: "+comment-solve"},
+		{name: "reopen", shortcut: &OKRReopenComment, command: "+comment-reopen"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err, _ := runCommentShortcut(t, tc.shortcut, []string{tc.command, "--comment-id", "10", "--user-id-type", "invalid"})
+			requireCommentValidationError(t, err, "--user-id-type")
+		})
 	}
 }
 
@@ -394,6 +531,9 @@ func TestCommentReopenDryRunUsesReopenPath(t *testing.T) {
 	output := stdout.String()
 	if !strings.Contains(output, "/open-apis/okr/v2/comments/2/reopen") {
 		t.Fatalf("dry-run should use reopen endpoint, got: %s", output)
+	}
+	if !strings.Contains(output, `"user_id_type": "open_id"`) {
+		t.Fatalf("dry-run should include default user_id_type, got: %s", output)
 	}
 	if strings.Contains(output, "department_id_type") {
 		t.Fatalf("dry-run must omit department_id_type, got: %s", output)

--- a/shortcuts/okr/okr_comment_test.go
+++ b/shortcuts/okr/okr_comment_test.go
@@ -1,0 +1,401 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package okr
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+func commentTestConfig(t *testing.T) *core.CliConfig {
+	t.Helper()
+	return &core.CliConfig{AppID: "test-okr-comment", AppSecret: "secret-okr-comment", Brand: core.BrandFeishu}
+}
+
+func runCommentShortcut(t *testing.T, shortcut *common.Shortcut, args []string) (error, *bytes.Buffer) {
+	t.Helper()
+	f, stdout, _, _ := cmdutil.TestFactory(t, commentTestConfig(t))
+	parent := &cobra.Command{Use: "okr"}
+	shortcut.Mount(parent, f)
+	args = append(args, "--as", "user")
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	return parent.Execute(), stdout
+}
+
+func runCommentWithFactory(t *testing.T, f *cmdutil.Factory, stdout *bytes.Buffer, shortcut *common.Shortcut, args []string) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "okr"}
+	shortcut.Mount(parent, f)
+	args = append(args, "--as", "user")
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	stdout.Reset()
+	return parent.Execute()
+}
+
+func commentEnvelope(data map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{"code": 0, "msg": "ok", "data": data}
+}
+
+func commentItem(id, created string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":             id,
+		"target":         map[string]interface{}{"target_type": "objective", "target_id": "1"},
+		"commentator_id": "ou_commentator", "status": "active",
+		"create_time": created, "update_time": created,
+		"content": map[string]interface{}{"blocks": []interface{}{}},
+	}
+}
+
+func TestCommentValidationBranches(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing target id", []string{"+comment-list", "--target-type", "cycle"}, "required"},
+		{"bad target type", []string{"+comment-list", "--target-id", "1", "--target-type", "bad"}, "target-type"},
+		{"bad target id", []string{"+comment-list", "--target-id", "0", "--target-type", "cycle"}, "positive int64"},
+		{"bad user id type", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--user-id-type", "bad"}, "user-id-type"},
+		{"bad style", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--style", "bad"}, "style"},
+		{"bad page size", []string{"+comment-list", "--target-id", "1", "--target-type", "cycle", "--page-size", "101"}, "page-size"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err, _ := runCommentShortcut(t, &OKRListComments, tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v", err)
+			}
+		})
+	}
+	for _, target := range []string{"cycle", "progress", "objective", "key_result"} {
+		args := []string{"+comment-create", "--target-id", "1", "--target-type", target, "--content", "{\"text\":\"x\"}"}
+		if target == "objective" || target == "key_result" {
+			args = append(args, "--selected-text", "x")
+		}
+		args = append(args, "--dry-run")
+		if err, _ := runCommentShortcut(t, &OKRCreateComment, args); err != nil {
+			t.Fatalf("target %s: %v", target, err)
+		}
+	}
+	invalid := [][]string{
+		{"--select-all", "--selected-text", "x"},
+		{"--ref-comment-id", "bad"},
+		{"--target-type", "objective"},
+		{"--target-type", "cycle", "--selected-text", "x"},
+		{"--target-type", "cycle", "--select-all"},
+	}
+	for i, extra := range invalid {
+		args := []string{"+comment-create", "--target-id", "1", "--target-type", "objective", "--content", "{\"text\":\"x\"}"}
+		args = append(args, extra...)
+		if err, _ := runCommentShortcut(t, &OKRCreateComment, args); err == nil {
+			t.Fatalf("case %d: expected error", i)
+		}
+	}
+}
+
+func TestCommentContentValidationBranches(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ name, content, style, want string }{
+		{"missing", "", "simple", "required"},
+		{"bad simple json", "not-json", "simple", "semi-plain JSON"},
+		{"empty simple text", "{\"text\":\"  \"}", "simple", "cannot be empty"},
+		{"simple docs", "{\"text\":\"x\",\"docs\":[{\"url\":\"u\"}]}", "simple", "docs and images"},
+		{"bad richtext json", "not-json", "richtext", "ContentBlock JSON"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shortcut := &OKRCreateComment
+			args := []string{"+comment-create", "--target-id", "1", "--target-type", "cycle", "--content", tc.content, "--style", tc.style}
+			if tc.name == "missing" {
+				shortcut = &OKRPatchComment
+				args = []string{"+comment-patch", "--comment-id", "1", "--style", tc.style}
+			}
+			err, _ := runCommentShortcut(t, shortcut, args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v", err)
+			}
+		})
+	}
+}
+
+func TestCommentListExecutePaginationAndThreads(t *testing.T) {
+	t.Parallel()
+	f, stdout, _, reg := cmdutil.TestFactory(t, commentTestConfig(t))
+	var queries []url.Values
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/comments", OnMatch: func(r *http.Request) { queries = append(queries, r.URL.Query()) }, Reusable: true, Body: commentEnvelope(map[string]interface{}{"items": []interface{}{commentItem("2", "20"), commentItem("1", "10")}, "has_more": false, "page_token": "next"})})
+	err := runCommentWithFactory(t, f, stdout, &OKRListComments, []string{"+comment-list", "--target-id", "1", "--target-type", "objective", "--page-size", "2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queries) != 1 || queries[0].Get("page_size") != "2" {
+		t.Fatalf("queries = %#v", queries)
+	}
+	data := decodeEnvelope(t, stdout)
+	threads, ok := data["comments"].([]interface{})
+	if !ok || len(threads) != 2 || len(threads[0].([]interface{})) != 1 || len(threads[1].([]interface{})) != 1 {
+		t.Fatalf("comments = %#v", data["comments"])
+	}
+}
+
+func TestCommentGetPatchExecute(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name         string
+		shortcut     *common.Shortcut
+		args         []string
+		method, path string
+	}{
+		{"get", &OKRGetComment, []string{"+comment-get", "--comment-id", "9"}, "GET", "/open-apis/okr/v2/comments/9"},
+		{"patch", &OKRPatchComment, []string{"+comment-patch", "--comment-id", "9", "--content", "{\"text\":\"updated\"}"}, "PATCH", "/open-apis/okr/v2/comments/9"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, commentTestConfig(t))
+			reg.Register(&httpmock.Stub{Method: tc.method, URL: tc.path, Body: commentEnvelope(map[string]interface{}{"comment": commentItem("9", "1735776000000")})})
+			if err := runCommentWithFactory(t, f, stdout, tc.shortcut, tc.args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(stdout.String(), "9") {
+				t.Fatalf("output = %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestCommentCreateSolveReopenDeleteExecute(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		shortcut     *common.Shortcut
+		args         []string
+		method, path string
+		response     map[string]interface{}
+	}{
+		{"create", &OKRCreateComment, []string{"+comment-create", "--target-type", "objective", "--target-id", "1", "--content", "{\"text\":\"hello\"}", "--selected-text", "he"}, "POST", "/open-apis/okr/v2/comments", map[string]interface{}{"comment_id": "10", "selection_id": "s1"}},
+		{"solve", &OKRSolveComment, []string{"+comment-solve", "--comment-id", "10"}, "POST", "/open-apis/okr/v2/comments/10/solve", map[string]interface{}{"affected_comments": []interface{}{commentItem("10", "10")}}},
+		{"reopen", &OKRReopenComment, []string{"+comment-reopen", "--comment-id", "10"}, "POST", "/open-apis/okr/v2/comments/10/reopen", map[string]interface{}{"affected_comments": []interface{}{}}},
+		{"delete", &OKRDeleteComment, []string{"+comment-delete", "--comment-id", "10", "--yes"}, "DELETE", "/open-apis/okr/v2/comments/10", map[string]interface{}{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, commentTestConfig(t))
+			reg.Register(&httpmock.Stub{Method: tc.method, URL: tc.path, Body: commentEnvelope(tc.response)})
+			if err := runCommentWithFactory(t, f, stdout, tc.shortcut, tc.args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCommentExecuteAPIErrorAndMalformedResponse(t *testing.T) {
+	t.Parallel()
+	f, stdout, _, reg := cmdutil.TestFactory(t, commentTestConfig(t))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/comments/500", Status: 500, Body: map[string]interface{}{"code": 500, "msg": "error"}})
+	if err := runCommentWithFactory(t, f, stdout, &OKRGetComment, []string{"+comment-get", "--comment-id", "500"}); err == nil {
+		t.Fatal("expected API error")
+	}
+	f, stdout, _, reg = cmdutil.TestFactory(t, commentTestConfig(t))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/comments/501", Body: commentEnvelope(map[string]interface{}{})})
+	if err := runCommentWithFactory(t, f, stdout, &OKRGetComment, []string{"+comment-get", "--comment-id", "501"}); err == nil {
+		t.Fatal("expected missing comment error")
+	}
+}
+
+func TestCommentResponseParsingErrors(t *testing.T) {
+	if _, err := parseComment(make(chan int)); err == nil {
+		t.Fatal("parseComment should reject values that cannot be marshaled")
+	}
+	if _, _, _, err := commentListResponse(map[string]interface{}{"items": []interface{}{make(chan int)}}); err == nil {
+		t.Fatal("commentListResponse should reject malformed items")
+	}
+	if _, err := commentResponse(map[string]interface{}{}); err == nil {
+		t.Fatal("commentResponse should reject a missing comment")
+	}
+}
+
+func TestCommentDetailTargetsAndExecute(t *testing.T) {
+	t.Parallel()
+	f, stdout, _, reg := cmdutil.TestFactory(t, commentTestConfig(t))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/cycles/1/objectives", Body: commentEnvelope(map[string]interface{}{"items": []interface{}{map[string]interface{}{"id": "o1"}}})})
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/objectives/o1/key_results", Body: commentEnvelope(map[string]interface{}{"items": []interface{}{map[string]interface{}{"id": "k1"}}})})
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/objectives/o1/progresses", Body: commentEnvelope(map[string]interface{}{"items": []interface{}{map[string]interface{}{"id": "p1"}}})})
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/key_results/k1/progresses", Body: commentEnvelope(map[string]interface{}{"items": []interface{}{map[string]interface{}{"id": "p2"}}})})
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/comments", Reusable: true, Body: commentEnvelope(map[string]interface{}{"items": []interface{}{}, "has_more": false})})
+	if err := runCommentWithFactory(t, f, stdout, &OKRCycleCommentDetail, []string{"+comment-detail", "--cycle-id", "1"}); err != nil {
+		t.Fatalf("unexpected detail error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "cycle_id") {
+		t.Fatalf("output = %s", stdout.String())
+	}
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope["data"] == nil {
+		t.Fatalf("envelope = %#v", envelope)
+	}
+}
+
+func TestCommentDetailFetchCommentsPagination(t *testing.T) {
+	t.Parallel()
+	f, stdout, _, reg := cmdutil.TestFactory(t, commentTestConfig(t))
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/okr/v2/cycles/2/objectives",
+		Body: commentEnvelope(map[string]interface{}{"items": []interface{}{}, "has_more": false}),
+	})
+	var queries []url.Values
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/okr/v2/comments",
+		OnMatch: func(r *http.Request) { queries = append(queries, r.URL.Query()) },
+		Body: commentEnvelope(map[string]interface{}{
+			"items": []interface{}{commentItem("1", "10")}, "has_more": true, "page_token": "comment-next",
+		}),
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/okr/v2/comments",
+		OnMatch: func(r *http.Request) { queries = append(queries, r.URL.Query()) },
+		Body: commentEnvelope(map[string]interface{}{
+			"items": []interface{}{commentItem("2", "20")}, "has_more": false,
+		}),
+	})
+	if err := runCommentWithFactory(t, f, stdout, &OKRCycleCommentDetail, []string{"+comment-detail", "--cycle-id", "2"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queries) != 2 || queries[1].Get("page_token") != "comment-next" {
+		t.Fatalf("queries = %#v", queries)
+	}
+}
+
+func TestCommentDetailProgressPaginationAndFailure(t *testing.T) {
+	t.Parallel()
+	f, stdout, _, reg := cmdutil.TestFactory(t, commentTestConfig(t))
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/okr/v2/cycles/3/objectives",
+		Body: commentEnvelope(map[string]interface{}{"items": []interface{}{map[string]interface{}{"id": "o3"}}, "has_more": false}),
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/okr/v2/objectives/o3/key_results",
+		Body: commentEnvelope(map[string]interface{}{"items": []interface{}{}, "has_more": false}),
+	})
+	var queries []url.Values
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/okr/v2/objectives/o3/progresses",
+		OnMatch: func(r *http.Request) { queries = append(queries, r.URL.Query()) },
+		Body: commentEnvelope(map[string]interface{}{
+			"items": []interface{}{map[string]interface{}{"id": "p1"}}, "has_more": true, "page_token": "progress-next",
+		}),
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/okr/v2/objectives/o3/progresses",
+		OnMatch: func(r *http.Request) { queries = append(queries, r.URL.Query()) },
+		Body: commentEnvelope(map[string]interface{}{
+			"items": []interface{}{map[string]interface{}{"id": "p2"}}, "has_more": false,
+		}),
+	})
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/comments", Reusable: true, Body: commentEnvelope(map[string]interface{}{"items": []interface{}{}, "has_more": false})})
+	if err := runCommentWithFactory(t, f, stdout, &OKRCycleCommentDetail, []string{"+comment-detail", "--cycle-id", "3"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queries) != 2 || queries[1].Get("page_token") != "progress-next" {
+		t.Fatalf("queries = %#v", queries)
+	}
+
+	f, _, _, reg = cmdutil.TestFactory(t, commentTestConfig(t))
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/okr/v2/cycles/4/objectives", Status: 500, Body: map[string]interface{}{"code": 500, "msg": "error"}})
+	if err := runCommentWithFactory(t, f, stdout, &OKRCycleCommentDetail, []string{"+comment-detail", "--cycle-id", "4"}); err == nil {
+		t.Fatal("expected cycle detail API error")
+	}
+}
+
+func TestCommentValidationSelectionModes(t *testing.T) {
+	args := []string{"+comment-create", "--target-id", "1", "--target-type", "objective", "--content", "{\"text\":\"x\"}"}
+	err, _ := runCommentShortcut(t, &OKRCreateComment, args)
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCommentThreadsGroupSelectionAndSort(t *testing.T) {
+	t.Parallel()
+	selection := "77"
+	threads := groupCommentThreads([]Comment{
+		{ID: "2", CreateTime: "20", Selection: &CommentSelection{ID: selection}},
+		{ID: "1", CreateTime: "10", Selection: &CommentSelection{ID: selection}},
+		{ID: "3", CreateTime: "15"},
+	})
+	if len(threads) != 2 || threads[0][0].ID != "1" || threads[0][1].ID != "2" || threads[1][0].ID != "3" {
+		t.Fatalf("threads = %#v", threads)
+	}
+	tie := groupCommentThreads([]Comment{{ID: "b", CreateTime: "10"}, {ID: "a", CreateTime: "10"}})
+	if tie[0][0].ID != "a" || tie[1][0].ID != "b" {
+		t.Fatalf("tie ordering = %#v", tie)
+	}
+}
+
+func TestCommentThreadOutputUsesDetailShape(t *testing.T) {
+	threads := commentThreadOutput("simple", []Comment{
+		{ID: "2", CreateTime: "20", Selection: &CommentSelection{ID: "77"}, Content: &ContentBlock{}},
+		{ID: "1", CreateTime: "10", Selection: &CommentSelection{ID: "77"}, Content: &ContentBlock{}},
+		{ID: "3", CreateTime: "15", Content: &ContentBlock{}},
+	})
+	if len(threads) != 2 || len(threads[0]) != 2 || threads[0][0].ID != "1" || threads[0][1].ID != "2" || len(threads[1]) != 1 || threads[1][0].ID != "3" {
+		t.Fatalf("threads = %#v", threads)
+	}
+}
+
+func TestCommentCreateDryRunUsesWildcardSelection(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, commentTestConfig(t))
+	parent := &cobra.Command{Use: "okr"}
+	OKRCreateComment.Mount(parent, f)
+	parent.SetArgs([]string{
+		"+comment-create",
+		"--target-type", "objective",
+		"--target-id", "1",
+		"--content", "{\"text\":\"hello\"}",
+		"--select-all",
+		"--as", "user",
+		"--dry-run",
+	})
+	if err := parent.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "\"selected_text\": \"*****\"") {
+		t.Fatalf("dry-run should use wildcard selection, got: %s", output)
+	}
+	if strings.Contains(output, "department_id_type") {
+		t.Fatalf("dry-run must omit department_id_type, got: %s", output)
+	}
+}
+
+func TestCommentReopenDryRunUsesReopenPath(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, commentTestConfig(t))
+	parent := &cobra.Command{Use: "okr"}
+	OKRReopenComment.Mount(parent, f)
+	parent.SetArgs([]string{"+comment-reopen", "--comment-id", "2", "--as", "user", "--dry-run"})
+	if err := parent.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "/open-apis/okr/v2/comments/2/reopen") {
+		t.Fatalf("dry-run should use reopen endpoint, got: %s", output)
+	}
+	if strings.Contains(output, "department_id_type") {
+		t.Fatalf("dry-run must omit department_id_type, got: %s", output)
+	}
+}

--- a/shortcuts/okr/okr_openapi.go
+++ b/shortcuts/okr/okr_openapi.go
@@ -228,6 +228,72 @@ type Owner struct {
 	UserID    *string   `json:"user_id,omitempty"`
 }
 
+// CommentTarget identifies the OKR entity a comment is attached to.
+type CommentTarget struct {
+	TargetType string `json:"target_type"`
+	TargetID   string `json:"target_id"`
+}
+
+// CommentSelection identifies the text selection shared by a comment thread.
+type CommentSelection struct {
+	ID           string  `json:"id"`
+	SelectedText *string `json:"selected_text,omitempty"`
+}
+
+// Comment is the v2 OKR comment representation returned by the comments API.
+type Comment struct {
+	ID            string            `json:"id"`
+	Target        CommentTarget     `json:"target"`
+	CommentatorID string            `json:"commentator_id"`
+	Status        string            `json:"status"`
+	CreateTime    string            `json:"create_time"`
+	UpdateTime    string            `json:"update_time"`
+	Content       *ContentBlock     `json:"content,omitempty"`
+	SolverID      *string           `json:"solver_id,omitempty"`
+	SolvedTime    *string           `json:"solved_time,omitempty"`
+	RefCommentID  *string           `json:"ref_comment_id,omitempty"`
+	Selection     *CommentSelection `json:"selection,omitempty"`
+}
+
+// RespComment is the user-facing comment representation. Content is either a
+// SemiPlainContent or a ContentBlock according to the shortcut's --style.
+type RespComment struct {
+	ID            string            `json:"id"`
+	Target        CommentTarget     `json:"target"`
+	CommentatorID string            `json:"commentator_id"`
+	Status        string            `json:"status"`
+	CreateTime    string            `json:"create_time"`
+	UpdateTime    string            `json:"update_time"`
+	Content       any               `json:"content,omitempty"`
+	SolverID      *string           `json:"solver_id,omitempty"`
+	SolvedTime    *string           `json:"solved_time,omitempty"`
+	RefCommentID  *string           `json:"ref_comment_id,omitempty"`
+	Selection     *CommentSelection `json:"selection,omitempty"`
+}
+
+func (c *Comment) ToResp(style string) *RespComment {
+	if c == nil {
+		return nil
+	}
+	r := &RespComment{
+		ID: c.ID, Target: c.Target, CommentatorID: c.CommentatorID, Status: c.Status,
+		CreateTime: formatTimestamp(c.CreateTime), UpdateTime: formatTimestamp(c.UpdateTime),
+		SolverID: c.SolverID, RefCommentID: c.RefCommentID, Selection: c.Selection,
+	}
+	if c.SolvedTime != nil {
+		t := formatTimestamp(*c.SolvedTime)
+		r.SolvedTime = &t
+	}
+	if c.Content != nil {
+		if style == "simple" {
+			r.Content = c.Content.ToSemiPlain()
+		} else {
+			r.Content = c.Content
+		}
+	}
+	return r
+}
+
 // ToString CycleStatus to string
 func (t CycleStatus) ToString() string {
 	switch t {

--- a/shortcuts/okr/shortcuts.go
+++ b/shortcuts/okr/shortcuts.go
@@ -24,5 +24,13 @@ func Shortcuts() []common.Shortcut {
 		OKRWeight,
 		OKRIndicatorUpdate,
 		OKRPatch,
+		OKRCycleCommentDetail,
+		OKRListComments,
+		OKRGetComment,
+		OKRCreateComment,
+		OKRPatchComment,
+		OKRDeleteComment,
+		OKRSolveComment,
+		OKRReopenComment,
 	}
 }

--- a/skills/lark-okr/SKILL.md
+++ b/skills/lark-okr/SKILL.md
@@ -16,19 +16,20 @@ metadata:
 
 ## 快速决策
 
-| 用户需求           | 操作路径                                                                             | 参考文档                                                                                                                                                                                                                 |
-|----------------|----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 查看自己/他人的 OKR   | 获取用户 ID -> `+cycle-list` -> `+cycle-detail` -> 按需查指标/进展记录                        | [`cycle-list`](references/lark-okr-cycle-list.md), [`cycle-detail`](references/lark-okr-cycle-detail.md), [`indicators`](references/lark-okr-indicators.md), [`progress-list`](references/lark-okr-progress-list.md) |
-| 为自己写一组 OKR     | 优先用 `+batch-create` 创建 Objective/KR 骨架                                           | [`batch-create`](references/lark-okr-batch-create.md), [`contentblock`](references/lark-okr-contentblock.md)                                                                                                         |
-| 只新增一条 O 或单条 KR | 用 `+create`                                                                      | [`create`](references/lark-okr-create.md)                                                                                                                                                                            |
-| 编辑内容/备注/截止时间   | 用 `+patch`                                                                       | [`patch`](references/lark-okr-patch.md)                                                                                                                                                                              |
-| 修改 OKR 分数      | 只有用户明确说“分数”“评分”“打分”“score”时才用 `+patch --score`；分数不是进度/完成度                        | [`patch`](references/lark-okr-patch.md)                                                                                                                                                                              |
-| 调整顺序或权重        | 用 `+reorder` / `+weight`                                                         | [`reorder`](references/lark-okr-reorder.md), [`weight`](references/lark-okr-weight.md)                                                                                                                               |
-| 更新数字进度/完成度     | 百分比或不带单位数字用 `+indicator-update`；需要改单位/目标值时查指标后用 `indicators patch`               | [`indicator-update`](references/lark-okr-indicator-update.md), [`indicators`](references/lark-okr-indicators.md)                                                                                                     |
-| 写文字进展          | 用 `+progress-create`；如果文本和数字都有，百分比或默认单位可使用 `--progress-percent` 统一改，非百分比单位更新量化指标 | [`progress-create`](references/lark-okr-progress-create.md), [`progress-list`](references/lark-okr-progress-list.md), [`progress-update`](references/lark-okr-progress-update.md)                                    |
-| 对齐目标           | 直接按对齐关系工作流处理                                                                     | [`alignments`](references/lark-okr-alignments.md)                                                                                                                                                                    |
+| 用户需求                     | 操作路径                                                                                                                | 参考文档                                                                                                                                                                                                             |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 查看自己/他人的 OKR          | 获取用户 ID -> `+cycle-list` -> `+cycle-detail` -> 按需查指标/进展记录                                                  | [`cycle-list`](references/lark-okr-cycle-list.md), [`cycle-detail`](references/lark-okr-cycle-detail.md), [`indicators`](references/lark-okr-indicators.md), [`progress-list`](references/lark-okr-progress-list.md) |
+| 为自己写一组 OKR             | 优先用 `+batch-create` 创建 Objective/KR 骨架                                                                           | [`batch-create`](references/lark-okr-batch-create.md), [`contentblock`](references/lark-okr-contentblock.md)                                                                                                         |
+| 只新增一条 O 或单条 KR       | 用 `+create`                                                                                                            | [`create`](references/lark-okr-create.md)                                                                                                                                                                            |
+| 编辑内容/备注/截止时间       | 用 `+patch`                                                                                                             | [`patch`](references/lark-okr-patch.md)                                                                                                                                                                              |
+| 修改 OKR 分数                | 只有用户明确说“分数”“评分”“打分”“score”时才用 `+patch --score`；分数不是进度/完成度                                     | [`patch`](references/lark-okr-patch.md)                                                                                                                                                                              |
+| 调整顺序或权重               | 用 `+reorder` / `+weight`                                                                                               | [`reorder`](references/lark-okr-reorder.md), [`weight`](references/lark-okr-weight.md)                                                                                                                               |
+| 更新数字进度/完成度          | 百分比或不带单位数字用 `+indicator-update`；需要改单位/目标值时查指标后用 `indicators patch`                            | [`indicator-update`](references/lark-okr-indicator-update.md), [`indicators`](references/lark-okr-indicators.md)                                                                                                     |
+| 写文字进展                   | 用 `+progress-create`；如果文本和数字都有，百分比或默认单位可使用 `--progress-percent` 统一改，非百分比单位更新量化指标 | [`progress-create`](references/lark-okr-progress-create.md), [`progress-list`](references/lark-okr-progress-list.md), [`progress-update`](references/lark-okr-progress-update.md)                                    |
+| 对齐目标                     | 直接按对齐关系工作流处理                                                                                                | [`alignments`](references/lark-okr-alignments.md)                                                                                                                                                                    |
+| 查询/创建/修改/解决 OKR 评论 | 获取周期下全部评论聚合用 `+comment-detail`，查询单个 O/KR/进展或仅查询周期全局评论用 `+comment-list`；                | [`comment`](references/lark-okr-comment-list.md), [`comment-create`](references/lark-okr-comment-create.md), [`comment-solve-reopen`](references/lark-okr-comment-solve-reopen.md)                                   |
 
-分类只在用户明确要求分类，或创建 Objective 返回 `invalid parameters` 且怀疑租户强制开启分类时处理：用 `lark-cli okr categories list --params '{"owner_type":"user","page_size":100}' --as user` 查可用分类，选择语义合适且 `enabled=true` 的分类 ID；分类可后续调整，不必停下等待用户确认。
+分类只在用户明确要求分类，或创建 Objective 返回 `invalid parameters` 且怀疑租户强制开启分类时处理：用 `lark-cli okr categories list --params '{"owner_type":"user","page_size":100}' --as user` 查可用分类，选择语义合适且`enabled=true` 的分类 ID；分类可后续调整，不必停下等待用户确认。
 
 获取当前用户用 `contact +get-user`；按姓名/邮箱查他人用 `contact +search-user`，拿到 `open_id` 后再查 OKR。
 
@@ -65,22 +66,30 @@ lark-cli okr +indicator-update \
 
 Shortcut 是对常用操作的高级封装（`lark-cli okr +<verb> [flags]`）。有 Shortcut 的操作优先使用。
 
-| Shortcut                                                       | 说明                                                                                |
-|----------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| [`+cycle-list`](references/lark-okr-cycle-list.md)             | 分页获取特定用户的 OKR 周期列表，可以用 `--time-range` 对当前页后置筛选                                    |
-| [`+cycle-detail`](references/lark-okr-cycle-detail.md)         | 获取特定 OKR 中所有目标和关键结果的内容                                                            |
-| [`+create`](references/lark-okr-create.md)                     | 创建单个 Objective（可带备注），或向已有 Objective 新增 KR                                      |
-| [`+progress-list`](references/lark-okr-progress-list.md)       | 分页获取目标或关键结果的进展记录列表                                                                |
-| [`+progress-get`](references/lark-okr-progress-get.md)         | 根据 ID 获取单条 OKR 进展记录                                                               |
-| [`+progress-create`](references/lark-okr-progress-create.md)   | 为目标或关键结果创建进展记录                                                                    |
-| [`+progress-update`](references/lark-okr-progress-update.md)   | 更新指定 ID 的进展记录内容                                                                   |
-| [`+progress-delete`](references/lark-okr-progress-delete.md)   | 删除指定 ID 的进展记录（不可恢复）                                                               |
-| [`+upload-image`](references/lark-okr-image-upload.md)         | 上传图片用于 OKR 进展记录的富文本内容                                                             |
-| [`+batch-create`](references/lark-okr-batch-create.md)         | 批量创建 Objective（可带备注）和 KR                                                        |
-| [`+reorder`](references/lark-okr-reorder.md)                   | 调整 Objective 或 KR 的顺位                                                             |
-| [`+weight`](references/lark-okr-weight.md)                     | 调整 Objective 或 KR 的权重                                                             |
-| [`+indicator-update`](references/lark-okr-indicator-update.md) | 更新 Objective 或 KR 的当前进度指标。更复杂的量化指标操作见 [量化指标管理](references/lark-okr-indicators.md) |
-| [`+patch`](references/lark-okr-patch.md)                       | 部分更新 Objective 或 KR（content、notes、score、deadline）                                 |
+| Shortcut                                                         | 说明                                                                                                          |
+|------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| [`+cycle-list`](references/lark-okr-cycle-list.md)               | 分页获取特定用户的 OKR 周期列表，可以用 `--time-range` 对当前页后置筛选                                       |
+| [`+cycle-detail`](references/lark-okr-cycle-detail.md)           | 获取特定 OKR 中所有目标和关键结果的内容                                                                       |
+| [`+create`](references/lark-okr-create.md)                       | 创建单个 Objective（可带备注），或向已有 Objective 新增 KR                                                    |
+| [`+progress-list`](references/lark-okr-progress-list.md)         | 分页获取目标或关键结果的进展记录列表                                                                          |
+| [`+progress-get`](references/lark-okr-progress-get.md)           | 根据 ID 获取单条 OKR 进展记录                                                                                 |
+| [`+progress-create`](references/lark-okr-progress-create.md)     | 为目标或关键结果创建进展记录                                                                                  |
+| [`+progress-update`](references/lark-okr-progress-update.md)     | 更新指定 ID 的进展记录内容                                                                                    |
+| [`+progress-delete`](references/lark-okr-progress-delete.md)     | 删除指定 ID 的进展记录（不可恢复）                                                                            |
+| [`+upload-image`](references/lark-okr-image-upload.md)           | 上传图片用于 OKR 进展记录的富文本内容                                                                         |
+| [`+batch-create`](references/lark-okr-batch-create.md)           | 批量创建 Objective（可带备注）和 KR                                                                           |
+| [`+reorder`](references/lark-okr-reorder.md)                     | 调整 Objective 或 KR 的顺位                                                                                   |
+| [`+weight`](references/lark-okr-weight.md)                       | 调整 Objective 或 KR 的权重                                                                                   |
+| [`+indicator-update`](references/lark-okr-indicator-update.md)   | 更新 Objective 或 KR 的当前进度指标。更复杂的量化指标操作见 [量化指标管理](references/lark-okr-indicators.md) |
+| [`+patch`](references/lark-okr-patch.md)                         | 部分更新 Objective 或 KR（content、notes、score、deadline）                                                   |
+| [`+comment-detail`](references/lark-okr-comment-detail.md)       | 获取周期下 Cycle/Objective/KeyResult/Progress 的全部评论                                                      |
+| [`+comment-list`](references/lark-okr-comment-list.md)           | 分页获取单个 OKR 实体下的评论                                                                                 |
+| [`+comment-get`](references/lark-okr-comment-get.md)             | 获取单条评论详情                                                                                              |
+| [`+comment-create`](references/lark-okr-comment-create.md)       | 创建新评论或回复已有评论(仅支持 --as user)                                                                    |
+| [`+comment-patch`](references/lark-okr-comment-patch.md)         | 修改评论内容(仅支持 --as user)                                                                                |
+| [`+comment-delete`](references/lark-okr-comment-delete.md)       | 永久删除单条评论(仅支持 --as user)                                                                            |
+| [`+comment-solve`](references/lark-okr-comment-solve-reopen.md)  | 解决评论或划词评论串(仅支持 --as user)                                                                        |
+| [`+comment-reopen`](references/lark-okr-comment-solve-reopen.md) | 重新打开评论或划词评论串(仅支持 --as user)                                                                    |
 
 ### 创建场景选择
 

--- a/skills/lark-okr/references/lark-okr-comment-create.md
+++ b/skills/lark-okr/references/lark-okr-comment-create.md
@@ -54,8 +54,9 @@ lark-cli okr +comment-create --target-type progress --target-id 3456789012345678
    - objective/key_result：在 selected-text、select-all、ref-comment-id 中选择且只能选择一个。
 3. 准备 content：通常建议使用 simple 格式，需要精确控制 @用户的位置时，可以使用 richtext 格式，参考 [ContentBlock 格式](lark-okr-contentblock.md)
 4. 执行命令；真实写入前可以先使用 --dry-run 检查 URL、query 和 body。
-5. 创建(而非回复) Objective/KeyResult 划词评论是，使用 selected-text 时，若用户未指定评论的具体位置，通常可以使用 select-all
-   - 若需使用 selected-text 精确选择划词选区时，只可传入正文中真实存在的连续纯文本片段；不要包含或跨越 mention 占位符。若 selected-text 无匹配内容，会 fallback 至选择全文。
+5. 在创建(而非回复) Objective/KeyResult 划词评论时，若用户未指定评论的具体位置，通常可以使用 select-all 而非自行指定 selected-text，除非用户需求中明确了具体的段落。
+   - 若需使用 selected-text 精确选择划词选区时，只可传入正文中真实存在的连续纯文本片段；不要包含或跨越 mention 占位符，否则无法命中具体内容。
+   - selected-text 会选择对应文本的首个命中。若 selected-text 未匹配到内容，会 fallback 至选择全文。
 
 ## 输出
 

--- a/skills/lark-okr/references/lark-okr-comment-create.md
+++ b/skills/lark-okr/references/lark-okr-comment-create.md
@@ -1,0 +1,90 @@
+# okr +comment-create
+> **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
+
+创建一条 OKR 评论，或回复已有的评论。只支持 user 身份。
+
+## 推荐命令
+
+```bash
+# 在 Progress 下创建实体级评论。
+lark-cli okr +comment-create --target-type progress --target-id 3456789012345678901 --content '{"text":"进展不错"}'
+
+# 在 Objective 正文中创建指定文本的划词评论。
+lark-cli okr +comment-create --target-type objective --target-id 2345678901234567890 --content '{"text":"请补充数据"}' --selected-text '提升核心接口稳定性'
+
+# 在 Objective 正文中创建划词评论。
+lark-cli okr +comment-create --target-type objective --target-id 2345678901234567890 --content '{"text":"请补充数据"}' --select-all
+
+# 在 KeyResult 的已有划词评论串中追加回复。
+lark-cli okr +comment-create --target-type key_result --target-id 4567890123456789012 --content '{"text":"已回复"}' --ref-comment-id 7000000000000000004
+
+# 使用 richtext 文件作为评论正文。
+lark-cli okr +comment-create --target-type progress --target-id 3456789012345678901 --style richtext --content '@comment.json'
+```
+
+```bash
+# 写入前预览创建评论的 URL、参数和请求体。
+lark-cli okr +comment-create --target-type progress --target-id 3456789012345678901 --content '{"text":"进展不错"}' --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| --target-type | 是 | — | cycle、progress、objective 或 key_result。 |
+| --target-id | 是 | — | 评论对象 ID，int64 正整数。 |
+| --content | 否¹ | — | 评论正文；simple 输入 SemiPlainContent JSON，richtext 输入 ContentBlock JSON。支持 @文件路径。 |
+| --selected-text | 否¹ | — | Objective/KeyResult 新建划词时的完整纯文本。 |
+| --select-all | 否¹ | false | Objective/KeyResult 使用全文 fallback；必须同时传 --content。 |
+| --ref-comment-id | 否¹ | — | 回复 Progress/Cycle 评论，或将 Objective/KeyResult 评论挂入已有划词串。 |
+| --style | 否 | simple | 输入/输出风格：simple 或 richtext。 |
+| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
+| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
+| --format | 否 | json | 输出格式。 |
+
+> ¹ content 对 Cycle/Progress 评论可选，但 select-all 必须有 content；Objective/KeyResult 新建评论需要 content。
+
+接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+
+## 工作流程
+
+1. 确定评论 target：使用 [+cycle-detail](lark-okr-cycle-detail.md) 获取 Objective/KeyResult ID，使用 [+progress-list](lark-okr-progress-list.md) 获取 Progress ID；已有评论串时使用 [+comment-list](lark-okr-comment-list.md) 或 [+comment-get](lark-okr-comment-get.md) 获取 comment-id。
+2. 根据 target-type 选择评论形式：
+   - cycle/progress：不传 selected-text 或 select-all；需要回复时传 ref-comment-id。
+   - objective/key_result：在 selected-text、select-all、ref-comment-id 中选择且只能选择一个。
+3. 准备 content：通常建议使用 simple 格式，需要精确控制 @用户的位置时，可以使用 richtext 格式，参考 [ContentBlock 格式](lark-okr-contentblock.md)
+4. 执行命令；真实写入前可以先使用 --dry-run 检查 URL、query 和 body。
+5. 创建(而非回复) Objective/KeyResult 划词评论是，使用 selected-text 时，若用户未指定评论的具体位置，通常可以使用 select-all
+   - 若需使用 selected-text 精确选择划词选区时，只可传入正文中真实存在的连续纯文本片段；不要包含或跨越 mention 占位符。若 selected-text 无匹配内容，会 fallback 至选择全文。
+
+## 输出
+
+创建成功返回 JSON：
+
+```json
+{
+  "comment_id": "7000000000000000004",
+  "selection_id": "8000000000000000002"
+}
+```
+
+- comment_id 是新评论 ID。
+- selection_id 只在创建划词评论时返回，用于识别评论串。
+- 创建接口不直接返回完整 Comment；需要详情时使用 [+comment-get](lark-okr-comment-get.md)。
+
+## 注意事项
+
+- Objective/KeyResult 的 ref-comment-id 只用于定位已有划词串，不会在新评论的 ref_comment_id 字段建立引用关系。
+- `--ref-comment-id` 必须传评论实体自身的 `id`，不能传 `selection.id`。`selection.id` 只用于识别同一个划词评论串；如果要回复某个划词串，应先从 +comment-list 或 +comment-detail 中找到该串内任意一条 Comment 的 `id`，再将这个 `id` 传给 `--ref-comment-id`。
+- Progress/Cycle 是实体级评论；Progress 的 ref-comment-id 会建立普通评论之间的引用关系。
+- 评论的 content 不支持 docs/images 字段，建议使用 simple 格式填写
+
+## 参考
+
+- [lark-okr](../SKILL.md) — OKR 命令、路由和通用约定
+- [OKR 实体定义](lark-okr-entities.md) — Comment、评论串和 target 类型
+- [ContentBlock 格式](lark-okr-contentblock.md) — simple/richtext 输入格式
+- [okr +comment-list](lark-okr-comment-list.md) — 查询已有评论和 selection.id
+- [okr +comment-get](lark-okr-comment-get.md) — 获取评论详情
+- [okr +comment-solve / +comment-reopen](lark-okr-comment-solve-reopen.md) — 管理评论状态
+- [lark-shared](../../lark-shared/SKILL.md) — 认证、身份、权限和安全规则

--- a/skills/lark-okr/references/lark-okr-comment-create.md
+++ b/skills/lark-okr/references/lark-okr-comment-create.md
@@ -6,8 +6,8 @@
 ## 推荐命令
 
 ```bash
-# 在 Progress 下创建实体级评论。
-lark-cli okr +comment-create --target-type progress --target-id 3456789012345678901 --content '{"text":"进展不错"}'
+# 在周期下创建实体级评论。
+lark-cli okr +comment-create --target-type cycle --target-id 3456789012345678901 --content '{"text":"进展不错"}'
 
 # 在 Objective 正文中创建指定文本的划词评论。
 lark-cli okr +comment-create --target-type objective --target-id 2345678901234567890 --content '{"text":"请补充数据"}' --selected-text '提升核心接口稳定性'
@@ -27,32 +27,44 @@ lark-cli okr +comment-create --target-type progress --target-id 3456789012345678
 lark-cli okr +comment-create --target-type progress --target-id 3456789012345678901 --content '{"text":"进展不错"}' --dry-run
 ```
 
+## 常用表述
+
+以下是一些用户需求中常见的表述:
+
+- 全局评论/周期评论/OKR评论: 指 OKR 周期的实体级评论，当用户要求创建全局评论，或对某个周期的 OKR 进行评论（不特指某个 Objective 或 KeyResult 时），可以创建周期实体级评论。
+- 划词评论: 指 Objective/KeyResult 下的划词评论。需要注意，Objective/KeyResult 下不能创建实体级评论（必须携带 selected-text 或 select-all）。若用户没有特别指定需评论的段落，使用 --select-all
+
 ## 参数
 
-| 参数 | 必填 | 默认值 | 说明 |
-|---|---|---|---|
-| --target-type | 是 | — | cycle、progress、objective 或 key_result。 |
-| --target-id | 是 | — | 评论对象 ID，int64 正整数。 |
-| --content | 否¹ | — | 评论正文；simple 输入 SemiPlainContent JSON，richtext 输入 ContentBlock JSON。支持 @文件路径。 |
-| --selected-text | 否¹ | — | Objective/KeyResult 新建划词时的完整纯文本。 |
-| --select-all | 否¹ | false | Objective/KeyResult 使用全文 fallback；必须同时传 --content。 |
-| --ref-comment-id | 否¹ | — | 回复 Progress/Cycle 评论，或将 Objective/KeyResult 评论挂入已有划词串。 |
-| --style | 否 | simple | 输入/输出风格：simple 或 richtext。 |
-| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
-| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
-| --format | 否 | json | 输出格式。 |
+| 参数             | 必填 | 默认值  | 说明                                                                                                          |
+|------------------|------|---------|---------------------------------------------------------------------------------------------------------------|
+| --target-type    | 是   | —       | cycle、progress、objective 或 key_result。                                                                    |
+| --target-id      | 是   | —       | 评论对象 ID，int64 正整数。                                                                                   |
+| --content        | 是   | —       | 评论正文；输入风格：`simple`（半纯文本 JSON，推荐） \| `richtext`（完整 ContentBlock JSON），支持 @文件路径。 |
+| --selected-text  | 否   | —       | Objective/KeyResult 新建划词时的完整纯文本。                                                                  |
+| --select-all     | 否   | false   | Objective/KeyResult 划词时选择全文。                                                                          |
+| --ref-comment-id | 否   | —       | 回复 Progress/Cycle 评论，或将 Objective/KeyResult 评论挂入已有划词串。                                       |
+| --style          | 否   | simple  | 输入/输出风格：simple 或 richtext。                                                                           |
+| --user-id-type   | 否   | open_id | open_id、union_id、user_id 或 user_key。                                                                      |
+| --dry-run        | 否   | —       | 预览 API 调用而不实际执行。                                                                                   |
+| --format         | 否   | json    | 输出格式。                                                                                                    |
 
-> ¹ content 对 Cycle/Progress 评论可选，但 select-all 必须有 content；Objective/KeyResult 新建评论需要 content。
+## 评论场景参数组合
 
-接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+| 场景                           | target-type             | 必须传                                                        | 不能传                                                |
+|--------------------------------|-------------------------|---------------------------------------------------------------|-------------------------------------------------------|
+| 创建周期/进展实体级评论        | cycle 或 progress       | `--content`                                                   | `--selected-text`、`--select-all`、`--ref-comment-id` |
+| 回复周期/进展已有评论          | cycle 或 progress       | `--content`、`--ref-comment-id`                               | `--selected-text`、`--select-all`                     |
+| 创建 Objective/KR 划词评论     | objective 或 key_result | `--content`，并在 `--selected-text` / `--select-all` 中二选一 | `--ref-comment-id`                                    |
+| 追加到 Objective/KR 划词评论串 | objective 或 key_result | `--content`、`--ref-comment-id`                               | `--selected-text`、`--select-all`                     |
 
 ## 工作流程
 
 1. 确定评论 target：使用 [+cycle-detail](lark-okr-cycle-detail.md) 获取 Objective/KeyResult ID，使用 [+progress-list](lark-okr-progress-list.md) 获取 Progress ID；已有评论串时使用 [+comment-list](lark-okr-comment-list.md) 或 [+comment-get](lark-okr-comment-get.md) 获取 comment-id。
 2. 根据 target-type 选择评论形式：
    - cycle/progress：不传 selected-text 或 select-all；需要回复时传 ref-comment-id。
-   - objective/key_result：在 selected-text、select-all、ref-comment-id 中选择且只能选择一个。
-3. 准备 content：通常建议使用 simple 格式，需要精确控制 @用户的位置时，可以使用 richtext 格式，参考 [ContentBlock 格式](lark-okr-contentblock.md)
+   - objective/key_result：在 selected-text、select-all、ref-comment-id 中选择且只能选择一个；selected-text 和 select-all 互斥，二者也都和 ref-comment-id 互斥。
+3. 准备 content：content 是业务必填，通常建议使用 simple 格式，需要精确控制 @用户的位置时，可以使用 richtext 格式，参考 [ContentBlock 格式](lark-okr-contentblock.md)
 4. 执行命令；真实写入前可以先使用 --dry-run 检查 URL、query 和 body。
 5. 在创建(而非回复) Objective/KeyResult 划词评论时，若用户未指定评论的具体位置，通常可以使用 select-all 而非自行指定 selected-text，除非用户需求中明确了具体的段落。
    - 若需使用 selected-text 精确选择划词选区时，只可传入正文中真实存在的连续纯文本片段；不要包含或跨越 mention 占位符，否则无法命中具体内容。

--- a/skills/lark-okr/references/lark-okr-comment-delete.md
+++ b/skills/lark-okr/references/lark-okr-comment-delete.md
@@ -1,0 +1,61 @@
+# okr +comment-delete
+> **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
+
+永久删除一条评论。删除划词评论时只删除指定评论，不会删除同一 selection.id 下的其他评论。
+
+## 功能简介
+
+删除一条特定评论。本 shortcut 为高风险接口，删除的评论不可找回，如果只是暂时结束讨论，可使用 +comment-solve。只支持 user 身份。
+
+## 推荐命令
+```bash
+# 预览删除请求，不实际执行永久删除。
+lark-cli okr +comment-delete --comment-id 7000000000000000004 --dry-run
+# 确认删除目标后，执行不可恢复的删除操作。
+lark-cli okr +comment-delete --comment-id 7000000000000000004 --yes
+```
+
+
+## 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| --comment-id | 是 | — | 要删除的评论 ID，int64 正整数。建议先由 +comment-get 核对。 |
+| --yes | 真实执行时是 | — | 确认 high-risk-write 操作。--dry-run 时不需要。 |
+| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
+| --format | 否 | json | 输出格式。 |
+
+接口的 user_id_type 和 department_id_type 参数由 shortcut 忽略并不会传递。
+
+## 工作流程
+
+1. 使用 [+comment-list](lark-okr-comment-list.md)、[+comment-detail](lark-okr-comment-detail.md) 或 [+comment-get](lark-okr-comment-get.md) 定位并确认 comment-id。
+2. 判断是否真的需要删除：解决评论使用 [+comment-solve](lark-okr-comment-solve-reopen.md)，删除只用于永久移除内容。
+3. 先执行带 --dry-run 的命令检查 URL 和 comment-id。
+4. 向用户明确说明删除不可恢复；得到确认后，在原始命令末尾追加 --yes 执行。
+5. 根据 deleted=true 和返回的 comment_id 确认结果。
+
+## 输出
+
+删除成功返回 JSON：
+```json
+{
+  "deleted": true,
+  "comment_id": "7000000000000000004"
+}
+```
+
+
+## 注意事项
+
+- 删除是单条评论级操作，即使评论属于划词评论串，也不会连带删除其他评论。
+- 删除后不能使用 +comment-reopen 恢复；暂时关闭讨论应使用 +comment-solve。
+- 该命令不需要 style，因为接口没有返回 Comment 正文。
+
+## 参考
+
+- [lark-okr](../SKILL.md) — OKR 命令、路由和通用约定
+- [OKR 实体定义](lark-okr-entities.md) — Comment、评论串和状态规则
+- [okr +comment-get](lark-okr-comment-get.md) — 删除前核对评论
+- [okr +comment-solve / +comment-reopen](lark-okr-comment-solve-reopen.md) — 暂时解决和恢复评论
+- [lark-shared](../../lark-shared/SKILL.md) — 高风险操作确认协议

--- a/skills/lark-okr/references/lark-okr-comment-delete.md
+++ b/skills/lark-okr/references/lark-okr-comment-delete.md
@@ -18,14 +18,12 @@ lark-cli okr +comment-delete --comment-id 7000000000000000004 --yes
 
 ## 参数
 
-| 参数 | 必填 | 默认值 | 说明 |
-|---|---|---|---|
-| --comment-id | 是 | — | 要删除的评论 ID，int64 正整数。建议先由 +comment-get 核对。 |
-| --yes | 真实执行时是 | — | 确认 high-risk-write 操作。--dry-run 时不需要。 |
-| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
-| --format | 否 | json | 输出格式。 |
-
-接口的 user_id_type 和 department_id_type 参数由 shortcut 忽略并不会传递。
+| 参数         | 必填         | 默认值 | 说明                                                        |
+|--------------|--------------|--------|-------------------------------------------------------------|
+| --comment-id | 是           | —      | 要删除的评论 ID，int64 正整数。建议先由 +comment-get 核对。 |
+| --yes        | 真实执行时是 | —      | 确认 high-risk-write 操作。--dry-run 时不需要。             |
+| --dry-run    | 否           | —      | 预览 API 调用而不实际执行。                                 |
+| --format     | 否           | json   | 输出格式。                                                  |
 
 ## 工作流程
 

--- a/skills/lark-okr/references/lark-okr-comment-detail.md
+++ b/skills/lark-okr/references/lark-okr-comment-detail.md
@@ -18,12 +18,12 @@ lark-cli okr +comment-detail --cycle-id 1234567890123456789 --dry-run
 
 ## 参数
 
-| 参数 | 必填 | 默认值 | 说明 |
-|---|---|---|---|
-| --cycle-id | 是 | — | OKR 周期 ID，int64 正整数，可从 +cycle-list 获取。 |
-| --style | 否 | simple | simple 返回 SemiPlainContent；richtext 返回原始 ContentBlock。 |
-| --dry-run | 否 | — | 预览聚合查询而不实际执行。 |
-| --format | 否 | json | 输出格式。 |
+| 参数       | 必填 | 默认值 | 说明                                                                                       |
+|------------|------|--------|--------------------------------------------------------------------------------------------|
+| --cycle-id | 是   | —      | OKR 周期 ID，int64 正整数，可从 +cycle-list 获取。                                         |
+| --style    | 否   | simple | simple 返回半纯文本格式，不涉及字体/颜色等信息时推荐使用；richtext 返回原始 ContentBlock。 |
+| --dry-run  | 否   | —      | 预览聚合查询而不实际执行。                                                                 |
+| --format   | 否   | json   | 输出格式。                                                                                 |
 
 ## 工作流程
 

--- a/skills/lark-okr/references/lark-okr-comment-detail.md
+++ b/skills/lark-okr/references/lark-okr-comment-detail.md
@@ -1,0 +1,80 @@
+# okr +comment-detail
+> **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
+
+获取指定 OKR 周期下 Cycle、Objective、KeyResult 和 Progress 的全部评论，并按评论对象和评论串整理后按时间升序排列。该 shortcut 是跨多个 OKR 接口的聚合查询。
+
+## 推荐命令
+
+```bash
+# 获取指定周期下所有 Cycle、Objective、KeyResult 和 Progress 的评论。
+lark-cli okr +comment-detail --cycle-id 1234567890123456789
+
+# 获取原始 ContentBlock 格式的评论正文。
+lark-cli okr +comment-detail --cycle-id 1234567890123456789 --style richtext
+
+# 预览聚合查询的 API 调用，不实际执行。
+lark-cli okr +comment-detail --cycle-id 1234567890123456789 --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| --cycle-id | 是 | — | OKR 周期 ID，int64 正整数，可从 +cycle-list 获取。 |
+| --style | 否 | simple | simple 返回 SemiPlainContent；richtext 返回原始 ContentBlock。 |
+| --dry-run | 否 | — | 预览聚合查询而不实际执行。 |
+| --format | 否 | json | 输出格式。 |
+
+## 工作流程
+
+1. 使用 +cycle-list 获取周期 ID；如果用户已经提供周期 ID，直接使用。
+2. 执行 +comment-detail --cycle-id "..."。shortcut 会依次获取周期下的 Objective、每个 Objective 下的 KeyResult、每个 Objective/KeyResult 下的 Progress，以及四类对象的评论。
+3. 评论接口自动处理分页；对象读取和评论读取使用有界并发。任一底层请求失败时整体返回错误，不返回静默不完整结果。
+4. 评论串按首条评论的 create_time 升序排列，串内评论也按 create_time 升序排列。
+
+## 输出
+
+返回 JSON 的核心结构如下：
+
+```json
+{
+  "cycle_id": "1234567890123456789",
+  "comments": {
+    "2345678901234567890": [
+      [
+        {
+          "id": "7000000000000000001",
+          "target": {"target_type": "objective", "target_id": "2345678901234567890"},
+          "commentator_id": "ou_xxx",
+          "status": "open",
+          "create_time": "2025-01-15 10:30:00",
+          "update_time": "2025-01-15 10:30:00",
+          "selection": {"id": "8000000000000000001", "selected_text": "提升核心接口稳定性"},
+          "content": {"text": "请补充指标", "mention": [], "docs": [], "images": []}
+        }
+      ]
+    ]
+  },
+  "style": "simple"
+}
+```
+
+- comments 第一层 key 是 target_id；value 是评论串数组；每个评论串是评论数组。
+- simple 风格下 content 是 SemiPlainContent；richtext 风格下 content 是 ContentBlock。
+- 评论时间戳会转换为可读日期时间；selection、状态和引用字段会保留。
+- `comments` 会为周期遍历到的每个 target 保留一个 target_id key；即使该对象没有评论，对应 value 也会是空的评论串数组。
+
+## 注意事项
+
+- 这是聚合查询，接口调用次数取决于周期下的 Objective、KeyResult 和 Progress 数量。
+- +comment-detail 不接受 department-id-type，该接口参数由 shortcut 忽略。
+- 该命令只读取评论，不会修改、解决或删除评论。
+
+## 参考
+
+- [lark-okr](../SKILL.md) — OKR 命令、路由和通用约定
+- [OKR 实体定义](lark-okr-entities.md) — Cycle、Objective、KeyResult、Progress 和 Comment 的关系
+- [ContentBlock 格式](lark-okr-contentblock.md) — ContentBlock 与 SemiPlainContent 格式
+- [okr +cycle-detail](lark-okr-cycle-detail.md) — 获取周期下的 Objective 和 KeyResult
+- [okr +progress-list](lark-okr-progress-list.md) — 获取 Objective 或 KeyResult 下的 Progress
+- [lark-shared](../../lark-shared/SKILL.md) — 认证、身份、权限和安全规则

--- a/skills/lark-okr/references/lark-okr-comment-get.md
+++ b/skills/lark-okr/references/lark-okr-comment-get.md
@@ -18,15 +18,13 @@ lark-cli okr +comment-get --comment-id 7000000000000000001 --dry-run
 
 ## 参数
 
-| 参数 | 必填 | 默认值 | 说明 |
-|---|---|---|---|
-| --comment-id | 是 | — | 评论 ID，int64 正整数。 |
-| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
-| --style | 否 | simple | simple 返回 SemiPlainContent；richtext 返回 ContentBlock。 |
-| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
-| --format | 否 | json | 输出格式。 |
-
-接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+| 参数           | 必填 | 默认值  | 说明                                                                                   |
+|----------------|------|---------|----------------------------------------------------------------------------------------|
+| --comment-id   | 是   | —       | 评论 ID，int64 正整数。                                                                |
+| --user-id-type | 否   | open_id | open_id、union_id、user_id 或 user_key。                                               |
+| --style        | 否   | simple  | simple 返回半纯文本格式，不涉及字体/颜色等信息时推荐使用；richtext 返回 ContentBlock。 |
+| --dry-run      | 否   | —       | 预览 API 调用而不实际执行。                                                            |
+| --format       | 否   | json    | 输出格式。                                                                             |
 
 ## 工作流程
 

--- a/skills/lark-okr/references/lark-okr-comment-get.md
+++ b/skills/lark-okr/references/lark-okr-comment-get.md
@@ -1,0 +1,68 @@
+# okr +comment-get
+> **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
+
+根据评论 ID 获取单条 OKR 评论，查看评论正文、状态、评论对象、引用关系和划词信息。本 shortcut 适合用于在编辑评论后确认其最终状态。
+
+## 推荐命令
+
+```bash
+# 获取一条评论的简化正文和元数据。
+lark-cli okr +comment-get --comment-id 7000000000000000001
+
+# 获取原始 ContentBlock 格式的评论正文。
+lark-cli okr +comment-get --comment-id 7000000000000000001 --style richtext
+
+# 预览获取评论的 API 调用，不实际执行。
+lark-cli okr +comment-get --comment-id 7000000000000000001 --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| --comment-id | 是 | — | 评论 ID，int64 正整数。 |
+| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
+| --style | 否 | simple | simple 返回 SemiPlainContent；richtext 返回 ContentBlock。 |
+| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
+| --format | 否 | json | 输出格式。 |
+
+接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+
+## 工作流程
+
+1. 如果只有目标 ID，先用 [+comment-list](lark-okr-comment-list.md) 或 [+comment-detail](lark-okr-comment-detail.md) 定位 comment-id。
+2. 执行 +comment-get --comment-id "..."。
+3. 根据后续操作检查 selection、status 和 ref_comment_id：selection.id 表示划词评论，status 为 solved 表示已解决，ref_comment_id 表示引用关系。
+
+## 输出
+
+```json
+{
+  "comment": {
+    "id": "7000000000000000001",
+    "target": {"target_type": "progress", "target_id": "3456789012345678901"},
+    "commentator_id": "ou_xxx",
+    "status": "open",
+    "create_time": "2025-01-15 10:30:00",
+    "update_time": "2025-01-15 10:30:00",
+    "content": {"text": "进展不错", "mention": [], "docs": [], "images": []},
+    "ref_comment_id": "7000000000000000000"
+  },
+  "style": "simple"
+}
+```
+
+selection、solver_id、solved_time 和 ref_comment_id 按接口是否返回保留。
+
+## 注意事项
+
+- Objective/KeyResult 的划词评论通过 selection.id 归属于评论串；实体级评论没有 selection。
+- 解决或重新打开请使用 [+comment-solve / +comment-reopen](lark-okr-comment-solve-reopen.md)。
+
+## 参考
+
+- [lark-okr](../SKILL.md) — OKR 命令、路由和通用约定
+- [OKR 实体定义](lark-okr-entities.md) — Comment 字段与评论串规则
+- [ContentBlock 格式](lark-okr-contentblock.md) — 评论正文格式
+- [okr +comment-list](lark-okr-comment-list.md) — 查询目标下的评论
+- [lark-shared](../../lark-shared/SKILL.md) — 认证、身份、权限和安全规则

--- a/skills/lark-okr/references/lark-okr-comment-list.md
+++ b/skills/lark-okr/references/lark-okr-comment-list.md
@@ -18,18 +18,16 @@ lark-cli okr +comment-list --target-type key_result --target-id 4567890123456789
 
 ## 参数
 
-| 参数             | 必填 | 默认值     | 说明                                                   |
-|----------------|----|---------|------------------------------------------------------|
-| --target-type  | 是  | —       | cycle、objective、key_result 或 progress。               |
-| --target-id    | 是  | —       | 评论对象 ID，int64 正整数。                                   |
-| --page-size    | 否  | 100     | 每页数量，范围 1-100。                                       |
-| --page-token   | 否  | ""      | 上一次响应中的 token；首页不传。                                  |
-| --user-id-type | 否  | open_id | open_id、union_id、user_id 或 user_key。                 |
-| --style        | 否  | simple  | simple 返回 SemiPlainContent；richtext 返回 ContentBlock。 |
-| --dry-run      | 否  | —       | 预览 API 调用而不实际执行。                                     |
-| --format       | 否  | json    | 输出格式。                                                |
-
-接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+| 参数           | 必填 | 默认值  | 说明                                                                                   |
+|----------------|------|---------|----------------------------------------------------------------------------------------|
+| --target-type  | 是   | —       | cycle、objective、key_result 或 progress。                                             |
+| --target-id    | 是   | —       | 评论对象 ID，int64 正整数。                                                            |
+| --page-size    | 否   | 100     | 每页数量，范围 1-100。                                                                 |
+| --page-token   | 否   | ""      | 上一次响应中的 token；首页不传。                                                       |
+| --user-id-type | 否   | open_id | open_id、union_id、user_id 或 user_key。                                               |
+| --style        | 否   | simple  | simple 返回半纯文本格式，不涉及字体/颜色等信息时推荐使用；richtext 返回 ContentBlock。 |
+| --dry-run      | 否   | —       | 预览 API 调用而不实际执行。                                                            |
+| --format       | 否   | json    | 输出格式。                                                                             |
 
 ## 工作流程
 
@@ -62,7 +60,7 @@ lark-cli okr +comment-list --target-type key_result --target-id 4567890123456789
 }
 ```
 
-comments 是当前页按评论串分组的二维数组，不会自动拉取所有分页；simple 风格返回 SemiPlainContent，richtext 风格返回 ContentBlock。
+comments 是当前页按评论串分组的二维数组，不会自动拉取所有分页；simple 风格返回简单的半纯文本格式，richtext 风格返回原生 ContentBlock。
 
 ## 注意事项
 

--- a/skills/lark-okr/references/lark-okr-comment-list.md
+++ b/skills/lark-okr/references/lark-okr-comment-list.md
@@ -1,0 +1,81 @@
+# okr +comment-list
+> **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
+
+分页获取单个 Cycle、Objective、KeyResult 或 Progress 下的评论。查询整个周期下所有评论时可使用 [+comment-detail](lark-okr-comment-detail.md)。
+
+## 推荐命令
+
+```bash
+# 获取 Objective 下的第一页评论。
+lark-cli okr +comment-list --target-type objective --target-id 2345678901234567890
+
+# 使用上一页 token 获取 Progress 下的下一页评论。
+lark-cli okr +comment-list --target-type progress --target-id 3456789012345678901 --page-size 100 --page-token "7000000000000000002"
+
+# 以 richtext 输出 KeyResult 评论，但是仅预览请求，不实际获取。
+lark-cli okr +comment-list --target-type key_result --target-id 4567890123456789012 --style richtext --dry-run
+```
+
+## 参数
+
+| 参数             | 必填 | 默认值     | 说明                                                   |
+|----------------|----|---------|------------------------------------------------------|
+| --target-type  | 是  | —       | cycle、objective、key_result 或 progress。               |
+| --target-id    | 是  | —       | 评论对象 ID，int64 正整数。                                   |
+| --page-size    | 否  | 100     | 每页数量，范围 1-100。                                       |
+| --page-token   | 否  | ""      | 上一次响应中的 token；首页不传。                                  |
+| --user-id-type | 否  | open_id | open_id、union_id、user_id 或 user_key。                 |
+| --style        | 否  | simple  | simple 返回 SemiPlainContent；richtext 返回 ContentBlock。 |
+| --dry-run      | 否  | —       | 预览 API 调用而不实际执行。                                     |
+| --format       | 否  | json    | 输出格式。                                                |
+
+接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+
+## 工作流程
+
+1. 根据用户需求选择 target-type：周期用 cycle，目标用 objective，关键结果用 key_result，进展用 progress。
+2. 如果缺少 ID，使用 [+cycle-list](lark-okr-cycle-list.md)、[+cycle-detail](lark-okr-cycle-detail.md) 或 [+progress-list](lark-okr-progress-list.md) 获取。
+3. 执行 +comment-list --target-type "..." --target-id "..."。
+4. has_more 为 true 且 page_token 非空时，将 page_token 原样作为下一次调用的 --page-token；不要自行解析或修改 token。
+
+## 输出
+
+```json
+{
+  "comments": [
+    [
+      {
+        "id": "7000000000000000001",
+        "target": {"target_type": "objective", "target_id": "2345678901234567890"},
+        "commentator_id": "ou_xxx",
+        "status": "open",
+        "create_time": "2025-01-15 10:30:00",
+        "update_time": "2025-01-15 10:30:00",
+        "selection": {"id": "8000000000000000001", "selected_text": "提升核心接口稳定性"},
+        "content": {"text": "请补充指标", "mention": [], "docs": [], "images": []}
+      }
+    ]
+  ],
+  "has_more": true,
+  "page_token": "7000000000000000002",
+  "style": "simple"
+}
+```
+
+comments 是当前页按评论串分组的二维数组，不会自动拉取所有分页；simple 风格返回 SemiPlainContent，richtext 风格返回 ContentBlock。
+
+## 注意事项
+
+- 实体级评论没有 selection；Objective/KeyResult 的划词评论带有 selection.id。
+- 只对当前页内的评论进行评论串分组；如果同一评论串跨越分页边界，需结合相邻页自行合并，或使用 +comment-detail 获取整个周期的聚合结果。
+- 评论串按首条评论的 create_time 升序排列，串内评论也按 create_time 升序排列；时间相同则按评论 ID 升序。
+- 该命令是只读操作，不会改变评论状态。
+
+## 参考
+
+- [lark-okr](../SKILL.md) — OKR 命令、路由和通用约定
+- [OKR 实体定义](lark-okr-entities.md) — Comment、评论串和 target 类型
+- [okr +comment-detail](lark-okr-comment-detail.md) — 聚合获取周期评论
+- [okr +cycle-detail](lark-okr-cycle-detail.md) — 获取 Objective 和 KeyResult ID
+- [okr +progress-list](lark-okr-progress-list.md) — 获取 Progress ID
+- [lark-shared](../../lark-shared/SKILL.md) — 认证、身份、权限和安全规则

--- a/skills/lark-okr/references/lark-okr-comment-patch.md
+++ b/skills/lark-okr/references/lark-okr-comment-patch.md
@@ -3,6 +3,8 @@
 
 修改指定评论的正文。评论目标、划词定位、引用关系则一经创建不可修改。只支持 user 身份。
 
+`--content` 是业务必填项：OpenAPI schema 中该字段可能表现为可选，但实际修改评论必须提供非空正文。
+
 ## 推荐命令
 
 ```bash
@@ -18,16 +20,14 @@ lark-cli okr +comment-patch --comment-id 7000000000000000004 --content '{"text":
 
 ## 参数
 
-| 参数 | 必填 | 默认值 | 说明 |
-|---|---|---|---|
-| --comment-id | 是 | — | 评论 ID，int64 正整数；可从 [+comment-list](lark-okr-comment-list.md) 或 [+comment-detail](lark-okr-comment-detail.md) 获取。 |
-| --content | 是 | — | 新正文；simple 输入 SemiPlainContent JSON，richtext 输入 ContentBlock JSON。支持 @文件路径。 |
-| --style | 否 | simple | 输入/输出风格：simple 或 richtext。 |
-| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
-| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
-| --format | 否 | json | 输出格式。 |
-
-接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+| 参数           | 必填 | 默认值  | 说明                                                                                                                          |
+|----------------|------|---------|-------------------------------------------------------------------------------------------------------------------------------|
+| --comment-id   | 是   | —       | 评论 ID，int64 正整数；可从 [+comment-list](lark-okr-comment-list.md) 或 [+comment-detail](lark-okr-comment-detail.md) 获取。 |
+| --content      | 是   | —       | 新正文；输入风格：`simple`（半纯文本 JSON，推荐） \| `richtext`（完整 ContentBlock JSON），支持 @文件路径。                   |
+| --style        | 否   | simple  | 输入/输出风格：simple 或 richtext。                                                                                           |
+| --user-id-type | 否   | open_id | open_id、union_id、user_id 或 user_key。                                                                                      |
+| --dry-run      | 否   | —       | 预览 API 调用而不实际执行。                                                                                                   |
+| --format       | 否   | json    | 输出格式。                                                                                                                    |
 
 ## 工作流程
 

--- a/skills/lark-okr/references/lark-okr-comment-patch.md
+++ b/skills/lark-okr/references/lark-okr-comment-patch.md
@@ -1,0 +1,73 @@
+# okr +comment-patch
+> **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
+
+修改指定评论的正文。评论目标、划词定位、引用关系则一经创建不可修改。只支持 user 身份。
+
+## 推荐命令
+
+```bash
+# 使用 simple 风格修改评论正文。
+lark-cli okr +comment-patch --comment-id 7000000000000000004 --content '{"text":"更新后的评论"}'
+
+# 使用 richtext 文件修改评论正文。
+lark-cli okr +comment-patch --comment-id 7000000000000000004 --style richtext --content '@comment.json'
+
+# 写入前预览修改评论的 API 调用，不实际执行。
+lark-cli okr +comment-patch --comment-id 7000000000000000004 --content '{"text":"预览更新"}' --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| --comment-id | 是 | — | 评论 ID，int64 正整数；可从 [+comment-list](lark-okr-comment-list.md) 或 [+comment-detail](lark-okr-comment-detail.md) 获取。 |
+| --content | 是 | — | 新正文；simple 输入 SemiPlainContent JSON，richtext 输入 ContentBlock JSON。支持 @文件路径。 |
+| --style | 否 | simple | 输入/输出风格：simple 或 richtext。 |
+| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
+| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
+| --format | 否 | json | 输出格式。 |
+
+接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+
+## 工作流程
+
+1. 使用 [+comment-list](lark-okr-comment-list.md)、[+comment-detail](lark-okr-comment-detail.md) 或 [+comment-get](lark-okr-comment-get.md) 确认 comment-id 和目标评论。
+2. 准备 content：通常建议使用 simple 格式，需要精确控制 @用户的位置时，可以使用 richtext 格式，参考 [ContentBlock 格式](lark-okr-contentblock.md)
+3. 执行 +comment-patch；真实写入前用 --dry-run 检查请求。
+4. 如果要解决或重新打开评论，不要使用 patch，改用 [+comment-solve](lark-okr-comment-solve-reopen.md) 或 [+comment-reopen](lark-okr-comment-solve-reopen.md)。
+
+## 输出
+
+返回 JSON：
+
+```json
+{
+  "comment": {
+    "id": "7000000000000000004",
+    "target": {"target_type": "progress", "target_id": "3456789012345678901"},
+    "commentator_id": "ou_xxx",
+    "status": "open",
+    "create_time": "2025-01-15 10:30:00",
+    "update_time": "2025-01-15 11:00:00",
+    "content": {"text": "更新后的评论", "mention": [], "docs": [], "images": []}
+  },
+  "style": "simple"
+}
+```
+
+simple 风格的 content 为 SemiPlainContent；richtext 风格的 content 为 ContentBlock。
+
+## 注意事项
+
+- patch 不会改变评论的 target、selection、ref_comment_id 或 status。
+- simple 输入不支持 docs/images；需要富文本元素时使用 richtext。
+- 空正文不允许提交；如需删除评论，请使用 [+comment-delete](lark-okr-comment-delete.md)，删除不可恢复。
+
+## 参考
+
+- [lark-okr](../SKILL.md) — OKR 命令、路由和通用约定
+- [OKR 实体定义](lark-okr-entities.md) — Comment 字段与评论串规则
+- [ContentBlock 格式](lark-okr-contentblock.md) — 评论正文格式
+- [okr +comment-get](lark-okr-comment-get.md) — 获取更新前后的评论
+- [okr +comment-delete](lark-okr-comment-delete.md) — 永久删除评论
+- [lark-shared](../../lark-shared/SKILL.md) — 认证、身份、权限和安全规则

--- a/skills/lark-okr/references/lark-okr-comment-solve-reopen.md
+++ b/skills/lark-okr/references/lark-okr-comment-solve-reopen.md
@@ -1,0 +1,76 @@
+# okr +comment-solve / +comment-reopen
+> **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
+
+解决/重新打开一条评论。实体级评论按单条评论处理；划词评论则是操作整个评论串。只支持 user 身份。
+
+## 推荐命令
+
+```bash
+# 解决实体级评论或整个划词评论串。
+lark-cli okr +comment-solve --comment-id 7000000000000000004
+
+# 重新打开已解决的实体级评论或划词评论串。
+lark-cli okr +comment-reopen --comment-id 7000000000000000004
+
+# 预览解决评论的状态变更请求，不实际执行。
+lark-cli okr +comment-solve --comment-id 7000000000000000004 --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| --comment-id | 是 | — | 评论 ID，int64 正整数。可从 +comment-list、+comment-detail 或 +comment-get 获取。 |
+| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
+| --style | 否 | simple | affected_comments 的正文风格：simple（SemiPlainContent）或 richtext（ContentBlock）。 |
+| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
+| --format | 否 | json | 输出格式。 |
+
+接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+
+## 工作流程
+
+1. 使用 [+comment-list](lark-okr-comment-list.md)、[+comment-detail](lark-okr-comment-detail.md) 或 [+comment-get](lark-okr-comment-get.md) 获取并确认 comment-id。
+2. 检查评论是否属于划词串：如果返回有 selection.id，solve/reopen 会影响同一 selection.id 下的全部评论。
+3. 根据用户动作选择 +comment-solve 或 +comment-reopen；先用 --dry-run 检查目标接口。
+4. 执行后检查 affected_comments，确认实体级评论或整条评论串的状态变化范围。
+
+## 输出
+
+返回 JSON：
+
+```json
+{
+  "affected_comments": [
+    {
+      "id": "7000000000000000004",
+      "target": {"target_type": "objective", "target_id": "2345678901234567890"},
+      "commentator_id": "ou_xxx",
+      "status": "solved",
+      "create_time": "2025-01-15 10:30:00",
+      "update_time": "2025-01-15 11:30:00",
+      "selection": {"id": "8000000000000000001", "selected_text": "提升核心接口稳定性"},
+      "content": {"text": "请补充指标", "mention": [], "docs": [], "images": []}
+    }
+  ],
+  "style": "simple"
+}
+```
+
+- +comment-solve 成功后 affected_comments 的 status 通常为 solved；+comment-reopen 成功后通常为 open。
+- simple 风格返回 SemiPlainContent；richtext 风格返回 ContentBlock。
+
+## 注意事项
+
+- 划词评论按评论串解决/重开，但 [+comment-delete](lark-okr-comment-delete.md) 仍然只删除单条评论。
+- 解决不是删除，之后可以用 +comment-reopen 恢复；删除后不可恢复。
+- 该操作是写操作，执行前应确认 comment-id 和目标动作。
+
+## 参考
+
+- [lark-okr](../SKILL.md) — OKR 命令、路由和通用约定
+- [OKR 实体定义](lark-okr-entities.md) — Comment、评论串和状态规则
+- [ContentBlock 格式](lark-okr-contentblock.md) — affected_comments 正文格式
+- [okr +comment-get](lark-okr-comment-get.md) — 获取状态和 selection.id
+- [okr +comment-delete](lark-okr-comment-delete.md) — 永久删除单条评论
+- [lark-shared](../../lark-shared/SKILL.md) — 认证、身份、权限和安全规则

--- a/skills/lark-okr/references/lark-okr-comment-solve-reopen.md
+++ b/skills/lark-okr/references/lark-okr-comment-solve-reopen.md
@@ -1,4 +1,5 @@
 # okr +comment-solve / +comment-reopen
+
 > **前置条件：** 先阅读 [lark-shared/SKILL.md](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则；
 
 解决/重新打开一条评论。实体级评论按单条评论处理；划词评论则是操作整个评论串。只支持 user 身份。
@@ -18,15 +19,13 @@ lark-cli okr +comment-solve --comment-id 7000000000000000004 --dry-run
 
 ## 参数
 
-| 参数 | 必填 | 默认值 | 说明 |
-|---|---|---|---|
-| --comment-id | 是 | — | 评论 ID，int64 正整数。可从 +comment-list、+comment-detail 或 +comment-get 获取。 |
-| --user-id-type | 否 | open_id | open_id、union_id、user_id 或 user_key。 |
-| --style | 否 | simple | affected_comments 的正文风格：simple（SemiPlainContent）或 richtext（ContentBlock）。 |
-| --dry-run | 否 | — | 预览 API 调用而不实际执行。 |
-| --format | 否 | json | 输出格式。 |
-
-接口的 department_id_type 参数不在 shortcut 中暴露，也不会传递。
+| 参数           | 必填 | 默认值  | 说明                                                                                  |
+|----------------|------|---------|---------------------------------------------------------------------------------------|
+| --comment-id   | 是   | —       | 评论 ID，int64 正整数。可从 +comment-list、+comment-detail 或 +comment-get 获取。     |
+| --user-id-type | 否   | open_id | open_id、union_id、user_id 或 user_key。                                              |
+| --style        | 否   | simple  | affected_comments 的正文风格：simple（SemiPlainContent）或 richtext（ContentBlock）。 |
+| --dry-run      | 否   | —       | 预览 API 调用而不实际执行。                                                           |
+| --format       | 否   | json    | 输出格式。                                                                            |
 
 ## 工作流程
 
@@ -44,13 +43,21 @@ lark-cli okr +comment-solve --comment-id 7000000000000000004 --dry-run
   "affected_comments": [
     {
       "id": "7000000000000000004",
-      "target": {"target_type": "objective", "target_id": "2345678901234567890"},
+      "target": {
+        "target_type": "objective",
+        "target_id": "2345678901234567890"
+      },
       "commentator_id": "ou_xxx",
       "status": "solved",
       "create_time": "2025-01-15 10:30:00",
       "update_time": "2025-01-15 11:30:00",
-      "selection": {"id": "8000000000000000001", "selected_text": "提升核心接口稳定性"},
-      "content": {"text": "请补充指标", "mention": [], "docs": [], "images": []}
+      "selection": {
+        "id": "8000000000000000001",
+        "selected_text": "提升核心接口稳定性"
+      },
+      "content": {
+        "text": "请补充指标", "mention": [], "docs": [], "images": []
+      }
     }
   ],
   "style": "simple"

--- a/skills/lark-okr/references/lark-okr-entities.md
+++ b/skills/lark-okr/references/lark-okr-entities.md
@@ -10,9 +10,12 @@ Cycle (用户周期)
         ├── KeyResult (关键结果)
         │     └── Indicator (指标)
         │     └── list<Progress> (进展记录列表)
+        │     └── list<Comment> (评论列表)
         └── Indicator (指标)
         └── list<Progress> (进展记录列表)
+        └── list<Comment> (评论列表)
 
+Cycle、Progress 也可以直接挂载 Comment。
 Alignment (对齐关系): Objective ↔ Objective
 Category (分类): Objective 的分组标签
 ```
@@ -49,8 +52,11 @@ Category (分类): Objective 的分组标签
 ### 常用术语
 
 - **当前周期**: 指周期的 start_time/end_time
-  指周期的 start_time / end_time 所在的时间段与当前时间重叠的周期（即： start_time <= 当前时间 且 end_time >= 当前时间）。 注意：时间重叠是判断当前周期的首要且必须的硬性条件，绝对不能仅仅根据 cycle_status == 1 去判断。 如果有多个符合时间重叠标准的周期，再在这些包含当前时间的周期中过滤，保留周期状态为 default (0) 或 normal (1) 的周期。如果仍然有多个，则选择其中较新的一个。当用户提及“上一个周期”，“下一个周期”一类的表述时，通常是以当前周期为准计算。
-  - 如果用户没有提及，那么当前周期一般不考虑年度周期（起止时间从 01-01 至 12-31 的周期）
+  指周期的 start_time / end_time 所在的时间段与当前时间重叠的周期（即： start_time <= 当前时间 且 end_time >= 当前时间）。
+  注意：时间重叠是判断当前周期的首要且必须的硬性条件，绝对不能仅仅根据 cycle_status == 1 去判断。
+  如果有多个符合时间重叠标准的周期，再在这些包含当前时间的周期中过滤，保留周期状态为 default (0) 或 normal (1)
+  的周期。如果仍然有多个，则选择其中较新的一个。当用户提及“上一个周期”，“下一个周期”一类的表述时，通常是以当前周期为准计算。
+    - 如果用户没有提及，那么当前周期一般不考虑年度周期（起止时间从 01-01 至 12-31 的周期）
 - **所有者**: 绝大多数所有者都是用户，少部分租户启用了“团队OKR”功能，所有者可能是部门。用户身份下，只能编辑所有者为当前用户的
   OKR。
 
@@ -173,6 +179,64 @@ Category (分类): Objective 的分组标签
 > - `okr +progress-update` [lark-okr-progress-update.md](lark-okr-progress-update.md) 更新进展记录内容
 > - `okr +progress-delete` [lark-okr-progress-delete.md](lark-okr-progress-delete.md) 删除进展记录
 > - `okr +progress-list` [lark-okr-progress-list.md](lark-okr-progress-list.md) 获取目标/关键结果下的进展记录
+
+---
+
+## Comment (评论)
+
+评论可以挂载在 Cycle、Objective、KeyResult 或 Progress 上，用于对 OKR 实体或正文中的一段文字进行讨论。评论分为实体级评论和划词评论两种：
+
+- **实体级评论**：直接附着在 Cycle 或 Progress 上。一条评论就是一个评论项，solve/reopen 只影响该评论。
+- **划词评论**：附着在 Objective 或 KeyResult 的正文选区上，带有 `selection`。同一个 `selection.id`
+  下的评论属于同一个评论串；solve/reopen 按评论串处理，但 delete 仍然只删除指定的一条评论。
+
+### Comment 字段
+
+| 字段               | 类型                 | 必填 | 说明                                                                                            |
+|------------------|--------------------|----|-----------------------------------------------------------------------------------------------|
+| `id`             | `string`           | 是  | 评论 ID，int64 正整数。                                                                              |
+| `target`         | `CommentTarget`    | 是  | 评论挂载对象，包含 `target_type` 和 `target_id`。类型为 `cycle`、`progress`、`objective` 或 `key_result`。      |
+| `commentator_id` | `string`           | 是  | 评论者 ID，返回 ID 类型由请求参数 `user_id_type` 决定。                                                       |
+| `status`         | `string`           | 是  | 评论状态：`open`（打开）或 `solved`（已解决）。                                                               |
+| `create_time`    | `string`           | 是  | 创建时间；                                                                                         |
+| `update_time`    | `string`           | 是  | 最后更新时间；                                                                                       |
+| `content`        | `ContentBlock`     | 否  | 评论正文，见 [ContentBlock 定义](lark-okr-contentblock.md)。                                           |
+| `solver_id`      | `string`           | 否  | 解决评论的用户 ID。                                                                                   |
+| `solved_time`    | `string`           | 否  | 评论解决时间，毫秒时间戳。                                                                                 |
+| `ref_comment_id` | `string`           | 否  | 被引用评论 ID。Progress/Cycle 等实体级评论可用它表示回复关系；Objective/KeyResult 的划词评论创建时可用它定位已有划词串，但新评论本身不建立引用关系。 |
+| `selection`      | `CommentSelection` | 否  | 划词信息。实体级评论为空；划词评论包含 selection ID 和可选的选区文本。                                                    |
+
+### CommentTarget (评论目标)
+
+| 字段            | 类型       | 必填 | 说明                                             |
+|---------------|----------|----|------------------------------------------------|
+| `target_type` | `string` | 是  | `cycle`、`progress`、`objective` 或 `key_result`。 |
+| `target_id`   | `string` | 是  | 对应 Cycle、Progress、Objective 或 KeyResult 的 ID。  |
+
+### CommentSelection (划词信息)
+
+| 字段              | 类型       | 必填 | 说明                          |
+|-----------------|----------|----|-----------------------------|
+| `id`            | `string` | 是  | 划词 ID。同一 `id` 下的评论属于同一个评论串。 |
+| `selected_text` | `string` | 否  | 划词锚定的正文文字。                  |
+
+### 评论创建与状态规则
+
+- Cycle/Progress 创建实体级评论时不传 `selected_text`；可以通过 `ref_comment_id` 回复已有评论。
+- Objective/KeyResult 创建划词评论时，`selected_text` 与 `ref_comment_id` 二选一：前者新建划词，后者将评论挂入被引用评论所属的已有划词串。shortcut
+  另外提供 `--select-all` 替代 `selected_text` 以选中 O/KR 内的全部内容。
+- `solve` / `reopen` 的请求参数是单条评论 ID。对实体级评论只影响该评论；对划词评论会影响整条评论串。
+- `delete` 永久删除指定评论，不会连带删除同一评论串的其他评论，且删除后不可找回。
+
+> **SHORTCUT：**
+> - `okr +comment-detail` [lark-okr-comment-detail.md](lark-okr-comment-detail.md) 获取周期下全部对象的评论并按评论串整理
+> - `okr +comment-list` [lark-okr-comment-list.md](lark-okr-comment-list.md) 分页获取单个评论目标下的评论
+> - `okr +comment-get` [lark-okr-comment-get.md](lark-okr-comment-get.md) 获取单条评论
+> - `okr +comment-create` [lark-okr-comment-create.md](lark-okr-comment-create.md) 创建评论、回复或挂入已有划词串
+> - `okr +comment-patch` [lark-okr-comment-patch.md](lark-okr-comment-patch.md) 修改评论正文
+> - `okr +comment-delete` [lark-okr-comment-delete.md](lark-okr-comment-delete.md) 永久删除单条评论
+> - `okr +comment-solve` [lark-okr-comment-solve-reopen.md](lark-okr-comment-solve-reopen.md) 解决评论/评论串
+> - `okr +comment-reopen` [lark-okr-comment-solve-reopen.md](lark-okr-comment-solve-reopen.md) 重新打开评论/评论串
 ---
 
 ## Indicator (指标)

--- a/tests/cli_e2e/okr/okr_comments_test.go
+++ b/tests/cli_e2e/okr/okr_comments_test.go
@@ -5,11 +5,13 @@ package okr
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func runCommentDryRun(t *testing.T, args ...string) *clie2e.Result {
@@ -25,6 +27,12 @@ func runCommentDryRun(t *testing.T, args ...string) *clie2e.Result {
 	return result
 }
 
+func assertCommentDryRunOmitsDepartmentIDType(t *testing.T, result *clie2e.Result) {
+	t.Helper()
+	require.False(t, clie2e.DryRunGet(result.Stdout, "api.0.params.department_id_type").Exists(), result.Stdout)
+	require.False(t, clie2e.DryRunGet(result.Stdout, "api.0.body.department_id_type").Exists(), result.Stdout)
+}
+
 func TestOKR_CommentListDryRun(t *testing.T) {
 	result := runCommentDryRun(t, "+comment-list", "--target-id", "123456", "--target-type", "objective", "--page-size", "25", "--page-token", "next_page", "--user-id-type", "union_id", "--dry-run")
 	require.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
@@ -34,6 +42,7 @@ func TestOKR_CommentListDryRun(t *testing.T) {
 	require.Equal(t, "25", clie2e.DryRunGet(result.Stdout, "api.0.params.page_size").String())
 	require.Equal(t, "next_page", clie2e.DryRunGet(result.Stdout, "api.0.params.page_token").String())
 	require.Equal(t, "union_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentGetDryRun(t *testing.T) {
@@ -41,6 +50,7 @@ func TestOKR_CommentGetDryRun(t *testing.T) {
 	require.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "/open-apis/okr/v2/comments/987654", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
 	require.Equal(t, "user_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentCreateDryRun_Entity(t *testing.T) {
@@ -50,6 +60,8 @@ func TestOKR_CommentCreateDryRun_Entity(t *testing.T) {
 	require.Equal(t, "123456", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_id").String())
 	require.Equal(t, "cycle", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_type").String())
 	require.Equal(t, "Cycle comment", clie2e.DryRunGet(result.Stdout, "api.0.body.content.blocks.0.paragraph.elements.0.text_run.text").String())
+	require.Equal(t, "open_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentCreateDryRun_SelectedText(t *testing.T) {
@@ -57,12 +69,15 @@ func TestOKR_CommentCreateDryRun_SelectedText(t *testing.T) {
 	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "important text", clie2e.DryRunGet(result.Stdout, "api.0.body.selected_text").String())
 	require.Equal(t, "key_result", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_type").String())
+	require.Equal(t, "open_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentCreateDryRun_SelectAll(t *testing.T) {
 	result := runCommentDryRun(t, "+comment-create", "--target-id", "345678", "--target-type", "objective", "--content", "{\"text\":\"whole objective\"}", "--select-all", "--dry-run")
 	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "***************", clie2e.DryRunGet(result.Stdout, "api.0.body.selected_text").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentCreateDryRun_RefComment(t *testing.T) {
@@ -70,6 +85,7 @@ func TestOKR_CommentCreateDryRun_RefComment(t *testing.T) {
 	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "111222", clie2e.DryRunGet(result.Stdout, "api.0.body.ref_comment_id").String())
 	require.Equal(t, "progress", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentPatchDryRun(t *testing.T) {
@@ -77,22 +93,148 @@ func TestOKR_CommentPatchDryRun(t *testing.T) {
 	require.Equal(t, "PATCH", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "/open-apis/okr/v2/comments/567890", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
 	require.Equal(t, "Updated comment", clie2e.DryRunGet(result.Stdout, "api.0.body.content.blocks.0.paragraph.elements.0.text_run.text").String())
+	require.Equal(t, "open_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentDeleteDryRun(t *testing.T) {
 	result := runCommentDryRun(t, "+comment-delete", "--comment-id", "678901", "--dry-run")
 	require.Equal(t, "DELETE", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "/open-apis/okr/v2/comments/678901", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentSolveDryRun(t *testing.T) {
 	result := runCommentDryRun(t, "+comment-solve", "--comment-id", "789012", "--dry-run")
 	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "/open-apis/okr/v2/comments/789012/solve", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	require.Equal(t, "open_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
 }
 
 func TestOKR_CommentReopenDryRun(t *testing.T) {
 	result := runCommentDryRun(t, "+comment-reopen", "--comment-id", "890123", "--dry-run")
 	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
 	require.Equal(t, "/open-apis/okr/v2/comments/890123/reopen", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	require.Equal(t, "open_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+	assertCommentDryRunOmitsDepartmentIDType(t, result)
+}
+
+// TestOKR_CommentLifecycleLive exercises every comment shortcut against one
+// cycle-level comment. It is opt-in because it writes and permanently deletes
+// tenant data; the created comment is cleaned up if any later step fails.
+func TestOKR_CommentLifecycleLive(t *testing.T) {
+	clie2e.SkipWithoutUserToken(t)
+	cycleID := getTestCycleID(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	commentIDs := []string{}
+	cleanup := func() {
+		if len(commentIDs) == 0 {
+			return
+		}
+		cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+		defer cleanupCancel()
+		for i := len(commentIDs) - 1; i >= 0; i-- {
+			commentID := commentIDs[i]
+			result, err := clie2e.RunCmd(cleanupCtx, clie2e.Request{
+				Args:      []string{"okr", "+comment-delete", "--comment-id", commentID},
+				DefaultAs: "user",
+				Yes:       true,
+			})
+			clie2e.ReportCleanupFailure(t, "delete live comment "+commentID, result, err)
+		}
+	}
+	t.Cleanup(cleanup)
+
+	create := func(content string) *clie2e.Result {
+		t.Helper()
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"okr", "+comment-create",
+				"--target-type", "cycle",
+				"--target-id", cycleID,
+				"--content", fmt.Sprintf("{\"text\":%q}", content),
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		return result
+	}
+
+	created := create("comment shortcut lifecycle")
+	commentID := gjson.Get(created.Stdout, "data.comment_id").String()
+	require.NotEmpty(t, commentID, "create should return data.comment_id")
+	commentIDs = append(commentIDs, commentID)
+
+	reply, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-create", "--target-type", "cycle", "--target-id", cycleID, "--content", `{"text":"comment shortcut reply"}`, "--ref-comment-id", commentID},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	reply.AssertExitCode(t, 0)
+	replyID := gjson.Get(reply.Stdout, "data.comment_id").String()
+	require.NotEmpty(t, replyID, "reply should return data.comment_id")
+	commentIDs = append(commentIDs, replyID)
+
+	list, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-list", "--target-type", "cycle", "--target-id", cycleID, "--user-id-type", "union_id"},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	list.AssertExitCode(t, 0)
+	require.Contains(t, list.Stdout, commentID)
+	require.Contains(t, list.Stdout, replyID)
+
+	detail, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-detail", "--cycle-id", cycleID},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	detail.AssertExitCode(t, 0)
+	require.Equal(t, cycleID, gjson.Get(detail.Stdout, "data.cycle_id").String())
+
+	get, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-get", "--comment-id", commentID, "--user-id-type", "union_id"},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	get.AssertExitCode(t, 0)
+	require.Equal(t, commentID, gjson.Get(get.Stdout, "data.comment.id").String())
+
+	patchResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-patch", "--comment-id", commentID, "--content", "{\"text\":\"patched comment\"}", "--user-id-type", "union_id"},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	patchResult.AssertExitCode(t, 0)
+	require.Equal(t, commentID, gjson.Get(patchResult.Stdout, "data.comment.id").String())
+
+	solve, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-solve", "--comment-id", commentID, "--user-id-type", "union_id"},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	solve.AssertExitCode(t, 0)
+	require.True(t, gjson.Get(solve.Stdout, "data.affected_comments").Exists())
+
+	reopen, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-reopen", "--comment-id", commentID, "--user-id-type", "union_id"},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	reopen.AssertExitCode(t, 0)
+	require.True(t, gjson.Get(reopen.Stdout, "data.affected_comments").Exists())
+
+	deleted, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"okr", "+comment-delete", "--comment-id", replyID},
+		DefaultAs: "user",
+		Yes:       true,
+	})
+	require.NoError(t, err)
+	deleted.AssertExitCode(t, 0)
+	require.True(t, gjson.Get(deleted.Stdout, "data.deleted").Bool())
+	commentIDs = []string{commentID}
 }

--- a/tests/cli_e2e/okr/okr_comments_test.go
+++ b/tests/cli_e2e/okr/okr_comments_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package okr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func runCommentDryRun(t *testing.T, args ...string) *clie2e.Result {
+	t.Helper()
+	setDryRunConfigEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	commandArgs := append([]string{"okr"}, args...)
+	commandArgs = append(commandArgs, "--as", "user")
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: commandArgs})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	return result
+}
+
+func TestOKR_CommentListDryRun(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-list", "--target-id", "123456", "--target-type", "objective", "--page-size", "25", "--page-token", "next_page", "--user-id-type", "union_id", "--dry-run")
+	require.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "/open-apis/okr/v2/comments", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	require.Equal(t, "123456", clie2e.DryRunGet(result.Stdout, "api.0.params.target_id").String())
+	require.Equal(t, "objective", clie2e.DryRunGet(result.Stdout, "api.0.params.target_type").String())
+	require.Equal(t, "25", clie2e.DryRunGet(result.Stdout, "api.0.params.page_size").String())
+	require.Equal(t, "next_page", clie2e.DryRunGet(result.Stdout, "api.0.params.page_token").String())
+	require.Equal(t, "union_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+}
+
+func TestOKR_CommentGetDryRun(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-get", "--comment-id", "987654", "--user-id-type", "user_id", "--dry-run")
+	require.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "/open-apis/okr/v2/comments/987654", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	require.Equal(t, "user_id", clie2e.DryRunGet(result.Stdout, "api.0.params.user_id_type").String())
+}
+
+func TestOKR_CommentCreateDryRun_Entity(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-create", "--target-id", "123456", "--target-type", "cycle", "--content", "{\"text\":\"Cycle comment\"}", "--dry-run")
+	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "/open-apis/okr/v2/comments", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	require.Equal(t, "123456", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_id").String())
+	require.Equal(t, "cycle", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_type").String())
+	require.Equal(t, "Cycle comment", clie2e.DryRunGet(result.Stdout, "api.0.body.content.blocks.0.paragraph.elements.0.text_run.text").String())
+}
+
+func TestOKR_CommentCreateDryRun_SelectedText(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-create", "--target-id", "234567", "--target-type", "key_result", "--content", "{\"text\":\"Selected comment\"}", "--selected-text", "important text", "--dry-run")
+	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "important text", clie2e.DryRunGet(result.Stdout, "api.0.body.selected_text").String())
+	require.Equal(t, "key_result", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_type").String())
+}
+
+func TestOKR_CommentCreateDryRun_SelectAll(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-create", "--target-id", "345678", "--target-type", "objective", "--content", "{\"text\":\"whole objective\"}", "--select-all", "--dry-run")
+	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "***************", clie2e.DryRunGet(result.Stdout, "api.0.body.selected_text").String())
+}
+
+func TestOKR_CommentCreateDryRun_RefComment(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-create", "--target-id", "456789", "--target-type", "progress", "--content", "{\"text\":\"Reply\"}", "--ref-comment-id", "111222", "--dry-run")
+	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "111222", clie2e.DryRunGet(result.Stdout, "api.0.body.ref_comment_id").String())
+	require.Equal(t, "progress", clie2e.DryRunGet(result.Stdout, "api.0.body.target.target_type").String())
+}
+
+func TestOKR_CommentPatchDryRun(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-patch", "--comment-id", "567890", "--content", "{\"text\":\"Updated comment\"}", "--dry-run")
+	require.Equal(t, "PATCH", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "/open-apis/okr/v2/comments/567890", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+	require.Equal(t, "Updated comment", clie2e.DryRunGet(result.Stdout, "api.0.body.content.blocks.0.paragraph.elements.0.text_run.text").String())
+}
+
+func TestOKR_CommentDeleteDryRun(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-delete", "--comment-id", "678901", "--dry-run")
+	require.Equal(t, "DELETE", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "/open-apis/okr/v2/comments/678901", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+}
+
+func TestOKR_CommentSolveDryRun(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-solve", "--comment-id", "789012", "--dry-run")
+	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "/open-apis/okr/v2/comments/789012/solve", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+}
+
+func TestOKR_CommentReopenDryRun(t *testing.T) {
+	result := runCommentDryRun(t, "+comment-reopen", "--comment-id", "890123", "--dry-run")
+	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
+	require.Equal(t, "/open-apis/okr/v2/comments/890123/reopen", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+}


### PR DESCRIPTION
## Summary

Add OKR comment shortcuts and document the comment entity / comment-thread semantics. 

## Changes

- Add shortcuts for listing, getting, creating, updating, deleting, solving, and reopening OKR comments.
- Add cycle-wide comment aggregation across Cycle, Objective, KeyResult, and Progress targets.
- Group Objective/KeyResult comments by selections, while keeping entity-level comments of Cycles/Progresses as single-comment threads.
- Update OKR references with Comment entities, rich-text handling, and reply rules.

## Test Plan

- [x] Unit tests pass
- [x] Manual local verification pass

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive OKR comment management for listing, retrieving, creating, replying, editing, deleting, solving, and reopening comments.
  * Added aggregated comment views across cycles, objectives, key results, and progress records.
  * Supports simple and rich-text content, threaded discussions, inline selections, pagination, and dry-run previews.

* **Documentation**
  * Added command references, usage guidance, workflows, and OKR comment entity documentation.

* **Tests**
  * Added coverage for validation, grouping, ordering, output formatting, error handling, lifecycle operations, and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->