### PR TITLE
feat(calendar): remove app_link outputs, emphasize event share link

### DIFF
--- a/shortcuts/calendar/calendar_get.go
+++ b/shortcuts/calendar/calendar_get.go
@@ -97,7 +97,6 @@ type calendarEvent struct {
 	RecurringEventID    string                    `json:"recurring_event_id,omitempty"`
 	CreateTime          string                    `json:"create_time,omitempty"`
 	EventOrganizer      *calendarEventOrganizer   `json:"event_organizer,omitempty"`
-	AppLink             string                    `json:"app_link,omitempty"`
 	Attachments         []calendarEventAttachment `json:"attachments,omitempty"`
 	EventCheckIn        *calendarEventCheckIn     `json:"event_check_in,omitempty"`
 }

--- a/shortcuts/calendar/calendar_meeting_test.go
+++ b/shortcuts/calendar/calendar_meeting_test.go
@@ -304,7 +304,6 @@ func TestSearchEvent_Execute_Success(t *testing.T) {
 								"timezone":  "Asia/Shanghai",
 							},
 							"is_all_day": false,
-							"app_link":   "https://applink.feishu.cn/...",
 						},
 					},
 				},

--- a/shortcuts/calendar/calendar_search_event.go
+++ b/shortcuts/calendar/calendar_search_event.go
@@ -58,7 +58,6 @@ type searchEventItem struct {
 	Start    *searchEventTimeInfo `json:"start,omitempty"`
 	End      *searchEventTimeInfo `json:"end,omitempty"`
 	IsAllDay bool                 `json:"is_all_day,omitempty"`
-	AppLink  string               `json:"app_link,omitempty"`
 }
 
 // searchEventOutput is the structured output for +search-event.
@@ -272,9 +271,6 @@ var CalendarSearchEvent = common.Shortcut{
 				}
 				if v, ok := meta["is_all_day"].(bool); ok {
 					out.IsAllDay = v
-				}
-				if v, ok := meta["app_link"].(string); ok {
-					out.AppLink = v
 				}
 				if start, ok := meta["start"].(map[string]any); ok {
 					out.Start = extractTimeInfo(start)

--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -148,7 +148,7 @@ lark-cli calendar +freebusy --start 2026-03-11T09:00:00+08:00 --end 2026-03-11T1
 - **会议室（Room）**："room"不是"房间"，是"会议室"。会议室是日程的一种参与人（resource attendee），不能脱离日程单独预定。
 - **日程会议 ID（Meeting ID）**：日程的历史视频会议 ID，在日程上开过视频会议才会有。
 - **日程分享链接 vs 会议链接**：两者是不同事物，不可混用。
-  - 日程分享链接：`https://<domain>/calendar/share?token=<token>`，指向日程本身，用于分享日程详情。
+  - 日程分享链接：`https://<domain>/calendar/share?token=<token>`，指向日程本身，用于分享日程详情。**分享日程给某个人、某个群或粘贴到文档中，需要的都是这个日程分享链接（通过 `calendar events share_info` 获取），不是 applink**；禁止自己拼接 applink 或用 applink 代替。
   - 会议链接：`https://<domain>/j/<number>`，指向视频会议入口；同一重复性日程序列的所有实例共用同一个会议链接。
 
 ## 术语映射
@@ -165,7 +165,7 @@ lark-cli calendar +freebusy --start 2026-03-11T09:00:00+08:00 --end 2026-03-11T1
 | 按关键词搜索日程 | 本 skill（`+search-event`） |
 | 从日程获取关联的视频会议 ID 或用户绑定的会议纪要文档 | 本 skill（`+meeting`） |
 | 查看日程的参会人 / 会议室（含 `--type resource` 只看会议室） | 本 skill（[`+list-attendees`](references/lark-calendar-list-attendees.md)） |
-| 把日程分享给某人 / 群 | 本 skill：先 `calendar events share_info` 取**日程分享链接**，再走 [lark-im](../lark-im/SKILL.md) 发送该链接；分享链接不是 applink，不要自己拼接或用 applink 代替 |
+| 把日程分享给某人 / 群 / 粘贴到文档 | 本 skill：先 `calendar events share_info` 取**日程分享链接**，再走 [lark-im](../lark-im/SKILL.md) 发送或粘贴该链接；**分享日程给某个人、某个群或粘贴到文档中，需要的都是日程分享链接，不是 applink**，不要自己拼接或用 applink 代替 |
 | 从日程进一步拿 AI 智能纪要 / 逐字稿 / 妙记产物 | 先 `+meeting` 取 `meeting_id`，再进入 [`lark-meeting`](../lark-meeting/SKILL.md)：[`vc +detail`](../lark-meeting/references/lark-vc-detail.md) → [`note +detail`](../lark-meeting/references/lark-note-detail.md) / [`minutes +detail`](../lark-meeting/references/lark-minutes-detail.md) |
 | 预约/改约日程、调整时间、添加/更换会议室、查会议室 | 先判断新建 vs 编辑，再进入 [schedule-meeting 工作流](references/lark-calendar-schedule-meeting.md) |
 | 仅编辑日程字段（标题/描述）或增删参会人（不涉及时间和会议室） | 先定位 `event_id`，再读 [+update](references/lark-calendar-update.md) 执行变更 |


### PR DESCRIPTION
## Summary
- Remove the `app_link` field from `+get` and `+search-event` outputs so calendar commands no longer surface applink URLs.
- Drop the now-unused `app_link` mock in the search-event test stub.
- Emphasize in the `lark-calendar` SKILL that sharing an event to a person, chat, or pasting into a document needs the **event share link** (via `events share_info`), not an applink — updated both the intent-routing table and the share-link vs meeting-link concept.

## Test plan
- [x] `go build ./shortcuts/calendar/...`
- [x] `go vet ./shortcuts/calendar/...`
- [x] `go test ./shortcuts/calendar/... -count=1`
- [x] `node scripts/skill-format-check/index.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Calendar event and search results no longer include or surface `app_link` values.

- **Documentation**
  - Clarified that sharing calendar events requires the official event share link.
  - Updated sharing guidance to cover pasting events into documents.
  - Specified that app links must not be constructed or used in place of event share links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->