### PR TITLE
docs(lark-doc): add shared edit safety guidance

### DIFF
--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -23,7 +23,7 @@ metadata:
 - **读取 / 摘要 — [`+fetch`](references/lark-doc-fetch.md)**：先读参考再获取文档。
 - **从零创作 — [`创建工作流`](references/lark-doc-create-workflow.md)**：先完整执行创建工作流，**简单任务不是跳过的理由**；
 - **导入 / 空文档 — [`+create`](references/lark-doc-create.md)**：仅创建空文档或原样导入用户提供的完整内容时，跳过创建工作流。
-- **编辑 / block 直达链接 — [`+update`](references/lark-doc-update.md)**：语义改写、润色、重组、补写或排版均按 update 参考完成。
+- **编辑 / block 直达链接 — [`+update`](references/lark-doc-update.md)**：语义改写、润色、重组、补写或排版均按 update 参考完成。编辑用户可能同步维护的已有文档时，每次写入前重新局部读取目标内容及可用的最新 revision，并且只修改用户本轮明确指定的最小范围。
 
 ### 辅助能力
 

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -23,7 +23,7 @@ metadata:
 - **读取 / 摘要 — [`+fetch`](references/lark-doc-fetch.md)**：先读参考再获取文档。
 - **从零创作 — [`创建工作流`](references/lark-doc-create-workflow.md)**：先完整执行创建工作流，**简单任务不是跳过的理由**；
 - **导入 / 空文档 — [`+create`](references/lark-doc-create.md)**：仅创建空文档或原样导入用户提供的完整内容时，跳过创建工作流。
-- **编辑 / block 直达链接 — [`+update`](references/lark-doc-update.md)**：语义改写、润色、重组、补写或排版均按 update 参考完成。编辑用户可能同步维护的已有文档时，每次写入前重新局部读取目标内容及可用的最新 revision，并且只修改用户本轮明确指定的最小范围。
+- **编辑 / block 直达链接 — [`+update`](references/lark-doc-update.md)**：语义改写、润色、重组、补写或排版均按 update 参考完成。编辑用户可能同步维护的已有文档时，每次写入前重新局部读取目标内容及最新 revision，并用本次读取的 revision ID 约束对应写入；若发生版本冲突，重新读取并基于最新内容生成修改。
 
 ### 辅助能力
 

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -23,7 +23,7 @@ metadata:
 - **读取 / 摘要 — [`+fetch`](references/lark-doc-fetch.md)**：先读参考再获取文档。
 - **从零创作 — [`创建工作流`](references/lark-doc-create-workflow.md)**：先完整执行创建工作流，**简单任务不是跳过的理由**；
 - **导入 / 空文档 — [`+create`](references/lark-doc-create.md)**：仅创建空文档或原样导入用户提供的完整内容时，跳过创建工作流。
-- **编辑 / block 直达链接 — [`+update`](references/lark-doc-update.md)**：语义改写、润色、重组、补写或排版均按 update 参考完成。编辑用户可能同步维护的已有文档时，每次写入前重新局部读取目标内容及最新 revision，并用本次读取的 revision ID 约束对应写入；若发生版本冲突，重新读取并基于最新内容生成修改。
+- **编辑 / block 直达链接 — [`+update`](references/lark-doc-update.md)**：语义改写、润色、重组、补写或排版均按 update 参考完成。编辑用户可能同步维护的已有文档时，每次写入前重新局部读取目标内容及最新 revision，并用本次读取的 revision ID 约束对应写入；若发生版本冲突，重新读取并基于最新内容生成修改。始终只修改用户本轮明确指定的最小范围。
 
 ### 辅助能力
 

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -75,7 +75,7 @@ lark-cli docs +update --doc "xx" --command block_delete --start-block-id blkFirs
 
 ## 通用安全规则
 
-- 对用户可能同步维护的已有文档，每次写操作前都重新局部 fetch 目标内容、block ID 和可用的最新 revision。若内容较先前读取结果已经变化，基于最新内容重新生成局部修改，不要沿用早期正文或 revision 重写目标章节。
+- 对用户可能同步维护的已有文档，每次写操作前重新局部 fetch 目标内容、block ID 和最新 revision，并在对应写操作中通过 `--revision-id` 显式传入本次 fetch 返回的 revision ID，不要依赖默认值 `-1`。若发生版本冲突，重新 fetch 最新内容，基于新版本重新生成局部修改后再重试。
 - 只修改用户本轮明确授权的最小范围，不要顺带调整未请求的结构、措辞或相邻内容；仅当用户明确要求整体重建时才使用 `overwrite`。
 - 每次写操作后都按 block ID 已变化处理。新插入或复制的内容一定使用新 ID；替换、删除和覆盖会使旧 ID 失效；移动会改变章节与 range 语义。
 - 同一 block 有多处修改时，应合并为一次 `block_replace`，避免连续使用旧 ID。

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -75,6 +75,8 @@ lark-cli docs +update --doc "xx" --command block_delete --start-block-id blkFirs
 
 ## 通用安全规则
 
+- 对用户可能同步维护的已有文档，每次写操作前都重新局部 fetch 目标内容、block ID 和可用的最新 revision。若内容较先前读取结果已经变化，基于最新内容重新生成局部修改，不要沿用早期正文或 revision 重写目标章节。
+- 只修改用户本轮明确授权的最小范围，不要顺带调整未请求的结构、措辞或相邻内容；仅当用户明确要求整体重建时才使用 `overwrite`。
 - 每次写操作后都按 block ID 已变化处理。新插入或复制的内容一定使用新 ID；替换、删除和覆盖会使旧 ID 失效；移动会改变章节与 range 语义。
 - 同一 block 有多处修改时，应合并为一次 `block_replace`，避免连续使用旧 ID。
 


### PR DESCRIPTION
## Summary

Add explicit shared-document write-safety guidance to the lark-doc skill. The change closes the stale-read and lost-update window described in #2457 by requiring a fresh targeted fetch before each write and limiting edits to the scope explicitly authorized by the user.

## Changes

- Add an entry-point reminder in `skills/lark-doc/SKILL.md` for shared document edits.
- Require re-fetching the latest target content, block IDs, and available revision before every write.
- Regenerate local edits when the document changed, avoid reusing stale content or revisions, and reserve `overwrite` for explicitly requested full rebuilds.

## Test Plan

- [x] These rules have been maintained and used in the local lark-doc skill over an extended period, resolving the stale-write overwrite and out-of-scope editing problems previously encountered.
- [x] Verified that the branch changes only the two intended lark-doc guidance files and preserves the existing Chinese documentation style.

## Related Issues

- Closes #2457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to re-read the target content and latest revision before each edit.
  * Clarified that write operations must use the revision ID from the corresponding pre-write fetch.
  * Added recovery guidance for version conflicts: re-fetch the latest content, regenerate changes, and retry.
  * Reinforced limiting edits to the explicitly requested scope.
  * Clarified that full-document overwrites should only be used when specifically requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->