### PR TITLE
feat(docs): add asynchronous Word PDF rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **docs**: add asynchronous local DOCX-to-PDF rendering and resumable download shortcuts
+- **docs**: expose a blocked short-lived PDF target as structured `error.download_url` for manual recovery
+
 ## [v1.0.92] - 2026-08-28
 
 ### Features

--- a/affordance/docs.md
+++ b/affordance/docs.md
@@ -55,3 +55,20 @@ Apply targeted text or block edits, append content, or deliberately replace an e
 
 ### Skills
 - lark-doc/references/lark-doc-history.md
+
+## +render-word
+Choose this workflow when the original Word pagination must be preserved in a downloadable PDF and heading page locations are useful.
+
+### Tips
+- A wait timeout is recoverable: keep the returned `task_id` and continue with [[+render-word-status]].
+
+### Skills
+- lark-doc/references/lark-doc-render-word.md
+
+## +render-word-status
+
+### Prerequisites
+- `task_id` from [[+render-word]]
+
+### Skills
+- lark-doc/references/lark-doc-render-word.md

--- a/content_embed_affordance_test.go
+++ b/content_embed_affordance_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"io/fs"
 	"slices"
 	"strings"
 	"testing"
@@ -80,6 +81,29 @@ func TestEmbeddedDocsAffordanceComplementsShortcutMetadata(t *testing.T) {
 				"`task_id` from `+history-revert`",
 			},
 		},
+		"+render-word": {
+			description: "Render a local DOCX file to PDF and download the result",
+			useWhen: []string{
+				"Choose this workflow when the original Word pagination must be preserved in a downloadable PDF and heading page locations are useful.",
+			},
+			tips: []string{
+				"A wait timeout is recoverable: keep the returned `task_id` and continue with `+render-word-status`.",
+			},
+			skills: []string{
+				"lark-doc",
+				"lark-doc/references/lark-doc-render-word.md",
+			},
+		},
+		"+render-word-status": {
+			description: "Get a Word render task and optionally download its PDF",
+			prerequisites: []string{
+				"`task_id` from `+render-word`",
+			},
+			skills: []string{
+				"lark-doc",
+				"lark-doc/references/lark-doc-render-word.md",
+			},
+		},
 	}
 
 	shortcuts := make(map[string]struct {
@@ -132,6 +156,16 @@ func TestEmbeddedDocsAffordanceComplementsShortcutMetadata(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestEmbeddedWordRenderSkillReferenceIsReachable(t *testing.T) {
+	content, err := fs.ReadFile(embeddedContentFS, "skills/lark-doc/references/lark-doc-render-word.md")
+	if err != nil {
+		t.Fatalf("read embedded Word render reference: %v", err)
+	}
+	if !strings.Contains(string(content), "docs +render-word-status") {
+		t.Fatalf("embedded Word render reference is incomplete")
 	}
 }
 

--- a/errs/ERROR_CONTRACT.md
+++ b/errs/ERROR_CONTRACT.md
@@ -65,6 +65,7 @@ Typed errors render to **stderr** as one JSON object per process exit:
 | `error.retry_after_seconds` | per-Subtype-stable | upstream-provided minimum delay before retry; emitted when available for retryable `api/rate_limit` and HTTP-backed `network` errors |
 | `error.param` | per-Subtype-stable | single offending parameter (`ValidationError`); see **Validation parameters** |
 | `error.params` | per-Subtype-stable | per-parameter validation detail array (`ValidationError`); see **Validation parameters** |
+| `error.download_url` | per-Subtype-stable | short-lived artifact URL when a `policy/access_denied` download can be completed or inspected manually; treat as sensitive |
 | per-Subtype extension fields | per-Subtype-stable | e.g. `missing_scopes`, `console_url`, `challenge_url`; `console_url` is emitted for developer/admin recovery such as `app_scope_not_applied`, not user `missing_scope` |
 
 For retryable `type=api, subtype=rate_limit`, and for a retryable HTTP-backed
@@ -644,6 +645,9 @@ string cannot be classified retroactively.
 - `missing_scopes` is app configuration, not user data.
 - `Message` and `Hint` must not contain tokens, JWTs, or personally
   identifying values. CI does not catch this — producer responsibility.
+- `download_url` may contain a short-lived signature. Emit it only for an
+  explicit structured recovery contract, never copy it into `Message` or
+  `Hint`, and treat it as sensitive until it expires.
 - Wrapped `Cause` is **not** serialized to the wire (`json:"-"`). It is
   retained for in-process `errors.Is` / `errors.Unwrap` traversal and
   optional debug logging only.

--- a/errs/doc.go
+++ b/errs/doc.go
@@ -13,7 +13,7 @@
 // Every typed error embeds Problem so the JSON wire shape (`type`,
 // `subtype`, `code`, `message`, `hint`, `log_id`, `retryable`) is uniform
 // across categories. Typed extensions (PermissionError.MissingScopes,
-// SecurityPolicyError.ChallengeURL, etc.) appear at the top level of the
+// SecurityPolicyError.ChallengeURL, SecurityPolicyError.DownloadURL, etc.) appear at the top level of the
 // envelope alongside the shared fields, not nested under a `detail` key.
 //
 // # Working with typed errors

--- a/errs/marshal_test.go
+++ b/errs/marshal_test.go
@@ -219,6 +219,7 @@ func TestSecurityPolicyError_MarshalJSON(t *testing.T) {
 	spe := &SecurityPolicyError{
 		Problem:      Problem{Category: CategoryPolicy, Subtype: SubtypeChallengeRequired, Message: "blocked"},
 		ChallengeURL: "https://chal.example",
+		DownloadURL:  "https://download.example/file.pdf?signature=short-lived",
 	}
 	b, _ := json.Marshal(spe)
 	s := string(b)
@@ -226,6 +227,7 @@ func TestSecurityPolicyError_MarshalJSON(t *testing.T) {
 		`"type":"policy"`,
 		`"subtype":"challenge_required"`,
 		`"challenge_url":"https://chal.example"`,
+		`"download_url":"https://download.example/file.pdf?signature=short-lived"`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("missing %q in %s", want, s)
@@ -241,7 +243,8 @@ func TestSecurityPolicyError_MarshalJSON(t *testing.T) {
 // path threaded through cmd/* sites that surface policy-deny outcomes.
 func TestSecurityPolicyError_MarshalJSON_AccessDenied(t *testing.T) {
 	err := NewSecurityPolicyError(SubtypeAccessDenied, "user denied").
-		WithChallengeURL("https://chal.example/2")
+		WithChallengeURL("https://chal.example/2").
+		WithDownloadURL("https://download.example/file.pdf?signature=short-lived")
 
 	b, e := json.Marshal(err)
 	if e != nil {
@@ -252,6 +255,7 @@ func TestSecurityPolicyError_MarshalJSON_AccessDenied(t *testing.T) {
 		`"type":"policy"`,
 		`"subtype":"access_denied"`,
 		`"challenge_url":"https://chal.example/2"`,
+		`"download_url":"https://download.example/file.pdf?signature=short-lived"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("envelope missing %s\nactual: %s", want, got)

--- a/errs/types.go
+++ b/errs/types.go
@@ -521,6 +521,7 @@ func (e *APIError) WithCause(cause error) *APIError {
 type SecurityPolicyError struct {
 	Problem
 	ChallengeURL string `json:"challenge_url,omitempty"`
+	DownloadURL  string `json:"download_url,omitempty"`
 	Cause        error  `json:"-"`
 }
 
@@ -572,6 +573,14 @@ func (e *SecurityPolicyError) WithRetryable() *SecurityPolicyError {
 
 func (e *SecurityPolicyError) WithChallengeURL(url string) *SecurityPolicyError {
 	e.ChallengeURL = url
+	return e
+}
+
+// WithDownloadURL exposes a blocked, short-lived artifact URL so a caller can
+// inspect or retrieve it manually. Producers must not copy this value into
+// Message or Hint, where signed query parameters could leak into prose logs.
+func (e *SecurityPolicyError) WithDownloadURL(url string) *SecurityPolicyError {
+	e.DownloadURL = url
 	return e
 }
 

--- a/errs/types_test.go
+++ b/errs/types_test.go
@@ -501,9 +501,13 @@ func TestBuilder_WithRetryable_OmittedWhenFalse(t *testing.T) {
 func TestNewSecurityPolicyError_ChallengeURL(t *testing.T) {
 	got := errs.NewSecurityPolicyError(errs.SubtypeChallengeRequired, "verify your device").
 		WithCode(21000).
-		WithChallengeURL("https://applink.feishu.cn/T/xxxxx")
+		WithChallengeURL("https://applink.feishu.cn/T/xxxxx").
+		WithDownloadURL("https://download.example/file.pdf?signature=short-lived")
 	if got.ChallengeURL == "" {
 		t.Error("ChallengeURL not set")
+	}
+	if got.DownloadURL == "" {
+		t.Error("DownloadURL not set")
 	}
 	if got.Code != 21000 {
 		t.Errorf("Code = %d, want 21000", got.Code)

--- a/internal/recovery/render_test.go
+++ b/internal/recovery/render_test.go
@@ -111,6 +111,7 @@ func TestRenderClonesEveryConcreteTypedErrorAndPreservesWireExtensions(t *testin
 			original: &errs.SecurityPolicyError{
 				Problem:      problem(errs.CategoryPolicy, errs.SubtypeChallengeRequired),
 				ChallengeURL: "https://example.test/challenge",
+				DownloadURL:  "https://example.test/download?signature=short-lived",
 				Cause:        sentinel,
 			},
 		},

--- a/shortcuts/doc/docs_render_word.go
+++ b/shortcuts/doc/docs_render_word.go
@@ -1,0 +1,496 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+)
+
+const (
+	wordRenderCreatePath       = "/open-apis/docs_ai/v1/word_render_tasks"
+	wordRenderStatusPath       = "/open-apis/docs_ai/v1/word_render_tasks/:task_id"
+	wordRenderMaxDOCXSizeBytes = int64(20 << 20)
+	wordRenderMaxWaitSeconds   = 600
+	wordRenderDefaultPoll      = 3 * time.Second
+	wordRenderMinPoll          = 500 * time.Millisecond
+	wordRenderMaxPoll          = 10 * time.Second
+
+	wordRenderIfExistsError     = "error"
+	wordRenderIfExistsOverwrite = "overwrite"
+	wordRenderIfExistsRename    = "rename"
+)
+
+type wordRenderPDF struct {
+	DownloadURL  string `json:"download_url,omitempty"`
+	Size         int64  `json:"size,omitempty"`
+	URLExpiresAt int64  `json:"url_expires_at,omitempty"`
+}
+
+type wordRenderHeading struct {
+	HeadingIndex int32  `json:"heading_index"`
+	Title        string `json:"title"`
+	Level        int32  `json:"level"`
+	PageIndex    *int32 `json:"page_index,omitempty"`
+	PageNumber   *int32 `json:"page_number,omitempty"`
+}
+
+type wordRenderWarning struct {
+	Code         string `json:"code"`
+	Message      string `json:"message"`
+	HeadingIndex *int32 `json:"heading_index,omitempty"`
+}
+
+type wordRenderFailure struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type wordRenderTask struct {
+	TaskID      string              `json:"task_id"`
+	Status      string              `json:"status"`
+	Stage       string              `json:"stage,omitempty"`
+	PollAfterMs int64               `json:"poll_after_ms,omitempty"`
+	PDF         *wordRenderPDF      `json:"pdf,omitempty"`
+	PageCount   int32               `json:"page_count,omitempty"`
+	Headings    []wordRenderHeading `json:"headings,omitempty"`
+	Warnings    []wordRenderWarning `json:"warnings,omitempty"`
+	Failure     *wordRenderFailure  `json:"failure,omitempty"`
+	ExpiresAt   int64               `json:"expires_at,omitempty"`
+}
+
+var DocsRenderWord = common.Shortcut{
+	Service:     "docs",
+	Command:     "+render-word",
+	Description: "Render a local DOCX file to PDF and download the result",
+	Risk:        "write",
+	Scopes:      []string{"docx:document:readonly"},
+	AuthTypes:   []string{"user"},
+	Flags: []common.Flag{
+		{Name: "file", Desc: "local DOCX file", Required: true},
+		{Name: "output", Desc: "PDF output path", Required: true},
+		{Name: "if-exists", Desc: "output conflict policy: error | overwrite | rename", Default: wordRenderIfExistsError, Enum: []string{wordRenderIfExistsError, wordRenderIfExistsOverwrite, wordRenderIfExistsRename}},
+		{Name: "wait-timeout-seconds", Type: "int", Desc: "maximum seconds to wait for rendering, range 0-600", Default: "600"},
+		{Name: "idempotency-key", Desc: "optional idempotency key; generated when omitted"},
+	},
+	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+		if err := validateWordRenderInputFile(runtime, runtime.Str("file")); err != nil {
+			return err
+		}
+		if err := validateWordRenderOutput(runtime, runtime.Str("output"), runtime.Str("if-exists"), true); err != nil {
+			return err
+		}
+		waitSeconds := runtime.Int("wait-timeout-seconds")
+		if waitSeconds < 0 || waitSeconds > wordRenderMaxWaitSeconds {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"invalid --wait-timeout-seconds %d: must be between 0 and 600", waitSeconds).
+				WithParam("--wait-timeout-seconds")
+		}
+		return validateWordRenderIdempotencyKey(runtime.Str("idempotency-key"))
+	},
+	DryRun: func(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		idempotencyKey := strings.TrimSpace(runtime.Str("idempotency-key"))
+		if idempotencyKey == "" {
+			idempotencyKey = "<generated>"
+		}
+		return common.NewDryRunAPI().
+			POST(wordRenderCreatePath).
+			Desc("Upload one DOCX file and create an asynchronous render task").
+			Body(map[string]interface{}{
+				"file":            "<contents of --file>",
+				"idempotency_key": idempotencyKey,
+			}).
+			GET(wordRenderStatusPath).
+			Desc("Poll the render task until it reaches a terminal state").
+			GET("https://presigned.invalid/render.pdf").
+			Desc("Download the PDF from the short-lived presigned URL without Authorization").
+			File(cmdutil.DryRunFileIntent{
+				Name:     runtime.Str("output"),
+				IfExists: runtime.Str("if-exists"),
+				Content:  "rendered PDF",
+			})
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		idempotencyKey := strings.TrimSpace(runtime.Str("idempotency-key"))
+		if idempotencyKey == "" {
+			var err error
+			idempotencyKey, err = newWordRenderIdempotencyKey()
+			if err != nil {
+				return errs.NewInternalError(errs.SubtypeSDKError, "failed to generate idempotency key").WithCause(err)
+			}
+		}
+		task, err := createWordRenderTask(ctx, runtime, runtime.Str("file"), idempotencyKey)
+		if err != nil {
+			return err
+		}
+
+		waitSeconds := runtime.Int("wait-timeout-seconds")
+		if strings.EqualFold(task.Status, "processing") {
+			if waitSeconds == 0 {
+				runtime.Out(wordRenderResult(task, "", 0, true, runtime.Str("output")), nil)
+				return nil
+			}
+			task, err = waitForWordRenderTask(ctx, runtime, task, time.Duration(waitSeconds)*time.Second)
+			if err != nil {
+				return err
+			}
+			if strings.EqualFold(task.Status, "processing") {
+				runtime.Out(wordRenderResult(task, "", 0, true, runtime.Str("output")), nil)
+				return nil
+			}
+		}
+
+		if err := wordRenderTaskTerminalError(task); err != nil {
+			return err
+		}
+		outputPath, downloadedSize, err := downloadWordRenderPDF(
+			ctx,
+			runtime,
+			task,
+			runtime.Str("output"),
+			runtime.Str("if-exists"),
+		)
+		if err != nil {
+			return err
+		}
+		runtime.Out(wordRenderResult(task, outputPath, downloadedSize, false, ""), nil)
+		return nil
+	},
+}
+
+var DocsRenderWordStatus = common.Shortcut{
+	Service:     "docs",
+	Command:     "+render-word-status",
+	Description: "Get a Word render task and optionally download its PDF",
+	Risk:        "read",
+	Scopes:      []string{"docx:document:readonly"},
+	AuthTypes:   []string{"user"},
+	Flags: []common.Flag{
+		{Name: "task-id", Desc: "task_id returned by docs +render-word", Required: true},
+		{Name: "output", Desc: "optional PDF output path"},
+		{Name: "if-exists", Desc: "output conflict policy: error | overwrite | rename", Default: wordRenderIfExistsError, Enum: []string{wordRenderIfExistsError, wordRenderIfExistsOverwrite, wordRenderIfExistsRename}},
+	},
+	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+		if err := validateWordRenderTaskID(runtime.Str("task-id")); err != nil {
+			return err
+		}
+		return validateWordRenderOutput(runtime, runtime.Str("output"), runtime.Str("if-exists"), false)
+	},
+	DryRun: func(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		taskID := strings.TrimSpace(runtime.Str("task-id"))
+		plan := common.NewDryRunAPI().
+			GET(wordRenderStatusPath).
+			Set("task_id", taskID).
+			Desc("Get the render task once")
+		if strings.TrimSpace(runtime.Str("output")) != "" {
+			plan.GET("https://presigned.invalid/render.pdf").
+				Desc("Download the PDF from the short-lived presigned URL without Authorization").
+				File(cmdutil.DryRunFileIntent{
+					Name:     runtime.Str("output"),
+					IfExists: runtime.Str("if-exists"),
+					Content:  "rendered PDF",
+				})
+		}
+		return plan
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		task, err := getWordRenderTask(ctx, runtime, runtime.Str("task-id"))
+		if err != nil {
+			return err
+		}
+		if strings.EqualFold(task.Status, "processing") {
+			runtime.Out(wordRenderResult(task, "", 0, false, ""), nil)
+			return nil
+		}
+		if err := wordRenderTaskTerminalError(task); err != nil {
+			return err
+		}
+		output := strings.TrimSpace(runtime.Str("output"))
+		if output == "" {
+			runtime.Out(wordRenderResult(task, "", 0, false, ""), nil)
+			return nil
+		}
+		outputPath, downloadedSize, err := downloadWordRenderPDF(ctx, runtime, task, output, runtime.Str("if-exists"))
+		if err != nil {
+			return err
+		}
+		runtime.Out(wordRenderResult(task, outputPath, downloadedSize, false, ""), nil)
+		return nil
+	},
+}
+
+func validateWordRenderInputFile(runtime *common.RuntimeContext, rawPath string) error {
+	filePath := strings.TrimSpace(rawPath)
+	if filePath == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file is required").WithParam("--file")
+	}
+	if !strings.EqualFold(filepath.Ext(filePath), ".docx") {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file must point to a .docx file").WithParam("--file")
+	}
+	if runtime.FileIO() == nil {
+		return errs.NewInternalError(errs.SubtypeFileIO, "file I/O is unavailable")
+	}
+	info, err := runtime.FileIO().Stat(filePath)
+	if err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "cannot access --file: %s", err).
+			WithParam("--file").
+			WithCause(err)
+	}
+	if !info.Mode().IsRegular() {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file must be a regular file").WithParam("--file")
+	}
+	if info.Size() <= 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file is empty").WithParam("--file")
+	}
+	if info.Size() > wordRenderMaxDOCXSizeBytes {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--file exceeds the 20 MiB limit (size is %d bytes)", info.Size()).WithParam("--file")
+	}
+	return nil
+}
+
+func validateWordRenderOutput(runtime *common.RuntimeContext, rawOutput, ifExists string, required bool) error {
+	output := strings.TrimSpace(rawOutput)
+	if output == "" {
+		if required {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output is required").WithParam("--output")
+		}
+		if strings.TrimSpace(ifExists) != "" && strings.TrimSpace(ifExists) != wordRenderIfExistsError {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--if-exists requires --output").WithParam("--if-exists")
+		}
+		return nil
+	}
+	if _, err := runtime.ResolveSavePath(output); err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe --output path: %s", err).
+			WithParam("--output").
+			WithCause(err)
+	}
+	return validateWordRenderIfExists(ifExists)
+}
+
+func validateWordRenderIfExists(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", wordRenderIfExistsError, wordRenderIfExistsOverwrite, wordRenderIfExistsRename:
+		return nil
+	default:
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"invalid --if-exists %q: allowed values are error, overwrite, rename", value).WithParam("--if-exists")
+	}
+}
+
+func validateWordRenderIdempotencyKey(value string) error {
+	if value == "" {
+		return nil
+	}
+	if strings.TrimSpace(value) != value || len(value) > 128 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--idempotency-key must be 1-128 characters without surrounding whitespace").WithParam("--idempotency-key")
+	}
+	return nil
+}
+
+func validateWordRenderTaskID(value string) error {
+	taskID := strings.TrimSpace(value)
+	if taskID == "" || len(taskID) > 128 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--task-id is required and must be at most 128 characters").WithParam("--task-id")
+	}
+	if err := validate.ResourceName(taskID, "--task-id"); err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --task-id: %s", err).WithParam("--task-id").WithCause(err)
+	}
+	return nil
+}
+
+func createWordRenderTask(
+	ctx context.Context,
+	runtime *common.RuntimeContext,
+	filePath string,
+	idempotencyKey string,
+) (wordRenderTask, error) {
+	file, err := runtime.FileIO().Open(strings.TrimSpace(filePath))
+	if err != nil {
+		return wordRenderTask{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "cannot open --file: %s", err).
+			WithParam("--file").
+			WithCause(err)
+	}
+	defer file.Close()
+
+	form := larkcore.NewFormdata()
+	form.AddFile("file", file)
+	form.AddField("idempotency_key", idempotencyKey)
+	response, err := runtime.DoAPI(&larkcore.ApiReq{
+		HttpMethod: http.MethodPost,
+		ApiPath:    wordRenderCreatePath,
+		Body:       form,
+	}, larkcore.WithFileUpload())
+	if err != nil {
+		return wordRenderTask{}, client.WrapDoAPIError(err)
+	}
+	data, err := runtime.ClassifyAPIResponse(response)
+	if err != nil {
+		return wordRenderTask{}, err
+	}
+	return parseWordRenderTask(data)
+}
+
+func getWordRenderTask(ctx context.Context, runtime *common.RuntimeContext, rawTaskID string) (wordRenderTask, error) {
+	taskID := strings.TrimSpace(rawTaskID)
+	data, err := runtime.CallAPITyped(
+		http.MethodGet,
+		strings.Replace(wordRenderStatusPath, ":task_id", validate.EncodePathSegment(taskID), 1),
+		nil,
+		nil,
+	)
+	if err != nil {
+		return wordRenderTask{}, err
+	}
+	return parseWordRenderTask(data)
+}
+
+func parseWordRenderTask(data map[string]interface{}) (wordRenderTask, error) {
+	rawTask := common.GetMap(data, "task")
+	if rawTask == nil {
+		rawTask = common.GetMap(data, "Task")
+	}
+	if rawTask == nil {
+		return wordRenderTask{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "Word render API returned no task")
+	}
+	raw, err := json.Marshal(rawTask)
+	if err != nil {
+		return wordRenderTask{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "failed to decode Word render task").WithCause(err)
+	}
+	var task wordRenderTask
+	if err := json.Unmarshal(raw, &task); err != nil {
+		return wordRenderTask{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "failed to decode Word render task").WithCause(err)
+	}
+	if strings.TrimSpace(task.TaskID) == "" || strings.TrimSpace(task.Status) == "" {
+		return wordRenderTask{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "Word render API returned an incomplete task")
+	}
+	return task, nil
+}
+
+func waitForWordRenderTask(
+	ctx context.Context,
+	runtime *common.RuntimeContext,
+	task wordRenderTask,
+	timeout time.Duration,
+) (wordRenderTask, error) {
+	deadline := time.Now().Add(timeout)
+	for strings.EqualFold(task.Status, "processing") {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return task, nil
+		}
+		wait := clampWordRenderPoll(task.PollAfterMs)
+		if wait > remaining {
+			wait = remaining
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return wordRenderTask{}, ctx.Err()
+		case <-timer.C:
+		}
+		if time.Until(deadline) <= 0 {
+			return task, nil
+		}
+		var err error
+		task, err = getWordRenderTask(ctx, runtime, task.TaskID)
+		if err != nil {
+			return wordRenderTask{}, err
+		}
+	}
+	return task, nil
+}
+
+func clampWordRenderPoll(pollAfterMillis int64) time.Duration {
+	if pollAfterMillis <= 0 {
+		return wordRenderDefaultPoll
+	}
+	duration := time.Duration(pollAfterMillis) * time.Millisecond
+	if duration < wordRenderMinPoll {
+		return wordRenderMinPoll
+	}
+	if duration > wordRenderMaxPoll {
+		return wordRenderMaxPoll
+	}
+	return duration
+}
+
+func wordRenderTaskTerminalError(task wordRenderTask) error {
+	switch strings.ToLower(strings.TrimSpace(task.Status)) {
+	case "succeeded":
+		if task.PDF == nil || strings.TrimSpace(task.PDF.DownloadURL) == "" {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "succeeded Word render task has no PDF download URL")
+		}
+		return nil
+	case "failed":
+		code := "drive_preview_failed"
+		message := "Word render task failed"
+		if task.Failure != nil {
+			if strings.TrimSpace(task.Failure.Code) != "" {
+				code = strings.TrimSpace(task.Failure.Code)
+			}
+			if strings.TrimSpace(task.Failure.Message) != "" {
+				message = strings.TrimSpace(task.Failure.Message)
+			}
+		}
+		return errs.NewAPIError(errs.SubtypeServerError, "%s (failure_code=%s)", message, code).
+			WithHint("retry docs +render-word with a new --idempotency-key; if it persists, contact support")
+	case "expired":
+		return errs.NewAPIError(errs.SubtypeNotFound, "Word render task expired").
+			WithHint("run docs +render-word again to create a new task")
+	case "processing":
+		return nil
+	default:
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "Word render API returned unknown task status %q", task.Status)
+	}
+}
+
+func wordRenderResult(task wordRenderTask, outputPath string, downloadedSize int64, timedOut bool, nextOutput string) map[string]interface{} {
+	raw, _ := json.Marshal(task)
+	result := make(map[string]interface{})
+	_ = json.Unmarshal(raw, &result)
+	if outputPath != "" {
+		result["output_path"] = outputPath
+		result["downloaded_size"] = downloadedSize
+	}
+	if timedOut {
+		result["timed_out"] = true
+		result["next_command"] = fmt.Sprintf(
+			"lark-cli docs +render-word-status --task-id %s --output %s",
+			shellQuoteWordRender(task.TaskID),
+			shellQuoteWordRender(nextOutput),
+		)
+	}
+	return result
+}
+
+func shellQuoteWordRender(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func newWordRenderIdempotencyKey() (string, error) {
+	randomBytes := make([]byte, 16)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", err
+	}
+	return "lark-cli-" + base64.RawURLEncoding.EncodeToString(randomBytes), nil
+}

--- a/shortcuts/doc/docs_render_word_download.go
+++ b/shortcuts/doc/docs_render_word_download.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func downloadWordRenderPDF(
+	ctx context.Context,
+	runtime *common.RuntimeContext,
+	task wordRenderTask,
+	output string,
+	ifExists string,
+) (string, int64, error) {
+	if task.PDF == nil || strings.TrimSpace(task.PDF.DownloadURL) == "" {
+		return "", 0, errs.NewInternalError(errs.SubtypeInvalidResponse, "Word render task has no PDF download URL")
+	}
+	finalPath, err := resolveWordRenderOutputPath(runtime, strings.TrimSpace(output), strings.TrimSpace(ifExists))
+	if err != nil {
+		return "", 0, err
+	}
+	if err := validate.ValidateDownloadSourceURL(ctx, task.PDF.DownloadURL); err != nil {
+		return "", 0, newWordRenderDownloadPolicyError(runtime, "blocked PDF download target: "+err.Error(), task.PDF.DownloadURL, err)
+	}
+	parsedURL, err := url.Parse(task.PDF.DownloadURL)
+	if err != nil {
+		return "", 0, newWordRenderDownloadPolicyError(runtime, "PDF download URL is invalid", task.PDF.DownloadURL, err)
+	}
+	if !strings.EqualFold(parsedURL.Scheme, "https") {
+		return "", 0, newWordRenderDownloadPolicyError(runtime, "PDF download URL must use HTTPS", task.PDF.DownloadURL, nil)
+	}
+	baseClient, err := runtime.Factory.ExternalHTTPClient()
+	if err != nil {
+		return "", 0, errs.NewNetworkError(errs.SubtypeNetworkTransport, "failed to initialize external download client").WithCause(err)
+	}
+	downloadClient := *baseClient
+	//nolint:forbidigo // Presigned Drive redirects stay outside the gateway; this hook validates every target and strips credentials.
+	downloadClient.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if len(via) >= 5 {
+			return newWordRenderDownloadPolicyError(runtime, "PDF download exceeded the redirect limit", request.URL.String(), nil)
+		}
+		if !strings.EqualFold(request.URL.Scheme, "https") {
+			return newWordRenderDownloadPolicyError(runtime, "PDF download redirect must use HTTPS", request.URL.String(), nil)
+		}
+		for _, header := range []string{"Authorization", "Cookie", "X-Lark-MCP-UAT", "X-Lark-MCP-TAT"} {
+			request.Header.Del(header)
+		}
+		if err := validate.ValidateDownloadSourceURL(request.Context(), request.URL.String()); err != nil {
+			return newWordRenderDownloadPolicyError(runtime, "blocked PDF download redirect: "+err.Error(), request.URL.String(), err)
+		}
+		return nil
+	}
+	//nolint:forbidigo // Drive returns a presigned external URL; the download-safe client enforces scheme, DNS/IP and redirect policy without attaching Lark auth.
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, task.PDF.DownloadURL, nil)
+	if err != nil {
+		return "", 0, errs.NewNetworkError(errs.SubtypeNetworkTransport, "invalid PDF download request").WithCause(err)
+	}
+	//nolint:forbidigo // Presigned Drive bytes cannot use RuntimeContext.DoAPI because attaching gateway auth would leak credentials.
+	response, err := downloadClient.Do(request)
+	if err != nil {
+		return "", 0, errs.NewNetworkError(errs.SubtypeNetworkTransport, "PDF download failed").WithCause(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+		subtype := errs.SubtypeNetworkTransport
+		if response.StatusCode >= http.StatusInternalServerError {
+			subtype = errs.SubtypeNetworkServer
+		}
+		networkErr := errs.NewNetworkError(subtype, "PDF download failed: HTTP %d", response.StatusCode).WithCode(response.StatusCode)
+		if response.StatusCode >= http.StatusInternalServerError {
+			networkErr = networkErr.WithRetryable()
+		}
+		return "", 0, networkErr
+	}
+
+	prefix := make([]byte, len("%PDF-"))
+	if _, err := io.ReadFull(response.Body, prefix); err != nil {
+		return "", 0, errs.NewNetworkError(errs.SubtypeNetworkProtocol, "downloaded response is shorter than a PDF header").WithCause(err)
+	}
+	if string(prefix) != "%PDF-" {
+		return "", 0, errs.NewNetworkError(errs.SubtypeNetworkProtocol, "downloaded response is not a PDF")
+	}
+	saveOptions := fileio.SaveOptions{
+		ContentType:   response.Header.Get("Content-Type"),
+		ContentLength: response.ContentLength,
+	}
+	body := io.MultiReader(bytes.NewReader(prefix), response.Body)
+	var result fileio.SaveResult
+	if strings.TrimSpace(ifExists) == wordRenderIfExistsOverwrite {
+		result, err = runtime.FileIO().Save(finalPath, saveOptions, body)
+	} else {
+		exclusive, ok := runtime.FileIO().(fileio.ExclusiveFileIO)
+		if !ok {
+			return "", 0, errs.NewValidationError(errs.SubtypeFailedPrecondition,
+				"the active file provider cannot guarantee --if-exists %s; use --if-exists overwrite", ifExists).
+				WithParam("--if-exists")
+		}
+		result, err = exclusive.SaveExclusive(finalPath, saveOptions, body)
+	}
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return "", 0, errs.NewValidationError(errs.SubtypeFailedPrecondition,
+				"output file was created concurrently: %s; retry the command", finalPath).WithParam("--output").WithCause(err)
+		}
+		return "", 0, common.WrapSaveErrorTypedForFlag(err, "--output")
+	}
+	resolved, resolveErr := runtime.ResolveSavePath(finalPath)
+	if resolveErr != nil || resolved == "" {
+		resolved = finalPath
+	}
+	return resolved, result.Size(), nil
+}
+
+func newWordRenderDownloadPolicyError(
+	runtime *common.RuntimeContext,
+	message string,
+	downloadURL string,
+	cause error,
+) *errs.SecurityPolicyError {
+	policyErr := errs.NewSecurityPolicyError(errs.SubtypeAccessDenied, "%s", message)
+	if runtime != nil && strings.EqualFold(strings.TrimSpace(runtime.Format), "json") {
+		policyErr.WithDownloadURL(strings.TrimSpace(downloadURL))
+	}
+	if cause != nil {
+		policyErr.WithCause(cause)
+	}
+	return policyErr
+}
+
+func resolveWordRenderOutputPath(runtime *common.RuntimeContext, output, ifExists string) (string, error) {
+	if _, err := runtime.ResolveSavePath(output); err != nil {
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe --output path: %s", err).
+			WithParam("--output").
+			WithCause(err)
+	}
+	switch ifExists {
+	case "", wordRenderIfExistsError:
+		if _, ok := runtime.FileIO().(fileio.ExclusiveFileIO); !ok {
+			return "", errs.NewValidationError(errs.SubtypeFailedPrecondition,
+				"the active file provider cannot guarantee --if-exists error; use --if-exists overwrite").WithParam("--if-exists")
+		}
+		if _, err := runtime.FileIO().Stat(output); err == nil {
+			return "", errs.NewValidationError(errs.SubtypeFailedPrecondition,
+				"output file already exists: %s (use --if-exists overwrite or rename)", output).WithParam("--output")
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", errs.NewInternalError(errs.SubtypeFileIO, "cannot access output path %s: %s", output, err).WithCause(err)
+		}
+		return output, nil
+	case wordRenderIfExistsOverwrite:
+		return output, nil
+	case wordRenderIfExistsRename:
+		if _, ok := runtime.FileIO().(fileio.ExclusiveFileIO); !ok {
+			return "", errs.NewValidationError(errs.SubtypeFailedPrecondition,
+				"the active file provider cannot guarantee --if-exists rename; use --if-exists overwrite").WithParam("--if-exists")
+		}
+		return nextAvailableWordRenderPath(runtime.FileIO(), output)
+	default:
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"invalid --if-exists %q: allowed values are error, overwrite, rename", ifExists).WithParam("--if-exists")
+	}
+}
+
+func nextAvailableWordRenderPath(fio fileio.FileIO, output string) (string, error) {
+	if _, err := fio.Stat(output); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return output, nil
+		}
+		return "", errs.NewInternalError(errs.SubtypeFileIO, "cannot access output path %s: %s", output, err).WithCause(err)
+	}
+	dir := filepath.Dir(output)
+	ext := filepath.Ext(output)
+	base := strings.TrimSuffix(filepath.Base(output), ext)
+	for index := 1; index < 10_000; index++ {
+		candidate := filepath.Join(dir, fmt.Sprintf("%s (%d)%s", base, index, ext))
+		if _, err := fio.Stat(candidate); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return candidate, nil
+			}
+			return "", errs.NewInternalError(errs.SubtypeFileIO, "cannot access output candidate %s: %s", candidate, err).WithCause(err)
+		}
+	}
+	return "", errs.NewInternalError(errs.SubtypeFileIO, "cannot allocate a unique PDF output path")
+}

--- a/shortcuts/doc/docs_render_word_test.go
+++ b/shortcuts/doc/docs_render_word_test.go
@@ -1,0 +1,470 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+const wordRenderTestDownloadURL = "https://93.184.216.34/render.pdf"
+
+func TestDocsRenderWordDryRunPlansCreatePollAndDownload(t *testing.T) {
+	dir := t.TempDir()
+	withDocsWorkingDir(t, dir)
+	if err := os.WriteFile("report.docx", []byte("docx"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	factory, stdout, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-dry-run"))
+	if err := mountAndRunDocs(t, DocsRenderWord, []string{
+		"+render-word", "--file", "report.docx", "--output", "report.pdf", "--dry-run", "--as", "user",
+	}, factory, stdout); err != nil {
+		t.Fatalf("dry-run error = %v", err)
+	}
+	var envelope struct {
+		Data struct {
+			API   []common.DryRunAPICall `json:"api"`
+			Files []struct {
+				Name     string `json:"name"`
+				IfExists string `json:"if_exists"`
+			} `json:"files"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode dry-run: %v\n%s", err, stdout.String())
+	}
+	if len(envelope.Data.API) != 3 {
+		t.Fatalf("API calls = %#v", envelope.Data.API)
+	}
+	if envelope.Data.API[0].Method != http.MethodPost || envelope.Data.API[0].URL != wordRenderCreatePath ||
+		envelope.Data.API[1].Method != http.MethodGet || envelope.Data.API[1].URL != wordRenderStatusPath ||
+		envelope.Data.API[2].URL != "https://presigned.invalid/render.pdf" {
+		t.Fatalf("API calls = %#v", envelope.Data.API)
+	}
+	if len(envelope.Data.Files) != 1 || envelope.Data.Files[0].Name != "report.pdf" || envelope.Data.Files[0].IfExists != wordRenderIfExistsError {
+		t.Fatalf("files = %#v", envelope.Data.Files)
+	}
+}
+
+func TestDocsRenderWordStatusDryRunPlansOptionalDownload(t *testing.T) {
+	factory, stdout, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-status-dry-run"))
+	if err := mountAndRunDocs(t, DocsRenderWordStatus, []string{
+		"+render-word-status", "--task-id", "render_test", "--output", "report.pdf", "--dry-run", "--as", "user",
+	}, factory, stdout); err != nil {
+		t.Fatalf("dry-run error = %v", err)
+	}
+	var envelope struct {
+		Data struct {
+			API []common.DryRunAPICall `json:"api"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode dry-run: %v", err)
+	}
+	if len(envelope.Data.API) != 2 || envelope.Data.API[0].URL != "/open-apis/docs_ai/v1/word_render_tasks/render_test" {
+		t.Fatalf("API calls = %#v", envelope.Data.API)
+	}
+}
+
+func TestDocsRenderWordFileValidationBoundaries(t *testing.T) {
+	dir := t.TempDir()
+	withDocsWorkingDir(t, dir)
+	writeSizedDocTestFile(t, "limit.docx", wordRenderMaxDOCXSizeBytes)
+	writeSizedDocTestFile(t, "too-large.docx", wordRenderMaxDOCXSizeBytes+1)
+
+	factory, stdout, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-size"))
+	if err := mountAndRunDocs(t, DocsRenderWord, []string{
+		"+render-word", "--file", "limit.docx", "--output", "limit.pdf", "--dry-run", "--as", "user",
+	}, factory, stdout); err != nil {
+		t.Fatalf("20 MiB boundary rejected: %v", err)
+	}
+	err := mountAndRunDocs(t, DocsRenderWord, []string{
+		"+render-word", "--file", "too-large.docx", "--output", "large.pdf", "--dry-run", "--as", "user",
+	}, factory, stdout)
+	assertWordRenderProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, "--file")
+
+	if err := os.WriteFile("empty.docx", nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = mountAndRunDocs(t, DocsRenderWord, []string{
+		"+render-word", "--file", "empty.docx", "--output", "empty.pdf", "--dry-run", "--as", "user",
+	}, factory, stdout)
+	assertWordRenderProblem(t, err, errs.CategoryValidation, errs.SubtypeInvalidArgument, "--file")
+}
+
+func TestDocsRenderWordProcessingToSucceededDownloadsPDF(t *testing.T) {
+	dir := t.TempDir()
+	withDocsWorkingDir(t, dir)
+	docxBytes := []byte("DOCX-BYTES")
+	if err := os.WriteFile("report.docx", docxBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pdfBytes := []byte("%PDF-1.7\nrendered")
+
+	factory, stdout, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-e2e"))
+	createStub := &httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    wordRenderCreatePath,
+		Body: wordRenderAPIResponse(map[string]interface{}{
+			"task_id":       "render_test",
+			"status":        "processing",
+			"stage":         "converting",
+			"poll_after_ms": 1,
+		}),
+	}
+	registry.Register(createStub)
+	registry.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/docs_ai/v1/word_render_tasks/render_test",
+		Body: wordRenderAPIResponse(map[string]interface{}{
+			"task_id":       "render_test",
+			"status":        "processing",
+			"stage":         "mapping",
+			"poll_after_ms": 1,
+		}),
+	})
+	succeededTask := wordRenderSucceededTask(int64(len(pdfBytes)))
+	succeededTask["task_id"] = "render_test"
+	registry.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/docs_ai/v1/word_render_tasks/render_test",
+		Body:   wordRenderAPIResponse(succeededTask),
+	})
+	downloadStub := &httpmock.Stub{
+		Method:      http.MethodGet,
+		URL:         wordRenderTestDownloadURL,
+		RawBody:     pdfBytes,
+		ContentType: "application/pdf",
+	}
+	registry.Register(downloadStub)
+
+	if err := mountAndRunDocs(t, DocsRenderWord, []string{
+		"+render-word",
+		"--file", "report.docx",
+		"--output", "report.pdf",
+		"--idempotency-key", "idem-explicit",
+		"--wait-timeout-seconds", "5",
+		"--as", "user",
+	}, factory, stdout); err != nil {
+		t.Fatalf("execute error = %v", err)
+	}
+	written, err := os.ReadFile("report.pdf")
+	if err != nil {
+		t.Fatalf("read PDF: %v", err)
+	}
+	if !bytes.Equal(written, pdfBytes) {
+		t.Fatalf("PDF bytes = %q", written)
+	}
+
+	multipartBody := decodeWordRenderMultipart(t, createStub)
+	if multipartBody.fields["idempotency_key"] != "idem-explicit" ||
+		multipartBody.fileName != "report.docx" || !bytes.Equal(multipartBody.file, docxBytes) {
+		t.Fatalf("multipart = %#v", multipartBody)
+	}
+	if got := downloadStub.CapturedHeaders.Get("Authorization"); got != "" {
+		t.Fatalf("presigned download leaked Authorization header: %q", got)
+	}
+
+	data := decodeWordRenderEnvelope(t, stdout)
+	if data["task_id"] != "render_test" || data["status"] != "succeeded" || data["downloaded_size"].(float64) != float64(len(pdfBytes)) {
+		t.Fatalf("output = %#v", data)
+	}
+	if path, _ := data["output_path"].(string); !filepath.IsAbs(path) || !strings.HasSuffix(path, "report.pdf") {
+		t.Fatalf("output_path = %#v", data["output_path"])
+	}
+	if headings, _ := data["headings"].([]interface{}); len(headings) != 1 {
+		t.Fatalf("headings = %#v", data["headings"])
+	}
+	if warnings, _ := data["warnings"].([]interface{}); len(warnings) != 1 {
+		t.Fatalf("warnings = %#v", data["warnings"])
+	}
+}
+
+func TestDocsRenderWordGeneratesIdempotencyKeyAndTimesOutCleanly(t *testing.T) {
+	dir := t.TempDir()
+	withDocsWorkingDir(t, dir)
+	if err := os.WriteFile("report.docx", []byte("docx"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	factory, stdout, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-timeout"))
+	createStub := &httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    wordRenderCreatePath,
+		Body: wordRenderAPIResponse(map[string]interface{}{
+			"task_id": "render_timeout", "status": "processing", "stage": "converting",
+		}),
+	}
+	registry.Register(createStub)
+	if err := mountAndRunDocs(t, DocsRenderWord, []string{
+		"+render-word", "--file", "report.docx", "--output", "report.pdf",
+		"--wait-timeout-seconds", "0", "--as", "user",
+	}, factory, stdout); err != nil {
+		t.Fatalf("execute error = %v", err)
+	}
+	multipartBody := decodeWordRenderMultipart(t, createStub)
+	if key := multipartBody.fields["idempotency_key"]; !strings.HasPrefix(key, "lark-cli-") || len(key) <= len("lark-cli-") {
+		t.Fatalf("generated idempotency key = %q", key)
+	}
+	data := decodeWordRenderEnvelope(t, stdout)
+	if data["timed_out"] != true || !strings.Contains(data["next_command"].(string), "+render-word-status") {
+		t.Fatalf("timeout output = %#v", data)
+	}
+	if _, err := os.Stat("report.pdf"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("timeout unexpectedly wrote output, stat error = %v", err)
+	}
+}
+
+func TestDocsRenderWordStatusDownloadsSucceededTask(t *testing.T) {
+	dir := t.TempDir()
+	withDocsWorkingDir(t, dir)
+	pdfBytes := []byte("%PDF-status")
+	factory, stdout, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-status"))
+	registry.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/docs_ai/v1/word_render_tasks/render_status",
+		Body:   wordRenderAPIResponse(wordRenderSucceededTask(int64(len(pdfBytes)))),
+	})
+	registry.Register(&httpmock.Stub{Method: http.MethodGet, URL: wordRenderTestDownloadURL, RawBody: pdfBytes, ContentType: "application/pdf"})
+	if err := mountAndRunDocs(t, DocsRenderWordStatus, []string{
+		"+render-word-status", "--task-id", "render_status", "--output", "status.pdf", "--as", "user",
+	}, factory, stdout); err != nil {
+		t.Fatalf("execute error = %v", err)
+	}
+	if got, err := os.ReadFile("status.pdf"); err != nil || !bytes.Equal(got, pdfBytes) {
+		t.Fatalf("downloaded PDF = %q, err=%v", got, err)
+	}
+}
+
+func TestDocsRenderWordStatusFailedAndExpiredAreTyped(t *testing.T) {
+	tests := []struct {
+		name    string
+		task    map[string]interface{}
+		subtype errs.Subtype
+	}{
+		{
+			name: "failed",
+			task: map[string]interface{}{
+				"task_id": "render_failed", "status": "failed",
+				"failure": map[string]interface{}{"code": "drive_preview_failed", "message": "conversion failed"},
+			},
+			subtype: errs.SubtypeServerError,
+		},
+		{
+			name:    "expired",
+			task:    map[string]interface{}{"task_id": "render_expired", "status": "expired"},
+			subtype: errs.SubtypeNotFound,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			factory, stdout, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-"+test.name))
+			taskID := test.task["task_id"].(string)
+			registry.Register(&httpmock.Stub{
+				Method: http.MethodGet,
+				URL:    "/open-apis/docs_ai/v1/word_render_tasks/" + taskID,
+				Body:   wordRenderAPIResponse(test.task),
+			})
+			err := mountAndRunDocs(t, DocsRenderWordStatus, []string{
+				"+render-word-status", "--task-id", taskID, "--as", "user",
+			}, factory, stdout)
+			assertWordRenderProblem(t, err, errs.CategoryAPI, test.subtype, "")
+		})
+	}
+}
+
+func TestDownloadWordRenderPDFRejectsBlockedAndNonPDFResponses(t *testing.T) {
+	dir := t.TempDir()
+	withDocsWorkingDir(t, dir)
+	factory, _, _, registry := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-download-security"))
+	runtime := common.TestNewRuntimeContextForAPI(context.Background(), &cobra.Command{Use: "+render-word-status"},
+		docsTestConfigWithAppID("word-render-download-security"), factory, core.AsUser)
+
+	blockedTask := wordRenderTask{TaskID: "render_blocked", Status: "succeeded", PDF: &wordRenderPDF{DownloadURL: "http://127.0.0.1/pdf"}}
+	runtime.Format = "json"
+	_, _, err := downloadWordRenderPDF(context.Background(), runtime, blockedTask, "blocked.pdf", wordRenderIfExistsError)
+	assertWordRenderProblem(t, err, errs.CategoryPolicy, errs.SubtypeAccessDenied, "")
+	var policyErr *errs.SecurityPolicyError
+	if !errors.As(err, &policyErr) {
+		t.Fatalf("blocked download error type = %T, want *errs.SecurityPolicyError", err)
+	}
+	if policyErr.DownloadURL != blockedTask.PDF.DownloadURL {
+		t.Fatalf("download_url = %q, want %q", policyErr.DownloadURL, blockedTask.PDF.DownloadURL)
+	}
+
+	runtime.Format = "pretty"
+	_, _, err = downloadWordRenderPDF(context.Background(), runtime, blockedTask, "blocked-pretty.pdf", wordRenderIfExistsError)
+	if !errors.As(err, &policyErr) {
+		t.Fatalf("pretty blocked download error type = %T, want *errs.SecurityPolicyError", err)
+	}
+	if policyErr.DownloadURL != "" {
+		t.Fatalf("pretty download_url = %q, want omitted", policyErr.DownloadURL)
+	}
+
+	registry.Register(&httpmock.Stub{Method: http.MethodGet, URL: wordRenderTestDownloadURL, RawBody: []byte("hello world"), ContentType: "text/plain"})
+	nonPDFTask := wordRenderTask{TaskID: "render_non_pdf", Status: "succeeded", PDF: &wordRenderPDF{DownloadURL: wordRenderTestDownloadURL}}
+	_, _, err = downloadWordRenderPDF(context.Background(), runtime, nonPDFTask, "non-pdf.pdf", wordRenderIfExistsError)
+	assertWordRenderProblem(t, err, errs.CategoryNetwork, errs.SubtypeNetworkProtocol, "")
+	if _, err := os.Stat("non-pdf.pdf"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("non-PDF response wrote a file, stat error = %v", err)
+	}
+}
+
+func TestResolveWordRenderOutputPolicies(t *testing.T) {
+	dir := t.TempDir()
+	withDocsWorkingDir(t, dir)
+	if err := os.WriteFile("report.pdf", []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("report (1).pdf", []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	factory, _, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("word-render-output"))
+	runtime := common.TestNewRuntimeContextForAPI(context.Background(), &cobra.Command{Use: "+render-word"},
+		docsTestConfigWithAppID("word-render-output"), factory, core.AsUser)
+
+	if _, err := resolveWordRenderOutputPath(runtime, "report.pdf", wordRenderIfExistsError); err == nil {
+		t.Fatal("error policy accepted an existing file")
+	}
+	if got, err := resolveWordRenderOutputPath(runtime, "report.pdf", wordRenderIfExistsOverwrite); err != nil || got != "report.pdf" {
+		t.Fatalf("overwrite path = %q, err=%v", got, err)
+	}
+	if got, err := resolveWordRenderOutputPath(runtime, "report.pdf", wordRenderIfExistsRename); err != nil || got != "report (2).pdf" {
+		t.Fatalf("rename path = %q, err=%v", got, err)
+	}
+}
+
+func TestClampWordRenderPoll(t *testing.T) {
+	for _, test := range []struct {
+		input int64
+		want  time.Duration
+	}{
+		{input: 0, want: 3 * time.Second},
+		{input: 1, want: 500 * time.Millisecond},
+		{input: 750, want: 750 * time.Millisecond},
+		{input: 20_000, want: 10 * time.Second},
+	} {
+		if got := clampWordRenderPoll(test.input); got != test.want {
+			t.Errorf("clampWordRenderPoll(%d) = %s, want %s", test.input, got, test.want)
+		}
+	}
+}
+
+func wordRenderAPIResponse(task map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"code": 0,
+		"msg":  "ok",
+		"data": map[string]interface{}{"task": task},
+	}
+}
+
+func wordRenderSucceededTask(pdfSize int64) map[string]interface{} {
+	pageIndex := 1
+	pageNumber := 2
+	return map[string]interface{}{
+		"task_id": "render_status",
+		"status":  "succeeded",
+		"pdf": map[string]interface{}{
+			"download_url":   wordRenderTestDownloadURL,
+			"size":           pdfSize,
+			"url_expires_at": 2_000_000_000,
+		},
+		"page_count": 2,
+		"headings": []interface{}{
+			map[string]interface{}{
+				"heading_index": 0, "title": "Overview", "level": 1,
+				"page_index": pageIndex, "page_number": pageNumber,
+			},
+		},
+		"warnings": []interface{}{
+			map[string]interface{}{"code": "heading_page_unresolved", "message": "one heading was unresolved", "heading_index": 1},
+		},
+	}
+}
+
+type capturedWordRenderMultipart struct {
+	fields   map[string]string
+	fileName string
+	file     []byte
+}
+
+func decodeWordRenderMultipart(t *testing.T, stub *httpmock.Stub) capturedWordRenderMultipart {
+	t.Helper()
+	mediaType, params, err := mime.ParseMediaType(stub.CapturedHeaders.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse multipart content type: %v", err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("content type = %q", mediaType)
+	}
+	reader := multipart.NewReader(bytes.NewReader(stub.CapturedBody), params["boundary"])
+	result := capturedWordRenderMultipart{fields: make(map[string]string)}
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read multipart part: %v", err)
+		}
+		content, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read multipart content: %v", err)
+		}
+		if part.FileName() != "" {
+			result.fileName = part.FileName()
+			result.file = content
+		} else {
+			result.fields[part.FormName()] = string(content)
+		}
+	}
+	return result
+}
+
+func decodeWordRenderEnvelope(t *testing.T, stdout *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	data, _ := envelope["data"].(map[string]interface{})
+	if data == nil {
+		t.Fatalf("missing data: %#v", envelope)
+	}
+	return data
+}
+
+func assertWordRenderProblem(t *testing.T, err error, category errs.Category, subtype errs.Subtype, param string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("error = nil")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != category || problem.Subtype != subtype {
+		t.Fatalf("problem = %#v, error=%T %v", problem, err, err)
+	}
+	if param != "" {
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) || validationErr.Param != param {
+			t.Fatalf("validation error = %#v, want param %q", validationErr, param)
+		}
+	}
+}

--- a/shortcuts/doc/shortcuts.go
+++ b/shortcuts/doc/shortcuts.go
@@ -21,6 +21,8 @@ func Shortcuts() []common.Shortcut {
 		DocsHistoryList,
 		DocsHistoryRevert,
 		DocsHistoryRevertStatus,
+		DocsRenderWord,
+		DocsRenderWordStatus,
 		DocMediaInsert,
 		DocMediaUpload,
 		DocMediaPreview,

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark-doc
-description: "飞书云文档（Docx / Wiki）内容操作：读取、创建、编辑文档，插入或下载图片附件，以及操作思维笔记。用户提供文档 URL/token（包括 doubao.com 的 /docx/、/wiki/）时使用；按 URL 路径/token 而非域名路由。文档内嵌资源按读取参考中的统一规则分流。独立评论操作走 lark-drive；随正文读取评论使用 docs +fetch。表格或 Base 内部数据操作不在本 skill。"
+description: "飞书云文档（Docx / Wiki）内容操作：读取、创建、编辑文档，插入或下载图片附件，把本地 DOCX 渲染为 PDF，以及操作思维笔记。用户提供文档 URL/token（包括 doubao.com 的 /docx/、/wiki/）或提出 DOCX 转 PDF 时使用；按 URL 路径/token 而非域名路由。文档内嵌资源按读取参考中的统一规则分流。独立评论操作走 lark-drive；随正文读取评论使用 docs +fetch。表格或 Base 内部数据操作不在本 skill。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -29,6 +29,7 @@ metadata:
 
 - **草稿初始化、解析与统计 — [`+script`](references/lark-doc-script.md)**：支持解析文档 URL / token 与本地 XML，统计字数并返回字符诊断；不支持 Markdown 输入。
 - **历史版本 — [`+history-list` / `+history-revert` / `+history-revert-status`](references/lark-doc-history.md)**：查询、回滚文档历史版本或检查回滚任务状态。
+- **本地 DOCX 渲染 — [`+render-word` / `+render-word-status`](references/lark-doc-render-word.md)**：把本地 `.docx` 异步渲染为 PDF；超时后凭 `task_id` 恢复查询和下载。
 
 ### 资源、画板与思维笔记
 

--- a/skills/lark-doc/references/lark-doc-render-word.md
+++ b/skills/lark-doc/references/lark-doc-render-word.md
@@ -1,0 +1,40 @@
+# DOCX 渲染 PDF
+
+用服务端 Word 渲染链路把本地 `.docx` 转成 PDF。该链路保留物理分页，并尽可能返回 Heading 1–9 对应的 PDF 页码。
+
+## 创建、等待并下载
+
+```bash
+lark-cli docs +render-word \
+  --file ./report.docx \
+  --output ./report.pdf \
+  --as user
+```
+
+- 输入必须是普通 `.docx` 文件，非空且不超过 20 MiB；加密、OLE、损坏或不安全的 ZIP/XML 会被服务端拒绝。
+- 命令创建异步任务，并在最多 600 秒内按服务端建议间隔轮询。`--wait-timeout-seconds 0` 可只创建任务、不等待。
+- `--if-exists` 默认为 `error`；需要覆盖或保留两个副本时显式选择 `overwrite` 或 `rename`。
+- `--idempotency-key` 省略时由 CLI 生成。同一 key 与同一文件会复用任务；把同一 key 用于不同文件会失败。
+
+成功结果包含绝对 `output_path`、`downloaded_size`、`page_count`、`headings` 和 `warnings`。标题页码无法确定时 PDF 仍可成功，相关标题没有 `page_index` / `page_number`，并返回 warning；不要把 warning 当作转换失败。
+
+## 超时后恢复
+
+等待超时是可恢复状态，不表示渲染失败。保存输出中的 `task_id`，稍后只查询一次：
+
+```bash
+lark-cli docs +render-word-status \
+  --task-id render_xxx \
+  --output ./report.pdf \
+  --as user
+```
+
+- `processing`：保留 `task_id`，稍后重试；不要重新上传同一文件。
+- `succeeded`：带 `--output` 时安全下载 PDF；不带时只返回任务和短时下载信息。
+- `failed` / `expired`：命令返回 typed error。失败后用新的 idempotency key 重建任务；过期任务不能恢复。
+
+## 安全边界
+
+- 仅支持 user 身份。
+- PDF 下载 URL 短时有效。CLI 会校验 HTTPS 目标和所有重定向，不向预签名 URL 附加 Lark Authorization，并在保存前校验 `%PDF-` 文件头。
+- 服务可用时使用该链路。只有服务不可用且用户明确要求本地转换时，才采用显式的本地 LibreOffice fallback；不得静默切换。


### PR DESCRIPTION
## Summary

- add `docs +render-word` to upload a local DOCX, wait for asynchronous rendering, and safely download the PDF
- add `docs +render-word-status` for one-shot status checks and resumable downloads
- validate file/output boundaries, clamp polling, preserve typed task failures, and verify HTTPS redirects plus the `%PDF-` header
- expose a blocked short-lived target as structured `error.download_url` in JSON so BOE/internal URLs can be inspected manually
- document the workflow in affordance and the lark-doc skill

## Verification

- `go test ./errs ./internal/recovery ./shortcuts/doc/...`
- `make fmt-check`
- `make vet`
- `make unit-test` (race-enabled full matrix)
- incremental source-contract lint against `origin/main`
- BOE E2E: create/poll succeeded for a two-page DOCX with repeated headings; PDF metadata and heading page mapping were correct
- BOE policy-path E2E: blocked private download target returns exit 6 with non-empty HTTPS `error.download_url`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous local DOCX-to-PDF rendering with `+render-word`.
  * Added `+render-word-status` to resume timed-out rendering tasks and optionally download results.
  * Added output file conflict handling, dry-run planning, validation, and secure PDF downloads.
  * Added structured short-lived download URLs to relevant access-denied errors.

* **Documentation**
  * Added usage guidance for rendering, resuming tasks, file limitations, failures, and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->