### PR TITLE
docs(lark-doc): retain draft workspaces after creation

### DIFF
--- a/shortcuts/doc/docs_script_test.go
+++ b/shortcuts/doc/docs_script_test.go
@@ -54,21 +54,29 @@ func TestDocsCreateWorkflowRetainsDraftWorkspace(t *testing.T) {
 	if !strings.Contains(text, "保留 Step 4 返回的 `work_dir` 及其中的创作草稿") {
 		t.Fatal("create workflow does not retain the draft workspace")
 	}
-	for _, forbidden := range []string{"cleanup-draft", "文件删除能力", "删除整个 `work_dir`"} {
-		if strings.Contains(text, forbidden) {
-			t.Fatalf("create workflow still instructs draft workspace cleanup %q", forbidden)
-		}
-	}
 
 	script, err := os.ReadFile("../../skills/lark-doc/references/lark-doc-script.md")
 	if err != nil {
 		t.Fatalf("read script reference: %v", err)
 	}
-	if !strings.Contains(string(script), "保留 `workspace` 及其中的创作草稿") {
+	scriptText := string(script)
+	if !strings.Contains(scriptText, "保留 `workspace` 及其中的创作草稿") {
 		t.Fatal("script reference does not retain the draft workspace")
 	}
-	if strings.Contains(string(script), "精确删除 `workspace`") {
-		t.Fatal("script reference still instructs draft workspace cleanup")
+
+	documents := []struct {
+		name    string
+		content string
+	}{
+		{name: "create workflow", content: text},
+		{name: "script reference", content: scriptText},
+	}
+	for _, document := range documents {
+		for _, forbidden := range []string{"cleanup-draft", "文件删除能力", "删除整个 `work_dir`", "精确删除 `workspace`"} {
+			if strings.Contains(document.content, forbidden) {
+				t.Fatalf("%s still instructs draft workspace cleanup %q", document.name, forbidden)
+			}
+		}
 	}
 }
 

--- a/shortcuts/doc/docs_script_test.go
+++ b/shortcuts/doc/docs_script_test.go
@@ -45,6 +45,33 @@ func TestDocsScriptDoesNotExposeRemovedCommandsOrFlags(t *testing.T) {
 	}
 }
 
+func TestDocsCreateWorkflowRetainsDraftWorkspace(t *testing.T) {
+	workflow, err := os.ReadFile("../../skills/lark-doc/references/lark-doc-create-workflow.md")
+	if err != nil {
+		t.Fatalf("read create workflow: %v", err)
+	}
+	text := string(workflow)
+	if !strings.Contains(text, "保留 Step 4 返回的 `work_dir` 及其中的创作草稿") {
+		t.Fatal("create workflow does not retain the draft workspace")
+	}
+	for _, forbidden := range []string{"cleanup-draft", "文件删除能力", "删除整个 `work_dir`"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("create workflow still instructs draft workspace cleanup %q", forbidden)
+		}
+	}
+
+	script, err := os.ReadFile("../../skills/lark-doc/references/lark-doc-script.md")
+	if err != nil {
+		t.Fatalf("read script reference: %v", err)
+	}
+	if !strings.Contains(string(script), "保留 `workspace` 及其中的创作草稿") {
+		t.Fatal("script reference does not retain the draft workspace")
+	}
+	if strings.Contains(string(script), "精确删除 `workspace`") {
+		t.Fatal("script reference still instructs draft workspace cleanup")
+	}
+}
+
 func TestDocsScriptPresentationDecisionFlagAcceptsFileAndStdin(t *testing.T) {
 	for _, flag := range DocsScript.Flags {
 		if flag.Name != "presentation-decision" {

--- a/skills/lark-doc/references/lark-doc-create-workflow.md
+++ b/skills/lark-doc/references/lark-doc-create-workflow.md
@@ -116,6 +116,6 @@ lark-cli docs +script --command init-draft --presentation-decision '<上方完�
 1. 只有最新 release candidate 完成 Draft Profile Check 和 XML 规则复查后，才读取 [`lark-doc-create.md`](lark-doc-create.md)，使用同一个 `draft_path` 创建文档。
 2. 创建结果存在 warning、局部资源失败或回查发现局部问题时，不得再次新建文档；读取 [`lark-doc-update.md`](lark-doc-update.md)，对已创建文档做最小范围修复，并按 update 流程 fetch 验证。
 
-### Step 8：清理并交付。
+### Step 8：交付。
 
-无论创建成功、失败或被阻塞，只要 Step 4 已返回 `work_dir`，就先离开该目录，再使用当前运行时的文件删除能力精确删除整个 `work_dir`；不要使用通配符，也不要删除目录外的用户原始文件。最终只交付用户需要的结果，并说明必要来源、未关闭缺口、异常、失败或阻塞原因，以及文档 URL 或 token。
+保留 Step 4 返回的 `work_dir` 及其中的创作草稿。最终只交付用户需要的结果，并说明必要来源、未关闭缺口、异常、失败或阻塞原因，以及文档 URL 或 token。

--- a/skills/lark-doc/references/lark-doc-script.md
+++ b/skills/lark-doc/references/lark-doc-script.md
@@ -38,7 +38,7 @@ lark-cli docs +script --command init-draft \
 - 决策必须是单个 JSON 对象，包含 `audience`、`reader_task`、`genre_contract`、`adapter`、`presentation_mode` 和 `visual_plan`。`presentation_mode` 取 `formal|normal|rich`；`genre_contract`、`adapter` 使用固定短名、`"none"` 或 `null`。
 - `visual_plan` 包含非空 `reason` 和 `blocks` 数组；每项为 `{type,min_count,purpose}`，`type` 不重复，`min_count` 为正整数。按本 Skill 创建文档时，`blocks` 只对 `whiteboard`、`img`、`html5-block` 设置最低数量，其他表达按内容需要使用但不设数量约束；三类均无需约束时写 `[]`。CLI 为外部决策兼容 `type: "list"`，检查时将 `<ul>` 与 `<ol>` 的数量相加。仅有字数要求时添加 `word_count: {min,max}`；未指定的一侧写 `null`，至少一侧为正整数，且 `min <= max`。
 - 返回 `data.workspace`（已创建的随机工作区）、`data.draft_path`（可直接写入的 XML 路径）和英文操作提示 `data.tip`。工作区及其中的 `.presentation-decision.json` 已存在，但 XML 尚不存在；遵循提示直接使用文件创建/写入能力在 `draft_path` 写入完整 XML，首次写入前不要读取该路径。
-- 后续始终使用 `draft_path`，不得另建 XML、复用其他任务的路径或修改工作区中的 `.presentation-decision.json`；使用完后精确删除 `workspace`。
+- 后续始终使用 `draft_path`，不得另建 XML、复用其他任务的路径或修改工作区中的 `.presentation-decision.json`；保留 `workspace` 及其中的创作草稿。
 
 ## `parse`
 


### PR DESCRIPTION
## Summary
Avoid interrupting the document authoring flow with draft-workspace cleanup. The lark-doc workflow now retains the workspace and authoring draft after delivery, leaving lifecycle cleanup to the host instead of the agent.

## Changes
- Change the final authoring step from cleanup-and-delivery to delivery while retaining `work_dir`.
- Align the `docs +script` guidance with the retained-workspace behavior.
- Add a regression test that rejects reintroduced cleanup instructions.

## Test Plan
- [x] `go test ./shortcuts/doc`
- [x] `node scripts/skill-format-check/index.js`
- [x] `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/lark-doc`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] Full E2E: 31/31 command cases passed across user and bot identities; 6/6 natural-language Skill cases passed; four draft workspaces remained after real document creation and fetch verification.

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated document-creation guidance to retain draft workspaces and their draft content.
  * Removed instructions to delete or clean up draft workspaces after document creation.
  * Clarified that subsequent operations should continue using the designated draft path.
  * Continued emphasizing delivery of required results along with sources, gaps, anomalies, failures, blockers, and document details.

* **Tests**
  * Added coverage to verify workspace-retention guidance remains consistent across documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->