### PR TITLE
docs(im): guide folder expansion via im files folder before child download

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -62,6 +62,8 @@ The four message-pulling shortcuts (`+messages-mget`, `+chat-messages-list`, `+m
 
 `+chat-messages-list`, `+messages-mget`, and `+threads-messages-list` accept `--download-resources` to save eligible attachments into `./lark-im-resources/` and add a `resources` array to each message. It is off by default; stickers are not downloadable. A failed attachment is reported on that resource without aborting the message pull. Use [`+messages-resources-download`](references/lark-im-messages-resources-download.md) for one attachment. See [`references/lark-im-message-enrichment.md`](references/lark-im-message-enrichment.md) for the output contract.
 
+**Folder resources** are containers, not files — a folder `file_key` cannot be downloaded directly. Expand it first with `lark-cli im files folder --recursive --file-key <folder_key> --srctype message --srcid <message_id>`, then download the files inside with [`+messages-resources-download`](references/lark-im-messages-resources-download.md).
+
 ### Card Messages (Interactive)
 
 **Before sending, replying with, or updating any `interactive` card (`+messages-send` / `+messages-reply` / `messages.patch`), you MUST read [`references/card/lark-im-card-create.md`](references/card/lark-im-card-create.md) and follow its workflow.** The card JSON passed to `--msg-type interactive --content` (send/reply) or `messages.patch --data` (update) must be the output of that workflow — never hand-write or copy a card payload.
@@ -118,7 +120,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。
 | [`+messages-mget`](references/lark-im-messages-mget.md) | Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies |
 | [`+messages-read-status`](references/lark-im-message-read-status.md) | Batch query whether the current user read 1–50 messages; user-only; returns readable items and invalid message IDs |
 | [`+messages-reply`](references/lark-im-messages-reply.md) | Reply to a message (supports thread replies); user/bot; supports text/markdown/post/media replies, reply-in-thread, idempotency key |
-| [`+messages-resources-download`](references/lark-im-messages-resources-download.md) | Download an image or file attached to a message; user/bot |
+| [`+messages-resources-download`](references/lark-im-messages-resources-download.md) | Download an image/file from a message; folders are not directly downloadable — expand with `im files folder --recursive` first, then download the files inside; user/bot |
 | [`+messages-search`](references/lark-im-messages-search.md) | Search messages across chats (supports keyword, sender, time range filters) with user or bot identity; filters by chat/sender/attachment/time, supports auto-pagination via `--page-all` / `--page-limit`, enriches results via batched mget and chats batch_query |
 | [`+messages-send`](references/lark-im-messages-send.md) | Send a message to a chat or direct message; user/bot; sends to chat-id or user-id with text/markdown/post/media, supports idempotency key |
 | [`+threads-messages-list`](references/lark-im-threads-messages-list.md) | List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports --order asc/desc sorting, auto-pagination |

--- a/skills/lark-im/references/lark-im-messages-mget.md
+++ b/skills/lark-im/references/lark-im-messages-mget.md
@@ -51,7 +51,7 @@ Each message contains:
 | `sender` | Sender information (includes `name`) |
 | `content` | Message content |
 
-For `folder` messages, `content` carries a folder key; `mget` expands the folder one level (`GET /files/:file_key/folder`), rendering first-level children inside the folder tag:
+For `folder` messages, `content` carries a folder key; `mget` expands the folder one level, rendering first-level children inside the folder tag (to expand/download folder children yourself, follow the Folder resources note in [`lark-im`](../SKILL.md)):
 
 ```
 <folder key="file_v3_...g" name="assets" child_count="5">

--- a/skills/lark-im/references/lark-im-messages-resources-download.md
+++ b/skills/lark-im/references/lark-im-messages-resources-download.md
@@ -51,6 +51,8 @@ Different resource markers in message content correspond to different `file_key`
 
 Stickers cannot be downloaded with this command.
 
+A folder itself cannot be downloaded: expand it with `lark-cli im files folder --recursive` first (see [lark-im](../SKILL.md)), then download the files it contains.
+
 ## Output
 
 On success, read:


### PR DESCRIPTION
## Summary
Teach the lark-im skill how to reach folder children for download. A folder message/attachment is a container, not a file: its `file_key` is **not** directly downloadable. The skill now instructs agents to expand the folder first via `lark-cli im files folder` (folder children browse API, `srctype=message` + `srcid=<message_id>`, optional `--recursive` for the full nested tree) and then download each child with `+messages-resources-download`.

## Changes
- `skills/lark-im/SKILL.md`: add a **Folder resources** note (expand with `im files folder`, then download children); update the `+messages-resources-download` command row to say folder resources are expanded first.
- `skills/lark-im/references/lark-im-messages-resources-download.md`: add a short section noting folder resources are not downloadable directly and must be expanded first.

The wording mirrors the enterprise vm-cli skill docs (already shipped there); `files.folder` is a public API registered in the API metadata, so open-source CLI users can rely on it.

## Test Plan
- Docs-only change; no code/tests. Link references resolve (SKILL.md ↔ download reference).

## Related Issues
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that folder attachments cannot be downloaded directly.
  - Documented the need to expand folders recursively before downloading files inside them.
  - Updated the resource-download shortcut to reflect the folder expansion workflow.
  - Updated folder message guidance to reference the folder-resource instructions for expanding or downloading child resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->