### PR TITLE
fix(mail): complete partial rule reorder IDs

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -370,7 +370,7 @@ var MailRuleReorder = common.Shortcut{
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule IDs in the desired leading order. Omitted current rules retain their relative order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1629,12 +1629,12 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 }
 
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
-	currentIDs := envelopeRuleIDs(current)
-	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
-			return nil, err
-		}
-		return ids, nil
+	currentIDs, err := validatedCurrentRuleIDs(current)
+	if err != nil {
+		return nil, err
+	}
+	if ids := rt.StrSlice("rule-ids"); len(ids) > 0 {
+		return completeRuleOrder(ids, currentIDs)
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1653,34 +1653,59 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 	}
 }
 
-func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
+func completeRuleOrder(target, current []string) ([]string, error) {
+	if len(target) == 0 {
+		return nil, mailValidationParamError("--rule-ids", "--rule-ids must contain at least one rule id")
 	}
-	want := make(map[string]int, len(current))
+	known := make(map[string]struct{}, len(current))
 	for _, id := range current {
-		want[id]++
+		known[id] = struct{}{}
 	}
-	for _, id := range target {
-		want[id]--
+	seen := make(map[string]struct{}, len(target))
+	result := make([]string, 0, len(current))
+	for _, rawID := range target {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids must not contain an empty rule id")
+		}
+		if _, duplicate := seen[id]; duplicate {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
+		}
+		if _, ok := known[id]; !ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains unknown rule id %s", id)
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
 	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+	for _, id := range current {
+		if _, supplied := seen[id]; !supplied {
+			result = append(result, id)
 		}
 	}
-	return nil
+	if len(result) != len(current) {
+		return nil, mailValidationError("computed rule order is incomplete")
+	}
+	return result, nil
 }
 
-func normalizeRuleIDs(ids []string) []string {
-	var out []string
-	for _, id := range ids {
-		id = strings.TrimSpace(id)
-		if id != "" {
-			out = append(out, id)
-		}
+func validatedCurrentRuleIDs(current []mailRuleEnvelope) ([]string, error) {
+	if len(current) == 0 {
+		return nil, mailValidationError("current mailbox has no reorderable rules")
 	}
-	return out
+	ids := make([]string, 0, len(current))
+	seen := make(map[string]struct{}, len(current))
+	for _, env := range current {
+		id := strings.TrimSpace(env.RuleID)
+		if id == "" {
+			return nil, mailValidationError("rule list response contains a rule without rule_id")
+		}
+		if _, duplicate := seen[id]; duplicate {
+			return nil, mailValidationError("rule list response contains duplicate rule_id %s", id)
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 func insertRelative(order []string, moveID, targetID string, after bool) ([]string, error) {

--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -364,7 +364,7 @@ var MailRuleDisable = makeRuleToggleShortcut("+rule-disable", false)
 var MailRuleReorder = common.Shortcut{
 	Service:     "mail",
 	Command:     "+rule-reorder",
-	Description: "Reorder mailbox rules by full rule_id list or by moving one rule before/after/top/bottom.",
+	Description: "Reorder mailbox rules with a full or partial rule_id prefix; omitted rules retain their relative order, or move one rule before/after/top/bottom.",
 	Risk:        "write",
 	Scopes:      []string{"mail:user_mailbox.rule:write"},
 	AuthTypes:   mailRuleAuthTypes,

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1590,7 +1590,7 @@ func TestMailRuleReorderCompletesPartialOrderAndSkipsPOSTOnInvalidList(t *testin
 	t.Run("partial order posts complete list once", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B"), mailRuleTestRawRule("c", "C")))
-		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
+		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Optional: true, Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
 		reg.Register(post)
 		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
 			t.Fatalf("run partial reorder error = %v", err)
@@ -1604,7 +1604,7 @@ func TestMailRuleReorderCompletesPartialOrderAndSkipsPOSTOnInvalidList(t *testin
 	t.Run("malformed list does not post", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("a", "duplicate")))
-		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
+		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Optional: true, Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
 		reg.Register(post)
 		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
 		if err == nil || !strings.Contains(err.Error(), "duplicate rule_id") {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1487,12 +1487,31 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 	}
 }
 
-func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+func TestMailRuleOrderCompletion(t *testing.T) {
+	got, err := completeRuleOrder([]string{"c", "a"}, []string{"a", "b", "c", "d"})
+	if err != nil {
+		t.Fatalf("completeRuleOrder partial error = %v", err)
 	}
-	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected duplicate mismatch error")
+	if want := "c,a,b,d"; strings.Join(got, ",") != want {
+		t.Fatalf("partial order = %v, want %s", got, want)
+	}
+	got, err = completeRuleOrder([]string{"c", "b", "a"}, []string{"a", "b", "c"})
+	if err != nil || strings.Join(got, ",") != "c,b,a" {
+		t.Fatalf("complete full order = %v, %v", got, err)
+	}
+	for _, target := range [][]string{{""}, {"a", "a"}, {"a", "z"}} {
+		if _, err := completeRuleOrder(target, []string{"a", "b"}); err == nil {
+			t.Fatalf("completeRuleOrder(%v) should fail", target)
+		}
+	}
+	if _, err := validatedCurrentRuleIDs([]mailRuleEnvelope{{RuleID: "a"}, {RuleID: "a"}}); err == nil {
+		t.Fatal("duplicate current IDs should fail")
+	}
+	if _, err := validatedCurrentRuleIDs([]mailRuleEnvelope{{RuleID: " "}}); err == nil {
+		t.Fatal("blank current ID should fail")
+	}
+	if _, err := validatedCurrentRuleIDs(nil); err == nil {
+		t.Fatal("empty current rules should fail")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1526,15 +1545,12 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			args: []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
 			want: "is not in current rule order",
 		},
-		{
-			name: "full mismatch",
-			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
-		},
+		{name: "unknown ID", args: []string{"+rule-reorder", "--rule-ids", "a,z"}, want: "unknown rule id"},
+		{name: "duplicate ID", args: []string{"+rule-reorder", "--rule-ids", "a,a"}, want: "duplicate rule id"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "rule id") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)
@@ -1546,6 +1562,36 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMailRuleReorderCompletesPartialOrderAndSkipsPOSTOnInvalidList(t *testing.T) {
+	t.Run("partial order posts complete list once", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B"), mailRuleTestRawRule("c", "C")))
+		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
+		reg.Register(post)
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run partial reorder error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b")
+		if len(post.CapturedBodies) != 1 {
+			t.Fatalf("POST count = %d, want 1", len(post.CapturedBodies))
+		}
+	})
+
+	t.Run("malformed list does not post", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("a", "duplicate")))
+		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
+		reg.Register(post)
+		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
+		if err == nil || !strings.Contains(err.Error(), "duplicate rule_id") {
+			t.Fatalf("malformed list error = %v", err)
+		}
+		if len(post.CapturedBodies) != 0 {
+			t.Fatalf("POST should not be sent, captured %d", len(post.CapturedBodies))
+		}
+	})
 }
 
 func mailRuleTestRawRule(ruleID, name string) map[string]interface{} {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -759,24 +759,28 @@ func TestMailRuleCreateValidationErrors(t *testing.T) {
 		wantParam string
 	}{
 		{
-			name: "missing name",
-			args: []string{"+rule-create", "--condition", "subject:contains:Alpha", "--action", "mark_read"},
-			want: "--name is required",
+			name:      "missing name",
+			args:      []string{"+rule-create", "--condition", "subject:contains:Alpha", "--action", "mark_read"},
+			want:      "--name is required",
+			wantParam: "--name",
 		},
 		{
-			name: "missing condition",
-			args: []string{"+rule-create", "--name", "Alpha", "--action", "mark_read"},
-			want: "at least one --condition",
+			name:      "missing condition",
+			args:      []string{"+rule-create", "--name", "Alpha", "--action", "mark_read"},
+			want:      "at least one --condition",
+			wantParam: "--condition",
 		},
 		{
-			name: "missing action",
-			args: []string{"+rule-create", "--name", "Alpha", "--condition", "subject:contains:Alpha"},
-			want: "at least one --action",
+			name:      "missing action",
+			args:      []string{"+rule-create", "--name", "Alpha", "--condition", "subject:contains:Alpha"},
+			want:      "at least one --action",
+			wantParam: "--action",
 		},
 		{
-			name: "invalid match",
-			args: []string{"+rule-create", "--name", "Alpha", "--match", "maybe", "--condition", "subject:contains:Alpha", "--action", "mark_read"},
-			want: "allowed: all, any",
+			name:      "invalid match",
+			args:      []string{"+rule-create", "--name", "Alpha", "--match", "maybe", "--condition", "subject:contains:Alpha", "--action", "mark_read"},
+			want:      "allowed: all, any",
+			wantParam: "--match",
 		},
 		{
 			name: "conflicting enable flags",
@@ -798,6 +802,7 @@ func TestMailRuleCreateValidationErrors(t *testing.T) {
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
+			assertMailRuleValidationError(t, err, tc.wantParam)
 		})
 	}
 }
@@ -1599,11 +1604,16 @@ func TestMailRuleReorderCompletesPartialOrderAndSkipsPOSTOnInvalidList(t *testin
 	t.Run("malformed list does not post", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("a", "duplicate")))
+		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
+		reg.Register(post)
 		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
 		if err == nil || !strings.Contains(err.Error(), "duplicate rule_id") {
 			t.Fatalf("malformed list error = %v", err)
 		}
 		assertMailRuleValidationError(t, err, "")
+		if len(post.CapturedBodies) != 0 {
+			t.Fatalf("POST should not be sent for malformed list, captured %d request(s)", len(post.CapturedBodies))
+		}
 	})
 }
 

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1617,6 +1617,20 @@ func TestMailRuleReorderCompletesPartialOrderAndSkipsPOSTOnInvalidList(t *testin
 	})
 }
 
+func TestMailRuleReorderDescriptionExplainsPartialRuleIDOrdering(t *testing.T) {
+	desc := strings.ToLower(MailRuleReorder.Description)
+	for _, want := range []string{
+		"partial",
+		"prefix",
+		"omitted",
+		"relative order",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("Description should mention %q; got: %s", want, MailRuleReorder.Description)
+		}
+	}
+}
+
 func assertMailRuleValidationError(t *testing.T, err error, wantParam string) {
 	t.Helper()
 	var got *errs.ValidationError

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -753,9 +753,10 @@ func TestMailRuleCreateRejectsOversizedRuleInputFile(t *testing.T) {
 
 func TestMailRuleCreateValidationErrors(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		args []string
-		want string
+		name      string
+		args      []string
+		want      string
+		wantParam string
 	}{
 		{
 			name: "missing name",
@@ -1300,9 +1301,10 @@ func TestMailRuleUpdateReplacesConditionItemsAndPreservesMatchType(t *testing.T)
 
 func TestMailRuleUpdateRejectsExplicitEmptyCollections(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		args []string
-		want string
+		name      string
+		args      []string
+		want      string
+		wantParam string
 	}{
 		{name: "empty conditions", args: []string{"+rule-update", "--rule-id", "rule_1", "--conditions", "[]", "--format", "json"}, want: "at least one --condition"},
 		{name: "empty actions", args: []string{"+rule-update", "--rule-id", "rule_1", "--actions", "[]", "--format", "json"}, want: "at least one --action"},
@@ -1502,28 +1504,41 @@ func TestMailRuleOrderCompletion(t *testing.T) {
 	for _, target := range [][]string{{""}, {"a", "a"}, {"a", "z"}} {
 		if _, err := completeRuleOrder(target, []string{"a", "b"}); err == nil {
 			t.Fatalf("completeRuleOrder(%v) should fail", target)
+		} else {
+			assertMailRuleValidationError(t, err, "--rule-ids")
 		}
 	}
 	if _, err := validatedCurrentRuleIDs([]mailRuleEnvelope{{RuleID: "a"}, {RuleID: "a"}}); err == nil {
 		t.Fatal("duplicate current IDs should fail")
+	} else {
+		assertMailRuleValidationError(t, err, "")
 	}
 	if _, err := validatedCurrentRuleIDs([]mailRuleEnvelope{{RuleID: " "}}); err == nil {
 		t.Fatal("blank current ID should fail")
+	} else {
+		assertMailRuleValidationError(t, err, "")
 	}
 	if _, err := validatedCurrentRuleIDs(nil); err == nil {
 		t.Fatal("empty current rules should fail")
+	} else {
+		assertMailRuleValidationError(t, err, "")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
+	} else {
+		assertMailRuleValidationError(t, err, "")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "z", true); err == nil {
 		t.Fatal("expected unknown target error")
+	} else {
+		assertMailRuleValidationError(t, err, "")
 	}
 
 	for _, tc := range []struct {
-		name string
-		args []string
-		want string
+		name      string
+		args      []string
+		want      string
+		wantParam string
 	}{
 		{
 			name: "no mode",
@@ -1541,12 +1556,13 @@ func TestMailRuleOrderCompletion(t *testing.T) {
 			want: "move mode requires exactly one",
 		},
 		{
-			name: "move missing rule",
-			args: []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
-			want: "is not in current rule order",
+			name:      "move missing rule",
+			args:      []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
+			want:      "is not in current rule order",
+			wantParam: "--move-rule-id",
 		},
-		{name: "unknown ID", args: []string{"+rule-reorder", "--rule-ids", "a,z"}, want: "unknown rule id"},
-		{name: "duplicate ID", args: []string{"+rule-reorder", "--rule-ids", "a,a"}, want: "duplicate rule id"},
+		{name: "unknown ID", args: []string{"+rule-reorder", "--rule-ids", "a,z"}, want: "unknown rule id", wantParam: "--rule-ids"},
+		{name: "duplicate ID", args: []string{"+rule-reorder", "--rule-ids", "a,a"}, want: "duplicate rule id", wantParam: "--rule-ids"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
@@ -1557,6 +1573,7 @@ func TestMailRuleOrderCompletion(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected reorder error")
 			}
+			assertMailRuleValidationError(t, err, tc.wantParam)
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
@@ -1582,16 +1599,26 @@ func TestMailRuleReorderCompletesPartialOrderAndSkipsPOSTOnInvalidList(t *testin
 	t.Run("malformed list does not post", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("a", "duplicate")))
-		post := &httpmock.Stub{Method: "POST", URL: "open-apis/mail/v1/user_mailboxes/me/rules/reorder", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{}}}
-		reg.Register(post)
 		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
 		if err == nil || !strings.Contains(err.Error(), "duplicate rule_id") {
 			t.Fatalf("malformed list error = %v", err)
 		}
-		if len(post.CapturedBodies) != 0 {
-			t.Fatalf("POST should not be sent, captured %d", len(post.CapturedBodies))
-		}
+		assertMailRuleValidationError(t, err, "")
 	})
+}
+
+func assertMailRuleValidationError(t *testing.T, err error, wantParam string) {
+	t.Helper()
+	var got *errs.ValidationError
+	if !errors.As(err, &got) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if got.Category != errs.CategoryValidation || got.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("validation metadata = category %q subtype %q, want validation/invalid_argument", got.Category, got.Subtype)
+	}
+	if got.Param != wantParam {
+		t.Fatalf("validation parameter = %q, want %q", got.Param, wantParam)
+	}
 }
 
 func mailRuleTestRawRule(ruleID, name string) map[string]interface{} {


### PR DESCRIPTION
## Summary
- complete partial mailbox rule reorder input with the current full rule collection
- validate unknown, duplicate, blank, and malformed rule IDs before submitting
- add focused coverage for completion and failure paths

## Validation
- focused Go service command tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Mail rule reordering now accepts a partial leading list of rule IDs.
  * Rules omitted from the request retain their existing relative order.
  * The final order is completed automatically while preserving the requested order.
  * Shortcut guidance now explains partial rule-ID ordering.

* **Bug Fixes**
  * Invalid or ambiguous rule lists are rejected before changes are submitted, with clearer validation details.
  * Reordering requests are prevented when the current rule list contains missing or duplicate IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->