### PR TITLE
feat(auth): support switching between logged-in users

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -64,6 +64,7 @@ func newCmdAuth(f *cmdutil.Factory, projector *recovery.Projector, registered []
 	cmd.AddCommand(newCmdAuthStatus(f, nil, projector))
 	cmd.AddCommand(NewCmdAuthScopes(f, nil))
 	cmd.AddCommand(newCmdAuthList(f, nil, projector))
+	cmd.AddCommand(NewCmdAuthUsers(f))
 	cmd.AddCommand(newCmdAuthCheck(f, nil, projector))
 	cmd.AddCommand(NewCmdAuthQRCode(f, nil))
 	return cmd

--- a/cmd/auth/config_lock.go
+++ b/cmd/auth/config_lock.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"errors"
+	"path/filepath"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/lockfile"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+const authConfigLockWait = 30 * time.Second
+
+// withAuthConfigLock serializes read-modify-write operations on config.json.
+// Token storage keeps its own per-user lock; this lock owns only selection and
+// membership changes in the auth/config surface.
+func withAuthConfigLock(fn func() error) error {
+	dir := filepath.Join(core.GetConfigDir(), "locks")
+	if err := vfs.MkdirAll(dir, 0700); err != nil {
+		return errs.NewInternalError(errs.SubtypeFileIO, "failed to prepare auth config lock: %v", err).WithCause(err)
+	}
+
+	lock := lockfile.New(filepath.Join(dir, "auth_config.lock"))
+	deadline := time.Now().Add(authConfigLockWait)
+	for {
+		err := lock.TryLock()
+		if err == nil {
+			runErr := fn()
+			unlockErr := lock.Unlock()
+			if runErr != nil {
+				return runErr
+			}
+			if unlockErr != nil {
+				return errs.NewInternalError(errs.SubtypeFileIO, "failed to release auth config lock: %v", unlockErr).WithCause(unlockErr)
+			}
+			return nil
+		}
+		if !errors.Is(err, lockfile.ErrHeld) {
+			return errs.NewInternalError(errs.SubtypeFileIO, "failed to acquire auth config lock: %v", err).WithCause(err)
+		}
+		if time.Now().After(deadline) {
+			return errs.NewInternalError(errs.SubtypeStorage, "timed out waiting for auth config lock").
+				WithRetryable().
+				WithHint("Retry the command.")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -405,8 +405,8 @@ func authLoginRun(opts *LoginOptions, resolver domainResolver) error {
 		return errs.NewInternalError(errs.SubtypeStorage, "failed to save token: %v", err).WithCause(err)
 	}
 
-	// Step 8: Update config — overwrite Users to single user, clean old tokens
-	if err := syncLoginUserToProfile(config.ProfileName, config.AppID, openId, userName); err != nil {
+	// Step 8: Update config — preserve other users and select this login.
+	if err := syncLoginUserToProfile(config.ProfileName, openId, userName); err != nil {
 		_ = larkauth.RemoveStoredToken(config.AppID, openId)
 		return err
 	}
@@ -488,8 +488,8 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 		return errs.NewInternalError(errs.SubtypeSDKError, "failed to save token: %v", err).WithCause(err)
 	}
 
-	// Update config — overwrite Users to single user, clean old tokens
-	if err := syncLoginUserToProfile(config.ProfileName, config.AppID, openId, userName); err != nil {
+	// Update config — preserve other users and select this login.
+	if err := syncLoginUserToProfile(config.ProfileName, openId, userName); err != nil {
 		_ = larkauth.RemoveStoredToken(config.AppID, openId)
 		return errs.NewInternalError(errs.SubtypeSDKError, "failed to update login profile: %v", err).WithCause(err)
 	}
@@ -503,29 +503,36 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 }
 
 // syncLoginUserToProfile persists the logged-in user info into the named profile.
-func syncLoginUserToProfile(profileName, appID, openID, userName string) error {
-	multi, err := core.LoadMultiAppConfig()
-	if err != nil {
-		return errs.NewInternalError(errs.SubtypeStorage, "load config: %v", err).WithCause(err)
-	}
+func syncLoginUserToProfile(profileName, openID, userName string) error {
+	return withAuthConfigLock(func() error {
+		multi, err := core.LoadMultiAppConfig()
+		if err != nil {
+			return errs.NewInternalError(errs.SubtypeStorage, "load config: %v", err).WithCause(err)
+		}
 
-	app := findProfileByName(multi, profileName)
-	if app == nil {
-		return errs.NewConfigError(errs.SubtypeNotConfigured, "profile %q not found in config", profileName)
-	}
+		app := findProfileByName(multi, profileName)
+		if app == nil {
+			return errs.NewConfigError(errs.SubtypeNotConfigured, "profile %q not found in config", profileName)
+		}
 
-	oldUsers := append([]core.AppUser(nil), app.Users...)
-	app.Users = []core.AppUser{{UserOpenId: openID, UserName: userName}}
-	if err := core.SaveMultiAppConfig(multi); err != nil {
-		return errs.NewInternalError(errs.SubtypeStorage, "save config: %v", err).WithCause(err)
-	}
+		upsertLoginUser(app, core.AppUser{UserOpenId: openID, UserName: userName})
+		if err := core.SaveMultiAppConfig(multi); err != nil {
+			return errs.NewInternalError(errs.SubtypeStorage, "save config: %v", err).WithCause(err)
+		}
+		return nil
+	})
+}
 
-	for _, oldUser := range oldUsers {
-		if oldUser.UserOpenId != openID {
-			_ = larkauth.RemoveStoredToken(appID, oldUser.UserOpenId)
+func upsertLoginUser(app *core.AppConfig, user core.AppUser) {
+	for i := range app.Users {
+		if app.Users[i].UserOpenId == user.UserOpenId {
+			app.Users[i] = user
+			app.CurrentUser = user.UserOpenId
+			return
 		}
 	}
-	return nil
+	app.Users = append(app.Users, user)
+	app.CurrentUser = user.UserOpenId
 }
 
 // findProfileByName returns the AppConfig matching profileName, or nil.

--- a/cmd/auth/login_config_test.go
+++ b/cmd/auth/login_config_test.go
@@ -7,15 +7,20 @@ import (
 	"strings"
 	"testing"
 
+	larkauth "github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/zalando/go-keyring"
 )
 
 func setupLoginConfigDir(t *testing.T) {
 	t.Helper()
+	keyring.MockInit()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
 }
 
-func TestSyncLoginUserToProfile_UpdatesOnlyTargetProfile(t *testing.T) {
+func TestSyncLoginUserToProfile_AppendsAndSelectsUserInTargetProfile(t *testing.T) {
 	setupLoginConfigDir(t)
 	multi := &core.MultiAppConfig{
 		CurrentApp: "target",
@@ -35,8 +40,11 @@ func TestSyncLoginUserToProfile_UpdatesOnlyTargetProfile(t *testing.T) {
 	if err := core.SaveMultiAppConfig(multi); err != nil {
 		t.Fatalf("SaveMultiAppConfig() error = %v", err)
 	}
+	if err := larkauth.SetStoredToken(&larkauth.StoredUAToken{AppId: "app-target", UserOpenId: "ou_old"}); err != nil {
+		t.Fatalf("SetStoredToken() error = %v", err)
+	}
 
-	if err := syncLoginUserToProfile("target", "app-target", "ou_new", "new-user"); err != nil {
+	if err := syncLoginUserToProfile("target", "ou_new", "new-user"); err != nil {
 		t.Fatalf("syncLoginUserToProfile() error = %v", err)
 	}
 
@@ -44,11 +52,17 @@ func TestSyncLoginUserToProfile_UpdatesOnlyTargetProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadMultiAppConfig() error = %v", err)
 	}
-	if got := saved.Apps[0].Users; len(got) != 1 || got[0].UserOpenId != "ou_new" || got[0].UserName != "new-user" {
-		t.Fatalf("target users = %#v, want replaced login user", got)
+	if got := saved.Apps[0].Users; len(got) != 2 || got[0].UserOpenId != "ou_old" || got[1].UserOpenId != "ou_new" || got[1].UserName != "new-user" {
+		t.Fatalf("target users = %#v, want existing user followed by new login", got)
+	}
+	if got := saved.Apps[0].CurrentUser; got != "ou_new" {
+		t.Fatalf("target currentUser = %q, want ou_new", got)
 	}
 	if got := saved.Apps[1].Users; len(got) != 1 || got[0].UserOpenId != "ou_other" {
 		t.Fatalf("other users = %#v, want unchanged", got)
+	}
+	if larkauth.GetStoredToken("app-target", "ou_old") == nil {
+		t.Fatal("existing user's stored token was removed")
 	}
 }
 
@@ -64,11 +78,46 @@ func TestSyncLoginUserToProfile_ProfileNotFoundReturnsError(t *testing.T) {
 		t.Fatalf("SaveMultiAppConfig() error = %v", err)
 	}
 
-	err := syncLoginUserToProfile("missing", "app-default", "ou_new", "new-user")
+	err := syncLoginUserToProfile("missing", "ou_new", "new-user")
 	if err == nil {
 		t.Fatal("expected error for missing profile")
 	}
 	if !strings.Contains(err.Error(), `profile "missing" not found`) {
 		t.Fatalf("error = %v, want missing profile", err)
+	}
+}
+
+func TestSyncLoginUserToProfile_UpdatesExistingUserWithoutDuplication(t *testing.T) {
+	setupLoginConfigDir(t)
+	multi := &core.MultiAppConfig{
+		CurrentApp: "target",
+		Apps: []core.AppConfig{{
+			Name:        "target",
+			AppId:       "app-target",
+			CurrentUser: "ou_other",
+			Users: []core.AppUser{
+				{UserOpenId: "ou_existing", UserName: "old-name"},
+				{UserOpenId: "ou_other", UserName: "other"},
+			},
+		}},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	if err := syncLoginUserToProfile("target", "ou_existing", "new-name"); err != nil {
+		t.Fatalf("syncLoginUserToProfile() error = %v", err)
+	}
+
+	saved, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiAppConfig() error = %v", err)
+	}
+	got := saved.Apps[0]
+	if len(got.Users) != 2 || got.Users[0].UserName != "new-name" {
+		t.Fatalf("users = %#v, want updated user without duplicate", got.Users)
+	}
+	if got.CurrentUser != "ou_existing" {
+		t.Fatalf("currentUser = %q, want ou_existing", got.CurrentUser)
 	}
 }

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -101,6 +101,7 @@ func authLogoutRun(opts *LogoutOptions) error {
 	}
 
 	app.Users = []core.AppUser{}
+	app.CurrentUser = ""
 	if err := core.SaveMultiAppConfig(multi); err != nil {
 		return errs.NewInternalError(errs.SubtypeStorage, "failed to save config: %v", err).WithCause(err)
 	}

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -354,3 +354,42 @@ func TestAuthLogoutRun_RevokeFailureStillClearsLocalState(t *testing.T) {
 		t.Fatalf("expected users cleared, got %#v", saved.Apps)
 	}
 }
+
+func TestAuthLogoutRun_ClearsCurrentUser(t *testing.T) {
+	keyring.MockInit()
+	setupLoginConfigDir(t)
+	t.Setenv("HOME", t.TempDir())
+
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{{
+			Name:        "default",
+			AppId:       "cli_test",
+			AppSecret:   core.PlainSecret("secret"),
+			Brand:       core.BrandFeishu,
+			CurrentUser: "ou_user",
+			Users:       []core.AppUser{{UserOpenId: "ou_user", UserName: "tester"}},
+		}},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		ProfileName: "default",
+		AppID:       "cli_test",
+		AppSecret:   "secret",
+		Brand:       core.BrandFeishu,
+	})
+	if err := authLogoutRun(&LogoutOptions{Factory: f}); err != nil {
+		t.Fatalf("authLogoutRun() error = %v", err)
+	}
+
+	saved, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiAppConfig() error = %v", err)
+	}
+	if saved.Apps[0].CurrentUser != "" {
+		t.Fatalf("CurrentUser = %q, want empty", saved.Apps[0].CurrentUser)
+	}
+}

--- a/cmd/auth/users.go
+++ b/cmd/auth/users.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+// NewCmdAuthUsers creates the auth users command group.
+func NewCmdAuthUsers(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users",
+		Short: "List, switch, or remove logged-in users",
+	}
+	cmdutil.SetRisk(cmd, "read")
+	cmd.AddCommand(NewCmdAuthUsersList(f, nil))
+	cmd.AddCommand(NewCmdAuthUsersUse(f, nil))
+	cmd.AddCommand(NewCmdAuthUsersLogout(f, nil))
+	return cmd
+}

--- a/cmd/auth/users_list.go
+++ b/cmd/auth/users_list.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	larkauth "github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// UsersListOptions holds inputs for auth users list.
+type UsersListOptions struct {
+	Factory *cmdutil.Factory
+}
+
+// NewCmdAuthUsersList creates the auth users list command.
+func NewCmdAuthUsersList(f *cmdutil.Factory, runF func(*UsersListOptions) error) *cobra.Command {
+	opts := &UsersListOptions{Factory: f}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List users in the current profile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+			return authUsersListRun(opts)
+		},
+	}
+	cmdutil.SetRisk(cmd, "read")
+	return cmd
+}
+
+func authUsersListRun(opts *UsersListOptions) error {
+	f := opts.Factory
+	multi, err := core.LoadOrNotConfigured()
+	if err != nil {
+		return err
+	}
+	app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+	if err != nil {
+		return err
+	}
+	if len(app.Users) == 0 {
+		fmt.Fprintln(f.IOStreams.ErrOut, "No logged-in users. Run `lark-cli auth login` to add one.")
+		return nil
+	}
+
+	active, err := app.ActiveUser()
+	if err != nil {
+		return err
+	}
+	items := make([]map[string]interface{}, 0, len(app.Users))
+	for _, user := range app.Users {
+		status := "no_token"
+		if token := larkauth.GetStoredToken(app.AppId, user.UserOpenId); token != nil {
+			status = larkauth.TokenStatus(token)
+		}
+		items = append(items, map[string]interface{}{
+			"userName":    user.UserName,
+			"userOpenId":  user.UserOpenId,
+			"tokenStatus": status,
+			"active":      active != nil && user.UserOpenId == active.UserOpenId,
+		})
+	}
+	output.PrintJson(f.IOStreams.Out, items)
+	return nil
+}

--- a/cmd/auth/users_logout.go
+++ b/cmd/auth/users_logout.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	larkauth "github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// UsersLogoutOptions holds inputs for auth users logout.
+type UsersLogoutOptions struct {
+	Factory *cmdutil.Factory
+	Target  string
+}
+
+// NewCmdAuthUsersLogout creates the auth users logout command.
+func NewCmdAuthUsersLogout(f *cmdutil.Factory, runF func(*UsersLogoutOptions) error) *cobra.Command {
+	opts := &UsersLogoutOptions{Factory: f}
+	cmd := &cobra.Command{
+		Use:   "logout <open_id|user_name>",
+		Short: "Remove one logged-in user from the current profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Target = args[0]
+			if runF != nil {
+				return runF(opts)
+			}
+			return authUsersLogoutRun(opts)
+		},
+	}
+	cmdutil.SetTips(cmd, []string{"AI agents: Do NOT log out users unless the user explicitly asks."})
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+func authUsersLogoutRun(opts *UsersLogoutOptions) error {
+	f := opts.Factory
+	target := strings.TrimSpace(opts.Target)
+	if target == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "user selector cannot be empty").WithParam("<open_id|user_name>")
+	}
+
+	var removed core.AppUser
+	var active *core.AppUser
+	var appID string
+	err := withAuthConfigLock(func() error {
+		multi, err := core.LoadOrNotConfigured()
+		if err != nil {
+			return err
+		}
+		app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+		if err != nil {
+			return err
+		}
+		user, err := findCommandUser(app, target)
+		if err != nil {
+			return err
+		}
+
+		removed = *user
+		appID = app.AppId
+		users := make([]core.AppUser, 0, len(app.Users)-1)
+		for _, candidate := range app.Users {
+			if candidate.UserOpenId != removed.UserOpenId {
+				users = append(users, candidate)
+			}
+		}
+		app.Users = users
+		if app.CurrentUser == removed.UserOpenId {
+			app.CurrentUser = ""
+			if len(app.Users) > 0 {
+				app.CurrentUser = app.Users[0].UserOpenId
+			}
+		}
+		if err := core.SaveMultiAppConfig(multi); err != nil {
+			return errs.NewInternalError(errs.SubtypeStorage, "failed to save config: %v", err).WithCause(err)
+		}
+		if app.CurrentUser != "" {
+			resolved, activeErr := app.ActiveUser()
+			if activeErr == nil && resolved != nil {
+				copy := *resolved
+				active = &copy
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Delete the token only after the config commit so a failed write cannot
+	// leave a configured user with no local credential.
+	if err := larkauth.RemoveStoredToken(appID, removed.UserOpenId); err != nil {
+		fmt.Fprintf(f.IOStreams.ErrOut, "Warning: failed to remove stored token: %v\n", err)
+	}
+
+	output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("Logged out: %s (%s)", removed.UserName, removed.UserOpenId))
+	if active != nil {
+		fmt.Fprintf(f.IOStreams.ErrOut, "Active user: %s (%s)\n", active.UserName, active.UserOpenId)
+	}
+	return nil
+}

--- a/cmd/auth/users_test.go
+++ b/cmd/auth/users_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	larkauth "github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/zalando/go-keyring"
+)
+
+func setupUsersConfig(t *testing.T) *core.MultiAppConfig {
+	t.Helper()
+	keyring.MockInit()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{{
+			Name:        "default",
+			AppId:       "cli_test",
+			AppSecret:   core.PlainSecret("secret"),
+			Brand:       core.BrandFeishu,
+			CurrentUser: "ou_second",
+			Users: []core.AppUser{
+				{UserOpenId: "ou_first", UserName: "first"},
+				{UserOpenId: "ou_second", UserName: "second"},
+			},
+		}},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+	return multi
+}
+
+func TestAuthUsersListRunMarksActiveUser(t *testing.T) {
+	setupUsersConfig(t)
+	if err := larkauth.SetStoredToken(&larkauth.StoredUAToken{
+		AppId:      "cli_test",
+		UserOpenId: "ou_second",
+		ExpiresAt:  1<<62 - 1,
+	}); err != nil {
+		t.Fatalf("SetStoredToken() error = %v", err)
+	}
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	if err := authUsersListRun(&UsersListOptions{Factory: f}); err != nil {
+		t.Fatalf("authUsersListRun() error = %v", err)
+	}
+
+	var rows []map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("stdout must be JSON: %v\n%s", err, stdout.String())
+	}
+	if len(rows) != 2 || rows[0]["active"] != false || rows[1]["active"] != true {
+		t.Fatalf("rows = %#v, want only second user active", rows)
+	}
+	if rows[1]["tokenStatus"] != "valid" {
+		t.Fatalf("second tokenStatus = %v, want valid", rows[1]["tokenStatus"])
+	}
+}
+
+func TestAuthUsersUseRunSwitchesCurrentUser(t *testing.T) {
+	setupUsersConfig(t)
+	f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+
+	if err := authUsersUseRun(&UsersUseOptions{Factory: f, Target: "first"}); err != nil {
+		t.Fatalf("authUsersUseRun() error = %v", err)
+	}
+	saved, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiAppConfig() error = %v", err)
+	}
+	if saved.Apps[0].CurrentUser != "ou_first" {
+		t.Fatalf("CurrentUser = %q, want ou_first", saved.Apps[0].CurrentUser)
+	}
+	if !strings.Contains(stderr.String(), "Active user: first (ou_first)") {
+		t.Fatalf("stderr = %q, want active user confirmation", stderr.String())
+	}
+}
+
+func TestAuthUsersUseRunRejectsAmbiguousName(t *testing.T) {
+	multi := setupUsersConfig(t)
+	multi.Apps[0].Users[0].UserName = "same"
+	multi.Apps[0].Users[1].UserName = "same"
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	err := authUsersUseRun(&UsersUseOptions{Factory: f, Target: "same"})
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || !strings.Contains(validationErr.Message, "ambiguous") {
+		t.Fatalf("error = %T %v, want ambiguous ValidationError", err, err)
+	}
+}
+
+func TestAuthUsersLogoutRunRemovesOnlyTargetAndSelectsFallback(t *testing.T) {
+	setupUsersConfig(t)
+	for _, openID := range []string{"ou_first", "ou_second"} {
+		if err := larkauth.SetStoredToken(&larkauth.StoredUAToken{
+			AppId:      "cli_test",
+			UserOpenId: openID,
+		}); err != nil {
+			t.Fatalf("SetStoredToken(%s) error = %v", openID, err)
+		}
+	}
+
+	f, _, stderr, _ := cmdutil.TestFactory(t, nil)
+	if err := authUsersLogoutRun(&UsersLogoutOptions{Factory: f, Target: "ou_second"}); err != nil {
+		t.Fatalf("authUsersLogoutRun() error = %v", err)
+	}
+
+	saved, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("LoadMultiAppConfig() error = %v", err)
+	}
+	app := saved.Apps[0]
+	if len(app.Users) != 1 || app.Users[0].UserOpenId != "ou_first" || app.CurrentUser != "ou_first" {
+		t.Fatalf("app = %#v, want only ou_first active", app)
+	}
+	if larkauth.GetStoredToken("cli_test", "ou_second") != nil {
+		t.Fatal("target token still exists")
+	}
+	if larkauth.GetStoredToken("cli_test", "ou_first") == nil {
+		t.Fatal("non-target token was removed")
+	}
+	if !strings.Contains(stderr.String(), "Active user: first (ou_first)") {
+		t.Fatalf("stderr = %q, want fallback identity", stderr.String())
+	}
+}
+
+func TestAuthUsersCommandsParseTargets(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	var useTarget, logoutTarget string
+	use := NewCmdAuthUsersUse(f, func(opts *UsersUseOptions) error {
+		useTarget = opts.Target
+		return nil
+	})
+	use.SetArgs([]string{"ou_use"})
+	if err := use.Execute(); err != nil {
+		t.Fatalf("users use execute error = %v", err)
+	}
+	logout := NewCmdAuthUsersLogout(f, func(opts *UsersLogoutOptions) error {
+		logoutTarget = opts.Target
+		return nil
+	})
+	logout.SetArgs([]string{"ou_logout"})
+	if err := logout.Execute(); err != nil {
+		t.Fatalf("users logout execute error = %v", err)
+	}
+	if useTarget != "ou_use" || logoutTarget != "ou_logout" {
+		t.Fatalf("targets = use:%q logout:%q", useTarget, logoutTarget)
+	}
+}

--- a/cmd/auth/users_use.go
+++ b/cmd/auth/users_use.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// UsersUseOptions holds inputs for auth users use.
+type UsersUseOptions struct {
+	Factory *cmdutil.Factory
+	Target  string
+}
+
+// NewCmdAuthUsersUse creates the auth users use command.
+func NewCmdAuthUsersUse(f *cmdutil.Factory, runF func(*UsersUseOptions) error) *cobra.Command {
+	opts := &UsersUseOptions{Factory: f}
+	cmd := &cobra.Command{
+		Use:   "use <open_id|user_name>",
+		Short: "Switch the active user in the current profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Target = args[0]
+			if runF != nil {
+				return runF(opts)
+			}
+			return authUsersUseRun(opts)
+		},
+	}
+	cmdutil.SetTips(cmd, []string{"AI agents: Do NOT switch users unless the user explicitly asks."})
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+func authUsersUseRun(opts *UsersUseOptions) error {
+	f := opts.Factory
+	target := strings.TrimSpace(opts.Target)
+	if target == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "user selector cannot be empty").WithParam("<open_id|user_name>")
+	}
+
+	return withAuthConfigLock(func() error {
+		multi, err := core.LoadOrNotConfigured()
+		if err != nil {
+			return err
+		}
+		app, err := multi.RequireAppConfig(f.Invocation.Profile, f.Invocation.ProfileSource)
+		if err != nil {
+			return err
+		}
+		user, err := findCommandUser(app, target)
+		if err != nil {
+			return err
+		}
+		if app.CurrentUser == user.UserOpenId {
+			fmt.Fprintf(f.IOStreams.ErrOut, "Already using %s (%s)\n", user.UserName, user.UserOpenId)
+			return nil
+		}
+
+		app.CurrentUser = user.UserOpenId
+		if err := core.SaveMultiAppConfig(multi); err != nil {
+			return errs.NewInternalError(errs.SubtypeStorage, "failed to save config: %v", err).WithCause(err)
+		}
+		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("Active user: %s (%s)", user.UserName, user.UserOpenId))
+		return nil
+	})
+}
+
+func findCommandUser(app *core.AppConfig, target string) (*core.AppUser, error) {
+	for i := range app.Users {
+		if app.Users[i].UserOpenId == target {
+			return &app.Users[i], nil
+		}
+	}
+
+	match := -1
+	for i := range app.Users {
+		if app.Users[i].UserName != target {
+			continue
+		}
+		if match >= 0 {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"user name %q is ambiguous in profile %q", target, app.ProfileName()).
+				WithHint("use the user's open_id from `lark-cli auth users list`")
+		}
+		match = i
+	}
+	if match >= 0 {
+		return &app.Users[match], nil
+	}
+	return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"user %q not found in profile %q", target, app.ProfileName()).
+		WithHint("run `lark-cli auth users list` to see available users")
+}

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -426,6 +426,28 @@ func TestSaveAsProfile_RejectsProfileNameCollisionWithExistingAppID(t *testing.T
 	}
 }
 
+func TestSaveAsProfile_AppIDChangeClearsCurrentUser(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	existing := &core.MultiAppConfig{
+		Apps: []core.AppConfig{{
+			Name:        "prod",
+			AppId:       "app-old",
+			AppSecret:   core.PlainSecret("old-secret"),
+			Brand:       core.BrandFeishu,
+			CurrentUser: "ou_old",
+			Users:       []core.AppUser{{UserOpenId: "ou_old", UserName: "old"}},
+		}},
+	}
+
+	if err := saveAsProfile(existing, keychain.KeychainAccess(&noopConfigKeychain{}), "prod", "app-new", core.PlainSecret("new-secret"), core.BrandLark, "en"); err != nil {
+		t.Fatalf("saveAsProfile() error = %v", err)
+	}
+	if len(existing.Apps[0].Users) != 0 || existing.Apps[0].CurrentUser != "" {
+		t.Fatalf("updated app = %#v, want users and currentUser cleared", existing.Apps[0])
+	}
+}
+
 // TestWrapSaveConfigError_PassesTypedValidationThrough pins that a user-input
 // validation error (e.g. the --name conflict) is not reclassified as an
 // internal storage failure on its way up through the save call sites.

--- a/cmd/config/init.go
+++ b/cmd/config/init.go
@@ -255,6 +255,7 @@ func saveAsProfile(existing *core.MultiAppConfig, kc keychain.KeychainAccess, pr
 				auth.RemoveStoredToken(multi.Apps[idx].AppId, user.UserOpenId)
 			}
 			multi.Apps[idx].Users = []core.AppUser{}
+			multi.Apps[idx].CurrentUser = ""
 		}
 		multi.Apps[idx].AppId = appId
 		multi.Apps[idx].AppSecret = secret

--- a/cmd/profile/list.go
+++ b/cmd/profile/list.go
@@ -95,10 +95,15 @@ func profileListRun(f *cmdutil.Factory) error {
 		}
 
 		if len(app.Users) > 0 {
-			item.User = app.Users[0].UserName
-			stored := larkauth.GetStoredToken(app.AppId, app.Users[0].UserOpenId)
-			if stored != nil {
-				item.TokenStatus = larkauth.TokenStatus(stored)
+			active, activeErr := app.ActiveUser()
+			if activeErr != nil {
+				fmt.Fprintf(f.IOStreams.ErrOut, "Warning: profile %q has an invalid active user: %v\n", name, activeErr)
+			} else if active != nil {
+				item.User = active.UserName
+				stored := larkauth.GetStoredToken(app.AppId, active.UserOpenId)
+				if stored != nil {
+					item.TokenStatus = larkauth.TokenStatus(stored)
+				}
 			}
 		}
 

--- a/cmd/profile/profile_list_current_user_test.go
+++ b/cmd/profile/profile_list_current_user_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package profile
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+)
+
+func TestProfileListRunShowsCurrentUser(t *testing.T) {
+	setupProfileConfigDir(t)
+	multi := &core.MultiAppConfig{
+		CurrentApp: "default",
+		Apps: []core.AppConfig{{
+			Name:        "default",
+			AppId:       "app-default",
+			AppSecret:   core.PlainSecret("secret"),
+			Brand:       core.BrandFeishu,
+			CurrentUser: "ou_second",
+			Users: []core.AppUser{
+				{UserOpenId: "ou_first", UserName: "first"},
+				{UserOpenId: "ou_second", UserName: "second"},
+			},
+		}},
+	}
+	if err := core.SaveMultiAppConfig(multi); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	if err := profileListRun(f); err != nil {
+		t.Fatalf("profileListRun() error = %v", err)
+	}
+	var rows []profileListItem
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("stdout must be JSON: %v\n%s", err, stdout.String())
+	}
+	if len(rows) != 1 || rows[0].User != "second" {
+		t.Fatalf("rows = %#v, want current user second", rows)
+	}
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -38,14 +38,36 @@ type AppUser struct {
 
 // AppConfig is a per-app configuration entry (stored format — secrets may be unresolved).
 type AppConfig struct {
-	Name       string      `json:"name,omitempty"`
-	AppId      string      `json:"appId"`
-	AppSecret  SecretInput `json:"appSecret"`
-	Brand      LarkBrand   `json:"brand"`
-	Lang       i18n.Lang   `json:"lang,omitempty"`
-	DefaultAs  Identity    `json:"defaultAs,omitempty"` // AsUser | AsBot | AsAuto
-	StrictMode *StrictMode `json:"strictMode,omitempty"`
-	Users      []AppUser   `json:"users"`
+	Name        string      `json:"name,omitempty"`
+	AppId       string      `json:"appId"`
+	AppSecret   SecretInput `json:"appSecret"`
+	Brand       LarkBrand   `json:"brand"`
+	Lang        i18n.Lang   `json:"lang,omitempty"`
+	DefaultAs   Identity    `json:"defaultAs,omitempty"` // AsUser | AsBot | AsAuto
+	StrictMode  *StrictMode `json:"strictMode,omitempty"`
+	Users       []AppUser   `json:"users"`
+	CurrentUser string      `json:"currentUser,omitempty"`
+}
+
+// ActiveUser returns the persisted active user. Configs written before
+// currentUser existed continue to resolve through Users[0]. A dangling
+// currentUser never silently dispatches as a different user.
+func (a *AppConfig) ActiveUser() (*AppUser, error) {
+	if a.CurrentUser != "" {
+		for i := range a.Users {
+			if a.Users[i].UserOpenId == a.CurrentUser {
+				return &a.Users[i], nil
+			}
+		}
+		return nil, errs.NewConfigError(errs.SubtypeInvalidConfig,
+			"active user %q not found in profile %q", a.CurrentUser, a.ProfileName()).
+			WithField("currentUser").
+			WithHint("run `lark-cli auth users list`, then select an available user with `lark-cli auth users use <open_id|user_name>`")
+	}
+	if len(a.Users) > 0 {
+		return &a.Users[0], nil
+	}
+	return nil, nil
 }
 
 // ProfileName returns the display name for this app config.
@@ -301,9 +323,13 @@ func ResolveConfigFromMulti(raw *MultiAppConfig, kc keychain.KeychainAccess, pro
 		Lang:        app.Lang,
 		DefaultAs:   app.DefaultAs,
 	}
-	if len(app.Users) > 0 {
-		cfg.UserOpenId = app.Users[0].UserOpenId
-		cfg.UserName = app.Users[0].UserName
+	user, err := app.ActiveUser()
+	if err != nil {
+		return nil, err
+	}
+	if user != nil {
+		cfg.UserOpenId = user.UserOpenId
+		cfg.UserName = user.UserName
 	}
 	return cfg, nil
 }

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -159,6 +159,69 @@ func TestResolveConfigFromMulti_CarriesLang(t *testing.T) {
 	}
 }
 
+func TestResolveConfigFromMulti_UsesCurrentUser(t *testing.T) {
+	raw := &MultiAppConfig{Apps: []AppConfig{{
+		Name:        "default",
+		AppId:       "cli_abc",
+		AppSecret:   PlainSecret("my-secret"),
+		Brand:       BrandFeishu,
+		CurrentUser: "ou_second",
+		Users: []AppUser{
+			{UserOpenId: "ou_first", UserName: "first"},
+			{UserOpenId: "ou_second", UserName: "second"},
+		},
+	}}}
+
+	cfg, err := ResolveConfigFromMulti(raw, nil, "", ProfileFromConfig)
+	if err != nil {
+		t.Fatalf("ResolveConfigFromMulti() error = %v", err)
+	}
+	if cfg.UserOpenId != "ou_second" || cfg.UserName != "second" {
+		t.Fatalf("resolved user = %s (%s), want second (ou_second)", cfg.UserName, cfg.UserOpenId)
+	}
+}
+
+func TestResolveConfigFromMulti_LegacyConfigFallsBackToFirstUser(t *testing.T) {
+	raw := &MultiAppConfig{Apps: []AppConfig{{
+		Name:      "default",
+		AppId:     "cli_abc",
+		AppSecret: PlainSecret("my-secret"),
+		Brand:     BrandFeishu,
+		Users: []AppUser{
+			{UserOpenId: "ou_first", UserName: "first"},
+			{UserOpenId: "ou_second", UserName: "second"},
+		},
+	}}}
+
+	cfg, err := ResolveConfigFromMulti(raw, nil, "", ProfileFromConfig)
+	if err != nil {
+		t.Fatalf("ResolveConfigFromMulti() error = %v", err)
+	}
+	if cfg.UserOpenId != "ou_first" {
+		t.Fatalf("resolved open ID = %q, want ou_first", cfg.UserOpenId)
+	}
+}
+
+func TestResolveConfigFromMulti_RejectsDanglingCurrentUser(t *testing.T) {
+	raw := &MultiAppConfig{Apps: []AppConfig{{
+		Name:        "default",
+		AppId:       "cli_abc",
+		AppSecret:   PlainSecret("my-secret"),
+		Brand:       BrandFeishu,
+		CurrentUser: "ou_missing",
+		Users:       []AppUser{{UserOpenId: "ou_first", UserName: "first"}},
+	}}}
+
+	_, err := ResolveConfigFromMulti(raw, nil, "", ProfileFromConfig)
+	if err == nil {
+		t.Fatal("expected dangling currentUser error")
+	}
+	var cfgErr *errs.ConfigError
+	if !errors.As(err, &cfgErr) || cfgErr.Field != "currentUser" {
+		t.Fatalf("error = %T %#v, want currentUser ConfigError", err, err)
+	}
+}
+
 func TestResolveConfigFromMulti_MatchingKeychainRefPassesValidation(t *testing.T) {
 	// Keychain ref matches appId, so validation passes.
 	// The subsequent ResolveSecretInput will fail (no real keychain),

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -21,6 +21,8 @@ metadata:
 
 4. **`--format json`（默认）下，判断成功用 `ok == true`（或进程退出码 0），不要用 `code == 0`**：成功信封没有顶层 `code` / `msg` 字段，`code` 只出现在错误信封的 `error` 内。按 OpenAPI 老格式 `{"code": 0, "msg": "ok"}`判断会把所有成功调用误判为失败——封装写入类命令时尤其危险。JSON 输出契约 → [`lark-shared-output-contract.md`](references/lark-shared-output-contract.md)。
 
+5. **同一 profile 可保存多个用户登录**：再次执行 `auth login` 会保留已有用户，并把本次扫码授权的用户设为当前用户。用 `lark-cli auth users list` 查看身份，用 `lark-cli auth users use <open_id|user_name>` 切换；只有用户明确要求退出某个身份时才执行 `lark-cli auth users logout <open_id|user_name>`。profile 仍表示应用凭据隔离，不要为同一 App ID 的不同用户重复创建 profile。
+
 
 ## 安全规则
 


### PR DESCRIPTION
## Summary

Add native multi-user authorization inside each existing profile, so one App ID can retain several QR-authorized Feishu/Lark identities and switch between them without logging out or duplicating profiles.

This is a focused replacement for the conflicting, unsigned, 89-file #1257. It follows the maintainer direction on #232 by keeping profiles as the application/credential isolation boundary and adding user selection within a profile.

## Changes

- Preserve existing users and tokens when `auth login` authorizes another user; the newly authorized user becomes active.
- Add `AppConfig.currentUser` with legacy fallback to `users[0]` and a typed error for dangling selectors.
- Add `lark-cli auth users list`, `auth users use <open_id|user_name>`, and `auth users logout <open_id|user_name>`.
- Serialize auth config mutations with a workspace-local lock and commit config changes before deleting a selected user's token.
- Clear `currentUser` when the whole profile is logged out or its App ID changes.
- Update profile status and the shared auth skill guidance to reflect the active user.

## Test Plan

- [x] `go test -race -gcflags='all=-N -l' -count=1 ./cmd/auth ./internal/core ./cmd/config ./cmd/profile`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `make quality-gate`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `make build` and command help smoke tests for `auth users`, `use`, and `logout`
- [ ] `make unit-test` is not fully green in this local environment: unchanged `main` reproduces the same `shortcuts/im` and `shortcuts/minutes` failures because `example.com` resolves as a blocked local/internal host. All other packages passed before those baseline failures.

## Related Issues

- Relates to #204
- Supersedes the implementation approach in #1257 with a smaller profile-aligned change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multi-user authentication within a profile.
  - Added commands to list, switch, and log out individual users.
  - Login now preserves existing users and selects the newly authenticated user.
  - User listings show names, identifiers, token status, and active status.

- **Bug Fixes**
  - Logout now clears the active user.
  - Profile listings display the selected active user.
  - Changing an app ID resets associated user selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->