### PR TITLE
fix(skills): hide nested suite guides from discovery

### DIFF
--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -88,7 +88,9 @@ func syncSuite(runner SkillsRunner, source string, plan SyncPlan, installed []in
 // standalone skills by recursive skill catalogues.
 func normalizeSuiteGuides(suitePath string) error {
 	root := filepath.Join(suitePath, "references")
-	var skillFiles, markdownFiles []string
+	type guideRename struct{ oldPath, newPath, dir string }
+	var renames []guideRename
+	markdownFiles := []string{filepath.Join(suitePath, "SKILL.md")}
 	var visit func(string) error
 	visit = func(dir string) error {
 		entries, err := vfs.ReadDir(dir)
@@ -104,9 +106,9 @@ func normalizeSuiteGuides(suitePath string) error {
 				continue
 			}
 			if entry.Name() == "SKILL.md" {
-				skillFiles = append(skillFiles, path)
+				renames = append(renames, guideRename{oldPath: path, newPath: filepath.Join(dir, "GUIDE.md"), dir: dir})
 			}
-			if strings.HasSuffix(entry.Name(), ".md") {
+			if strings.HasSuffix(entry.Name(), ".md") && entry.Name() != "SKILL.md" {
 				markdownFiles = append(markdownFiles, path)
 			}
 		}
@@ -115,20 +117,35 @@ func normalizeSuiteGuides(suitePath string) error {
 	if err := visit(root); err != nil {
 		return fmt.Errorf("inspect suite guides: %w", err)
 	}
-	for _, path := range skillFiles {
-		if err := vfs.Rename(path, filepath.Join(filepath.Dir(path), "GUIDE.md")); err != nil {
+	for _, rename := range renames {
+		if _, err := vfs.Stat(rename.newPath); err == nil {
+			return fmt.Errorf("rename nested suite guide: destination already exists: %s", filepath.Base(rename.newPath))
+		}
+		if err := vfs.Rename(rename.oldPath, rename.newPath); err != nil {
 			return fmt.Errorf("rename nested suite guide: %w", err)
 		}
+		markdownFiles = append(markdownFiles, rename.newPath)
 	}
 	for _, path := range markdownFiles {
-		if filepath.Base(path) == "SKILL.md" {
-			path = filepath.Join(filepath.Dir(path), "GUIDE.md")
-		}
 		content, err := vfs.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("read suite guide %s: %w", filepath.Base(path), err)
 		}
-		updated := strings.ReplaceAll(string(content), "SKILL.md", "GUIDE.md")
+		updated := string(content)
+		for _, rename := range renames {
+			oldRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.oldPath))
+			newRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.newPath))
+			if oldRel == "SKILL.md" {
+				updated = regexp.MustCompile(`(^|[^.])\./SKILL\.md`).ReplaceAllString(updated, `$1./GUIDE.md`)
+			} else {
+				updated = replaceSuitePathToken(updated, oldRel, newRel)
+				updated = replaceSuitePathToken(updated, strings.ReplaceAll(oldRel, "/", `\`), strings.ReplaceAll(newRel, "/", `\`))
+			}
+		}
+		if path == filepath.Join(suitePath, "SKILL.md") {
+			updated = strings.ReplaceAll(updated, "references/<skill-name>/SKILL.md", "references/<skill-name>/GUIDE.md")
+			updated = strings.ReplaceAll(updated, `references\<skill-name>\SKILL.md`, `references\<skill-name>\GUIDE.md`)
+		}
 		if updated != string(content) {
 			if err := vfs.WriteFile(path, []byte(updated), 0o644); err != nil {
 				return fmt.Errorf("rewrite suite guide %s: %w", filepath.Base(path), err)
@@ -136,6 +153,44 @@ func normalizeSuiteGuides(suitePath string) error {
 		}
 	}
 	return nil
+}
+
+func replaceSuitePathToken(content, oldPath, newPath string) string {
+	for cursor := 0; ; {
+		rel := strings.Index(content[cursor:], oldPath)
+		if rel < 0 {
+			break
+		}
+		start := cursor + rel
+		end := start + len(oldPath)
+		beforeOK := start == 0 || !suitePathChar(content[start-1])
+		afterOK := end == len(content) || !suitePathContinuation(content[end])
+		if beforeOK && afterOK {
+			content = content[:start] + newPath + content[end:]
+			cursor = start + len(newPath)
+		} else {
+			cursor = start + 1
+		}
+	}
+	return content
+}
+
+func suitePathChar(value byte) bool {
+	return value == '/' || value == '\\' || value == '-' || value == '_' ||
+		(value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z') || (value >= '0' && value <= '9')
+}
+
+func suitePathContinuation(value byte) bool {
+	return value == '/' || value == '\\' || value == '-' || value == '_' ||
+		(value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z') || (value >= '0' && value <= '9')
+}
+
+func relativePath(root, target string) string {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return target
+	}
+	return rel
 }
 
 func prepareSuite(suitePath string, official, target []string) error {

--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -136,7 +136,7 @@ func normalizeSuiteGuides(suitePath string) error {
 			oldRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.oldPath))
 			newRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.newPath))
 			if oldRel == "SKILL.md" {
-				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])(\./|\.\\)?SKILL\.md`).ReplaceAllString(updated, `${1}${2}GUIDE.md`)
+				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])(\./|\.\\)SKILL\.md`).ReplaceAllString(updated, `${1}${2}GUIDE.md`)
 			} else {
 				oldBackslash := strings.ReplaceAll(oldRel, "/", `\`)
 				newBackslash := strings.ReplaceAll(newRel, "/", `\`)

--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -68,6 +68,9 @@ func syncSuite(runner SkillsRunner, source string, plan SyncPlan, installed []in
 	}
 
 	suitePath := filepath.Join(stagingRoot, ".agents", "skills", "lark-suite")
+	if err := normalizeSuiteGuides(suitePath); err != nil {
+		return err
+	}
 	if err := prepareSuite(suitePath, plan.OfficialSkills, plan.ToUpdate); err != nil {
 		return err
 	}
@@ -77,6 +80,60 @@ func syncSuite(runner SkillsRunner, source string, plan SyncPlan, installed []in
 	}
 	if err := removeSkills(runner, installedSeparate); err != nil {
 		return err
+	}
+	return nil
+}
+
+// normalizeSuiteGuides keeps nested domain guides from being discovered as
+// standalone skills by recursive skill catalogues.
+func normalizeSuiteGuides(suitePath string) error {
+	root := filepath.Join(suitePath, "references")
+	var skillFiles, markdownFiles []string
+	var visit func(string) error
+	visit = func(dir string) error {
+		entries, err := vfs.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			path := filepath.Join(dir, entry.Name())
+			if entry.IsDir() {
+				if err := visit(path); err != nil {
+					return err
+				}
+				continue
+			}
+			if entry.Name() == "SKILL.md" {
+				skillFiles = append(skillFiles, path)
+			}
+			if strings.HasSuffix(entry.Name(), ".md") {
+				markdownFiles = append(markdownFiles, path)
+			}
+		}
+		return nil
+	}
+	if err := visit(root); err != nil {
+		return fmt.Errorf("inspect suite guides: %w", err)
+	}
+	for _, path := range skillFiles {
+		if err := vfs.Rename(path, filepath.Join(filepath.Dir(path), "GUIDE.md")); err != nil {
+			return fmt.Errorf("rename nested suite guide: %w", err)
+		}
+	}
+	for _, path := range markdownFiles {
+		if filepath.Base(path) == "SKILL.md" {
+			path = filepath.Join(filepath.Dir(path), "GUIDE.md")
+		}
+		content, err := vfs.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read suite guide %s: %w", filepath.Base(path), err)
+		}
+		updated := strings.ReplaceAll(string(content), "SKILL.md", "GUIDE.md")
+		if updated != string(content) {
+			if err := vfs.WriteFile(path, []byte(updated), 0o644); err != nil {
+				return fmt.Errorf("rewrite suite guide %s: %w", filepath.Base(path), err)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -136,7 +136,7 @@ func normalizeSuiteGuides(suitePath string) error {
 			oldRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.oldPath))
 			newRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.newPath))
 			if oldRel == "SKILL.md" {
-				updated = regexp.MustCompile(`(^|[^.])\./SKILL\.md`).ReplaceAllString(updated, `$1./GUIDE.md`)
+				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])SKILL\.md`).ReplaceAllString(updated, `${1}GUIDE.md`)
 			} else {
 				updated = replaceSuitePathToken(updated, oldRel, newRel)
 				updated = replaceSuitePathToken(updated, strings.ReplaceAll(oldRel, "/", `\`), strings.ReplaceAll(newRel, "/", `\`))
@@ -144,6 +144,7 @@ func normalizeSuiteGuides(suitePath string) error {
 		}
 		if path == filepath.Join(suitePath, "SKILL.md") {
 			updated = strings.ReplaceAll(updated, "references/<skill-name>/SKILL.md", "references/<skill-name>/GUIDE.md")
+			updated = regexp.MustCompile(`(references/[A-Za-z0-9_-]+)/SKILL\.md`).ReplaceAllString(updated, `${1}/GUIDE.md`)
 			updated = strings.ReplaceAll(updated, `references\<skill-name>\SKILL.md`, `references\<skill-name>\GUIDE.md`)
 		}
 		if updated != string(content) {

--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -136,7 +136,7 @@ func normalizeSuiteGuides(suitePath string) error {
 			oldRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.oldPath))
 			newRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.newPath))
 			if oldRel == "SKILL.md" {
-				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])SKILL\.md`).ReplaceAllString(updated, `${1}GUIDE.md`)
+				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])(\./)?SKILL\.md`).ReplaceAllString(updated, `${1}${2}GUIDE.md`)
 			} else {
 				updated = replaceSuitePathToken(updated, oldRel, newRel)
 				updated = replaceSuitePathToken(updated, strings.ReplaceAll(oldRel, "/", `\`), strings.ReplaceAll(newRel, "/", `\`))

--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -136,15 +136,18 @@ func normalizeSuiteGuides(suitePath string) error {
 			oldRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.oldPath))
 			newRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.newPath))
 			if oldRel == "SKILL.md" {
-				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])(\./)?SKILL\.md`).ReplaceAllString(updated, `${1}${2}GUIDE.md`)
+				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])(\./|\.\\)?SKILL\.md`).ReplaceAllString(updated, `${1}${2}GUIDE.md`)
 			} else {
+				oldBackslash := strings.ReplaceAll(oldRel, "/", `\`)
+				newBackslash := strings.ReplaceAll(newRel, "/", `\`)
+				updated = replaceSuitePathToken(updated, "./"+oldRel, "./"+newRel)
+				updated = replaceSuitePathToken(updated, `.\`+oldBackslash, `.\`+newBackslash)
 				updated = replaceSuitePathToken(updated, oldRel, newRel)
-				updated = replaceSuitePathToken(updated, strings.ReplaceAll(oldRel, "/", `\`), strings.ReplaceAll(newRel, "/", `\`))
+				updated = replaceSuitePathToken(updated, oldBackslash, newBackslash)
 			}
 		}
 		if path == filepath.Join(suitePath, "SKILL.md") {
 			updated = strings.ReplaceAll(updated, "references/<skill-name>/SKILL.md", "references/<skill-name>/GUIDE.md")
-			updated = regexp.MustCompile(`(references/[A-Za-z0-9_-]+)/SKILL\.md`).ReplaceAllString(updated, `${1}/GUIDE.md`)
 			updated = strings.ReplaceAll(updated, `references\<skill-name>\SKILL.md`, `references\<skill-name>\GUIDE.md`)
 		}
 		if updated != string(content) {
@@ -177,7 +180,7 @@ func replaceSuitePathToken(content, oldPath, newPath string) string {
 }
 
 func suitePathChar(value byte) bool {
-	return value == '/' || value == '\\' || value == '-' || value == '_' ||
+	return value == '.' || value == '/' || value == '\\' || value == '-' || value == '_' ||
 		(value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z') || (value >= '0' && value <= '9')
 }
 

--- a/internal/skillscheck/layout.go
+++ b/internal/skillscheck/layout.go
@@ -136,7 +136,8 @@ func normalizeSuiteGuides(suitePath string) error {
 			oldRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.oldPath))
 			newRel := filepath.ToSlash(relativePath(filepath.Dir(path), rename.newPath))
 			if oldRel == "SKILL.md" {
-				updated = regexp.MustCompile(`(^|[^A-Za-z0-9_./\\-])(\./|\.\\)SKILL\.md`).ReplaceAllString(updated, `${1}${2}GUIDE.md`)
+				updated = replaceCurrentSuiteGuideToken(updated, "./SKILL.md", "./GUIDE.md")
+				updated = replaceCurrentSuiteGuideToken(updated, `.\SKILL.md`, `.\GUIDE.md`)
 			} else {
 				oldBackslash := strings.ReplaceAll(oldRel, "/", `\`)
 				newBackslash := strings.ReplaceAll(newRel, "/", `\`)
@@ -157,6 +158,36 @@ func normalizeSuiteGuides(suitePath string) error {
 		}
 	}
 	return nil
+}
+
+func replaceCurrentSuiteGuideToken(content, oldPath, newPath string) string {
+	for cursor := 0; ; {
+		rel := strings.Index(content[cursor:], oldPath)
+		if rel < 0 {
+			break
+		}
+		start := cursor + rel
+		end := start + len(oldPath)
+		beforeOK := start == 0 || !suitePathChar(content[start-1])
+		afterOK := end == len(content) || !currentGuideContinuation(content, end)
+		if beforeOK && afterOK {
+			content = content[:start] + newPath + content[end:]
+			cursor = start + len(newPath)
+		} else {
+			cursor = start + 1
+		}
+	}
+	return content
+}
+
+func currentGuideContinuation(content string, index int) bool {
+	if content[index] != '.' {
+		return suitePathContinuation(content[index])
+	}
+	for index < len(content) && content[index] == '.' {
+		index++
+	}
+	return index < len(content) && suitePathContinuation(content[index])
 }
 
 func replaceSuitePathToken(content, oldPath, newPath string) string {

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/larksuite/cli/internal/selfupdate"
+	"github.com/larksuite/cli/internal/vfs"
 )
 
 func TestParseSkillsListIgnoresUnsupportedFormat(t *testing.T) {
@@ -265,7 +266,7 @@ func (f *fakeSkillsRunner) StageSuite(source, dir string) *selfupdate.NpmResult 
 			return &selfupdate.NpmResult{Err: err}
 		}
 		if f.stageNestedGuides {
-			if err := os.WriteFile(filepath.Join(suite, "references", name, "SKILL.md"), []byte("read SKILL.md"), 0o644); err != nil {
+			if err := vfs.WriteFile(filepath.Join(suite, "references", name, "SKILL.md"), []byte("read SKILL.md"), 0o644); err != nil {
 				return &selfupdate.NpmResult{Err: err}
 			}
 		}
@@ -274,18 +275,18 @@ func (f *fakeSkillsRunner) StageSuite(source, dir string) *selfupdate.NpmResult 
 	if f.stageNestedGuides {
 		fixture += "Read references/lark-calendar/SKILL.md.\n"
 	}
-	if err := os.WriteFile(filepath.Join(suite, "SKILL.md"), []byte(fixture), 0o644); err != nil {
+	if err := vfs.WriteFile(filepath.Join(suite, "SKILL.md"), []byte(fixture), 0o644); err != nil {
 		return &selfupdate.NpmResult{Err: err}
 	}
 	return &selfupdate.NpmResult{}
 }
 func (f *fakeSkillsRunner) InstallLocalSuite(path string) *selfupdate.NpmResult {
 	f.localSuite = path
-	root, err := os.ReadFile(filepath.Join(path, "SKILL.md"))
+	root, err := vfs.ReadFile(filepath.Join(path, "SKILL.md"))
 	if err == nil {
 		f.localRoot = string(root)
 	}
-	_, err = os.Stat(filepath.Join(path, "references", "lark-calendar", "GUIDE.md"))
+	_, err = vfs.Stat(filepath.Join(path, "references", "lark-calendar", "GUIDE.md"))
 	f.localGuide = err == nil
 	return &selfupdate.NpmResult{}
 }
@@ -730,7 +731,7 @@ func TestPrepareSuiteCropsRoutesKeywordsAndReferences(t *testing.T) {
 func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T) {
 	suite := t.TempDir()
 	guideDir := filepath.Join(suite, "references", "lark-calendar", "references")
-	if err := os.MkdirAll(guideDir, 0o755); err != nil {
+	if err := vfs.MkdirAll(guideDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	paths := []string{
@@ -738,20 +739,24 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 		filepath.Join(guideDir, "SKILL.md"),
 		filepath.Join(suite, "references", "lark-mail", "SKILL.md"),
 	}
-	if err := os.MkdirAll(filepath.Dir(paths[2]), 0o755); err != nil {
+	if err := vfs.MkdirAll(filepath.Dir(paths[2]), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(suite, "SKILL.md"), []byte("read references/lark-calendar/SKILL.md and references/<skill-name>/SKILL.md; keep the word SKILL.md"), 0o644); err != nil {
+	if err := vfs.WriteFile(filepath.Join(suite, "SKILL.md"), []byte("read references/lark-calendar/SKILL.md and references/<skill-name>/SKILL.md; keep references/not-renamed/SKILL.md"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	for _, path := range paths {
-		content := "read SKILL.md and ./SKILL.md and ../../SKILL.md"
+		content := "read SKILL.md and ./SKILL.md and .\\SKILL.md and ../../SKILL.md"
 		if path == paths[0] {
-			content += " and ../lark-mail/SKILL.md"
+			content += " and ../lark-mail/SKILL.md and ./../lark-mail/SKILL.md and .\\..\\lark-mail\\SKILL.md"
 		}
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		if err := vfs.WriteFile(path, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
+	}
+	readme := filepath.Join(suite, "references", "lark-calendar", "README.md")
+	if err := vfs.WriteFile(readme, []byte("read ../lark-mail/SKILL.md and ./../lark-mail/SKILL.md"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 	if err := normalizeSuiteGuides(suite); err != nil {
 		t.Fatal(err)
@@ -766,24 +771,31 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 		filepath.Join(guideDir, "GUIDE.md"),
 		filepath.Join(suite, "references", "lark-mail", "GUIDE.md"),
 	} {
-		content, err := os.ReadFile(path)
+		content, err := vfs.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := "read GUIDE.md and ./GUIDE.md and ../../SKILL.md"
+		want := "read GUIDE.md and ./GUIDE.md and .\\GUIDE.md and ../../SKILL.md"
 		if strings.Contains(path, "lark-calendar"+string(filepath.Separator)+"GUIDE.md") {
-			want += " and ../lark-mail/GUIDE.md"
+			want += " and ../lark-mail/GUIDE.md and ./../lark-mail/GUIDE.md and .\\..\\lark-mail\\GUIDE.md"
 		}
 		if string(content) != want {
 			t.Fatalf("content at %s = %q", path, content)
 		}
 	}
-	rootContent, err := os.ReadFile(filepath.Join(suite, "SKILL.md"))
+	rootContent, err := vfs.ReadFile(filepath.Join(suite, "SKILL.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(rootContent) != "read references/lark-calendar/GUIDE.md and references/<skill-name>/GUIDE.md; keep the word SKILL.md" {
+	if string(rootContent) != "read references/lark-calendar/GUIDE.md and references/<skill-name>/GUIDE.md; keep references/not-renamed/SKILL.md" {
 		t.Fatalf("root router content = %q", rootContent)
+	}
+	readmeContent, err := vfs.ReadFile(readme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(readmeContent) != "read ../lark-mail/GUIDE.md and ./../lark-mail/GUIDE.md" {
+		t.Fatalf("README.md content = %q", readmeContent)
 	}
 }
 

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -185,17 +185,20 @@ func TestPlanForceRestoresAllOfficial(t *testing.T) {
 }
 
 type fakeSkillsRunner struct {
-	sources       []string
-	indexes       map[string]string
-	indexErrors   map[string]error
-	installErrors map[string]error
-	stageErrors   map[string]error
-	stageChildren map[string][]string
-	globalJSON    string
-	installs      []string
-	removals      [][]string
-	localSuite    string
-	stages        []string
+	sources           []string
+	indexes           map[string]string
+	indexErrors       map[string]error
+	installErrors     map[string]error
+	stageErrors       map[string]error
+	stageChildren     map[string][]string
+	stageNestedGuides bool
+	globalJSON        string
+	installs          []string
+	removals          [][]string
+	localSuite        string
+	localGuide        bool
+	localRoot         string
+	stages            []string
 }
 
 func officialSkillsIndexOutput(names ...string) string {
@@ -261,14 +264,29 @@ func (f *fakeSkillsRunner) StageSuite(source, dir string) *selfupdate.NpmResult 
 		if err := os.MkdirAll(filepath.Join(suite, "references", name), 0o755); err != nil {
 			return &selfupdate.NpmResult{Err: err}
 		}
+		if f.stageNestedGuides {
+			if err := os.WriteFile(filepath.Join(suite, "references", name, "SKILL.md"), []byte("read SKILL.md"), 0o644); err != nil {
+				return &selfupdate.NpmResult{Err: err}
+			}
+		}
 	}
-	if err := os.WriteFile(filepath.Join(suite, "SKILL.md"), []byte(suiteFixture), 0o644); err != nil {
+	fixture := suiteFixture
+	if f.stageNestedGuides {
+		fixture += "Read references/lark-calendar/SKILL.md.\n"
+	}
+	if err := os.WriteFile(filepath.Join(suite, "SKILL.md"), []byte(fixture), 0o644); err != nil {
 		return &selfupdate.NpmResult{Err: err}
 	}
 	return &selfupdate.NpmResult{}
 }
 func (f *fakeSkillsRunner) InstallLocalSuite(path string) *selfupdate.NpmResult {
 	f.localSuite = path
+	root, err := os.ReadFile(filepath.Join(path, "SKILL.md"))
+	if err == nil {
+		f.localRoot = string(root)
+	}
+	_, err = os.Stat(filepath.Join(path, "references", "lark-calendar", "GUIDE.md"))
+	f.localGuide = err == nil
 	return &selfupdate.NpmResult{}
 }
 func (f *fakeSkillsRunner) RemoveGlobalSkills(names []string) *selfupdate.NpmResult {
@@ -592,6 +610,26 @@ func TestSyncSkillsSuiteStagesCropsAndRemovesSeparate(t *testing.T) {
 	assertStrings(t, state.SkippedDeletedSkills, []string{"lark-mail"})
 }
 
+func TestSyncSkillsSuiteNormalizesStagedArchiveBeforeInstall(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	runner := &fakeSkillsRunner{
+		sources:     []string{"primary"},
+		indexes:     map[string]string{"primary": officialSkillsIndexOutput("lark-calendar", "lark-mail")},
+		indexErrors: map[string]error{}, installErrors: map[string]error{}, stageErrors: map[string]error{},
+		globalJSON: globalSkillsJSONOutput(), stageNestedGuides: true,
+	}
+	result := SyncSkills(SyncOptions{Version: "1.0.33", Layout: LayoutSuite, Runner: runner, Now: time.Now})
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	if !runner.localGuide {
+		t.Fatal("staged nested guide was not renamed before installation")
+	}
+	if !strings.Contains(runner.localRoot, "references/lark-calendar/GUIDE.md") || strings.Contains(runner.localRoot, "references/lark-calendar/SKILL.md") {
+		t.Fatalf("staged router references = %q", runner.localRoot)
+	}
+}
+
 func TestSyncSkillsSwitchToSuiteRemovesPreviouslyOfficialSkillMissingFromIndex(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	if err := WriteState(SkillsState{
@@ -698,9 +736,20 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 	paths := []string{
 		filepath.Join(suite, "references", "lark-calendar", "SKILL.md"),
 		filepath.Join(guideDir, "SKILL.md"),
+		filepath.Join(suite, "references", "lark-mail", "SKILL.md"),
+	}
+	if err := os.MkdirAll(filepath.Dir(paths[2]), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(suite, "SKILL.md"), []byte("read references/lark-calendar/SKILL.md; keep the word SKILL.md"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 	for _, path := range paths {
-		if err := os.WriteFile(path, []byte("read SKILL.md"), 0o644); err != nil {
+		content := "read ./SKILL.md and ../../SKILL.md"
+		if path == paths[0] {
+			content += " and ../lark-mail/SKILL.md"
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -715,14 +764,26 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 	for _, path := range []string{
 		filepath.Join(suite, "references", "lark-calendar", "GUIDE.md"),
 		filepath.Join(guideDir, "GUIDE.md"),
+		filepath.Join(suite, "references", "lark-mail", "GUIDE.md"),
 	} {
 		content, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if string(content) != "read GUIDE.md" {
+		want := "read ./GUIDE.md and ../../SKILL.md"
+		if strings.Contains(path, "lark-calendar"+string(filepath.Separator)+"GUIDE.md") {
+			want += " and ../lark-mail/GUIDE.md"
+		}
+		if string(content) != want {
 			t.Fatalf("content at %s = %q", path, content)
 		}
+	}
+	rootContent, err := os.ReadFile(filepath.Join(suite, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(rootContent) != "read references/lark-calendar/GUIDE.md; keep the word SKILL.md" {
+		t.Fatalf("root router content = %q", rootContent)
 	}
 }
 

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -765,7 +765,7 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 			t.Fatal(err)
 		}
 	}
-	if err := vfs.WriteFile(skillMaker, []byte("Skill = a `SKILL.md`.\n## SKILL.md template\nFile: `skills/lark-<name>/SKILL.md`.\nRead ../lark-shared/SKILL.md."), 0o644); err != nil {
+	if err := vfs.WriteFile(skillMaker, []byte("Skill = a `SKILL.md`.\n## SKILL.md template\nFile: `skills/lark-<name>/SKILL.md`.\nRead ../lark-shared/SKILL.md.\nPaths: ./SKILL.md.template, ./SKILL.md.bak, ./SKILL.md-old, ./SKILL.md, and ./SKILL.md."), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := vfs.WriteFile(shared, []byte("shared guide"), 0o644); err != nil {
@@ -814,7 +814,7 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(skillMakerContent) != "Skill = a `SKILL.md`.\n## SKILL.md template\nFile: `skills/lark-<name>/SKILL.md`.\nRead ../lark-shared/GUIDE.md." {
+	if string(skillMakerContent) != "Skill = a `SKILL.md`.\n## SKILL.md template\nFile: `skills/lark-<name>/SKILL.md`.\nRead ../lark-shared/GUIDE.md.\nPaths: ./SKILL.md.template, ./SKILL.md.bak, ./SKILL.md-old, ./GUIDE.md, and ./GUIDE.md." {
 		t.Fatalf("skill-maker guide content = %q", skillMakerContent)
 	}
 }

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -689,6 +689,43 @@ func TestPrepareSuiteCropsRoutesKeywordsAndReferences(t *testing.T) {
 	}
 }
 
+func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T) {
+	suite := t.TempDir()
+	guideDir := filepath.Join(suite, "references", "lark-calendar", "references")
+	if err := os.MkdirAll(guideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	paths := []string{
+		filepath.Join(suite, "references", "lark-calendar", "SKILL.md"),
+		filepath.Join(guideDir, "SKILL.md"),
+	}
+	for _, path := range paths {
+		if err := os.WriteFile(path, []byte("read SKILL.md"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := normalizeSuiteGuides(suite); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("nested SKILL.md still exists at %s: %v", path, err)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(suite, "references", "lark-calendar", "GUIDE.md"),
+		filepath.Join(guideDir, "GUIDE.md"),
+	} {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(content) != "read GUIDE.md" {
+			t.Fatalf("content at %s = %q", path, content)
+		}
+	}
+}
+
 func TestCropSuiteRoutesRemovesBoundaryLinesWithoutChangingNeighbors(t *testing.T) {
 	routes := []string{
 		"- lark-approval（审批）: approval",

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -741,11 +741,11 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 	if err := os.MkdirAll(filepath.Dir(paths[2]), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(suite, "SKILL.md"), []byte("read references/lark-calendar/SKILL.md; keep the word SKILL.md"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(suite, "SKILL.md"), []byte("read references/lark-calendar/SKILL.md and references/<skill-name>/SKILL.md; keep the word SKILL.md"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	for _, path := range paths {
-		content := "read ./SKILL.md and ../../SKILL.md"
+		content := "read SKILL.md and ../../SKILL.md"
 		if path == paths[0] {
 			content += " and ../lark-mail/SKILL.md"
 		}
@@ -770,7 +770,7 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := "read ./GUIDE.md and ../../SKILL.md"
+		want := "read GUIDE.md and ../../SKILL.md"
 		if strings.Contains(path, "lark-calendar"+string(filepath.Separator)+"GUIDE.md") {
 			want += " and ../lark-mail/GUIDE.md"
 		}
@@ -782,7 +782,7 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(rootContent) != "read references/lark-calendar/GUIDE.md; keep the word SKILL.md" {
+	if string(rootContent) != "read references/lark-calendar/GUIDE.md and references/<skill-name>/GUIDE.md; keep the word SKILL.md" {
 		t.Fatalf("root router content = %q", rootContent)
 	}
 }

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -758,6 +758,19 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 	if err := vfs.WriteFile(readme, []byte("read ../lark-mail/SKILL.md and ./../lark-mail/SKILL.md"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	skillMaker := filepath.Join(suite, "references", "lark-skill-maker", "SKILL.md")
+	shared := filepath.Join(suite, "references", "lark-shared", "SKILL.md")
+	for _, path := range []string{skillMaker, shared} {
+		if err := vfs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := vfs.WriteFile(skillMaker, []byte("Skill = a `SKILL.md`.\n## SKILL.md template\nFile: `skills/lark-<name>/SKILL.md`.\nRead ../lark-shared/SKILL.md."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := vfs.WriteFile(shared, []byte("shared guide"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := normalizeSuiteGuides(suite); err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +788,7 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := "read GUIDE.md and ./GUIDE.md and .\\GUIDE.md and ../../SKILL.md"
+		want := "read SKILL.md and ./GUIDE.md and .\\GUIDE.md and ../../SKILL.md"
 		if strings.Contains(path, "lark-calendar"+string(filepath.Separator)+"GUIDE.md") {
 			want += " and ../lark-mail/GUIDE.md and ./../lark-mail/GUIDE.md and .\\..\\lark-mail\\GUIDE.md"
 		}
@@ -796,6 +809,13 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 	}
 	if string(readmeContent) != "read ../lark-mail/GUIDE.md and ./../lark-mail/GUIDE.md" {
 		t.Fatalf("README.md content = %q", readmeContent)
+	}
+	skillMakerContent, err := vfs.ReadFile(filepath.Join(suite, "references", "lark-skill-maker", "GUIDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(skillMakerContent) != "Skill = a `SKILL.md`.\n## SKILL.md template\nFile: `skills/lark-<name>/SKILL.md`.\nRead ../lark-shared/GUIDE.md." {
+		t.Fatalf("skill-maker guide content = %q", skillMakerContent)
 	}
 }
 

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -745,7 +745,7 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 		t.Fatal(err)
 	}
 	for _, path := range paths {
-		content := "read SKILL.md and ../../SKILL.md"
+		content := "read SKILL.md and ./SKILL.md and ../../SKILL.md"
 		if path == paths[0] {
 			content += " and ../lark-mail/SKILL.md"
 		}
@@ -770,7 +770,7 @@ func TestNormalizeSuiteGuidesRenamesNestedEntrypointsAndReferences(t *testing.T)
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := "read GUIDE.md and ../../SKILL.md"
+		want := "read GUIDE.md and ./GUIDE.md and ../../SKILL.md"
 		if strings.Contains(path, "lark-calendar"+string(filepath.Separator)+"GUIDE.md") {
 			want += " and ../lark-mail/GUIDE.md"
 		}

--- a/isolated-skills/lark-suite/SKILL.md
+++ b/isolated-skills/lark-suite/SKILL.md
@@ -14,12 +14,12 @@ metadata:
 
 `lark-suite` 不直接承载具体 API 操作步骤。除非对应子能力已被读取，否则不要仅根据本文件拼命令、猜参数或执行复杂操作。
 
-所有子能力统一收纳在当前 skill 的 `references/` 目录。选择 `lark-foo` 后，直接读取 `references/lark-foo/SKILL.md`；不要再次调用 `Skill(lark-foo)`，也不要使用 Find/Glob 遍历或探测整个 references 目录。
+所有子能力统一收纳在当前 skill 的 `references/` 目录。选择 `lark-foo` 后，直接读取 `references/lark-foo/GUIDE.md`；不要再次调用 `Skill(lark-foo)`，也不要使用 Find/Glob 遍历或探测整个 references 目录。
 
 ## 使用流程
 
 1. 根据用户意图从下方路由表选择一个或多个子能力；即使用户尚未提供链接、ID 或具体工作表，也先选择能力，再由子能力询问缺失信息。
-2. 直接读取 `references/<skill-name>/SKILL.md` 加载所选子能力，不要把收纳后的子能力当作独立 skill 再次调用。
+2. 直接读取 `references/<skill-name>/GUIDE.md` 加载所选子能力，不要把收纳后的子能力当作独立 skill 再次调用。
 3. 仅使用本文件列出的路由与对应子能力入口，不要遍历或探测其他技能目录。
 4. 如果目标能力未列出，返回无法路由的明确提示。
 5. 仅读取当前已选子能力明确要求的前置文件。


### PR DESCRIPTION
## Summary

Fixes #2573. Suite synchronization now renames nested domain entrypoints from `SKILL.md` to `GUIDE.md` and rewrites only references that resolve to renamed files, so recursive skill discovery sees only the top-level `lark-suite` entrypoint. Separate layout behavior is unchanged.

## Changes

- Normalize every nested `references/**/SKILL.md` in the staged suite to `GUIDE.md` before cropping and installation.
- Rewrite root router placeholders and relative references only when they point at a renamed guide; parent links to the suite root remain unchanged.
- Update the tracked suite router template.
- Add unit coverage for parent and sibling reference boundaries, plus an end-to-end `SyncSkills` staging/install regression.

## Test Plan

- [x] `go test ./internal/skillscheck ./internal/selfupdate -count=1` (94 passed)
- [x] `node scripts/skill-format-check/index.js`
- [x] `git diff --check`

The focused tests and skill format check pass. Repository-wide `make unit-test`,
`make vet`, `make fmt-check`, `make quality-gate`, and `make live-skills-test`
were not run because `make` is unavailable in this environment; live external
skill installation and Codex catalogue discovery were also not run. `go mod
tidy`, license checks, and broad lint gates were not run because this focused
change does not add dependencies and the required repository toolchain is
unavailable; CI and maintainer environment validation remain the relevant
boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Skill suites now consistently use `GUIDE.md` files for nested capabilities.
  * References to nested guides are automatically updated during suite setup, including relative, nested, and Windows-style paths.
  * Suite normalization now occurs before installation, ensuring staged nested guides are handled correctly.
  * Existing routing instructions continue to work with normalized guide locations.

* **Bug Fixes**
  * Prevented installation from proceeding when a guide rename would overwrite an existing `GUIDE.md` file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->