### PR TITLE
feat: add calendar +list-attendees / +delete and enhance +freebusy & +update

### DIFF
--- a/shortcuts/calendar/calendar_agenda.go
+++ b/shortcuts/calendar/calendar_agenda.go
@@ -179,7 +179,14 @@ var CalendarAgenda = common.Shortcut{
 		{Name: "calendar-id", Desc: "calendar ID (default: primary)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		return rejectCalendarAutoBotFallback(runtime)
+		if err := rejectCalendarAutoBotFallback(runtime); err != nil {
+			return err
+		}
+		warnCalendarTimezoneMismatch(runtime,
+			calendarTimeInputRange{Flag: "start", Value: runtime.Str("start")},
+			calendarTimeInputRange{Flag: "end", Value: runtime.Str("end")},
+		)
+		return nil
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		startInt, endInt, err := parseTimeRange(runtime)

--- a/shortcuts/calendar/calendar_create.go
+++ b/shortcuts/calendar/calendar_create.go
@@ -191,6 +191,10 @@ var CalendarCreate = common.Shortcut{
 		if e <= s {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "end time must be after start time")
 		}
+		warnCalendarTimezoneMismatch(runtime,
+			calendarTimeInputRange{Flag: "start", Value: runtime.Str("start")},
+			calendarTimeInputRange{Flag: "end", Value: runtime.Str("end")},
+		)
 		return nil
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {

--- a/shortcuts/calendar/calendar_delete.go
+++ b/shortcuts/calendar/calendar_delete.go
@@ -1,0 +1,478 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// calendar +delete — delete a calendar event with explicit recurring-event
+// scope handling. See calendar_recurring.go for --apply-to semantics.
+
+package calendar
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const deleteLogPrefix = "[calendar +delete]"
+
+var CalendarDelete = common.Shortcut{
+	Service:     "calendar",
+	Command:     "+delete",
+	Description: "Delete a calendar event; requires --apply-to for recurring events and exceptions",
+	Risk:        "high-risk-write",
+	Scopes:      []string{"calendar:calendar.event:read", "calendar:calendar.event:delete"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "event-id", Desc: "event ID to delete", Required: true},
+		{Name: "calendar-id", Desc: "calendar ID (default: primary)"},
+		{
+			Name: flagApplyTo,
+			Enum: applyToValues,
+			Desc: "recurring scope: single (this occurrence / exception only) | all (whole series and every exception) | this-and-following (truncate the series at this instance and drop every exception on/after it). Required on recurring events; ignored on non-recurring events.",
+		},
+		{Name: "notify", Type: "bool", Default: "true", Desc: "send delete notification to attendees for the master event; exception cleanup silently uses need_notification=false so participants are not spammed"},
+	},
+	Tips: []string{
+		"Deleting an entire recurring series also removes every exception; pass --apply-to=all to confirm intent.",
+		"Deleting `this-and-following` truncates the master (UNTIL = midnight of the pivot day in the event's timezone) and removes exceptions on/after that instance.",
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return validateCalendarDelete(runtime)
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return dryRunCalendarDelete(runtime)
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return executeCalendarDelete(ctx, runtime)
+	},
+}
+
+func validateCalendarDelete(runtime *common.RuntimeContext) error {
+	if err := rejectCalendarAutoBotFallback(runtime); err != nil {
+		return err
+	}
+	for _, flag := range []string{"event-id", "calendar-id"} {
+		if val := strings.TrimSpace(runtime.Str(flag)); val != "" {
+			if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+				return err
+			}
+		}
+	}
+	if strings.TrimSpace(runtime.Str("event-id")) == "" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --event-id").WithParam("--event-id")
+	}
+	return nil
+}
+
+func dryRunCalendarDelete(runtime *common.RuntimeContext) *common.DryRunAPI {
+	calendarID := strings.TrimSpace(runtime.Str("calendar-id"))
+	displayCalendarID := calendarID
+	if displayCalendarID == "" || displayCalendarID == PrimaryCalendarIDStr {
+		displayCalendarID = "<primary>"
+	}
+	eventID := strings.TrimSpace(runtime.Str("event-id"))
+	scope := strings.TrimSpace(runtime.Str(flagApplyTo))
+	if scope == "" {
+		scope = "<inferred from event kind>"
+	}
+
+	d := common.NewDryRunAPI().
+		Set("calendar_id", displayCalendarID).
+		Set("event_id", eventID).
+		Set("apply_to", scope)
+
+	// Every path starts with a GET so we can classify the event (master /
+	// exception / plain instance / normal) before choosing the delete
+	// strategy. The one exception is a malformed id, where Execute short-
+	// circuits with a validation error; the dry run mirrors that by omitting
+	// the read step.
+	if hasStandardEventIDShape(eventID) {
+		d.GET("/open-apis/calendar/v4/calendars/:calendar_id/events/:event_id").
+			Desc("[1] Read event to detect recurring kind (master / exception / plain instance / normal)")
+	}
+	switch scope {
+	case applyToAll:
+		d.GET("/open-apis/calendar/v4/calendars/:calendar_id/events/:master_event_id/instances").
+			Desc("[2] Page /instances across the master's window to list exceptions")
+		d.DELETE("/open-apis/calendar/v4/calendars/:calendar_id/events/:exception_event_id").
+			Desc("[3] Delete every non-cancelled exception").
+			Params(map[string]interface{}{"need_notification": false})
+		d.DELETE("/open-apis/calendar/v4/calendars/:calendar_id/events/:master_event_id").
+			Desc("[4] Delete the master event last").
+			Params(map[string]interface{}{"need_notification": runtime.Bool("notify")})
+	case applyToThisAndFollowing:
+		d.GET("/open-apis/calendar/v4/calendars/:calendar_id/events/:master_event_id/instances").
+			Desc("[2] Page /instances from the pivot day midnight to master end (in the event's timezone)")
+		d.DELETE("/open-apis/calendar/v4/calendars/:calendar_id/events/:exception_event_id").
+			Desc("[3] Delete exceptions with originalTime >= pivot").
+			Params(map[string]interface{}{"need_notification": false})
+		d.PATCH("/open-apis/calendar/v4/calendars/:calendar_id/events/:master_event_id").
+			Desc("[4] Truncate master rrule with UNTIL = pivot-day midnight (in the event's timezone)").
+			Body(map[string]interface{}{"recurrence": "<rewritten with UNTIL>", "need_notification": runtime.Bool("notify")})
+	default:
+		d.DELETE("/open-apis/calendar/v4/calendars/:calendar_id/events/:event_id").
+			Desc(fmt.Sprintf("[2] Delete this event (--apply-to=%s)", applyToSingle)).
+			Params(map[string]interface{}{"need_notification": runtime.Bool("notify")})
+	}
+	return d
+}
+
+func executeCalendarDelete(ctx context.Context, runtime *common.RuntimeContext) error {
+	calendarID := strings.TrimSpace(runtime.Str("calendar-id"))
+	if calendarID == "" {
+		calendarID = PrimaryCalendarIDStr
+	}
+	eventID := strings.TrimSpace(runtime.Str("event-id"))
+	notify := runtime.Bool("notify")
+
+	current, err := resolveCalendarEventOrMaster(runtime, calendarID, eventID)
+	if err != nil {
+		return err
+	}
+	kind := classifyRecurringEvent(current)
+	scope, err := validateApplyTo(runtime, kind, eventID)
+	if err != nil {
+		return err
+	}
+
+	switch scope {
+	case applyToSingle:
+		return deleteApplyToSingle(runtime, calendarID, eventID, notify)
+	case applyToAll:
+		return deleteApplyToAll(ctx, runtime, calendarID, current, eventID, notify)
+	case applyToThisAndFollowing:
+		return deleteApplyToThisAndFollowing(ctx, runtime, calendarID, current, eventID, notify)
+	}
+	return errs.NewInternalError(errs.SubtypeUnknown, "unhandled apply-to scope %q", scope)
+}
+
+func deleteApplyToSingle(runtime *common.RuntimeContext, calendarID, eventID string, notify bool) error {
+	if err := deleteEventOnce(runtime, calendarID, eventID, notify, false); err != nil {
+		return err
+	}
+	result := map[string]interface{}{
+		"calendar_id": calendarID,
+		"apply_to":    applyToSingle,
+		"deleted_event": map[string]interface{}{
+			"event_id": eventID,
+			"action":   "deleted",
+		},
+	}
+	writeCalendarDeleteResult(runtime, result, eventID, applyToSingle, "deleted_event", "Deleted event")
+	return nil
+}
+
+// deleteApplyToAll executes: list exceptions → delete them (future first,
+// then past) with concurrency & retry → delete the master last. The master
+// id is derived when the caller passed an exception id. Per-exception
+// failures do not abort the run; the summary reports them.
+func deleteApplyToAll(ctx context.Context, runtime *common.RuntimeContext, calendarID string, current *calendarEvent, eventID string, notify bool) error {
+	errOut := runtime.IO().ErrOut
+	master, err := ensureMasterEvent(runtime, calendarID, current, eventID)
+	if err != nil {
+		return err
+	}
+	masterID := master.EventID
+	if masterID == "" {
+		masterID = masterEventID(eventID)
+	}
+	window, err := recurringWindowFromMaster(master, time.Now())
+	if err != nil {
+		return err
+	}
+	// apply-to=all destroys every exception (deleteException=true → is_deleted=true),
+	// so include cancelled placeholders in the scan — the cleanup pass wants
+	// to destroy them alongside the live rows.
+	exceptions, err := listExceptionsInWindow(ctx, runtime, calendarID, masterID, window, true)
+	if err != nil {
+		return err
+	}
+
+	var worker *exceptionWorker
+	// Only spin up the worker + progress ticker when there is actual exception
+	// work to do — a series with no live exceptions should proceed straight to
+	// the master delete without emitting "0 exception(s)" noise.
+	if len(exceptions) > 0 {
+		worker = &exceptionWorker{
+			Concurrency: 3,
+			Runtime:     runtime,
+			Label:       deleteLogPrefix,
+			Total:       len(exceptions),
+			Do: func(_ context.Context, ex exceptionInstance) error {
+				return deleteEventOnce(runtime, calendarID, ex.EventID, false, true)
+			},
+		}
+		nowSec := time.Now().Unix()
+		future, past := splitFutureThenPast(exceptions, nowSec)
+		fmt.Fprintf(errOut, "%s deleting %d exception(s) then the master event\n",
+			deleteLogPrefix, len(exceptions))
+		if err := worker.Run(ctx, future); err != nil {
+			return err
+		}
+		if err := worker.Run(ctx, past); err != nil {
+			return err
+		}
+		worker.finalSummary(errOut, "deleted")
+	}
+
+	fmt.Fprintf(errOut, "%s deleting master event %s\n", deleteLogPrefix, masterID)
+	if err := deleteEventOnce(runtime, calendarID, masterID, notify, false); err != nil {
+		return withStepContext(err, "failed to delete master event %s", masterID)
+	}
+
+	deletedEvent := map[string]interface{}{
+		"event_id":        eventID,
+		"master_event_id": masterID,
+		"action":          "deleted",
+	}
+	result := map[string]interface{}{
+		"calendar_id":   calendarID,
+		"apply_to":      applyToAll,
+		"deleted_event": deletedEvent,
+	}
+	if worker != nil {
+		exceptionsSummary := map[string]interface{}{
+			"total":   len(exceptions),
+			"deleted": int(worker.processed.Load()),
+			"failed":  int(worker.failed.Load()),
+		}
+		if failures := worker.Failures(); len(failures) > 0 {
+			exceptionsSummary["failures"] = failures
+		}
+		result["exceptions"] = exceptionsSummary
+	}
+	writeCalendarDeleteResult(runtime, result, eventID, applyToAll, "deleted_event", "Deleted event")
+	return nil
+}
+
+// deleteApplyToThisAndFollowing executes: list exceptions on/after the pivot
+// day midnight → delete them (per-item failures recorded, batch continues)
+// → PATCH master rrule with UNTIL = pivot day midnight (in event's timezone).
+func deleteApplyToThisAndFollowing(ctx context.Context, runtime *common.RuntimeContext, calendarID string, current *calendarEvent, eventID string, notify bool) error {
+	pivotUnix, ok := parseInstanceOriginalTime(eventID)
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--%s=%s needs a recurring instance event_id (shape `{uid}_{originalTime}` with a positive originalTime); got %q",
+			flagApplyTo, applyToThisAndFollowing, eventID).WithParam("--event-id")
+	}
+	errOut := runtime.IO().ErrOut
+	master, err := ensureMasterEvent(runtime, calendarID, current, eventID)
+	if err != nil {
+		return err
+	}
+	masterID := master.EventID
+	if masterID == "" {
+		masterID = masterEventID(eventID)
+	}
+	if strings.TrimSpace(master.Recurrence) == "" {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"master event %s has no recurrence rule; cannot truncate", masterID)
+	}
+
+	// The scan window starts at the pivot day's midnight (in the event's
+	// timezone) — every exception with originalTime >= pivot is on that same
+	// day or later, so the scan is bounded to the tail of the series.
+	loc := eventLocation(master)
+	pivotDay := pivotDayMidnight(pivotUnix, loc)
+	windowEnd := recurringEndFromRRule(master.Recurrence, pivotDay.Unix(), time.Now())
+	if windowEnd <= pivotDay.Unix() {
+		windowEnd = pivotDay.Unix()
+	}
+	all, err := listExceptionsInWindow(ctx, runtime, calendarID, masterID,
+		recurringWindow{Start: pivotDay.Unix(), End: windowEnd}, true)
+	if err != nil {
+		return err
+	}
+	future := filterOnOrAfter(all, pivotUnix)
+
+	var worker *exceptionWorker
+	// Only run the worker + progress ticker when there is exception work to
+	// do. A this-and-following with no live exceptions on/after the pivot
+	// goes straight to the master truncation.
+	if len(future) > 0 {
+		worker = &exceptionWorker{
+			Concurrency: 3,
+			Runtime:     runtime,
+			Label:       deleteLogPrefix,
+			Total:       len(future),
+			Do: func(_ context.Context, ex exceptionInstance) error {
+				return deleteEventOnce(runtime, calendarID, ex.EventID, false, true)
+			},
+		}
+		fmt.Fprintf(errOut, "%s deleting %d exception(s) on/after pivot %d (%s) then truncating master rrule at %s\n",
+			deleteLogPrefix, len(future), pivotUnix,
+			formatPivotDatetime(pivotUnix, loc),
+			pivotDay.Format(time.RFC3339))
+		if err := worker.Run(ctx, future); err != nil {
+			return err
+		}
+		worker.finalSummary(errOut, "deleted")
+	}
+
+	newRRule := truncateRecurrenceUntil(master.Recurrence, pivotDay)
+	patchBody := map[string]interface{}{
+		"recurrence":        newRRule,
+		"need_notification": notify,
+	}
+	if _, err := runtime.CallAPITyped("PATCH",
+		calendarUpdateEventPath(calendarID, masterID),
+		map[string]interface{}{"user_id_type": "open_id"},
+		patchBody); err != nil {
+		return withStepContext(err, "failed to truncate master event %s", masterID)
+	}
+
+	truncatedEvent := map[string]interface{}{
+		"event_id":        eventID,
+		"master_event_id": masterID,
+		"action":          "truncated",
+	}
+	if strings.TrimSpace(newRRule) != "" {
+		truncatedEvent["recurrence_truncated"] = newRRule
+	}
+	result := map[string]interface{}{
+		"calendar_id":     calendarID,
+		"apply_to":        applyToThisAndFollowing,
+		"truncated_event": truncatedEvent,
+	}
+	if worker != nil {
+		exceptionsSummary := map[string]interface{}{
+			"total":   len(future),
+			"deleted": int(worker.processed.Load()),
+			"failed":  int(worker.failed.Load()),
+		}
+		if failures := worker.Failures(); len(failures) > 0 {
+			exceptionsSummary["failures"] = failures
+		}
+		result["exceptions"] = exceptionsSummary
+	}
+	writeCalendarDeleteResult(runtime, result, eventID, applyToThisAndFollowing, "truncated_event", "Truncated event")
+	return nil
+}
+
+// resolveCalendarEventOrMaster GETs the event by id. If the id is an instance
+// shape (`{uid}_{originalTime}` with originalTime > 0) and the server responds
+// with 193001 (not found) — which is how the API reports "the instance has no
+// stored record because it is a plain unmaterialised occurrence of a
+// recurring series" — we fall back to the master and clone it as if the
+// caller had passed the instance id. When the master itself does not exist,
+// we surface a `not_found` error with the raw event id, so callers get an
+// actionable message instead of the generic 193001.
+//
+// The event-id shape check lives here so every entry point (delete / update)
+// gets the same typed rejection without repeating the guard in Execute.
+func resolveCalendarEventOrMaster(runtime *common.RuntimeContext, calendarID, eventID string) (*calendarEvent, error) {
+	if !hasStandardEventIDShape(eventID) {
+		return nil, errMalformedEventID(eventID)
+	}
+	event, err := fetchCalendarEvent(runtime, calendarID, eventID)
+	if err == nil {
+		return event, nil
+	}
+	if !isEventNotFound(err) {
+		return nil, err
+	}
+	// Try the master fallback: any instance-shaped id can degrade to the
+	// master. If the id is already the master (`_0`), masterEventID is a
+	// no-op and this second GET is redundant, so short-circuit.
+	masterID := masterEventID(eventID)
+	if masterID == eventID {
+		return nil, errs.NewAPIError(errs.SubtypeNotFound,
+			"calendar event %s not found", eventID)
+	}
+	master, mErr := fetchCalendarEvent(runtime, calendarID, masterID)
+	if mErr != nil {
+		if isEventNotFound(mErr) {
+			return nil, errs.NewAPIError(errs.SubtypeNotFound,
+				"calendar event %s not found (also tried master %s)", eventID, masterID)
+		}
+		return nil, mErr
+	}
+	if master == nil {
+		return nil, errs.NewAPIError(errs.SubtypeNotFound,
+			"calendar event %s not found (also tried master %s)", eventID, masterID)
+	}
+	// Clone the master into a synthetic snapshot for the instance the caller
+	// asked about. The classifier keys off (IsException, Recurrence, EventID
+	// shape); dropping Recurrence lets classifyRecurringEvent tag this as a
+	// plain recurring instance (EventID has a positive originalTime) rather
+	// than a master. ensureMasterEvent still does the real master GET when
+	// downstream needs the master's stored recurrence.
+	shadow := *master
+	shadow.EventID = eventID
+	// 根据eventID的originalTime对齐shadow的StartTime和EndTime
+	if originalTime, ok := parseInstanceOriginalTime(eventID); ok &&
+		master.StartTime != nil &&
+		master.EndTime != nil &&
+		master.StartTime.Timestamp != "" &&
+		master.EndTime.Timestamp != "" {
+		st, e1 := strconv.ParseInt(master.StartTime.Timestamp, 10, 64)
+		et, e2 := strconv.ParseInt(master.EndTime.Timestamp, 10, 64)
+		if e1 != nil || e2 != nil {
+			parseErr := e1
+			if parseErr == nil {
+				parseErr = e2
+			}
+			return nil, withStepContext(parseErr, "failed to parse start time %s or end time %s", master.StartTime.Timestamp, master.EndTime.Timestamp)
+		}
+		duration := et - st
+		shadow.StartTime.Timestamp = strconv.FormatInt(originalTime, 10)
+		shadow.EndTime.Timestamp = strconv.FormatInt(originalTime+duration, 10)
+	}
+	shadow.IsException = false
+	shadow.Recurrence = ""
+	return &shadow, nil
+}
+
+// ensureMasterEvent returns the master calendar event. It avoids a redundant
+// GET when the caller already has a snapshot carrying the master's recurrence
+// rule — that snapshot is either the real fetched master or the shadow
+// returned by resolveCalendarEventOrMaster when the caller passed an
+// unmaterialised instance id.
+func ensureMasterEvent(runtime *common.RuntimeContext, calendarID string, current *calendarEvent, eventID string) (*calendarEvent, error) {
+	if current != nil && current.Recurrence != "" && !current.IsException {
+		return current, nil
+	}
+	masterID := masterEventID(eventID)
+	master, err := fetchCalendarEvent(runtime, calendarID, masterID)
+	if err != nil {
+		return nil, withStepContext(err, "failed to read master event %s", masterID)
+	}
+	if master.Recurrence == "" {
+		return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"resolved master event %s has no recurrence rule; --apply-to=all / this-and-following require a recurring series", masterID)
+	}
+	return master, nil
+}
+
+func writeCalendarDeleteResult(runtime *common.RuntimeContext, result map[string]interface{}, targetEventID, scope, eventKey, eventLabel string) {
+	runtime.OutFormat(result, nil, func(w io.Writer) {
+		writeDeletePretty(w, result, targetEventID, scope, eventKey, eventLabel)
+	})
+}
+
+// writeDeletePretty renders the +delete pretty output in the shape the user
+// asked for: (1) header stating which apply_to scope ran on which event_id,
+// (2) the deleted/truncated event details, (3) an optional exceptions summary.
+// eventKey is the top-level key in `result` that carries the event details
+// ("deleted_event" or "truncated_event"); eventLabel is the section title.
+func writeDeletePretty(w io.Writer, result map[string]interface{}, targetEventID, scope, eventKey, eventLabel string) {
+	fmt.Fprintf(w, "Applied `%s` on %s\n\n", scope, targetEventID)
+	if ev, ok := result[eventKey].(map[string]interface{}); ok {
+		fmt.Fprintf(w, "%s:\n", eventLabel)
+		output.PrintTable(w, []map[string]interface{}{ev})
+		fmt.Fprintln(w)
+	}
+	if exceptions, ok := result["exceptions"].(map[string]interface{}); ok {
+		fmt.Fprintln(w, "Exceptions removed:")
+		output.PrintTable(w, []map[string]interface{}{exceptions})
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintln(w, "Event deleted successfully")
+}

--- a/shortcuts/calendar/calendar_freebusy.go
+++ b/shortcuts/calendar/calendar_freebusy.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/larksuite/cli/errs"
@@ -15,37 +17,499 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-// parseFreebusyTimeRange parses --start/--end into RFC3339.
-func parseFreebusyTimeRange(runtime *common.RuntimeContext) (string, string, error) {
+const (
+	freebusyBatchPath = "/open-apis/calendar/v4/freebusy/batch"
+
+	flagFreebusyUserID      = "user-id"
+	flagFreebusyType        = "type"
+	flagFreebusyMinDuration = "min-duration"
+
+	freebusyTypeBusy       = "busy"
+	freebusyTypeRawBusy    = "raw_busy"
+	freebusyTypeFree       = "free"
+	freebusyTypeCommonFree = "common_free"
+)
+
+// freebusyInterval is a merged busy period for one user (busy view).
+type freebusyInterval struct {
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+}
+
+// freebusyRawItem is an un-merged upstream busy item carrying rsvp_status
+// (raw_busy view). Same time slice may repeat when the user has multiple
+// overlapping events.
+type freebusyRawItem struct {
+	StartTime  string `json:"start_time"`
+	EndTime    string `json:"end_time"`
+	RSVPStatus string `json:"rsvp_status,omitempty"`
+}
+
+// freebusyFreeSlot is a free window with its duration.
+type freebusyFreeSlot struct {
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+	Duration  string `json:"duration"`
+}
+
+// freebusyUserBusy is the busy view payload for one user.
+type freebusyUserBusy struct {
+	UserID string              `json:"user_id"`
+	Busy   []*freebusyInterval `json:"busy"`
+}
+
+// freebusyUserRawBusy is the raw_busy view payload for one user.
+type freebusyUserRawBusy struct {
+	UserID  string             `json:"user_id"`
+	RawBusy []*freebusyRawItem `json:"raw_busy"`
+}
+
+// freebusyUserFree is the free view payload for one user.
+type freebusyUserFree struct {
+	UserID string              `json:"user_id"`
+	Free   []*freebusyFreeSlot `json:"free"`
+}
+
+// parseFreebusyTimeRange parses --start / --end into
+// (timeMinRFC3339, timeMaxRFC3339, startUnix, endUnix, error).
+func parseFreebusyTimeRange(runtime *common.RuntimeContext) (string, string, int64, int64, error) {
 	startInput, endInput := resolveStartEnd(runtime)
 
 	startTs, err := common.ParseTime(startInput)
 	if err != nil {
-		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
+		return "", "", 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
 	}
 	endTs, err := common.ParseTime(endInput, "end")
 	if err != nil {
-		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
+		return "", "", 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
 	}
 
 	startSec, err := strconv.ParseInt(startTs, 10, 64)
 	if err != nil {
-		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start timestamp: %v", err)
+		return "", "", 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start timestamp: %v", err)
 	}
 	endSec, err := strconv.ParseInt(endTs, 10, 64)
 	if err != nil {
-		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end timestamp: %v", err)
+		return "", "", 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end timestamp: %v", err)
 	}
-
+	if endSec <= startSec {
+		return "", "", 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--end must be after --start").WithParam("--end")
+	}
 	timeMin := time.Unix(startSec, 0).Format(time.RFC3339)
 	timeMax := time.Unix(endSec, 0).Format(time.RFC3339)
-	return timeMin, timeMax, nil
+	return timeMin, timeMax, startSec, endSec, nil
+}
+
+// collectFreebusyUserIDs resolves --user-id (repeatable / CSV) into a
+// deduplicated list. When empty and identity is user, defaults to current
+// user; bot identity must provide at least one.
+func collectFreebusyUserIDs(runtime *common.RuntimeContext) ([]string, error) {
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, raw := range runtime.StrSlice(flagFreebusyUserID) {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		if _, err := common.ValidateUserIDTyped("--user-id", id); err != nil {
+			return nil, err
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		if runtime.IsBot() {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--user-id is required for bot identity").WithParam("--user-id")
+		}
+		me := runtime.UserOpenId()
+		if me == "" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"cannot determine user ID, specify --user-id or ensure you are logged in").WithParam("--user-id")
+		}
+		out = append(out, me)
+	}
+	return out, nil
+}
+
+func parseFreebusyType(runtime *common.RuntimeContext) (string, error) {
+	v := strings.TrimSpace(runtime.Str(flagFreebusyType))
+	if v == "" {
+		return freebusyTypeBusy, nil
+	}
+	switch v {
+	case freebusyTypeBusy, freebusyTypeRawBusy, freebusyTypeFree, freebusyTypeCommonFree:
+		return v, nil
+	default:
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--type %q: expected one of %s | %s | %s | %s", v,
+			freebusyTypeBusy, freebusyTypeRawBusy, freebusyTypeFree, freebusyTypeCommonFree).
+			WithParam("--type")
+	}
+}
+
+func parseFreebusyMinDuration(runtime *common.RuntimeContext) (time.Duration, error) {
+	raw := strings.TrimSpace(runtime.Str(flagFreebusyMinDuration))
+	if raw == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--min-duration %q: %v (expected Go duration like 30m or 1h)", raw, err).
+			WithParam("--min-duration")
+	}
+	if d < 0 {
+		return 0, errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--min-duration %s: must be non-negative", d).WithParam("--min-duration")
+	}
+	return d, nil
+}
+
+// mergeBusyIntervals sorts by start and merges overlapping / adjacent
+// intervals. Adjacent means end == next.start. Merging is lossless for the
+// busy/free question: it does not change "is this instant busy for this user".
+// todo hg 逻辑cr
+func mergeBusyIntervals(items []*freebusyInterval) []*freebusyInterval {
+	if len(items) == 0 {
+		return nil
+	}
+	type parsed struct {
+		start time.Time
+		end   time.Time
+	}
+	arr := make([]parsed, 0, len(items))
+	for _, it := range items {
+		s, err := time.Parse(time.RFC3339, it.StartTime)
+		if err != nil {
+			continue
+		}
+		e, err := time.Parse(time.RFC3339, it.EndTime)
+		if err != nil {
+			continue
+		}
+		if !e.After(s) {
+			continue
+		}
+		arr = append(arr, parsed{s, e})
+	}
+	if len(arr) == 0 {
+		return nil
+	}
+	sort.SliceStable(arr, func(i, j int) bool {
+		if !arr[i].start.Equal(arr[j].start) {
+			return arr[i].start.Before(arr[j].start)
+		}
+		return arr[i].end.Before(arr[j].end)
+	})
+	loc := arr[0].start.Location()
+	merged := []parsed{arr[0]}
+	for _, cur := range arr[1:] {
+		last := &merged[len(merged)-1]
+		if !cur.start.After(last.end) {
+			if cur.end.After(last.end) {
+				last.end = cur.end
+			}
+			continue
+		}
+		merged = append(merged, cur)
+	}
+	out := make([]*freebusyInterval, 0, len(merged))
+	for _, m := range merged {
+		out = append(out, &freebusyInterval{
+			StartTime: m.start.In(loc).Format(time.RFC3339),
+			EndTime:   m.end.In(loc).Format(time.RFC3339),
+		})
+	}
+	return out
+}
+
+// clipInterval intersects [s, e] with [winStart, winEnd] and reports whether
+// the result is non-empty.
+func clipInterval(s, e, winStart, winEnd time.Time) (time.Time, time.Time, bool) {
+	if s.Before(winStart) {
+		s = winStart
+	}
+	if e.After(winEnd) {
+		e = winEnd
+	}
+	if !e.After(s) {
+		return time.Time{}, time.Time{}, false
+	}
+	return s, e, true
+}
+
+// perUserFree computes W \ busy for one user within [winStart, winEnd],
+// clipping and filtering by minDur.
+// todo hg 逻辑cr
+func perUserFree(busy []*freebusyInterval, winStart, winEnd time.Time, minDur time.Duration) []*freebusyFreeSlot {
+	loc := winStart.Location()
+	if len(busy) > 0 {
+		if t, err := time.Parse(time.RFC3339, busy[0].StartTime); err == nil {
+			loc = t.Location()
+		}
+	}
+	emit := func(out *[]*freebusyFreeSlot, from, to time.Time) {
+		if !to.After(from) {
+			return
+		}
+		d := to.Sub(from)
+		if minDur > 0 && d < minDur {
+			return
+		}
+		*out = append(*out, &freebusyFreeSlot{
+			StartTime: from.In(loc).Format(time.RFC3339),
+			EndTime:   to.In(loc).Format(time.RFC3339),
+			Duration:  d.String(),
+		})
+	}
+	cursor := winStart
+	var out []*freebusyFreeSlot
+	for _, b := range busy {
+		s, err := time.Parse(time.RFC3339, b.StartTime)
+		if err != nil {
+			continue
+		}
+		e, err := time.Parse(time.RFC3339, b.EndTime)
+		if err != nil {
+			continue
+		}
+		cs, ce, ok := clipInterval(s, e, winStart, winEnd)
+		if !ok {
+			continue
+		}
+		emit(&out, cursor, cs)
+		if ce.After(cursor) {
+			cursor = ce
+		}
+	}
+	emit(&out, cursor, winEnd)
+	return out
+}
+
+// commonFree computes W \ ∪ busy_i via sweep line, clipped to [winStart,
+// winEnd] and filtered by minDur.
+// todo hg 逻辑cr
+func commonFree(usersBusy [][]*freebusyInterval, winStart, winEnd time.Time, minDur time.Duration) []*freebusyFreeSlot {
+	type event struct {
+		t     time.Time
+		delta int
+	}
+	var evs []event
+	loc := winStart.Location()
+	for _, busy := range usersBusy {
+		for _, b := range busy {
+			s, err := time.Parse(time.RFC3339, b.StartTime)
+			if err != nil {
+				continue
+			}
+			e, err := time.Parse(time.RFC3339, b.EndTime)
+			if err != nil {
+				continue
+			}
+			cs, ce, ok := clipInterval(s, e, winStart, winEnd)
+			if !ok {
+				continue
+			}
+			evs = append(evs, event{cs, +1}, event{ce, -1})
+		}
+	}
+	sort.SliceStable(evs, func(i, j int) bool {
+		if !evs[i].t.Equal(evs[j].t) {
+			return evs[i].t.Before(evs[j].t)
+		}
+		// same instant: process -1 before +1 so a touching pair of busy
+		// intervals never emits a zero-length free slot in the middle.
+		return evs[i].delta < evs[j].delta
+	})
+	emit := func(out *[]*freebusyFreeSlot, from, to time.Time) {
+		if !to.After(from) {
+			return
+		}
+		d := to.Sub(from)
+		if minDur > 0 && d < minDur {
+			return
+		}
+		*out = append(*out, &freebusyFreeSlot{
+			StartTime: from.In(loc).Format(time.RFC3339),
+			EndTime:   to.In(loc).Format(time.RFC3339),
+			Duration:  d.String(),
+		})
+	}
+	var out []*freebusyFreeSlot
+	busy := 0
+	freeStart := winStart
+	for _, e := range evs {
+		if busy == 0 {
+			emit(&out, freeStart, e.t)
+		}
+		busy += e.delta
+		if busy == 0 {
+			freeStart = e.t
+		}
+	}
+	if busy == 0 {
+		emit(&out, freeStart, winEnd)
+	}
+	return out
+}
+
+// parseFreebusyBatchResponse extracts per-user raw busy items from
+// /freebusy/batch's `freebusy_lists`, preserving upstream order and each
+// item's rsvp_status. Callers that need merged busy intervals feed the
+// result into mergeBusyIntervals; raw_busy view uses it directly.
+func parseFreebusyBatchResponse(data map[string]interface{}, userOrder []string) map[string][]*freebusyRawItem {
+	out := make(map[string][]*freebusyRawItem, len(userOrder))
+	for _, u := range userOrder {
+		out[u] = nil
+	}
+	raw, _ := data["freebusy_lists"].([]interface{})
+	for _, item := range raw {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		uid, _ := m["user_id"].(string)
+		if uid == "" {
+			continue
+		}
+		items, _ := m["freebusy_items"].([]interface{})
+		bucket := make([]*freebusyRawItem, 0, len(items))
+		for _, it := range items {
+			im, ok := it.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			startStr, _ := im["start_time"].(string)
+			endStr, _ := im["end_time"].(string)
+			if startStr == "" || endStr == "" {
+				continue
+			}
+			rsvp, _ := im["rsvp_status"].(string)
+			bucket = append(bucket, &freebusyRawItem{
+				StartTime:  startStr,
+				EndTime:    endStr,
+				RSVPStatus: rsvp,
+			})
+		}
+		out[uid] = bucket
+	}
+	return out
+}
+
+// rawToBusyIntervals strips rsvp_status and returns the plain busy list ready
+// for mergeBusyIntervals / free-slot computation.
+func rawToBusyIntervals(raw []*freebusyRawItem) []*freebusyInterval {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]*freebusyInterval, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, &freebusyInterval{StartTime: r.StartTime, EndTime: r.EndTime})
+	}
+	return out
+}
+
+// sortRawItemsByStart sorts raw items ascending by start_time to give the
+// caller a stable ordering; end_time / rsvp_status are otherwise preserved.
+func sortRawItemsByStart(items []*freebusyRawItem) []*freebusyRawItem {
+	if len(items) <= 1 {
+		return items
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].StartTime < items[j].StartTime
+	})
+	return items
+}
+
+func writeFreebusyMinDurationHints(runtime *common.RuntimeContext, typ string, minDur time.Duration, winStart, winEnd time.Time) {
+	if minDur == 0 {
+		return
+	}
+	if runtime == nil || runtime.Factory == nil || runtime.Factory.IOStreams == nil {
+		return
+	}
+	stderr := runtime.Factory.IOStreams.ErrOut
+	if stderr == nil {
+		return
+	}
+	if typ == freebusyTypeBusy || typ == freebusyTypeRawBusy {
+		fmt.Fprintf(stderr, "hint: --min-duration is ignored when --type=%s\n", typ)
+	}
+	if window := winEnd.Sub(winStart); window > 0 && minDur > window {
+		fmt.Fprintf(stderr, "hint: --min-duration %s exceeds the requested window %s; no free slot can satisfy it\n",
+			minDur, window)
+	}
+}
+
+// Off-hours window is [22:00, 24:00) ∪ [00:00, 08:00) in each slot's timezone.
+const (
+	freebusyEarlyMorningEndHour = 8
+	freebusyLateNightStartHour  = 22
+)
+
+// slotOverlapsOffHours reports whether the free slot [startStr, endStr]
+// (RFC3339) intersects 22:00-24:00 or 00:00-08:00 in the slot's own timezone.
+func slotOverlapsOffHours(startStr, endStr string) bool {
+	s, err := time.Parse(time.RFC3339, startStr)
+	if err != nil {
+		return false
+	}
+	e, err := time.Parse(time.RFC3339, endStr)
+	if err != nil {
+		return false
+	}
+	if !e.After(s) {
+		return false
+	}
+	loc := s.Location()
+	// Walk each calendar day the slot touches so DST-adjacent days still
+	// use the correct 22-24 / 0-8 boundaries.
+	day := time.Date(s.Year(), s.Month(), s.Day(), 0, 0, 0, 0, loc)
+	for !day.After(e) {
+		morningEnd := time.Date(day.Year(), day.Month(), day.Day(),
+			freebusyEarlyMorningEndHour, 0, 0, 0, loc)
+		if s.Before(morningEnd) && e.After(day) {
+			return true
+		}
+		lateStart := time.Date(day.Year(), day.Month(), day.Day(),
+			freebusyLateNightStartHour, 0, 0, 0, loc)
+		nextDay := day.AddDate(0, 0, 1)
+		if s.Before(nextDay) && e.After(lateStart) {
+			return true
+		}
+		day = nextDay
+	}
+	return false
+}
+
+// writeFreebusyOffHoursHint prints a single stderr hint the first time any of
+// the given free slots touches the off-hours window; no-op otherwise.
+func writeFreebusyOffHoursHint(runtime *common.RuntimeContext, typ string, slots []*freebusyFreeSlot) {
+	if runtime == nil || runtime.Factory == nil || runtime.Factory.IOStreams == nil {
+		return
+	}
+	stderr := runtime.Factory.IOStreams.ErrOut
+	if stderr == nil {
+		return
+	}
+	for _, sl := range slots {
+		if slotOverlapsOffHours(sl.StartTime, sl.EndTime) {
+			fmt.Fprintf(stderr,
+				"hint: some %s slots fall into off-hours 22:00-08:00 (may be non-working time); \n", typ)
+			return
+		}
+	}
 }
 
 var CalendarFreebusy = common.Shortcut{
 	Service:     "calendar",
 	Command:     "+freebusy",
-	Description: "Query user free/busy and RSVP status",
+	Description: "Query free/busy for one or more users. Merges overlapping busy intervals and supports per-user free / common-free views for multi-user scheduling.",
 	Risk:        "read",
 	Scopes:      []string{"calendar:calendar.free_busy:read"},
 	AuthTypes:   []string{"user", "bot"},
@@ -53,83 +517,241 @@ var CalendarFreebusy = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "start", Desc: "start time (ISO 8601, default: today)"},
 		{Name: "end", Desc: "end time (ISO 8601, default: end of start day)"},
-		{Name: "user-id", Desc: "target user open_id (ou_ prefix, default: current user)"},
+		{Name: flagFreebusyUserID, Type: "string_slice", Desc: "target user open_id(s); repeatable or comma-separated; default: current user; bot identity must provide at least one"},
+		{Name: flagFreebusyType, Type: "string", Default: freebusyTypeBusy, Enum: []string{freebusyTypeBusy, freebusyTypeRawBusy, freebusyTypeFree, freebusyTypeCommonFree}, Desc: "output view: busy (default, per-user merged busy) | raw_busy (per-user upstream events with rsvp_status) | free (per-user free windows) | common_free (all-users common free)"},
+		{Name: flagFreebusyMinDuration, Type: "string", Desc: "minimum length for free/common_free candidates (Go duration, e.g. 30m, 1h); ignored for busy / raw_busy"},
+	},
+	Tips: []string{
+		"`--type busy` merges adjacent busy intervals, so item count != event count. For events/rsvp use `--type raw_busy` (own or others' calendars); for own attendees/details use `+get` / `+list-attendees`.",
+		"Multi-user scheduling raw view: use `--type common_free --min-duration <dur>` and let the CLI compute the intersection instead of merging by hand.",
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		userId := runtime.Str("user-id")
-		if userId == "" {
-			userId = runtime.UserOpenId()
-		}
-		timeMin, timeMax, err := parseFreebusyTimeRange(runtime)
+		timeMin, timeMax, _, _, err := parseFreebusyTimeRange(runtime)
 		if err != nil {
 			return common.NewDryRunAPI().Set("error", err.Error())
 		}
-		return common.NewDryRunAPI().
-			POST("/open-apis/calendar/v4/freebusy/list").
-			Body(map[string]interface{}{"time_min": timeMin, "time_max": timeMax, "user_id": userId, "need_rsvp_status": true})
+		userIDs, err := collectFreebusyUserIDs(runtime)
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		typ, err := parseFreebusyType(runtime)
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		body := map[string]interface{}{
+			"time_min":         timeMin,
+			"time_max":         timeMax,
+			"user_ids":         userIDs,
+			"need_rsvp_status": true,
+		}
+		d := common.NewDryRunAPI().POST(freebusyBatchPath).Body(body).Set("type", typ)
+		if raw := strings.TrimSpace(runtime.Str(flagFreebusyMinDuration)); raw != "" {
+			d.Set("min_duration", raw)
+		}
+		return d
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := rejectCalendarAutoBotFallback(runtime); err != nil {
 			return err
 		}
-		userId := runtime.Str("user-id")
-		if userId == "" && runtime.IsBot() {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id is required for bot identity").WithParam("--user-id")
+		if _, _, _, _, err := parseFreebusyTimeRange(runtime); err != nil {
+			return err
 		}
-		if userId == "" && runtime.UserOpenId() == "" {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "cannot determine user ID, specify --user-id or ensure you are logged in").WithParam("--user-id")
+		if _, err := collectFreebusyUserIDs(runtime); err != nil {
+			return err
 		}
-		if userId != "" {
-			if _, err := common.ValidateUserIDTyped("--user-id", userId); err != nil {
-				return err
-			}
+		if _, err := parseFreebusyType(runtime); err != nil {
+			return err
 		}
+		if _, err := parseFreebusyMinDuration(runtime); err != nil {
+			return err
+		}
+		warnCalendarTimezoneMismatch(runtime,
+			calendarTimeInputRange{Flag: "start", Value: runtime.Str("start")},
+			calendarTimeInputRange{Flag: "end", Value: runtime.Str("end")},
+		)
 		return nil
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		userId := runtime.Str("user-id")
-		if userId == "" {
-			userId = runtime.UserOpenId()
-		}
-
-		timeMin, timeMax, err := parseFreebusyTimeRange(runtime)
+		timeMin, timeMax, startSec, endSec, err := parseFreebusyTimeRange(runtime)
 		if err != nil {
-			// parseFreebusyTimeRange already returns a typed *errs.ValidationError
-			// carrying the offending flag in .Param; pass it through unchanged.
+			return err
+		}
+		userIDs, err := collectFreebusyUserIDs(runtime)
+		if err != nil {
+			return err
+		}
+		typ, err := parseFreebusyType(runtime)
+		if err != nil {
+			return err
+		}
+		minDur, err := parseFreebusyMinDuration(runtime)
+		if err != nil {
 			return err
 		}
 
-		data, err := runtime.CallAPITyped("POST", "/open-apis/calendar/v4/freebusy/list", nil, map[string]interface{}{
+		winStart := time.Unix(startSec, 0)
+		winEnd := time.Unix(endSec, 0)
+		writeFreebusyMinDurationHints(runtime, typ, minDur, winStart, winEnd)
+
+		data, err := runtime.CallAPITyped("POST", freebusyBatchPath, nil, map[string]interface{}{
 			"time_min":         timeMin,
 			"time_max":         timeMax,
-			"user_id":          userId,
+			"user_ids":         userIDs,
 			"need_rsvp_status": true,
 		})
 		if err != nil {
 			return err
 		}
-		items, _ := data["freebusy_list"].([]interface{})
+		perUser := parseFreebusyBatchResponse(data, userIDs)
+		mergedByUser := make(map[string][]*freebusyInterval, len(userIDs))
+		for _, u := range userIDs {
+			mergedByUser[u] = mergeBusyIntervals(rawToBusyIntervals(perUser[u]))
+		}
 
-		runtime.OutFormat(items, &output.Meta{Count: len(items)}, func(w io.Writer) {
-			if len(items) == 0 {
-				fmt.Fprintln(w, "No busy periods in this time range.")
-				return
-			}
-
-			var rows []map[string]interface{}
-			for _, item := range items {
-				m, ok := item.(map[string]interface{})
-				if !ok {
-					continue
+		switch typ {
+		case freebusyTypeBusy:
+			users := make([]*freebusyUserBusy, 0, len(userIDs))
+			total := 0
+			for _, u := range userIDs {
+				items := mergedByUser[u]
+				if items == nil {
+					items = []*freebusyInterval{}
 				}
-				rows = append(rows, map[string]interface{}{
-					"start": m["start_time"],
-					"end":   m["end_time"],
-				})
+				users = append(users, &freebusyUserBusy{UserID: u, Busy: items})
+				total += len(items)
 			}
-			output.PrintTable(w, rows)
-			fmt.Fprintf(w, "\n%d busy period(s) total\n", len(items))
-		})
+			out := map[string]interface{}{"users": users}
+			runtime.OutFormat(out, &output.Meta{Count: total}, func(w io.Writer) {
+				if total == 0 {
+					fmt.Fprintln(w, "No busy periods in this time range.")
+					return
+				}
+				for _, u := range users {
+					fmt.Fprintf(w, "user %s\n", u.UserID)
+					if len(u.Busy) == 0 {
+						fmt.Fprintln(w, "  (no busy periods)")
+						continue
+					}
+					rows := make([]map[string]interface{}, 0, len(u.Busy))
+					for _, it := range u.Busy {
+						rows = append(rows, map[string]interface{}{
+							"start": it.StartTime,
+							"end":   it.EndTime,
+						})
+					}
+					output.PrintTable(w, rows)
+				}
+				fmt.Fprintf(w, "\n%d busy period(s) across %d user(s)\n", total, len(users))
+			})
+			return nil
+
+		case freebusyTypeRawBusy:
+			users := make([]*freebusyUserRawBusy, 0, len(userIDs))
+			total := 0
+			for _, u := range userIDs {
+				items := sortRawItemsByStart(perUser[u])
+				if items == nil {
+					items = []*freebusyRawItem{}
+				}
+				users = append(users, &freebusyUserRawBusy{UserID: u, RawBusy: items})
+				total += len(items)
+			}
+			out := map[string]interface{}{"users": users}
+			runtime.OutFormat(out, &output.Meta{Count: total}, func(w io.Writer) {
+				if total == 0 {
+					fmt.Fprintln(w, "No events in this time range.")
+					return
+				}
+				for _, u := range users {
+					fmt.Fprintf(w, "user %s\n", u.UserID)
+					if len(u.RawBusy) == 0 {
+						fmt.Fprintln(w, "  (no events)")
+						continue
+					}
+					rows := make([]map[string]interface{}, 0, len(u.RawBusy))
+					for _, it := range u.RawBusy {
+						rows = append(rows, map[string]interface{}{
+							"start":       it.StartTime,
+							"end":         it.EndTime,
+							"rsvp_status": it.RSVPStatus,
+						})
+					}
+					output.PrintTable(w, rows)
+				}
+				fmt.Fprintf(w, "\n%d event(s) across %d user(s)\n", total, len(users))
+			})
+			return nil
+
+		case freebusyTypeFree:
+			users := make([]*freebusyUserFree, 0, len(userIDs))
+			total := 0
+			var allFreeForHint []*freebusyFreeSlot
+			for _, u := range userIDs {
+				free := perUserFree(mergedByUser[u], winStart, winEnd, minDur)
+				if free == nil {
+					free = []*freebusyFreeSlot{}
+				}
+				users = append(users, &freebusyUserFree{UserID: u, Free: free})
+				total += len(free)
+				allFreeForHint = append(allFreeForHint, free...)
+			}
+			writeFreebusyOffHoursHint(runtime, freebusyTypeFree, allFreeForHint)
+			out := map[string]interface{}{"users": users}
+			runtime.OutFormat(out, &output.Meta{Count: total}, func(w io.Writer) {
+				if total == 0 {
+					fmt.Fprintln(w, "No free slots in this time range.")
+					return
+				}
+				for _, u := range users {
+					fmt.Fprintf(w, "user %s\n", u.UserID)
+					if len(u.Free) == 0 {
+						fmt.Fprintln(w, "  (no free slots)")
+						continue
+					}
+					rows := make([]map[string]interface{}, 0, len(u.Free))
+					for _, it := range u.Free {
+						rows = append(rows, map[string]interface{}{
+							"start":    it.StartTime,
+							"end":      it.EndTime,
+							"duration": it.Duration,
+						})
+					}
+					output.PrintTable(w, rows)
+				}
+				fmt.Fprintf(w, "\n%d free slot(s) across %d user(s)\n", total, len(users))
+			})
+			return nil
+
+		case freebusyTypeCommonFree:
+			usersBusy := make([][]*freebusyInterval, 0, len(userIDs))
+			for _, u := range userIDs {
+				usersBusy = append(usersBusy, mergedByUser[u])
+			}
+			free := commonFree(usersBusy, winStart, winEnd, minDur)
+			if free == nil {
+				free = []*freebusyFreeSlot{}
+			}
+			writeFreebusyOffHoursHint(runtime, freebusyTypeCommonFree, free)
+			out := map[string]interface{}{"common_free": free}
+			runtime.OutFormat(out, &output.Meta{Count: len(free)}, func(w io.Writer) {
+				if len(free) == 0 {
+					fmt.Fprintln(w, "No common free slots in this time range.")
+					return
+				}
+				rows := make([]map[string]interface{}, 0, len(free))
+				for _, it := range free {
+					rows = append(rows, map[string]interface{}{
+						"start":    it.StartTime,
+						"end":      it.EndTime,
+						"duration": it.Duration,
+					})
+				}
+				output.PrintTable(w, rows)
+				fmt.Fprintf(w, "\n%d common free slot(s) across %d user(s)\n", len(free), len(userIDs))
+			})
+			return nil
+		}
 		return nil
 	},
 }

--- a/shortcuts/calendar/calendar_freebusy_test.go
+++ b/shortcuts/calendar/calendar_freebusy_test.go
@@ -1,0 +1,778 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// -----------------------------------------------------------------------------
+// Pure helpers
+// -----------------------------------------------------------------------------
+
+func TestMergeBusyIntervals_OverlapAndAdjacent(t *testing.T) {
+	in := []*freebusyInterval{
+		{StartTime: "2026-03-21T10:00:00+08:00", EndTime: "2026-03-21T11:00:00+08:00"},
+		{StartTime: "2026-03-21T10:30:00+08:00", EndTime: "2026-03-21T12:00:00+08:00"},
+		{StartTime: "2026-03-21T12:00:00+08:00", EndTime: "2026-03-21T13:00:00+08:00"},
+		{StartTime: "2026-03-21T14:00:00+08:00", EndTime: "2026-03-21T15:00:00+08:00"},
+	}
+	got := mergeBusyIntervals(in)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 merged intervals, got %d: %+v", len(got), got)
+	}
+	if got[0].StartTime[:19] != "2026-03-21T10:00:00" || got[0].EndTime[:19] != "2026-03-21T13:00:00" {
+		t.Errorf("first merged interval = %+v", got[0])
+	}
+	if got[1].StartTime[:19] != "2026-03-21T14:00:00" || got[1].EndTime[:19] != "2026-03-21T15:00:00" {
+		t.Errorf("second merged interval = %+v", got[1])
+	}
+}
+
+func TestMergeBusyIntervals_DedupExactDuplicates(t *testing.T) {
+	in := []*freebusyInterval{
+		{StartTime: "2026-03-21T10:00:00+08:00", EndTime: "2026-03-21T11:00:00+08:00"},
+		{StartTime: "2026-03-21T10:00:00+08:00", EndTime: "2026-03-21T11:00:00+08:00"},
+	}
+	got := mergeBusyIntervals(in)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 merged interval, got %d: %+v", len(got), got)
+	}
+}
+
+func TestPerUserFree_ClipsToWindowAndFiltersMinDuration(t *testing.T) {
+	// window 09:00 - 12:00; busy 10:00 - 10:30 → free: 09:00-10:00, 10:30-12:00.
+	loc, _ := time.LoadLocation("Asia/Shanghai")
+	winStart := time.Date(2026, 3, 21, 9, 0, 0, 0, loc)
+	winEnd := time.Date(2026, 3, 21, 12, 0, 0, 0, loc)
+	busy := []*freebusyInterval{
+		{StartTime: "2026-03-21T10:00:00+08:00", EndTime: "2026-03-21T10:30:00+08:00"},
+	}
+	// no filter → both slots
+	full := perUserFree(busy, winStart, winEnd, 0)
+	if len(full) != 2 {
+		t.Fatalf("expected 2 free slots without filter, got %d: %+v", len(full), full)
+	}
+	// filter 90m → only the 10:30-12:00 slot survives
+	filtered := perUserFree(busy, winStart, winEnd, 90*time.Minute)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 free slot with 90m filter, got %d: %+v", len(filtered), filtered)
+	}
+	if filtered[0].StartTime[:19] != "2026-03-21T10:30:00" || filtered[0].EndTime[:19] != "2026-03-21T12:00:00" {
+		t.Errorf("filtered slot = %+v", filtered[0])
+	}
+	if filtered[0].Duration != "1h30m0s" {
+		t.Errorf("duration = %q, want 1h30m0s", filtered[0].Duration)
+	}
+}
+
+// commonFree replays the case 202 regression: three targets whose union
+// covers 09:00-17:00; only 17:00-18:00 survives.
+func TestCommonFree_Case202Regression(t *testing.T) {
+	loc, _ := time.LoadLocation("Asia/Shanghai")
+	winStart := time.Date(2026, 3, 21, 9, 0, 0, 0, loc)
+	winEnd := time.Date(2026, 3, 21, 18, 0, 0, 0, loc)
+
+	a := []*freebusyInterval{
+		{StartTime: "2026-03-21T09:00:00+08:00", EndTime: "2026-03-21T11:00:00+08:00"},
+		{StartTime: "2026-03-21T12:00:00+08:00", EndTime: "2026-03-21T13:00:00+08:00"},
+		{StartTime: "2026-03-21T14:00:00+08:00", EndTime: "2026-03-21T16:00:00+08:00"},
+	}
+	b := []*freebusyInterval{
+		{StartTime: "2026-03-21T10:00:00+08:00", EndTime: "2026-03-21T12:00:00+08:00"},
+		{StartTime: "2026-03-21T15:00:00+08:00", EndTime: "2026-03-21T17:00:00+08:00"},
+	}
+	c := []*freebusyInterval{
+		{StartTime: "2026-03-21T09:00:00+08:00", EndTime: "2026-03-21T10:00:00+08:00"},
+		{StartTime: "2026-03-21T12:00:00+08:00", EndTime: "2026-03-21T14:00:00+08:00"},
+	}
+
+	got := commonFree([][]*freebusyInterval{a, b, c}, winStart, winEnd, 30*time.Minute)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 common-free slot (17-18), got %d: %+v", len(got), got)
+	}
+	if got[0].StartTime[:19] != "2026-03-21T17:00:00" || got[0].EndTime[:19] != "2026-03-21T18:00:00" {
+		t.Errorf("free slot = %+v; want 17:00~18:00", got[0])
+	}
+	if got[0].Duration != "1h0m0s" {
+		t.Errorf("duration = %q, want 1h0m0s", got[0].Duration)
+	}
+}
+
+// case 268 replay: two users share a 08:00-09:00 gap while both are busy the
+// rest of the window; the LLM missed it, the sweep line must not.
+func TestCommonFree_Case268Regression(t *testing.T) {
+	loc, _ := time.LoadLocation("Asia/Shanghai")
+	winStart := time.Date(2026, 8, 4, 7, 0, 0, 0, loc)
+	winEnd := time.Date(2026, 8, 4, 18, 0, 0, 0, loc)
+	a := []*freebusyInterval{
+		{StartTime: "2026-08-04T07:00:00+08:00", EndTime: "2026-08-04T08:00:00+08:00"},
+		{StartTime: "2026-08-04T09:00:00+08:00", EndTime: "2026-08-04T18:00:00+08:00"},
+	}
+	b := []*freebusyInterval{
+		{StartTime: "2026-08-04T07:30:00+08:00", EndTime: "2026-08-04T08:00:00+08:00"},
+		{StartTime: "2026-08-04T09:00:00+08:00", EndTime: "2026-08-04T18:00:00+08:00"},
+	}
+	got := commonFree([][]*freebusyInterval{a, b}, winStart, winEnd, time.Hour)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 common-free slot, got %d: %+v", len(got), got)
+	}
+	if got[0].StartTime[:19] != "2026-08-04T08:00:00" || got[0].EndTime[:19] != "2026-08-04T09:00:00" {
+		t.Errorf("free slot = %+v", got[0])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Batch endpoint / view switches
+// -----------------------------------------------------------------------------
+
+func TestFreebusy_UsesBatchEndpoint_And_MergesPerUser(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id": "ou_a",
+						"freebusy_items": []interface{}{
+							map[string]interface{}{
+								"start_time": "2026-03-21T10:00:00+08:00",
+								"end_time":   "2026-03-21T11:00:00+08:00",
+							},
+							map[string]interface{}{
+								// overlap → must merge with the previous.
+								"start_time": "2026-03-21T10:30:00+08:00",
+								"end_time":   "2026-03-21T12:00:00+08:00",
+							},
+							map[string]interface{}{
+								// adjacent → must merge.
+								"start_time": "2026-03-21T12:00:00+08:00",
+								"end_time":   "2026-03-21T13:00:00+08:00",
+							},
+						},
+					},
+					map[string]interface{}{
+						"user_id": "ou_b",
+						"freebusy_items": []interface{}{
+							map[string]interface{}{
+								"start_time": "2026-03-21T14:00:00+08:00",
+								"end_time":   "2026-03-21T15:00:00+08:00",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	reg.Register(stub)
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21",
+		"--end", "2026-03-21",
+		"--user-id", "ou_a,ou_b",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	// Assert the request body carried user_ids batch.
+	var req struct {
+		UserIDs []string `json:"user_ids"`
+	}
+	if err := json.Unmarshal(stub.CapturedBody, &req); err != nil {
+		t.Fatalf("captured body was not JSON: %v", err)
+	}
+	if len(req.UserIDs) != 2 || req.UserIDs[0] != "ou_a" || req.UserIDs[1] != "ou_b" {
+		t.Errorf("user_ids body = %v", req.UserIDs)
+	}
+
+	// Assert response shape: users[].busy after merge.
+	var payload struct {
+		Data struct {
+			Users []struct {
+				UserID string              `json:"user_id"`
+				Busy   []*freebusyInterval `json:"busy"`
+			} `json:"users"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v (out=%s)", err, stdout.String())
+	}
+	if len(payload.Data.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(payload.Data.Users))
+	}
+	if payload.Data.Users[0].UserID != "ou_a" || len(payload.Data.Users[0].Busy) != 1 {
+		t.Errorf("ou_a busy should merge to 1 interval, got %+v", payload.Data.Users[0].Busy)
+	}
+	if payload.Data.Users[0].Busy[0].EndTime[:19] != "2026-03-21T13:00:00" {
+		t.Errorf("ou_a merged end wrong: %+v", payload.Data.Users[0].Busy[0])
+	}
+}
+
+func TestFreebusy_FreeView(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id": "ou_a",
+						"freebusy_items": []interface{}{
+							map[string]interface{}{
+								"start_time": "2026-03-21T10:00:00+08:00",
+								"end_time":   "2026-03-21T11:00:00+08:00",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21T09:00:00+08:00",
+		"--end", "2026-03-21T12:00:00+08:00",
+		"--user-id", "ou_a",
+		"--type", "free",
+		"--min-duration", "30m",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var payload struct {
+		Data struct {
+			Users []struct {
+				UserID string              `json:"user_id"`
+				Free   []*freebusyFreeSlot `json:"free"`
+			} `json:"users"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v (out=%s)", err, stdout.String())
+	}
+	if len(payload.Data.Users) != 1 {
+		t.Fatalf("want 1 user, got %d", len(payload.Data.Users))
+	}
+	if len(payload.Data.Users[0].Free) != 2 {
+		t.Fatalf("want 2 free slots (09-10, 11-12), got %d: %+v", len(payload.Data.Users[0].Free), payload.Data.Users[0].Free)
+	}
+	if payload.Data.Users[0].Free[0].Duration != "1h0m0s" {
+		t.Errorf("first free duration = %q", payload.Data.Users[0].Free[0].Duration)
+	}
+}
+
+func TestFreebusy_CommonFreeView(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id": "ou_a",
+						"freebusy_items": []interface{}{
+							map[string]interface{}{
+								"start_time": "2026-03-21T09:00:00+08:00",
+								"end_time":   "2026-03-21T10:00:00+08:00",
+							},
+						},
+					},
+					map[string]interface{}{
+						"user_id": "ou_b",
+						"freebusy_items": []interface{}{
+							map[string]interface{}{
+								"start_time": "2026-03-21T11:00:00+08:00",
+								"end_time":   "2026-03-21T12:00:00+08:00",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21T09:00:00+08:00",
+		"--end", "2026-03-21T18:00:00+08:00",
+		"--user-id", "ou_a,ou_b",
+		"--type", "common_free",
+		"--min-duration", "30m",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var payload struct {
+		Data struct {
+			CommonFree []*freebusyFreeSlot `json:"common_free"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v (out=%s)", err, stdout.String())
+	}
+	// Expect free slots: 10-11 (1h), 12-18 (6h) — compare as absolute instants
+	// so the assertion is stable regardless of the runner's local TZ.
+	if len(payload.Data.CommonFree) != 2 {
+		t.Fatalf("want 2 common-free slots, got %d: %+v", len(payload.Data.CommonFree), payload.Data.CommonFree)
+	}
+	assertFreebusySlotInstant(t, "first common-free slot",
+		payload.Data.CommonFree[0],
+		"2026-03-21T10:00:00+08:00", "2026-03-21T11:00:00+08:00")
+	assertFreebusySlotInstant(t, "second common-free slot",
+		payload.Data.CommonFree[1],
+		"2026-03-21T12:00:00+08:00", "2026-03-21T18:00:00+08:00")
+}
+
+// assertFreebusySlotInstant compares a slot's emitted start/end to the expected
+// wall-clock at a specific offset by parsing both sides as RFC3339, so the
+// assertion holds under any TZ the test runner uses.
+func assertFreebusySlotInstant(t *testing.T, label string, slot *freebusyFreeSlot, wantStart, wantEnd string) {
+	t.Helper()
+	wantStartT, err := time.Parse(time.RFC3339, wantStart)
+	if err != nil {
+		t.Fatalf("%s: bad wantStart %q: %v", label, wantStart, err)
+	}
+	wantEndT, err := time.Parse(time.RFC3339, wantEnd)
+	if err != nil {
+		t.Fatalf("%s: bad wantEnd %q: %v", label, wantEnd, err)
+	}
+	gotStart, err := time.Parse(time.RFC3339, slot.StartTime)
+	if err != nil {
+		t.Fatalf("%s: unparseable slot.StartTime %q: %v", label, slot.StartTime, err)
+	}
+	gotEnd, err := time.Parse(time.RFC3339, slot.EndTime)
+	if err != nil {
+		t.Fatalf("%s: unparseable slot.EndTime %q: %v", label, slot.EndTime, err)
+	}
+	if !gotStart.Equal(wantStartT) || !gotEnd.Equal(wantEndT) {
+		t.Errorf("%s = %+v, want start=%s end=%s", label, slot, wantStart, wantEnd)
+	}
+}
+
+// A single --user-id with common_free returns the same shape as multi-user
+// common_free; spec explicitly forbids a distinct single-user error path.
+func TestFreebusy_CommonFree_SingleUser_UsesSameShape(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id": "ou_a",
+						"freebusy_items": []interface{}{
+							map[string]interface{}{
+								"start_time": "2026-03-21T10:00:00+08:00",
+								"end_time":   "2026-03-21T11:00:00+08:00",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21T09:00:00+08:00",
+		"--end", "2026-03-21T12:00:00+08:00",
+		"--user-id", "ou_a",
+		"--type", "common_free",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var payload struct {
+		Data struct {
+			CommonFree []*freebusyFreeSlot `json:"common_free"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v (out=%s)", err, stdout.String())
+	}
+	if len(payload.Data.CommonFree) != 2 {
+		t.Fatalf("want 2 free slots for single user, got %d: %+v", len(payload.Data.CommonFree), payload.Data.CommonFree)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Validation
+// -----------------------------------------------------------------------------
+
+func TestFreebusy_InvalidTypeEnum(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21",
+		"--end", "2026-03-21",
+		"--user-id", "ou_a",
+		"--type", "bogus",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error for --type")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--type" {
+		t.Errorf("param=%q, want --type", ve.Param)
+	}
+}
+
+func TestFreebusy_InvalidMinDuration(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21",
+		"--end", "2026-03-21",
+		"--user-id", "ou_a",
+		"--min-duration", "not-a-duration",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error for --min-duration")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--min-duration" {
+		t.Errorf("param=%q, want --min-duration", ve.Param)
+	}
+}
+
+func TestFreebusy_UserIdSliceDedup(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id":        "ou_a",
+						"freebusy_items": []interface{}{},
+					},
+					map[string]interface{}{
+						"user_id":        "ou_b",
+						"freebusy_items": []interface{}{},
+					},
+				},
+			},
+		},
+	}
+	reg.Register(stub)
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21",
+		"--end", "2026-03-21",
+		"--user-id", "ou_a,ou_a, ou_b ",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(string(stub.CapturedBody), `"user_ids":["ou_a","ou_b"]`) {
+		t.Errorf("captured body did not carry deduped user_ids: %s", string(stub.CapturedBody))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// raw_busy view
+// -----------------------------------------------------------------------------
+
+// raw_busy must NOT merge and MUST preserve rsvp_status per event, so callers
+// can count events and read the per-event rsvp signal.
+func TestFreebusy_RawBusyView_NoMerge_KeepsRSVP(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id": "ou_a",
+						"freebusy_items": []interface{}{
+							// Two overlapping events at the same time slice; busy view
+							// would merge these into one, raw_busy must keep both.
+							map[string]interface{}{
+								"start_time":  "2026-03-21T10:00:00+08:00",
+								"end_time":    "2026-03-21T11:00:00+08:00",
+								"rsvp_status": "accept",
+							},
+							map[string]interface{}{
+								"start_time":  "2026-03-21T10:30:00+08:00",
+								"end_time":    "2026-03-21T11:30:00+08:00",
+								"rsvp_status": "tentative",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21",
+		"--end", "2026-03-21",
+		"--user-id", "ou_a",
+		"--type", "raw_busy",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	var payload struct {
+		Data struct {
+			Users []struct {
+				UserID  string             `json:"user_id"`
+				RawBusy []*freebusyRawItem `json:"raw_busy"`
+			} `json:"users"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v (out=%s)", err, stdout.String())
+	}
+	if len(payload.Data.Users) != 1 || len(payload.Data.Users[0].RawBusy) != 2 {
+		t.Fatalf("raw_busy must keep 2 events, got %+v", payload.Data.Users)
+	}
+	got := payload.Data.Users[0].RawBusy
+	if got[0].RSVPStatus != "accept" || got[1].RSVPStatus != "tentative" {
+		t.Errorf("rsvp_status lost or reordered: %+v, %+v", got[0], got[1])
+	}
+	// Sort by start ascending.
+	if got[0].StartTime > got[1].StartTime {
+		t.Errorf("raw_busy items must be sorted by start ascending, got: %+v, %+v", got[0], got[1])
+	}
+}
+
+// raw_busy on a user with no events emits an empty array, not nil, keeping
+// the JSON shape stable for downstream parsers.
+func TestFreebusy_RawBusyView_EmptyUserYieldsEmptyArray(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id":        "ou_a",
+						"freebusy_items": []interface{}{},
+					},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21",
+		"--end", "2026-03-21",
+		"--user-id", "ou_a",
+		"--type", "raw_busy",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"raw_busy": []`) {
+		t.Errorf("expected explicit empty array raw_busy: [], got: %s", stdout.String())
+	}
+}
+
+// --min-duration is documented as ignored for raw_busy: caller passing it must
+// receive a stderr hint but the command must not fail and payload is unchanged.
+func TestFreebusy_RawBusy_MinDurationEmitsHintOnStderr(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"freebusy_lists": []interface{}{
+					map[string]interface{}{
+						"user_id":        "ou_a",
+						"freebusy_items": []interface{}{},
+					},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy",
+		"--start", "2026-03-21",
+		"--end", "2026-03-21",
+		"--user-id", "ou_a",
+		"--type", "raw_busy",
+		"--min-duration", "30m",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "ignored when --type=raw_busy") {
+		t.Errorf("expected stderr hint about ignored min-duration for raw_busy, got: %s", stderr.String())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// off-hours hint (--type free / common_free)
+// -----------------------------------------------------------------------------
+
+func TestSlotOverlapsOffHours(t *testing.T) {
+	cases := []struct {
+		name  string
+		start string
+		end   string
+		want  bool
+	}{
+		{"pure working hours", "2026-03-21T10:00:00+08:00", "2026-03-21T12:00:00+08:00", false},
+		{"early-morning start", "2026-03-21T07:00:00+08:00", "2026-03-21T09:00:00+08:00", true},
+		{"exact 08 boundary is working", "2026-03-21T08:00:00+08:00", "2026-03-21T09:00:00+08:00", false},
+		{"late-night end", "2026-03-21T21:00:00+08:00", "2026-03-21T23:30:00+08:00", true},
+		{"exact 22 boundary hits off-hours", "2026-03-21T22:00:00+08:00", "2026-03-21T23:00:00+08:00", true},
+		{"cross-midnight into next day early morning", "2026-03-21T21:00:00+08:00", "2026-03-22T09:00:00+08:00", true},
+		{"multi-day but only working hours each day (impossible)", "2026-03-21T09:00:00+08:00", "2026-03-21T18:00:00+08:00", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := slotOverlapsOffHours(c.start, c.end)
+			if got != c.want {
+				t.Errorf("slotOverlapsOffHours(%s,%s)=%v want %v", c.start, c.end, got, c.want)
+			}
+		})
+	}
+}
+
+// A --type free response whose slots straddle off-hours must emit a stderr
+// hint about the off-hours band. Exercised directly against
+// writeFreebusyOffHoursHint so the slot's own offset (+08:00) drives the check
+// and the assertion is independent of the runner's local TZ.
+func TestFreebusy_FreeView_OffHoursHint(t *testing.T) {
+	f, _, stderr, _ := cmdutil.TestFactory(t, defaultConfig())
+	runtime := &common.RuntimeContext{Factory: f}
+	slots := []*freebusyFreeSlot{
+		{
+			StartTime: "2026-03-21T06:00:00+08:00",
+			EndTime:   "2026-03-21T09:00:00+08:00",
+			Duration:  "3h0m0s",
+		},
+	}
+	writeFreebusyOffHoursHint(runtime, freebusyTypeFree, slots)
+	if !strings.Contains(stderr.String(), "off-hours 22:00-08:00") {
+		t.Errorf("expected off-hours hint on stderr, got: %q", stderr.String())
+	}
+}
+
+// A --type free response that stays inside working hours must NOT emit the
+// off-hours hint. Same rationale as TestFreebusy_FreeView_OffHoursHint.
+func TestFreebusy_FreeView_NoHintDuringWorkingHours(t *testing.T) {
+	f, _, stderr, _ := cmdutil.TestFactory(t, defaultConfig())
+	runtime := &common.RuntimeContext{Factory: f}
+	slots := []*freebusyFreeSlot{
+		{
+			StartTime: "2026-03-21T09:00:00+08:00",
+			EndTime:   "2026-03-21T18:00:00+08:00",
+			Duration:  "9h0m0s",
+		},
+	}
+	writeFreebusyOffHoursHint(runtime, freebusyTypeFree, slots)
+	if strings.Contains(stderr.String(), "off-hours") {
+		t.Errorf("unexpected off-hours hint on stderr for 09-18 window: %q", stderr.String())
+	}
+}
+
+// The hint also fires for --type common_free.
+func TestFreebusy_CommonFree_OffHoursHint(t *testing.T) {
+	f, _, stderr, _ := cmdutil.TestFactory(t, defaultConfig())
+	runtime := &common.RuntimeContext{Factory: f}
+	slots := []*freebusyFreeSlot{
+		{
+			StartTime: "2026-03-21T21:00:00+08:00",
+			EndTime:   "2026-03-21T23:30:00+08:00",
+			Duration:  "2h30m0s",
+		},
+	}
+	writeFreebusyOffHoursHint(runtime, freebusyTypeCommonFree, slots)
+	if !strings.Contains(stderr.String(), "off-hours 22:00-08:00") {
+		t.Errorf("expected off-hours hint on stderr for common_free spanning 21-23:30, got: %q", stderr.String())
+	}
+}
+
+// The off-hours hint must NOT fire for --type busy or --type raw_busy since
+// those views are not about candidate slots.
+func TestFreebusy_BusyAndRawBusy_NoOffHoursHint(t *testing.T) {
+	for _, typ := range []string{"busy", "raw_busy"} {
+		t.Run(typ, func(t *testing.T) {
+			f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+			reg.Register(&httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/calendar/v4/freebusy/batch",
+				Body: map[string]interface{}{
+					"code": 0, "msg": "ok",
+					"data": map[string]interface{}{
+						"freebusy_lists": []interface{}{
+							map[string]interface{}{
+								"user_id":        "ou_a",
+								"freebusy_items": []interface{}{},
+							},
+						},
+					},
+				},
+			})
+
+			err := mountAndRun(t, CalendarFreebusy, []string{
+				"+freebusy",
+				"--start", "2026-03-21T06:00:00+08:00",
+				"--end", "2026-03-21T09:00:00+08:00",
+				"--user-id", "ou_a",
+				"--type", typ,
+				"--as", "bot",
+			}, f, stdout)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if strings.Contains(stderr.String(), "off-hours") {
+				t.Errorf("%s must not emit off-hours hint, got: %q", typ, stderr.String())
+			}
+		})
+	}
+}

--- a/shortcuts/calendar/calendar_get.go
+++ b/shortcuts/calendar/calendar_get.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
-	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -227,16 +226,7 @@ var CalendarGet = common.Shortcut{
 		}
 		eventId := strings.TrimSpace(runtime.Str("event-id"))
 
-		data, err := runtime.CallAPITyped("GET",
-			fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s",
-				validate.EncodePathSegment(calendarId),
-				validate.EncodePathSegment(eventId)),
-			nil, nil)
-		if err != nil {
-			return err
-		}
-
-		event, err := parseCalendarEvent(data)
+		event, err := resolveCalendarEventOrMaster(runtime, calendarId, eventId)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/calendar/calendar_list_attendees.go
+++ b/shortcuts/calendar/calendar_list_attendees.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+//
+// calendar +list-attendees — list attendees of a single calendar event with type filter.
+
+package calendar
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// attendeeType is one of the four upstream attendee types.
+type attendeeType string
+
+const (
+	attendeeTypeUser       attendeeType = "user"
+	attendeeTypeResource   attendeeType = "resource"
+	attendeeTypeChat       attendeeType = "chat"
+	attendeeTypeThirdParty attendeeType = "third_party"
+)
+
+var validAttendeeTypes = map[string]struct{}{
+	string(attendeeTypeUser):       {},
+	string(attendeeTypeResource):   {},
+	string(attendeeTypeChat):       {},
+	string(attendeeTypeThirdParty): {},
+}
+
+// listAttendeesOutput is the structured output for +list-attendees.
+type listAttendeesOutput struct {
+	Attendees []map[string]interface{} `json:"attendees"`
+	HasMore   bool                     `json:"has_more"`
+	PageToken string                   `json:"page_token"`
+}
+
+// projectAttendee copies the fields relevant to an attendee's `type`, dropping
+// upstream fields that do not apply. It keeps upstream ordering by preserving
+// the incoming map keys via explicit copy.
+func projectAttendee(a map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+
+	// Always-present shared fields.
+	if v, ok := a["type"].(string); ok && v != "" {
+		out["type"] = v
+	}
+	if v, ok := a["display_name"].(string); ok && v != "" {
+		out["display_name"] = v
+	}
+	// rsvp_status is meaningful for user / resource / third_party attendees only.
+	// Chat attendees don't carry a group-level RSVP — the "rsvp_status" upstream
+	// returns for a chat entry is not semantically valid; the per-member RSVP is
+	// retrieved separately via event.attendees.chat_members.list.
+	attendeeT := attendeeType(strings.TrimSpace(strings.ToLower(fmt.Sprint(a["type"]))))
+	if attendeeT != attendeeTypeChat {
+		if v, ok := a["rsvp_status"].(string); ok && v != "" {
+			out["rsvp_status"] = v
+		}
+	}
+	if v, ok := a["is_optional"].(bool); ok && v {
+		out["is_optional"] = v
+	}
+	if v, ok := a["is_organizer"].(bool); ok && v {
+		out["is_organizer"] = v
+	}
+	if v, ok := a["is_external"].(bool); ok {
+		out["is_external"] = v
+	}
+	if v, ok := a["operate_id"].(string); ok && v != "" {
+		out["operate_id"] = v
+	}
+
+	// Type-specific fields.
+	switch attendeeT {
+	case attendeeTypeUser:
+		if v, ok := a["user_id"].(string); ok && v != "" {
+			out["user_id"] = v
+		}
+	case attendeeTypeResource:
+		if v, ok := a["room_id"].(string); ok && v != "" {
+			out["room_id"] = v
+		}
+		if v, ok := a["resource_customization"]; ok && v != nil {
+			out["resource_customization"] = v
+		}
+	case attendeeTypeChat:
+		if v, ok := a["chat_id"].(string); ok && v != "" {
+			out["chat_id"] = v
+		}
+	case attendeeTypeThirdParty:
+		if v, ok := a["third_party_email"].(string); ok && v != "" {
+			out["third_party_email"] = v
+		}
+	}
+	return out
+}
+
+// normalizeTypeFilter deduplicates and validates the --type flag values.
+func normalizeTypeFilter(rawTypes []string) (map[string]struct{}, error) {
+	if len(rawTypes) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]struct{}, len(rawTypes))
+	for _, raw := range rawTypes {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if _, ok := validAttendeeTypes[v]; !ok {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"invalid --type %q, allowed: user, resource, chat, third_party", v).
+				WithParam("--type")
+		}
+		out[v] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+const (
+	// listAttendeesDefaultPageSize is used when --page-size is not provided.
+	listAttendeesDefaultPageSize = 20
+	// listAttendeesMinPageSize is the floor for --page-size. Values below this
+	// are silently raised to the floor and reported on stderr as a hint.
+	listAttendeesMinPageSize = 10
+	// listAttendeesMaxPageSize is the ceiling for --page-size. Values above this
+	// are silently clamped to the ceiling and reported on stderr as a hint.
+	listAttendeesMaxPageSize = 100
+)
+
+// resolveListAttendeesPageSize decides the effective page_size sent upstream
+// and returns an optional stderr hint when the caller's value was clamped to
+// the [min, max] range. Not providing --page-size falls back to the default; a
+// negative value is rejected by Validate before Execute reaches this helper.
+func resolveListAttendeesPageSize(runtime *common.RuntimeContext) (int, string) {
+	if !runtime.Changed("page-size") {
+		return listAttendeesDefaultPageSize, ""
+	}
+	requested := runtime.Int("page-size")
+	if requested < listAttendeesMinPageSize {
+		return listAttendeesMinPageSize, fmt.Sprintf(
+			"[calendar +list-attendees] --page-size %d is below the minimum %d; using %d instead",
+			requested, listAttendeesMinPageSize, listAttendeesMinPageSize,
+		)
+	}
+	if requested > listAttendeesMaxPageSize {
+		return listAttendeesMaxPageSize, fmt.Sprintf(
+			"[calendar +list-attendees] --page-size %d exceeds the maximum %d; using %d instead",
+			requested, listAttendeesMaxPageSize, listAttendeesMaxPageSize,
+		)
+	}
+	return requested, ""
+}
+
+// CalendarListAttendees lists attendees of a calendar event.
+var CalendarListAttendees = common.Shortcut{
+	Service:     "calendar",
+	Command:     "+list-attendees",
+	Description: "List attendees of a calendar event; supports --type filter and page-token pagination",
+	Risk:        "read",
+	Scopes:      []string{"calendar:calendar.event:read"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "calendar-id", Desc: "calendar ID (default: primary)"},
+		{Name: "event-id", Desc: "event ID", Required: true},
+		{Name: "type", Type: "string_slice", Desc: "filter by attendee type; repeatable or comma-separated (user|resource|chat|third_party); empty means all"},
+		{Name: "page-size", Type: "int", Desc: fmt.Sprintf("upstream page size; range [%d, %d] (values outside are clamped), default %d", listAttendeesMinPageSize, listAttendeesMaxPageSize, listAttendeesDefaultPageSize)},
+		{Name: "page-token", Desc: "upstream page token for the next page"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := rejectCalendarAutoBotFallback(runtime); err != nil {
+			return err
+		}
+		for _, flag := range []string{"calendar-id", "event-id", "page-token"} {
+			if val := strings.TrimSpace(runtime.Str(flag)); val != "" {
+				if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+					return err
+				}
+			}
+		}
+		eventId := strings.TrimSpace(runtime.Str("event-id"))
+		if eventId == "" {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "event-id cannot be empty").WithParam("--event-id")
+		}
+		if _, err := normalizeTypeFilter(runtime.StrSlice("type")); err != nil {
+			return err
+		}
+		if pageSize := runtime.Int("page-size"); pageSize < 0 {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-size must be a non-negative integer").WithParam("--page-size")
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		calendarId := strings.TrimSpace(runtime.Str("calendar-id"))
+		d := common.NewDryRunAPI()
+		switch calendarId {
+		case "":
+			d.Desc("(calendar-id omitted) Will use primary calendar")
+			calendarId = "<primary>"
+		case "primary":
+			calendarId = "<primary>"
+		}
+		eventId := strings.TrimSpace(runtime.Str("event-id"))
+		pageSize, _ := resolveListAttendeesPageSize(runtime)
+		params := map[string]interface{}{
+			"page_size": pageSize,
+		}
+		if pageToken := strings.TrimSpace(runtime.Str("page-token")); pageToken != "" {
+			params["page_token"] = pageToken
+		}
+		return d.
+			GET("/open-apis/calendar/v4/calendars/:calendar_id/events/:event_id/attendees").
+			Params(params).
+			Set("calendar_id", calendarId).
+			Set("event_id", eventId)
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		calendarId := strings.TrimSpace(runtime.Str("calendar-id"))
+		if calendarId == "" {
+			calendarId = PrimaryCalendarIDStr
+		}
+		eventId := strings.TrimSpace(runtime.Str("event-id"))
+
+		allowed, err := normalizeTypeFilter(runtime.StrSlice("type"))
+		if err != nil {
+			return err
+		}
+
+		pageSize, hint := resolveListAttendeesPageSize(runtime)
+		if hint != "" {
+			fmt.Fprintln(runtime.IO().ErrOut, hint)
+		}
+		params := map[string]interface{}{
+			"page_size": pageSize,
+		}
+		if pageToken := strings.TrimSpace(runtime.Str("page-token")); pageToken != "" {
+			params["page_token"] = pageToken
+		}
+
+		data, err := runtime.CallAPITyped("GET",
+			fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s/attendees",
+				validate.EncodePathSegment(calendarId),
+				validate.EncodePathSegment(eventId)),
+			params, nil)
+		if err != nil {
+			return err
+		}
+		if data == nil {
+			data = map[string]interface{}{}
+		}
+
+		items := common.GetSlice(data, "items")
+		hasMore, _ := data["has_more"].(bool)
+		pageToken, _ := data["page_token"].(string)
+
+		attendees := make([]map[string]interface{}, 0, len(items))
+		for _, raw := range items {
+			item, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if len(allowed) > 0 {
+				t, _ := item["type"].(string)
+				if _, keep := allowed[t]; !keep {
+					continue
+				}
+			}
+			attendees = append(attendees, projectAttendee(item))
+		}
+
+		out := listAttendeesOutput{
+			Attendees: attendees,
+			HasMore:   hasMore,
+			PageToken: pageToken,
+		}
+
+		runtime.OutFormat(out, &output.Meta{Count: len(attendees)}, func(w io.Writer) {
+			if len(attendees) == 0 {
+				fmt.Fprintln(w, "No attendees found.")
+				return
+			}
+
+			// Group by type for pretty rendering while JSON stays flat.
+			groups := map[string][]map[string]interface{}{}
+			order := []string{string(attendeeTypeResource), string(attendeeTypeUser), string(attendeeTypeChat), string(attendeeTypeThirdParty)}
+			for _, a := range attendees {
+				t, _ := a["type"].(string)
+				groups[t] = append(groups[t], a)
+			}
+			titles := map[string]string{
+				string(attendeeTypeResource):   "rooms",
+				string(attendeeTypeUser):       "users",
+				string(attendeeTypeChat):       "chats",
+				string(attendeeTypeThirdParty): "third_parties",
+			}
+			for _, t := range order {
+				group := groups[t]
+				if len(group) == 0 {
+					continue
+				}
+				fmt.Fprintf(w, "%s (%d)\n", titles[t], len(group))
+				var rows []map[string]interface{}
+				for _, a := range group {
+					row := map[string]interface{}{
+						"display_name": a["display_name"],
+					}
+					if attendeeType(t) != attendeeTypeChat {
+						row["rsvp_status"] = a["rsvp_status"]
+					}
+					switch attendeeType(t) {
+					case attendeeTypeUser:
+						row["user_id"] = a["user_id"]
+					case attendeeTypeResource:
+						row["room_id"] = a["room_id"]
+					case attendeeTypeChat:
+						row["chat_id"] = a["chat_id"]
+					case attendeeTypeThirdParty:
+						row["third_party_email"] = a["third_party_email"]
+					}
+					rows = append(rows, row)
+				}
+				output.PrintTable(w, rows)
+				fmt.Fprintln(w)
+			}
+			fmt.Fprintf(w, "%d attendee(s) total", len(attendees))
+			if hasMore {
+				fmt.Fprintf(w, "; more available, page_token: %s", pageToken)
+			}
+			fmt.Fprintln(w)
+		})
+		return nil
+	},
+}

--- a/shortcuts/calendar/calendar_list_attendees_test.go
+++ b/shortcuts/calendar/calendar_list_attendees_test.go
@@ -1,0 +1,548 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+// attendeesResponseFixture returns a canned upstream response covering the four
+// upstream attendee types with representative sparse fields.
+func attendeesResponseFixture(hasMore bool, pageToken string) map[string]interface{} {
+	return map[string]interface{}{
+		"code": 0, "msg": "ok",
+		"data": map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{
+					"type":         "user",
+					"attendee_id":  "att_user1",
+					"user_id":      "ou_user1",
+					"display_name": "张三",
+					"rsvp_status":  "accept",
+					"is_external":  false,
+				},
+				map[string]interface{}{
+					"type":         "resource",
+					"attendee_id":  "att_room1",
+					"room_id":      "omm_room1",
+					"display_name": "会议室 A",
+					"rsvp_status":  "accept",
+				},
+				map[string]interface{}{
+					"type":         "chat",
+					"attendee_id":  "att_chat1",
+					"chat_id":      "oc_chat1",
+					"display_name": "风险评审群",
+					"rsvp_status":  "needs_action",
+				},
+				map[string]interface{}{
+					"type":              "third_party",
+					"attendee_id":       "att_ext1",
+					"third_party_email": "guest@example.com",
+					"display_name":      "外部访客",
+					"rsvp_status":       "needs_action",
+					"is_external":       true,
+				},
+			},
+			"has_more":   hasMore,
+			"page_token": pageToken,
+		},
+	}
+}
+
+func TestListAttendees_Success_FlatShapeAndTypeFieldsOmitEmpty(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Attendees []map[string]interface{} `json:"attendees"`
+			HasMore   bool                     `json:"has_more"`
+			PageToken string                   `json:"page_token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nraw=%s", err, stdout.String())
+	}
+	if !envelope.OK {
+		t.Fatalf("envelope.ok=false")
+	}
+	if got := len(envelope.Data.Attendees); got != 4 {
+		t.Fatalf("attendees len=%d, want 4", got)
+	}
+
+	// Upstream order preserved: user, resource, chat, third_party.
+	wantTypes := []string{"user", "resource", "chat", "third_party"}
+	for i, wt := range wantTypes {
+		if got, _ := envelope.Data.Attendees[i]["type"].(string); got != wt {
+			t.Errorf("attendees[%d].type=%q, want %q", i, got, wt)
+		}
+	}
+
+	// Type-specific fields only appear where relevant.
+	user := envelope.Data.Attendees[0]
+	if got, _ := user["user_id"].(string); got != "ou_user1" {
+		t.Errorf("user.user_id=%q, want ou_user1", got)
+	}
+	if _, ok := user["attendee_id"]; ok {
+		t.Errorf("attendee_id must not be surfaced in output")
+	}
+	if _, ok := user["room_id"]; ok {
+		t.Errorf("user attendee should not carry room_id")
+	}
+	if _, ok := user["chat_id"]; ok {
+		t.Errorf("user attendee should not carry chat_id")
+	}
+
+	resource := envelope.Data.Attendees[1]
+	if got, _ := resource["room_id"].(string); got != "omm_room1" {
+		t.Errorf("resource.room_id=%q, want omm_room1", got)
+	}
+	if _, ok := resource["user_id"]; ok {
+		t.Errorf("resource attendee should not carry user_id")
+	}
+
+	chat := envelope.Data.Attendees[2]
+	if got, _ := chat["chat_id"].(string); got != "oc_chat1" {
+		t.Errorf("chat.chat_id=%q, want oc_chat1", got)
+	}
+	if _, ok := chat["rsvp_status"]; ok {
+		t.Errorf("chat attendee must not carry rsvp_status (groups have no group-level RSVP)")
+	}
+
+	third := envelope.Data.Attendees[3]
+	if got, _ := third["third_party_email"].(string); got != "guest@example.com" {
+		t.Errorf("third_party.third_party_email=%q, want guest@example.com", got)
+	}
+	if got, _ := third["is_external"].(bool); !got {
+		t.Errorf("third_party.is_external=false, want true")
+	}
+}
+
+func TestListAttendees_TypeFilter_KeepsMatchingOnly(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--type", "resource",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Attendees []map[string]interface{} `json:"attendees"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nraw=%s", err, stdout.String())
+	}
+	if got := len(envelope.Data.Attendees); got != 1 {
+		t.Fatalf("attendees len=%d, want 1 (resource only)", got)
+	}
+	if got, _ := envelope.Data.Attendees[0]["type"].(string); got != "resource" {
+		t.Errorf("filtered attendee type=%q, want resource", got)
+	}
+}
+
+func TestListAttendees_TypeFilter_Repeatable(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--type", "user",
+		"--type", "chat",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Attendees []map[string]interface{} `json:"attendees"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nraw=%s", err, stdout.String())
+	}
+	if got := len(envelope.Data.Attendees); got != 2 {
+		t.Fatalf("attendees len=%d, want 2 (user + chat)", got)
+	}
+	seen := map[string]bool{}
+	for _, a := range envelope.Data.Attendees {
+		if t, _ := a["type"].(string); t != "" {
+			seen[t] = true
+		}
+	}
+	if !seen["user"] || !seen["chat"] {
+		t.Errorf("filtered types=%v, want user and chat", seen)
+	}
+}
+
+func TestListAttendees_InvalidType_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--type", "bogus",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q, want invalid_argument", ve.Subtype)
+	}
+	if ve.Param != "--type" {
+		t.Errorf("param=%q, want --type", ve.Param)
+	}
+}
+
+func TestListAttendees_MissingEventID_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "event-id") {
+		t.Fatalf("expected event-id in error, got: %v", err)
+	}
+}
+
+func TestListAttendees_PaginationFlagsPassThroughAndSurface(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	var capturedURL string
+	stub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(true, "next-page-token-xyz"),
+		OnMatch: func(req *http.Request) {
+			capturedURL = req.URL.String()
+		},
+	}
+	reg.Register(stub)
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--page-size", "50",
+		"--page-token", "prev-token",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedURL == "" {
+		t.Fatal("stub did not capture request URL")
+	}
+	for _, want := range []string{"page_size=50", "page_token=prev-token"} {
+		if !strings.Contains(capturedURL, want) {
+			t.Errorf("captured URL missing %q, got: %s", want, capturedURL)
+		}
+	}
+
+	var envelope struct {
+		Data struct {
+			HasMore   bool   `json:"has_more"`
+			PageToken string `json:"page_token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nraw=%s", err, stdout.String())
+	}
+	if !envelope.Data.HasMore {
+		t.Error("expected has_more=true to be surfaced")
+	}
+	if envelope.Data.PageToken != "next-page-token-xyz" {
+		t.Errorf("page_token=%q, want next-page-token-xyz", envelope.Data.PageToken)
+	}
+}
+
+func TestListAttendees_PageSizeDefaultsTo20(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	var capturedURL string
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+		OnMatch: func(req *http.Request) {
+			capturedURL = req.URL.String()
+		},
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedURL, "page_size=20") {
+		t.Errorf("default page_size=20 must be sent upstream; captured URL: %s", capturedURL)
+	}
+}
+
+func TestListAttendees_PageSizeBelowFloor_RaisedAndHinted(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	var capturedURL string
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+		OnMatch: func(req *http.Request) {
+			capturedURL = req.URL.String()
+		},
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--page-size", "3",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedURL, "page_size=10") {
+		t.Errorf("expected page-size to be raised to floor 10; captured URL: %s", capturedURL)
+	}
+	if !strings.Contains(stderr.String(), "below the minimum") {
+		t.Errorf("expected stderr hint about page-size floor, got: %s", stderr.String())
+	}
+}
+
+func TestListAttendees_PageSizeAtFloor_NoHint(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	var capturedURL string
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+		OnMatch: func(req *http.Request) {
+			capturedURL = req.URL.String()
+		},
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--page-size", "10",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedURL, "page_size=10") {
+		t.Errorf("expected page-size 10 forwarded verbatim; captured URL: %s", capturedURL)
+	}
+	if strings.Contains(stderr.String(), "below the minimum") {
+		t.Errorf("no floor hint expected when page-size == floor, got: %s", stderr.String())
+	}
+}
+
+func TestListAttendees_PageSizeAboveCeiling_ClampedAndHinted(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	var capturedURL string
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+		OnMatch: func(req *http.Request) {
+			capturedURL = req.URL.String()
+		},
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--page-size", "500",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedURL, "page_size=100") {
+		t.Errorf("expected page-size clamped to ceiling 100; captured URL: %s", capturedURL)
+	}
+	if !strings.Contains(stderr.String(), "exceeds the maximum") {
+		t.Errorf("expected stderr hint about page-size ceiling, got: %s", stderr.String())
+	}
+}
+
+func TestListAttendees_PageSizeAtCeiling_NoHint(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
+	var capturedURL string
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   attendeesResponseFixture(false, ""),
+		OnMatch: func(req *http.Request) {
+			capturedURL = req.URL.String()
+		},
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--page-size", "100",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedURL, "page_size=100") {
+		t.Errorf("expected page-size 100 forwarded verbatim; captured URL: %s", capturedURL)
+	}
+	if strings.Contains(stderr.String(), "exceeds the maximum") {
+		t.Errorf("no ceiling hint expected when page-size == ceiling, got: %s", stderr.String())
+	}
+}
+
+func TestListAttendees_DryRun_TargetsAttendeesEndpoint(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_dry",
+		"--calendar-id", "cal_dry",
+		"--type", "resource",
+		"--page-size", "20",
+		"--page-token", "tok",
+		"--dry-run",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`"method": "GET"`,
+		`/calendars/cal_dry/events/evt_dry/attendees`,
+		`"page_size": 20`,
+		`"page_token": "tok"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q, got: %s", want, out)
+		}
+	}
+}
+
+func TestListAttendees_DryRun_PrimaryCalendarDefault(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_dry",
+		"--dry-run",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/calendars/%3Cprimary%3E/events/evt_dry/attendees") &&
+		!strings.Contains(out, "/calendars/<primary>/events/evt_dry/attendees") {
+		t.Errorf("dry-run should target primary calendar placeholder, got: %s", out)
+	}
+}
+
+func TestListAttendees_APIError(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body:   map[string]interface{}{"code": 190001, "msg": "permission denied"},
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected API error, got nil")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T (%v)", err, err)
+	}
+	if ae.Code != 190001 {
+		t.Errorf("code=%d, want 190001", ae.Code)
+	}
+}
+
+func TestListAttendees_EmptyItems_PrettyBanner(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/primary/events/evt_1/attendees",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarListAttendees, []string{
+		"+list-attendees",
+		"--event-id", "evt_1",
+		"--format", "pretty",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("No attendees found")) {
+		t.Errorf("expected empty banner, got: %s", stdout.String())
+	}
+}

--- a/shortcuts/calendar/calendar_recurring.go
+++ b/shortcuts/calendar/calendar_recurring.go
@@ -1,0 +1,871 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// calendar recurring-event support: apply-to scope helpers, exception scanning,
+// bounded-concurrency worker, and rate-limit retry used by +update and +delete
+// when acting on recurring series or exceptions.
+
+package calendar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// applyTo* enumerate --apply-to values shared by +update and +delete. The
+// values are surfaced to cobra via Flag.Enum so the framework rejects unknown
+// values before any code in this package runs.
+const (
+	flagApplyTo             = "apply-to"
+	applyToSingle           = "single"
+	applyToAll              = "all"
+	applyToThisAndFollowing = "this-and-following"
+)
+
+// applyToValues is the ordered public enum surfaced in flag registration and
+// `--help`. Passed to Flag.Enum so the shared validateEnumFlags step returns
+// a typed ValidationError for unknown values before Validate/Execute runs.
+var applyToValues = []string{applyToSingle, applyToAll, applyToThisAndFollowing}
+
+// recurringKind is what classifyRecurringEvent returns after a GET on the
+// target event: normal (non-recurring), master, materialized exception, or a
+// plain (mirrored) recurring instance whose id carries originalTime > 0.
+type recurringKind int
+
+const (
+	recurringKindNormal recurringKind = iota
+	recurringKindMaster
+	recurringKindException
+	recurringKindPlainInstance
+)
+
+// exceptionMaxCount caps how many exceptions we hold in memory at once, so a
+// pathological series (thousands of exceptions) cannot exhaust RAM before we
+// fail fast with actionable guidance.
+const exceptionMaxCount = 5000
+
+// exceptionInstance is a minimal projection of an /instances item: the caller
+// only needs the exception's event_id and its instance start time (unix
+// seconds), which together let us both operate on the exception and decide
+// whether it sits on/after the "this" pivot for this-and-following.
+type exceptionInstance struct {
+	EventID   string
+	StartUnix int64
+}
+
+// recurringWindow describes the scan range fed to the /instances API. The
+// caller derives it from the master event's start_time and rrule (UNTIL /
+// COUNT) with a 5-year cap when the rrule is open-ended.
+type recurringWindow struct {
+	Start int64
+	End   int64
+}
+
+// parseInstanceOriginalTime extracts the numeric suffix from an event_id
+// shaped like `{uid}_{originalTime}`. Returns (0, false) if the id is not a
+// recurring instance id, or if the suffix is not a positive integer. A `_0`
+// suffix returns (0, false) because zero is not a real occurrence position —
+// the master and every normal (non-recurring) event carry `_0`.
+func parseInstanceOriginalTime(eventID string) (int64, bool) {
+	idx := strings.LastIndex(eventID, "_")
+	if idx <= 0 || idx == len(eventID)-1 {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(eventID[idx+1:], 10, 64)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// hasStandardEventIDShape returns true when the id matches the standard Lark
+// event shape `{uid}_{digits}`. Every real calendar event id has this shape:
+// the master and normal (non-recurring) events use `_0`; instances / exceptions
+// use `_{originalTime > 0}`. Any id fitting the shape might therefore be
+// recurring, so callers must GET the event to know for sure — we cannot
+// classify from the id alone.
+func hasStandardEventIDShape(eventID string) bool {
+	idx := strings.LastIndex(eventID, "_")
+	if idx <= 0 || idx == len(eventID)-1 {
+		return false
+	}
+	_, err := strconv.ParseInt(eventID[idx+1:], 10, 64)
+	return err == nil
+}
+
+// errMalformedEventID returns the typed validation error surfaced when a
+// caller passes an event_id that does not match the standard Lark shape
+// `{uid}_{digits}`. Rejecting up front (instead of silently degrading to a
+// single-event path) prevents guessing recurring vs. non-recurring from
+// garbage input and gives the caller an actionable message.
+func errMalformedEventID(eventID string) error {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument,
+		"invalid --event-id %q: every Lark calendar event id has the shape `{uid}_{originalTime}` (`_0` for masters/normal events, `_{unix seconds}` for instances/exceptions)",
+		eventID).WithParam("--event-id")
+}
+
+// classifyRecurringEvent looks at the GET /events/:event_id response and
+// decides whether we are dealing with the master, an exception, a plain
+// recurring instance whose id carries an originalTime, or a normal
+// (non-recurring) event.
+func classifyRecurringEvent(event *calendarEvent) recurringKind {
+	if event == nil {
+		return recurringKindNormal
+	}
+	if event.IsException {
+		return recurringKindException
+	}
+	if event.Recurrence != "" {
+		return recurringKindMaster
+	}
+	if event.EventID != "" {
+		if ot, ok := parseInstanceOriginalTime(event.EventID); ok && ot > 0 {
+			return recurringKindPlainInstance
+		}
+	}
+	return recurringKindNormal
+}
+
+// fetchCalendarEvent reads the calendar event by id. It only issues the GET
+// and parses the response envelope — callers apply classifyRecurringEvent
+// afterward to decide whether the event is a master, exception, plain
+// instance, or normal one-shot. Named without a "recurring" qualifier
+// because the fetch itself is oblivious to the recurring/non-recurring split.
+func fetchCalendarEvent(runtime *common.RuntimeContext, calendarID, eventID string) (*calendarEvent, error) {
+	data, err := runtime.CallAPITyped("GET",
+		fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s",
+			validate.EncodePathSegment(calendarID), validate.EncodePathSegment(eventID)),
+		nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return parseCalendarEvent(data)
+}
+
+// validateApplyTo enforces the shared contract:
+//   - single is legal on any non-master event
+//   - all / this-and-following are only meaningful on recurring events
+//   - master ids reject `single` and `this-and-following` because they lack a
+//     concrete instance position; caller must pass an instance id instead
+//   - exception ids reject `this-and-following` (an exception cannot be the
+//     pivot; caller must pass the underlying instance id)
+//
+// Every rejection message states the concrete reason and lists the scopes
+// legal on the current event kind, so the caller can self-correct in one read.
+//
+// The framework's Enum check has already rejected unknown values before this
+// function runs, so we only reason about the four legal states here.
+func validateApplyTo(runtime *common.RuntimeContext, kind recurringKind, eventID string) (string, error) {
+	scope := strings.TrimSpace(runtime.Str(flagApplyTo))
+
+	switch kind {
+	case recurringKindNormal:
+		if scope != "" && scope != applyToSingle {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"`--%s=%s` is not valid on a normal (non-recurring) event; only `--%s=%s` is accepted (or leave `--%s` unset)",
+				flagApplyTo, scope, flagApplyTo, applyToSingle, flagApplyTo).
+				WithParam("--" + flagApplyTo)
+		}
+		return applyToSingle, nil
+
+	case recurringKindException:
+		if scope == "" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"`--%s` is required on a recurring exception; valid scopes are `%s` (this exception only) or `%s` (the whole series and every exception)",
+				flagApplyTo, applyToSingle, applyToAll).WithParam("--" + flagApplyTo)
+		}
+		if scope == applyToThisAndFollowing {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"`--%s=%s` is not valid on a recurring exception; valid scopes here are `%s` | `%s`. To truncate the series from a specific occurrence, pass the `event_id` of a non-exception instance (`{uid}_{originalTime}`, originalTime > 0) — look it up via `+agenda` or `+search-event`",
+				flagApplyTo, applyToThisAndFollowing, applyToSingle, applyToAll).
+				WithParam("--" + flagApplyTo)
+		}
+		return scope, nil
+
+	case recurringKindPlainInstance:
+		if scope == "" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"`--%s` is required on a recurring instance; valid scopes are `%s` | `%s` | `%s`",
+				flagApplyTo, applyToSingle, applyToAll, applyToThisAndFollowing).WithParam("--" + flagApplyTo)
+		}
+		return scope, nil
+
+	case recurringKindMaster:
+		if scope == "" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"`--%s` is required on the recurring master; only `--%s=%s` is valid on the master id (the whole series and every exception). To operate on one occurrence, pass the instance `event_id` (`{uid}_{originalTime}`, originalTime > 0) — look it up via `+agenda` or `+search-event`",
+				flagApplyTo, flagApplyTo, applyToAll).WithParam("--" + flagApplyTo)
+		}
+		if scope == applyToSingle {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"`--%s=%s` is not valid on the recurring master; only `--%s=%s` is accepted here. To operate on one occurrence, pass the instance `event_id` (`{uid}_{originalTime}`, originalTime > 0) — look it up via `+agenda` or `+search-event`",
+				flagApplyTo, applyToSingle, flagApplyTo, applyToAll).
+				WithParam("--" + flagApplyTo)
+		}
+		if scope == applyToThisAndFollowing {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"`--%s=%s` is not valid on the recurring master; only `--%s=%s` is accepted here. To truncate the series from a specific occurrence, pass that instance's `event_id`",
+				flagApplyTo, applyToThisAndFollowing, flagApplyTo, applyToAll).
+				WithParam("--" + flagApplyTo)
+		}
+		return scope, nil
+	}
+	return "", errs.NewInternalError(errs.SubtypeUnknown, "unknown recurring kind %d", kind)
+}
+
+// masterEventID rewrites an instance / exception event_id into its master id
+// by stripping the `_{originalTime}` suffix and re-appending `_0`. Callers use
+// this when the user passed an exception id under --apply-to=all so the
+// downstream truncation / PATCH goes to the master.
+func masterEventID(eventID string) string {
+	idx := strings.LastIndex(eventID, "_")
+	if idx <= 0 {
+		return eventID
+	}
+	return eventID[:idx] + "_0"
+}
+
+// eventLocation returns the IANA timezone declared on the event (start_time
+// preferred, end_time as fallback), or time.UTC when the field is missing or
+// unrecognised. Used for all-day boundary math and pivot-day UNTIL cutoff.
+func eventLocation(event *calendarEvent) *time.Location {
+	if event == nil {
+		return time.Local
+	}
+	tz := ""
+	if event.StartTime != nil {
+		tz = event.StartTime.Timezone
+	}
+	if tz == "" && event.EndTime != nil {
+		tz = event.EndTime.Timezone
+	}
+	if tz == "" {
+		return time.Local
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return time.Local
+	}
+	return loc
+}
+
+// isAllDayEvent reports whether the event is stored as an all-day event: the
+// API returns `date` (YYYY-MM-DD) without `timestamp` for both endpoints.
+func isAllDayEvent(event *calendarEvent) bool {
+	if event == nil || event.StartTime == nil {
+		return false
+	}
+	return event.StartTime.Date != "" && event.StartTime.Timestamp == ""
+}
+
+// masterStartUnix returns the unix second at 00:00 of the master's start day,
+// interpreted in the event's own timezone. Used as the exception-scan window's
+// lower bound: pinning to day-midnight (rather than the raw start timestamp)
+// keeps the window aligned with how downstream logic — pivotDayMidnight for
+// this-and-following truncation, and /instances originalTime probes — thinks
+// about a "day" in the event's timezone, and can only widen the scan (an
+// exception can never sit before the master's day anyway).
+//
+// Timed events: shift the stored timestamp back to that day's midnight in the
+// event's timezone. All-day events: parse `date` in the event's timezone
+// (Lark's `date` is a wall-clock day, not a UTC instant).
+func masterStartUnix(master *calendarEvent) (int64, error) {
+	if master == nil || master.StartTime == nil {
+		return 0, errs.NewInternalError(errs.SubtypeInvalidResponse,
+			"missing start_time on the recurring master event")
+	}
+	loc := eventLocation(master)
+	if ts := master.StartTime.Timestamp; ts != "" {
+		n, err := strconv.ParseInt(ts, 10, 64)
+		if err != nil || n <= 0 {
+			return 0, errs.NewInternalError(errs.SubtypeInvalidResponse,
+				"invalid start_time.timestamp %q on the recurring master event", ts)
+		}
+		t := time.Unix(n, 0).In(loc)
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc).Unix(), nil
+	}
+	if date := master.StartTime.Date; date != "" {
+		t, err := time.ParseInLocation("2006-01-02", date, time.UTC)
+		if err != nil {
+			return 0, errs.NewInternalError(errs.SubtypeInvalidResponse,
+				"invalid all-day start_time.date %q on the recurring master event: %v", date, err)
+		}
+		return t.Unix(), nil
+	}
+	return 0, errs.NewInternalError(errs.SubtypeInvalidResponse,
+		"start_time on the recurring master event has neither timestamp nor date")
+}
+
+// recurringWindowFromMaster derives the exception scan window. Start is the
+// master's start-day midnight in the event's timezone (see masterStartUnix);
+// End is the master's UNTIL if the rrule has one, an approximation from
+// COUNT+INTERVAL/FREQ,
+// or start + 5 years.
+func recurringWindowFromMaster(master *calendarEvent, now time.Time) (recurringWindow, error) {
+	startSec, err := masterStartUnix(master)
+	if err != nil {
+		return recurringWindow{}, err
+	}
+	end := recurringEndFromRRule(master.Recurrence, startSec, now)
+	if end < startSec {
+		end = startSec
+	}
+	return recurringWindow{Start: startSec, End: end}, nil
+}
+
+const recurringDefaultHorizon = 5 * 365 * 24 * time.Hour
+
+// recurringEndFromRRule parses the rrule and returns a unix-seconds upper
+// bound for the last instance's end time. It errs on the side of being
+// generous (adds a small buffer) so an instance whose end sits exactly on the
+// boundary is still returned by /instances.
+func recurringEndFromRRule(rrule string, startSec int64, now time.Time) int64 {
+	upper := now.Add(recurringDefaultHorizon).Unix()
+	if rrule == "" {
+		return upper
+	}
+	// The API prefixes the rule with RRULE:; strip it before parsing.
+	rule := strings.TrimPrefix(strings.TrimSpace(rrule), "RRULE:")
+	parts := strings.Split(rule, ";")
+	kv := map[string]string{}
+	for _, p := range parts {
+		if eq := strings.IndexByte(p, '='); eq > 0 {
+			kv[strings.ToUpper(strings.TrimSpace(p[:eq]))] = strings.TrimSpace(p[eq+1:])
+		}
+	}
+	if until, ok := kv["UNTIL"]; ok {
+		if t, ok := parseRRuleUntil(until); ok {
+			// Add a day of slack so the query window includes the last instance
+			// regardless of the event duration.
+			return t.Add(24 * time.Hour).Unix()
+		}
+	}
+	if countStr, ok := kv["COUNT"]; ok {
+		if n, err := strconv.Atoi(countStr); err == nil && n > 0 {
+			interval := 1
+			if s, ok := kv["INTERVAL"]; ok {
+				if v, err := strconv.Atoi(s); err == nil && v > 0 {
+					interval = v
+				}
+			}
+			step := recurringFreqDuration(kv["FREQ"])
+			if step > 0 {
+				horizon := time.Unix(startSec, 0).Add(step * time.Duration(interval) * time.Duration(n+1))
+				h := horizon.Unix()
+				if h < upper {
+					return h
+				}
+			}
+		}
+	}
+	return upper
+}
+
+// parseRRuleUntil accepts the two RFC5545 UNTIL grammars we see in Lark
+// events: `20260901T090000Z` (UTC) and `20260901` (date-only). Everything
+// else falls back to (_, false).
+func parseRRuleUntil(v string) (time.Time, bool) {
+	v = strings.TrimSpace(v)
+	for _, layout := range []string{"20060102T150405Z", "20060102"} {
+		if t, err := time.ParseInLocation(layout, v, time.UTC); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func recurringFreqDuration(freq string) time.Duration {
+	switch strings.ToUpper(strings.TrimSpace(freq)) {
+	case "DAILY":
+		return 24 * time.Hour
+	case "WEEKLY":
+		return 7 * 24 * time.Hour
+	case "MONTHLY":
+		return 31 * 24 * time.Hour
+	case "YEARLY":
+		return 366 * 24 * time.Hour
+	}
+	return 0
+}
+
+// listExceptionsInWindow scans /events/:event_id/instances across the given
+// window in ≤ 1-year chunks (well below the API's 2-year cap) and returns
+// exceptions. When includeCancelled is false (default use: apply-to=all
+// non-time PATCH), cancelled exceptions are skipped — patching a cancelled row
+// would only revive noise. When includeCancelled is true (apply-to=all /
+// this-and-following exception cleanup, which reissue DELETE with
+// delete_exception=true), cancelled rows are also returned so the cleanup pass
+// can destroy the placeholder (mark it is_deleted=true) alongside the live
+// exceptions — otherwise the cancelled row would keep participating in
+// downstream series expansion.
+//
+// Note both states are soft deletions at the DB level: `cancelled` is a still-
+// valid business status (occurrence-subtracted placeholder), while
+// `is_deleted=true` means the exception has been destroyed and no longer
+// participates. The scan de-duplicates by event_id — page or chunk overlap can
+// otherwise surface the same exception twice — and enforces exceptionMaxCount
+// to protect against memory blowup.
+func listExceptionsInWindow(ctx context.Context, runtime *common.RuntimeContext, calendarID, masterID string, w recurringWindow, includeCancelled bool) ([]exceptionInstance, error) {
+	if w.End <= w.Start {
+		return nil, nil
+	}
+	const oneYearSec int64 = 365 * 24 * 60 * 60
+	seen := make(map[string]struct{})
+	var out []exceptionInstance
+	chunkStart := w.Start
+	for chunkStart < w.End {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		chunkEnd := chunkStart + oneYearSec
+		if chunkEnd > w.End {
+			chunkEnd = w.End
+		}
+		pageToken := ""
+		for {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			params := map[string]interface{}{
+				"start_time": strconv.FormatInt(chunkStart, 10),
+				"end_time":   strconv.FormatInt(chunkEnd, 10),
+				"page_size":  500,
+			}
+			if pageToken != "" {
+				params["page_token"] = pageToken
+			}
+			path := fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s/instances",
+				validate.EncodePathSegment(calendarID), validate.EncodePathSegment(masterID))
+			data, err := runtime.CallAPITyped("GET", path, params, nil)
+			if err != nil {
+				return nil, err
+			}
+			items, _ := data["items"].([]interface{})
+			for _, raw := range items {
+				item, _ := raw.(map[string]interface{})
+				if item == nil {
+					continue
+				}
+				isException, _ := item["is_exception"].(bool)
+				if !isException {
+					continue
+				}
+				status, _ := item["status"].(string)
+				if status == "cancelled" && !includeCancelled {
+					continue
+				}
+				eventID, _ := item["event_id"].(string)
+				if eventID == "" {
+					continue
+				}
+				if _, dup := seen[eventID]; dup {
+					continue
+				}
+				seen[eventID] = struct{}{}
+				var startSec int64
+				if st, ok := item["start_time"].(map[string]interface{}); ok {
+					if ts, _ := st["timestamp"].(string); ts != "" {
+						startSec, _ = strconv.ParseInt(ts, 10, 64)
+					}
+				}
+				if startSec == 0 {
+					if ot, ok := parseInstanceOriginalTime(eventID); ok {
+						startSec = ot
+					}
+				}
+				out = append(out, exceptionInstance{EventID: eventID, StartUnix: startSec})
+				if len(out) > exceptionMaxCount {
+					return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition,
+						"this recurring series has more than %d exceptions; refuse to load them all into memory. Narrow --apply-to or clean up exceptions incrementally", exceptionMaxCount).
+						WithParam("--" + flagApplyTo)
+				}
+			}
+			pageToken, _ = data["page_token"].(string)
+			hasMore, _ := data["has_more"].(bool)
+			if !hasMore || pageToken == "" {
+				break
+			}
+		}
+		chunkStart = chunkEnd + 1
+	}
+	return out, nil
+}
+
+// splitFutureThenPast partitions exceptions into a future-first pair
+// (relative to nowSec) and sorts each half for predictable processing:
+// future ascending (near-term first), past descending (recent past first).
+func splitFutureThenPast(items []exceptionInstance, nowSec int64) (future, past []exceptionInstance) {
+	future = make([]exceptionInstance, 0, len(items))
+	past = make([]exceptionInstance, 0, len(items))
+	for _, it := range items {
+		if it.StartUnix >= nowSec {
+			future = append(future, it)
+		} else {
+			past = append(past, it)
+		}
+	}
+	sort.SliceStable(future, func(i, j int) bool { return future[i].StartUnix < future[j].StartUnix })
+	sort.SliceStable(past, func(i, j int) bool { return past[i].StartUnix > past[j].StartUnix })
+	return future, past
+}
+
+// filterOnOrAfter returns items whose StartUnix is >= pivot, sorted ascending
+// so callers process the earliest post-pivot exception first.
+func filterOnOrAfter(items []exceptionInstance, pivot int64) []exceptionInstance {
+	out := make([]exceptionInstance, 0, len(items))
+	for _, it := range items {
+		if it.StartUnix >= pivot {
+			out = append(out, it)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].StartUnix < out[j].StartUnix })
+	return out
+}
+
+// exceptionOperationFailure is the per-item error record collected by
+// exceptionWorker. Callers surface it in the JSON result so a partial failure
+// is machine-readable and the user can retry the specific ids.
+type exceptionOperationFailure struct {
+	EventID string `json:"event_id"`
+	Error   string `json:"error"`
+}
+
+// exceptionWorker orchestrates concurrent per-exception work with a 3-way
+// worker pool, rate-limit retry, and a 2s progress ticker. It does NOT
+// short-circuit on failure: a failing exception is recorded via Failures()
+// and the rest of the batch keeps running, matching the requirement that
+// per-item failures should not block later exceptions from being processed.
+type exceptionWorker struct {
+	Concurrency int
+	Runtime     *common.RuntimeContext
+	Label       string // e.g. "[calendar +delete]"
+	Total       int
+	Do          func(ctx context.Context, ex exceptionInstance) error
+
+	processed atomic.Int64
+	failed    atomic.Int64
+
+	mu       sync.Mutex
+	failures []exceptionOperationFailure
+}
+
+// exceptionRetryBudget is the max retries per exception when the API returns
+// a rate-limit / concurrency code.
+const (
+	exceptionRetryBudget      = 5
+	exceptionRetryInitialWait = 500 * time.Millisecond
+	exceptionRetryMaxWait     = 10 * time.Second
+)
+
+// isRateLimitedAPIError returns true when the API classified the failure as
+// rate-limit (99991400) or when the calendar-side codes 190004 / 190005 /
+// 190010 surface unclassified through the raw APIError.Code.
+func isRateLimitedAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errs.IsRetryable(err) {
+		if p, ok := errs.ProblemOf(err); ok && p.Subtype == errs.SubtypeRateLimit {
+			return true
+		}
+	}
+	var ae *errs.APIError
+	if errors.As(err, &ae) {
+		switch ae.Code {
+		case 190004, 190005, 190010:
+			return true
+		}
+	}
+	return false
+}
+
+// backoffWait returns exponential + jitter (bounded by exceptionRetryMaxWait)
+// for the given attempt (0-indexed).
+func backoffWait(attempt int) time.Duration {
+	d := exceptionRetryInitialWait << attempt
+	if d > exceptionRetryMaxWait {
+		d = exceptionRetryMaxWait
+	}
+	// Add up to 20% jitter so N workers waking together do not all retry in
+	// lock-step and trip the same limiter window again.
+	jitter := time.Duration(rand.Int63n(int64(d) / 5)) //nolint:gosec // jitter randomness only
+	return d + jitter
+}
+
+// Run consumes the given exception slice. It always processes every item —
+// per-item failures are recorded in w.failures and reported afterward by the
+// caller via Failures(). The only ways Run returns a non-nil error are
+// context cancellation or a developer error (Do not set).
+func (w *exceptionWorker) Run(ctx context.Context, items []exceptionInstance) error {
+	if w.Concurrency <= 0 {
+		w.Concurrency = 3
+	}
+	if w.Do == nil {
+		return errs.NewInternalError(errs.SubtypeUnknown, "exceptionWorker.Do not set")
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	tickerStop := w.startProgressTicker(ctx)
+	defer tickerStop()
+
+	sem := make(chan struct{}, w.Concurrency)
+	var wg sync.WaitGroup
+
+	for _, ex := range items {
+		if err := ctx.Err(); err != nil {
+			wg.Wait()
+			return err
+		}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return ctx.Err()
+		}
+		wg.Add(1)
+		go func(ex exceptionInstance) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := w.runOne(ctx, ex); err != nil {
+				w.failed.Add(1)
+				w.recordFailure(ex.EventID, err)
+				return
+			}
+			w.processed.Add(1)
+		}(ex)
+	}
+	wg.Wait()
+	return nil
+}
+
+// recordFailure stores the (id, message) pair so callers can surface the
+// per-item outcomes after the whole batch finishes.
+func (w *exceptionWorker) recordFailure(id string, err error) {
+	msg := err.Error()
+	if m := unwrapCalendarAPIError(err); m != "" {
+		msg = m
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.failures = append(w.failures, exceptionOperationFailure{EventID: id, Error: msg})
+}
+
+// Failures returns a copy of per-item failures collected during Run so the
+// caller can serialise them into the JSON result without holding the mutex.
+func (w *exceptionWorker) Failures() []exceptionOperationFailure {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]exceptionOperationFailure, len(w.failures))
+	copy(out, w.failures)
+	return out
+}
+
+// runOne calls Do with rate-limit retry. Any non-rate-limit failure is
+// returned immediately; a rate-limit failure sleeps with exponential
+// backoff (respecting Retry-After when the API provided one) and retries up
+// to exceptionRetryBudget times.
+func (w *exceptionWorker) runOne(ctx context.Context, ex exceptionInstance) error {
+	var lastErr error
+	for attempt := 0; attempt <= exceptionRetryBudget; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := w.Do(ctx, ex)
+		if err == nil {
+			return nil
+		}
+		if !isRateLimitedAPIError(err) {
+			return err
+		}
+		lastErr = err
+		if attempt == exceptionRetryBudget {
+			break
+		}
+		wait := backoffWait(attempt)
+		if server, ok := errs.RetryAfter(err); ok && server > wait {
+			wait = server
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return lastErr
+}
+
+// startProgressTicker prints one status line to stderr every 2 seconds until
+// the returned stop function is called (typically from `defer`). It never
+// panics or blocks the worker.
+func (w *exceptionWorker) startProgressTicker(ctx context.Context) func() {
+	if w.Runtime == nil || w.Runtime.IO() == nil {
+		return func() {}
+	}
+	out := w.Runtime.IO().ErrOut
+	if out == nil {
+		return func() {}
+	}
+	ticker := time.NewTicker(2 * time.Second)
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-ticker.C:
+				w.writeProgress(out)
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
+}
+
+func (w *exceptionWorker) writeProgress(out io.Writer) {
+	processed := w.processed.Load()
+	failed := w.failed.Load()
+	fmt.Fprintf(out, "%s progress: %d/%d exceptions processed (%d failed)\n",
+		w.Label, processed+failed, w.Total, failed)
+}
+
+// finalSummary writes a one-line completion notice used by callers after Run
+// returns. Kept separate so callers control whether to emit success or
+// failure text.
+func (w *exceptionWorker) finalSummary(out io.Writer, verb string) {
+	processed := w.processed.Load()
+	failed := w.failed.Load()
+	fmt.Fprintf(out, "%s %s %d exception(s) (%d failed)\n",
+		w.Label, verb, processed+failed, failed)
+}
+
+// deleteEventOnce issues a DELETE for one calendar event.
+//
+//   - notify controls need_notification (whether attendees are notified).
+//   - deleteException controls the new delete_exception query flag. Both values
+//     are soft deletions at the DB level; the difference is business state:
+//     false (default): the API marks the exception as `cancelled`. That is a
+//     still-valid business status — the row is kept as a data point so it can
+//     be subtracted from the recurring series when re-computing occurrences
+//     downstream.
+//     true: the API marks the exception as destroyed (is_deleted=true). Used
+//     by +delete / +update paths that intentionally clear exceptions ahead of
+//     a series-wide operation, where a cancelled placeholder would only add
+//     noise to a subsequent series-view.
+//
+// Callers deleting the user-facing target (a normal event, an exception the
+// caller pointed at, or the master itself) must pass deleteException=false;
+// only the exception-cleanup passes inside apply-to=all / this-and-following
+// pass true.
+//
+// A 193003 ("event is deleted") response is treated as success: the target has
+// already been destroyed on the server, which is the outcome the caller asked
+// for. This makes the batch idempotent under concurrent or repeated runs.
+func deleteEventOnce(runtime *common.RuntimeContext, calendarID, eventID string, notify, deleteException bool) error {
+	params := map[string]interface{}{"need_notification": notify}
+	if deleteException {
+		params["delete_exception"] = true
+	}
+	_, err := runtime.CallAPITyped("DELETE",
+		fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s",
+			validate.EncodePathSegment(calendarID), validate.EncodePathSegment(eventID)),
+		params, nil)
+	if isEventAlreadyDeleted(err) {
+		return nil
+	}
+	return err
+}
+
+// isEventAlreadyDeleted reports whether err is a calendar 193003 ("event is
+// deleted") API error. The server has already destroyed the target, which is
+// exactly what the caller asked for — the exception-cleanup and master-delete
+// paths treat it as success so a racing / repeated cleanup does not fail the
+// batch.
+func isEventAlreadyDeleted(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		return false
+	}
+	return ae.Code == 193003
+}
+
+// truncateRecurrenceUntil rewrites a Lark RRULE's UNTIL to the given time
+// (formatted UTC, RFC5545 "YYYYMMDDThhmmssZ"). It appends UNTIL if none
+// exists, or replaces the existing UNTIL / COUNT clauses (they are mutually
+// exclusive in RFC5545).
+func truncateRecurrenceUntil(rrule string, until time.Time) string {
+	body := strings.TrimSpace(rrule)
+	prefix := ""
+	if strings.HasPrefix(body, "RRULE:") {
+		prefix = "RRULE:"
+		body = strings.TrimPrefix(body, "RRULE:")
+	}
+	newUntil := "UNTIL=" + until.UTC().Format("20060102T150405Z")
+	var kept []string
+	replaced := false
+	for _, part := range strings.Split(body, ";") {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		up := strings.ToUpper(p)
+		if strings.HasPrefix(up, "UNTIL=") {
+			if !replaced {
+				kept = append(kept, newUntil)
+				replaced = true
+			}
+			continue
+		}
+		if strings.HasPrefix(up, "COUNT=") {
+			// UNTIL and COUNT are mutually exclusive per RFC5545; drop COUNT.
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if !replaced {
+		kept = append(kept, newUntil)
+	}
+	return prefix + strings.Join(kept, ";")
+}
+
+// pivotDayMidnight returns midnight (00:00:00) of the calendar day that
+// pivotUnix lands on, interpreted in the event's timezone. Used both as the
+// UNTIL cutoff for a this-and-following truncation ("stop the series just
+// before the pivot day starts") and as the exception-scan lower bound.
+func pivotDayMidnight(pivotUnix int64, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.Local
+	}
+	t := time.Unix(pivotUnix, 0).In(loc)
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc).Add(-time.Second)
+}
+
+// formatPivotDatetime renders pivotUnix as an RFC3339 string in the event's
+// timezone so log lines are human-readable ("2026-03-20T09:00:00+08:00")
+// alongside the raw unix seconds.
+func formatPivotDatetime(pivotUnix int64, loc *time.Location) string {
+	if loc == nil {
+		loc = time.Local
+	}
+	return time.Unix(pivotUnix, 0).In(loc).Format(time.RFC3339)
+}

--- a/shortcuts/calendar/calendar_recurring_test.go
+++ b/shortcuts/calendar/calendar_recurring_test.go
@@ -1,0 +1,1164 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// ---------------------------------------------------------------------------
+// looksLikeRecurringEventID
+// ---------------------------------------------------------------------------
+
+func TestHasStandardEventIDShape(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"", false},
+		{"evt_plain", false},
+		{"evt_update1", false},
+		{"uid_0", true},
+		{"uid_1742515200", true},
+		{"75d28f9b-e35c-4230-8a83-4a661497db54_0", true},
+		{"75d28f9b-e35c-4230-8a83-4a661497db54_1602504000", true},
+	}
+	for _, tc := range cases {
+		if got := hasStandardEventIDShape(tc.id); got != tc.want {
+			t.Errorf("hasStandardEventIDShape(%q) = %v, want %v", tc.id, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseInstanceOriginalTime
+// ---------------------------------------------------------------------------
+
+func TestParseInstanceOriginalTime(t *testing.T) {
+	if v, ok := parseInstanceOriginalTime("uid_0"); ok || v != 0 {
+		t.Errorf("uid_0 should be (0,false), got (%d,%v)", v, ok)
+	}
+	if v, ok := parseInstanceOriginalTime("uid_1742515200"); !ok || v != 1742515200 {
+		t.Errorf("uid_1742515200 => (%d,%v)", v, ok)
+	}
+	if _, ok := parseInstanceOriginalTime("noise"); ok {
+		t.Error("noise should be false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// truncateRecurrenceUntil / inheritRRuleForFollowing
+// ---------------------------------------------------------------------------
+
+func TestTruncateRecurrenceUntil(t *testing.T) {
+	pivot := time.Date(2026, 3, 20, 8, 0, 0, 0, time.UTC)
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"FREQ=WEEKLY;BYDAY=MO", "FREQ=WEEKLY;BYDAY=MO;UNTIL=20260320T080000Z"},
+		{"FREQ=WEEKLY;COUNT=10", "FREQ=WEEKLY;UNTIL=20260320T080000Z"},
+		{"FREQ=WEEKLY;UNTIL=20250101T000000Z", "FREQ=WEEKLY;UNTIL=20260320T080000Z"},
+		{"RRULE:FREQ=DAILY;INTERVAL=2", "RRULE:FREQ=DAILY;INTERVAL=2;UNTIL=20260320T080000Z"},
+	}
+	for _, tc := range cases {
+		got := truncateRecurrenceUntil(tc.in, pivot)
+		if got != tc.want {
+			t.Errorf("truncateRecurrenceUntil(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestInheritRRuleForFollowing(t *testing.T) {
+	// UNTIL is retained (fixed wall-clock cutoff copies cleanly); COUNT is
+	// dropped (occurrence count relative to old dtstart is meaningless for a
+	// new pivot). Every other segment (FREQ, INTERVAL, BYDAY...) passes
+	// through untouched.
+	cases := map[string]string{
+		"FREQ=WEEKLY":                        "FREQ=WEEKLY",
+		"FREQ=WEEKLY;COUNT=10":               "FREQ=WEEKLY",
+		"FREQ=WEEKLY;UNTIL=20260901T000000Z": "FREQ=WEEKLY;UNTIL=20260901T000000Z",
+		"RRULE:FREQ=WEEKLY;UNTIL=20260901T000000Z;COUNT=5;BYDAY=MO": "RRULE:FREQ=WEEKLY;UNTIL=20260901T000000Z;BYDAY=MO",
+	}
+	for in, want := range cases {
+		if got := inheritRRuleForFollowing(in); got != want {
+			t.Errorf("inheritRRuleForFollowing(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// recurringWindowFromMaster
+// ---------------------------------------------------------------------------
+
+func TestRecurringWindowFromMaster_OpenEndedFallsBackTo5Years(t *testing.T) {
+	now := time.Date(2026, 8, 26, 0, 0, 0, 0, time.UTC)
+	master := &calendarEvent{
+		StartTime:  &calendarEventTime{Timestamp: "1500000000", Timezone: "UTC"},
+		Recurrence: "FREQ=WEEKLY",
+	}
+	w, err := recurringWindowFromMaster(master, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1500000000 = 2017-07-14T02:40:00Z; masterStartUnix rolls back to the
+	// event-timezone day midnight (UTC 2017-07-14T00:00:00Z = 1499990400).
+	if w.Start != 1499990400 {
+		t.Errorf("start=%d, want 1499990400 (UTC midnight of 2017-07-14)", w.Start)
+	}
+	// end should be now + ~5 years
+	fiveYearsLater := now.Add(5 * 365 * 24 * time.Hour).Unix()
+	if w.End < fiveYearsLater-time.Hour.Milliseconds() || w.End > fiveYearsLater+time.Hour.Milliseconds() {
+		// approximate check (5y default)
+		if w.End < now.Add(4*365*24*time.Hour).Unix() {
+			t.Errorf("end=%d unexpectedly low", w.End)
+		}
+	}
+}
+
+func TestRecurringWindowFromMaster_AllDayStart_ParsedInUTC(t *testing.T) {
+	// All-day master: start_time carries date only. Lark's `date` is treated
+	// as a UTC wall-clock day.
+	now := time.Date(2026, 8, 26, 0, 0, 0, 0, time.UTC)
+	master := &calendarEvent{
+		StartTime:  &calendarEventTime{Date: "2026-03-01", Timezone: "Asia/Shanghai"},
+		Recurrence: "FREQ=DAILY;UNTIL=20260305T000000Z",
+	}
+	w, err := recurringWindowFromMaster(master, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Unix()
+	if w.Start != want {
+		t.Errorf("start=%d, want %d (UTC midnight of 2026-03-01)", w.Start, want)
+	}
+}
+
+func TestPivotDayMidnight_UsesEventTimezone(t *testing.T) {
+	// A pivot at 2026-03-20T02:00:00Z is 10:00 Asia/Shanghai; the function
+	// returns "one second before that day's Shanghai midnight" — the shape
+	// truncateRecurrenceUntil consumes as UNTIL ("stop the series just before
+	// the pivot day starts"), reused as the exception-scan lower bound.
+	loc, _ := time.LoadLocation("Asia/Shanghai")
+	pivot := time.Date(2026, 3, 20, 2, 0, 0, 0, time.UTC).Unix()
+	got := pivotDayMidnight(pivot, loc)
+	want := time.Date(2026, 3, 20, 0, 0, 0, 0, loc).Add(-time.Second)
+	if !got.Equal(want) {
+		t.Errorf("midnight=%s, want %s", got, want)
+	}
+}
+
+func TestFormatPivotDatetime_UsesEventTimezone(t *testing.T) {
+	loc, _ := time.LoadLocation("Asia/Shanghai")
+	pivot := time.Date(2026, 3, 20, 2, 0, 0, 0, time.UTC).Unix()
+	got := formatPivotDatetime(pivot, loc)
+	if got != "2026-03-20T10:00:00+08:00" {
+		t.Errorf("got %q, want 2026-03-20T10:00:00+08:00", got)
+	}
+}
+
+func TestListExceptionsInWindow_Dedupes(t *testing.T) {
+	// Emulate two page hits returning the same exception id — the second copy
+	// must be dropped.
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_0/instances",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id": "uid_100", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "100"},
+					},
+					map[string]interface{}{
+						"event_id": "uid_100", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "100"},
+					},
+					map[string]interface{}{
+						"event_id": "uid_200", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "200"},
+					},
+				},
+			},
+		},
+	})
+	rt := common.TestNewRuntimeContextForAPI(context.Background(), &cobra.Command{Use: "test"}, defaultConfig(), f, core.AsBot)
+	warmTokenCache(t)
+	got, err := listExceptionsInWindow(context.Background(), rt, "cal_r", "uid_0",
+		recurringWindow{Start: 0, End: 1000}, false)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len=%d ids=%v; want 2 (duplicate uid_100 must be dropped)", len(got), got)
+	}
+}
+
+func TestRecurringWindowFromMaster_UntilRespected(t *testing.T) {
+	now := time.Date(2026, 8, 26, 0, 0, 0, 0, time.UTC)
+	master := &calendarEvent{
+		StartTime:  &calendarEventTime{Timestamp: "1500000000"},
+		Recurrence: "FREQ=WEEKLY;UNTIL=20260401T000000Z",
+	}
+	w, err := recurringWindowFromMaster(master, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// UNTIL 2026-04-01 + 1 day slack → 2026-04-02.
+	want := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC).Unix()
+	if w.End != want {
+		t.Errorf("end=%d, want %d", w.End, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// splitFutureThenPast / filterOnOrAfter
+// ---------------------------------------------------------------------------
+
+func TestSplitFutureThenPast_SortsFutureAscPastDesc(t *testing.T) {
+	// Purposefully unsorted input: future should come back ascending,
+	// past should come back descending.
+	items := []exceptionInstance{
+		{EventID: "c", StartUnix: 300},
+		{EventID: "a", StartUnix: 100},
+		{EventID: "d", StartUnix: 400},
+		{EventID: "b", StartUnix: 200},
+		{EventID: "z", StartUnix: 50},
+	}
+	f, p := splitFutureThenPast(items, 200)
+	if len(f) != 3 || f[0].EventID != "b" || f[1].EventID != "c" || f[2].EventID != "d" {
+		t.Errorf("future=%v; want [b c d] ascending", f)
+	}
+	if len(p) != 2 || p[0].EventID != "a" || p[1].EventID != "z" {
+		t.Errorf("past=%v; want [a z] descending (100, 50)", p)
+	}
+}
+
+func TestFilterOnOrAfter_SortsAscending(t *testing.T) {
+	items := []exceptionInstance{{StartUnix: 300}, {StartUnix: 100}, {StartUnix: 200}}
+	got := filterOnOrAfter(items, 150)
+	if len(got) != 2 || got[0].StartUnix != 200 || got[1].StartUnix != 300 {
+		t.Errorf("got=%v; want [200 300] ascending", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// exceptionWorker: rate-limit retry & fail-fast
+// ---------------------------------------------------------------------------
+
+// makeIORuntime returns a minimal RuntimeContext with only the IO plumbing
+// wired — enough for exceptionWorker's progress ticker without dragging in
+// APIClient / token resolution.
+func makeIORuntime(t *testing.T) *common.RuntimeContext {
+	t.Helper()
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	return common.TestNewRuntimeContextForAPI(context.Background(), &cobra.Command{Use: "test"}, defaultConfig(), f, core.AsBot)
+}
+
+func TestExceptionWorker_RetriesOnRateLimit(t *testing.T) {
+	rt := makeIORuntime(t)
+
+	var calls atomic.Int32
+	worker := &exceptionWorker{
+		Concurrency: 1,
+		Runtime:     rt,
+		Label:       "[test]",
+		Total:       1,
+		Do: func(_ context.Context, _ exceptionInstance) error {
+			n := calls.Add(1)
+			if n < 3 {
+				return errs.NewAPIError(errs.SubtypeRateLimit, "slow").WithCode(190004).WithRetryable()
+			}
+			return nil
+		},
+	}
+	if err := worker.Run(context.Background(), []exceptionInstance{{EventID: "e1"}}); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if calls.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls.Load())
+	}
+}
+
+func TestExceptionWorker_ContinuesAfterFailure(t *testing.T) {
+	rt := makeIORuntime(t)
+
+	worker := &exceptionWorker{
+		Concurrency: 1,
+		Runtime:     rt,
+		Label:       "[test]",
+		Total:       2,
+		Do: func(_ context.Context, ex exceptionInstance) error {
+			if ex.EventID == "e1" {
+				return errs.NewAPIError(errs.SubtypeInvalidParameters, "boom").WithCode(190002)
+			}
+			return nil
+		},
+	}
+	if err := worker.Run(context.Background(), []exceptionInstance{{EventID: "e1"}, {EventID: "e2"}}); err != nil {
+		t.Fatalf("Run should not return per-item errors, got %v", err)
+	}
+	if worker.processed.Load() != 1 || worker.failed.Load() != 1 {
+		t.Errorf("processed=%d failed=%d, want 1/1", worker.processed.Load(), worker.failed.Load())
+	}
+	failures := worker.Failures()
+	if len(failures) != 1 || failures[0].EventID != "e1" {
+		t.Errorf("failures = %+v, want single record for e1", failures)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// +delete: dry-run, normal (non-recurring) fast path, apply-to enforcement
+// ---------------------------------------------------------------------------
+
+// A properly-shaped normal-event id ({uid}_0 with no recurrence field on the
+// server response) is classified after one GET and then deleted; the total
+// wire traffic is exactly one GET plus one DELETE.
+func TestDelete_Normal_PreFetchesThenDeletes(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// GET the event: no recurrence, so classifyRecurringEvent returns
+	// recurringKindNormal and --apply-to defaults to single.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test/events/uid_normal_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_normal_0",
+				"summary":    "One-off",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	stub := &httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test/events/uid_normal_0",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
+	}
+	reg.Register(stub)
+
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete",
+		"--event-id", "uid_normal_0",
+		"--calendar-id", "cal_test",
+		"--yes", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "uid_normal_0") {
+		t.Errorf("stdout should contain event id, got: %s", stdout.String())
+	}
+}
+
+// A malformed event id (no `_{digits}` suffix) is rejected up front with a
+// typed validation error; no HTTP calls are attempted.
+func TestDelete_MalformedEventID_Rejected(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete",
+		"--event-id", "evt_plain",
+		"--calendar-id", "cal_test",
+		"--yes", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error for malformed event id")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--event-id" {
+		t.Errorf("param=%q, want --event-id", ve.Param)
+	}
+}
+
+func TestDelete_Recurring_MissingApplyTo_Rejected(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// GET on the id: server says it's a recurring master.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test/events/uid_master_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"event": map[string]interface{}{
+					"event_id":   "uid_master_0",
+					"summary":    "Weekly",
+					"start_time": map[string]interface{}{"timestamp": "1742515200"},
+					"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+					"recurrence": "FREQ=WEEKLY",
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete",
+		"--event-id", "uid_master_0",
+		"--calendar-id", "cal_test",
+		"--yes", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error for missing --apply-to")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--"+flagApplyTo {
+		t.Errorf("param=%q, want --%s", ve.Param, flagApplyTo)
+	}
+}
+
+func TestDelete_Recurring_ApplyToSingleOnMaster_Rejected(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test/events/uid_master_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_master_0",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+				"recurrence": "FREQ=WEEKLY",
+			}},
+		},
+	})
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_master_0", "--calendar-id", "cal_test",
+		"--apply-to", "single", "--yes", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error for --apply-to=single on master id")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("got %T", err)
+	}
+	if ve.Param != "--"+flagApplyTo {
+		t.Errorf("param=%q", ve.Param)
+	}
+}
+
+func TestDelete_Exception_ApplyToThisAndFollowing_Rejected(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test/events/uid_1742515200",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":     "uid_1742515200",
+				"is_exception": true,
+				"start_time":   map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":     map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_1742515200", "--calendar-id", "cal_test",
+		"--apply-to", "this-and-following", "--yes", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected validation error for --apply-to=this-and-following on exception")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("got %T", err)
+	}
+}
+
+func TestDelete_ApplyToAll_DryRunLists4Steps(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_master_0", "--calendar-id", "cal_test",
+		"--apply-to", "all", "--dry-run", "--yes", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := stdout.String()
+	// Sanity: exception deletion step and master deletion step both appear.
+	for _, want := range []string{"instances", "exception", "master"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run should mention %q, got: %s", want, out)
+		}
+	}
+}
+
+func TestDelete_InvalidApplyToValue(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_0", "--apply-to", "everything", "--yes", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected invalid value error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("got %T", err)
+	}
+	if ve.Param != "--"+flagApplyTo {
+		t.Errorf("param=%q", ve.Param)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// +delete: full apply-to=all flow (GET → instances → DELETE exception → DELETE master)
+// ---------------------------------------------------------------------------
+
+func TestDelete_ApplyToAll_DeletesExceptionsThenMaster(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// GET master.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"recurrence": "FREQ=WEEKLY;UNTIL=20260901T000000Z",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	// /instances returns two confirmed and one cancelled exception. All three
+	// are deleted: apply-to=all runs the delete_exception=true cleanup path,
+	// which destroys cancelled placeholders (is_deleted=true) alongside live
+	// rows so the series is fully cleared.
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_0/instances",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id": "uid_1742600000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742600000"},
+					},
+					map[string]interface{}{
+						"event_id": "uid_1742700000", "is_exception": true, "status": "cancelled",
+						"start_time": map[string]interface{}{"timestamp": "1742700000"},
+					},
+					map[string]interface{}{
+						"event_id": "uid_1742800000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742800000"},
+					},
+				},
+			},
+		},
+	})
+	// Exception deletes (reusable — url matches all three exception ids).
+	deleteEx := &httpmock.Stub{
+		Method:   "DELETE",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_174",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 0, "msg": "ok"},
+	}
+	reg.Register(deleteEx)
+	// Master delete.
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+	})
+
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_0", "--calendar-id", "cal_r",
+		"--apply-to", "all", "--yes", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal stdout: %v; raw=%s", err, stdout.String())
+	}
+	data, _ := out["data"].(map[string]interface{})
+	deletedEvent, _ := data["deleted_event"].(map[string]interface{})
+	if deletedEvent["action"] != "deleted" {
+		t.Errorf("deleted_event.action = %v", deletedEvent["action"])
+	}
+	exceptions, _ := data["exceptions"].(map[string]interface{})
+	if v, _ := exceptions["deleted"].(float64); int(v) != 3 {
+		t.Errorf("exceptions.deleted = %v, want 3 (cancelled placeholders are destroyed too)", exceptions["deleted"])
+	}
+	// All three exception DELETEs were captured.
+	if len(deleteEx.CapturedBodies) != 3 {
+		t.Errorf("expected 3 exception DELETEs, got %d", len(deleteEx.CapturedBodies))
+	}
+}
+
+// Exception-cleanup DELETEs (inside --apply-to=all) carry delete_exception=true
+// so the API destroys the exception row (is_deleted=true); the master DELETE,
+// which is the user-facing target, must NOT carry that flag so downstream
+// series computations still see it as a normal terminal delete.
+func TestDelete_ApplyToAll_ExceptionDeletesUseDeleteExceptionFlag(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"recurrence": "FREQ=WEEKLY;UNTIL=20260901T000000Z",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_0/instances",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id": "uid_1742600000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742600000"},
+					},
+				},
+			},
+		},
+	})
+
+	var (
+		mu         sync.Mutex
+		exURLs     []string
+		masterURLs []string
+	)
+	// Exception DELETE — must include delete_exception=true.
+	reg.Register(&httpmock.Stub{
+		Method:   "DELETE",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_1742600000",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 0, "msg": "ok"},
+		OnMatch: func(req *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			exURLs = append(exURLs, req.URL.String())
+		},
+	})
+	// Master DELETE — user-facing target, must NOT include delete_exception.
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+		OnMatch: func(req *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			masterURLs = append(masterURLs, req.URL.String())
+		},
+	})
+
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_0", "--calendar-id", "cal_r",
+		"--apply-to", "all", "--yes", "--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if len(exURLs) != 1 {
+		t.Fatalf("expected 1 exception DELETE, got %d (urls=%v)", len(exURLs), exURLs)
+	}
+	if !strings.Contains(exURLs[0], "delete_exception=true") {
+		t.Errorf("exception DELETE must carry delete_exception=true, got url=%s", exURLs[0])
+	}
+	if len(masterURLs) != 1 {
+		t.Fatalf("expected 1 master DELETE, got %d (urls=%v)", len(masterURLs), masterURLs)
+	}
+	if strings.Contains(masterURLs[0], "delete_exception") {
+		t.Errorf("master DELETE must NOT carry delete_exception, got url=%s", masterURLs[0])
+	}
+}
+
+// The apply-to=all cleanup pass destroys exceptions (delete_exception=true →
+// is_deleted=true). cancelled exception rows are still occupying series-view
+// slots, so they must be scanned in and destroyed along with the confirmed
+// ones — otherwise a subsequent series-view would still see the cancelled
+// placeholder.
+func TestDelete_ApplyToAll_CancelledExceptionsAreAlsoDeleted(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"recurrence": "FREQ=WEEKLY;UNTIL=20260901T000000Z",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_0/instances",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id": "uid_1742600000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742600000"},
+					},
+					map[string]interface{}{
+						"event_id": "uid_1742700000", "is_exception": true, "status": "cancelled",
+						"start_time": map[string]interface{}{"timestamp": "1742700000"},
+					},
+				},
+			},
+		},
+	})
+
+	var (
+		mu         sync.Mutex
+		deletedIDs []string
+	)
+	captured := func(req *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		deletedIDs = append(deletedIDs, req.URL.Path)
+	}
+	reg.Register(&httpmock.Stub{
+		Method:   "DELETE",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_1742600000",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 0, "msg": "ok"},
+		OnMatch:  captured,
+	})
+	reg.Register(&httpmock.Stub{
+		Method:   "DELETE",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_1742700000",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 0, "msg": "ok"},
+		OnMatch:  captured,
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+	})
+
+	if err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_0", "--calendar-id", "cal_r",
+		"--apply-to", "all", "--yes", "--as", "bot",
+	}, f, nil); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if len(deletedIDs) != 2 {
+		t.Fatalf("expected 2 exception DELETEs (confirmed + cancelled), got %d: %v", len(deletedIDs), deletedIDs)
+	}
+	// Both ids must have been hit.
+	var sawConfirmed, sawCancelled bool
+	for _, p := range deletedIDs {
+		if strings.HasSuffix(p, "/uid_1742600000") {
+			sawConfirmed = true
+		}
+		if strings.HasSuffix(p, "/uid_1742700000") {
+			sawCancelled = true
+		}
+	}
+	if !sawConfirmed || !sawCancelled {
+		t.Errorf("cleanup must delete both confirmed and cancelled exceptions; got %v", deletedIDs)
+	}
+}
+
+// DELETE returning 193003 ("event is deleted") is idempotent from the CLI's
+// viewpoint — the row is already gone. deleteEventOnce swallows the error so
+// exception-cleanup batches and master-delete steps do not fail when the
+// target has been removed concurrently or on a previous run.
+func TestDelete_193003_TreatedAsSuccess(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// Normal (non-recurring) event so the flow goes single-delete.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	// The server returns 193003 — deleteEventOnce must treat this as success.
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body:   map[string]interface{}{"code": 193003, "msg": "event is deleted"},
+	})
+
+	if err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_0", "--calendar-id", "cal_r",
+		"--yes", "--as", "bot",
+	}, f, stdout); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal stdout: %v; raw=%s", err, stdout.String())
+	}
+	data, _ := out["data"].(map[string]interface{})
+	deleted, _ := data["deleted_event"].(map[string]interface{})
+	if deleted["action"] != "deleted" {
+		t.Errorf("deleted_event.action = %v, want deleted (193003 must be treated as success)", deleted["action"])
+	}
+}
+
+// Direct unit-level pin on isEventAlreadyDeleted so the classification stays
+// wired to APIError.Code == 193003 even if the surrounding call flow changes.
+func TestIsEventAlreadyDeleted(t *testing.T) {
+	if isEventAlreadyDeleted(nil) {
+		t.Error("nil err must not be reported as already-deleted")
+	}
+	if isEventAlreadyDeleted(errors.New("plain")) {
+		t.Error("non-APIError must not be reported as already-deleted")
+	}
+	if isEventAlreadyDeleted(errs.NewAPIError(errs.SubtypeNotFound, "gone").WithCode(193001)) {
+		t.Error("193001 (not found) must not be reported as already-deleted")
+	}
+	if !isEventAlreadyDeleted(errs.NewAPIError(errs.SubtypeNotFound, "gone").WithCode(193003)) {
+		t.Error("193003 must be reported as already-deleted")
+	}
+}
+
+// Regression: --apply-to=all with --start/--end that echo the master's stored
+// time must not push start_time/end_time onto the PATCH bodies. Prior to the
+// fix, buildCalendarUpdateEventData added start_time/end_time whenever the
+// flags were set, even though masterTimeChanged had already classified this as
+// a non-time change and taken the exception-PATCH branch. Every exception then
+// got rewritten to the master's first-instance time, collapsing the series.
+func TestUpdate_ApplyToAll_EchoedTime_DoesNotOverwriteExceptionTime(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// Master at ts=1742515200 / 1742518800, weekly rrule.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"recurrence": "FREQ=WEEKLY;UNTIL=20260901T000000Z",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	// One live exception at a different time — this is the row the bug would
+	// clobber back to the master's 1742515200.
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_0/instances",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id": "uid_1742600000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742600000"},
+					},
+				},
+			},
+		},
+	})
+	patchException := &httpmock.Stub{
+		Method:   "PATCH",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_1742600000",
+		Reusable: true,
+		Body: map[string]interface{}{"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "uid_1742600000"}}},
+	}
+	reg.Register(patchException)
+	patchMaster := &httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "uid_0"}}},
+	}
+	reg.Register(patchMaster)
+
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update", "--event-id", "uid_0", "--calendar-id", "cal_r",
+		"--apply-to", "all",
+		// Echo master's stored time — masterTimeChanged should return false.
+		"--start", "1742515200", "--end", "1742518800",
+		"--summary", "NEW",
+		"--skip-room-check", "--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	assertNoTimeFields := func(name string, raw []byte) {
+		var body map[string]interface{}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("%s: unmarshal body: %v; raw=%s", name, err, string(raw))
+		}
+		if _, ok := body["start_time"]; ok {
+			t.Errorf("%s PATCH must NOT carry start_time (echoed time = non-time change); body=%s", name, string(raw))
+		}
+		if _, ok := body["end_time"]; ok {
+			t.Errorf("%s PATCH must NOT carry end_time (echoed time = non-time change); body=%s", name, string(raw))
+		}
+		if got, _ := body["summary"].(string); got != "NEW" {
+			t.Errorf("%s PATCH should still carry summary=NEW, got %v", name, body["summary"])
+		}
+	}
+	if len(patchException.CapturedBodies) != 1 {
+		t.Fatalf("expected 1 exception PATCH, got %d", len(patchException.CapturedBodies))
+	}
+	assertNoTimeFields("exception", patchException.CapturedBodies[0])
+	assertNoTimeFields("master", patchMaster.CapturedBody)
+}
+
+// Sanity: a real time change (different --start/--end) still triggers the
+// exception-deletion branch, so no exception PATCH goes out and the master
+// PATCH carries the new start_time/end_time.
+func TestUpdate_ApplyToAll_RealTimeChange_DeletesExceptionsAndPatchesMasterTime(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"recurrence": "FREQ=WEEKLY;UNTIL=20260901T000000Z",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_0/instances",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id": "uid_1742600000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742600000"},
+					},
+				},
+			},
+		},
+	})
+	// Time change → the exception gets DELETEd, not PATCHed.
+	reg.Register(&httpmock.Stub{
+		Method:   "DELETE",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_1742600000",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 0, "msg": "ok"},
+	})
+	patchMaster := &httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "uid_0"}}},
+	}
+	reg.Register(patchMaster)
+
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update", "--event-id", "uid_0", "--calendar-id", "cal_r",
+		"--apply-to", "all",
+		"--start", "1742600000", "--end", "1742603600",
+		"--skip-room-check", "--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(patchMaster.CapturedBody, &body); err != nil {
+		t.Fatalf("master PATCH body: %v", err)
+	}
+	st, _ := body["start_time"].(map[string]interface{})
+	if got, _ := st["timestamp"].(string); got != "1742600000" {
+		t.Errorf("real time change: master PATCH start_time.timestamp = %v, want 1742600000", st)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// +delete: this-and-following truncates rrule with UNTIL = pivot-1s
+// ---------------------------------------------------------------------------
+
+func TestDelete_ApplyToThisAndFollowing_TruncatesMaster(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// Pivot instance id contains original time 1742600000; the server returns
+	// it as a plain (non-exception) recurring instance, which our validator
+	// allows for --apply-to=this-and-following.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_1742600000",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_1742600000",
+				"start_time": map[string]interface{}{"timestamp": "1742600000"},
+				"end_time":   map[string]interface{}{"timestamp": "1742603600"},
+			}},
+		},
+	})
+	// Fetch master via masterEventID rewrite.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"recurrence": "FREQ=WEEKLY",
+				"start_time": map[string]interface{}{"timestamp": "1742500000"},
+				"end_time":   map[string]interface{}{"timestamp": "1742503600"},
+			}},
+		},
+	})
+	// instances returns two exceptions: one before pivot (ignored), one on/after
+	// pivot (deleted).
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_r/events/uid_0/instances",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id": "uid_1742500000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742500000"},
+					},
+					map[string]interface{}{
+						"event_id": "uid_1742600000", "is_exception": true, "status": "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742600000"},
+					},
+				},
+			},
+		},
+	})
+	// The one exception ≥ pivot gets DELETEd. Reusable+BodyFilter is not
+	// needed here because the shape of the URL is unambiguous — only this
+	// stub carries method=DELETE.
+	deleteEx := &httpmock.Stub{
+		Method:   "DELETE",
+		URL:      "cal_r/events/uid_1742600000",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 0, "msg": "ok"},
+	}
+	reg.Register(deleteEx)
+	// Master PATCH.
+	patchMaster := &httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/calendar/v4/calendars/cal_r/events/uid_0",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"event": map[string]interface{}{"event_id": "uid_0"}}},
+	}
+	reg.Register(patchMaster)
+
+	err := mountAndRun(t, CalendarDelete, []string{
+		"+delete", "--event-id", "uid_1742600000", "--calendar-id", "cal_r",
+		"--apply-to", "this-and-following", "--yes", "--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(patchMaster.CapturedBody, &body); err != nil {
+		t.Fatalf("patch body: %v", err)
+	}
+	rrule, _ := body["recurrence"].(string)
+	if !strings.Contains(rrule, "UNTIL=") {
+		t.Errorf("expected UNTIL in truncated rrule, got %q", rrule)
+	}
+	if len(deleteEx.CapturedBodies) == 0 {
+		t.Error("expected DELETE for the on/after-pivot exception")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// +update: apply-to enforcement mirrors +delete
+// ---------------------------------------------------------------------------
+
+func TestUpdate_Recurring_MissingApplyTo_Rejected(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test/events/uid_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"event": map[string]interface{}{
+				"event_id":   "uid_0",
+				"recurrence": "FREQ=WEEKLY",
+				"start_time": map[string]interface{}{"timestamp": "1742515200"},
+				"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+			}},
+		},
+	})
+
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update", "--event-id", "uid_0", "--calendar-id", "cal_test",
+		"--summary", "New", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected --apply-to validation error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("got %T", err)
+	}
+	if ve.Param != "--"+flagApplyTo {
+		t.Errorf("param=%q", ve.Param)
+	}
+}

--- a/shortcuts/calendar/calendar_room_find.go
+++ b/shortcuts/calendar/calendar_room_find.go
@@ -353,6 +353,11 @@ var CalendarRoomFind = common.Shortcut{
 		if minCapacity, maxCapacity := runtime.Int(flagMinCapacity), runtime.Int(flagMaxCapacity); minCapacity > 0 && maxCapacity > 0 && minCapacity > maxCapacity {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--min-capacity must be <= --max-capacity").WithParam("--min-capacity")
 		}
+		var tzInputs []calendarTimeInputRange
+		for _, raw := range runtime.StrArray(flagSlot) {
+			tzInputs = append(tzInputs, collectCalendarRangeInputs(flagSlot, raw)...)
+		}
+		warnCalendarTimezoneMismatch(runtime, tzInputs...)
 		return nil
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/calendar/calendar_search_event.go
+++ b/shortcuts/calendar/calendar_search_event.go
@@ -195,6 +195,10 @@ var CalendarSearchEvent = common.Shortcut{
 		if _, err := common.ValidatePageSizeTyped(runtime, "page-size", defaultSearchEventPageSize, 1, maxSearchEventPageSize); err != nil {
 			return err
 		}
+		warnCalendarTimezoneMismatch(runtime,
+			calendarTimeInputRange{Flag: "start", Value: runtime.Str("start")},
+			calendarTimeInputRange{Flag: "end", Value: runtime.Str("end")},
+		)
 		return nil
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {

--- a/shortcuts/calendar/calendar_suggestion.go
+++ b/shortcuts/calendar/calendar_suggestion.go
@@ -278,6 +278,12 @@ var CalendarSuggestion = common.Shortcut{
 			}
 		}
 
+		tzInputs := []calendarTimeInputRange{
+			{Flag: flagStart, Value: runtime.Str(flagStart)},
+			{Flag: flagEnd, Value: runtime.Str(flagEnd)},
+		}
+		warnCalendarTimezoneMismatch(runtime, tzInputs...)
+
 		return nil
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/calendar/calendar_test.go
+++ b/shortcuts/calendar/calendar_test.go
@@ -9,9 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -1048,14 +1050,15 @@ func TestCreate_WithAttendees_RollbackAlsoFails(t *testing.T) {
 func TestUpdate_PatchEventOnly(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
+	reg.Register(plainEventStub("cal_test123", "evt_update1_0"))
 	stub := &httpmock.Stub{
 		Method: "PATCH",
-		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_update1",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_update1_0",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
 			"data": map[string]interface{}{
 				"event": map[string]interface{}{
-					"event_id": "evt_update1",
+					"event_id": "evt_update1_0",
 					"summary":  "Updated Meeting",
 					"start_time": map[string]interface{}{
 						"timestamp": "1742518800",
@@ -1071,7 +1074,7 @@ func TestUpdate_PatchEventOnly(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_update1",
+		"--event-id", "evt_update1_0",
 		"--calendar-id", "cal_test123",
 		"--summary", "Updated Meeting",
 		"--description", "Updated description",
@@ -1100,7 +1103,7 @@ func TestUpdate_PatchEventOnly(t *testing.T) {
 	if body["need_notification"] != false {
 		t.Fatalf("need_notification = %#v, want false", body["need_notification"])
 	}
-	if !strings.Contains(stdout.String(), "evt_update1") {
+	if !strings.Contains(stdout.String(), "evt_update1_0") {
 		t.Fatalf("stdout should contain event id, got: %s", stdout.String())
 	}
 }
@@ -1108,16 +1111,17 @@ func TestUpdate_PatchEventOnly(t *testing.T) {
 func TestUpdate_AddAttendees(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
+	reg.Register(plainEventStub("cal_test123", "evt_update2_0"))
 	stub := &httpmock.Stub{
 		Method: "POST",
-		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_update2/attendees",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_update2_0/attendees",
 		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
 	}
 	reg.Register(stub)
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_update2",
+		"--event-id", "evt_update2_0",
 		"--calendar-id", "cal_test123",
 		"--add-attendee-ids", "ou_user1,oc_group1,omm_room1",
 		"--as", "bot",
@@ -1138,16 +1142,17 @@ func TestUpdate_AddAttendees(t *testing.T) {
 func TestUpdate_RemoveAttendees(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
+	reg.Register(plainEventStub("cal_test123", "evt_update3_0"))
 	stub := &httpmock.Stub{
 		Method: "POST",
-		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_update3/attendees/batch_delete",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_update3_0/attendees/batch_delete",
 		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
 	}
 	reg.Register(stub)
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_update3",
+		"--event-id", "evt_update3_0",
 		"--calendar-id", "cal_test123",
 		"--remove-attendee-ids", "ou_user1,oc_group1,omm_room1",
 		"--notify=false",
@@ -1172,22 +1177,23 @@ func TestUpdate_RemoveAttendees(t *testing.T) {
 func TestUpdate_CombinedPatchRemoveAdd(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
+	reg.Register(plainEventStub("primary", "evt_update4_0"))
 	patchStub := &httpmock.Stub{
 		Method: "PATCH",
-		URL:    "/events/evt_update4",
+		URL:    "/events/evt_update4_0",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
-			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_update4", "summary": "Combined"}},
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_update4_0", "summary": "Combined"}},
 		},
 	}
 	removeStub := &httpmock.Stub{
 		Method: "POST",
-		URL:    "/events/evt_update4/attendees/batch_delete",
+		URL:    "/events/evt_update4_0/attendees/batch_delete",
 		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
 	}
 	addStub := &httpmock.Stub{
 		Method: "POST",
-		URL:    "/events/evt_update4/attendees",
+		URL:    "/events/evt_update4_0/attendees",
 		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
 	}
 	reg.Register(patchStub)
@@ -1196,7 +1202,7 @@ func TestUpdate_CombinedPatchRemoveAdd(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_update4",
+		"--event-id", "evt_update4_0",
 		"--summary", "Combined",
 		"--remove-attendee-ids", "ou_old",
 		"--add-attendee-ids", "ou_new",
@@ -1345,6 +1351,11 @@ func TestCalendarShortcuts_RequireLoginUnlessExplicitBot(t *testing.T) {
 			name:     "suggestion",
 			shortcut: CalendarSuggestion,
 			args:     []string{"+suggestion", "--start", "2025-03-21", "--end", "2025-03-21"},
+		},
+		{
+			name:     "list-attendees",
+			shortcut: CalendarListAttendees,
+			args:     []string{"+list-attendees", "--event-id", "evt_1"},
 		},
 	}
 
@@ -1821,14 +1832,19 @@ func TestFreebusy_Success(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
-		URL:    "/open-apis/calendar/v4/freebusy/list",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
 			"data": map[string]interface{}{
-				"freebusy_list": []interface{}{
+				"freebusy_lists": []interface{}{
 					map[string]interface{}{
-						"start_time": "2025-03-21T10:00:00+08:00",
-						"end_time":   "2025-03-21T11:00:00+08:00",
+						"user_id": "ou_someone",
+						"freebusy_items": []interface{}{
+							map[string]interface{}{
+								"start_time": "2025-03-21T10:00:00+08:00",
+								"end_time":   "2025-03-21T11:00:00+08:00",
+							},
+						},
 					},
 				},
 			},
@@ -1873,7 +1889,7 @@ func TestFreebusy_APIError(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
-		URL:    "/open-apis/calendar/v4/freebusy/list",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
 		Body: map[string]interface{}{
 			"code": 190001,
 			"msg":  "permission denied",
@@ -1898,7 +1914,7 @@ func TestFreebusy_InvalidParamsWithDetail(t *testing.T) {
 
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
-		URL:    "/open-apis/calendar/v4/freebusy/list",
+		URL:    "/open-apis/calendar/v4/freebusy/batch",
 		Body: map[string]interface{}{
 			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
@@ -2596,17 +2612,17 @@ func TestResolveStartEnd_ExplicitValues(t *testing.T) {
 // Shortcuts() registration test
 // ---------------------------------------------------------------------------
 
-func TestShortcuts_Returns12(t *testing.T) {
+func TestShortcuts_Returns14(t *testing.T) {
 	shortcuts := Shortcuts()
-	if len(shortcuts) != 12 {
-		t.Fatalf("expected 12 shortcuts, got %d", len(shortcuts))
+	if len(shortcuts) != 14 {
+		t.Fatalf("expected 14 shortcuts, got %d", len(shortcuts))
 	}
 
 	names := map[string]bool{}
 	for _, s := range shortcuts {
 		names[s.Command] = true
 	}
-	for _, want := range []string{"+agenda", "+create", "+update", "+freebusy", "+room-find", "+rsvp", "+suggestion", "+get", "+transfer", "+join-event"} {
+	for _, want := range []string{"+agenda", "+create", "+update", "+delete", "+freebusy", "+room-find", "+rsvp", "+suggestion", "+get", "+transfer", "+join-event", "+list-attendees", "+meeting", "+search-event"} {
 		if !names[want] {
 			t.Errorf("missing shortcut %s", want)
 		}
@@ -3124,15 +3140,16 @@ func TestAgenda_TimeRangeExceeded_CannotSplit(t *testing.T) {
 // the typed API error wrapped with completed-step context.
 func TestUpdate_PatchStepFails_TypedError(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(plainEventStub("cal_test123", "evt_patchfail_0"))
 	reg.Register(&httpmock.Stub{
 		Method: "PATCH",
-		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_patchfail",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_patchfail_0",
 		Body:   map[string]interface{}{"code": 190001, "msg": "permission denied"},
 	})
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_patchfail",
+		"--event-id", "evt_patchfail_0",
 		"--calendar-id", "cal_test123",
 		"--summary", "New title",
 		"--as", "bot",
@@ -3150,15 +3167,16 @@ func TestUpdate_PatchStepFails_TypedError(t *testing.T) {
 // TestUpdate_RemoveStepFails_TypedError pins the batch_delete failure path.
 func TestUpdate_RemoveStepFails_TypedError(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(plainEventStub("primary", "evt_removefail_0"))
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
-		URL:    "/events/evt_removefail/attendees/batch_delete",
+		URL:    "/events/evt_removefail_0/attendees/batch_delete",
 		Body:   map[string]interface{}{"code": 190001, "msg": "permission denied"},
 	})
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_removefail",
+		"--event-id", "evt_removefail_0",
 		"--remove-attendee-ids", "ou_user1",
 		"--as", "bot",
 	}, f, nil)
@@ -3175,15 +3193,16 @@ func TestUpdate_RemoveStepFails_TypedError(t *testing.T) {
 // TestUpdate_AddStepFails_TypedError pins the add-attendees failure path.
 func TestUpdate_AddStepFails_TypedError(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(plainEventStub("primary", "evt_addfail_0"))
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
-		URL:    "/events/evt_addfail/attendees",
+		URL:    "/events/evt_addfail_0/attendees",
 		Body:   map[string]interface{}{"code": 190001, "msg": "permission denied"},
 	})
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_addfail",
+		"--event-id", "evt_addfail_0",
 		"--add-attendee-ids", "ou_user1",
 		"--as", "bot",
 	}, f, nil)
@@ -3544,12 +3563,12 @@ func TestGet_UnifiesDescriptionRich(t *testing.T) {
 		f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 		reg.Register(&httpmock.Stub{
 			Method: "GET",
-			URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_rich",
+			URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_rich_0",
 			Body: map[string]interface{}{
 				"code": 0, "msg": "success",
 				"data": map[string]interface{}{
 					"event": map[string]interface{}{
-						"event_id":         "evt_rich",
+						"event_id":         "evt_rich_0",
 						"summary":          "Rich",
 						"description":      "[表格]",
 						"description_rich": "| a | b |\n| --- | --- |\n| c | d |",
@@ -3559,7 +3578,7 @@ func TestGet_UnifiesDescriptionRich(t *testing.T) {
 				},
 			},
 		})
-		if err := mountAndRun(t, CalendarGet, []string{"+get", "--calendar-id", "cal_test123", "--event-id", "evt_rich", "--as", "bot"}, f, stdout); err != nil {
+		if err := mountAndRun(t, CalendarGet, []string{"+get", "--calendar-id", "cal_test123", "--event-id", "evt_rich_0", "--as", "bot"}, f, stdout); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		out := stdout.String()
@@ -3576,12 +3595,12 @@ func TestGet_UnifiesDescriptionRich(t *testing.T) {
 		f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 		reg.Register(&httpmock.Stub{
 			Method: "GET",
-			URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_plain",
+			URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_plain_0",
 			Body: map[string]interface{}{
 				"code": 0, "msg": "success",
 				"data": map[string]interface{}{
 					"event": map[string]interface{}{
-						"event_id":    "evt_plain",
+						"event_id":    "evt_plain_0",
 						"summary":     "Plain",
 						"description": "just text",
 						"start_time":  map[string]interface{}{"timestamp": "1742515200", "timezone": "Asia/Shanghai"},
@@ -3590,7 +3609,7 @@ func TestGet_UnifiesDescriptionRich(t *testing.T) {
 				},
 			},
 		})
-		if err := mountAndRun(t, CalendarGet, []string{"+get", "--calendar-id", "cal_test123", "--event-id", "evt_plain", "--as", "bot"}, f, stdout); err != nil {
+		if err := mountAndRun(t, CalendarGet, []string{"+get", "--calendar-id", "cal_test123", "--event-id", "evt_plain_0", "--as", "bot"}, f, stdout); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		out := stdout.String()
@@ -3702,7 +3721,7 @@ func TestGet_MissingEventField_TypedInternal(t *testing.T) {
 
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_404",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_404_0",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{},
@@ -3712,7 +3731,7 @@ func TestGet_MissingEventField_TypedInternal(t *testing.T) {
 	err := mountAndRun(t, CalendarGet, []string{
 		"+get",
 		"--calendar-id", "cal_test123",
-		"--event-id", "evt_404",
+		"--event-id", "evt_404_0",
 		"--as", "bot",
 	}, f, nil)
 	if err == nil {
@@ -3724,6 +3743,75 @@ func TestGet_MissingEventField_TypedInternal(t *testing.T) {
 	}
 	if ie.Subtype != errs.SubtypeInvalidResponse {
 		t.Errorf("subtype=%q, want invalid_response", ie.Subtype)
+	}
+}
+
+// A recurring instance id ({uid}_{originalTime > 0}) is not stored on its own
+// until it is edited. When the direct GET returns 193001, +get transparently
+// falls back to the master and returns a synthetic snapshot: the master's
+// fields (summary, description, rrule, ...) with the instance's original
+// start/end so the output still describes the instance the caller asked about.
+func TestGet_UnmaterialisedInstance_FallsBackToMaster(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// Instance start = master start + 7 * 86400 (one week after the master).
+	const masterStart int64 = 1742515200
+	const masterEnd int64 = 1742518800
+	const instanceOriginalTime int64 = masterStart + 7*86400
+
+	// Direct GET on the instance id -> 193001 not found.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_series_" + strconv.FormatInt(instanceOriginalTime, 10),
+		Body: map[string]interface{}{
+			"code": 193001, "msg": "event not found",
+			"data": map[string]interface{}{},
+		},
+	})
+	// Fallback GET on master returns the recurring series.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_series_0",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"event": map[string]interface{}{
+					"event_id":   "evt_series_0",
+					"summary":    "Weekly Sync",
+					"recurrence": "FREQ=WEEKLY;INTERVAL=1",
+					"start_time": map[string]interface{}{"timestamp": strconv.FormatInt(masterStart, 10), "timezone": "Asia/Shanghai"},
+					"end_time":   map[string]interface{}{"timestamp": strconv.FormatInt(masterEnd, 10), "timezone": "Asia/Shanghai"},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarGet, []string{
+		"+get",
+		"--calendar-id", "cal_test123",
+		"--event-id", "evt_series_" + strconv.FormatInt(instanceOriginalTime, 10),
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	// The instance id is echoed (not the master id).
+	if !strings.Contains(out, "\"event_id\": \"evt_series_"+strconv.FormatInt(instanceOriginalTime, 10)+"\"") {
+		t.Errorf("expected instance event_id in output, got: %s", out)
+	}
+	// Start datetime reflects the instance's originalTime, not the master's start.
+	instanceStartRFC := time.Unix(instanceOriginalTime, 0).Local().Format(time.RFC3339)
+	if !strings.Contains(out, instanceStartRFC) {
+		t.Errorf("expected instance start %s in output, got: %s", instanceStartRFC, out)
+	}
+	// Master's summary is inherited on the synthetic instance snapshot.
+	if !strings.Contains(out, "\"summary\": \"Weekly Sync\"") {
+		t.Errorf("expected inherited summary in output, got: %s", out)
+	}
+	// The synthetic snapshot drops recurrence so classifiers see a plain instance.
+	if strings.Contains(out, "\"recurrence\":") {
+		t.Errorf("recurrence must be stripped from the synthetic instance snapshot, got: %s", out)
 	}
 }
 
@@ -3760,24 +3848,47 @@ func eventSnapshotStub(calendarID, eventID, startTs, endTs string, roomIDs ...st
 	}
 }
 
+// plainEventStub returns a GET-event fixture for a non-recurring event. +update
+// resolves the event first (see resolveCalendarEventOrMaster) to route to the
+// single / recurring branch; tests that only assert on the PATCH / attendee
+// payload still need this fixture to satisfy the classifier fetch.
+func plainEventStub(calendarID, eventID string) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/calendar/v4/calendars/" + calendarID + "/events/" + eventID,
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"event": map[string]interface{}{
+					"event_id": eventID,
+					"summary":  "Existing",
+				},
+			},
+		},
+		Reusable: true,
+	}
+}
+
 func TestUpdate_RoomCheck_SkipFlag_BypassesAPI(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	// Register the PATCH stub but no room-check stub — the test asserts that no
-	// unmatched request is made.
+	// The event snapshot GET is unavoidable — +update resolves the event first
+	// to classify recurring vs. single. The test asserts that no room-check
+	// call is made once --skip-room-check is set.
+	reg.Register(plainEventStub("cal_rc", "evt_rc1_0"))
 	patchStub := &httpmock.Stub{
 		Method: "PATCH",
-		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc1",
+		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc1_0",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
-			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_rc1"}},
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_rc1_0"}},
 		},
 	}
 	reg.Register(patchStub)
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc1",
+		"--event-id", "evt_rc1_0",
 		"--calendar-id", "cal_rc",
 		"--summary", "Skip",
 		"--start", "2025-03-21T00:00:00+08:00",
@@ -3797,21 +3908,23 @@ func TestUpdate_RoomCheck_SkipFlag_BypassesAPI(t *testing.T) {
 func TestUpdate_RoomCheck_TitleOnly_SkipsCheck(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	// Only registered PATCH; title-only changes should never trigger room-check
-	// and never fetch the event snapshot.
+	// The event snapshot GET is unavoidable — +update resolves the event first
+	// to classify recurring vs. single. The test asserts that title-only changes
+	// never trigger the additional room-availability check.
+	reg.Register(plainEventStub("cal_rc", "evt_rc2_0"))
 	patchStub := &httpmock.Stub{
 		Method: "PATCH",
-		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc2",
+		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc2_0",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
-			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_rc2"}},
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_rc2_0"}},
 		},
 	}
 	reg.Register(patchStub)
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc2",
+		"--event-id", "evt_rc2_0",
 		"--calendar-id", "cal_rc",
 		"--summary", "New title only",
 		"--as", "bot",
@@ -3829,7 +3942,7 @@ func TestUpdate_RoomCheck_NewRoomAvailable_Allows(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
 	// Snapshot has no existing rooms; we're adding omm_new.
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc3", "1742515200", "1742518800"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc3_0", "1742515200", "1742518800"))
 
 	checkStub := &httpmock.Stub{
 		Method: "POST",
@@ -3847,14 +3960,14 @@ func TestUpdate_RoomCheck_NewRoomAvailable_Allows(t *testing.T) {
 
 	addStub := &httpmock.Stub{
 		Method: "POST",
-		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc3/attendees",
+		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc3_0/attendees",
 		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
 	}
 	reg.Register(addStub)
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc3",
+		"--event-id", "evt_rc3_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_new",
 		"--as", "bot",
@@ -3871,7 +3984,7 @@ func TestUpdate_RoomCheck_NewRoomAvailable_Allows(t *testing.T) {
 	if len(rooms) != 1 || rooms[0] != "omm_new" {
 		t.Fatalf("room_ids should be [omm_new], got %#v", rooms)
 	}
-	if body["calendar_id"] != "cal_rc" || body["event_id"] != "evt_rc3" {
+	if body["calendar_id"] != "cal_rc" || body["event_id"] != "evt_rc3_0" {
 		t.Fatalf("room-check body missing ids: %#v", body)
 	}
 	if body["start_timezone"] != "Asia/Shanghai" {
@@ -3891,7 +4004,7 @@ func TestUpdate_RoomCheck_NewRoomAvailable_Allows(t *testing.T) {
 func TestUpdate_RoomCheck_NewRoomUnavailable_Blocks(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc4", "1742515200", "1742518800"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc4_0", "1742515200", "1742518800"))
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/freebusy/room_availability_check",
@@ -3911,7 +4024,7 @@ func TestUpdate_RoomCheck_NewRoomUnavailable_Blocks(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc4",
+		"--event-id", "evt_rc4_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_busy",
 		"--as", "bot",
@@ -3939,7 +4052,7 @@ func TestUpdate_RoomCheck_TimeChanged_ChecksExistingRoom(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
 	// Existing event already has omm_existing booked.
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc5", "1742515200", "1742518800", "omm_existing"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc5_0", "1742515200", "1742518800", "omm_existing"))
 
 	checkStub := &httpmock.Stub{
 		Method: "POST",
@@ -3957,17 +4070,17 @@ func TestUpdate_RoomCheck_TimeChanged_ChecksExistingRoom(t *testing.T) {
 
 	patchStub := &httpmock.Stub{
 		Method: "PATCH",
-		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc5",
+		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc5_0",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
-			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_rc5"}},
+			"data": map[string]interface{}{"event": map[string]interface{}{"event_id": "evt_rc5_0"}},
 		},
 	}
 	reg.Register(patchStub)
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc5",
+		"--event-id", "evt_rc5_0",
 		"--calendar-id", "cal_rc",
 		"--start", "2025-03-21T02:00:00+08:00",
 		"--end", "2025-03-21T03:00:00+08:00",
@@ -3993,7 +4106,7 @@ func TestUpdate_RoomCheck_TimeChanged_ChecksExistingRoom(t *testing.T) {
 func TestUpdate_RoomCheck_APIFailure_DegradesGracefully(t *testing.T) {
 	f, _, stderr, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc6", "1742515200", "1742518800"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc6_0", "1742515200", "1742518800"))
 	// Simulate room-check API failure (e.g., not yet rolled out) so the CLI
 	// degrades gracefully instead of blocking the update.
 	reg.Register(&httpmock.Stub{
@@ -4006,14 +4119,14 @@ func TestUpdate_RoomCheck_APIFailure_DegradesGracefully(t *testing.T) {
 	})
 	addStub := &httpmock.Stub{
 		Method: "POST",
-		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc6/attendees",
+		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/evt_rc6_0/attendees",
 		Body:   map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{}},
 	}
 	reg.Register(addStub)
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc6",
+		"--event-id", "evt_rc6_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_new",
 		"--as", "bot",
@@ -4035,7 +4148,7 @@ func TestUpdate_RoomCheck_DryRun_IncludesPrecheckStep(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc7",
+		"--event-id", "evt_rc7_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_dryrun",
 		"--start", "2025-03-21T00:00:00+08:00",
@@ -4060,7 +4173,7 @@ func TestUpdate_RoomCheck_DryRun_SkipFlagOmitsStep(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc8",
+		"--event-id", "evt_rc8_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_dryrun2",
 		"--start", "2025-03-21T00:00:00+08:00",
@@ -4166,7 +4279,7 @@ func TestStrategyDetail_ByReason(t *testing.T) {
 func TestUpdate_RoomCheck_StrategyDetailInMessage(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_strategy", "1742515200", "1742525200"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_strategy_0", "1742515200", "1742525200"))
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/freebusy/room_availability_check",
@@ -4190,7 +4303,7 @@ func TestUpdate_RoomCheck_StrategyDetailInMessage(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc_strategy",
+		"--event-id", "evt_rc_strategy_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_toolong",
 		"--as", "bot",
@@ -4266,7 +4379,7 @@ func TestRequisitionDetail_ByBounds(t *testing.T) {
 func TestUpdate_RoomCheck_RequisitionDetailInMessage(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_req", "1742515200", "1742525200"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_req_0", "1742515200", "1742525200"))
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/freebusy/room_availability_check",
@@ -4291,7 +4404,7 @@ func TestUpdate_RoomCheck_RequisitionDetailInMessage(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc_req",
+		"--event-id", "evt_rc_req_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_req",
 		"--as", "bot",
@@ -4376,10 +4489,14 @@ func TestRecurringMasterEventID_Shapes(t *testing.T) {
 func TestUpdate_RoomCheck_EventNotFound_FallsBackToMaster(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	// First GET on the instance event: 193001.
+	// First GET on the instance event: 193001. Reusable because both the
+	// +update pre-fetch (recurring-kind detection) and the room-check
+	// snapshot GET hit this same URL; they both need the 193001 answer to
+	// fall through to the master snapshot.
 	instanceStub := &httpmock.Stub{
-		Method: "GET",
-		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/uid_master_1742515200",
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_rc/events/uid_master_1742515200",
+		Reusable: true,
 		Body: map[string]interface{}{
 			"code": 193001,
 			"msg":  "event not found",
@@ -4390,8 +4507,9 @@ func TestUpdate_RoomCheck_EventNotFound_FallsBackToMaster(t *testing.T) {
 	// Fallback GET on the master event: 200 with an existing room attendee, so
 	// the pre-check has something to reason about.
 	masterStub := &httpmock.Stub{
-		Method: "GET",
-		URL:    "/open-apis/calendar/v4/calendars/cal_rc/events/uid_master_0",
+		Method:   "GET",
+		URL:      "/open-apis/calendar/v4/calendars/cal_rc/events/uid_master_0",
+		Reusable: true,
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
 			"data": map[string]interface{}{
@@ -4400,6 +4518,7 @@ func TestUpdate_RoomCheck_EventNotFound_FallsBackToMaster(t *testing.T) {
 					"summary":    "Weekly sync",
 					"start_time": map[string]interface{}{"timestamp": "1742515200", "timezone": "Asia/Shanghai"},
 					"end_time":   map[string]interface{}{"timestamp": "1742518800", "timezone": "Asia/Shanghai"},
+					"recurrence": "FREQ=DAILY;INTERVAL=1",
 					"attendees":  []interface{}{map[string]interface{}{"type": "resource", "room_id": "omm_from_master"}},
 				},
 			},
@@ -4442,6 +4561,7 @@ func TestUpdate_RoomCheck_EventNotFound_FallsBackToMaster(t *testing.T) {
 		"--calendar-id", "cal_rc",
 		"--start", "2025-03-21T08:00:00+08:00",
 		"--end", "2025-03-21T09:00:00+08:00",
+		"--apply-to", "single",
 		"--as", "bot",
 	}, f, nil)
 	if err != nil {
@@ -4559,7 +4679,7 @@ func TestUpdate_RoomCheck_NeedApproval_Blocks(t *testing.T) {
 
 	// Snapshot window: 1742515200 -> 1742522400 (2h). Threshold is 1h, so the
 	// current duration is over threshold.
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_approval", "1742515200", "1742522400"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_approval_0", "1742515200", "1742522400"))
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/freebusy/room_availability_check",
@@ -4583,7 +4703,7 @@ func TestUpdate_RoomCheck_NeedApproval_Blocks(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc_approval",
+		"--event-id", "evt_rc_approval_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_approval",
 		"--as", "bot",
@@ -4636,7 +4756,7 @@ func TestUpdate_RoomCheck_NeedApproval_Blocks(t *testing.T) {
 func TestUpdate_RoomCheck_RequisitionMissingBoundsStillCoherent(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
-	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_req2", "1742515200", "1742525200"))
+	reg.Register(eventSnapshotStub("cal_rc", "evt_rc_req2_0", "1742515200", "1742525200"))
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/freebusy/room_availability_check",
@@ -4656,7 +4776,7 @@ func TestUpdate_RoomCheck_RequisitionMissingBoundsStillCoherent(t *testing.T) {
 
 	err := mountAndRun(t, CalendarUpdate, []string{
 		"+update",
-		"--event-id", "evt_rc_req2",
+		"--event-id", "evt_rc_req2_0",
 		"--calendar-id", "cal_rc",
 		"--add-attendee-ids", "omm_req_nobounds",
 		"--as", "bot",

--- a/shortcuts/calendar/calendar_update.go
+++ b/shortcuts/calendar/calendar_update.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/larksuite/cli/errs"
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -35,6 +34,11 @@ var CalendarUpdate = common.Shortcut{
 		{Name: "rrule", Desc: "recurrence rule (rfc5545)"},
 		{Name: "add-attendee-ids", Desc: "attendee IDs to add, comma-separated (supports user ou_, chat oc_, room omm_)"},
 		{Name: "remove-attendee-ids", Desc: "attendee IDs to remove, comma-separated (supports user ou_, chat oc_, room omm_)"},
+		{
+			Name: flagApplyTo,
+			Enum: applyToValues,
+			Desc: "recurring scope: single (this occurrence / exception only) | all (whole series and every exception) | this-and-following (truncate the series at this instance and create a new series carrying the requested edits). Required on recurring events; ignored on non-recurring events.",
+		},
 		{Name: "notify", Type: "bool", Default: "true", Desc: "send update notification to attendees"},
 		{Name: flagSkipRoomCheck, Type: "bool", Default: "false", Hidden: true, Desc: "skip meeting-room availability precheck (default checks rooms whenever a new room is added or the time/rrule of a room-attached event changes)"},
 	},
@@ -73,6 +77,10 @@ func validateCalendarUpdate(runtime *common.RuntimeContext) error {
 	if !hasCalendarUpdateOperation(runtime) {
 		return errs.NewValidationError(errs.SubtypeInvalidArgument, "nothing to update: specify at least one of --summary, --description, --start/--end, --rrule, --add-attendee-ids, or --remove-attendee-ids")
 	}
+	warnCalendarTimezoneMismatch(runtime,
+		calendarTimeInputRange{Flag: "start", Value: runtime.Str("start")},
+		calendarTimeInputRange{Flag: "end", Value: runtime.Str("end")},
+	)
 	return nil
 }
 
@@ -279,6 +287,15 @@ func dryRunCalendarUpdate(runtime *common.RuntimeContext) *common.DryRunAPI {
 	}
 
 	d := common.NewDryRunAPI().Set("calendar_id", displayCalendarID).Set("event_id", eventID)
+	if scope := strings.TrimSpace(runtime.Str(flagApplyTo)); scope != "" {
+		d.Set("apply_to", scope)
+		switch scope {
+		case applyToAll:
+			d.Desc("recurring --apply-to=all: PATCH every exception first (only user-set fields), then the master; if --start/--end changed, exceptions are deleted first instead")
+		case applyToThisAndFollowing:
+			d.Desc("recurring --apply-to=this-and-following: delete exceptions on/after pivot → truncate master rrule with UNTIL → POST a new event carrying the requested edits (inherits master defaults for anything not overridden)")
+		}
+	}
 	opCount := 0
 	if hasEventFields {
 		opCount++
@@ -364,65 +381,53 @@ func executeCalendarUpdate(ctx context.Context, runtime *common.RuntimeContext) 
 		}
 	}
 
-	body, hasEventFields, err := buildCalendarUpdateEventData(runtime)
+	current, err := resolveCalendarEventOrMaster(runtime, calendarID, eventID)
 	if err != nil {
 		return err
 	}
+	kind := classifyRecurringEvent(current)
+	scope, err := validateApplyTo(runtime, kind, eventID)
+	if err != nil {
+		return err
+	}
+	switch scope {
+	case applyToSingle:
+		return executeCalendarUpdateSingle(ctx, runtime, calendarID, eventID)
+	case applyToAll:
+		return executeCalendarUpdateAll(ctx, runtime, calendarID, current, eventID)
+	case applyToThisAndFollowing:
+		return executeCalendarUpdateThisAndFollowing(ctx, runtime, calendarID, current, eventID)
+	}
+	return errs.NewInternalError(errs.SubtypeUnknown, "unhandled apply-to scope %q", scope)
+}
 
+// executeCalendarUpdateSingle mirrors the historical +update behavior when
+// scope resolves to "single" (normal event or one recurring instance /
+// exception). Delegates to applyUpdateToEvent so the master, every exception
+// and single-event paths share the exact same PATCH + attendee-batch logic.
+func executeCalendarUpdateSingle(ctx context.Context, runtime *common.RuntimeContext, calendarID, eventID string) error {
 	if !runtime.Bool(flagSkipRoomCheck) {
+		body, _, err := buildCalendarUpdateEventData(runtime)
+		if err != nil {
+			return err
+		}
 		if err := runRoomAvailabilityPrecheck(ctx, runtime, calendarID, eventID, body); err != nil {
 			return err
 		}
 	}
 
-	completed := []string{}
-	event := map[string]interface{}{}
-	if hasEventFields {
-		data, err := runtime.CallAPITyped("PATCH", calendarUpdateEventPath(calendarID, eventID), map[string]interface{}{"user_id_type": "open_id"}, body)
-		if err != nil {
-			return withStepContext(err, "failed to update event %s after completed steps %v", eventID, completed)
-		}
-		if v, _ := data["event"].(map[string]interface{}); v != nil {
-			event = v
-		}
-		completed = append(completed, "event")
+	event, addedCount, removedCount, err := applyUpdateToEvent(runtime, calendarID, eventID, false)
+	if err != nil {
+		return withStepContext(err, "failed to update event %s", eventID)
 	}
 
-	removedCount := 0
-	if removeStr := runtime.Str("remove-attendee-ids"); strings.TrimSpace(removeStr) != "" {
-		deleteIDs, err := attendeeDeleteIDs(removeStr)
-		if err != nil {
-			return err
-		}
-		_, err = runtime.CallAPITyped("POST", calendarUpdateAttendeesPath(calendarID, eventID)+"/batch_delete",
-			map[string]interface{}{"user_id_type": "open_id"},
-			map[string]interface{}{"delete_ids": deleteIDs, "need_notification": runtime.Bool("notify")})
-		if err != nil {
-			return withStepContext(err, "failed to remove attendees from event %s after completed steps %v", eventID, completed)
-		}
-		removedCount = len(deleteIDs)
-		completed = append(completed, "remove_attendees")
+	result := map[string]interface{}{
+		"calendar_id":   calendarID,
+		"apply_to":      applyToSingle,
+		"updated_event": calendarUpdateResult(eventID, event, addedCount, removedCount),
 	}
-
-	addedCount := 0
-	if addStr := runtime.Str("add-attendee-ids"); strings.TrimSpace(addStr) != "" {
-		attendees, err := parseAttendees(addStr, "")
-		if err != nil {
-			return withParam(err, "--add-attendee-ids")
-		}
-		_, err = runtime.CallAPITyped("POST", calendarUpdateAttendeesPath(calendarID, eventID),
-			map[string]interface{}{"user_id_type": "open_id"},
-			map[string]interface{}{"attendees": attendees, "need_notification": runtime.Bool("notify")})
-		if err != nil {
-			return withStepContext(err, "failed to add attendees to event %s after completed steps %v", eventID, completed)
-		}
-		addedCount = len(attendees)
-	}
-
-	result := calendarUpdateResult(eventID, event, addedCount, removedCount)
 	runtime.OutFormat(result, nil, func(w io.Writer) {
-		output.PrintTable(w, []map[string]interface{}{result})
-		fmt.Fprintln(w, "\nEvent updated successfully")
+		writeUpdatePretty(w, result, eventID, applyToSingle, "updated_event", "Updated event", "Exceptions updated")
 	})
 	return nil
 }
@@ -467,4 +472,24 @@ func formatCalendarEventTime(v interface{}) string {
 		return date
 	}
 	return ""
+}
+
+// eventTimeAsMap projects a typed calendarEventTime back into the loose map
+// shape formatCalendarEventTime expects, so callers with a parsed event can
+// reuse the same rendering path as callers holding a raw response map.
+func eventTimeAsMap(t *calendarEventTime) map[string]interface{} {
+	if t == nil {
+		return nil
+	}
+	m := map[string]interface{}{}
+	if t.Date != "" {
+		m["date"] = t.Date
+	}
+	if t.Timestamp != "" {
+		m["timestamp"] = t.Timestamp
+	}
+	if t.Timezone != "" {
+		m["timezone"] = t.Timezone
+	}
+	return m
 }

--- a/shortcuts/calendar/calendar_update_recurring.go
+++ b/shortcuts/calendar/calendar_update_recurring.go
@@ -1,0 +1,843 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// calendar +update: --apply-to=all and --apply-to=this-and-following
+// implementations. Split from calendar_update.go so the historical single-event
+// path stays isolated.
+
+package calendar
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const updateLogPrefix = "[calendar +update]"
+
+// executeCalendarUpdateAll implements --apply-to=all.
+//
+//   - If the caller changed --start/--end (time change), exceptions are dropped
+//     first (their original occurrence slot is now meaningless), then the
+//     master is patched with the new time.
+//   - Otherwise the caller changed non-time fields (summary, description,
+//     rrule, attendees). We apply the exact same PATCH / attendee-batch calls
+//     to every exception first, then to the master. Only fields the caller
+//     explicitly set are propagated — the exception's independent customization
+//     of other fields is preserved.
+func executeCalendarUpdateAll(ctx context.Context, runtime *common.RuntimeContext, calendarID string, current *calendarEvent, targetEventID string) error {
+	master, err := ensureMasterEvent(runtime, calendarID, current, targetEventID)
+	if err != nil {
+		return err
+	}
+	masterID := master.EventID
+	if masterID == "" {
+		masterID = masterEventID(targetEventID)
+		master.EventID = masterID
+	}
+
+	if !runtime.Bool(flagSkipRoomCheck) {
+		// Reuse the existing precheck against the master; the precheck understands
+		// time and rrule change semantics.
+		body, _, buildErr := buildCalendarUpdateEventData(runtime)
+		if buildErr != nil {
+			return buildErr
+		}
+		if err := runRoomAvailabilityPrecheck(ctx, runtime, calendarID, masterID, body); err != nil {
+			return err
+		}
+	}
+
+	window, err := recurringWindowFromMaster(master, time.Now())
+	if err != nil {
+		return err
+	}
+	timeChanged, err := masterTimeChanged(runtime, master)
+	if err != nil {
+		return err
+	}
+	// A time-change apply-to=all also destroys exceptions (deleteException=true,
+	// i.e. is_deleted=true), so scan cancelled placeholders too — they need to
+	// be destroyed for the same reason live ones do. A non-time PATCH walks the
+	// same rows to replay the field changes, and there is nothing to replay
+	// onto a cancelled row.
+	exceptions, err := listExceptionsInWindow(ctx, runtime, calendarID, masterID, window, timeChanged)
+	if err != nil {
+		return err
+	}
+
+	nowSec := time.Now().Unix()
+	future, past := splitFutureThenPast(exceptions, nowSec)
+
+	errOut := runtime.IO().ErrOut
+
+	var worker *exceptionWorker
+	if len(exceptions) > 0 {
+		if timeChanged {
+			fmt.Fprintf(errOut, "%s time change: deleting %d exception(s) first, then patching master %s\n",
+				updateLogPrefix, len(exceptions), masterID)
+			worker, err = runExceptionDeletion(ctx, runtime, calendarID, future, past)
+			if err != nil {
+				return err
+			}
+		} else {
+			fmt.Fprintf(errOut, "%s non-time change: patching %d exception(s) with the same fields, then the master %s\n",
+				updateLogPrefix, len(exceptions), masterID)
+			worker, err = runExceptionPatch(ctx, runtime, calendarID, future, past)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	fmt.Fprintf(errOut, "%s patching master event %s\n", updateLogPrefix, masterID)
+	event, addedCount, removedCount, err := applyUpdateToEvent(runtime, calendarID, masterID, !timeChanged)
+	if err != nil {
+		return withStepContext(err, "failed to update master event %s", masterID)
+	}
+	updatedEvent := calendarUpdateResult(masterID, event, addedCount, removedCount)
+	updatedEvent["action"] = "patched"
+	result := map[string]interface{}{
+		"calendar_id":   calendarID,
+		"apply_to":      applyToAll,
+		"updated_event": updatedEvent,
+	}
+	if worker != nil {
+		exceptionsSummary := map[string]interface{}{
+			"total":   len(exceptions),
+			"updated": int(worker.processed.Load()),
+			"failed":  int(worker.failed.Load()),
+		}
+		if failures := worker.Failures(); len(failures) > 0 {
+			exceptionsSummary["failures"] = failures
+		}
+		result["exceptions"] = exceptionsSummary
+	}
+	runtime.OutFormat(result, nil, func(w io.Writer) {
+		writeUpdatePretty(w, result, targetEventID, applyToAll, "updated_event", "Updated event", "Exceptions updated")
+	})
+	return nil
+}
+
+// writeUpdatePretty renders the +update pretty output in the shape the user
+// asked for: (1) header stating which apply_to scope ran on which event_id,
+// (2) the updated master/single event details, (3) an optional exceptions
+// summary. eventKey is the top-level key in `result` that carries the event
+// details ("updated_event"); eventLabel and exceptionsLabel are section titles.
+func writeUpdatePretty(w io.Writer, result map[string]interface{}, targetEventID, scope, eventKey, eventLabel, exceptionsLabel string) {
+	fmt.Fprintf(w, "Applied `%s` on %s\n\n", scope, targetEventID)
+	if ev, ok := result[eventKey].(map[string]interface{}); ok {
+		fmt.Fprintf(w, "%s:\n", eventLabel)
+		output.PrintTable(w, []map[string]interface{}{ev})
+		fmt.Fprintln(w)
+	}
+	if exceptions, ok := result["exceptions"].(map[string]interface{}); ok {
+		fmt.Fprintf(w, "%s:\n", exceptionsLabel)
+		output.PrintTable(w, []map[string]interface{}{exceptions})
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintln(w, "Event updated successfully")
+}
+
+// runExceptionDeletion deletes every exception in future-first order using the
+// shared worker and returns the worker so the caller can surface Failures().
+// A returned error indicates only context cancellation; per-item failures do
+// not abort the batch. delete_exception=true so each row is destroyed
+// (is_deleted=true) rather than left as a cancelled placeholder — this path
+// only runs when a series-wide time change has invalidated the original
+// occurrence slot, so a lingering cancelled marker would only add noise to a
+// subsequent series-view.
+func runExceptionDeletion(ctx context.Context, runtime *common.RuntimeContext, calendarID string, future, past []exceptionInstance) (*exceptionWorker, error) {
+	worker := &exceptionWorker{
+		Concurrency: 3,
+		Runtime:     runtime,
+		Label:       updateLogPrefix,
+		Total:       len(future) + len(past),
+		Do: func(_ context.Context, ex exceptionInstance) error {
+			return deleteEventOnce(runtime, calendarID, ex.EventID, false, true)
+		},
+	}
+	if err := worker.Run(ctx, future); err != nil {
+		return worker, err
+	}
+	if err := worker.Run(ctx, past); err != nil {
+		return worker, err
+	}
+	worker.finalSummary(runtime.IO().ErrOut, "deleted")
+	return worker, nil
+}
+
+// runExceptionPatch applies the same field-level update (built from the same
+// flags) to every exception. Attendee add/remove is replayed per exception —
+// participants have separate acceptance state, so a name/description change
+// stays semantically consistent while attendee changes propagate to the
+// series as a whole. Per-item failures are recorded on the worker and do not
+// abort the batch.
+//
+// This runs only in the apply-to=all non-time branch (a real time change
+// deletes exceptions instead). It therefore always strips start_time/end_time
+// from the PATCH body — even when the caller passed --start/--end, they must
+// have echoed the master's time (that's why we're here), and pushing the
+// master's time onto every exception would overwrite each exception's own
+// occurrence slot.
+func runExceptionPatch(ctx context.Context, runtime *common.RuntimeContext, calendarID string, future, past []exceptionInstance) (*exceptionWorker, error) {
+	worker := &exceptionWorker{
+		Concurrency: 3,
+		Runtime:     runtime,
+		Label:       updateLogPrefix,
+		Total:       len(future) + len(past),
+		Do: func(_ context.Context, ex exceptionInstance) error {
+			if _, _, _, err := applyUpdateToEvent(runtime, calendarID, ex.EventID, true); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	if err := worker.Run(ctx, future); err != nil {
+		return worker, err
+	}
+	if err := worker.Run(ctx, past); err != nil {
+		return worker, err
+	}
+	worker.finalSummary(runtime.IO().ErrOut, "patched")
+	return worker, nil
+}
+
+// masterTimeChanged reports whether --start / --end (once parsed) actually
+// differ from the master's stored time. A caller that re-passes the master's
+// current time — common when a script echoes the fetched event back — should
+// not force the "time change" branch, which would delete every exception. The
+// caller must have set both flags; --start and --end are wired to travel
+// together upstream. Returns false when either flag was omitted or the input
+// exactly matches the master.
+//
+// Timed and all-day masters carry different fields (`timestamp` vs `date`), and
+// common.ParseTime normalises date-only input against time.Local, whereas Lark
+// stores all-day dates at UTC midnight (see masterStartUnix). Comparing the two
+// via unix seconds therefore never matches for a legitimate echo of an all-day
+// event. We branch on the master shape: all-day masters compare on the raw
+// YYYY-MM-DD date, timed masters compare on the unix-second string.
+func masterTimeChanged(runtime *common.RuntimeContext, master *calendarEvent) (bool, error) {
+	if !(runtime.Cmd.Flags().Changed("start") && runtime.Cmd.Flags().Changed("end")) {
+		return false, nil
+	}
+	if master == nil || master.StartTime == nil || master.EndTime == nil {
+		return true, nil
+	}
+	startInput := strings.TrimSpace(runtime.Str("start"))
+	endInput := strings.TrimSpace(runtime.Str("end"))
+
+	if isAllDayEvent(master) {
+		// All-day master: only a bare YYYY-MM-DD input can echo the stored
+		// `date` unchanged. A timestamped or datetime input inherently drops
+		// all-day semantics and is a real time change.
+		startDate, ok := parseDateOnly(startInput, time.UTC)
+		if !ok {
+			return true, nil
+		}
+		endDate, ok := parseDateOnly(endInput, time.UTC)
+		if !ok {
+			return true, nil
+		}
+		return !(startDate == master.StartTime.Date && endDate == master.EndTime.Date), nil
+	}
+
+	startTs, err := common.ParseTime(startInput)
+	if err != nil {
+		return false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
+	}
+	endTs, err := common.ParseTime(endInput, "end")
+	if err != nil {
+		return false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
+	}
+	return !(startTs == master.StartTime.Timestamp && endTs == master.EndTime.Timestamp), nil
+}
+
+// parseDateOnly returns the canonical YYYY-MM-DD form when s is exactly a
+// date (no time component). Used to compare user input against an all-day
+// master's stored `date` without going through timezone-sensitive unix math.
+func parseDateOnly(s string, loc *time.Location) (string, bool) {
+	t, err := time.ParseInLocation("2006-01-02", s, loc)
+	if err != nil {
+		return "", false
+	}
+	return t.Format("2006-01-02"), true
+}
+
+// applyUpdateToEvent runs the field PATCH + attendee add/remove trio against a
+// single event id. Extracted so the master and every exception share exactly
+// the same code path — including field selection logic (only user-set flags
+// are propagated).
+//
+// omitTime, when true, strips start_time/end_time from the PATCH body before
+// sending. Used by the apply-to=all non-time branch: masterTimeChanged already
+// confirmed the caller's --start/--end just echo the master's stored time
+// (common when a script fetches the event and passes it back), so those flags
+// were logically not a time change — but buildCalendarUpdateEventData only
+// knows the flag was set. Sending the master's time on to every exception PATCH
+// would overwrite each exception's own occurrence slot with the master's first
+// instance time, which is the bug this parameter guards against. The single-
+// event and time-change paths pass false; only the non-time apply-to=all path
+// needs the strip.
+func applyUpdateToEvent(runtime *common.RuntimeContext, calendarID, eventID string, omitTime bool) (map[string]interface{}, int, int, error) {
+	body, hasEventFields, err := buildCalendarUpdateEventData(runtime)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if omitTime {
+		delete(body, "start_time")
+		delete(body, "end_time")
+		delete(body, "need_notification")
+		hasEventFields = len(body) > 0
+		if hasEventFields {
+			body["need_notification"] = runtime.Bool("notify")
+		}
+	}
+	event := map[string]interface{}{}
+	if hasEventFields {
+		data, err := runtime.CallAPITyped("PATCH", calendarUpdateEventPath(calendarID, eventID),
+			map[string]interface{}{"user_id_type": "open_id"}, body)
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		if v, _ := data["event"].(map[string]interface{}); v != nil {
+			event = v
+		}
+	}
+	removed := 0
+	if removeStr := runtime.Str("remove-attendee-ids"); strings.TrimSpace(removeStr) != "" {
+		deleteIDs, err := attendeeDeleteIDs(removeStr)
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		_, err = runtime.CallAPITyped("POST", calendarUpdateAttendeesPath(calendarID, eventID)+"/batch_delete",
+			map[string]interface{}{"user_id_type": "open_id"},
+			map[string]interface{}{"delete_ids": deleteIDs, "need_notification": runtime.Bool("notify")})
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		removed = len(deleteIDs)
+	}
+	added := 0
+	if addStr := runtime.Str("add-attendee-ids"); strings.TrimSpace(addStr) != "" {
+		attendees, err := parseAttendees(addStr, "")
+		if err != nil {
+			return nil, 0, 0, withParam(err, "--add-attendee-ids")
+		}
+		_, err = runtime.CallAPITyped("POST", calendarUpdateAttendeesPath(calendarID, eventID),
+			map[string]interface{}{"user_id_type": "open_id"},
+			map[string]interface{}{"attendees": attendees, "need_notification": runtime.Bool("notify")})
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		added = len(attendees)
+	}
+	return event, added, removed, nil
+}
+
+// executeCalendarUpdateThisAndFollowing implements --apply-to=this-and-following.
+//
+// Steps:
+//  1. delete exceptions on/after the pivot instance
+//  2. PATCH the master's rrule with UNTIL = pivot - 1s (truncating the old
+//     series before the pivot)
+//  3. POST a new event starting at the pivot instance, inheriting the master's
+//     summary/description/attendees/vchat/reminders/location, overlaid by any
+//     flag values the caller passed. This is the "carry the edits forward"
+//     step users expect from Google/Apple.
+func executeCalendarUpdateThisAndFollowing(ctx context.Context, runtime *common.RuntimeContext, calendarID string, current *calendarEvent, targetEventID string) error {
+	pivotUnix, ok := parseInstanceOriginalTime(targetEventID)
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"--%s=%s needs a recurring instance event_id (shape `{uid}_{originalTime}` with a positive originalTime); got %q",
+			flagApplyTo, applyToThisAndFollowing, targetEventID).WithParam("--event-id")
+	}
+	master, err := ensureMasterEvent(runtime, calendarID, current, targetEventID)
+	if err != nil {
+		return err
+	}
+	masterID := master.EventID
+	if masterID == "" {
+		masterID = masterEventID(targetEventID)
+		master.EventID = masterID
+	}
+	if strings.TrimSpace(master.Recurrence) == "" {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"master event %s has no recurrence rule; cannot truncate", masterID)
+	}
+
+	// The scan window starts at the pivot day's midnight (in the event's
+	// timezone) — every exception with originalTime >= pivot is on that same
+	// day or later, so the scan is bounded to the tail of the series.
+	loc := eventLocation(master)
+	pivotDay := pivotDayMidnight(pivotUnix, loc)
+	windowEnd := recurringEndFromRRule(master.Recurrence, pivotDay.Unix(), time.Now())
+	if windowEnd <= pivotDay.Unix() {
+		windowEnd = pivotDay.Unix()
+	}
+	// this-and-following always destroys exceptions on/after the pivot
+	// (deleteException=true → is_deleted=true), so include cancelled
+	// placeholders in the scan so they get destroyed alongside the live rows.
+	all, err := listExceptionsInWindow(ctx, runtime, calendarID, masterID,
+		recurringWindow{Start: pivotDay.Unix(), End: windowEnd}, true)
+	if err != nil {
+		return err
+	}
+	future := filterOnOrAfter(all, pivotUnix)
+
+	errOut := runtime.IO().ErrOut
+	var worker *exceptionWorker
+	if len(future) > 0 {
+		fmt.Fprintf(errOut, "%s this-and-following: deleting %d exception(s) on/after pivot %d (%s)\n",
+			updateLogPrefix, len(future), pivotUnix, formatPivotDatetime(pivotUnix, loc))
+		worker, err = runExceptionDeletion(ctx, runtime, calendarID, future, nil)
+		if err != nil {
+			return err
+		}
+	}
+	truncatedRRule := truncateRecurrenceUntil(master.Recurrence, pivotDay)
+	fmt.Fprintf(errOut, "%s truncating master rrule at %s (UNTIL=%s)\n",
+		updateLogPrefix, pivotDay.Format(time.RFC3339), truncatedRRule)
+	patchResp, err := runtime.CallAPITyped("PATCH", calendarUpdateEventPath(calendarID, masterID),
+		map[string]interface{}{"user_id_type": "open_id"},
+		map[string]interface{}{
+			"recurrence":        truncatedRRule,
+			"need_notification": runtime.Bool("notify"),
+		})
+	if err != nil {
+		return withStepContext(err, "future exceptions deleted but master rrule truncation failed for %s", masterID)
+	}
+	truncatedMaster, err := parseCalendarEvent(patchResp)
+	if err != nil {
+		return withStepContext(err, "master rrule truncated but response parsing failed for %s", masterID)
+	}
+
+	newEventID, newEvent, addedCount, removedCount, err := createFollowingSeries(runtime, calendarID, master, current, pivotUnix)
+	if err != nil {
+		return withStepContext(err, "master truncated but the new (following) series could not be created; you may need to recreate it manually with `+create`")
+	}
+	fmt.Fprintf(errOut, "%s created new following series event_id=%s\n", updateLogPrefix, newEventID)
+
+	truncatedEvent := map[string]interface{}{
+		"master_event_id": masterID,
+		"rrule_truncated": truncatedRRule,
+	}
+	if start := formatCalendarEventTime(eventTimeAsMap(truncatedMaster.StartTime)); start != "" {
+		truncatedEvent["start"] = start
+	}
+	if end := formatCalendarEventTime(eventTimeAsMap(truncatedMaster.EndTime)); end != "" {
+		truncatedEvent["end"] = end
+	}
+	followEvent := calendarUpdateResult(newEventID, newEvent, addedCount, removedCount)
+	if rrule, _ := newEvent["recurrence"].(string); rrule != "" {
+		followEvent["rrule"] = rrule
+	}
+
+	result := map[string]interface{}{
+		"calendar_id":     calendarID,
+		"apply_to":        applyToThisAndFollowing,
+		"truncated_event": truncatedEvent,
+		"follow_event":    followEvent,
+	}
+	if worker != nil {
+		exceptions := map[string]interface{}{
+			"total":   len(future),
+			"deleted": int(worker.processed.Load()),
+			"failed":  int(worker.failed.Load()),
+		}
+		if failures := worker.Failures(); len(failures) > 0 {
+			exceptions["failures"] = failures
+		}
+		result["exceptions"] = exceptions
+	}
+	runtime.OutFormat(result, nil, func(w io.Writer) {
+		writeThisAndFollowingPretty(w, result, targetEventID)
+	})
+	return nil
+}
+
+// writeThisAndFollowingPretty renders the three sections users expect in this
+// order (only the ones with content):
+//  1. Header: which apply_to scope was executed on which event_id.
+//  2. Truncated event: the pivot-instance id, its master id, and the master's
+//     new (truncated) recurrence rule.
+//  3. Follow-up event: the newly created series' event_id, start/end (RFC3339),
+//     rrule, attendee counts, summary/description.
+//  4. Exception deletion summary (skipped when there was nothing to delete).
+func writeThisAndFollowingPretty(w io.Writer, result map[string]interface{}, targetEventID string) {
+	fmt.Fprintf(w, "Applied `%s` on %s\n\n", applyToThisAndFollowing, targetEventID)
+	if truncated, ok := result["truncated_event"].(map[string]interface{}); ok {
+		fmt.Fprintln(w, "Truncated event:")
+		output.PrintTable(w, []map[string]interface{}{truncated})
+		fmt.Fprintln(w)
+	}
+	if follow, ok := result["follow_event"].(map[string]interface{}); ok {
+		fmt.Fprintln(w, "Follow-up event:")
+		output.PrintTable(w, []map[string]interface{}{follow})
+		fmt.Fprintln(w)
+	}
+	if exceptions, ok := result["exceptions"].(map[string]interface{}); ok {
+		fmt.Fprintln(w, "Exceptions removed:")
+		output.PrintTable(w, []map[string]interface{}{exceptions})
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintln(w, "Recurring series updated successfully")
+}
+
+// createFollowingSeries assembles the request body for the new "following"
+// series and POSTs /events. Inheritance rules (base = master, overlaid by
+// caller flags):
+//   - summary / description: caller flag when Changed(), else master value
+//   - start / end: caller flag when Changed(), else the pivot instance's
+//     start/end (so the new series begins exactly where the old one was
+//     truncated)
+//   - rrule: caller flag when Changed(), else the master's original rrule
+//     with its UNTIL kept verbatim and COUNT dropped. UNTIL is a fixed
+//     absolute date so it copies cleanly; COUNT anchors on the old dtstart
+//     and has no meaning against a new pivot.
+//   - vchat / reminders / attendee_ability / free_busy_status / location /
+//     visibility: inherited from the master untouched.
+//
+// The create endpoint does not accept attendees inline, so participants and
+// meeting rooms are propagated in a follow-up POST /attendees: the master's
+// existing attendees are fetched and re-added on the new series, then
+// --remove-attendee-ids is subtracted and --add-attendee-ids is unioned in.
+func createFollowingSeries(runtime *common.RuntimeContext, calendarID string, master, pivot *calendarEvent, pivotUnix int64) (string, map[string]interface{}, int, int, error) {
+	body := map[string]interface{}{
+		"summary":          "",
+		"attendee_ability": firstNonEmpty(master.AttendeeAbility, "can_modify_event"),
+		"free_busy_status": firstNonEmpty(master.FreeBusyStatus, "busy"),
+		"reminders": func() interface{} {
+			if len(master.Reminders) == 0 {
+				return []map[string]int{{"minutes": 5}}
+			}
+			return master.Reminders
+		}(),
+		"color": master.Color,
+	}
+	if master.VChat != nil {
+		body["vchat"] = master.VChat
+	}
+	if master.Location != nil {
+		body["location"] = master.Location
+	}
+	if master.Visibility != "" {
+		body["visibility"] = master.Visibility
+	}
+
+	if master.Attachments != nil {
+		body["attachments"] = master.Attachments
+	}
+
+	if master.EventCheckIn != nil {
+		body["event_check_in"] = master.EventCheckIn
+	}
+
+	if runtime.Cmd.Flags().Changed("summary") {
+		body["summary"] = runtime.Str("summary")
+	} else if master.Summary != "" {
+		body["summary"] = master.Summary
+	}
+	if runtime.Cmd.Flags().Changed("description") {
+		body["description_rich"] = runtime.Str("description")
+	} else if master.DescriptionRich != "" {
+		body["description_rich"] = master.DescriptionRich
+	} else if master.Description != "" {
+		body["description_rich"] = master.Description
+	}
+
+	startTs, endTs, err := resolveFollowingSeriesTimes(runtime, pivot, pivotUnix)
+	if err != nil {
+		return "", nil, 0, 0, err
+	}
+	startTimeMap := map[string]string{"timestamp": startTs}
+	if master.StartTime != nil && master.StartTime.Timezone != "" {
+		startTimeMap["timezone"] = master.StartTime.Timezone
+	}
+	body["start_time"] = startTimeMap
+	endTimeMap := map[string]string{"timestamp": endTs}
+	if master.EndTime != nil && master.EndTime.Timezone != "" {
+		endTimeMap["timezone"] = master.EndTime.Timezone
+	}
+	body["end_time"] = endTimeMap
+
+	newRRule := ""
+	if runtime.Cmd.Flags().Changed("rrule") {
+		newRRule = strings.TrimSpace(runtime.Str("rrule"))
+	} else {
+		newRRule = strings.TrimSpace(inheritRRuleForFollowing(master.Recurrence))
+	}
+	if newRRule != "" {
+		body["recurrence"] = newRRule
+	}
+
+	data, err := runtime.CallAPITyped("POST",
+		fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events", validate.EncodePathSegment(calendarID)),
+		nil, body)
+	if err != nil {
+		return "", nil, 0, 0, err
+	}
+	newEvent, _ := data["event"].(map[string]interface{})
+	newEventID, _ := newEvent["event_id"].(string)
+	if newEventID == "" {
+		return "", nil, 0, 0, errs.NewInternalError(errs.SubtypeInvalidResponse, "create returned empty event_id for the new following series")
+	}
+
+	// Attendees / rooms: inherit master's, subtract --remove, union --add.
+	inherited, err := fetchInheritableAttendees(runtime, calendarID, master.EventID)
+	if err != nil {
+		return newEventID, newEvent, 0, 0, withStepContext(err, "new series %s created but master attendee inheritance failed", newEventID)
+	}
+	removeIDs := map[string]struct{}{}
+	removedCount := 0
+	if removeStr := runtime.Str("remove-attendee-ids"); strings.TrimSpace(removeStr) != "" {
+		ids, err := parseCalendarAttendeeIDs(removeStr)
+		if err != nil {
+			return newEventID, newEvent, 0, 0, withParam(err, "--remove-attendee-ids")
+		}
+		for _, id := range ids {
+			removeIDs[id] = struct{}{}
+		}
+		removedCount = len(ids)
+	}
+	final := filterOutAttendees(inherited, removeIDs)
+	addedCount := 0
+	if addStr := runtime.Str("add-attendee-ids"); strings.TrimSpace(addStr) != "" {
+		added, err := parseAttendees(addStr, "")
+		if err != nil {
+			return newEventID, newEvent, 0, 0, withParam(err, "--add-attendee-ids")
+		}
+		final = mergeAttendees(final, added)
+		addedCount = len(added)
+	}
+	if len(final) > 0 {
+		_, err = runtime.CallAPITyped("POST",
+			calendarUpdateAttendeesPath(calendarID, newEventID),
+			map[string]interface{}{"user_id_type": "open_id"},
+			map[string]interface{}{"attendees": final, "need_notification": runtime.Bool("notify")})
+		if err != nil {
+			return newEventID, newEvent, addedCount, removedCount, withStepContext(err, "new series %s created but attendee sync failed", newEventID)
+		}
+	}
+	return newEventID, newEvent, addedCount, removedCount, nil
+}
+
+// inheritRRuleForFollowing keeps every rrule segment except COUNT. UNTIL is a
+// fixed wall-clock cutoff and copies cleanly onto the new series; COUNT is an
+// occurrence total anchored on the old dtstart and would be misinterpreted
+// against the new pivot, so we drop it.
+func inheritRRuleForFollowing(rrule string) string {
+	body := strings.TrimSpace(rrule)
+	prefix := ""
+	if strings.HasPrefix(body, "RRULE:") {
+		prefix = "RRULE:"
+		body = strings.TrimPrefix(body, "RRULE:")
+	}
+	var kept []string
+	for _, part := range strings.Split(body, ";") {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToUpper(p), "COUNT=") {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	return prefix + strings.Join(kept, ";")
+}
+
+// fetchInheritableAttendees pages through the master's attendee list and
+// projects each entry back into the create/attendees request shape
+// ({type, user_id|chat_id|room_id, ...}). Third-party attendees are skipped
+// because /events/{id}/attendees does not accept them.
+func fetchInheritableAttendees(runtime *common.RuntimeContext, calendarID, masterID string) ([]map[string]interface{}, error) {
+	if strings.TrimSpace(masterID) == "" {
+		return nil, nil
+	}
+	out := []map[string]interface{}{}
+	pageToken := ""
+	for {
+		params := map[string]interface{}{"page_size": 100, "user_id_type": "open_id"}
+		if pageToken != "" {
+			params["page_token"] = pageToken
+		}
+		data, err := runtime.CallAPITyped("GET",
+			fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s/attendees",
+				validate.EncodePathSegment(calendarID), validate.EncodePathSegment(masterID)),
+			params, nil)
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range common.GetSlice(data, "items") {
+			item, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if projected := projectInheritedAttendee(item); projected != nil {
+				out = append(out, projected)
+			}
+		}
+		hasMore, _ := data["has_more"].(bool)
+		pageToken, _ = data["page_token"].(string)
+		if !hasMore || pageToken == "" {
+			break
+		}
+	}
+	return out, nil
+}
+
+// projectInheritedAttendee reduces a fetched attendee entry to the fields the
+// create/attendees endpoint accepts on a new event. Returns nil when the entry
+// is not carriable (unknown type, third-party without shape guarantees, or
+// missing the id field its type requires).
+func projectInheritedAttendee(a map[string]interface{}) map[string]interface{} {
+	t, _ := a["type"].(string)
+	switch t {
+	case "user":
+		userID, _ := a["user_id"].(string)
+		if userID == "" {
+			return nil
+		}
+		return map[string]interface{}{"type": "user", "user_id": userID}
+	case "resource":
+		roomID, _ := a["room_id"].(string)
+		if roomID == "" {
+			return nil
+		}
+		out := map[string]interface{}{"type": "resource", "room_id": roomID}
+		if v, ok := a["resource_customization"]; ok && v != nil {
+			out["resource_customization"] = v
+		}
+		return out
+	case "chat":
+		chatID, _ := a["chat_id"].(string)
+		if chatID == "" {
+			return nil
+		}
+		return map[string]interface{}{"type": "chat", "chat_id": chatID}
+	case "third_party":
+		thirdPartyEmail, _ := a["third_party_email"].(string)
+		if thirdPartyEmail == "" {
+			return nil
+		}
+		return map[string]interface{}{"type": "third_party", "third_party_email": thirdPartyEmail}
+	}
+	return nil
+}
+
+// filterOutAttendees drops entries whose id matches a value in removeIDs. It
+// only inspects the id field appropriate to each type.
+func filterOutAttendees(list []map[string]interface{}, removeIDs map[string]struct{}) []map[string]interface{} {
+	if len(removeIDs) == 0 {
+		return list
+	}
+	out := make([]map[string]interface{}, 0, len(list))
+	for _, a := range list {
+		if attendeeMatchesRemoval(a, removeIDs) {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+func attendeeMatchesRemoval(a map[string]interface{}, removeIDs map[string]struct{}) bool {
+	for _, key := range []string{"user_id", "chat_id", "room_id"} {
+		if id, _ := a[key].(string); id != "" {
+			if _, ok := removeIDs[id]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// mergeAttendees appends parsed --add-attendee-ids entries (map[string]string
+// as produced by parseAttendees) onto the inherited list without duplicating
+// an entry already present.
+func mergeAttendees(inherited []map[string]interface{}, added []map[string]string) []map[string]interface{} {
+	seen := map[string]struct{}{}
+	for _, a := range inherited {
+		if key := attendeeKey(a); key != "" {
+			seen[key] = struct{}{}
+		}
+	}
+	out := inherited
+	for _, a := range added {
+		entry := map[string]interface{}{}
+		for k, v := range a {
+			entry[k] = v
+		}
+		key := attendeeKey(entry)
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func attendeeKey(a map[string]interface{}) string {
+	t, _ := a["type"].(string)
+	for _, key := range []string{"user_id", "chat_id", "room_id"} {
+		if id, _ := a[key].(string); id != "" {
+			return t + ":" + id
+		}
+	}
+	return ""
+}
+
+// resolveFollowingSeriesTimes returns the (start, end) unix-seconds strings
+// to use for the new series. If the caller explicitly set --start/--end, they
+// take precedence; otherwise the pivot instance's own times are reused so the
+// new series begins right where the caller pointed.
+func resolveFollowingSeriesTimes(runtime *common.RuntimeContext, pivot *calendarEvent, pivotUnix int64) (string, string, error) {
+	if runtime.Cmd.Flags().Changed("start") && runtime.Cmd.Flags().Changed("end") {
+		startTs, err := common.ParseTime(runtime.Str("start"))
+		if err != nil {
+			return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
+		}
+		endTs, err := common.ParseTime(runtime.Str("end"), "end")
+		if err != nil {
+			return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
+		}
+		return startTs, endTs, nil
+	}
+	// Fall back to the pivot instance times when the caller only changed
+	// non-time fields.
+	if pivot != nil && pivot.StartTime != nil && pivot.EndTime != nil {
+		startTs := pivot.StartTime.Timestamp
+		endTs := pivot.EndTime.Timestamp
+		if startTs != "" && endTs != "" {
+			return startTs, endTs, nil
+		}
+	}
+	// Last-resort: same duration as one hour starting at pivot. The instances
+	// API always returns instance timestamps, so this should not happen in
+	// practice.
+	return fmt.Sprintf("%d", pivotUnix), fmt.Sprintf("%d", pivotUnix+3600), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/shortcuts/calendar/calendar_update_recurring_test.go
+++ b/shortcuts/calendar/calendar_update_recurring_test.go
@@ -1,0 +1,490 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Focused unit tests for pure helpers in calendar_update_recurring.go. The
+// end-to-end +update flow is exercised elsewhere; these tests cover the small
+// deterministic pieces (attendee projection, dedup, key derivation, time
+// comparison, pretty output) that would otherwise sit at 0% coverage.
+
+package calendar
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// -----------------------------------------------------------------------------
+// projectInheritedAttendee
+// -----------------------------------------------------------------------------
+
+func TestProjectInheritedAttendee(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]interface{}
+		want map[string]interface{}
+	}{
+		{"user ok", map[string]interface{}{"type": "user", "user_id": "u1"},
+			map[string]interface{}{"type": "user", "user_id": "u1"}},
+		{"user missing id → nil", map[string]interface{}{"type": "user"}, nil},
+		{"resource ok", map[string]interface{}{"type": "resource", "room_id": "r1"},
+			map[string]interface{}{"type": "resource", "room_id": "r1"}},
+		{"resource with customization carried", map[string]interface{}{
+			"type": "resource", "room_id": "r1",
+			"resource_customization": []interface{}{"opt1"},
+		}, map[string]interface{}{
+			"type": "resource", "room_id": "r1",
+			"resource_customization": []interface{}{"opt1"},
+		}},
+		{"resource missing room_id → nil", map[string]interface{}{"type": "resource"}, nil},
+		{"chat ok", map[string]interface{}{"type": "chat", "chat_id": "oc"},
+			map[string]interface{}{"type": "chat", "chat_id": "oc"}},
+		{"chat missing id → nil", map[string]interface{}{"type": "chat"}, nil},
+		{"third_party ok", map[string]interface{}{"type": "third_party", "third_party_email": "x@y"},
+			map[string]interface{}{"type": "third_party", "third_party_email": "x@y"}},
+		{"third_party missing email → nil", map[string]interface{}{"type": "third_party"}, nil},
+		{"unknown type → nil", map[string]interface{}{"type": "alien", "user_id": "u1"}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := projectInheritedAttendee(c.in)
+			if !mapsShallowEqual(got, c.want) {
+				t.Errorf("projectInheritedAttendee(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// filterOutAttendees / attendeeMatchesRemoval
+// -----------------------------------------------------------------------------
+
+func TestFilterOutAttendees(t *testing.T) {
+	list := []map[string]interface{}{
+		{"type": "user", "user_id": "u1"},
+		{"type": "user", "user_id": "u2"},
+		{"type": "chat", "chat_id": "oc1"},
+		{"type": "resource", "room_id": "r1"},
+	}
+	t.Run("empty removeIDs → list unchanged", func(t *testing.T) {
+		got := filterOutAttendees(list, map[string]struct{}{})
+		if len(got) != len(list) {
+			t.Errorf("len=%d, want %d", len(got), len(list))
+		}
+	})
+	t.Run("drops matches across id fields", func(t *testing.T) {
+		remove := map[string]struct{}{"u1": {}, "r1": {}, "oc1": {}}
+		got := filterOutAttendees(list, remove)
+		if len(got) != 1 || got[0]["user_id"] != "u2" {
+			t.Errorf("got %+v, want only u2 to survive", got)
+		}
+	})
+	t.Run("no match → list unchanged", func(t *testing.T) {
+		got := filterOutAttendees(list, map[string]struct{}{"nobody": {}})
+		if len(got) != len(list) {
+			t.Errorf("len=%d, want %d", len(got), len(list))
+		}
+	})
+}
+
+func TestAttendeeMatchesRemoval(t *testing.T) {
+	remove := map[string]struct{}{"u1": {}}
+	if !attendeeMatchesRemoval(map[string]interface{}{"user_id": "u1"}, remove) {
+		t.Error("user_id match should return true")
+	}
+	if attendeeMatchesRemoval(map[string]interface{}{"user_id": "u2"}, remove) {
+		t.Error("non-match should return false")
+	}
+	if attendeeMatchesRemoval(map[string]interface{}{}, remove) {
+		t.Error("no id fields → false")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// attendeeKey / mergeAttendees
+// -----------------------------------------------------------------------------
+
+func TestAttendeeKey(t *testing.T) {
+	cases := []struct {
+		in   map[string]interface{}
+		want string
+	}{
+		{map[string]interface{}{"type": "user", "user_id": "u1"}, "user:u1"},
+		{map[string]interface{}{"type": "chat", "chat_id": "oc1"}, "chat:oc1"},
+		{map[string]interface{}{"type": "resource", "room_id": "r1"}, "resource:r1"},
+		{map[string]interface{}{"type": "user"}, ""},
+		{map[string]interface{}{}, ""},
+	}
+	for _, c := range cases {
+		got := attendeeKey(c.in)
+		if got != c.want {
+			t.Errorf("attendeeKey(%v)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestMergeAttendees_DedupsAndPreservesInherited(t *testing.T) {
+	inherited := []map[string]interface{}{
+		{"type": "user", "user_id": "u1"},
+	}
+	added := []map[string]string{
+		{"type": "user", "user_id": "u1"},  // duplicate → dropped
+		{"type": "user", "user_id": "u2"},  // new → kept
+		{"type": "chat", "chat_id": "oc1"}, // new → kept
+		{"type": "user"},                   // no id → dropped
+	}
+	got := mergeAttendees(inherited, added)
+	if len(got) != 3 {
+		t.Fatalf("want 3 attendees, got %d: %+v", len(got), got)
+	}
+	if got[0]["user_id"] != "u1" {
+		t.Errorf("first entry should be preserved inherited u1, got %+v", got[0])
+	}
+	// second and third are the added u2 and oc1, in order.
+	if got[1]["user_id"] != "u2" || got[2]["chat_id"] != "oc1" {
+		t.Errorf("unexpected merged order: %+v", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// firstNonEmpty
+// -----------------------------------------------------------------------------
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "", "a", "b"); got != "a" {
+		t.Errorf("got %q want %q", got, "a")
+	}
+	if got := firstNonEmpty("", ""); got != "" {
+		t.Errorf("got %q want empty", got)
+	}
+	if got := firstNonEmpty("x"); got != "x" {
+		t.Errorf("got %q want %q", got, "x")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// parseDateOnly
+// -----------------------------------------------------------------------------
+
+func TestParseDateOnly(t *testing.T) {
+	if s, ok := parseDateOnly("2026-03-21", time.UTC); !ok || s != "2026-03-21" {
+		t.Errorf("got (%q,%v), want (2026-03-21,true)", s, ok)
+	}
+	if _, ok := parseDateOnly("2026-03-21T09:00:00", time.UTC); ok {
+		t.Error("datetime input should not parse as bare date")
+	}
+	if _, ok := parseDateOnly("not-a-date", time.UTC); ok {
+		t.Error("garbage input should not parse")
+	}
+	if _, ok := parseDateOnly("", time.UTC); ok {
+		t.Error("empty input should not parse")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// masterTimeChanged
+// -----------------------------------------------------------------------------
+
+// timeFlagsRuntime returns a runtime whose Cmd carries string --start / --end
+// flags. Passing "" leaves the flag unchanged (as if the user omitted it).
+func timeFlagsRuntime(t *testing.T, start, end string) *common.RuntimeContext {
+	t.Helper()
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("start", "", "")
+	cmd.Flags().String("end", "", "")
+	if start != "" {
+		if err := cmd.Flags().Set("start", start); err != nil {
+			t.Fatalf("set --start: %v", err)
+		}
+	}
+	if end != "" {
+		if err := cmd.Flags().Set("end", end); err != nil {
+			t.Fatalf("set --end: %v", err)
+		}
+	}
+	return common.TestNewRuntimeContextForAPI(context.Background(), cmd, defaultConfig(), f, core.AsBot)
+}
+
+func TestMasterTimeChanged_FlagsUnset_ReturnsFalse(t *testing.T) {
+	rt := timeFlagsRuntime(t, "", "")
+	master := &calendarEvent{
+		StartTime: &calendarEventTime{Timestamp: "100"},
+		EndTime:   &calendarEventTime{Timestamp: "200"},
+	}
+	changed, err := masterTimeChanged(rt, master)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false when neither flag was set")
+	}
+}
+
+func TestMasterTimeChanged_NilMaster_ReturnsTrue(t *testing.T) {
+	rt := timeFlagsRuntime(t, "1700000000", "1700003600")
+	changed, err := masterTimeChanged(rt, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !changed {
+		t.Error("nil master with both flags set should be treated as changed")
+	}
+}
+
+func TestMasterTimeChanged_TimedEcho_ReturnsFalse(t *testing.T) {
+	rt := timeFlagsRuntime(t, "1700000000", "1700003600")
+	master := &calendarEvent{
+		StartTime: &calendarEventTime{Timestamp: "1700000000"},
+		EndTime:   &calendarEventTime{Timestamp: "1700003600"},
+	}
+	changed, err := masterTimeChanged(rt, master)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if changed {
+		t.Error("echoing master's timestamp should not be considered a change")
+	}
+}
+
+func TestMasterTimeChanged_TimedDifferent_ReturnsTrue(t *testing.T) {
+	rt := timeFlagsRuntime(t, "1700000000", "1700007200")
+	master := &calendarEvent{
+		StartTime: &calendarEventTime{Timestamp: "1700000000"},
+		EndTime:   &calendarEventTime{Timestamp: "1700003600"},
+	}
+	changed, err := masterTimeChanged(rt, master)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !changed {
+		t.Error("different end should be flagged as changed")
+	}
+}
+
+func TestMasterTimeChanged_AllDayEcho_ReturnsFalse(t *testing.T) {
+	rt := timeFlagsRuntime(t, "2026-03-21", "2026-03-22")
+	master := &calendarEvent{
+		StartTime: &calendarEventTime{Date: "2026-03-21"},
+		EndTime:   &calendarEventTime{Date: "2026-03-22"},
+	}
+	changed, err := masterTimeChanged(rt, master)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if changed {
+		t.Error("echoing all-day dates should not be treated as changed")
+	}
+}
+
+func TestMasterTimeChanged_AllDayDifferent_ReturnsTrue(t *testing.T) {
+	rt := timeFlagsRuntime(t, "2026-03-22", "2026-03-23")
+	master := &calendarEvent{
+		StartTime: &calendarEventTime{Date: "2026-03-21"},
+		EndTime:   &calendarEventTime{Date: "2026-03-22"},
+	}
+	changed, err := masterTimeChanged(rt, master)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !changed {
+		t.Error("different all-day date should be flagged as changed")
+	}
+}
+
+func TestMasterTimeChanged_AllDayWithTimedInput_ReturnsTrue(t *testing.T) {
+	// A timestamped input against an all-day master inherently drops all-day
+	// semantics — must be treated as a change.
+	rt := timeFlagsRuntime(t, "2026-03-21T09:00:00Z", "2026-03-21T10:00:00Z")
+	master := &calendarEvent{
+		StartTime: &calendarEventTime{Date: "2026-03-21"},
+		EndTime:   &calendarEventTime{Date: "2026-03-22"},
+	}
+	changed, err := masterTimeChanged(rt, master)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !changed {
+		t.Error("timed input against all-day master should be flagged as changed")
+	}
+}
+
+func TestMasterTimeChanged_InvalidStart_ReturnsError(t *testing.T) {
+	rt := timeFlagsRuntime(t, "not-a-time", "1700003600")
+	master := &calendarEvent{
+		StartTime: &calendarEventTime{Timestamp: "1700000000"},
+		EndTime:   &calendarEventTime{Timestamp: "1700003600"},
+	}
+	if _, err := masterTimeChanged(rt, master); err == nil {
+		t.Error("expected error for unparseable --start")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// resolveFollowingSeriesTimes
+// -----------------------------------------------------------------------------
+
+func TestResolveFollowingSeriesTimes_UsesFlagsWhenChanged(t *testing.T) {
+	rt := timeFlagsRuntime(t, "1700000000", "1700003600")
+	startTs, endTs, err := resolveFollowingSeriesTimes(rt, nil, 1700000000)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if startTs != "1700000000" || endTs != "1700003600" {
+		t.Errorf("got (%s,%s), want flag values", startTs, endTs)
+	}
+}
+
+func TestResolveFollowingSeriesTimes_FallsBackToPivot(t *testing.T) {
+	rt := timeFlagsRuntime(t, "", "")
+	pivot := &calendarEvent{
+		StartTime: &calendarEventTime{Timestamp: "1700100000"},
+		EndTime:   &calendarEventTime{Timestamp: "1700103600"},
+	}
+	startTs, endTs, err := resolveFollowingSeriesTimes(rt, pivot, 1700100000)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if startTs != "1700100000" || endTs != "1700103600" {
+		t.Errorf("got (%s,%s), want pivot times", startTs, endTs)
+	}
+}
+
+func TestResolveFollowingSeriesTimes_LastResortDefaultsToPivotPlusHour(t *testing.T) {
+	rt := timeFlagsRuntime(t, "", "")
+	// pivot has empty timestamps → last-resort branch.
+	startTs, endTs, err := resolveFollowingSeriesTimes(rt, nil, 1700200000)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if startTs != "1700200000" || endTs != "1700203600" {
+		t.Errorf("got (%s,%s), want (1700200000,1700203600)", startTs, endTs)
+	}
+}
+
+func TestResolveFollowingSeriesTimes_InvalidStartInput_ReturnsError(t *testing.T) {
+	rt := timeFlagsRuntime(t, "not-a-time", "1700003600")
+	if _, _, err := resolveFollowingSeriesTimes(rt, nil, 0); err == nil {
+		t.Error("expected error for unparseable --start")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// writeUpdatePretty
+// -----------------------------------------------------------------------------
+
+func TestWriteUpdatePretty_RendersHeaderEventAndExceptions(t *testing.T) {
+	var buf bytes.Buffer
+	result := map[string]interface{}{
+		"updated_event": map[string]interface{}{
+			"event_id": "evt_1",
+			"action":   "patched",
+		},
+		"exceptions": map[string]interface{}{
+			"total":   float64(2),
+			"patched": float64(2),
+		},
+	}
+	writeUpdatePretty(&buf, result, "evt_1", "all", "updated_event",
+		"Updated event", "Exceptions patched")
+	out := buf.String()
+	for _, want := range []string{
+		"Applied `all` on evt_1",
+		"Updated event:",
+		"Exceptions patched:",
+		"Event updated successfully",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteUpdatePretty_SkipsMissingExceptionsSection(t *testing.T) {
+	var buf bytes.Buffer
+	result := map[string]interface{}{
+		"updated_event": map[string]interface{}{"event_id": "evt_1"},
+	}
+	writeUpdatePretty(&buf, result, "evt_1", "all", "updated_event",
+		"Updated event", "Exceptions patched")
+	out := buf.String()
+	if strings.Contains(out, "Exceptions patched:") {
+		t.Errorf("should not render exceptions section when absent, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Event updated successfully") {
+		t.Errorf("footer missing:\n%s", out)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// writeDeletePretty
+// -----------------------------------------------------------------------------
+
+func TestWriteDeletePretty_RendersHeaderEventAndExceptions(t *testing.T) {
+	var buf bytes.Buffer
+	result := map[string]interface{}{
+		"deleted_event": map[string]interface{}{
+			"event_id": "evt_1",
+			"action":   "deleted",
+		},
+		"exceptions": map[string]interface{}{
+			"total":   float64(1),
+			"deleted": float64(1),
+		},
+	}
+	writeDeletePretty(&buf, result, "evt_1", "all", "deleted_event", "Deleted event")
+	out := buf.String()
+	for _, want := range []string{
+		"Applied `all` on evt_1",
+		"Deleted event:",
+		"Exceptions removed:",
+		"Event deleted successfully",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+func mapsShallowEqual(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok {
+			return false
+		}
+		// Two nil interface values compare equal; a slice compare below covers
+		// the resource_customization case (single-level).
+		as, aOK := va.([]interface{})
+		bs, bOK := vb.([]interface{})
+		if aOK && bOK {
+			if len(as) != len(bs) {
+				return false
+			}
+			for i := range as {
+				if as[i] != bs[i] {
+					return false
+				}
+			}
+			continue
+		}
+		if va != vb {
+			return false
+		}
+	}
+	return true
+}

--- a/shortcuts/calendar/helpers.go
+++ b/shortcuts/calendar/helpers.go
@@ -4,6 +4,8 @@
 package calendar
 
 import (
+	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -83,4 +85,144 @@ func rejectCalendarAutoBotFallback(runtime *common.RuntimeContext) error {
 		hint,
 	)
 	return recovery.AnnotateMessage(err, message)
+}
+
+// calendarTimeInputRange declares a single time input to check for offset drift.
+// A start/end pair is passed as two separate entries so each label is reported
+// independently.
+type calendarTimeInputRange struct {
+	Flag  string
+	Value string
+}
+
+// calendarTimezoneMismatch captures one input whose explicit offset differs
+// from the local system offset at the same instant, together with the values
+// needed to render a self-explanatory line to the user.
+type calendarTimezoneMismatch struct {
+	flag      string
+	value     string
+	inputZone string
+	localZone string
+}
+
+// warnCalendarTimezoneMismatch inspects each provided time input and, when the
+// input carries an explicit UTC offset that differs from the current system
+// local offset at that instant, writes a single non-blocking hint to stderr.
+// It never returns an error — the goal is to catch accidental cross-timezone
+// scheduling before an event lands on the wrong wall clock.
+//
+// Inputs without an explicit offset (bare date, "YYYY-MM-DDTHH:MM(:SS)" with no
+// zone, Unix timestamps, empty strings, unparseable strings) are skipped: the
+// user has not asserted a specific zone, so there is nothing to reconcile.
+func warnCalendarTimezoneMismatch(runtime *common.RuntimeContext, inputs ...calendarTimeInputRange) {
+	if runtime == nil || runtime.Factory == nil || runtime.Factory.IOStreams == nil {
+		return
+	}
+	stderr := runtime.Factory.IOStreams.ErrOut
+	if stderr == nil {
+		return
+	}
+	var mismatches []calendarTimezoneMismatch
+	seen := map[string]struct{}{}
+	for _, in := range inputs {
+		val := strings.TrimSpace(in.Value)
+		if val == "" {
+			continue
+		}
+		t, ok := parseTimeWithExplicitOffset(val)
+		if !ok {
+			continue
+		}
+		_, inOffset := t.Zone()
+		_, localOffset := t.In(time.Local).Zone()
+		if inOffset == localOffset {
+			continue
+		}
+		key := in.Flag + "|" + val
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		mismatches = append(mismatches, calendarTimezoneMismatch{
+			flag:      in.Flag,
+			value:     val,
+			inputZone: formatTimezoneOffset(inOffset),
+			localZone: formatTimezoneOffset(localOffset),
+		})
+	}
+	if len(mismatches) == 0 {
+		return
+	}
+	writeCalendarTimezoneMismatchHint(stderr, mismatches)
+}
+
+// writeCalendarTimezoneMismatchHint renders the shared hint header plus one
+// line per mismatched input. Kept separate from the collection loop so the
+// message format stays in one place. Only the timezone labels are shown —
+// the wall-clock digits do not change when relabeling an instant into another
+// zone, so printing a "local time" column would misleadingly imply otherwise.
+func writeCalendarTimezoneMismatchHint(w io.Writer, mismatches []calendarTimezoneMismatch) {
+	fmt.Fprintf(w,
+		"hint: the timezone in the provided time differs from the local system timezone (local: %s); if the user explicitly requested that timezone, ignore this hint — otherwise prefer the local timezone.\n",
+		mismatches[0].localZone)
+}
+
+// parseTimeWithExplicitOffset returns the parsed time when input is an ISO 8601
+// string that carries an explicit UTC offset (e.g. "+08:00", "-05:00", or "Z").
+// Inputs without an explicit offset return (_, false) so the caller can skip
+// them: the user has not claimed a zone, so there is no mismatch to detect.
+func parseTimeWithExplicitOffset(input string) (time.Time, bool) {
+	formats := []string{
+		time.RFC3339,
+		"2006-01-02T15:04Z07:00",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, input); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// collectCalendarRangeInputs splits a comma-separated list of "start~end" pairs
+// (as used by --exclude / --slot) into individual entries suitable for
+// warnCalendarTimezoneMismatch. Malformed pairs are skipped silently because
+// the calling shortcut's Validate step already surfaces those as errors.
+func collectCalendarRangeInputs(flag, raw string) []calendarTimeInputRange {
+	var out []calendarTimeInputRange
+	for _, r := range strings.Split(strings.TrimSpace(raw), ",") {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		parts := strings.SplitN(r, "~", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		out = append(out,
+			calendarTimeInputRange{Flag: flag, Value: strings.TrimSpace(parts[0])},
+			calendarTimeInputRange{Flag: flag, Value: strings.TrimSpace(parts[1])},
+		)
+	}
+	return out
+}
+
+// formatTimezoneOffset renders an offset in seconds as "UTC+8" / "UTC-5:30" /
+// "UTC". Minute precision is included only when the offset has a non-zero
+// minute component so the common whole-hour case stays terse.
+func formatTimezoneOffset(offsetSec int) string {
+	if offsetSec == 0 {
+		return "UTC"
+	}
+	sign := "+"
+	if offsetSec < 0 {
+		sign = "-"
+		offsetSec = -offsetSec
+	}
+	h := offsetSec / 3600
+	m := (offsetSec % 3600) / 60
+	if m == 0 {
+		return fmt.Sprintf("UTC%s%d", sign, h)
+	}
+	return fmt.Sprintf("UTC%s%d:%02d", sign, h, m)
 }

--- a/shortcuts/calendar/helpers_test.go
+++ b/shortcuts/calendar/helpers_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func TestWarnCalendarTimezoneMismatch_MatchingOffsetSilent(t *testing.T) {
+	f, _, stderrBuf, _ := cmdutil.TestFactory(t, defaultConfig())
+	rt := &common.RuntimeContext{Factory: f}
+
+	_, localOffset := time.Now().Zone()
+	val := time.Now().Format("2006-01-02T15:04:05") + formatOffsetSuffix(localOffset)
+
+	warnCalendarTimezoneMismatch(rt, calendarTimeInputRange{Flag: "start", Value: val})
+	if got := stderrBuf.String(); got != "" {
+		t.Fatalf("expected no warning for matching offset, got: %q", got)
+	}
+}
+
+func TestWarnCalendarTimezoneMismatch_MismatchedOffsetWarns(t *testing.T) {
+	f, _, stderrBuf, _ := cmdutil.TestFactory(t, defaultConfig())
+	rt := &common.RuntimeContext{Factory: f}
+
+	// Shift the local offset by 1 hour so it's guaranteed different; fold back
+	// if the shift lands outside the valid IANA range.
+	_, localOffset := time.Now().Zone()
+	shifted := localOffset + 3600
+	if shifted >= 14*3600 {
+		shifted = localOffset - 3600
+	}
+	val := "2026-03-21T09:00:00" + formatOffsetSuffix(shifted)
+
+	warnCalendarTimezoneMismatch(rt, calendarTimeInputRange{Flag: "start", Value: val})
+	got := stderrBuf.String()
+	if !strings.Contains(got, "local system timezone") || !strings.Contains(got, "(local: UTC") {
+		t.Fatalf("expected timezone mismatch hint with local zone on stderr, got: %q", got)
+	}
+	if !strings.Contains(got, "prefer the local timezone") || !strings.Contains(got, "ignore this hint") {
+		t.Fatalf("expected guidance to prefer local timezone with ignore-if-intentional escape, got: %q", got)
+	}
+}
+
+func TestWarnCalendarTimezoneMismatch_NoExplicitOffsetSkipped(t *testing.T) {
+	f, _, stderrBuf, _ := cmdutil.TestFactory(t, defaultConfig())
+	rt := &common.RuntimeContext{Factory: f}
+
+	warnCalendarTimezoneMismatch(rt,
+		calendarTimeInputRange{Flag: "start", Value: "2026-03-21T09:00:00"},
+		calendarTimeInputRange{Flag: "end", Value: "2026-03-21"},
+		calendarTimeInputRange{Flag: "start", Value: "1710982800"},
+		calendarTimeInputRange{Flag: "end", Value: ""},
+	)
+	if got := stderrBuf.String(); got != "" {
+		t.Fatalf("expected no warning for inputs without explicit offset, got: %q", got)
+	}
+}
+
+func TestCollectCalendarRangeInputs_SplitsPairs(t *testing.T) {
+	out := collectCalendarRangeInputs("exclude",
+		"2026-03-21T09:00:00+08:00~2026-03-21T10:00:00+08:00, 2026-03-22T09:00:00Z~2026-03-22T10:00:00Z")
+	if len(out) != 4 {
+		t.Fatalf("expected 4 entries, got %d: %#v", len(out), out)
+	}
+	for _, e := range out {
+		if e.Flag != "exclude" {
+			t.Errorf("expected flag=exclude, got %q", e.Flag)
+		}
+	}
+}
+
+func TestFormatTimezoneOffset(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{0, "UTC"},
+		{8 * 3600, "UTC+8"},
+		{-5 * 3600, "UTC-5"},
+		{5*3600 + 30*60, "UTC+5:30"},
+		{-3*3600 - 30*60, "UTC-3:30"},
+	}
+	for _, c := range cases {
+		if got := formatTimezoneOffset(c.in); got != c.want {
+			t.Errorf("formatTimezoneOffset(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// formatOffsetSuffix renders a signed offset as the "+HH:MM" / "-HH:MM"
+// suffix accepted by ISO 8601 parsers.
+func formatOffsetSuffix(offsetSec int) string {
+	sign := "+"
+	if offsetSec < 0 {
+		sign = "-"
+		offsetSec = -offsetSec
+	}
+	return fmt.Sprintf("%s%02d:%02d", sign, offsetSec/3600, (offsetSec%3600)/60)
+}

--- a/shortcuts/calendar/shortcuts.go
+++ b/shortcuts/calendar/shortcuts.go
@@ -10,6 +10,7 @@ func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{
 		CalendarAgenda,
 		CalendarCreate,
+		CalendarDelete,
 		CalendarUpdate,
 		CalendarFreebusy,
 		CalendarRoomFind,
@@ -20,5 +21,6 @@ func Shortcuts() []common.Shortcut {
 		CalendarGet,
 		CalendarTransfer,
 		CalendarJoinEvent,
+		CalendarListAttendees,
 	}
 }

--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -35,15 +35,17 @@ lark-cli calendar +agenda --as bot
 | Shortcut | 说明 |
 |----------|------|
 | `+agenda` | 查看日程安排（默认今天） |
-| [`+meeting`](references/lark-calendar-meeting.md) | 通过日程事件 ID 获取关联的视频会议信息（meeting_id、meeting_note），日程开过视频会议才会有meeting_id |
+| [`+meeting`](references/lark-calendar-meeting.md) | 通过日程事件 ID 获取关联的视频会议信息（meeting_id、meeting_note），日程开过视频会议才会有meeting_id,**注意**: 视频会议链接获取走+get命令 |
 | [`+create`](references/lark-calendar-create.md) | 创建日程并邀请参会人（ISO 8601 时间） |
-| [`+update`](references/lark-calendar-update.md) | 更新既有日程字段，或独立增量添加/移除参会人和会议室 |
-| `+freebusy` | 查询用户主日历的忙闲信息和 RSVP 状态（纯查询场景；预约场景走 `+suggestion`） |
+| [`+update`](references/lark-calendar-update.md) | 更新既有日程字段，或独立增量添加/移除参会人和会议室；重复性日程/例外必须传 `--apply-to`（详见 [重复性日程操作规范](references/lark-calendar-recurring.md)） |
+| `+delete` | 删除日程；重复性日程/例外必须传 `--apply-to`（详见 [重复性日程操作规范](references/lark-calendar-recurring.md)） |
+| `+freebusy` | 查询主日历的忙闲/RSVP状态/空闲时间段。(**如需预约/推荐时间段**走 `+suggestion`——它综合工作时间、忙碌区间和休息时间推荐。) |
 | [`+room-find`](references/lark-calendar-room-find.md) | 针对一个或多个**明确的**时间块查找可用会议室（无明确时间时禁止直接调用，需先走 +suggestion） |
 | [`+rsvp`](references/lark-calendar-rsvp.md) | 回复日程（接受/拒绝/待定） |
 | [`+join-event`](references/lark-calendar-join-event.md) | 凭分享 token 加入日程（分享链接/二维码/分享卡片/RSVP 卡片） |
 | [`+suggestion`](references/lark-calendar-suggestion.md) | 根据非明确时间或一段时间范围，推荐多个可用时间块方案 |
 | [`+transfer`](references/lark-calendar-transfer.md) | 把日程组织者转让给另一个用户或机器人；不可逆，需 `--yes` |
+| [`+list-attendees`](references/lark-calendar-list-attendees.md) | 列出日程的参与人和会议室（支持按 `--type` 过滤：user / resource / chat / third_party） |
 
 ### `+get` — 单日程详情
 
@@ -56,6 +58,8 @@ lark-cli calendar +get --calendar-id <calendar_id> --event-id <event_id>
 
 日程描述统一使用 `description` 一个字段，按 **Markdown** 富文本处理。读取日程时 `description` 返回 Markdown 富文本（仅有纯文本描述时返回该纯文本）；创建/更新日程时也通过 `--description` 传入 Markdown。
 
+> `+get` 返回不含参会人和会议室。需要参与人视角（用户 / 会议室 / 群 / 三方邮箱）请调用 [`+list-attendees`](references/lark-calendar-list-attendees.md)。
+
 ### `+search-event` — 按关键词、时间范围和参会人搜索日程
 
 仅返回基础字段（`event_id`/`summary`/`start`/`end` 等），需要详情请走 `+get`。
@@ -67,6 +71,13 @@ lark-cli calendar +get --calendar-id <calendar_id> --event-id <event_id>
 # page-token 分页游标，用于继续翻页 可选
 # page-size 每页数量，默认 30 可选
 lark-cli calendar +search-event --query "周会" --start 2026-04-20 --end 2026-04-27 --attendee-ids "ou_user1,oc_chat1,omm_room1" --page-token <page_token> --page-size 30
+```
+
+### `+delete` — 删除日程
+
+```bash
+# calendar_id不传，默认primary
+lark-cli calendar +delete --calendar-id <calendar_id> --event-id <event_id> --notify true
 ```
 
 ### `+agenda` — 查看近期日程安排
@@ -83,20 +94,36 @@ lark-cli calendar +agenda --start 2026-03-10 --end 2026-03-17 --calendar-id <cal
 - 已取消的日程自动过滤；无日程时直接告知"日程清空"。
 - 时间范围超过 40 天会自动拆分查询并合并结果。
 
-### `+freebusy` — 查询主日历忙闲时段和 RSVP 状态
+### `+freebusy` — 查询主日历忙闲时段 / 事件 / 公共空闲
 
-仅返回忙碌时段起止时间，不含日程标题等隐私信息；其他订阅日历不在范围内。
+`+freebusy` 一个入口承担四种视角：几何计算类（`busy` / `free` / `common_free`）走自动合并；事件维度类（`raw_busy`）保留每条上游日程 + `rsvp_status`。
 
 ```bash
 # start/end 时间范围（ISO 8601 / YYYY-MM-DD / Unix 秒），均可选；默认当天
-# user-id 目标用户 open_id（ou_ 前缀）可选；默认当前登录用户，bot 身份必须显式指定
-lark-cli calendar +freebusy --start 2026-03-11 --end 2026-03-12 --user-id ou_xxx
+# user-id 目标用户 open_id，可重复或用逗号分隔；默认当前登录用户，bot 身份必须显式传至少一个
+# type 视角四选一（默认 busy）：
+#   busy         每个 user 合并后的忙碌区间（找空档、看忙碌时段）
+#   raw_busy     每个 user 的原始日程块 + rsvp_status（数会议、看每个会的 rsvp）
+#   free         每个 user 在时间窗内的空闲区间（可带 --min-duration 过滤）
+#   common_free  所有 user 的共同空闲区间（可带 --min-duration 过滤）
+# min-duration 仅对 free / common_free 生效；Go duration 格式，例如 30m、1h、90m
+
+# 查询忙碌时间段（去重并合并相邻/重叠段）
+lark-cli calendar +freebusy --start 2026-03-11 --end 2026-03-11 --user-id ou_a,ou_b --type busy
+
+# 看别人有几个会、每个会的起止 + rsvp（不合并相邻/重叠段，带rsvp状态）
+lark-cli calendar +freebusy --start 2026-03-11 --end 2026-03-11 --user-id ou_a,ou_b --type raw_busy
+
+# 查询用户空闲时间段
+lark-cli calendar +freebusy --start 2026-03-11 --end 2026-03-11 --user-id ou_a,ou_b --type free
+
+# 多人公共空闲时间段（推荐替代手工合并）
+lark-cli calendar +freebusy --start 2026-03-11T09:00:00+08:00 --end 2026-03-11T18:00:00+08:00 --user-id ou_a,ou_b --type common_free --min-duration 30m
 ```
 
 用法提示：
-- **仅判断是否有空** → `+freebusy`；**需要日程详情** → `+agenda`。
-- 检查多人可用性：分别调用并对比，找共同空闲。
-- 预约/改约场景下，调用规则（参与人过多、含群组、来自 `+suggestion` 等）详见 [schedule-clear-time.md § 查询忙闲](references/lark-calendar-schedule-clear-time.md#2-查询忙闲)。
+- **`+freebusy` 只适用于查询忙碌/空闲时间段这一事实**。如果目标是"给会议**推荐**一个合适的时间段"（单人或多人），必须优先使用 [`+suggestion`](references/lark-calendar-suggestion.md)——它会综合**工作时间段、忙碌时间段、休息时间段**来推荐，`+freebusy` 只回答"哪些区间空着"，不判断该区间是否适合排会。
+- **多人公共空闲**：只想拿"哪些区间共同没被占"→ `--type common_free [--min-duration <dur>]`；想拿"推荐的会议时间段"→ 走 `+suggestion`。
 
 ## 前置条件路由
 
@@ -120,6 +147,9 @@ lark-cli calendar +freebusy --start 2026-03-11 --end 2026-03-12 --user-id ou_xxx
 - **时间块 vs 时间范围**：时间块是具体确定的连续时间段（如 `14:00~15:00`），时间范围是泛指（如"今天下午"）。`+room-find` 必须基于确定时间块，不能基于模糊范围。
 - **会议室（Room）**："room"不是"房间"，是"会议室"。会议室是日程的一种参与人（resource attendee），不能脱离日程单独预定。
 - **日程会议 ID（Meeting ID）**：日程的历史视频会议 ID，在日程上开过视频会议才会有。
+- **日程分享链接 vs 会议链接**：两者是不同事物，不可混用。
+  - 日程分享链接：`https://<domain>/calendar/share?token=<token>`，指向日程本身，用于分享日程详情。
+  - 会议链接：`https://<domain>/j/<number>`，指向视频会议入口；同一重复性日程序列的所有实例共用同一个会议链接。
 
 ## 术语映射
 
@@ -134,11 +164,12 @@ lark-cli calendar +freebusy --start 2026-03-11 --end 2026-03-12 --user-id ou_xxx
 | 查询日历/日程或未来时间的会议 | 本 skill |
 | 按关键词搜索日程 | 本 skill（`+search-event`） |
 | 从日程获取关联的视频会议 ID 或用户绑定的会议纪要文档 | 本 skill（`+meeting`） |
+| 查看日程的参会人 / 会议室（含 `--type resource` 只看会议室） | 本 skill（[`+list-attendees`](references/lark-calendar-list-attendees.md)） |
 | 把日程分享给某人 / 群 | 本 skill：先 `calendar events share_info` 取**日程分享链接**，再走 [lark-im](../lark-im/SKILL.md) 发送该链接；分享链接不是 applink，不要自己拼接或用 applink 代替 |
 | 从日程进一步拿 AI 智能纪要 / 逐字稿 / 妙记产物 | 先 `+meeting` 取 `meeting_id`，再进入 [`lark-meeting`](../lark-meeting/SKILL.md)：[`vc +detail`](../lark-meeting/references/lark-vc-detail.md) → [`note +detail`](../lark-meeting/references/lark-note-detail.md) / [`minutes +detail`](../lark-meeting/references/lark-minutes-detail.md) |
 | 预约/改约日程、调整时间、添加/更换会议室、查会议室 | 先判断新建 vs 编辑，再进入 [schedule-meeting 工作流](references/lark-calendar-schedule-meeting.md) |
 | 仅编辑日程字段（标题/描述）或增删参会人（不涉及时间和会议室） | 先定位 `event_id`，再读 [+update](references/lark-calendar-update.md) 执行变更 |
-| 编辑/删除重复性日程（「改这个重复日程」「删掉后面的」「全部取消」等） | 先读 [重复性日程操作规范](references/lark-calendar-recurring.md)，确认操作范围后执行 |
+| 编辑/删除重复性日程（「改这个重复日程」「删掉后面的」「全部取消」等） | 先读 [重复性日程操作规范](references/lark-calendar-recurring.md)；`+update` / `+delete` 均通过 `--apply-to=single|all|this-and-following` 指定范围 |
 | 转让日程组织者（「把这个日程交给 XX」「组织者改成 XX」「这个会转给我」「bot 建完还给我」） | 读 [+transfer](references/lark-calendar-transfer.md)；`--as` 用**当前组织者**身份，`--to-user-id` 传接收人，用户和机器人任意互转 |
 
 ## 任务类型分流
@@ -170,9 +201,6 @@ lark-cli calendar <resource> <method> [flags]
 # 查询用户主日历
 lark-cli calendar calendars primary
 
-# 获取日程详情及 app_link
-lark-cli calendar events get --calendar-id <calendar_id> --event-id <event_id>
-
 # 获取日程分享链接（分享给他人/群前必须先拿到）
 # 返回形如 {{domain}}/calendar/share?token=<token> 的分享链接，不是 applink；直接把该链接发给对方（对方可凭链接中的 token 走 +join-event 加入）
 lark-cli calendar events share_info --calendar-id <calendar_id> --event-id <event_id>
@@ -194,8 +222,8 @@ lark-cli calendar events delete --calendar-id <calendar_id> --event-id <event_id
 ## 常用其他域命令
 
 ```bash
-# 搜索用户，更多参数详见 lark-contact
-lark-cli contact +search-user --query <query> --as user
+# 批量搜索多个用户，更多参数详见 lark-contact
+lark-cli contact +search-user --queries "<q1>,<q2>" --as user
 
 # 搜索群聊，更多参数详见 lark-im
 lark-cli im +chat-search --query <query> --as user

--- a/skills/lark-calendar/references/lark-calendar-list-attendees.md
+++ b/skills/lark-calendar/references/lark-calendar-list-attendees.md
@@ -1,0 +1,33 @@
+# calendar +list-attendees
+
+列出单个日程的参与人（用户 / 会议室 / 群 / 三方邮箱）。只读。
+
+## 命令
+
+```bash
+# 查看指定日历（默认primary）下某日程的全部类型参与人和会议室
+lark-cli calendar +list-attendees --calendar-id <calendar_id> --event-id <event_id>
+
+# 只看会议室
+lark-cli calendar +list-attendees --event-id <event_id> --type resource
+
+# 同时看用户与会议室
+lark-cli calendar +list-attendees --event-id <event_id> --type user --type resource
+
+# 分页续拉（由调用方基于 has_more / page_token 决定是否再调一次）
+lark-cli calendar +list-attendees --event-id <event_id> --page-size 100 --page-token <page_token>
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--event-id <id>` | **是** | 目标日程 ID |
+| `--calendar-id <id>` | 否 | 日历 ID，省略则使用主日历（`primary`） |
+| `--type <type>` | 否 | 按 attendee 类型过滤；可重复或逗号分隔。枚举：`user` / `resource` / `chat` / `third_party`。留空返回全部类型|
+| `--page-size <n>` | 否 | 上游分页大小；默认 `20`|
+| `--page-token <token>` | 否 | 上游分页游标，来自上一次返回的 `page_token` |
+
+## 提示
+
+- `type=chat` 的群参与人**不返回 `rsvp_status`**（群本身没有群级 RSVP 状态）。需要群成员的 RSVP 请走原生 OpenAPI。

--- a/skills/lark-calendar/references/lark-calendar-recurring.md
+++ b/skills/lark-calendar/references/lark-calendar-recurring.md
@@ -1,91 +1,87 @@
 # 重复性日程操作规范
 
-重复性日程的编辑/删除分为三种范围：「仅此次」「全部」「此次及后续」。用户未明确范围时，**必须询问确认**。
+重复性日程/例外的编辑和删除必须显式指定操作范围。相关命令：
+
+- `lark-cli calendar +delete` — 删除日程；重复性日程/例外必须传 `--apply-to`。
+- `lark-cli calendar +update` — 更新日程；重复性日程/例外必须传 `--apply-to`。
+
+> **强制规则：用户未明确操作范围时，必须先向用户确认，禁止 Agent 默认选取任何 `--apply-to`。** 用户表达含糊（如「删掉这个会」「改一下这个日程」）时也必须确认——`--apply-to=single` 只删/改一次，`--apply-to=all` 会影响整个序列及所有例外，代价截然不同。
+
+## `--apply-to` 与日程类型的匹配矩阵
+
+先记住四种日程类型：**普通日程（Normal）**、**重复性日程本体（Master）**、**重复性日程实例（Instance）**、**重复性日程例外（Exception）**。四种类型允许的 `--apply-to` 组合如下（❌ = 传入即报错）：
+
+| 日程类型 | event_id 形状 | `single` | `all` | `this-and-following` |
+|----------|--------------|:--------:|:-----:|:--------------------:|
+| Normal（普通日程）          | `{uid}_0`（无 rrule） | 隐含默认 | ❌ | ❌ |
+| Master（重复性日程本体）    | `{uid}_0`（有 rrule） | ❌ | ✅ | ❌ |
+| Instance（重复性日程实例）  | `{uid}_{ts>0}`，`is_exception=false` | ✅ | ✅ | ✅ |
+| Exception（重复性日程例外）| `{uid}_{ts>0}`，`is_exception=true`  | ✅ | ✅ | ❌（Exception 已占据该时间位，需改传另一个未被独立化的 Instance id 作为分割点） |
+
+三个 `--apply-to` 的含义与影响面：
+
+| 值 | 语义 | 影响面 |
+|----|------|--------|
+| `single` | 只操作当前这一次 | 只改/删传入的这一个 event_id 本身；例外不动其它例外，实例不动整个序列 |
+| `all` | 操作整条重复性序列 | Master 本体 **和** 所有例外都会被处理（时间变更时例外先被删除，其它字段则会同步 PATCH 到每个例外） |
+| `this-and-following` | 从「起始实例」起截断并新建后续序列 | 用 UNTIL 截断 Master、删除起始实例起的所有未来例外、以起始实例的时间为起点 创建 一条新序列继承 Master 的默认字段 |
 
 ## 关键概念
 
-- **event_id 结构**：`event_id` 的格式为 `{event_uid}_{originalTime}`。普通日程或重复性日程本体的 `originalTime` 为 `0`；例外的 `originalTime > 0`，代表该例外在原重复性序列中本来的时间位置。因此 `{event_uid}_0` 即为原重复性日程的 `event_id`。
-- **原重复性日程**：携带 `rrule` 的日程本体，`event_id` 形如 `{event_uid}_0`。系列的所有属性（标题、时间、rrule、描述等）都挂在本体上。
-- **例外（Exception）**：对某次实例做过「仅此次」编辑后产生的独立日程，`event_id` 形如 `{event_uid}_{originalTime}`（`originalTime > 0`）。通过 `event_uid` 部分即可关联回原重复性日程。
-- 删除/更新原重复性日程 **不会** 级联处理例外——必须手动逐个处理。
+- **event_id 结构**：`event_id` 的格式为 `{event_uid}_{originalTime}`。`originalTime = 0` 表示 Master 或 Normal；`originalTime > 0` 表示某一次在原序列中本来的时间戳（Unix 秒）。因此 `{event_uid}_0` 即为重复性日程本体的 `event_id`。
+- **Master（重复性日程本体）**：携带 `rrule` 的日程本体，`event_id` 形如 `{event_uid}_0`。序列的所有默认属性（标题、时间、rrule、描述、参会人等）都挂在本体上。
+- **Normal（普通日程）**：不携带 `rrule`，`event_id` 也是 `{event_uid}_0`，但没有序列概念。只能用 `--apply-to=single`（可省略）。
+- **Instance vs Exception —— 二者最容易混淆，务必区分**：
+  - **Instance（实例）**：由 rrule 展开出来的「虚拟」发生点，本身不落库。`event_id` 形如 `{event_uid}_{originalTime}`（`originalTime > 0`），是从 `+agenda` / `+search-event` 返回的可寻址标识。**从未被单独编辑过**——所有属性都从 Master 继承而来。在 API 层可以对 Instance id 发 GET，但对它发写操作时（操作此次），会先把它「实体化」成一条 Exception。
+  - **Exception（例外）**：某个 Instance 被显式修改（改时间、改标题、改参会人等）或被显式删除标记后落库产生的**独立日程**。`event_id` 形状与 Instance 完全一样（`{event_uid}_{originalTime}`），肉眼**无法**区分——唯一可靠的判据是 `calendar +get` 返回的 `is_exception=true`（Instance 为 false）。Exception 已经脱离 Master 的字段继承，是一份可独立编辑/删除的实体。
+  - **一句话总结**：Instance 是 rrule 展开出来的「占位符」，Exception 是「已经被独立化的实例」。判断当前 event_id 是哪种，先跑 `+get` 看 `is_exception`。
+- 删除/更新 Master **不会** 级联处理例外——命令内部会显式扫描并处理例外。
 
 ## 前置步骤（所有范围通用）
 
-1. 通过 `+agenda` 或 `+search-event` 定位重复性日程，获取原重复性日程的 `event_id`。
-2. 通过 `events instance_view` 或 `+agenda` 列出实例，识别哪些是例外（`event_id` 中 `originalTime > 0` 的即为例外）。
-3. 确认用户的操作范围。
+1. 通过 `+agenda` 或 `+search-event` 定位到目标日程 / 实例，拿到 `event_id`。
+2. 判断日程类型：
+   - `event_id` 后缀 `_0` 且无 `recurrence` → Normal；
+   - `event_id` 后缀 `_0` 且有 `recurrence` → Master；
+   - `event_id` 后缀 `_{数字>0}` 且 `is_exception=false` → Instance；
+   - `event_id` 后缀 `_{数字>0}` 且 `is_exception=true` → Exception。
+   - 需要精确判断时跑 `calendar +get` 看 `recurrence` 和 `is_exception` 字段。
+3. **与用户确认 `--apply-to` 范围（未明确一律先问，禁止默认）**。
 
-## 编辑全部（更新时间）
+## 常见命令
 
-| 步骤 | 命令 | 说明 |
-|------|------|------|
-| 1 | `lark-cli calendar +update --event-id <原重复日程ID> --start ... --end ...` | 更新原重复性日程的时间 |
-| 2 | `lark-cli calendar events delete --params '{"calendar_id":"<CAL_ID>","event_id":"<例外ID>","need_notification":false}'` （逐个） | 时间变更后例外已无意义，必须删除 |
+### 删除
 
-> 理由：更新时间会改变重复起止点，例外日程的原始占位已变，若保留会导致时间冲突或残留。
+```bash
+# 删除此次（例外或instance）
+lark-cli calendar +delete --event-id <uid_originalTime> --apply-to single
 
-## 编辑全部（更新非时间字段）
+# 删除全部（主日程 id 或任意 例外/instance id）
+lark-cli calendar +delete --event-id <uid_originalTime> --apply-to all
 
-| 步骤 | 命令 | 说明 |
-|------|------|------|
-| 1 | `lark-cli calendar +update --event-id <原重复日程ID> --summary ... --description ...` | 更新原重复性日程的标题/描述等 |
-| 2 | `lark-cli calendar +update --event-id <例外ID> --summary ... --description ...` （逐个） | 同步更新例外日程的对应字段 |
+# 删除此次及后续（必须传具体instance id）
+lark-cli calendar +delete --event-id <uid_originalTime> --apply-to this-and-following
+```
 
-> 理由：例外已脱离原重复性日程独立存在，不会自动继承原日程的更新。
+### 更新
 
-## 删除全部
+```bash
+# 编辑此次（单个实例 / 例外）
+lark-cli calendar +update --event-id <uid_originalTime> --apply-to single --summary <summary>
 
-| 步骤 | 命令 | 说明 |
-|------|------|------|
-| 1 | `lark-cli calendar events delete --params '{"calendar_id":"<CAL_ID>","event_id":"<原重复日程ID>","need_notification":true}'` | 删除重复性日程本体 |
-| 2 | `lark-cli calendar events delete --params '{"calendar_id":"<CAL_ID>","event_id":"<例外ID>","need_notification":false}'` （逐个） | 删除所有例外日程 |
+# 编辑全部（主日程 id 或任意 例外/instance id）
+lark-cli calendar +update --event-id <uid_originalTime> --apply-to all --summary <summary>
 
-> 理由：例外是独立实体，删除原重复性日程不会级联删除例外。
+# 编辑全部：改时间
+lark-cli calendar +update --event-id <uid_originalTime> --apply-to all --start <start> --end <end>
 
-## 编辑此次及后续
+# 编辑此次及后续：截断主日程 + 删未来例外 + 创建新序列
+lark-cli calendar +update --event-id <uid_originalTime> --apply-to this-and-following --summary <summary>
+```
 
-| 步骤 | 命令 | 说明 |
-|------|------|------|
-| 1 | `lark-cli calendar +update --event-id <原重复日程ID> --rrule "FREQ=...;UNTIL=<截止日期>"` | 截短原重复性日程（UNTIL 设为指定时间前一次实例的日期） |
-| 2 | `lark-cli calendar events delete ...` （逐个） | 删除指定时间之后（含）的例外日程 |
-| 3 | `lark-cli calendar +create --summary ... --start <指定时间> --end ... --rrule "FREQ=..." --attendee-ids ...` | 从指定时间开始创建新的重复性日程（即「后续」部分，携带编辑后的内容） |
+## 语义细则
 
-> UNTIL 计算规则：若用户选择「从第 N 次开始编辑」，UNTIL 应设置为第 N-1 次实例的日期（即保留到指定时间之前的最后一次）。
-> 新日程应继承原日程的参会人、会议室等配置（除非用户明确要修改）。
-
-## 删除此次及后续
-
-| 步骤 | 命令 | 说明 |
-|------|------|------|
-| 1 | `lark-cli calendar +update --event-id <原重复日程ID> --rrule "FREQ=...;UNTIL=<截止日期>"` | 截短原重复性日程（UNTIL 设为指定时间前一次实例的日期） |
-| 2 | `lark-cli calendar events delete ...` （逐个） | 删除指定时间之后（含）的例外日程 |
-
-> 与「编辑此次及后续」的区别：不需要步骤 3（创建新的重复性日程），因为目标是删除后续而非替换。
-
-## 仅此次
-
-- **编辑仅此次**：通过 `+agenda` / `+search-event` 定位到具体实例的 `event_id`，然后正常调用 `+update`。
-- **删除仅此次**：定位到具体实例的 `event_id`，调用 `events delete`。
-
-## 用户意图映射
-
-| 用户表达 | 操作范围 |
-|----------|----------|
-| 「改这个重复日程的标题」「全部改」「每次都改」 | 编辑全部 |
-| 「删掉这个重复日程」「取消所有」 | 删除全部 |
-| 「从下周开始改时间」「后面的都改」 | 编辑此次及后续 |
-| 「从下周开始不要了」「后面的都删」 | 删除此次及后续 |
-| 「就改这一次」「只删这一次」 | 仅此次 |
-| 「给明天的日程加个会议室」（且为重复日程） | 范围不明确，**必须询问用户** |
-| 未明确范围 | **必须询问用户** |
-
-## 注意事项
-
-- 涉及时间戳计算（如推算 UNTIL 日期）时，必须调用系统命令或脚本，禁止心算。
-
-## 参考
-
-- [lark-calendar](../SKILL.md) — 日历全部命令
-- [lark-calendar-update](lark-calendar-update.md) — 更新日程 Shortcut
-- [lark-calendar-create](lark-calendar-create.md) — 创建日程 Shortcut
-- [lark-shared](../../lark-shared/SKILL.md) — 认证和全局参数
+- **`--apply-to=all` 时的字段传播**：只把用户本次显式传的 flag 应用到每个例外和主日程。例外原本自定义过的其他字段（例如自己的描述）保持不变。
+- **`--apply-to=this-and-following` 的字段继承**：新创建的日程从原主日程继承 summary、description、rrule、start/end（用起始实例的时间）、vchat/reminders/location/visibility；用户任何显式传的 flag 优先。
+- **`--start/--end` 变更**：`all` 场景下，例外会被删除（原始占位已无意义），主日程再 PATCH；`this-and-following` 场景下，`--start/--end` 传了会作为新序列的时间，否则用起始实例的时间。
+- **参会人**：`this-and-following` 创建新序列时，若传了 `--add-attendee-ids`，会额外 添加attendees 到新序列；`--remove-attendee-ids` 会从新序列的参与人列表移除。

--- a/skills/lark-calendar/references/lark-calendar-schedule-clear-time.md
+++ b/skills/lark-calendar/references/lark-calendar-schedule-clear-time.md
@@ -35,7 +35,12 @@ lark-cli calendar +room-find \
 ### 2. 查询忙闲
 
 ```bash
-lark-cli calendar +freebusy --start "<start>" --end "<end>"
+# 单人 / 多人查忙：--user-id 可重复或逗号分隔；服务端已合并相邻/重叠忙碌区间
+lark-cli calendar +freebusy --start "<start>" --end "<end>" --user-id "ou_a,ou_b"
+
+# 直接求共同空闲（推荐用于「找几个人一起有空」）
+lark-cli calendar +freebusy --start "<start>" --end "<end>" \
+  --user-id "ou_a,ou_b,ou_c" --type common_free --min-duration 30m
 ```
 
 规则：
@@ -43,6 +48,7 @@ lark-cli calendar +freebusy --start "<start>" --end "<end>"
 - 参与人过多（超过 5 人）：仅查询**当前用户**及少数核心人员忙闲即可
 - 参与人含**群组**：无需展开群组成员查询忙闲
 - 如果用户是从 `+suggestion` 确认了时间块后进入本分支的，**无需再调用 `+freebusy`**
+- 找多人共同空闲：直接用 `--type common_free [--min-duration <dur>]`，让 CLI 一次算出共同空闲；不要自己再合并求交
 
 ### 3. 冲突处理
 

--- a/tests/cli_e2e/calendar/calendar_freebusy_test.go
+++ b/tests/cli_e2e/calendar/calendar_freebusy_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestCalendar_FreebusyDryRun asserts the freebusy shortcut's outgoing request
+// shape without hitting the API. Covers all four --type values plus
+// --min-duration passthrough.
+func TestCalendar_FreebusyDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	cases := []struct {
+		name          string
+		typ           string
+		userIDs       []string
+		minDuration   string
+		wantUsersLen  int
+		wantMinInBody bool
+	}{
+		{"type=busy default view", "busy", []string{"ou_dry_a"}, "", 1, false},
+		{"type=raw_busy carries rsvp", "raw_busy", []string{"ou_dry_a"}, "", 1, false},
+		{"type=free with min-duration", "free", []string{"ou_dry_a"}, "45m", 1, true},
+		{"type=common_free multi-user", "common_free", []string{"ou_dry_a", "ou_dry_b"}, "30m", 2, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			args := []string{
+				"calendar", "+freebusy",
+				"--start", "2026-04-25T09:00:00+08:00",
+				"--end", "2026-04-25T18:00:00+08:00",
+				"--type", c.typ,
+				"--dry-run",
+			}
+			for _, id := range c.userIDs {
+				args = append(args, "--user-id", id)
+			}
+			if c.minDuration != "" {
+				args = append(args, "--min-duration", c.minDuration)
+			}
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      args,
+				DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+
+			out := result.Stdout
+			require.Equal(t, "POST", clie2e.DryRunGet(out, "api.0.method").String(), "stdout:\n%s", out)
+			require.Equal(t, "/open-apis/calendar/v4/freebusy/batch", clie2e.DryRunGet(out, "api.0.url").String(), "stdout:\n%s", out)
+			require.Equal(t, c.typ, clie2e.DryRunGet(out, "type").String(), "stdout:\n%s", out)
+			require.Equal(t, true, clie2e.DryRunGet(out, "api.0.body.need_rsvp_status").Bool(), "stdout:\n%s", out)
+
+			userIDs := clie2e.DryRunGet(out, "api.0.body.user_ids").Array()
+			require.Len(t, userIDs, c.wantUsersLen, "stdout:\n%s", out)
+			for i, id := range c.userIDs {
+				assert.Equal(t, id, userIDs[i].String(), "stdout:\n%s", out)
+			}
+
+			if c.wantMinInBody {
+				require.Equal(t, c.minDuration, clie2e.DryRunGet(out, "min_duration").String(), "stdout:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestCalendar_FreebusyDryRun_BotWithoutUserIDsFails asserts the shortcut
+// refuses to run under bot identity when no --user-id is provided; that fallback
+// only exists for user identity. Verified in dry-run so the check does not
+// depend on network state.
+func TestCalendar_FreebusyDryRun_BotWithoutUserIDsFails(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"calendar", "+freebusy",
+			"--start", "2026-04-25T09:00:00+08:00",
+			"--end", "2026-04-25T18:00:00+08:00",
+			"--type", "busy",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, result.ExitCode, "stdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
+}
+
+// TestCalendar_Freebusy runs live against the API and asserts the JSON envelope
+// shape for each --type view. Live-safe: read-only query over a small window.
+func TestCalendar_Freebusy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	clie2e.SkipWithoutUserToken(t)
+	openID := getCurrentUserOpenIDForCalendar(t, ctx)
+
+	// A one-day window is enough for a live freebusy read; keeps the response
+	// small and the assertions cheap.
+	start := time.Now().UTC().Truncate(24 * time.Hour)
+	end := start.Add(24 * time.Hour)
+
+	t.Run("type=busy for self as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"calendar", "+freebusy",
+				"--start", unixSecondsRFC3339(start),
+				"--end", unixSecondsRFC3339(end),
+				"--user-id", openID,
+				"--type", "busy",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+		users := gjson.Get(result.Stdout, "data.users")
+		require.True(t, users.IsArray(), "stdout:\n%s", result.Stdout)
+		require.GreaterOrEqual(t, len(users.Array()), 1, "stdout:\n%s", result.Stdout)
+		assert.Equal(t, openID, gjson.Get(result.Stdout, "data.users.0.user_id").String(), "stdout:\n%s", result.Stdout)
+		assert.True(t, gjson.Get(result.Stdout, "data.users.0.busy").IsArray(), "stdout:\n%s", result.Stdout)
+	})
+
+	t.Run("type=raw_busy for self as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"calendar", "+freebusy",
+				"--start", unixSecondsRFC3339(start),
+				"--end", unixSecondsRFC3339(end),
+				"--user-id", openID,
+				"--type", "raw_busy",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+		assert.Equal(t, openID, gjson.Get(result.Stdout, "data.users.0.user_id").String(), "stdout:\n%s", result.Stdout)
+		assert.True(t, gjson.Get(result.Stdout, "data.users.0.raw_busy").IsArray(), "stdout:\n%s", result.Stdout)
+	})
+
+	t.Run("type=free for self as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"calendar", "+freebusy",
+				"--start", unixSecondsRFC3339(start),
+				"--end", unixSecondsRFC3339(end),
+				"--user-id", openID,
+				"--type", "free",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+		assert.Equal(t, openID, gjson.Get(result.Stdout, "data.users.0.user_id").String(), "stdout:\n%s", result.Stdout)
+		assert.True(t, gjson.Get(result.Stdout, "data.users.0.free").IsArray(), "stdout:\n%s", result.Stdout)
+	})
+
+	t.Run("type=common_free for self as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"calendar", "+freebusy",
+				"--start", unixSecondsRFC3339(start),
+				"--end", unixSecondsRFC3339(end),
+				"--user-id", openID,
+				"--type", "common_free",
+				"--min-duration", "30m",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+		assert.True(t, gjson.Get(result.Stdout, "data.common_free").IsArray(), "stdout:\n%s", result.Stdout)
+	})
+
+	t.Run("pretty output does not fail", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"calendar", "+freebusy",
+				"--start", unixSecondsRFC3339(start),
+				"--end", unixSecondsRFC3339(end),
+				"--user-id", openID,
+				"--type", "busy",
+			},
+			DefaultAs: "user",
+			Format:    "pretty",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+	})
+}


### PR DESCRIPTION

## Summary
Extend the `calendar` shortcut suite with new attendee/delete commands and richer freebusy views, and add recurring-event scope handling to `+update` / `+delete`. These changes give agents a more complete calendar toolkit for scheduling, cleanup, and multi-user coordination.

## Changes
- Add `+list-attendees` to fetch event attendees filtered by attendee type.
- Enhance `+freebusy` with per-user busy / free views and a common-free view for multi-user scheduling.
- Add `+delete` for removing calendar events, with recurring-scope support (single occurrence, entire series, this-and-following).
- Extend `+update` to honor the same recurring-scope options (single / all / this-and-following).

## Test Plan
- [ ] Unit tests pass (`go test ./shortcuts/calendar/...`)
- [ ] Manual verification: `lark-cli calendar +list-attendees` returns the expected attendee subsets
- [ ] Manual verification: `lark-cli calendar +freebusy` returns correct busy / free / common-free results
- [ ] Manual verification: `lark-cli calendar +delete` and `+update` behave correctly across `single`, `all`, and `this-and-following` scopes on recurring events

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added calendar event deletion with recurring-event scopes, dry runs, and failure reporting.
  * Added attendee listing with type filters and pagination.
  * Expanded multi-person free/busy searches with busy, raw, free, and common-free views.
  * Added recurring-event update scopes for a single event, entire series, or this and following.
* **Bug Fixes**
  * Improved recurring-event resolution, including unmaterialized instances.
  * Added timezone mismatch warnings for calendar time inputs.
* **Documentation**
  * Updated calendar guidance and added attendee and recurring-event references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->