### PR TITLE
fix(output): preserve non-data payloads in the api success envelope

### DIFF
--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -195,6 +195,73 @@ func TestApiCmd_BotMode(t *testing.T) {
 	}
 }
 
+func TestApiCmd_NonDataPayload_PreservedInEnvelope(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-nondata", AppSecret: "test-secret-nondata", Brand: core.BrandFeishu,
+	})
+
+	// /bot/v3/info is a legacy endpoint whose payload sits beside code/msg
+	// under "bot" instead of inside "data" (#2428).
+	reg.Register(&httpmock.Stub{
+		URL: "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"bot": map[string]interface{}{"open_id": "ou_123", "app_name": "TestBot"},
+		},
+	})
+
+	cmd := newTestApiCmd(f, nil)
+	cmd.SetArgs([]string{"GET", "/open-apis/bot/v3/info", "--as", "bot"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout.String())
+	}
+	if got["ok"] != true || got["identity"] != "bot" {
+		t.Fatalf("unexpected envelope: %#v", got)
+	}
+	data, ok := got["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data = %#v, want object", got["data"])
+	}
+	bot, ok := data["bot"].(map[string]interface{})
+	if !ok || bot["open_id"] != "ou_123" {
+		t.Fatalf("data.bot = %#v, want the legacy payload preserved", data["bot"])
+	}
+	for _, k := range []string{"code", "msg"} {
+		if _, leaked := data[k]; leaked {
+			t.Fatalf("transport field %q leaked into data: %s", k, stdout.String())
+		}
+	}
+}
+
+func TestApiCmd_NonObjectBody_FailsLoudly(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app-arraybody", AppSecret: "test-secret-arraybody", Brand: core.BrandFeishu,
+	})
+
+	// The SDK rejects a body that is not a JSON object before it reaches the
+	// output layer. Pin that this surfaces as an error: the #2428 failure mode
+	// is a silent ok:true with empty data, and an array body must not regress
+	// into that shape either.
+	reg.Register(&httpmock.Stub{
+		URL:  "/open-apis/test/list",
+		Body: []interface{}{map[string]interface{}{"id": "1"}, map[string]interface{}{"id": "2"}},
+	})
+
+	cmd := newTestApiCmd(f, nil)
+	cmd.SetArgs([]string{"GET", "/open-apis/test/list", "--as", "bot"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("array body must not be reported as success; stdout:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), `"ok": true`) {
+		t.Fatalf("array body produced a success envelope: %s", stdout.String())
+	}
+}
+
 func TestApiCmd_MissingArgs(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
 		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -195,7 +195,7 @@ func TestApiCmd_BotMode(t *testing.T) {
 	}
 }
 
-func TestApiCmd_NonDataPayload_PreservedInEnvelope(t *testing.T) {
+func TestApiCmd_BotPayload_NormalizedInEnvelope(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
 		AppID: "test-app-nondata", AppSecret: "test-secret-nondata", Brand: core.BrandFeishu,
 	})
@@ -226,9 +226,11 @@ func TestApiCmd_NonDataPayload_PreservedInEnvelope(t *testing.T) {
 	if !ok {
 		t.Fatalf("data = %#v, want object", got["data"])
 	}
-	bot, ok := data["bot"].(map[string]interface{})
-	if !ok || bot["open_id"] != "ou_123" {
-		t.Fatalf("data.bot = %#v, want the legacy payload preserved", data["bot"])
+	if _, ok := data["bot"]; ok {
+		t.Fatalf("data = %#v, want legacy bot container normalized away", data)
+	}
+	if data["open_id"] != "ou_123" || data["app_name"] != "TestBot" {
+		t.Fatalf("data = %#v, want normalized bot fields", data)
 	}
 	for _, k := range []string{"code", "msg"} {
 		if _, leaked := data[k]; leaked {

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -237,31 +237,6 @@ func TestApiCmd_NonDataPayload_PreservedInEnvelope(t *testing.T) {
 	}
 }
 
-func TestApiCmd_NonObjectBody_FailsLoudly(t *testing.T) {
-	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
-		AppID: "test-app-arraybody", AppSecret: "test-secret-arraybody", Brand: core.BrandFeishu,
-	})
-
-	// The SDK rejects a body that is not a JSON object before it reaches the
-	// output layer. Pin that this surfaces as an error: the #2428 failure mode
-	// is a silent ok:true with empty data, and an array body must not regress
-	// into that shape either.
-	reg.Register(&httpmock.Stub{
-		URL:  "/open-apis/test/list",
-		Body: []interface{}{map[string]interface{}{"id": "1"}, map[string]interface{}{"id": "2"}},
-	})
-
-	cmd := newTestApiCmd(f, nil)
-	cmd.SetArgs([]string{"GET", "/open-apis/test/list", "--as", "bot"})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatalf("array body must not be reported as success; stdout:\n%s", stdout.String())
-	}
-	if strings.Contains(stdout.String(), `"ok": true`) {
-		t.Fatalf("array body produced a success envelope: %s", stdout.String())
-	}
-}
-
 func TestApiCmd_MissingArgs(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
 		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,

--- a/internal/output/envelope_success.go
+++ b/internal/output/envelope_success.go
@@ -23,11 +23,19 @@ func SuccessEnvelopeData(result interface{}) interface{} {
 	if !ok {
 		return map[string]interface{}{}
 	}
-	data, ok := m["data"]
-	if !ok || data == nil {
-		return map[string]interface{}{}
+	if data, ok := m["data"]; ok && data != nil {
+		return data
 	}
-	return data
+	// Fallback: return envelope minus transport fields (code, msg, data)
+	// for APIs that use non-data keys (e.g., /bot/v3/info uses "bot").
+	fallback := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		if k == "code" || k == "msg" || k == "data" {
+			continue
+		}
+		fallback[k] = v
+	}
+	return fallback
 }
 
 // WriteSuccessEnvelope emits the standard success envelope used by shortcuts.

--- a/internal/output/envelope_success.go
+++ b/internal/output/envelope_success.go
@@ -18,24 +18,30 @@ type SuccessEnvelopeOptions struct {
 // SuccessEnvelopeData extracts the business payload for the standard success
 // envelope from a Lark API response. Outer code/msg fields are transport
 // protocol details and are intentionally not exposed as business data.
+//
+// Most endpoints wrap the payload in "data". Legacy endpoints such as
+// /open-apis/bot/v3/info put it beside code/msg under another key; everything
+// except the transport fields is then the payload. A non-object body is passed
+// through untouched so this function never collapses a payload to {}.
 func SuccessEnvelopeData(result interface{}) interface{} {
+	if result == nil {
+		return map[string]interface{}{}
+	}
 	m, ok := result.(map[string]interface{})
 	if !ok {
-		return map[string]interface{}{}
+		return result
 	}
 	if data, ok := m["data"]; ok && data != nil {
 		return data
 	}
-	// Fallback: return envelope minus transport fields (code, msg, data)
-	// for APIs that use non-data keys (e.g., /bot/v3/info uses "bot").
-	fallback := make(map[string]interface{}, len(m))
+	payload := make(map[string]interface{}, len(m))
 	for k, v := range m {
 		if k == "code" || k == "msg" || k == "data" {
 			continue
 		}
-		fallback[k] = v
+		payload[k] = v
 	}
-	return fallback
+	return payload
 }
 
 // WriteSuccessEnvelope emits the standard success envelope used by shortcuts.

--- a/internal/output/envelope_success.go
+++ b/internal/output/envelope_success.go
@@ -19,10 +19,11 @@ type SuccessEnvelopeOptions struct {
 // envelope from a Lark API response. Outer code/msg fields are transport
 // protocol details and are intentionally not exposed as business data.
 //
-// Most endpoints wrap the payload in "data". Legacy endpoints such as
-// /open-apis/bot/v3/info put it beside code/msg under another key; everything
-// except the transport fields is then the payload. A non-object body is passed
-// through untouched so this function never collapses a payload to {}.
+// Most endpoints wrap the payload in "data". The legacy /open-apis/bot/v3/info
+// endpoint uses "bot" as that payload container; normalize its sole business
+// field to the same data shape. Other non-data responses fall back to everything
+// except the transport fields. A non-object body is passed through untouched so
+// this function never collapses a payload to {}.
 func SuccessEnvelopeData(result interface{}) interface{} {
 	if result == nil {
 		return map[string]interface{}{}
@@ -40,6 +41,11 @@ func SuccessEnvelopeData(result interface{}) interface{} {
 			continue
 		}
 		payload[k] = v
+	}
+	if len(payload) == 1 {
+		if bot, ok := payload["bot"].(map[string]interface{}); ok {
+			return bot
+		}
 	}
 	return payload
 }

--- a/internal/output/envelope_success_test.go
+++ b/internal/output/envelope_success_test.go
@@ -55,6 +55,41 @@ func TestSuccessEnvelopeData_NilDataUsesEmptyObject(t *testing.T) {
 	}
 }
 
+func TestSuccessEnvelopeData_NonDataPayloadKeyPreserved(t *testing.T) {
+	// /bot/v3/info returns payload under "bot" key, not "data"
+	result := map[string]interface{}{
+		"code": float64(0),
+		"msg":  "ok",
+		"bot": map[string]interface{}{
+			"activate_status": 2,
+			"app_name":       "TestBot",
+			"open_id":        "ou_123",
+		},
+	}
+
+	got := SuccessEnvelopeData(result)
+	m, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("business data type = %T, want map", got)
+	}
+	if _, ok := m["code"]; ok {
+		t.Fatal("business data must not contain outer code")
+	}
+	if _, ok := m["msg"]; ok {
+		t.Fatal("business data must not contain outer msg")
+	}
+	bot, ok := m["bot"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("business data.bot type = %T, want map", m["bot"])
+	}
+	if bot["activate_status"] != 2 {
+		t.Fatalf("bot.activate_status = %v, want 2", bot["activate_status"])
+	}
+	if bot["app_name"] != "TestBot" {
+		t.Fatalf("bot.app_name = %v, want TestBot", bot["app_name"])
+	}
+}
+
 func TestWriteSuccessEnvelope_PrintsShortcutCompatibleEnvelope(t *testing.T) {
 	var out strings.Builder
 

--- a/internal/output/envelope_success_test.go
+++ b/internal/output/envelope_success_test.go
@@ -34,6 +34,21 @@ func TestSuccessEnvelopeData_ExtractsBusinessData(t *testing.T) {
 	}
 }
 
+func TestSuccessEnvelopeData_StandardDataTakesPrecedenceOverBot(t *testing.T) {
+	result := map[string]interface{}{
+		"code": float64(0),
+		"msg":  "ok",
+		"data": map[string]interface{}{"id": "1"},
+		"bot":  map[string]interface{}{"open_id": "ou_legacy"},
+	}
+
+	got := SuccessEnvelopeData(result)
+	want := map[string]interface{}{"id": "1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("business data = %#v, want standard data payload %#v", got, want)
+	}
+}
+
 func TestSuccessEnvelopeData_MissingDataUsesEmptyObject(t *testing.T) {
 	got := SuccessEnvelopeData(map[string]interface{}{"code": float64(0), "msg": "ok"})
 	m, ok := got.(map[string]interface{})
@@ -56,7 +71,7 @@ func TestSuccessEnvelopeData_NilDataUsesEmptyObject(t *testing.T) {
 	}
 }
 
-func TestSuccessEnvelopeData_NonDataPayloadKeyPreserved(t *testing.T) {
+func TestSuccessEnvelopeData_BotPayloadNormalized(t *testing.T) {
 	// /bot/v3/info returns payload under "bot" key, not "data"
 	result := map[string]interface{}{
 		"code": float64(0),
@@ -79,21 +94,35 @@ func TestSuccessEnvelopeData_NonDataPayloadKeyPreserved(t *testing.T) {
 	if _, ok := m["msg"]; ok {
 		t.Fatal("business data must not contain outer msg")
 	}
-	bot, ok := m["bot"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("business data.bot type = %T, want map", m["bot"])
+	if _, ok := m["bot"]; ok {
+		t.Fatalf("business data = %#v, want legacy bot container normalized away", m)
 	}
-	if bot["activate_status"] != float64(2) {
-		t.Fatalf("bot.activate_status = %v, want 2", bot["activate_status"])
+	if m["activate_status"] != float64(2) {
+		t.Fatalf("activate_status = %v, want 2", m["activate_status"])
 	}
-	if bot["app_name"] != "TestBot" {
-		t.Fatalf("bot.app_name = %v, want TestBot", bot["app_name"])
+	if m["app_name"] != "TestBot" {
+		t.Fatalf("app_name = %v, want TestBot", m["app_name"])
 	}
 }
 
-func TestSuccessEnvelopeData_NullDataWithSiblingPayloadPreserved(t *testing.T) {
+func TestSuccessEnvelopeData_UnknownNonDataPayloadPreserved(t *testing.T) {
+	result := map[string]interface{}{
+		"code":       float64(0),
+		"msg":        "ok",
+		"result":     "success",
+		"request_id": "req_123",
+	}
+
+	got := SuccessEnvelopeData(result)
+	want := map[string]interface{}{"result": "success", "request_id": "req_123"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("business data = %#v, want %#v", got, want)
+	}
+}
+
+func TestSuccessEnvelopeData_NullDataWithBotPayloadNormalized(t *testing.T) {
 	// A null "data" next to a payload key used to collapse to {} and lose the
-	// payload; the sibling key is the business data in that shape.
+	// payload; the legacy bot container is normalized like standard data.
 	result := map[string]interface{}{
 		"code": float64(0),
 		"msg":  "ok",
@@ -109,12 +138,14 @@ func TestSuccessEnvelopeData_NullDataWithSiblingPayloadPreserved(t *testing.T) {
 	if _, ok := m["data"]; ok {
 		t.Fatal("business data must not contain the null data key")
 	}
-	bot, ok := m["bot"].(map[string]interface{})
-	if !ok || bot["open_id"] != "ou_123" {
-		t.Fatalf("business data.bot = %#v, want sibling payload preserved", m["bot"])
+	if _, ok := m["bot"]; ok {
+		t.Fatalf("business data = %#v, want legacy bot container normalized away", m)
+	}
+	if m["open_id"] != "ou_123" {
+		t.Fatalf("business data.open_id = %#v, want ou_123", m["open_id"])
 	}
 	if len(m) != 1 {
-		t.Fatalf("business data = %#v, want only the bot key", m)
+		t.Fatalf("business data = %#v, want only the normalized bot fields", m)
 	}
 }
 

--- a/internal/output/envelope_success_test.go
+++ b/internal/output/envelope_success_test.go
@@ -6,6 +6,7 @@ package output
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -61,9 +62,9 @@ func TestSuccessEnvelopeData_NonDataPayloadKeyPreserved(t *testing.T) {
 		"code": float64(0),
 		"msg":  "ok",
 		"bot": map[string]interface{}{
-			"activate_status": 2,
-			"app_name":       "TestBot",
-			"open_id":        "ou_123",
+			"activate_status": float64(2),
+			"app_name":        "TestBot",
+			"open_id":         "ou_123",
 		},
 	}
 
@@ -82,11 +83,39 @@ func TestSuccessEnvelopeData_NonDataPayloadKeyPreserved(t *testing.T) {
 	if !ok {
 		t.Fatalf("business data.bot type = %T, want map", m["bot"])
 	}
-	if bot["activate_status"] != 2 {
+	if bot["activate_status"] != float64(2) {
 		t.Fatalf("bot.activate_status = %v, want 2", bot["activate_status"])
 	}
 	if bot["app_name"] != "TestBot" {
 		t.Fatalf("bot.app_name = %v, want TestBot", bot["app_name"])
+	}
+}
+
+func TestSuccessEnvelopeData_NilResultUsesEmptyObject(t *testing.T) {
+	got := SuccessEnvelopeData(nil)
+	m, ok := got.(map[string]interface{})
+	if !ok || len(m) != 0 {
+		t.Fatalf("business data = %#v, want empty object", got)
+	}
+}
+
+func TestSuccessEnvelopeData_NonObjectBodyPreserved(t *testing.T) {
+	cases := []struct {
+		name string
+		body interface{}
+	}{
+		{"array", []interface{}{map[string]interface{}{"id": "1"}, map[string]interface{}{"id": "2"}}},
+		{"string", "pong"},
+		{"number", json.Number("42")},
+		{"bool", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SuccessEnvelopeData(tc.body)
+			if !reflect.DeepEqual(got, tc.body) {
+				t.Fatalf("business data = %#v, want body %#v preserved", got, tc.body)
+			}
+		})
 	}
 }
 

--- a/internal/output/envelope_success_test.go
+++ b/internal/output/envelope_success_test.go
@@ -91,6 +91,33 @@ func TestSuccessEnvelopeData_NonDataPayloadKeyPreserved(t *testing.T) {
 	}
 }
 
+func TestSuccessEnvelopeData_NullDataWithSiblingPayloadPreserved(t *testing.T) {
+	// A null "data" next to a payload key used to collapse to {} and lose the
+	// payload; the sibling key is the business data in that shape.
+	result := map[string]interface{}{
+		"code": float64(0),
+		"msg":  "ok",
+		"data": nil,
+		"bot":  map[string]interface{}{"open_id": "ou_123"},
+	}
+
+	got := SuccessEnvelopeData(result)
+	m, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("business data type = %T, want map", got)
+	}
+	if _, ok := m["data"]; ok {
+		t.Fatal("business data must not contain the null data key")
+	}
+	bot, ok := m["bot"].(map[string]interface{})
+	if !ok || bot["open_id"] != "ou_123" {
+		t.Fatalf("business data.bot = %#v, want sibling payload preserved", m["bot"])
+	}
+	if len(m) != 1 {
+		t.Fatalf("business data = %#v, want only the bot key", m)
+	}
+}
+
 func TestSuccessEnvelopeData_NilResultUsesEmptyObject(t *testing.T) {
 	got := SuccessEnvelopeData(nil)
 	m, ok := got.(map[string]interface{})

--- a/skill-template/domains/drive.md
+++ b/skill-template/domains/drive.md
@@ -204,8 +204,8 @@ lark-cli drive file.comments list --params '{"file_token": "xxx", "file_type": "
 
 ```bash
 # 1. 获取当前应用的 open_id
-lark-cli api GET /open-apis/bot/v3/info --as bot
-# 从返回值中取 bot.open_id
+lark-cli api GET /open-apis/bot/v3/info --as bot --jq '.data.open_id'
+# 输出即当前应用的 open_id
 
 # 2. 授权当前应用访问文档
 lark-cli drive permission.members create \

--- a/skills/lark-drive/references/lark-drive-permission-guide.md
+++ b/skills/lark-drive/references/lark-drive-permission-guide.md
@@ -39,7 +39,7 @@
 
 需要将文档权限授予当前应用（bot）自身时：
 
-1. 先执行 `lark-cli api GET /open-apis/bot/v3/info --as bot`，从返回值取 `bot.open_id`。
+1. 先执行 `lark-cli api GET /open-apis/bot/v3/info --as bot --jq '.data.open_id'`，直接取得当前应用的 `open_id`。
 2. 再调用 `lark-cli drive permission.members create`，用 `member_type=openid`、`member_id=<bot_open_id>` 授权。
 
 ```bash


### PR DESCRIPTION
## Summary
`lark-cli api` reported success but printed `data: {}` for endpoints whose payload is not wrapped in `data`, e.g. `/open-apis/bot/v3/info` returns it under `bot`. This PR preserves unknown non-`data` payloads while normalizing the known legacy `bot` container to the standard success-envelope `data` shape.

## Changes
- `internal/output/envelope_success.go`: standard `data` remains authoritative. When it is absent or null, transport fields (`code`, `msg`, `data`) are removed; a sole object-valued `bot` field is unwrapped as the canonical payload, while other unknown top-level payloads are preserved. Nil bodies stay `{}` and non-object bodies pass through unchanged.
- `internal/output/envelope_success_test.go`: covers standard-data precedence, legacy `bot` normalization with missing or null `data`, generic unknown payload fallback, nil bodies, and non-object bodies.
- `cmd/api/api_test.go`: pins the user-visible `/bot/v3/info` result at `data.open_id` / `data.app_name`, with no nested `data.bot` and no transport fields leaking into `data`.
- `skills/lark-drive/references/lark-drive-permission-guide.md` and `skill-template/domains/drive.md`: use `--jq '.data.open_id'` when resolving the current app's bot open ID.

Before:
```console
$ lark-cli api --as bot GET /open-apis/bot/v3/info
{"ok": true, "identity": "bot", "data": {}}
```

After:
```console
$ lark-cli api --as bot GET /open-apis/bot/v3/info
{"ok": true, "identity": "bot", "data": {"activate_status": 2, "app_name": "...", "open_id": "ou_..."}}
```

## Test Plan
- [x] `go test ./internal/output ./cmd/api ./cmd/service ./internal/client ./internal/skillscheck -count=1`
- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] `node scripts/skill-format-check/index.js`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] Command-level httpmock test pins the final JSON envelope without requiring tenant credentials

## Related Issues
- Fixes #2428
- Supersedes #2472 (its original fix commit is included with original authorship). #2429 proposes returning the whole upstream envelope including `code`/`msg`; this PR intentionally keeps those transport fields out of success `data` so the `ok`-based output contract remains authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized legacy bot information so fields such as `open_id` and `app_name` appear directly in response data.
  * Prevented transport metadata such as `code` and `msg` from appearing in returned payload data.
  * Preserved non-object response bodies, including arrays, strings, numbers, and boolean values.
  * Handled null or missing payload data consistently while retaining available response fields.

* **Documentation**
  * Updated guidance and command examples to extract the current app’s `open_id` directly from the response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
