### PR TITLE
docs: add approval comments skill guidance

### DIFF
--- a/skill-template/domains/approval.md
+++ b/skill-template/domains/approval.md
@@ -9,10 +9,11 @@
 出现以下任一语义时，优先走 `lark-approval`：
 
 - 审批待办 / 审批单据 / 审批实例 / 审批意见 / 审批定义
+- 审批评论 / 评论 / 回复；前提是上下文对象是审批实例
 - 同意 / 拒绝 / 转交 / 退回 / 撤回 / 催办 / 加签 / 抄送
 - 待办列表 / 待办单据 / 已发起审批 / 已办审批 / 审批详情 / 同意可编辑
 
-**判定规则：** 只要最终动作是对审批单据做同意、拒绝、转交、退回、撤回、催办、加签、抄送、查详情、查已发起/已办/待办，就归 `lark-approval`。只有当用户处理的是**非审批类任务/待办**时，才走 [`lark-task`](../lark-task/SKILL.md)。
+**判定规则：** 只要最终动作是对审批单据做同意、拒绝、转交、退回、撤回、催办、加签、抄送、查详情、查已发起/已办/待办，或对审批实例评论做查询、创建、回复、编辑、删除，就归 `lark-approval`。只有当用户处理的是**非审批类任务/待办**时，才走 [`lark-task`](../lark-task/SKILL.md)。
 
 ## 选哪个命令
 
@@ -32,11 +33,15 @@
 | 撤回已发起审批 | `instances cancel` | [`lark-approval-instances-cancel.md`](references/lark-approval-instances-cancel.md) |
 | 给审批实例追加抄送 | `instances cc` | [`lark-approval-instances-cc.md`](references/lark-approval-instances-cc.md)     |
 | 按定义/关键词查已发起审批 | `instances initiated` | [`lark-approval-instances-initiated.md`](references/lark-approval-instances-initiated.md) |
+| 查询审批实例评论 | `comments list` | [`lark-approval-comments-list.md`](references/lark-approval-comments-list.md) |
+| 创建、回复或编辑审批实例评论 | `comments create` | [`lark-approval-comments-create.md`](references/lark-approval-comments-create.md) |
+| 删除单条审批评论或回复 | `comments delete` | [`lark-approval-comments-delete.md`](references/lark-approval-comments-delete.md) |
 
 处理链：
 
 - 发起审批：`approvals search` -> `approvals get` -> `instances create`
 - 处理审批：`tasks query` 拿 `instance_code` + `task_id`（操作必须成对带上）→ 只有用户明确需要查看详情、当前节点、表单内容、或流程进度时，再 `instances get` → 执行操作
+- 审批评论：`comments list` 查评论树 → `comments create` 创建/回复/编辑 → 必要时 `comments delete` 删除单条评论或回复
 
 ## 执行原则（减少误路由、误重试和无效消耗）
 
@@ -51,6 +56,7 @@
 - 已拿到 `instance_code` + `task_id` 后，优先直接执行 `tasks approve/reject/transfer/add_sign/rollback/remind`
 - 同一轮里如果已有足够的新鲜查询结果，不要重复 `tasks query`
 - 不要默认走 `list -> filter -> detail -> write` 全链路；对象已明确时应压缩步骤
+- 评论操作已拿到 `instance_code` 和 `comment_id` 时，直接执行对应 `comments` 命令；不要把审批评论误路由到 Drive 文档评论或飞书任务评论
 
 ### 3) 错误码驱动，而不是盲目重试
 
@@ -79,6 +85,8 @@ lark-cli approval approvals get --params '{"approval_code":"<code>"}' --as user
 lark-cli approval instances create --data '{"approval_code":"<code>","form":"[...]"}' --yes --as user
 lark-cli approval tasks query --params '{"topic":"1"}' --as user
 lark-cli approval tasks approve --data '{"instance_code":"<ic>","task_id":"<tid>","comment":"同意"}' --as user
+lark-cli approval comments list --params '{"instance_id":"<ic>"}' --as user
+lark-cli approval comments create --params '{"instance_id":"<ic>"}' --data '{"content":"{\"text\":\"请补充说明\"}"}' --as user
 ```
 
 ## 不在本 skill 范围

--- a/skills/lark-approval/SKILL.md
+++ b/skills/lark-approval/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-approval
-version: 1.2.0
-description: "飞书审批：查询和处理审批待办/已办/实例，搜索可发起审批定义、查看定义详情并发起原生审批实例。当用户要处理审批任务、查看审批实例、搜索或发起审批时使用。审批待办不是飞书任务；非审批类待办走 lark-task。不负责创建审批定义；三方审批定义不走原生提单。"
+version: 1.3.0
+description: "飞书审批：查询和处理审批待办/已办/实例，搜索可发起审批定义、查看定义详情、发起原生审批实例，以及查询、创建、回复、编辑、删除审批评论。当用户要处理审批任务、查看审批实例、搜索或发起审批、操作审批评论时使用。审批待办不是飞书任务；非审批类待办走 lark-task。不负责创建审批定义；三方审批定义不走原生提单。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -22,10 +22,11 @@ metadata:
 出现以下任一语义时，优先走 `lark-approval`：
 
 - 审批待办 / 审批单据 / 审批实例 / 审批意见 / 审批定义
+- 审批评论 / 评论 / 回复；前提是上下文对象是审批实例
 - 同意 / 拒绝 / 转交 / 退回 / 撤回 / 催办 / 加签 / 抄送
 - 待办列表 / 待办单据 / 已发起审批 / 已办审批 / 审批详情 / 同意可编辑
 
-**判定规则：** 只要最终动作是对审批单据做同意、拒绝、转交、退回、撤回、催办、加签、抄送、查详情、查已发起/已办/待办，就归 `lark-approval`。只有当用户处理的是**非审批类任务/待办**时，才走 [`lark-task`](../lark-task/SKILL.md)。
+**判定规则：** 只要最终动作是对审批单据做同意、拒绝、转交、退回、撤回、催办、加签、抄送、查详情、查已发起/已办/待办，或对审批实例评论做查询、创建、回复、编辑、删除，就归 `lark-approval`。只有当用户处理的是**非审批类任务/待办**时，才走 [`lark-task`](../lark-task/SKILL.md)。
 
 ## 选哪个命令
 
@@ -45,11 +46,15 @@ metadata:
 | 撤回已发起审批 | `instances cancel` | [`lark-approval-instances-cancel.md`](references/lark-approval-instances-cancel.md) |
 | 给审批实例追加抄送 | `instances cc` | [`lark-approval-instances-cc.md`](references/lark-approval-instances-cc.md)     |
 | 按定义/关键词查已发起审批 | `instances initiated` | [`lark-approval-instances-initiated.md`](references/lark-approval-instances-initiated.md) |
+| 查询审批实例评论 | `comments list` | [`lark-approval-comments-list.md`](references/lark-approval-comments-list.md) |
+| 创建、回复或编辑审批实例评论 | `comments create` | [`lark-approval-comments-create.md`](references/lark-approval-comments-create.md) |
+| 删除单条审批评论或回复 | `comments delete` | [`lark-approval-comments-delete.md`](references/lark-approval-comments-delete.md) |
 
 处理链：
 
 - 发起审批：`approvals search` -> `approvals get` -> `instances create`
 - 处理审批：`tasks query` 拿 `instance_code` + `task_id`（操作必须成对带上）→ 只有用户明确需要查看详情、当前节点、表单内容、或流程进度时，再 `instances get` → 执行操作
+- 审批评论：`comments list` 查评论树 → `comments create` 创建/回复/编辑 → 必要时 `comments delete` 删除单条评论或回复
 
 ## 执行原则（减少误路由、误重试和无效消耗）
 
@@ -64,6 +69,7 @@ metadata:
 - 已拿到 `instance_code` + `task_id` 后，优先直接执行 `tasks approve/reject/transfer/add_sign/rollback/remind`
 - 同一轮里如果已有足够的新鲜查询结果，不要重复 `tasks query`
 - 不要默认走 `list -> filter -> detail -> write` 全链路；对象已明确时应压缩步骤
+- 评论操作已拿到 `instance_code` 和 `comment_id` 时，直接执行对应 `comments` 命令；不要把审批评论误路由到 Drive 文档评论或飞书任务评论
 
 ### 3) 错误码驱动，而不是盲目重试
 
@@ -92,6 +98,8 @@ lark-cli approval approvals get --params '{"approval_code":"<code>"}' --as user
 lark-cli approval instances create --data '{"approval_code":"<code>","form":"[...]"}' --yes --as user
 lark-cli approval tasks query --params '{"topic":"1"}' --as user
 lark-cli approval tasks approve --data '{"instance_code":"<ic>","task_id":"<tid>","comment":"同意"}' --as user
+lark-cli approval comments list --params '{"instance_id":"<ic>"}' --as user
+lark-cli approval comments create --params '{"instance_id":"<ic>"}' --data '{"content":"{\"text\":\"请补充说明\"}"}' --as user
 ```
 
 ## 不在本 skill 范围

--- a/skills/lark-approval/references/lark-approval-comments-create.md
+++ b/skills/lark-approval/references/lark-approval-comments-create.md
@@ -1,0 +1,99 @@
+# approval comments create
+
+创建、回复或编辑审批实例评论（用户级写操作）。同一个命令通过请求体区分三种行为：不传 `parent_comment_id` 和 `comment_id` 是创建顶层评论；传 `parent_comment_id` 是回复；传 `comment_id` 是编辑本人已有评论或回复。
+
+需要的 scopes: ["approval:instance:write"]
+
+## 命令
+
+```bash
+# 创建顶层评论
+lark-cli approval comments create \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --data '{"content":"{\"text\":\"请补充报销说明\"}"}' \
+  --as user
+
+# 回复一条顶层评论
+lark-cli approval comments create \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --data '{"parent_comment_id":"<PARENT_COMMENT_ID>","content":"{\"text\":\"已补充，请查看\"}"}' \
+  --as user
+
+# 编辑本人评论或回复
+lark-cli approval comments create \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --data '{"comment_id":"<COMMENT_ID>","content":"{\"text\":\"更新后的评论内容\"}"}' \
+  --as user
+
+# 只同步评论数据，不触发 bot
+lark-cli approval comments create \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --data '{"content":"{\"text\":\"仅同步评论\"}","disable_bot":true}' \
+  --as user
+
+# 创建带 @ 人的文本评论
+lark-cli approval comments create \
+  --params '{"instance_id":"<INSTANCE_CODE>","user_id_type":"open_id"}' \
+  --data '{"content":"{\"text\":\"@张三 请补充说明\"}","at_info_list":[{"user_id":"ou_xxx","name":"张三","offset":"0"}]}' \
+  --as user
+
+# 预览 API 调用，不执行
+lark-cli approval comments create \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --data '{"content":"{\"text\":\"请补充说明\"}"}' \
+  --as user \
+  --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--params '{...}'` | 是 | 路径和查询参数，使用 JSON 传入 |
+| `instance_id` | 是 | 审批实例 Code；也兼容租户自定义审批实例 ID |
+| `user_id_type` | 否 | 评论相关用户字段的 ID 类型：`open_id`、`user_id`、`union_id`；不填默认 `open_id` |
+| `--data '{...}'` | 是 | 请求体 JSON，使用 JSON 传入 |
+| `content` | 是 | 评论内容字符串；当前 CLI 引导只支持 `{"text":"..."}` 文本结构 |
+| `at_info_list` | 否 | @ 人信息数组；元素包含 `user_id`、`name`、`offset`，并与 `content.text` 中的 @ 文案对应 |
+| `parent_comment_id` | 回复时必填 | 父评论 ID；传入后创建回复 |
+| `comment_id` | 编辑时必填 | 要编辑的评论或回复 ID；传入后编辑本人已有评论或回复 |
+| `disable_bot` | 否 | `true` 表示只同步评论数据，不触发 bot |
+| `extra` | 否 | 附加字段字符串 |
+| `--as user` | 否 | 建议显式指定用户身份；当前操作人来自用户身份令牌，不从参数指定 |
+| `--dry-run` | 否 | 预览 API 调用，不执行 |
+
+## content 格式
+
+`content` 是字符串，不是 JSON 对象。当前只按文本评论暴露：
+
+```json
+{
+  "content": "{\"text\":\"请补充说明\"}"
+}
+```
+
+@ 人评论需要同时设置 `content.text` 和 `at_info_list`：
+
+```json
+{
+  "content": "{\"text\":\"@张三 请补充说明\"}",
+  "at_info_list": [
+    {
+      "user_id": "ou_xxx",
+      "name": "张三",
+      "offset": "0"
+    }
+  ]
+}
+```
+
+其中 `offset` 从 0 开始，表示 `content.text` 中对应 @ 符号的位置；`user_id` 的类型需要和 `user_id_type` 保持一致。
+
+## 使用建议
+
+- 创建、回复、编辑是同一个 OpenAPI action；根据 `parent_comment_id` 和 `comment_id` 判断语义。
+- 编辑只能编辑当前用户自己的评论或回复；不要尝试用参数伪造操作人。
+- `user_id_type` 只影响评论相关用户字段的 ID 类型，不用于指定当前操作人。
+- 先用 `comments list` 获取 `comment_id`，再执行回复、编辑或删除。
+- 当前只引导创建文本评论；不要写入非 `text` 的内容结构。
+- 这个接口不是清空评论；本期不要暴露或使用 `clear`。

--- a/skills/lark-approval/references/lark-approval-comments-delete.md
+++ b/skills/lark-approval/references/lark-approval-comments-delete.md
@@ -1,0 +1,49 @@
+# approval comments delete
+
+删除审批实例下的一条评论或回复（用户级高风险写操作）。这个命令只删除指定 `comment_id`，不会清空实例下的全部评论。
+
+> [!CAUTION]
+> 这是 **high-risk-write** 写操作。建议先用 `--dry-run` 预览；真正执行时，如果用户已明确要删除该条审批评论或回复且 `instance_id`、`comment_id` 都无误，再带 `--yes` 运行。不要在未获用户明确同意时静默追加 `--yes`。
+
+需要的 scopes: ["approval:instance:write"]
+
+## 命令
+
+```bash
+# 先预览请求，不实际执行
+lark-cli approval comments delete \
+  --params '{"instance_id":"<INSTANCE_CODE>","comment_id":"<COMMENT_ID>"}' \
+  --as user \
+  --dry-run
+
+# 删除一条顶层评论或回复
+lark-cli approval comments delete \
+  --params '{"instance_id":"<INSTANCE_CODE>","comment_id":"<COMMENT_ID>"}' \
+  --as user \
+  --yes
+
+# 删除后回查确认 is_delete
+lark-cli approval comments list \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --as user
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--params '{...}'` | 是 | 路径参数，使用 JSON 传入 |
+| `instance_id` | 是 | 审批实例 Code；也兼容租户自定义审批实例 ID |
+| `comment_id` | 是 | 要删除的评论或回复 ID |
+| `--as user` | 否 | 建议显式指定用户身份；当前操作人来自用户身份令牌，不从参数指定 |
+| `--yes` | 是 | 确认执行高风险写操作；未带时可能返回 `confirmation_required` / exit 10 |
+| `--format` | 否 | 输出格式：`json`（默认）、`ndjson`、`table`、`csv` |
+| `--dry-run` | 否 | 预览 API 调用，不执行；dry-run 不需要 `--yes` |
+
+## 使用建议
+
+- 先用 `comments list` 获取并确认目标 `comment_id`，再执行删除。
+- 这个命令删除单条评论或回复，不是清空全部评论；不要使用或暴露 `clear`。
+- 只能删除当前用户有权删除的评论或回复。通常本人评论可删除，非本人评论会被服务端权限校验拦截。
+- 删除后建议回查 `comments list`，确认目标评论或回复的 `is_delete=1`。
+- 不要通过额外参数指定操作人；UAT 接口会从当前用户身份令牌识别操作人。

--- a/skills/lark-approval/references/lark-approval-comments-list.md
+++ b/skills/lark-approval/references/lark-approval-comments-list.md
@@ -1,0 +1,63 @@
+# approval comments list
+
+查询审批实例的评论树（用户级只读操作）。适合查看顶层评论、回复、评论创建人、删除标记、@ 人信息和图片 / 文件内容结构。
+
+需要的 scopes: ["approval:instance:read"]
+
+## 命令
+
+```bash
+# 查询审批实例评论
+lark-cli approval comments list \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --as user
+
+# 指定返回用户字段的 ID 类型
+lark-cli approval comments list \
+  --params '{"instance_id":"<INSTANCE_CODE>","user_id_type":"open_id"}' \
+  --as user
+
+# 表格格式输出，便于快速浏览顶层字段
+lark-cli approval comments list \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --format table \
+  --as user
+
+# 预览 API 调用，不执行
+lark-cli approval comments list \
+  --params '{"instance_id":"<INSTANCE_CODE>"}' \
+  --as user \
+  --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--params '{...}'` | 是 | 路径和查询参数，使用 JSON 传入 |
+| `instance_id` | 是 | 审批实例 Code；也兼容租户自定义审批实例 ID |
+| `user_id_type` | 否 | 返回结果中用户字段的 ID 类型：`open_id`、`user_id`、`union_id`；不填默认 `open_id` |
+| `--as user` | 否 | 建议显式指定用户身份；审批评论是用户态接口 |
+| `--format` | 否 | 输出格式：`json`（默认）、`ndjson`、`table`、`csv` |
+| `--dry-run` | 否 | 预览 API 调用，不执行 |
+
+## 输出重点字段
+
+| 字段 | 说明 |
+|------|------|
+| `comments[].id` | 顶层评论 ID；回复、编辑、删除时常用 |
+| `comments[].content` | 评论内容字符串；按服务端原样返回，可能包含 `text`、`files` 等结构 |
+| `comments[].commentator` | 评论创建人，格式受 `user_id_type` 影响 |
+| `comments[].create_time` | 评论创建时间，毫秒级时间戳字符串 |
+| `comments[].update_time` | 评论更新时间，毫秒级时间戳字符串 |
+| `comments[].is_delete` | 是否已删除，`0` 未删除，`1` 已删除 |
+| `comments[].replies[]` | 当前评论下的回复列表，字段结构与顶层评论类似 |
+| `comments[].at_info_list[]` | 评论中的 @ 人信息 |
+
+## 使用建议
+
+- 审批评论挂在审批实例上，输入字段叫 `instance_id`，实际通常传审批实例 Code。
+- 如果要回复、编辑或删除评论，先用 `comments list` 获取目标 `comment_id`。
+- `comments list` 返回评论树；删除后的评论或回复可能仍在树中出现，但 `is_delete=1`。
+- `user_id_type` 只影响返回结果中的用户 ID 展示，不用于指定当前操作人；当前操作人来自用户身份令牌。
+- 这不是 Drive 文档评论；不要把审批实例评论误路由到 `drive +add-comment` 或 Drive comment API。


### PR DESCRIPTION
## Summary

Add lark-approval Skill guidance for approval instance comments. This documents the registry-backed `approval comments list/create/delete` commands while keeping `clear` out of CLI guidance and limiting create guidance to text comments.

## Changes

- Add `comments list`, `comments create`, and `comments delete` routing to `skills/lark-approval/SKILL.md`.
- Add reference docs for listing, creating/replying/editing, and deleting approval comments.
- Sync the approval domain template with the new comment routing.
- Keep `clear` unexposed in CLI guidance.
- Keep `comments create` guidance text-only and include an @ mention example.

## Test Plan

- [ ] Unit tests pass
  - Not run locally: this machine has `go1.18.10`, while `go.mod` requires `go 1.23.0`.
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected
  - Not run locally for the same Go toolchain constraint.
- [x] `git diff --check`
- [x] `node scripts/skill-format-check/index.js skills`
- [x] Verified registry output contains only `comments.list`, `comments.create`, and `comments.delete`; `clear` is not exposed.

## Related Issues

- None