### PR TITLE
fix(base): validate dashboard update filters

### DIFF
--- a/shortcuts/base/base_dashboard_execute_test.go
+++ b/shortcuts/base/base_dashboard_execute_test.go
@@ -399,6 +399,8 @@ func TestBaseDashboardBlockExecuteCreate(t *testing.T) {
 
 // TestBaseDashboardBlockExecuteUpdate tests the +dashboard-block-update command.
 func TestBaseDashboardBlockExecuteUpdate(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	t.Run("update name and data-config", func(t *testing.T) {
 		factory, stdout, reg := newExecuteFactory(t)
 		reg.Register(&httpmock.Stub{
@@ -460,6 +462,91 @@ func TestBaseDashboardBlockExecuteUpdate(t *testing.T) {
 			"--data-config", "bad-json"}
 		if err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout); err == nil {
 			t.Fatalf("expected error for invalid data-config JSON")
+		}
+	})
+
+	t.Run("filter operator requiring value rejects missing value before request", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		stub := &httpmock.Stub{
+			Method:   "PATCH",
+			URL:      "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks/blk_a",
+			Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{"block_id": "blk_a"}},
+			Optional: true,
+		}
+		reg.Register(stub)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_001", "--block-id", "blk_a",
+			"--data-config", `{"filter":{"conjunction":"and","conditions":[{"field_name":"Segment","operator":"is"}]}}`}
+		err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout)
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("err type=%T want *errs.ValidationError: %v", err, err)
+		}
+		if validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--data-config" {
+			t.Fatalf("problem=%#v want invalid_argument param --data-config", validationErr.Problem)
+		}
+		if !strings.Contains(validationErr.Message, "filter.conditions[0].value 缺失") {
+			t.Fatalf("message=%q missing precise filter path", validationErr.Message)
+		}
+		if !strings.Contains(validationErr.Hint, "lark-base-dashboard-block-config.md") {
+			t.Fatalf("hint=%q missing data_config recovery reference", validationErr.Hint)
+		}
+		if len(stub.CapturedBodies) != 0 {
+			t.Fatalf("validation failure must not send PATCH, captured=%d", len(stub.CapturedBodies))
+		}
+	})
+
+	t.Run("empty filter operators do not require value", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		stub := &httpmock.Stub{
+			Method: "PATCH",
+			URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks/blk_a",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{"block_id": "blk_a"}},
+		}
+		reg.Register(stub)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_001", "--block-id", "blk_a",
+			"--data-config", `{"filter":{"conjunction":"and","conditions":[{"field_name":"Segment","operator":"isEmpty"},{"field_name":"Region","operator":"isNotEmpty"}]}}`}
+		if err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout); err != nil {
+			t.Fatalf("empty operators without value must remain valid: %v", err)
+		}
+		if len(stub.CapturedBodies) != 1 {
+			t.Fatalf("valid empty filter must send one PATCH, captured=%d", len(stub.CapturedBodies))
+		}
+	})
+
+	t.Run("filter accepts field_id references", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		stub := &httpmock.Stub{
+			Method: "PATCH",
+			URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks/blk_a",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{"block_id": "blk_a"}},
+		}
+		reg.Register(stub)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_001", "--block-id", "blk_a",
+			"--data-config", `{"filter":{"conjunction":"and","conditions":[{"field_id":"fld_segment","operator":"is","value":["Enterprise"]}]}}`}
+		if err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout); err != nil {
+			t.Fatalf("field_id filters must remain valid on update: %v", err)
+		}
+		if len(stub.CapturedBodies) != 1 {
+			t.Fatalf("valid field_id filter must send one PATCH, captured=%d", len(stub.CapturedBodies))
+		}
+	})
+
+	t.Run("no-validate bypasses filter validation", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		stub := &httpmock.Stub{
+			Method: "PATCH",
+			URL:    "/open-apis/base/v3/bases/app_x/dashboards/dsh_001/blocks/blk_a",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{"block_id": "blk_a"}},
+		}
+		reg.Register(stub)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_001", "--block-id", "blk_a",
+			"--data-config", `{"filter":{"conjunction":"and","conditions":[{"field_name":"Segment","operator":"is"}]}}`,
+			"--no-validate"}
+		if err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout); err != nil {
+			t.Fatalf("--no-validate must bypass filter validation: %v", err)
+		}
+		if len(stub.CapturedBodies) != 1 {
+			t.Fatalf("bypassed filter must send one PATCH, captured=%d", len(stub.CapturedBodies))
 		}
 	})
 }
@@ -625,6 +712,72 @@ func TestBaseDashboardBlockDryRun_Update(t *testing.T) {
 	if !strings.Contains(got, "PATCH /open-apis/base/v3/bases/app_x/dashboards/dsh_1/blocks/blk_a") || !strings.Contains(got, "订单趋势v2") || !strings.Contains(got, "订单表2") {
 		t.Fatalf("stdout=%s", got)
 	}
+}
+
+func TestBaseDashboardBlockDryRun_UpdateFilterValidation(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	t.Run("rejects missing value", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_1", "--block-id", "blk_a",
+			"--data-config", `{"filter":{"conjunction":"and","conditions":[{"field_name":"Segment","operator":"is"}]}}`,
+			"--dry-run"}
+		err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout)
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("err type=%T want *errs.ValidationError: %v", err, err)
+		}
+		if validationErr.Subtype != errs.SubtypeInvalidArgument || validationErr.Param != "--data-config" ||
+			!strings.Contains(validationErr.Message, "filter.conditions[0].value 缺失") {
+			t.Fatalf("unexpected validation error: %#v", validationErr.Problem)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("rejected dry-run must not print a request preview: %s", stdout.String())
+		}
+	})
+
+	t.Run("previews empty operators without value", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_1", "--block-id", "blk_a",
+			"--data-config", `{"filter":{"conjunction":"and","conditions":[{"field_name":"Segment","operator":"isEmpty"},{"field_name":"Region","operator":"isNotEmpty"}]}}`,
+			"--dry-run", "--format", "pretty"}
+		if err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout); err != nil {
+			t.Fatalf("empty operators without value must remain valid: %v", err)
+		}
+		got := stdout.String()
+		for _, want := range []string{"PATCH /open-apis/base/v3/bases/app_x/dashboards/dsh_1/blocks/blk_a", `"operator":"isEmpty"`, `"operator":"isNotEmpty"`} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("dry-run missing %s: %s", want, got)
+			}
+		}
+	})
+
+	t.Run("no-validate preserves missing value in preview", func(t *testing.T) {
+		factory, stdout, _ := newExecuteFactory(t)
+		args := []string{"+dashboard-block-update", "--base-token", "app_x", "--dashboard-id", "dsh_1", "--block-id", "blk_a",
+			"--data-config", `{"filter":{"conjunction":"and","conditions":[{"field_name":"Segment","operator":"is"}]}}`,
+			"--no-validate", "--dry-run"}
+		if err := runShortcut(t, BaseDashboardBlockUpdate, args, factory, stdout); err != nil {
+			t.Fatalf("--no-validate dry-run must preserve the filter: %v", err)
+		}
+		body, call := dryRunPreviewBody(t, stdout.Bytes())
+		if call.Method != "PATCH" || call.URL != "/open-apis/base/v3/bases/app_x/dashboards/dsh_1/blocks/blk_a" {
+			t.Fatalf("unexpected preview call: %#v", call)
+		}
+		dataConfig, _ := body["data_config"].(map[string]interface{})
+		filter, _ := dataConfig["filter"].(map[string]interface{})
+		conditions, _ := filter["conditions"].([]interface{})
+		if len(conditions) != 1 {
+			t.Fatalf("preview lost filter condition: %#v", body)
+		}
+		condition, _ := conditions[0].(map[string]interface{})
+		if condition["field_name"] != "Segment" || condition["operator"] != "is" {
+			t.Fatalf("preview rewrote filter condition: %#v", condition)
+		}
+		if _, hasValue := condition["value"]; hasValue {
+			t.Fatalf("preview injected omitted value: %#v", condition)
+		}
+	})
 }
 
 func TestBaseDashboardBlockDryRun_UpdateRankingKeepsPatch(t *testing.T) {

--- a/shortcuts/base/block_data_config.go
+++ b/shortcuts/base/block_data_config.go
@@ -706,52 +706,90 @@ func validProtocolFilterValue(value interface{}) bool {
 	}
 }
 
+type blockFilterConditionInput struct {
+	index     int
+	isObject  bool
+	fieldName string
+	fieldID   string
+	operator  string
+	hasValue  bool
+}
+
+type blockFilterValidationInput struct {
+	conjunction       string
+	conditions        []blockFilterConditionInput
+	hasConditionArray bool
+}
+
+// projectBlockFilter narrows the loose JSON map to the fields used by the
+// type-independent filter validator while preserving missing-key semantics.
+func projectBlockFilter(cfg map[string]interface{}, key string) (blockFilterValidationInput, bool) {
+	f, ok := cfg[key].(map[string]interface{})
+	if !ok {
+		return blockFilterValidationInput{}, false
+	}
+	input := blockFilterValidationInput{
+		conjunction: strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", f["conjunction"]))),
+	}
+	conditions, ok := f["conditions"].([]interface{})
+	if !ok {
+		return input, true
+	}
+	input.hasConditionArray = true
+	input.conditions = make([]blockFilterConditionInput, 0, len(conditions))
+	for i, item := range conditions {
+		condition := blockFilterConditionInput{index: i}
+		if raw, ok := item.(map[string]interface{}); ok {
+			condition.isObject = true
+			condition.fieldName, _ = raw["field_name"].(string)
+			condition.fieldID, _ = raw["field_id"].(string)
+			condition.operator, _ = raw["operator"].(string)
+			_, condition.hasValue = raw["value"]
+		}
+		input.conditions = append(input.conditions, condition)
+	}
+	return input, true
+}
+
 // validateBlockFilter validates the filter object shared by chart and list
 // data_config. key is the config key holding the filter ("filter").
 // allowFieldID lets list blocks reference a field by ID; chart blocks keep the
 // dashboard rule of field_name only.
 func validateBlockFilter(cfg map[string]interface{}, key string, allowFieldID bool) []string {
-	f, ok := cfg[key].(map[string]interface{})
-	if !ok {
+	input, exists := projectBlockFilter(cfg, key)
+	if !exists {
 		return nil
 	}
 	var problems []string
-	conj := strings.ToLower(strings.TrimSpace(fmt.Sprintf("%v", f["conjunction"])))
-	if conj == "" {
-		conj = "and"
+	conjunction := input.conjunction
+	if conjunction == "" {
+		conjunction = "and"
 	}
-	if conj != "and" && conj != "or" {
+	if conjunction != "and" && conjunction != "or" {
 		problems = append(problems, key+".conjunction 仅支持 and|or")
 	}
-	conds, ok := f["conditions"].([]interface{})
-	if !ok {
+	if !input.hasConditionArray {
 		return problems
 	}
 	allowedOps := map[string]bool{"is": true, "isnot": true, "contains": true, "doesnotcontain": true, "isempty": true, "isnotempty": true, "isgreater": true, "isgreaterequal": true, "isless": true, "islessequal": true}
-	for i, it := range conds {
-		m, ok := it.(map[string]interface{})
-		if !ok {
-			problems = append(problems, fmt.Sprintf("%s.conditions[%d] 必须是对象", key, i))
+	for _, condition := range input.conditions {
+		if !condition.isObject {
+			problems = append(problems, fmt.Sprintf("%s.conditions[%d] 必须是对象", key, condition.index))
 			continue
 		}
-		fn, _ := m["field_name"].(string)
-		hasRef := strings.TrimSpace(fn) != ""
+		hasRef := strings.TrimSpace(condition.fieldName) != ""
 		if !hasRef && allowFieldID {
-			fid, _ := m["field_id"].(string)
-			hasRef = strings.TrimSpace(fid) != ""
+			hasRef = strings.TrimSpace(condition.fieldID) != ""
 		}
 		if !hasRef {
-			problems = append(problems, fmt.Sprintf("%s.conditions[%d].field_name 不能为空", key, i))
+			problems = append(problems, fmt.Sprintf("%s.conditions[%d].field_name 不能为空", key, condition.index))
 		}
-		op, _ := m["operator"].(string)
-		opKey := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(op), " ", ""))
+		opKey := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(condition.operator), " ", ""))
 		if !allowedOps[opKey] {
-			problems = append(problems, fmt.Sprintf("%s.conditions[%d].operator 不支持: %s", key, i, op))
+			problems = append(problems, fmt.Sprintf("%s.conditions[%d].operator 不支持: %s", key, condition.index, condition.operator))
 		}
-		if opKey != "isempty" && opKey != "isnotempty" {
-			if _, has := m["value"]; !has {
-				problems = append(problems, fmt.Sprintf("%s.conditions[%d].value 缺失", key, i))
-			}
+		if opKey != "isempty" && opKey != "isnotempty" && !condition.hasValue {
+			problems = append(problems, fmt.Sprintf("%s.conditions[%d].value 缺失", key, condition.index))
 		}
 	}
 	return problems
@@ -761,5 +799,7 @@ func formatDataConfigErrors(problems []string) error {
 	if len(problems) == 0 {
 		return nil
 	}
-	return errs.NewValidationError(errs.SubtypeInvalidArgument, "data_config 校验失败:\n- %s\n参考: skills/lark-base/references/lark-base-dashboard-block-config.md（应用页面组件见 lark-base-app-block-data-config.md）", strings.Join(problems, "\n- ")).WithParam("--data-config")
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, "data_config 校验失败:\n- %s", strings.Join(problems, "\n- ")).
+		WithParam("--data-config").
+		WithHint("read skills/lark-base/references/lark-base-dashboard-block-config.md (for app page blocks, read lark-base-app-block-data-config.md)")
 }

--- a/shortcuts/base/dashboard_block_update.go
+++ b/shortcuts/base/dashboard_block_update.go
@@ -57,15 +57,14 @@ var BaseDashboardBlockUpdate = common.Shortcut{
 		effective := cfg
 		if !runtime.Bool("no-validate") {
 			effective = normalizeDataConfig(cfg)
-			// update 不传 type，其余字段交给后端按组件现有类型校验。
-			// number_format 是例外：它必须和 create 一样在本地拦截，否则同一份
-			// 非法取值在 create 报错、在 update 却要等一次网络往返才失败。这里
-			// 只复用 number_format 子校验，不走 validateBlockDataConfig 全量分支
-			// ——后者会误报 table_name/series 缺失，破坏“只改 number_format”的用法。
+			// Update 不传 type，因此只执行与组件类型无关的局部校验；全量校验
+			// 会误报局部 patch 未提交的 table_name/series 等字段。
+			problems := validateBlockFilter(effective, "filter", true)
 			if rawNumberFormat, hasNumberFormat := effective["number_format"]; hasNumberFormat {
-				if problems := validateNumberFormat(rawNumberFormat); len(problems) > 0 {
-					return formatDataConfigErrors(problems)
-				}
+				problems = append(problems, validateNumberFormat(rawNumberFormat)...)
+			}
+			if len(problems) > 0 {
+				return formatDataConfigErrors(problems)
 			}
 		}
 		// Fold @file input into inline JSON after the first successful parse.

--- a/skills/lark-base/references/lark-base-dashboard-block-config.md
+++ b/skills/lark-base/references/lark-base-dashboard-block-config.md
@@ -224,7 +224,7 @@ user / created_by / updated_by: is, isNot, isEmpty, isNotEmpty
   - `group_by[].sort.type` 为 `group` 或 `view` 且缺少 `order` 时，自动补 `order:"asc"`；`value` 排序不会自动补方向
 - 本地校验（可通过 `--no-validate` 跳过）
   - `+dashboard-block-create` 默认对 `data_config` 做轻量校验；失败会聚合错误并给出修复建议
-  - `+dashboard-block-update` 不带 `--type`，所以不做按组件类型的强校验，字段由后端验证；但 `number_format` 子字段与 create 一样本地拦截（见下方 number_format 小节）
+  - `+dashboard-block-update` 不带 `--type`，所以不做按组件类型的强校验；但会对可解析的 `filter` 条件做轻量校验，包括 `conjunction`、字段引用、`operator` 和必需的 `value`，并与 create 一样拦截非法 `number_format` 子字段（见下方 number_format 小节）
   - 仅需传入合法 JSON；CLI 不会擅自改写你的业务含义
 
 ## 可复制模板


### PR DESCRIPTION
## Summary

Reject dashboard block update filters that omit `value` for operators that require one, before sending the PATCH request. This reconnects the update validation path to the existing filter validator while preserving partial updates and `--no-validate`.

## Changes

- Aggregate type-independent filter and number-format validation for `+dashboard-block-update`.
- Preserve `isEmpty`/`isNotEmpty`, partial patch, malformed JSON, and explicit `--no-validate` behavior with execute and dry-run regression coverage.
- Document the update command's local filter-validation boundary.

## Test Plan

- [x] `go test ./shortcuts/base/... -count=1`
- [x] `go vet ./shortcuts/base/...`
- [x] `node scripts/skill-format-check/index.js`
- [x] `make fmt-check`
- [x] `git diff --check origin/main...HEAD`
- [ ] Live write E2E was not run: this coding stage prohibits E2E, and the test requires a manually confirmed identity, disposable Dashboard Block, and cleanup plan. Execute/no-request and placeholder-ID dry-run tests provide substitute evidence.

## Related Issues

- https://meego.larkoffice.com/larksuite/issue/detail/7372678659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard block updates now validate filter configurations before sending changes, including `field_id` filters.
  * Dry-run previews apply the same validation and preserve omitted filter values.
  * Use `--no-validate` to bypass local filter validation.

* **Bug Fixes**
  * Operators requiring values now reject missing values.
  * Operators allowing empty values remain valid.
  * Filter and number-format validation errors are reported together.

* **Documentation**
  * Updated local validation guidance for dashboard block filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->