### PR TITLE
Support partial mail rule reorder IDs

### DIFF
--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -24,12 +24,13 @@ type Envelope struct {
 // zero, and without omitempty it would pollute every other domain's meta. Every
 // non-batch command leaves them nil, so this stays invisible outside batch use.
 type Meta struct {
-	Count       int             `json:"count,omitempty"`
-	Rollback    string          `json:"rollback,omitempty"`
-	Pagination  *PaginationMeta `json:"pagination,omitempty"`
-	Total       *int            `json:"total,omitempty"`
-	HitCount    *int            `json:"hit_count,omitempty"`
-	MissedCount *int            `json:"missed_count,omitempty"`
+	Count                int             `json:"count,omitempty"`
+	Rollback             string          `json:"rollback,omitempty"`
+	Pagination           *PaginationMeta `json:"pagination,omitempty"`
+	Total                *int            `json:"total,omitempty"`
+	HitCount             *int            `json:"hit_count,omitempty"`
+	MissedCount          *int            `json:"missed_count,omitempty"`
+	SubmittedRuleIDCount *int            `json:"submitted_rule_id_count,omitempty"`
 }
 
 // PaginationMeta reports how a paginated read ended.

--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -364,13 +364,13 @@ var MailRuleDisable = makeRuleToggleShortcut("+rule-disable", false)
 var MailRuleReorder = common.Shortcut{
 	Service:     "mail",
 	Command:     "+rule-reorder",
-	Description: "Reorder mailbox rules by full rule_id list or by moving one rule before/after/top/bottom.",
+	Description: "Reorder mailbox rules by partial or full rule_id list, or by moving one rule before/after/top/bottom.",
 	Risk:        "write",
 	Scopes:      []string{"mail:user_mailbox.rule:write"},
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Partial or full target rule ID order. Missing current rules are appended in their existing order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -391,7 +391,7 @@ var MailRuleReorder = common.Shortcut{
 	Execute: func(ctx context.Context, rt *common.RuntimeContext) error {
 		before, err := listMailRuleEnvelopes(rt, ruleMailboxID(rt))
 		if err != nil {
-			return mailDecorateProblemMessage(err, "list mail rules before reorder failed")
+			return mailDecorateProblemMessage(err, "list_rules_failed: list mail rules before reorder failed")
 		}
 		target, err := buildRuleTargetOrder(rt, before)
 		if err != nil {
@@ -399,10 +399,11 @@ var MailRuleReorder = common.Shortcut{
 		}
 		raw := map[string]any{"rule_ids": target}
 		if _, err := rt.CallAPITyped("POST", mailRuleReorderPath(ruleMailboxID(rt)), nil, raw); err != nil {
-			return mailDecorateProblemMessage(err, "reorder mail rules failed")
+			return mailDecorateProblemMessage(err, "reorder_failed: reorder mail rules failed")
 		}
 		out := map[string]any{"before_rule_ids": envelopeRuleIDs(before), "after_rule_ids": target, "raw_request": raw}
-		rt.OutFormat(out, &output.Meta{Count: len(target)}, func(w io.Writer) {
+		submittedRuleIDCount := len(target)
+		rt.OutFormat(out, &output.Meta{Count: len(target), SubmittedRuleIDCount: &submittedRuleIDCount}, func(w io.Writer) {
 			fmt.Fprintf(w, "Reordered %d rule(s).\n", len(target))
 		})
 		return nil
@@ -1630,16 +1631,16 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
+	if len(currentIDs) == 0 {
+		return nil, mailValidationError("empty_rule_list: current mailbox has no rules to reorder")
+	}
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
-			return nil, err
-		}
-		return ids, nil
+		return completeRuleOrder(ids, currentIDs)
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
 	if len(order) == len(currentIDs) {
-		return nil, mailValidationParamError("--move-rule-id", "--move-rule-id %s is not in current rule order", moveID)
+		return nil, mailValidationParamError("--move-rule-id", "unknown_rule_id: --move-rule-id %s is not in current rule order", moveID)
 	}
 	switch {
 	case rt.Bool("to-top"):
@@ -1654,22 +1655,33 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 }
 
 func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
-	}
+	_, err := completeRuleOrder(target, current)
+	return err
+}
+
+func completeRuleOrder(userIDs, current []string) ([]string, error) {
 	want := make(map[string]int, len(current))
 	for _, id := range current {
-		want[id]++
+		want[id] = 1
 	}
-	for _, id := range target {
-		want[id]--
+	seen := make(map[string]struct{}, len(userIDs))
+	out := make([]string, 0, len(current))
+	for _, id := range userIDs {
+		if _, ok := seen[id]; ok {
+			return nil, mailValidationParamError("--rule-ids", "duplicate_rule_id: --rule-ids contains duplicate rule id %s", id)
+		}
+		seen[id] = struct{}{}
+		if _, ok := want[id]; !ok {
+			return nil, mailValidationParamError("--rule-ids", "unknown_rule_id: --rule-ids contains unknown rule id %s", id)
+		}
+		out = append(out, id)
 	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+	for _, id := range current {
+		if _, ok := seen[id]; !ok {
+			out = append(out, id)
 		}
 	}
-	return nil
+	return out, nil
 }
 
 func normalizeRuleIDs(ids []string) []string {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1163,6 +1163,37 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 			t.Fatalf("run +rule-reorder full error = %v", err)
 		}
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
+		envelope := decodeShortcutEnvelope(t, stdout)
+		meta := envelope["meta"].(map[string]interface{})
+		if got := meta["submitted_rule_id_count"]; got != float64(3) {
+			t.Fatalf("submitted_rule_id_count = %v, want 3", got)
+		}
+	})
+
+	t.Run("partial order appends omitted rules", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+			mailRuleTestRawRule("d", "D"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b,d")
+		data := decodeShortcutEnvelopeData(t, stdout)
+		after := data["after_rule_ids"].([]interface{})
+		if strings.Join([]string{after[0].(string), after[1].(string), after[2].(string), after[3].(string)}, ",") != "c,a,b,d" {
+			t.Fatalf("after_rule_ids = %v, want c,a,b,d", after)
+		}
 	})
 
 	t.Run("move to bottom", func(t *testing.T) {
@@ -1223,6 +1254,51 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 			t.Fatalf("run +rule-reorder after error = %v", err)
 		}
 		assertRuleIDsBody(t, post.CapturedBody, "b,c,a")
+	})
+
+	t.Run("list failure skips reorder post", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "GET",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules",
+			Body:   map[string]interface{}{"code": 500, "msg": "list unavailable"},
+		})
+		post := &httpmock.Stub{
+			Method:   "POST",
+			URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Optional: true,
+			Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
+		if err == nil {
+			t.Fatal("expected list failure")
+		}
+		if !strings.Contains(err.Error(), "list_rules_failed") {
+			t.Fatalf("error = %v, want list_rules_failed", err)
+		}
+		if len(post.CapturedBodies) != 0 {
+			t.Fatalf("POST should not be sent after list failure, captured %d request(s)", len(post.CapturedBodies))
+		}
+	})
+
+	t.Run("reorder failure reports stable reason", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 500, "msg": "reorder unavailable"},
+		})
+
+		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "b", "--format", "json"}, f, stdout)
+		if err == nil {
+			t.Fatal("expected reorder failure")
+		}
+		if !strings.Contains(err.Error(), "reorder_failed") {
+			t.Fatalf("error = %v, want reorder_failed", err)
+		}
 	})
 }
 
@@ -1488,11 +1564,14 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 }
 
 func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+	if got, err := completeRuleOrder([]string{"b"}, []string{"a", "b", "c"}); err != nil || strings.Join(got, ",") != "b,a,c" {
+		t.Fatalf("completeRuleOrder() = %v, %v; want b,a,c", got, err)
 	}
-	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected duplicate mismatch error")
+	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil || !strings.Contains(err.Error(), "duplicate_rule_id") {
+		t.Fatalf("expected duplicate_rule_id error, got %v", err)
+	}
+	if err := validateFullRuleOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil || !strings.Contains(err.Error(), "unknown_rule_id") {
+		t.Fatalf("expected unknown_rule_id error, got %v", err)
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1524,18 +1603,31 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 		{
 			name: "move missing rule",
 			args: []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
-			want: "is not in current rule order",
+			want: "unknown_rule_id",
 		},
 		{
-			name: "full mismatch",
+			name: "unknown partial id",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
+			want: "unknown_rule_id",
+		},
+		{
+			name: "duplicate partial id",
+			args: []string{"+rule-reorder", "--rule-ids", "a,a"},
+			want: "duplicate_rule_id",
+		},
+		{
+			name: "empty rule list",
+			args: []string{"+rule-reorder", "--rule-ids", "a"},
+			want: "empty_rule_list",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if tc.name != "empty rule list" && (strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "unknown_rule_id") || strings.Contains(tc.want, "duplicate_rule_id")) {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
+			}
+			if tc.name == "empty rule list" {
+				reg.Register(mailRuleListStub())
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)
 			if err == nil {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1275,9 +1275,7 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected list failure")
 		}
-		if !strings.Contains(err.Error(), "list_rules_failed") {
-			t.Fatalf("error = %v, want list_rules_failed", err)
-		}
+		assertMailRuleErrorContract(t, err, errs.CategoryAPI, errs.SubtypeUnknown, "list_rules_failed", "list unavailable")
 		if len(post.CapturedBodies) != 0 {
 			t.Fatalf("POST should not be sent after list failure, captured %d request(s)", len(post.CapturedBodies))
 		}
@@ -1296,10 +1294,25 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected reorder failure")
 		}
-		if !strings.Contains(err.Error(), "reorder_failed") {
-			t.Fatalf("error = %v, want reorder_failed", err)
-		}
+		assertMailRuleErrorContract(t, err, errs.CategoryAPI, errs.SubtypeUnknown, "reorder_failed", "reorder unavailable")
 	})
+}
+
+func assertMailRuleErrorContract(t *testing.T, err error, category errs.Category, subtype errs.Subtype, wantMessages ...string) {
+	t.Helper()
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("error type = %T, want typed errs problem", err)
+	}
+	if problem.Category != category || problem.Subtype != subtype {
+		t.Fatalf("problem = %s/%s, want %s/%s", problem.Category, problem.Subtype, category, subtype)
+	}
+	for _, want := range wantMessages {
+		if !strings.Contains(problem.Message, want) {
+			t.Fatalf("problem message = %q, want substring %q", problem.Message, want)
+		}
+	}
 }
 
 func TestMailRuleUpdateReplacesUnknownConditionCollection(t *testing.T) {

--- a/shortcuts/mail/mail_shortcut_test.go
+++ b/shortcuts/mail/mail_shortcut_test.go
@@ -85,6 +85,18 @@ func decodeShortcutEnvelopeData(t *testing.T, stdout *bytes.Buffer) map[string]i
 	return envelope.Data
 }
 
+func decodeShortcutEnvelope(t *testing.T, stdout *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("Unmarshal(stdout) error = %v, stdout=%s", err, stdout.String())
+	}
+	if envelope["ok"] != true {
+		t.Fatalf("expected ok output, stdout=%s", stdout.String())
+	}
+	return envelope
+}
+
 func encodeFixtureEMLForMailTest(raw string) string {
 	return base64.URLEncoding.EncodeToString([]byte(raw))
 }

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -39,8 +39,8 @@ lark-cli mail +rule-enable --as user --rule-id "<rule_id>"
 lark-cli mail +rule-delete --as user --rule-id "<rule_id>" --dry-run
 lark-cli mail +rule-delete --as user --rule-id "<rule_id>" --yes
 
-# 调整顺序：完整顺序或单条移动二选一
-lark-cli mail +rule-reorder --as user --rule-ids "<rule_id_1>,<rule_id_2>,<rule_id_3>"
+# 调整顺序：可只写要前置排序的部分 ID；CLI 会按当前列表补齐未提及规则
+lark-cli mail +rule-reorder --as user --rule-ids "<rule_id_3>,<rule_id_1>"
 lark-cli mail +rule-reorder --as user --move-rule-id "<rule_id_3>" --before-rule-id "<rule_id_1>"
 ```
 
@@ -81,6 +81,7 @@ lark-cli mail +rule-reorder --as user --move-rule-id "<rule_id_3>" --before-rule
 
 - 读路径宽容：`+rule-list` / `+rule-get` 遇到未知枚举或扩展字段仍输出规则，`unknowns[]` 会说明无法识别的 raw 片段，`raw` 会保留原始规则。
 - 更新规则：`+rule-update` 是“传什么改什么”。只改名称、启停、match 或 stop-after-match 时保留未触碰的 raw；传入新的 `--condition(s)` 时替换 condition items，未传 `--match` 就保留当前 match_type；传入新的 `--action(s)` 时替换 action items。
+- 排序规则：`+rule-reorder --rule-ids` 接受当前规则 ID 的有序子集。CLI 会先读取当前规则列表，提交顺序为“用户给出的 ID + 当前列表中未提及的 ID（保持原相对顺序）”。输入重复 ID、未知 ID 或当前列表为空时不会调用排序接口。
 - 输入校验：用户输入 alias/语义字符串时必须能映射到当前 shortcut 支持的枚举，否则报错；用户直接输入当前 shortcut 不认识的枚举数字，也报错。
 - raw fallback：需要写入当前 shortcut 尚未建模的服务端字段时，读取 `raw` 后使用原子 `user_mailbox.rules` 命令。
 


### PR DESCRIPTION
Adds client-side completion for mail rule reorder requests so callers can provide only the rules they want to move while the CLI submits the complete ordered list required by the API.

- Fetches the current mailbox rule order before reordering.
- Completes partial input IDs with the remaining existing rules.
- Returns structured errors for duplicate, unknown, empty, list, and reorder failures.
- Adds unit coverage and updates the mail rules reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail rule reordering now accepts a partial list of rule IDs, preserving the existing order of omitted rules.
  * Output metadata reports the number of submitted rule IDs.
* **Bug Fixes**
  * Added validation for empty, duplicate, and unknown rule ID lists.
  * Improved error reporting for invalid reorder requests and failures.
* **Documentation**
  * Updated mail rule guidance to describe partial ordering and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->