### PR TITLE
fix(install): ensure bin directory exists before copying binary

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -265,6 +265,7 @@ function install() {
     const binaryName = NAME + (isWindows ? ".exe" : "");
     const extractedBinary = path.join(tmpDir, binaryName);
 
+    fs.mkdirSync(binDir, { recursive: true });
     fs.copyFileSync(extractedBinary, dest);
     fs.chmodSync(dest, 0o755);
     console.log(`${NAME} v${VERSION} installed successfully`);


### PR DESCRIPTION
## Summary
Fixes an `ENOENT: no such file or directory` installation/update failure in `scripts/install.js` where the `bin/` destination directory could disappear during download due to a race condition with npm package lifecycle reification.

- **Affected versions**: `<= v1.0.92`
- **Observed Environment**:
  - **OS / Platform**: macOS (Darwin 25.6.0, `darwin-arm64` / Apple Silicon)
  - **Node.js**: v26.8.1
  - **npm**: v12.0.2
- **Symptom**:
  ```text
  npm error Failed to install lark-cli: ENOENT: no such file or directory, copyfile '/tmp/.../lark-cli' -> '/opt/homebrew/lib/node_modules/@larksuite/cli/bin/lark-cli'
  ```

## Problem & Root Cause
In `scripts/install.js`, `fs.mkdirSync(binDir, { recursive: true })` was called at the start of `install()`, prior to fetching the ~13.8MB release asset over the network. 

During the remote asset download (which can take 5–30s depending on network/mirror latency), npm's global install/update pipeline (e.g. `npm install -g @larksuite/cli` or `lark-cli update --force`) continues extracting and reifying the package. Because `bin/` is not listed in `package.json`'s `files` field (it is populated purely post-install), npm can prune or recreate the package directory tree while the download is in-flight.

When the download finishes and the archive is extracted, `fs.copyFileSync(extractedBinary, dest)` executes while the target `../bin` directory is missing, resulting in `ENOENT`.

## Changes
- Add `fs.mkdirSync(binDir, { recursive: true })` immediately before `fs.copyFileSync(extractedBinary, dest)` in `scripts/install.js` to guarantee destination directory existence at copy time regardless of download duration or npm tree modifications.

## Test Plan
- [x] Ran `make script-test` (165/165 tests passing across all test suites including `scripts/install.test.js`).
- [x] Verified manual binary extraction and installation locally on macOS (`darwin-arm64`).
- [x] Verified `lark-cli --version` (`v1.0.92`) and `lark-cli --help` execute correctly.

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability by ensuring the required executable directory exists before files are copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->