### PR TITLE
docs: fix task shared skill reference paths

### DIFF
--- a/skills/lark-task/references/lark-task-assign.md
+++ b/skills/lark-task/references/lark-task-assign.md
@@ -1,6 +1,6 @@
 # task +assign
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Assign or remove members (assignees) from a task.
 

--- a/skills/lark-task/references/lark-task-comment.md
+++ b/skills/lark-task/references/lark-task-comment.md
@@ -1,6 +1,6 @@
 # task +comment
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Add a comment to an existing task.
 

--- a/skills/lark-task/references/lark-task-complete.md
+++ b/skills/lark-task/references/lark-task-complete.md
@@ -1,6 +1,6 @@
 # task +complete
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Mark a task as completed.
 

--- a/skills/lark-task/references/lark-task-create.md
+++ b/skills/lark-task/references/lark-task-create.md
@@ -1,6 +1,6 @@
 # task +create
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Create a new task in Lark.
 

--- a/skills/lark-task/references/lark-task-followers.md
+++ b/skills/lark-task/references/lark-task-followers.md
@@ -1,6 +1,6 @@
 # task +followers
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Manage task followers. Add or remove followers from an existing task.
 

--- a/skills/lark-task/references/lark-task-get-my-tasks.md
+++ b/skills/lark-task/references/lark-task-get-my-tasks.md
@@ -2,7 +2,7 @@
 
 If the user query only specifies a task name (e.g., "Complete task Lobster No. 1"), use this command to list and search for the task by its summary.
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 > 
 > **⚠️ Note:** This API must be called with a user identity. **Do NOT use an app identity, otherwise the call will fail.**
 >

--- a/skills/lark-task/references/lark-task-get-related-tasks.md
+++ b/skills/lark-task/references/lark-task-get-related-tasks.md
@@ -1,6 +1,6 @@
 # task +get-related-tasks
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 >
 > **⚠️ Note:** This API must be called with a user identity. **Do NOT use an app identity, otherwise the call will fail.**
 >

--- a/skills/lark-task/references/lark-task-reminder.md
+++ b/skills/lark-task/references/lark-task-reminder.md
@@ -1,6 +1,6 @@
 # task +reminder
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 > **Priority:** For creating or modifying task reminder times, prioritize using this `+reminder` shortcut over other task update methods. It provides a more reliable and direct way to manage reminders.
 
 Manage task reminders. Set new reminders or remove existing ones. Note that setting a task reminder requires a due date.

--- a/skills/lark-task/references/lark-task-reopen.md
+++ b/skills/lark-task/references/lark-task-reopen.md
@@ -1,6 +1,6 @@
 # task +reopen
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Reopen a previously completed task.
 

--- a/skills/lark-task/references/lark-task-search.md
+++ b/skills/lark-task/references/lark-task-search.md
@@ -1,6 +1,6 @@
 # task +search
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 >
 > **⚠️ Note:** This API must be called with a user identity. **Do NOT use an app identity, otherwise the call will fail.**
 

--- a/skills/lark-task/references/lark-task-set-ancestor.md
+++ b/skills/lark-task/references/lark-task-set-ancestor.md
@@ -1,6 +1,6 @@
 # task +set-ancestor
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Set a parent task for a task, or clear the parent to make it independent.
 

--- a/skills/lark-task/references/lark-task-tasklist-create.md
+++ b/skills/lark-task/references/lark-task-tasklist-create.md
@@ -1,6 +1,6 @@
 # task +tasklist-create
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Create a new tasklist, and optionally batch create tasks within it.
 

--- a/skills/lark-task/references/lark-task-tasklist-members.md
+++ b/skills/lark-task/references/lark-task-tasklist-members.md
@@ -1,6 +1,6 @@
 # task +tasklist-members
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Manage tasklist members (editors/owners).
 

--- a/skills/lark-task/references/lark-task-tasklist-search.md
+++ b/skills/lark-task/references/lark-task-tasklist-search.md
@@ -1,6 +1,6 @@
 # task +tasklist-search
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 >
 > **⚠️ Note:** This shortcut uses tasklist search followed by tasklist detail queries to render the final output.
 

--- a/skills/lark-task/references/lark-task-tasklist-task-add.md
+++ b/skills/lark-task/references/lark-task-tasklist-task-add.md
@@ -1,6 +1,6 @@
 # task +tasklist-task-add
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Add existing tasks to a tasklist.
 

--- a/skills/lark-task/references/lark-task-update.md
+++ b/skills/lark-task/references/lark-task-update.md
@@ -1,6 +1,6 @@
 # task +update
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Update an existing task in Lark.
 

--- a/skills/lark-task/references/lark-task-upload-attachment.md
+++ b/skills/lark-task/references/lark-task-upload-attachment.md
@@ -1,6 +1,6 @@
 # task +upload-attachment
 
-> **Prerequisites:** Please read `../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
+> **Prerequisites:** Please read `../../lark-shared/SKILL.md` to understand authentication, global parameters, and security rules.
 
 Upload a single local file as an attachment to a task (or any resource type accepted by the Task attachment endpoint). Max file size per upload is **50 MB**. For task agents, use `--resource-type=task_delivery`.
 


### PR DESCRIPTION
## Summary
Task reference guides point to a nonexistent `lark-task/lark-shared/SKILL.md` when their prerequisite path is resolved relative to the guide. Correct the relative path so agents can read the shared authentication and safety instructions.

## Changes
- Change `../lark-shared/SKILL.md` to `../../lark-shared/SKILL.md` in 17 files under `skills/lark-task/references/`.
- Preserve all other guide content and CLI behavior.

## Test Plan
- [x] Read all 17 corrected paths successfully; the original paths fail with file-not-found errors.
- [x] Verified every changed file contains exactly one prerequisite-path replacement.
- [x] `node scripts/skill-format-check/index.js` and `git diff --check`.
- [x] `make quality-gate QUALITY_GATE_CHANGED_FROM=7fd6ef3c07182257ce776cdc5a614e122d5bd4b3`.
- [x] Full local validation: `make build`, `go vet ./...`, unit tests for `cmd`, `internal`, and `shortcuts`, and non-live integration tests.
- [x] Independent acceptance: 2 scenarios covering all 17 references.
- [ ] Live API E2E and skill evaluation not run: this change only corrects local documentation paths and does not change commands or API requests.
- [ ] Standalone formatting, module-tidy, license, and broad lint checks not run for this documentation-only change.

## Related Issues

Related to #2573; fixes pre-existing reference paths independently of suite layout changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected prerequisite links across Lark task and task-list reference documentation.
  - Links now point to the shared skill documentation at the correct relative location.
  - No functional or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->