### PR TITLE
feat(docs): route local Word media uploads to office mount point

### DIFF
--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -178,6 +178,146 @@ func TestDocMediaInsertDryRunWikiAddsResolveStep(t *testing.T) {
 	}
 }
 
+func TestDocMediaParentType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		parentType string
+		parentNode string
+		want       string
+	}{
+		{
+			name:       "local Word token uses office mount point",
+			parentType: "docx_image",
+			parentNode: "aaaaOaaaaFaaaaLaaaa0aaaaXaW",
+			want:       officeDocxFileParentType,
+		},
+		{
+			name:       "ordinary docx preserves parent type",
+			parentType: "docx_image",
+			parentNode: "blkcnNative123",
+			want:       "docx_image",
+		},
+		{
+			name:       "local Excel token preserves parent type",
+			parentType: "docx_image",
+			parentNode: "aaaaOaaaaFaaaaLaaaa0aaaaXaE",
+			want:       "docx_image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := docMediaParentType(tt.parentType, tt.parentNode); got != tt.want {
+				t.Fatalf("docMediaParentType(%q, %q) = %q, want %q", tt.parentType, tt.parentNode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsLocalWordToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{name: "27 character Word token", token: "aaaaOaaaaFaaaaLaaaa0aaaaXaW", want: true},
+		{name: "28 character Word token", token: "aaaaOaaaaFaaaaLaaaa0aaaaXaaW", want: true},
+		{name: "Excel token", token: "aaaaOaaaaFaaaaLaaaa0aaaaXaE"},
+		{name: "PPT token", token: "aaaaOaaaaFaaaaLaaaa0aaaaXaP"},
+		{name: "legacy numeric Word type", token: "aaaaOaaaaFaaaaLaaaa0aaaaXa3"},
+		{name: "wrong marker", token: "aaaaOaaaaFaaaaLaaaa0aaaaYaW"},
+		{name: "short token", token: "aaaaOaaaaFaaaaLaaaa0aaa"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isLocalWordToken(tt.token); got != tt.want {
+				t.Fatalf("isLocalWordToken(%q) = %v, want %v", tt.token, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDocMediaUploadDryRunUsesOfficeParentTypeForLocalWord(t *testing.T) {
+	cmd := &cobra.Command{Use: "docs +media-upload"}
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().String("parent-type", "", "")
+	cmd.Flags().String("parent-node", "", "")
+	cmd.Flags().String("doc-id", "", "")
+	if err := cmd.Flags().Set("file", "./image.png"); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+	if err := cmd.Flags().Set("parent-type", "docx_image"); err != nil {
+		t.Fatalf("set --parent-type: %v", err)
+	}
+	const localToken = "aaaaOaaaaFaaaaLaaaa0aaaaXaW"
+	if err := cmd.Flags().Set("parent-node", localToken); err != nil {
+		t.Fatalf("set --parent-node: %v", err)
+	}
+
+	dry := decodeDocDryRun(t, DocMediaUpload.DryRun(context.Background(), common.TestNewRuntimeContext(cmd, nil)))
+	if len(dry.API) != 1 {
+		t.Fatalf("expected 1 API call, got %d", len(dry.API))
+	}
+	if got, _ := dry.API[0].Body["parent_type"].(string); got != officeDocxFileParentType {
+		t.Fatalf("parent_type = %q, want %q", got, officeDocxFileParentType)
+	}
+	if got, _ := dry.API[0].Body["parent_node"].(string); got != localToken {
+		t.Fatalf("parent_node = %q, want %q", got, localToken)
+	}
+}
+
+func TestDocMediaUploadExecuteUsesOfficeParentTypeForLocalWord(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-local-office-upload-app"))
+	uploadStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_all",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"file_token": "file_local_office_123"},
+		},
+	}
+	reg.Register(uploadStub)
+
+	tmpDir := t.TempDir()
+	withDocsWorkingDir(t, tmpDir)
+	if err := os.WriteFile("image.png", []byte("png-bytes"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	const localToken = "aaaaOaaaaFaaaaLaaaa0aaaaXaW"
+	err := mountAndRunDocs(t, DocMediaUpload, []string{
+		"+media-upload",
+		"--file", "image.png",
+		"--parent-type", "docx_image",
+		"--parent-node", localToken,
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := string(uploadStub.CapturedBody)
+	if !strings.Contains(body, "\r\n\r\n"+officeDocxFileParentType+"\r\n") {
+		t.Fatalf("upload body missing parent_type %q: %s", officeDocxFileParentType, body)
+	}
+	if strings.Contains(body, "\r\n\r\ndocx_image\r\n") {
+		t.Fatalf("upload body retained caller parent_type docx_image: %s", body)
+	}
+	if !strings.Contains(body, "\r\n\r\n"+localToken+"\r\n") {
+		t.Fatalf("upload body missing local parent_node %q: %s", localToken, body)
+	}
+	if !strings.Contains(stdout.String(), "file_local_office_123") {
+		t.Fatalf("stdout missing file token: %s", stdout.String())
+	}
+}
+
 func TestDocMediaUploadDryRunUsesMultipartForLargeFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	withDocsWorkingDir(t, tmpDir)

--- a/shortcuts/doc/doc_media_upload.go
+++ b/shortcuts/doc/doc_media_upload.go
@@ -23,14 +23,14 @@ var DocMediaUpload = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "file", Desc: "local file path (files > 20MB use multipart upload automatically)", Required: true},
-		{Name: "parent-type", Desc: "parent type: docx_image | docx_file | whiteboard | mindnote_image", Required: true},
+		{Name: "parent-type", Desc: "parent type: docx_image | docx_file | whiteboard | mindnote_image (local Office Word tokens automatically use office_docx_file)", Required: true},
 		{Name: "parent-node", Desc: "parent node ID (block_id for docx, board_token for whiteboard, mindnote token for mindnote)", Required: true},
 		{Name: "doc-id", Desc: "document ID (for drive_route_token)"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		filePath := runtime.Str("file")
-		parentType := runtime.Str("parent-type")
 		parentNode := runtime.Str("parent-node")
+		parentType := docMediaParentType(runtime.Str("parent-type"), parentNode)
 		docId := runtime.Str("doc-id")
 		body := map[string]interface{}{
 			"file_name":   filepath.Base(filePath),
@@ -77,8 +77,8 @@ var DocMediaUpload = common.Shortcut{
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		filePath := runtime.Str("file")
-		parentType := runtime.Str("parent-type")
 		parentNode := runtime.Str("parent-node")
+		parentType := docMediaParentType(runtime.Str("parent-type"), parentNode)
 		docId := runtime.Str("doc-id")
 
 		// Validate file
@@ -115,6 +115,23 @@ var DocMediaUpload = common.Shortcut{
 		}, nil)
 		return nil
 	},
+}
+
+const (
+	officeDocxFileParentType = "office_docx_file"
+	localOfficeWordType      = byte('W')
+)
+
+// Local Word media uploads use a dedicated Drive mount point.
+func docMediaParentType(parentType, parentNode string) string {
+	if !isLocalWordToken(parentNode) {
+		return parentType
+	}
+	return officeDocxFileParentType
+}
+
+func isLocalWordToken(token string) bool {
+	return common.IsLocalOfficeToken(token) && len(token) > 0 && token[len(token)-1] == localOfficeWordType
 }
 
 // UploadDocMediaFileConfig groups the inputs to uploadDocMediaFile so the


### PR DESCRIPTION
## 背景
本地 Word 文档上传媒体时，需要使用 Office 文档挂载点。

## 改动
- 复用通用本地 Office token 识别，并限制仅 Word token 映射为 `office_docx_file`
- 本地 Word 媒体上传请求自动改写 `parent_type`
- 覆盖普通文档、Word、Excel/PPT token 及 multipart 请求场景

## 验证
- `go test ./shortcuts/doc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media uploads from local Word documents now use the correct Office document type automatically.
  * Dry-run previews and completed uploads consistently apply the correct parent type and local document token.
  * Updated the parent-type option description to clarify this automatic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->