### PR TITLE
feat: expand folder one level in message content (folder children browse)

### DIFF
--- a/shortcuts/im/convert_lib/content_convert.go
+++ b/shortcuts/im/convert_lib/content_convert.go
@@ -43,6 +43,13 @@ type ConvertContext struct {
 	// per-message inline GET", which keeps non-shortcut callers (events,
 	// ad-hoc tests) working unchanged.
 	MergeForwardSubItems map[string][]map[string]interface{}
+
+	// FolderChildren is an optional pre-fetched cache of folder-expansion XML,
+	// keyed by folder-message message_id. When set, the folder converter uses
+	// the cached entry instead of issuing its own GET; populated by callers
+	// via PrefetchFolderChildren before the FormatMessageItem loop. nil means
+	// "no prefetch — fall back to the per-message inline GET".
+	FolderChildren map[string]string
 }
 
 // converters maps message types to their ContentConverter implementations.
@@ -131,7 +138,7 @@ func FormatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 	if len(senderNames) > 0 {
 		nameCache = senderNames[0]
 	}
-	return formatMessageItem(m, runtime, nameCache, nil, false)
+	return formatMessageItem(m, runtime, nameCache, nil, nil, false)
 }
 
 // FormatMessageItemWithMergePrefetch is like FormatMessageItem but threads a
@@ -140,8 +147,11 @@ func FormatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 // can skip its own per-message GET. Shortcuts that iterate a page of raw
 // items should pre-fetch once and call this variant in the loop to avoid the
 // N × ~1s serial-merge_forward stall in the original code path.
+//
+// Kept as a nil-folder-prefetch compatibility wrapper for external callers;
+// internal list commands have migrated to FormatMessageItemWithFolderPrefetchOpts.
 func FormatMessageItemWithMergePrefetch(m map[string]interface{}, runtime *common.RuntimeContext, nameCache map[string]string, mergePrefetch map[string][]map[string]interface{}) map[string]interface{} {
-	return formatMessageItem(m, runtime, nameCache, mergePrefetch, false)
+	return formatMessageItem(m, runtime, nameCache, mergePrefetch, nil, false)
 }
 
 // FormatMessageItemWithMergePrefetchOpts is FormatMessageItemWithMergePrefetch
@@ -150,11 +160,24 @@ func FormatMessageItemWithMergePrefetch(m map[string]interface{}, runtime *commo
 // without local_path/size_bytes) is attached for the download enrichment stage
 // to fill. The other entry points are thin extractResources=false wrappers, so
 // default output is unchanged.
+//
+// Kept as a nil-folder-prefetch compatibility wrapper for external callers;
+// internal list commands use FormatMessageItemWithFolderPrefetchOpts when a
+// page may contain folder messages.
 func FormatMessageItemWithMergePrefetchOpts(m map[string]interface{}, runtime *common.RuntimeContext, nameCache map[string]string, mergePrefetch map[string][]map[string]interface{}, extractResources bool) map[string]interface{} {
-	return formatMessageItem(m, runtime, nameCache, mergePrefetch, extractResources)
+	return formatMessageItem(m, runtime, nameCache, mergePrefetch, nil, extractResources)
 }
 
-func formatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext, nameCache map[string]string, mergePrefetch map[string][]map[string]interface{}, extractResources bool) map[string]interface{} {
+// FormatMessageItemWithFolderPrefetchOpts is FormatMessageItemWithMergePrefetchOpts
+// with an additional folder-children prefetch cache (built via
+// PrefetchFolderChildren) keyed by folder-message message_id. Callers that
+// render a page that may contain folder messages pass both prefetch maps so
+// the folder converter reuses cached XML instead of N serial GETs.
+func FormatMessageItemWithFolderPrefetchOpts(m map[string]interface{}, runtime *common.RuntimeContext, nameCache map[string]string, mergePrefetch map[string][]map[string]interface{}, folderPrefetch map[string]string, extractResources bool) map[string]interface{} {
+	return formatMessageItem(m, runtime, nameCache, mergePrefetch, folderPrefetch, extractResources)
+}
+
+func formatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext, nameCache map[string]string, mergePrefetch map[string][]map[string]interface{}, folderPrefetch map[string]string, extractResources bool) map[string]interface{} {
 	msgType, _ := m["msg_type"].(string)
 	messageId, _ := m["message_id"].(string)
 	mentions, _ := m["mentions"].([]interface{})
@@ -173,6 +196,7 @@ func formatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 			Runtime:              runtime,
 			SenderNames:          nameCache,
 			MergeForwardSubItems: mergePrefetch,
+			FolderChildren:       folderPrefetch,
 		})
 	}
 

--- a/shortcuts/im/convert_lib/folder_test.go
+++ b/shortcuts/im/convert_lib/folder_test.go
@@ -1,0 +1,398 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package convertlib
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+// fetchFolderChildrenTree unit tests (httpmock, no real openapi).
+// Covers XML one-level output (folder key+name+child_count / file key+name /
+// sub-folder key+name+child_count / has_more) and fallback paths.
+
+// folderChildrenRoundTrip answers any GET /files/:key/folder request with a
+// one-child expansion (or a failure when fail is true). Built on the roundtrip
+// runtime with a static token resolver so the concurrent prefetch fan-out does
+// not race the credential provider under -race (same approach as merge tests).
+func folderChildrenRoundTrip(fail bool) convertlibRoundTripFunc {
+	return func(req *http.Request) (*http.Response, error) {
+		if fail {
+			return convertlibJSONResponse(503, map[string]interface{}{}), nil
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items":     []interface{}{map[string]interface{}{"file_key": "f1", "name": "a.pdf", "is_folder": false}},
+				"all_count": float64(1),
+			},
+		}), nil
+	}
+}
+
+func folderTestRuntime(t *testing.T) (*common.RuntimeContext, *httpmock.Registry) {
+	t.Helper()
+	cfg := &core.CliConfig{Brand: core.BrandFeishu, AppID: "cli_x"}
+	f, _, _, reg := cmdutil.TestFactory(t, cfg)
+	rt := common.TestNewRuntimeContextForAPI(context.Background(), &cobra.Command{Use: "+x"}, cfg, f, core.AsUser)
+	return rt, reg
+}
+
+const folderURL = "/open-apis/im/v1/files/fld_root/folder?recursive=false&srcid=om_123&srctype=message"
+
+// C4: expand one level (files + sub-folder with child_count), no has_more (items == all_count).
+func TestFetchFolderChildrenTree_XMLOneLevel(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    folderURL,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"file_key": "f1", "name": "报告.pdf", "is_folder": false},
+					map[string]interface{}{"file_key": "f2", "name": "文档.docx", "is_folder": false},
+					map[string]interface{}{"file_key": "f3", "name": "子文件夹", "is_folder": true, "children_count": float64(3)},
+				},
+				"all_count": float64(3),
+			},
+		},
+	})
+	got := fetchFolderChildrenTree(rt, "fld_root", "tmpavatra", "om_123")
+	want := `<folder key="fld_root" name="tmpavatra" child_count="3"><file key="f1" name="报告.pdf"/><file key="f2" name="文档.docx"/><folder key="f3" name="子文件夹" child_count="3"/></folder>`
+	if got != want {
+		t.Fatalf("fetchFolderChildrenTree() = %q, want %q", got, want)
+	}
+}
+
+// C4b: sub-folder with children_count missing (unknown) omits child_count instead of "0".
+func TestFetchFolderChildrenTree_SubFolderUnknownCount(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    folderURL,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"file_key": "f3", "name": "子文件夹", "is_folder": true}, // no children_count
+				},
+				"all_count": float64(1),
+			},
+		},
+	})
+	got := fetchFolderChildrenTree(rt, "fld_root", "x", "om_123")
+	want := `<folder key="fld_root" name="x" child_count="1"><folder key="f3" name="子文件夹"/></folder>`
+	if got != want {
+		t.Fatalf("fetchFolderChildrenTree() = %q, want %q", got, want)
+	}
+}
+
+// C4c: items < all_count -> root folder carries has_more="true".
+func TestFetchFolderChildrenTree_HasMore(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    folderURL,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"file_key": "f1", "name": "a.pdf", "is_folder": false},
+				},
+				"all_count": float64(100),
+			},
+		},
+	})
+	got := fetchFolderChildrenTree(rt, "fld_root", "big", "om_123")
+	want := `<folder key="fld_root" name="big" child_count="100" has_more="true"><file key="f1" name="a.pdf"/></folder>`
+	if got != want {
+		t.Fatalf("fetchFolderChildrenTree() = %q, want %q", got, want)
+	}
+}
+
+// C4d: more than 10 first-level items -> render first 10 + has_more="true" (rendering cap).
+func TestFetchFolderChildrenTree_CapAtTen(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	items := make([]interface{}, 0, 12)
+	for i := 0; i < 12; i++ {
+		items = append(items, map[string]interface{}{"file_key": fmt.Sprintf("f%d", i), "name": fmt.Sprintf("f%d.pdf", i), "is_folder": false})
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    folderURL,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items":     items,
+				"all_count": float64(12),
+			},
+		},
+	})
+	got := fetchFolderChildrenTree(rt, "fld_root", "big", "om_123")
+	// first 10 rendered, has_more present, last item f11 absent
+	if !strings.Contains(got, `child_count="12" has_more="true"`) {
+		t.Fatalf("want child_count=12 + has_more, got %q", got)
+	}
+	if !strings.Contains(got, `<file key="f9" name="f9.pdf"/>`) || strings.Contains(got, `name="f10.pdf"`) {
+		t.Fatalf("want first 10 items only, got %q", got)
+	}
+}
+
+// C5: transport error (no stub registered) -> "" so callers fall back; warning goes to stderr.
+func TestFetchFolderChildrenTree_APIFailure(t *testing.T) {
+	rt, _ := folderTestRuntime(t)
+	got := fetchFolderChildrenTree(rt, "fld_root", "x", "om_123")
+	if got != "" {
+		t.Fatalf("fetchFolderChildrenTree() on API failure = %q, want empty (caller downgrades)", got)
+	}
+}
+
+// C5b: HTTP 200 + business code != 0 (e.g. permission denied) -> "" + stderr warning.
+func TestFetchFolderChildrenTree_BusinessError(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    folderURL,
+		Body:   map[string]interface{}{"code": 14009, "msg": "dlp deny"},
+	})
+	got := fetchFolderChildrenTree(rt, "fld_root", "x", "om_123")
+	if got != "" {
+		t.Fatalf("fetchFolderChildrenTree() on business error = %q, want empty", got)
+	}
+}
+
+// C6: genuinely empty folder (items empty, all_count 0) keeps child_count="0"
+// instead of degrading to the pre-expand single-line output.
+func TestFetchFolderChildrenTree_EmptyFolder(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    folderURL,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items":     []interface{}{},
+				"all_count": float64(0),
+			},
+		},
+	})
+	got := fetchFolderChildrenTree(rt, "fld_root", "x", "om_123")
+	want := `<folder key="fld_root" name="x" child_count="0"/>`
+	if got != want {
+		t.Fatalf("fetchFolderChildrenTree() empty folder = %q, want %q", got, want)
+	}
+}
+
+// Prefetch: multiple folder messages in one page -> concurrent prefetch returns
+// a cache keyed by message_id; Convert reuses it without a second GET.
+func TestPrefetchFolderChildren(t *testing.T) {
+	// roundtrip runtime (static token resolver): concurrent prefetch fan-out
+	// must not trip the credential resolver under -race, same as merge tests.
+	rt := newBotConvertlibRuntime(t, folderChildrenRoundTrip(false))
+	rawItems := []interface{}{
+		map[string]interface{}{"msg_type": "folder", "message_id": "om_100",
+			"body": map[string]interface{}{"content": `{"file_key":"fld_om_100","file_name":"d1"}`}},
+		map[string]interface{}{"msg_type": "folder", "message_id": "om_200",
+			"body": map[string]interface{}{"content": `{"file_key":"fld_om_200","file_name":"d2"}`}},
+		map[string]interface{}{"msg_type": "text", "message_id": "om_300"}, // non-folder ignored
+	}
+	cache := PrefetchFolderChildren(rt, rawItems)
+	if len(cache) != 2 {
+		t.Fatalf("PrefetchFolderChildren() = %d entries, want 2 (om_100/om_200)", len(cache))
+	}
+	for _, mid := range []string{"om_100", "om_200"} {
+		xml, ok := cache[mid]
+		if !ok || !strings.Contains(xml, `<folder key="fld_`+mid) || !strings.Contains(xml, `name="d`) {
+			t.Fatalf("cache[%s] = %q, want expanded folder XML", mid, xml)
+		}
+	}
+}
+
+// Convert fast path: cached FolderChildren XML is reused (no second stub needed).
+func TestFolderConverter_ConvertUsesPrefetchCache(t *testing.T) {
+	rt, _ := folderTestRuntime(t)
+	ctx := &ConvertContext{
+		RawContent:     `{"file_key":"fld_x","file_name":"Docs"}`,
+		MessageID:      "om_9",
+		Runtime:        rt,
+		FolderChildren: map[string]string{"om_9": `<folder key="fld_x" name="Docs" child_count="1"><file key="f1" name="a.pdf"/></folder>`},
+	}
+	got := (folderConverter{}).Convert(ctx)
+	if got != `<folder key="fld_x" name="Docs" child_count="1"><file key="f1" name="a.pdf"/></folder>` {
+		t.Fatalf("Convert() = %q, want cached XML (fast path)", got)
+	}
+}
+
+// Convert-level inline expansion: folderConverter.Convert issues the GET when no
+// prefetch cache is present, then renders the expanded XML (regression guard so
+// removing the Convert-level call fails this test).
+func TestFolderConverter_ConvertInline(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/im/v1/files/fld_root/folder?recursive=false&srcid=om_123&srctype=message",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"items":     []interface{}{map[string]interface{}{"file_key": "f1", "name": "a.pdf", "is_folder": false}},
+			"all_count": float64(1),
+		}},
+	})
+	ctx := &ConvertContext{RawContent: `{"file_key":"fld_root","file_name":"Docs"}`, MessageID: "om_123", Runtime: rt}
+	got := (folderConverter{}).Convert(ctx)
+	if !strings.Contains(got, `<folder key="fld_root" name="Docs" child_count="1">`) || !strings.Contains(got, `<file key="f1" name="a.pdf"/>`) {
+		t.Fatalf("Convert() inline = %q, want expanded XML", got)
+	}
+}
+
+// Convert-level fallback: GET failure (no stub) -> single-line tag + stderr warning.
+func TestFolderConverter_ConvertInlineFallback(t *testing.T) {
+	rt, _ := folderTestRuntime(t)
+	ctx := &ConvertContext{RawContent: `{"file_key":"fld_root","file_name":"Docs"}`, MessageID: "om_123", Runtime: rt}
+	got := (folderConverter{}).Convert(ctx)
+	want := `<folder key="fld_root" name="Docs"/>`
+	if got != want {
+		t.Fatalf("Convert() fallback = %q, want %q", got, want)
+	}
+	if errOut := rt.IO().ErrOut.(*bytes.Buffer).String(); !strings.Contains(errOut, "folder_fetch_failed") {
+		t.Fatalf("Convert() failure stderr = %q, want folder_fetch_failed warning", errOut)
+	}
+}
+
+// Post message with a folder attachment expands one level (same fetch path as
+// folder messages) — regression guard for renderPostAttachments.
+func TestPostConverter_FolderAttachmentExpansion(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/im/v1/files/fld_att/folder?recursive=false&srcid=om_p&srctype=message",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"items":     []interface{}{map[string]interface{}{"file_key": "c1", "name": "sub.png", "is_folder": false}},
+			"all_count": float64(1),
+		}},
+	})
+	post := `{"zh_cn":{"text":"hi"},"files":[{"file_key":"fld_att","file_name":"assets","is_folder":true},{"file_key":"f1","file_name":"a.pdf"}]}`
+	ctx := &ConvertContext{RawContent: post, MessageID: "om_p", Runtime: rt}
+	got := (postConverter{}).Convert(ctx)
+	if !strings.Contains(got, `<folder key="fld_att" name="assets" child_count="1">`) ||
+		!strings.Contains(got, `<file key="c1" name="sub.png"/>`) ||
+		!strings.Contains(got, `<file key="f1" name="a.pdf"/>`) {
+		t.Fatalf("post Convert() = %q, want expanded folder attachment + file lines", got)
+	}
+}
+
+// Transport/business failures must emit the stable folder_fetch_failed warning
+// prefix on stderr (regression guard for the warning side effect).
+func TestFolderChildrenTree_WarningOnStderr(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{Method: "GET", URL: folderURL, Body: map[string]interface{}{"code": 14009, "msg": "dlp deny"}})
+	fetchFolderChildrenTree(rt, "fld_root", "x", "om_123")
+	errOut := rt.IO().ErrOut.(*bytes.Buffer).String()
+	// stable warning prefix; the payload (err text or code) may vary by failure path
+	if !strings.Contains(errOut, "folder_fetch_failed: fld_root:") {
+		t.Fatalf("stderr = %q, want folder_fetch_failed warning for fld_root", errOut)
+	}
+}
+
+// Prefetch failure sentinel (""): Convert degrades to the single-line tag and
+// does NOT issue an inline retry (no stderr warning, no extra GET) — prevents
+// page-wide failures (missing scope / DLP) from doubling every folder request.
+func TestFolderConverter_PrefetchFailureSkipsInlineRetry(t *testing.T) {
+	rt, _ := folderTestRuntime(t)
+	ctx := &ConvertContext{
+		RawContent:     `{"file_key":"fld_root","file_name":"Docs"}`,
+		MessageID:      "om_fail",
+		Runtime:        rt,
+		FolderChildren: map[string]string{"om_fail": ""}, // prefetch tried & failed
+	}
+	got := (folderConverter{}).Convert(ctx)
+	if got != `<folder key="fld_root" name="Docs"/>` {
+		t.Fatalf("Convert() failure sentinel = %q, want single-line degrade", got)
+	}
+	if errOut := rt.IO().ErrOut.(*bytes.Buffer).String(); errOut != "" {
+		t.Fatalf("Convert() sentinel stderr = %q, want empty (no inline retry)", errOut)
+	}
+}
+
+// PrefetchFolderChildren records failures as "" sentinels (not absent keys), so
+// the render loop never retries inline after a failed prefetch.
+func TestPrefetchFolderChildren_FailureSentinel(t *testing.T) {
+	rt := newBotConvertlibRuntime(t, folderChildrenRoundTrip(true)) // every fetch fails
+	rawItems := []interface{}{
+		map[string]interface{}{"msg_type": "folder", "message_id": "om_f1",
+			"body": map[string]interface{}{"content": `{"file_key":"fld_f1","file_name":"d1"}`}},
+		map[string]interface{}{"msg_type": "folder", "message_id": "om_f2",
+			"body": map[string]interface{}{"content": `{"file_key":"fld_f2","file_name":"d2"}`}},
+	}
+	cache := PrefetchFolderChildren(rt, rawItems)
+	if cache["om_f1"] != "" || cache["om_f2"] != "" {
+		t.Fatalf("PrefetchFolderChildren() failures = %#v, want both \"\" sentinels", cache)
+	}
+	errOut := rt.IO().ErrOut.(*bytes.Buffer).String()
+	if strings.Count(errOut, "folder_fetch_failed") != 2 {
+		t.Fatalf("stderr warnings = %q, want 2 folder_fetch_failed (one per prefetch)", errOut)
+	}
+}
+
+// Post messages with folder attachments are picked up by PrefetchFolderChildren
+// (cache key message_id + folder key); the post converter reuses the cached XML
+// instead of an inline GET.
+func TestPostFolderAttachmentPrefetch(t *testing.T) {
+	rt := newBotConvertlibRuntime(t, folderChildrenRoundTrip(false))
+	raw := map[string]interface{}{
+		"msg_type": "post", "message_id": "om_p1",
+		"body": map[string]interface{}{"content": `{"zh_cn":{"text":"hi"},"files":[{"file_key":"fld_p1","file_name":"assets","is_folder":true}]}`},
+	}
+	cache := PrefetchFolderChildren(rt, []interface{}{raw})
+	xml, ok := cache["om_p1\x00fld_p1"]
+	if !ok || !strings.Contains(xml, `<folder key="fld_p1" name="assets" child_count="1">`) {
+		t.Fatalf("PrefetchFolderChildren() post attachment = %q (ok=%v), want cached expansion", xml, ok)
+	}
+	// Render via postConverter — should reuse the cache (stub would only answer once).
+	ctx := &ConvertContext{RawContent: raw["body"].(map[string]interface{})["content"].(string), MessageID: "om_p1", Runtime: rt, FolderChildren: cache}
+	got := (postConverter{}).Convert(ctx)
+	if !strings.Contains(got, `<folder key="fld_p1" name="assets" child_count="1">`) || !strings.Contains(got, `<file key="f1" name="a.pdf"/>`) {
+		t.Fatalf("post Convert() with prefetch = %q, want cached folder expansion", got)
+	}
+}
+
+// Server returns all_count > 0 but no items -> self-closing folder tag with
+// child_count + has_more (no odd empty open/close pair).
+func TestFetchFolderChildrenTree_NoItemsButAllCount(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    folderURL,
+		Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{"items": []interface{}{}, "all_count": float64(3)}},
+	})
+	got := fetchFolderChildrenTree(rt, "fld_root", "x", "om_123")
+	want := `<folder key="fld_root" name="x" child_count="3" has_more="true"/>`
+	if got != want {
+		t.Fatalf("fetchFolderChildrenTree() no-items-all-count = %q, want %q", got, want)
+	}
+}
+
+// code:0 without a data field -> "" (degrade) plus an "empty data" stderr
+// warning (not a misleading "<nil>").
+func TestFetchFolderChildrenTree_EmptyData(t *testing.T) {
+	rt, reg := folderTestRuntime(t)
+	reg.Register(&httpmock.Stub{Method: "GET", URL: folderURL, Body: map[string]interface{}{"code": 0}})
+	got := fetchFolderChildrenTree(rt, "fld_root", "x", "om_123")
+	if got != "" {
+		t.Fatalf("fetchFolderChildrenTree() empty data = %q, want empty", got)
+	}
+	errOut := rt.IO().ErrOut.(*bytes.Buffer).String()
+	if !strings.Contains(errOut, "folder_fetch_failed: fld_root: empty data") {
+		t.Fatalf("stderr = %q, want 'empty data' warning", errOut)
+	}
+}

--- a/shortcuts/im/convert_lib/merge.go
+++ b/shortcuts/im/convert_lib/merge.go
@@ -83,7 +83,8 @@ func renderMergeForwardTree(ctx *ConvertContext, subItems []map[string]interface
 // PrefetchMergeForwardSubItems scans rawItems for merge_forward messages,
 // concurrently fetches each one's flat sub-message list, and returns a map
 // keyed by the merge_forward message_id. Callers thread the returned map
-// through FormatMessageItemWithMergePrefetch (or directly into a
+// through FormatMessageItemWithMergePrefetch /
+// FormatMessageItemWithFolderPrefetchOpts (or directly into a
 // ConvertContext.MergeForwardSubItems) so the per-item conversion loop can
 // reuse cached sub-trees instead of issuing its own serial GET.
 //

--- a/shortcuts/im/convert_lib/misc.go
+++ b/shortcuts/im/convert_lib/misc.go
@@ -4,9 +4,16 @@
 package convertlib
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
+	"sync"
+
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 type stickerConverter struct{}
@@ -72,10 +79,279 @@ func (folderConverter) Convert(ctx *ConvertContext) string {
 		return "[Folder]"
 	}
 	name, _ := parsed["file_name"].(string)
+
+	// Fast path: caller pre-fetched this folder's expansion XML (see
+	// PrefetchFolderChildren) keyed by message_id — reuse it, no GET.
+	// "" as the cached value means "prefetch tried and failed": degrade to the
+	// single-line output without an inline retry, so a page-wide failure (missing
+	// scope, DLP deny, …) does not double every folder GET inside the render loop.
+	if ctx.FolderChildren != nil && ctx.MessageID != "" {
+		if xml, ok := ctx.FolderChildren[ctx.MessageID]; ok {
+			if xml == "" {
+				return fallbackFolderLine(key, name)
+			}
+			return xml
+		}
+	}
+	// Inline path: expand one level via openapi folder-children (recursive=false).
+	// Requires Runtime + MessageID; falls back to the old single-line output when
+	// unavailable or on failure.
+	if ctx.Runtime != nil && ctx.MessageID != "" {
+		if tree := fetchFolderChildrenTree(ctx.Runtime, key, name, ctx.MessageID); tree != "" {
+			return tree
+		}
+	}
+	return fallbackFolderLine(key, name)
+}
+
+// fallbackFolderLine renders the pre-expansion single-line folder tag used when
+// expansion data is unavailable (no runtime/message id, API failure, or a
+// prefetch that already tried and failed).
+func fallbackFolderLine(key, name string) string {
 	if name != "" {
 		return fmt.Sprintf(`<folder key="%s" name="%s"/>`, cardEscapeAttr(key), cardEscapeAttr(name))
 	}
 	return fmt.Sprintf(`<folder key="%s"/>`, cardEscapeAttr(key))
+}
+
+// folderWarnMu serializes stderr warnings from folder fetches: the same
+// function runs both inline (single-threaded) and inside the concurrent
+// PrefetchFolderChildren fan-out, so the ErrOut write must be mutex-guarded
+// (bytes.Buffer-backed in tests, where a data race would fail -race CI).
+var folderWarnMu sync.Mutex
+
+func folderWarnf(runtime *common.RuntimeContext, format string, args ...interface{}) {
+	folderWarnMu.Lock()
+	defer folderWarnMu.Unlock()
+	fmt.Fprintf(runtime.IO().ErrOut, format, args...)
+}
+
+// fetchFolderChildrenTree calls the folder-children openapi to expand one level and returns
+// XML (folder child_count hint / file key+name). Returns "" on failure so callers fall back.
+func fetchFolderChildrenTree(runtime *common.RuntimeContext, folderKey, folderName, messageID string) string {
+	data, err := runtime.DoAPIJSONTyped(http.MethodGet,
+		"/open-apis/im/v1/files/"+validate.EncodePathSegment(folderKey)+"/folder",
+		larkcore.QueryParams{
+			"srctype":   []string{"message"},
+			"srcid":     []string{messageID},
+			"recursive": []string{"false"},
+		}, nil)
+	// DoAPIJSONTyped unwraps the envelope and returns the response body's data
+	// field; non-zero envelope codes already surface as err (BuildAPIError), so
+	// no code re-check is needed here.
+	if err != nil {
+		folderWarnf(runtime, "warning: folder_fetch_failed: %s: %v\n", folderKey, err)
+		return ""
+	}
+	if data == nil {
+		folderWarnf(runtime, "warning: folder_fetch_failed: %s: empty data\n", folderKey)
+		return ""
+	}
+	rawItems, _ := data["items"].([]interface{})
+	allCount := numToInt64(data["all_count"])
+	// One level only, capped at maxFolderChildren rendered items: files use <file key name/>;
+	// sub-folders <folder key name child_count/> (no recursion; child_count hints deeper
+	// levels). Root folder carries child_count (=all_count) + has_more when more children
+	// remain than were rendered (cap reached or all_count > items returned). A genuinely
+	// empty folder (items + all_count both 0) keeps child_count="0".
+	const maxFolderChildren = 10
+	hasMore := allCount > int64(len(rawItems)) // server may cap items below all_count
+	shown := len(rawItems)
+	if shown > maxFolderChildren {
+		shown = maxFolderChildren
+		hasMore = true // rendering cap reached
+	}
+	var b strings.Builder
+	writeFolderOpen(&b, folderKey, folderName, allCount, shown == 0 && allCount == 0, hasMore, shown == 0)
+	if shown == 0 {
+		// No renderable children: self-closing tag (empty folder -> child_count="0";
+		// server said all_count > 0 but returned no items -> child_count=all_count +
+		// has_more). Self-closing avoids an odd empty open/close pair.
+		return b.String()
+	}
+	for i := 0; i < shown; i++ {
+		raw := rawItems[i]
+		item, _ := raw.(map[string]interface{})
+		k, _ := item["file_key"].(string)
+		n, _ := item["name"].(string)
+		isFolder, _ := item["is_folder"].(bool)
+		if isFolder {
+			fmt.Fprintf(&b, `<folder key="%s" name="%s"`, cardEscapeAttr(k), cardEscapeAttr(n))
+			if cc := numToInt64(item["children_count"]); cc > 0 {
+				fmt.Fprintf(&b, ` child_count="%d"`, cc)
+			}
+			b.WriteString(`/>`)
+		} else {
+			fmt.Fprintf(&b, `<file key="%s" name="%s"/>`, cardEscapeAttr(k), cardEscapeAttr(n))
+		}
+	}
+	b.WriteString("</folder>")
+	return b.String()
+}
+
+// writeFolderOpen writes the root <folder ...> opening tag: key + name attrs,
+// then child_count (= allCount; forceChildZero renders an explicit "0" for a
+// genuinely empty folder), then has_more, closing with "/>" when selfClose.
+func writeFolderOpen(b *strings.Builder, folderKey, folderName string, childCount int64, forceChildZero, hasMore, selfClose bool) {
+	b.WriteString(`<folder key="` + cardEscapeAttr(folderKey) + `"`)
+	if folderName != "" {
+		b.WriteString(` name="` + cardEscapeAttr(folderName) + `"`)
+	}
+	if forceChildZero || childCount > 0 {
+		fmt.Fprintf(b, ` child_count="%d"`, childCount)
+	}
+	if hasMore {
+		b.WriteString(` has_more="true"`)
+	}
+	if selfClose {
+		b.WriteString(`/>`)
+	} else {
+		b.WriteString(`>`)
+	}
+}
+
+// numToInt64 converts a JSON numeric value to int64 (json.Number is what the JSON
+// decoder produces under dec.UseNumber(); other numeric kinds are tolerated).
+func numToInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i
+		}
+	case float64:
+		return int64(n)
+	case float32:
+		return int64(n)
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	}
+	return 0
+}
+
+// folderPrefetchConcurrency bounds the folder-children fan-out. A message-list
+// page rarely carries more than a handful of folder messages, and each folder
+// expansion is a single ~1 RTT GET, so 8 concurrent workers comfortably drain
+// one page without stampeding the gateway; the result cache also makes later
+// renders of the same message free. Serial fallbacks still apply when a caller
+// skips prefetching.
+const folderPrefetchConcurrency = 8
+
+// folderCacheKeySep separates message_id from folder file_key in the prefetch
+// cache for post-message folder attachments (a post may carry several folders,
+// so message_id alone is not a unique cache key). Folder messages use the bare
+// message_id as their key.
+const folderCacheKeySep = "\x00"
+
+// PrefetchFolderChildren scans rawItems for folder messages (msg_type == folder,
+// keyed by message_id) and for folder attachments inside post messages (keyed
+// by message_id + folderCacheKeySep + folder key), concurrently expanding each
+// one level (bounded by folderPrefetchConcurrency) and returning the expansion
+// XML. Callers thread the map through FormatMessageItemWithFolderPrefetchOpts
+// so the per-item folder/post converters reuse cached XML instead of issuing N
+// serial GETs inside the FormatMessageItem loop.
+//
+// A "" value means the prefetch already tried and failed: converters degrade to
+// the single-line tag without an inline retry (so page-wide failures — missing
+// scope, DLP deny — do not double every folder GET). A single-entry fast path
+// avoids goroutine overhead.
+func PrefetchFolderChildren(runtime *common.RuntimeContext, rawItems []interface{}) map[string]string {
+	if runtime == nil || len(rawItems) == 0 {
+		return nil
+	}
+	type folderRef struct{ cacheKey, id, key, name string }
+	var refs []folderRef
+	for _, item := range rawItems {
+		m, _ := item.(map[string]interface{})
+		if m == nil {
+			continue
+		}
+		mt, _ := m["msg_type"].(string)
+		if mt == "folder" {
+			// Standalone folder message: content carries one file_key; the whole
+			// expansion is keyed by message_id.
+			id, _ := m["message_id"].(string)
+			if id == "" {
+				continue
+			}
+			key, name := "", ""
+			if body, ok := m["body"].(map[string]interface{}); ok {
+				if c, ok := body["content"].(string); ok {
+					if parsed, err := ParseJSONObject(c); err == nil {
+						key, _ = parsed["file_key"].(string)
+						name, _ = parsed["file_name"].(string)
+					}
+				}
+			}
+			if key == "" {
+				continue
+			}
+			refs = append(refs, folderRef{cacheKey: id, id: id, key: key, name: name})
+			continue
+		}
+		if mt == "post" {
+			// Post message: folder attachments live in the attachment zone
+			// ("files": [{file_key, file_name, is_folder}]). Each folder is a
+			// separate expansion keyed by message_id + folder_key.
+			id, _ := m["message_id"].(string)
+			if id == "" {
+				continue
+			}
+			if body, ok := m["body"].(map[string]interface{}); ok {
+				if c, ok := body["content"].(string); ok {
+					if parsed, err := ParseJSONObject(c); err == nil {
+						if rawFiles, ok := parsed["files"].([]interface{}); ok {
+							for _, raw := range rawFiles {
+								f, _ := raw.(map[string]interface{})
+								if f == nil {
+									continue
+								}
+								if isF, _ := f["is_folder"].(bool); !isF {
+									continue
+								}
+								key, _ := f["file_key"].(string)
+								name, _ := f["file_name"].(string)
+								if key == "" {
+									continue
+								}
+								refs = append(refs, folderRef{cacheKey: id + folderCacheKeySep + key, id: id, key: key, name: name})
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+
+	result := make(map[string]string, len(refs))
+	if len(refs) == 1 {
+		// Single-entry fast path; "" records "tried and failed" so the converter
+		// skips an inline retry (systemic failures would otherwise double GETs).
+		result[refs[0].cacheKey] = fetchFolderChildrenTree(runtime, refs[0].key, refs[0].name, refs[0].id)
+		return result
+	}
+
+	var mu sync.Mutex
+	sem := make(chan struct{}, folderPrefetchConcurrency)
+	var wg sync.WaitGroup
+	for _, ref := range refs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			xml := fetchFolderChildrenTree(runtime, ref.key, ref.name, ref.id)
+			mu.Lock()
+			result[ref.cacheKey] = xml // "" = tried and failed: converter degrades, no retry
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return result
 }
 
 type calendarEventConverter struct{}

--- a/shortcuts/im/convert_lib/text.go
+++ b/shortcuts/im/convert_lib/text.go
@@ -59,7 +59,7 @@ func (postConverter) Convert(ctx *ConvertContext) string {
 	result = ResolveMentionKeys(result, ctx.MentionMap)
 	// Attachment zone (top-level "files" array, sibling of the locale keys) is
 	// rendered as trailing lines so agents can see file/folder keys for download.
-	if attachments := renderPostAttachments(parsed); attachments != "" {
+	if attachments := renderPostAttachments(ctx, parsed); attachments != "" {
 		result += "\n" + attachments
 	}
 	return result
@@ -80,7 +80,7 @@ func (postConverter) Convert(ctx *ConvertContext) string {
 //
 //	<file key="file_xxx" name="report.pdf"/>
 //	<folder key="file_yyy" name="assets"/>
-func renderPostAttachments(parsed map[string]interface{}) string {
+func renderPostAttachments(ctx *ConvertContext, parsed map[string]interface{}) string {
 	rawFiles, ok := parsed["files"].([]interface{})
 	if !ok || len(rawFiles) == 0 {
 		return ""
@@ -95,11 +95,35 @@ func renderPostAttachments(parsed map[string]interface{}) string {
 		if key == "" {
 			continue
 		}
+		name, _ := f["file_name"].(string)
 		tag := "file"
 		if isFolder, _ := f["is_folder"].(bool); isFolder {
 			tag = "folder"
+			// Expand folder attachments one level (same as folder messages):
+			// 1) prefetch cache hit (message_id + folder key) -> use cached XML;
+			// 2) "" cached value = prefetch already tried & failed -> degrade to
+			//    the single-line tag, no inline retry (page-wide failures must
+			//    not double GETs);
+			// 3) cache miss (or no cache) + Runtime + MessageID -> inline fetch;
+			// 4) otherwise fall back to the single-line tag below.
+			expanded := ""
+			if ctx != nil && ctx.MessageID != "" && ctx.FolderChildren != nil {
+				if xml, ok := ctx.FolderChildren[ctx.MessageID+folderCacheKeySep+key]; ok {
+					if xml != "" {
+						expanded = xml
+					}
+					// "" sentinel: leave expanded empty -> single-line, no retry
+				} else if ctx.Runtime != nil {
+					expanded = fetchFolderChildrenTree(ctx.Runtime, key, name, ctx.MessageID)
+				}
+			} else if ctx != nil && ctx.Runtime != nil && ctx.MessageID != "" {
+				expanded = fetchFolderChildrenTree(ctx.Runtime, key, name, ctx.MessageID)
+			}
+			if expanded != "" {
+				lines = append(lines, expanded)
+				continue
+			}
 		}
-		name, _ := f["file_name"].(string)
 		if name != "" {
 			lines = append(lines, fmt.Sprintf(`<%s key="%s" name="%s"/>`, tag, cardEscapeAttr(key), cardEscapeAttr(name)))
 		} else {

--- a/shortcuts/im/convert_lib/thread.go
+++ b/shortcuts/im/convert_lib/thread.go
@@ -197,6 +197,11 @@ func ExpandThreadRepliesWithResources(runtime *common.RuntimeContext, messages [
 		}
 	}
 	mergePrefetch := PrefetchMergeForwardSubItems(runtime, allRawReplies, nameCache)
+	// Folder replies get the same treatment: a thread reply that is a folder
+	// message would otherwise trigger another serial GET per reply inside
+	// FormatMessageItem. PrefetchFolderChildren bounds the fan-out and caches
+	// XML keyed by reply message_id for the render loop below.
+	folderPrefetch := PrefetchFolderChildren(runtime, allRawReplies)
 
 	// Phase 2a: format every plan's replies sequentially. FormatMessageItem
 	// may still touch nameCache for non-merge_forward content types
@@ -214,7 +219,7 @@ func ExpandThreadRepliesWithResources(runtime *common.RuntimeContext, messages [
 		}
 		replies := make([]map[string]interface{}, 0, len(r.rawReplies))
 		for _, raw := range r.rawReplies {
-			replies = append(replies, FormatMessageItemWithMergePrefetchOpts(raw, runtime, nameCache, mergePrefetch, extractResources))
+			replies = append(replies, FormatMessageItemWithFolderPrefetchOpts(raw, runtime, nameCache, mergePrefetch, folderPrefetch, extractResources))
 		}
 		preparedReplies[i] = replies
 	}

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -156,11 +156,12 @@ var ImChatMessageList = common.Shortcut{
 		// call, so the per-merge_forward render path doesn't fan out N more
 		// serial contact requests during the FormatMessageItem loop.
 		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, rawItems, nameCache)
+		folderPrefetch := convertlib.PrefetchFolderChildren(runtime, rawItems)
 
 		downloadResources := runtime.Bool("download-resources")
 		messages := make([]map[string]interface{}, 0, len(rawItems))
 		for _, m := range result.items {
-			messages = append(messages, convertlib.FormatMessageItemWithMergePrefetchOpts(m, runtime, nameCache, mergePrefetch, downloadResources))
+			messages = append(messages, convertlib.FormatMessageItemWithFolderPrefetchOpts(m, runtime, nameCache, mergePrefetch, folderPrefetch, downloadResources))
 		}
 
 		// Enrich: resolve sender names for outer messages (reuses cache from merge_forward)

--- a/shortcuts/im/im_messages_mget.go
+++ b/shortcuts/im/im_messages_mget.go
@@ -78,12 +78,13 @@ var ImMessagesMGet = common.Shortcut{
 		// also pre-resolves every sub-item's sender open_id in one batched
 		// contact API call.
 		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, rawItems, nameCache)
+		folderPrefetch := convertlib.PrefetchFolderChildren(runtime, rawItems)
 
 		downloadResources := runtime.Bool("download-resources")
 		messages := make([]map[string]interface{}, 0, len(rawItems))
 		for _, item := range rawItems {
 			m, _ := item.(map[string]interface{})
-			messages = append(messages, convertlib.FormatMessageItemWithMergePrefetchOpts(m, runtime, nameCache, mergePrefetch, downloadResources))
+			messages = append(messages, convertlib.FormatMessageItemWithFolderPrefetchOpts(m, runtime, nameCache, mergePrefetch, folderPrefetch, downloadResources))
 		}
 
 		convertlib.ResolveSenderNames(runtime, messages, nameCache)

--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -172,13 +172,14 @@ var ImMessagesSearch = common.Shortcut{
 		// nameCache also pre-resolves every sub-item's sender open_id in one
 		// batched contact API call.
 		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, msgItems, nameCache)
+		folderPrefetch := convertlib.PrefetchFolderChildren(runtime, msgItems)
 		enriched := make([]map[string]interface{}, 0, len(msgItems))
 		for _, item := range msgItems {
 			m, _ := item.(map[string]interface{})
 			chatId, _ := m["chat_id"].(string)
 
 			// Reuse unified content converter
-			msg := convertlib.FormatMessageItemWithMergePrefetch(m, runtime, nameCache, mergePrefetch)
+			msg := convertlib.FormatMessageItemWithFolderPrefetchOpts(m, runtime, nameCache, mergePrefetch, folderPrefetch, false)
 			if chatId != "" {
 				msg["chat_id"] = chatId
 			}

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -129,11 +129,12 @@ var ImThreadsMessagesList = common.Shortcut{
 		// Passing nameCache also pre-resolves every sub-item's sender open_id
 		// in one batched contact API call.
 		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, rawItems, nameCache)
+		folderPrefetch := convertlib.PrefetchFolderChildren(runtime, rawItems)
 
 		downloadResources := runtime.Bool("download-resources")
 		messages := make([]map[string]interface{}, 0, len(rawItems))
 		for _, m := range result.items {
-			messages = append(messages, convertlib.FormatMessageItemWithMergePrefetchOpts(m, runtime, nameCache, mergePrefetch, downloadResources))
+			messages = append(messages, convertlib.FormatMessageItemWithFolderPrefetchOpts(m, runtime, nameCache, mergePrefetch, folderPrefetch, downloadResources))
 		}
 
 		// Enrich: resolve sender names for outer messages (reuses cache from merge_forward)

--- a/skills/lark-im/references/lark-im-chat-messages-list.md
+++ b/skills/lark-im/references/lark-im-chat-messages-list.md
@@ -58,7 +58,7 @@ lark-cli im +chat-messages-list --chat-id oc_xxx --format json
 
 ## Resource Rendering
 
-Messages are rendered into human-readable text for inspection. Image messages are shown as placeholders such as `![Image](img_xxx)`; files, audio, and videos are rendered with resource keys in the content (e.g. `<audio key="file_xxx" duration="Xs"/>`). By default resource binaries are **not** downloaded.
+Messages are rendered into human-readable text for inspection. Image messages are shown as placeholders such as `![Image](img_xxx)`; files, audio, and videos are rendered with resource keys in the content (e.g. `<audio key="file_xxx" duration="Xs"/>`). `folder` messages are expanded one level (children rendered inside the tag, see the row below). By default resource binaries are **not** downloaded.
 
 Two ways to get the binaries:
 - **In one pass:** add `--download-resources` to this command — every eligible resource (image/file/audio/video/media + post-embedded, excluding stickers) is downloaded into `./lark-im-resources/` and a `resources` block (`{message_id, key, type, local_path, size_bytes}`) is attached to each message. See [message enrichment](lark-im-message-enrichment.md#resource-auto-download---download-resources-opt-in).
@@ -68,6 +68,7 @@ Two ways to get the binaries:
 |---------|-------------|------|
 | Image | `![Image](img_xxx)` | `--download-resources`, or manually `im +messages-resources-download --type image` |
 | File | `<file key="file_xxx" .../>` | `--download-resources`, or manually `im +messages-resources-download --type file` |
+| Folder (message) | `<folder key="file_xxx" name="assets" child_count="N"><file key="..." .../>…</folder>` (first-level children rendered inside; `has_more="true"` past the 10-item cap) | Folder itself is not a single-file resource; children are real files — download one with explicit `im +messages-resources-download --message-id <id> --file-key <child_key> --type file` (`--download-resources` auto-collection does not include folder children) |
 | Audio | `<audio key="file_xxx" duration="Xs"/>` | `--download-resources`, or manually `im +messages-resources-download --type file` |
 | Video | `<video key="file_xxx" .../>` | `--download-resources`, or manually `im +messages-resources-download --type file` |
 | Sticker | `[Sticker]` | Not downloadable (Feishu does not support fetching sticker resources) |

--- a/skills/lark-im/references/lark-im-messages-mget.md
+++ b/skills/lark-im/references/lark-im-messages-mget.md
@@ -51,13 +51,30 @@ Each message contains:
 | `sender` | Sender information (includes `name`) |
 | `content` | Message content |
 
+For `folder` messages, `content` carries a folder key; `mget` expands the folder one level (`GET /files/:file_key/folder`), rendering first-level children inside the folder tag:
+
+```
+<folder key="file_v3_...g" name="assets" child_count="5">
+  <file key="file_v3_...g" name="a.pdf"/>
+  <folder key="file_v3_...g" name="sub" child_count="2"/>
+</folder>
+```
+
+- `child_count` on the root folder is the total first-level item count reported by the API; when a folder has more first-level children than the render cap (10), the tag carries `has_more="true"`.
+- `child_count` on a nested `<folder>` child is that child's own child count (a depth hint; nested folders are not expanded further).
+- A genuinely empty folder renders as `<folder key="..." name="..." child_count="0"/>`.
+
 For `post` messages, the attachment zone (top-level `files` array) is rendered as trailing lines in `content`, one per attachment:
 
 - `<file key="file_xxx" name="report.pdf"/>` — a file with a display name (same tag style as a standalone `file` message)
 - `<file key="file_xxx"/>` — a file with an empty display name (the server always backfills names, so this branch is rare but valid on the wire)
-- `<folder key="file_xxx" name="assets"/>` — a folder (`is_folder: true`, same tag style as a standalone `folder` message)
+- `<folder key="file_xxx" name="assets"/>` — a folder attachment (`is_folder: true`). Like folder messages, the attachment is expanded one level (children rendered inside the tag) when runtime + message id are available; otherwise it degrades to this single-line tag.
 
-Use `--format json` to see the full content without table truncation — note the content is the rendered text (including the `<file>`/`<folder>` lines above), not the raw post JSON. Attachment file keys rendered in the tags are eligible for [`+messages-resources-download`](lark-im-messages-resources-download.md) via `--download-resources`.
+Use `--format json` to see the full content without table truncation — note the content is the rendered text (including the `<file>`/`<folder>` lines above), not the raw post JSON.
+
+Downloading: [`+messages-resources-download`](lark-im-messages-resources-download.md) takes an explicit `--message-id` + `--file-key` and fetches `GET /messages/:id/resources/:file_key` — this works for standalone `file` message keys, top-level `post` attachment `files[]` entries, **and file keys rendered inside `<folder>...</folder>` (folder children are real files addressed by their own file_key)**. Two caveats:
+- `--download-resources` (the automatic enrichment flag on list/get commands) only auto-collects top-level single-file resources from the raw content — folder children are expanded at render time and are **not** auto-added to that worklist, so to download a folder child you pass its key explicitly to `+messages-resources-download`.
+- `is_folder` entries themselves (a folder, not a file) are not downloadable as a single resource.
 
 ## Usage Scenarios
 

--- a/skills/lark-im/references/lark-im-messages-search.md
+++ b/skills/lark-im/references/lark-im-messages-search.md
@@ -151,7 +151,7 @@ lark-cli im +threads-messages-list --thread <thread_id>
 
 ## Resource Rendering
 
-Search results reuse the same content formatter as other read commands. Image messages are rendered as placeholders such as `![Image](img_xxx)`; resource binaries are **not** downloaded automatically.
+Search results reuse the same content formatter as other read commands. Image messages are rendered as placeholders such as `![Image](img_xxx)`; `folder` messages in results are expanded one level (see [`lark-im-chat-messages-list`](lark-im-chat-messages-list.md#resource-rendering) for the marker/download contract); resource binaries are **not** downloaded automatically.
 
 Use `im +messages-resources-download` if you need to fetch the underlying image or file bytes from a specific message.
 

--- a/skills/lark-im/references/lark-im-threads-messages-list.md
+++ b/skills/lark-im/references/lark-im-threads-messages-list.md
@@ -100,7 +100,7 @@ lark-cli im +threads-messages-list --thread omt_xxx --page-token <PAGE_TOKEN>
 
 ## Resource Rendering
 
-Thread replies are rendered into human-readable text. Image messages appear as placeholders such as `![Image](img_xxx)`; by default resource binaries are **not** downloaded.
+Thread replies are rendered into human-readable text. Image messages appear as placeholders such as `![Image](img_xxx)`; `folder` replies are expanded one level (children rendered inside a `<folder ...>` tag); by default resource binaries are **not** downloaded.
 
 Pass `--download-resources` to download every eligible resource (image/file/audio/video/media + post-embedded, excluding stickers) into `./lark-im-resources/` in one pass and attach a `resources` block to each reply (see [message enrichment](lark-im-message-enrichment.md#resource-auto-download---download-resources-opt-in)). Otherwise download individual resources manually through `im +messages-resources-download` (see [lark-im-messages-resources-download](lark-im-messages-resources-download.md)).
 


### PR DESCRIPTION
## Summary
Extend the IM shortcut suite with folder children browsing: message content rendering expands a `folder`-type message one level via the folder-children API, rendering first-level children (files and subfolders with child counts) directly in message output. The same expansion applies to folder attachments inside `post` messages and to folder replies in threads.

## Changes
- **Folder message expansion** (`folderConverter`): with Runtime + MessageID available, call `GET /open-apis/im/v1/files/:file_key/folder` (srctype=message, srcid=MessageID, recursive=false) and render one level.
- **Output shape** (key-first attributes): root `<folder key="..." name="..." child_count="...">` (child_count = all_count), `has_more="true"` when first-level items exceed the render cap (10) or all_count > items. Children render as `<file key="..." name="..."/>` and nested folders as `<folder key="..." name="..." child_count="..."/>` (no recursion; `child_count` on a nested folder is a depth hint, omitted when unknown). A genuinely empty folder renders `<folder key="..." name="..." child_count="0"/>`.
- **Prefetch**: list commands (chat-messages-list, messages-mget, messages-search, threads-messages-list) scan the page for folder messages **and post folder attachments** before the render loop and fan out the expansions concurrently (bounded to 8) — `PrefetchFolderChildren` caches XML keyed by message id (post attachments keyed message id + folder key). The per-item converter reuses the cache; a prefetch that already failed records a sentinel so the render loop degrades to the single-line tag without doubling requests.
- **Post attachments & threads**: post folder attachments and thread-reply folder messages use the same prefetch/cache path.
- **Graceful fallback**: without Runtime/MessageID or on API failure, output degrades to the single-line `<folder key="..." name="..."/>` — no crash. Failures emit a `folder_fetch_failed` warning on stderr.
- **Unit tests** (httpmock, no network): XML one-level output / unknown child_count omission / has_more / cap-10 / API failure & business-error fallback / empty folder / prefetch success + failure sentinel / converter-level inline + fallback / post folder-attachment expansion (inline + prefetch) / stderr warning prefix.

## Test Plan
- `go test ./shortcuts/im/...` green (convert_lib + shortcuts).
- Manual verification (BOE/PRE): a folder message expands to XML with root `child_count` and file/folder children (e.g. folder `file_v3_01155_...` in message `om_x100b66490b8678acb15859e1e1b66ab`).
- Manual verification: API failure / missing MessageID degrades to single-line folder output with stderr warning, no crash.

## Related Issues
None
