### PR TITLE
fix(base): correct reminder trigger offset direction

### DIFF
--- a/skills/lark-base/references/lark-base-workflow-schema.md
+++ b/skills/lark-base/references/lark-base-workflow-schema.md
@@ -252,7 +252,7 @@
 | `table_name` | 是 | 数据表名 |
 | `field_name` | 是 | 日期字段名（必须为 `datetime` / `created_at` / `formula` / `lookup` 类型） |
 | `unit` | 是 | 偏移单位：`MINUTE` / `HOUR` / `DAY` / `WEEK` / `MONTH` |
-| `offset` | 是 | 提前/延后的偏移量（正数=提前，负数=延后；范围由 `unit` 决定）：`MINUTE` ∈ {0, 5, 15, 30, -5, -15, -30}；`HOUR` ∈ [-6, -1] ∪ [1, 6]；`DAY` ∈ [-7, 7]；`WEEK` ∈ [-7, -1] ∪ [1, 7]；`MONTH` ∈ [-7, -1] ∪ [1, 7] |
+| `offset` | 是 | 提前/延后的偏移量（触发时间 = 日期字段时间 + `offset` × `unit`，因此负数=提前、正数=延后；范围由 `unit` 决定）：`MINUTE` ∈ {0, 5, 15, 30, -5, -15, -30}；`HOUR` ∈ [-6, -1] ∪ [1, 6]；`DAY` ∈ [-7, 7]；`WEEK` ∈ [-7, -1] ∪ [1, 7]；`MONTH` ∈ [-7, -1] ∪ [1, 7] |
 | `hour` | 是 | 触发小时 (0-23)，默认 9 |
 | `minute` | 是 | 触发分钟 (0-59)，默认 0 |
 | `condition_list` | 否 | 过滤条件数组，数组中每个元素为 AndCondition 结构，多个 AndCondition 之间为 OR 关系  | 

--- a/skills/lark-base/references/lark-base-workflow-schema.md
+++ b/skills/lark-base/references/lark-base-workflow-schema.md
@@ -239,7 +239,7 @@
 {
   "table_name": "项目表",
   "field_name": "截止日期",
-  "offset": 1,
+  "offset": -1,
   "unit": "DAY",
   "hour": 9,
   "minute": 0,


### PR DESCRIPTION
## Summary
- correct the documented `ReminderTrigger.offset` direction
- define trigger time as field time plus `offset * unit`
- clarify that negative offsets trigger before the field time and positive offsets trigger after it

## Verification
- `node scripts/skill-format-check/index.js`
- `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the reminder trigger example to use a one-day earlier offset.
  * Clarified that negative offsets trigger reminders earlier, while positive offsets trigger them later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->