### PR TITLE
fix(errors): prefer rendered OpenAPI messages

### DIFF
--- a/internal/errclass/classify.go
+++ b/internal/errclass/classify.go
@@ -52,6 +52,14 @@ func BuildAPIError(resp map[string]any, cc ClassifyContext) error {
 		return nil
 	}
 	msg, _ := resp["msg"].(string)
+	// Error templates are rendered by OpenAPI into error.message while msg
+	// remains the static error-mapping label. Prefer the rendered message when
+	// present so the CLI preserves the server's actionable diagnostic.
+	if errBlock, ok := resp["error"].(map[string]any); ok {
+		if rendered, _ := errBlock["message"].(string); rendered != "" {
+			msg = rendered
+		}
+	}
 	if msg == "" {
 		// Upstream omitted or sent non-string msg. Keep Problem.Message non-empty
 		// so the typed wire envelope still carries a human-readable signal.

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -183,6 +183,111 @@ func TestBuildAPIError_TaskInvalidParamsRoutesToAPIError(t *testing.T) {
 	}
 }
 
+func TestBuildAPIError_PrefersRenderedErrorMessage(t *testing.T) {
+	resp := map[string]any{
+		"code": 3350001,
+		"msg":  "invalid param",
+		"error": map[string]any{
+			"message": "Invalid request parameter: request. Invalid reason: insertion is required.",
+		},
+	}
+	err := errclass.BuildAPIError(resp, errclass.ClassifyContext{})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if got, want := p.Message, "Invalid request parameter: request. Invalid reason: insertion is required."; got != want {
+		t.Errorf("Message = %q, want %q", got, want)
+	}
+}
+
+func TestBuildAPIError_FallsBackToTopLevelMessageWhenRenderedMessageEmpty(t *testing.T) {
+	resp := map[string]any{
+		"code": 3350001,
+		"msg":  "invalid param",
+		"error": map[string]any{
+			"message": "",
+		},
+	}
+	err := errclass.BuildAPIError(resp, errclass.ClassifyContext{})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if got, want := p.Message, "invalid param"; got != want {
+		t.Errorf("Message = %q, want %q", got, want)
+	}
+}
+
+func TestBuildAPIError_PrefersRenderedErrorMessageAfterJSONDecode(t *testing.T) {
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(`{
+		"code": 3350001,
+		"msg": "invalid param",
+		"error": {"message": "Invalid request parameter: request. Invalid reason: insertion is required."}
+	}`), &resp); err != nil {
+		t.Fatalf("Unmarshal response: %v", err)
+	}
+	err := errclass.BuildAPIError(resp, errclass.ClassifyContext{})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if got, want := p.Message, "Invalid request parameter: request. Invalid reason: insertion is required."; got != want {
+		t.Errorf("Message = %q, want %q", got, want)
+	}
+}
+
+func TestBuildAPIError_PermissionMessageOverridesRenderedErrorMessage(t *testing.T) {
+	resp := map[string]any{
+		"code": 99991679,
+		"msg":  "scope missing",
+		"error": map[string]any{
+			"message": "Refer to documentation.",
+			"permission_violations": []any{
+				map[string]any{"subject": "contact:contact"},
+			},
+		},
+	}
+	err := errclass.BuildAPIError(resp, errclass.ClassifyContext{Brand: "feishu", AppID: "cli_xyz", Identity: "user"})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if p.Message == "Refer to documentation." {
+		t.Errorf("Message must retain canonical permission guidance, got %q", p.Message)
+	}
+	if !strings.Contains(p.Message, "contact:contact") {
+		t.Errorf("Message = %q, want canonical missing-scope context", p.Message)
+	}
+}
+
+func TestBuildAPIError_FallsBackToTopLevelMessageForMalformedErrorBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		error any
+	}{
+		{name: "nil", error: nil},
+		{name: "array", error: []any{"not an object"}},
+		{name: "non_string_message", error: map[string]any{"message": 123}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errclass.BuildAPIError(map[string]any{
+				"code": 3350001,
+				"msg":  "invalid param",
+				"error": tc.error,
+			}, errclass.ClassifyContext{})
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatal("ProblemOf returned !ok")
+			}
+			if got, want := p.Message, "invalid param"; got != want {
+				t.Errorf("Message = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 // TestBuildAPIError_TroubleshooterLiftedOnAPIArm pins that BuildAPIError lifts
 // resp.error.troubleshooter into Problem.Troubleshooter when the response
 // routes to the catch-all CategoryAPI arm. troubleshooter is the only

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -273,8 +273,8 @@ func TestBuildAPIError_FallsBackToTopLevelMessageForMalformedErrorBlock(t *testi
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := errclass.BuildAPIError(map[string]any{
-				"code": 3350001,
-				"msg":  "invalid param",
+				"code":  3350001,
+				"msg":   "invalid param",
 				"error": tc.error,
 			}, errclass.ClassifyContext{})
 			p, ok := errs.ProblemOf(err)


### PR DESCRIPTION
## Background

When Slides APIs return validation errors, the backend may provide a business-specific `statusMessage`. The current larksuite-cli error handling path can drop this message or replace it with a generic error template, preventing callers from seeing the actual invalid-parameter reason.

## Changes

- Preserve the server-provided `statusMessage` in the shared CLI error handling layer
- Surface it in the final CLI error output without relying on non-stable fields such as `extra`
- Keep existing error codes, HTTP status handling, and successful-response behavior unchanged

## Scope

- Only affects failed responses that already include a `statusMessage`
- Domain-agnostic and reusable by APIs beyond Slides
- Does not change requests, authentication, error-code mapping, or success response structures

## Validation

- Covered validation-error responses containing a backend `statusMessage`
- Verified that the CLI exposes the business error message in its final error output
- Verified that legacy error responses without `statusMessage` retain their existing output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now preserve actionable diagnostics returned by the server when available.
  * Fallback guidance remains available for empty, malformed, or unsupported error responses.
  * Permission-related errors continue to display their standard scope guidance.
  * Error handling now safely accommodates unexpected message formats without losing the appropriate fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->