### PR TITLE
fix(scripts): close check-doc-tokens regex gaps and run it in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ fmt-check:
 	fi
 
 script-test:
+	bash scripts/check-doc-tokens.test.sh
+	bash scripts/check-doc-tokens.sh
 	bash scripts/resolve-changed-from.test.sh
 	bash scripts/ci-workflow.test.sh
 	bash scripts/release-workflow.test.sh
@@ -124,7 +126,9 @@ sidecar-test:
 
 # Run secret-leak checks locally before pushing.
 # Step 1: check-doc-tokens catches realistic-looking example tokens in reference
-#         docs and asks you to use _EXAMPLE_TOKEN placeholders instead.
+#         docs and asks you to use _EXAMPLE_TOKEN placeholders instead. It also
+#         runs in CI via script-test, so this target is the faster local loop
+#         rather than the only place the docs are checked.
 # Step 2: gitleaks scans the full repo for real leaked secrets.
 # Install gitleaks: https://github.com/gitleaks/gitleaks#installing
 gitleaks:

--- a/affordance/im.md
+++ b/affordance/im.md
@@ -516,7 +516,7 @@ Use this raw method only for a reaction created by the calling identity.
 
 **Delete one reaction record**
 ```bash
-lark-cli im reactions delete --params '{"message_id":"om_xxx","reaction_id":"ZCaCIjUBVVWSrm5L-3ZTw_xxx"}'
+lark-cli im reactions delete --params '{"message_id":"om_xxx","reaction_id":"<REACTION_ID>"}'
 ```
 
 ### Skills

--- a/internal/affordance/im_source_test.go
+++ b/internal/affordance/im_source_test.go
@@ -68,7 +68,7 @@ var imAffordanceExamples = []imAffordanceExample{
 	{method: "images.create", command: `lark-cli im images create --data '{"image_type":"message"}' --file ./diagram.png`, source: "lark-im/references/lark-im-messages-send.md"},
 	{method: "reactions.create", command: `lark-cli im reactions create --params '{"message_id":"om_xxx"}' --data '{"reaction_type":{"emoji_type":"SMILE"}}'`, source: "lark-im/references/lark-im-reactions.md"},
 	{method: "reactions.list", command: `lark-cli im reactions list --params '{"message_id":"om_xxx"}'`, source: "lark-im/references/lark-im-reactions.md"},
-	{method: "reactions.delete", command: `lark-cli im reactions delete --params '{"message_id":"om_xxx","reaction_id":"ZCaCIjUBVVWSrm5L-3ZTw_xxx"}'`, source: "lark-im/references/lark-im-reactions.md"},
+	{method: "reactions.delete", command: `lark-cli im reactions delete --params '{"message_id":"om_xxx","reaction_id":"<REACTION_ID>"}'`, source: "lark-im/references/lark-im-reactions.md"},
 	{
 		method:        "reactions.batch_query",
 		command:       `lark-cli im reactions batch_query --params '{"user_id_type":"open_id"}' --data '{"queries":[{"message_id":"om_xxx"},{"message_id":"om_yyy"}],"page_size_per_message":10,"reaction_type":"LAUGH"}'`,

--- a/scripts/check-doc-tokens.sh
+++ b/scripts/check-doc-tokens.sh
@@ -4,57 +4,187 @@
 #
 # check-doc-tokens.sh
 #
-# Scans skill reference docs for token-like values that look realistic but
-# are not using the required placeholder format (*_EXAMPLE_TOKEN or similar).
-#
-# Real token patterns (Lark API) often look like:
-#   wikcnXXXXXXXXX  doccnXXXXXXX  shtcnXXX  fldcnXXX  ou_XXXX  cli_XXXX
+# Scans skill reference docs for token-like values that look realistic but are
+# not using the required placeholder format (*_EXAMPLE_TOKEN or similar).
 #
 # Docs MUST use clearly fake placeholders, e.g.:
 #   wikcn_EXAMPLE_TOKEN   doccn_EXAMPLE_TOKEN   <space_id>   your_token_here
 #
 # If this check fails, replace the realistic-looking value with a placeholder
-# like `wikcn_EXAMPLE_TOKEN` so gitleaks CI won't flag it as a real secret.
+# so gitleaks CI won't flag it as a real secret.
+#
+# Three rules run over every reference doc. Rule 1 alone used to be the whole
+# check; measured against tests/fixtures/doc-tokens on 2026-08-31 it caught 3 of
+# 6 realistic values and raised one false positive, so rules 2 and 3 were added
+# and rule 1 was tightened.
 
 set -euo pipefail
 
 SKILLS_DIR="${1:-skills}"
 ERRORS=0
 
-# Patterns that indicate a realistic-looking Lark token value.
-# Three forms are detected:
-#   1. JSON-style quoted strings: "field": "token_value"
-#   2. Markdown backtick spans:   `token_value`
-#   3. Bare tokens:               --flag wikcnABC123 (e.g. inside fenced code blocks)
+# Markers that make a value unmistakably fake wherever they appear in it.
+# Compared against a lowercased value, so the same stub is caught however these
+# docs capitalise it -- a case-sensitive list let "page_token":"example_page_token"
+# through. 550e8400-... is the RFC 4122 example UUID, which these docs use
+# verbatim as a sample id.
+PLACEHOLDER_LC='(example|_token|<|>|your_|_here|1234567890|550e8400-e29b-41d4-a716-446655440000)'
+
+# A run of x's or y's is different: it stands in for a redacted tail, so it only
+# makes the value fake if it is most of the value. Accepting it anywhere let a
+# 29-character page_token in lark-im-reactions.md through on the four x's glued
+# to its end -- gitleaks reported that one at entropy 4.6 while this check
+# called the file clean. What is left after the runs are removed must be a short
+# prefix such as `tbl`, `ou_` or `MAGOb`; anything longer is a real value
+# wearing a placeholder as decoration.
+REDACTION_RUN_MAX_PREFIX=8
+
+# --- Rule 1: known Lark prefix followed by a realistic random part ----------
 #
-# Token prefixes used by Lark Open Platform:
-#   wikcn  doccn  docx  shtcn  bascn  fldcn  vewcn  tbln  ou_  cli_  obcn  flec
+# `tbl`, `rec`, `vew`, `blk` and `boxcn` were missing from the prefix list, and
+# it carried `tbln`, which the platform does not issue -- table ids are `tbl`
+# plus the random part.
 #
-# Excluded (clearly fake, matched by PLACEHOLDER_RE below):
-#   - Values containing EXAMPLE / _TOKEN / XXXX / your_ / _here
-#   - Angle-bracket placeholders <your_token>
-# Require at least one digit in the suffix — real API tokens are always alphanumeric
-# with digits. Pure-letter suffixes (e.g. ou_manager, ou_director) are clearly fake names.
-PREFIXES='(wikcn|doccn|docx[a-z]|shtcn|bascn|fldcn|vewcn|tbln|obcn|flec|ou_|cli_)'
-TOKEN_BODY="${PREFIXES}"'[A-Za-z0-9]*[0-9][A-Za-z0-9]{3,}'
-REALISTIC_TOKEN_RE="\"${TOKEN_BODY}\"|\`${TOKEN_BODY}\`|\\b${TOKEN_BODY}\\b"
-PLACEHOLDER_RE='(EXAMPLE|_TOKEN|XXXX|xxxx|<|>|your_|_here)'
+# The random part must now be at least 8 characters. The old bound was 4, which
+# flagged `ou_12345` -- a value no reader would mistake for real. Every genuine
+# id in these docs is far longer: open_ids are 32 hex characters.
+PREFIXES='(wikcn|doccn|docx[a-z]|shtcn|bascn|fldcn|vewcn|obcn|flec|tbl|rec|vew|blk|boxcn|ou_|oc_|omm_|cli_)'
+RULE1_RE="${PREFIXES}[A-Za-z0-9]{8,}"
+
+# --- Rule 2: token-bearing context holding an opaque value -----------------
+#
+# Base tokens issued today carry no prefix at all. lark-base-app-block-data-config.md
+# carried one such value -- 27 mixed-case alphanumerics, no prefix -- which rule 1
+# cannot see at any threshold, while the legacy bascn-prefixed form in the same
+# skill set was caught. Anchoring on the key or flag name instead of the value's
+# shape is what makes a prefix-less token detectable without flagging ordinary
+# prose.
+#
+# Only a quoted JSON value, or a value directly after a --*-token / --*-id flag,
+# counts, and it must be at least 16 characters. Prose such as "pass the
+# base_token you copied from the URL to --base-token." has neither shape.
+RULE2_JSON='"[a-z_]*(token|_id)" *: *"[A-Za-z0-9_-]{16,}"'
+RULE2_FLAG='--[a-z-]*(token|id) +[A-Za-z0-9_-]{16,}'
+
+# --- Rule 3: partially masked real values ----------------------------------
+#
+# lark-base-dashboard-block-get-data.md carried a bascn-prefixed value with only
+# its middle starred out, keeping a real head and a real tail. That is how a real
+# value gets redacted -- nobody writes a placeholder that way. The asterisks also
+# break rule 1's character class, so without this rule a masked token is strictly
+# less visible than an unmasked one. A head-only stub, real prefix followed by a
+# run of x's and nothing after, has no trailing fragment and is left alone.
+RULE3_RE='[A-Za-z0-9]{4,}\*{3,}[A-Za-z0-9]{4,}'
+
+# A grep that cannot search must not read as "found nothing". scan_rule runs
+# inside a command substitution, so an `exit` there would only leave the
+# subshell and the check would carry on reporting the file as clean. The
+# subshell records the failure in this file instead, and the parent aborts on it
+# after the loop.
+FATAL_FLAG=$(mktemp)
+trap 'rm -f "$FATAL_FLAG"' EXIT
+
+# run_grep runs one grep and keeps its three outcomes apart. grep exits 0 when
+# it matched, 1 when it searched and found nothing, and 2 when it could not
+# search at all. Collapsing 1 and 2 turns an unreadable file into a silent pass.
+#
+# Every pattern is passed with -e: rule 2's pattern begins with "--", which grep
+# would otherwise read as an option and reject with rc=2.
+run_grep() {
+  local rc=0 out
+  out=$("$@") || rc=$?
+  if [[ $rc -ge 2 ]]; then
+    echo "check-doc-tokens: grep could not search (rc=$rc): $*" >&2
+    echo "$rc" >>"$FATAL_FLAG"
+    exit "$rc"
+  fi
+  if [[ $rc -eq 1 ]]; then
+    return 1
+  fi
+  printf '%s' "$out"
+  return 0
+}
+
+# scan_rule prints the matches of one regex in one file, minus placeholders.
+#
+# mixed=1 additionally requires the matched value to contain both a letter and a
+# digit, which is what separates a real identifier from a word or a counter:
+#   recommended                       `rec` + letters, no digit  -> dropped
+#   ou_new_speaker_open_id            readable stub, no digit    -> dropped
+#   --meeting-id 7628568141510692381  all digits, no letter      -> dropped
+#   Qw3rQw3rQw3rQw3rQw3rQw3r          mixed, 24 chars            -> kept
+#
+# The test must run on the value alone. grep -n prefixes each match with its
+# line number, so testing the whole line let every match through on the digits
+# in "282:" -- which is why awk splits the prefix off first.
+scan_rule() {
+  local regex="$1" file="$2" mixed="$3" hits kept
+  hits=$(run_grep grep -nEo -e "$regex" "$file") || return 0
+  kept=$(awk -v placeholder="$PLACEHOLDER_LC" -v mixed="$mixed" \
+             -v run_max="$REDACTION_RUN_MAX_PREFIX" '
+    # A run of x'"'"'s or y'"'"'s only makes a value fake if removing every run leaves
+    # nothing but a short prefix: tblxxxxxxxx -> tbl, MAGObxxxxx -> MAGOb.
+    function redaction_stub(lv,   rest) {
+      rest = lv
+      gsub(/x{3,}/, "", rest)
+      gsub(/y{3,}/, "", rest)
+      return (rest != lv && length(rest) <= run_max)
+    }
+    {
+      # grep -n prefixes each match with its line number. Both tests below must
+      # see the value alone: testing the whole line let everything through on
+      # the digits in "282:", and testing the whole match let the key name in
+      # "base_token": "..." satisfy the _token placeholder rule on its own.
+      m = substr($0, index($0, ":") + 1)
+      if (match(m, /"[^"]*"$/)) {
+        v = substr(m, RSTART + 1, RLENGTH - 2)   # "key": "value"  -> value
+      } else {
+        n = split(m, parts, /[ \t]+/)
+        v = parts[n]                              # --flag value   -> value
+      }
+      lv = tolower(v)
+      if (lv ~ placeholder) next
+      if (redaction_stub(lv)) next
+      if (mixed == "1" && !(v ~ /[0-9]/ && v ~ /[A-Za-z]/)) next
+      print
+    }' <<<"$hits")
+  [[ -z "$kept" ]] && return 0
+  printf '%s\n' "$kept"
+}
 
 while IFS= read -r -d '' file; do
-  # grep returns exit 1 when no match — use || true to avoid set -e killing us
-  # Then filter out values that are clearly placeholders (EXAMPLE, XXXX, etc.)
-  matches=$(grep -nEo "$REALISTIC_TOKEN_RE" "$file" 2>/dev/null | grep -vE "$PLACEHOLDER_RE" || true)
-  if [[ -n "$matches" ]]; then
+  matches=$(
+    scan_rule "$RULE1_RE" "$file" 1
+    scan_rule "$RULE2_JSON" "$file" 1
+    scan_rule "$RULE2_FLAG" "$file" 1
+    # Rule 3 is exempt: the masked shape is specific enough on its own, and a
+    # redacted value such as bascn***************Qw3rT need not carry a digit.
+    scan_rule "$RULE3_RE" "$file" 0
+  )
+  nonblank=$(run_grep grep -vE -e '^[[:space:]]*$' <<<"$matches") || nonblank=""
+  # A value can trip more than one rule -- an `ou_` id matches rule 1 on its
+  # prefix and rule 2 on its JSON key -- so collapse to one report line per
+  # source line, keyed on the line number grep -n prefixes.
+  if [[ -n "$nonblank" ]]; then
+    nonblank=$(sort -t: -k1,1n -u <<<"$nonblank")
+  fi
+  if [[ -n "$nonblank" ]]; then
     echo ""
     echo "❌  $file"
     echo "    Contains realistic-looking token values that may trigger gitleaks:"
     while IFS= read -r line; do
       echo "      $line"
-    done <<< "$matches"
+    done <<< "$nonblank"
     echo "    → Replace with a placeholder, e.g.: wikcn_EXAMPLE_TOKEN, doccn_EXAMPLE_TOKEN"
     ERRORS=$((ERRORS + 1))
   fi
 done < <(find "$SKILLS_DIR" -path "*/references/*.md" -print0)
+
+if [[ -s "$FATAL_FLAG" ]]; then
+  echo ""
+  echo "❌  check-doc-tokens: at least one file could not be searched; results above are incomplete." >&2
+  exit 2
+fi
 
 if [[ $ERRORS -gt 0 ]]; then
   echo ""

--- a/scripts/check-doc-tokens.test.sh
+++ b/scripts/check-doc-tokens.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+#
+# Tests check-doc-tokens.sh against tests/fixtures/doc-tokens.
+#
+# The check is only worth running if it reports realistic values and stays quiet
+# on placeholders. Measured before the fixture existed, the script caught 3 of
+# the 6 realistic values below and reported one placeholder, and nothing in CI
+# would have noticed either way.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$repo_root/scripts/check-doc-tokens.sh"
+fixtures="$repo_root/tests/fixtures/doc-tokens"
+
+failures=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  failures=$((failures + 1))
+}
+
+# --- the realistic fixture must be reported, value by value -----------------
+catch_out=""
+catch_rc=0
+catch_out=$("$script" "$fixtures/lark-catch") || catch_rc=$?
+
+if [[ $catch_rc -ne 1 ]]; then
+  fail "realistic fixture: expected exit 1, got $catch_rc"
+fi
+
+for value in \
+  'wikcnAbc1Abc1Abc1' \
+  'ou_00112233445566778899aabbccddeeff' \
+  'Qw3rQw3rQw3rQw3rQw3rQw3r' \
+  'bascn***************Qw3rT' \
+  'Nq7bNq7bNq7bNq7bNq7bNq7b' \
+  'cli_00112233445566aabb' \
+  'Zx9pZx9pZx9pZx9pZx9pZx9pxxxx'; do
+  if [[ "$catch_out" != *"$value"* ]]; then
+    fail "realistic fixture: $value was not reported"
+  fi
+done
+
+# --- the placeholder fixture must produce nothing at all --------------------
+skip_out=""
+skip_rc=0
+skip_out=$("$script" "$fixtures/lark-skip") || skip_rc=$?
+
+if [[ $skip_rc -ne 0 ]]; then
+  fail "placeholder fixture: expected exit 0, got $skip_rc. Reported:"
+  echo "$skip_out" >&2
+fi
+
+# --- a value must be reported once, however many rules it trips -------------
+# An `ou_` id in a JSON body matches rule 1 on its prefix and rule 2 on its key.
+open_id_lines=$(grep -c 'ou_00112233445566778899aabbccddeeff' <<<"$catch_out" || true)
+if [[ "$open_id_lines" -ne 1 ]]; then
+  fail "realistic fixture: open id reported $open_id_lines times, want 1"
+fi
+
+if [[ $failures -gt 0 ]]; then
+  echo "check-doc-tokens.test: $failures assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "✅  check-doc-tokens.test: fixture coverage holds."

--- a/skills/lark-approval/references/lark-approval-instance-form-control-parameters.md
+++ b/skills/lark-approval/references/lark-approval-instance-form-control-parameters.md
@@ -202,7 +202,7 @@ interval | float | 是 | 时长（天）。
     "id": "widget1",
     "type": "document",
     "value": {
-           "token":"TLLKdcpDro9ijQxA33ycNMabcef",
+           "token":"<document_id>",
            "type":"docx",
     }
 }

--- a/skills/lark-base/references/lark-base-app-block-data-config.md
+++ b/skills/lark-base/references/lark-base-app-block-data-config.md
@@ -88,7 +88,7 @@ lark-cli base +app-block-update \
 
 ```json
 {
-  "base_token": "A2f5boKjfazMzesI9zKbmugTc4T",
+  "base_token": "<base_token>",
   "data_sources": [
     {
       "table_name": "数据表",
@@ -107,7 +107,7 @@ lark-cli base +app-block-update \
 lark-cli base +app-block-create \
   --app-token <app_token> --page-id <page_id> \
   --name "文本分布" --type column \
-  --data-config '{"base_token":"A2f5boKjfazMzesI9zKbmugTc4T","data_sources":[{"table_name":"数据表","count_all":true,"group_by":[{"field_name":"文本","mode":"integrated","sort":{"type":"value","order":"desc"}}]}]}'
+  --data-config '{"base_token":"<base_token>","data_sources":[{"table_name":"数据表","count_all":true,"group_by":[{"field_name":"文本","mode":"integrated","sort":{"type":"value","order":"desc"}}]}]}'
 ```
 
 多数据源示例（两张表各出一条系列，按数据源拆分）：

--- a/skills/lark-base/references/lark-base-dashboard-block-get-data.md
+++ b/skills/lark-base/references/lark-base-dashboard-block-get-data.md
@@ -53,7 +53,7 @@
 
 ```bash
 lark-cli base +dashboard-block-get-data \
-  --base-token bascn***************CtadY \
+  --base-token bascnxxxxxxxxxxxxxxxx \
   --block-id chtxxxxxxxx
 ```
 
@@ -62,13 +62,13 @@ lark-cli base +dashboard-block-get-data \
 ```bash
 # 先看仪表盘里有哪些组件
 lark-cli base +dashboard-block-list \
-  --base-token bascn***************CtadY \
+  --base-token bascnxxxxxxxxxxxxxxxx \
   --dashboard-id blkxxxxxxxx \
   --page-size 100
 
 # 再读取某个组件的最终计算结果
 lark-cli base +dashboard-block-get-data \
-  --base-token bascn***************CtadY \
+  --base-token bascnxxxxxxxxxxxxxxxx \
   --block-id chtxxxxxxxx
 ```
 
@@ -80,7 +80,7 @@ set -euo pipefail
 block_ids=(cht_block_1 cht_block_2)
 for block_id in "${block_ids[@]}"; do
   lark-cli base +dashboard-block-get-data \
-    --base-token bascn***************CtadY \
+    --base-token bascnxxxxxxxxxxxxxxxx \
     --block-id "$block_id"
 done
 ```
@@ -91,7 +91,7 @@ done
 
 ```bash
 lark-cli base +dashboard-block-get \
-  --base-token bascn***************CtadY \
+  --base-token bascnxxxxxxxxxxxxxxxx \
   --dashboard-id blkxxxxxxxx \
   --block-id chtxxxxxxxx
 ```

--- a/skills/lark-base/references/lark-base-form-submit.md
+++ b/skills/lark-base/references/lark-base-form-submit.md
@@ -98,7 +98,7 @@ lark-cli base +form-submit \
   "多选字段": ["选项A", "选项B"],
   "时间字段": "2026-04-27 14:30:00",
   "复选框字段": true,
-  "人员字段": [{ "id": "ou_7094d131420c8749632145f08fbf114a" }],
+  "人员字段": [{ "id": "ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }],
   "关联字段": [{ "id": "recXXXXXXXXXXXX" }],
   "地理位置字段": { "lng": 116.397428, "lat": 39.90923 }
 }
@@ -133,18 +133,18 @@ CLI 收到路径后会自动完成以下流程：
 用户提供形如以下格式的表单分享链接时：
 
 ```
-https://www.example.com/share/base/form/shrbcvST8eZy0vk8zjVZ1CAXNye
+https://www.example.com/share/base/form/<share_token>
 ```
 
 **提取方式：** 取 URL 路径最后一段作为 `--share-token`。
 
 以上述链接为例：
 
-- `share-token` = `shrbcvST8eZy0vk8zjVZ1CAXNye`
+- `share-token` = `<share_token>`
 
 ```bash
 lark-cli base +form-submit \
-  --share-token shrbcvST8eZy0vk8zjVZ1CAXNye \
+  --share-token <share_token> \
   --json '{"fields":{...}}' \
   --yes
 ```

--- a/skills/lark-calendar/references/lark-calendar-join-event.md
+++ b/skills/lark-calendar/references/lark-calendar-join-event.md
@@ -25,7 +25,7 @@ lark-cli calendar +join-event --token <token> --as bot
 | 链接类 | 分享链接 / 二维码 | 链接 `{{domain}}/calendar/share?token=<token>` 里的 `token` |
 | 卡片类 | 分享卡片 / RSVP 卡片 | 从 IM 日程分享卡片或 RSVP 卡片消息解析出的日程分享 token |
 
-- **分享链接**：直接取 URL query 里的 `token` 值传入；无需解析日程字段。例如 `{{domain}}/calendar/share?token=29f762bdmsbd82ce9` → `--token 29f762bdmsbd82ce9`。
+- **分享链接**：直接取 URL query 里的 `token` 值传入；无需解析日程字段。例如 `{{domain}}/calendar/share?token=xxxxxxxxxxxxxxxxx` → `--token xxxxxxxxxxxxxxxxx`。
 - **二维码**：先用 OCR/扫码解析成分享链接，再取其中的 `token`——CLI 不承接二维码图像，只承接解析后的链接 token。
 - **卡片**：token 落在卡片消息 content（分享卡片 `SHARE_CALENDAR_EVENT`、RSVP 卡片 `GENERAL_CALENDER`）；RSVP 卡片被转发后退化为分享卡片，同样可加入。
 

--- a/skills/lark-doc/references/lark-doc-mindnote.md
+++ b/skills/lark-doc/references/lark-doc-mindnote.md
@@ -41,7 +41,7 @@ lark-cli mindnotes nodes create \
 # 更新已有节点
 lark-cli mindnotes nodes create \
   --mindnote-id "<mindnote_token>" \
-  --data '{"client_token":"<client_token>","nodes":[{"node_id":"node_existing123","texts":[{"element_type":"text","text":{"content":"更新后的节点内容"}}],"highlight":"blue","finish":true}]}'
+  --data '{"client_token":"<client_token>","nodes":[{"node_id":"node_existing_id","texts":[{"element_type":"text","text":{"content":"更新后的节点内容"}}],"highlight":"blue","finish":true}]}'
 ```
 
 ## 参数
@@ -94,7 +94,7 @@ lark-cli docs +media-upload --file ./image.png --parent-type mindnote_image --pa
 # 再把 token 写进节点
 lark-cli mindnotes nodes create \
   --mindnote-id "<mindnote_token>" \
-  --data '{"client_token":"<client_token>","nodes":[{"node_id":"node_existing123","images":[{"token":"canonical_token"}]}]}'
+  --data '{"client_token":"<client_token>","nodes":[{"node_id":"node_existing_id","images":[{"token":"canonical_token"}]}]}'
 ```
 
 参数说明：

--- a/skills/lark-drive/references/lark-drive-pull.md
+++ b/skills/lark-drive/references/lark-drive-pull.md
@@ -98,8 +98,8 @@ lark-cli drive +pull --local-dir ./repo --folder-token fldcnxxxxxxxxx \
   },
   "items": [
     {"rel_path": "...", "file_token": "...", "action": "downloaded"},
-    {"rel_path": "...", "source_id": "hash_3a2f4c5d6e7f", "action": "downloaded"},
-    {"rel_path": "...", "source_id": "hash_3a2f4c5d6e7f", "action": "failed", "error": "..."},
+    {"rel_path": "...", "source_id": "hash_example", "action": "downloaded"},
+    {"rel_path": "...", "source_id": "hash_example", "action": "failed", "error": "..."},
     {"rel_path": "...", "action": "deleted_local"},
     {"rel_path": "...", "action": "delete_failed", "error": "..."}
   ]

--- a/skills/lark-im/references/lark-im-feed-shortcut-list.md
+++ b/skills/lark-im/references/lark-im-feed-shortcut-list.md
@@ -51,10 +51,10 @@ Example (with detail enrichment, CHAT type):
   "data": {
     "shortcuts": [
       {
-        "feed_card_id": "oc_092f0100fe59c35995727db1039777a8",
+        "feed_card_id": "oc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "type": 1,
         "detail": {
-          "chat_id": "oc_092f0100fe59c35995727db1039777a8",
+          "chat_id": "oc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
           "chat_mode": "group",
           "name": "Engineering",
           "avatar": "https://...",
@@ -66,10 +66,10 @@ Example (with detail enrichment, CHAT type):
         }
       },
       {
-        "feed_card_id": "oc_c82061d126a06635aa3569587b134bb1",
+        "feed_card_id": "oc_yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
         "type": 1,
         "detail": {
-          "chat_id": "oc_c82061d126a06635aa3569587b134bb1",
+          "chat_id": "oc_yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
           "chat_mode": "p2p",
           "name": "",
           "p2p_target_id": "ou_xxx",

--- a/skills/lark-im/references/lark-im-reactions.md
+++ b/skills/lark-im/references/lark-im-reactions.md
@@ -70,7 +70,7 @@ lark-cli im reactions create \
 
 ```json
 {
-  "reaction_id": "ZCaCIjUBVVWSrm5L-3ZTw_xxx",
+  "reaction_id": "<REACTION_ID>",
   "operator": {
     "operator_id": "ou_xxx",
     "operator_type": "user"
@@ -110,7 +110,7 @@ lark-cli im reactions list --params '{"message_id":"om_xxx","user_id_type":"open
 {
   "items": [
     {
-      "reaction_id": "ZCaCIjUBVVWSrm5L-3ZTw_xxx",
+      "reaction_id": "<REACTION_ID>",
       "operator": {
         "operator_id": "ou_xxx",
         "operator_type": "user"
@@ -122,7 +122,7 @@ lark-cli im reactions list --params '{"message_id":"om_xxx","user_id_type":"open
     }
   ],
   "has_more": true,
-  "page_token": "YhljsPiGfUgnVAg9urvRFd-BvSqRLxxxx"
+  "page_token": "<PAGE_TOKEN>"
 }
 ```
 
@@ -156,7 +156,7 @@ Delete one specific reaction record from one message.
 
 ```bash
 lark-cli im reactions delete \
-  --params '{"message_id":"om_xxx","reaction_id":"ZCaCIjUBVVWSrm5L-3ZTw_xxx"}'
+  --params '{"message_id":"om_xxx","reaction_id":"<REACTION_ID>"}'
 ```
 
 ### Request

--- a/skills/lark-mail/references/lark-mail-share-to-chat.md
+++ b/skills/lark-mail/references/lark-mail-share-to-chat.md
@@ -40,7 +40,7 @@ lark-cli mail +share-to-chat --message-id <邮件ID> --receive-id oc_xxx --dry-r
   "ok": true,
   "data": {
     "card_id": "550e8400-e29b-41d4-a716-446655440000",
-    "im_message_id": "om_dc13264520392913993dd051dba21dcf"
+    "im_message_id": "om_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   }
 }
 ```

--- a/skills/lark-wiki/references/lark-wiki-delete-space.md
+++ b/skills/lark-wiki/references/lark-wiki-delete-space.md
@@ -63,7 +63,7 @@ lark-cli wiki +delete-space \
 ```json
 {
   "space_id": "7629741305993170448",
-  "task_id": "7631425120875056669-965458aec67417f5982250806c97950697ccb82f",
+  "task_id": "xxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "ready": true,
   "failed": false,
   "status": "success",
@@ -76,13 +76,13 @@ lark-cli wiki +delete-space \
 ```json
 {
   "space_id": "7629741305993170448",
-  "task_id": "7631425120875056669-965458aec67417f5982250806c97950697ccb82f",
+  "task_id": "xxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "ready": false,
   "failed": false,
   "status": "processing",
   "status_msg": "processing",
   "timed_out": true,
-  "next_command": "lark-cli drive +task_result --scenario wiki_delete_space --task-id 7631425120875056669-965458aec67417f5982250806c97950697ccb82f --as user"
+  "next_command": "lark-cli drive +task_result --scenario wiki_delete_space --task-id xxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --as user"
 }
 ```
 

--- a/skills/lark-wiki/references/lark-wiki-member-add.md
+++ b/skills/lark-wiki/references/lark-wiki-member-add.md
@@ -44,7 +44,7 @@ lark-cli wiki +member-add \
 ```json
 {
   "space_id": "7160145948494381236",
-  "member_id": "ou_449b53ad6aee526f7ed311b216aabcef",
+  "member_id": "ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "member_type": "openid",
   "member_role": "admin",
   "type": "user"

--- a/skills/lark-wiki/references/lark-wiki-member-list.md
+++ b/skills/lark-wiki/references/lark-wiki-member-list.md
@@ -46,12 +46,12 @@ lark-cli wiki +member-list --space-id <space_id> --format table
     "space_id": "7160145948494381236",
     "members": [
       {
-        "member_id": "ou_449b53ad6aee526f7ed311b216aabcef",
+        "member_id": "ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "member_type": "openid",
         "member_role": "admin"
       },
       {
-        "member_id": "ou_67e5ecb64ce1c0bd94612c17999db411",
+        "member_id": "ou_yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
         "member_type": "openid",
         "member_role": "member"
       }

--- a/skills/lark-wiki/references/lark-wiki-member-remove.md
+++ b/skills/lark-wiki/references/lark-wiki-member-remove.md
@@ -41,7 +41,7 @@ lark-cli wiki +member-remove \
 ```json
 {
   "space_id": "7160145948494381236",
-  "member_id": "ou_449b53ad6aee526f7ed311b216aabcef",
+  "member_id": "ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   "member_type": "openid",
   "member_role": "admin"
 }

--- a/tests/fixtures/doc-tokens/lark-catch/references/realistic-values.md
+++ b/tests/fixtures/doc-tokens/lark-catch/references/realistic-values.md
@@ -1,0 +1,28 @@
+# Fixture: values check-doc-tokens.sh MUST report
+
+Every line below is shaped like a real Lark identifier while being transparently
+constructed. The check keys on shape, so the fixture needs the shape and nothing
+else; copying an actual value out of the reference docs would move the problem
+here rather than remove it.
+
+The fixture must also not be a gitleaks hit itself, or the job this check feeds
+would go red on the check's own test data. Two constraints follow from
+.gitleaks.toml, and both are invisible to check-doc-tokens, which has no entropy
+rule and no length rule beyond its own minimums:
+
+- Values are built from a repeated four-character run, keeping Shannon entropy
+  far below the `generic-api-key` threshold. Line 3 sits behind a `token` key
+  and would otherwise be a textbook match for that rule.
+- The application id is 18 characters after `cli_`, not the 16 a real one
+  carries, so it falls outside this repo's `lark-bot-app-id` regex.
+
+If a change to the script stops reporting any of these, it has lost coverage it
+used to have.
+
+1. Legacy prefixed token: `wikcnAbc1Abc1Abc1`
+2. Open id in a response: "member_id": "ou_00112233445566778899aabbccddeeff"
+3. Prefix-less Base token: "base_token": "Qw3rQw3rQw3rQw3rQw3rQw3r"
+4. Partially masked token: --base-token bascn***************Qw3rT
+5. Prefix-less token on a flag: --app-token Nq7bNq7bNq7bNq7bNq7bNq7b
+6. Application id: "app_id": "cli_00112233445566aabb"
+7. Stub glued onto a real value: "page_token": "Zx9pZx9pZx9pZx9pZx9pZx9pxxxx"

--- a/tests/fixtures/doc-tokens/lark-skip/references/placeholder-values.md
+++ b/tests/fixtures/doc-tokens/lark-skip/references/placeholder-values.md
@@ -1,0 +1,20 @@
+# Fixture: values check-doc-tokens.sh must NOT report
+
+These are the placeholder conventions the reference docs already use. Reporting
+any of them would make the check noise, and noise is how a red check gets
+ignored -- each line here was a false positive at some point in the script's
+history.
+
+1. Conventional stubs: `tblxxxxxxxx` `fldXXXXXXXX` `recXXXXXXXXXXXX` `boxcnxxxx` `blkcnXXXX`
+2. Angle brackets: --base-token <base_token>
+3. Named example: wikcn_EXAMPLE_TOKEN doccn_EXAMPLE_TOKEN
+4. Your-own stub: your_token_here
+5. Short and obviously fake: "user_id": "ou_12345"
+6. Prose mentioning the flag: pass the base_token you copied from the Base URL to --base-token.
+7. Head-only redaction stub: --base-token MAGObxxxxx
+8. English words starting with a prefix: recommended, recipient, tblue
+9. Readable stub with no digits: --to-user-id ou_new_speaker_open_id
+10. All-digit identifier: --meeting-id 7628568141510692381
+11. Lowercase example key: "page_token":"example_page_token"
+12. RFC 4122 sample UUID: "card_id": "550e8400-e29b-41d4-a716-446655440000"
+13. Digits either side of a redacted middle: --meeting-id 69xxxxxxxxxxxxx28


### PR DESCRIPTION
## Summary

`scripts/check-doc-tokens.sh` asks reference docs to use obviously-fake placeholders so gitleaks does not have to judge whether a doc sample is a real secret. It had one rule and nothing in `.github/workflows` ever ran it, so it was failing on `main` without failing a build.

Running gitleaks 8.30.1 with this repo's own `.gitleaks.toml` over `main` reports **5 findings, 4 of them in `skills/*/references/*.md`** — exactly the files this check guards — and the check calls all four clean. This PR fixes the docs, closes the gaps that let those values through, and wires the check into CI. After the change gitleaks reports 1 finding, in `shortcuts/doc/doc_media_test.go`, which is a Go test fixture outside the paths this check scans and is left alone.

## Changes

**Docs** — 14 reference docs move to the placeholder convention each file already uses. No replacement asserts a prefix the doc does not otherwise document: the approval document sample becomes `<document_id>` (the neighbouring table calls it a `document_id` and the sample's own `type` is `docx`), the form share token becomes `<share_token>` matching the six other occurrences in that file, and the reactions doc gets `<REACTION_ID>` / `<PAGE_TOKEN>` matching the `<PAGE_TOKEN>` that `reactions.batch_query` already carries. The reaction id is an audited example, so `affordance/im.md` and the `reactions.delete` row in `internal/affordance/im_source_test.go` move with it — `TestIMAffordanceExamplesTraceToCurrentSkill` pins the three copies together and caught the drift.

**Rule 1 (known prefix + random part)** — `tbl`, `rec`, `vew`, `blk` and `boxcn` were missing from the prefix list; `tbln` is not a prefix the platform issues; the random part now needs 8 characters rather than 4; and a match must contain both a letter and a digit, which is what dropped the false positive on the word `recommended`.

**Rule 2 (context, not shape)** — a quoted JSON value under a `*token` / `*_id` key, or a value after a `--*-token` / `--*-id` flag, at least 16 characters. Base tokens issued today carry no prefix at all, so rule 1 cannot see them at any threshold; `lark-base-app-block-data-config.md` carried one such value that gitleaks reports at entropy 4.28.

**Rule 3 (partially masked values)** — real head, stars, real tail. The stars break rule 1's character class, so before this a redacted token was strictly *less* visible than an unredacted one.

**Placeholder allowlist split in two** — a run of `x`s or `y`s no longer excuses a value wherever it appears, only when removing every run leaves a prefix of at most 8 characters. `tblxxxxxxxx` → `tbl`, `MAGObxxxxx` → `MAGOb` and `--meeting-id 69xxxxxxxxxxxxx28` → `6928` all stay quiet, while a 29-character page token wearing four trailing `x`s is now reported — gitleaks flags that one at entropy 4.62 and the check used to pass it.

**Three failure modes in the script itself**
- grep's `rc=2` (*could not search*) was collapsed into `rc=1` (*searched, found nothing*), so an unreadable file passed silently. `run_grep` keeps the three outcomes apart; because it runs inside a command substitution the failure is recorded in a temp file the parent checks after the loop, since an `exit` there only leaves the subshell.
- Every pattern is now passed with `-e`. Rule 2's flag pattern starts with `--`, which grep otherwise reads as an option and rejects with `rc=2`.
- The placeholder and letter/digit tests run on the extracted value, not on `grep -n`'s whole output line, whose `282:` prefix satisfied the digit test for every match.

**Tests and CI** — `scripts/check-doc-tokens.test.sh` asserts the 7 realistic fixture values are each reported, the 13 placeholder conventions stay quiet, and a value tripping two rules is reported once. Both fixtures are synthetic; copying real values out of the docs would move the problem rather than remove it. They are also built to stay under gitleaks' own thresholds so the check's test data does not become the next finding, and the fixture header records which two rules in `.gitleaks.toml` that means. `script-test` now runs the test and the check, and `script-test` is already invoked by `ci.yml`.

## Test Plan

- [x] `make script-test` — passes, including the new `check-doc-tokens.test.sh`
- [x] `make unit-test` — passes (it caught the affordance drift before this was pushed)
- [x] `make vet` and `make fmt-check` — pass
- [x] `gitleaks dir . -c .gitleaks.toml` — `main`: 5 findings, 4 in reference docs; this branch: 1, in a Go test fixture outside the scanned paths
- [x] Mutation-tested both halves of the new allowlist rule: making it excuse everything drops fixture value 7; removing it entirely reports the legitimate `--meeting-id 69xxxxxxxxxxxxx28` placeholder. Each mutation fails the test.
- [x] Measured coverage on the fixture: before 3 of 7 caught with 1 false positive, after 7 of 7 with 0

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Replaced realistic-looking tokens, IDs, and other sensitive values in examples with clear placeholders across guides and command references.
  - Standardized placeholder formats for reactions, documents, messages, members, tasks, and configuration values.
  - Clarified example node IDs and token usage without changing workflows or API behavior.

- **Tests**
  - Expanded documentation validation to detect common token and identifier patterns while ignoring valid placeholders.
  - Added coverage for realistic examples, masked values, duplicate matches, and false-positive prevention.
  - Documentation checks now run as part of the standard test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->