### PR TITLE
feat(drive): resumable chunked downloads for +download and +pull

### DIFF
--- a/extension/download/README.md
+++ b/extension/download/README.md
@@ -15,6 +15,11 @@ Choose the representation contract deliberately:
 - `download.ImmutableSource`: permits multipart assembly without an ETag because
   the caller guarantees the source identifier pins the bytes.
 
+When resuming from a local offset, set `Transfer.StartOffset` together with
+the checkpoint's strong `Transfer.ExpectedETag`. The engine sends `If-Range`
+on the first resumed request and rejects a changed representation; the caller
+owns the partial artifact and may discard it before reopening from byte zero.
+
 External commands normally use the higher-level `command.Download`, which wires
 an authenticated OpenAPI transport and invocation-scoped FileIO while retaining
 the same engine options:

--- a/extension/download/download.go
+++ b/extension/download/download.go
@@ -80,6 +80,16 @@ type Options struct {
 	// PartSize is the maximum byte count requested per range. Zero selects
 	// DefaultPartSize.
 	PartSize int64
+	// StartOffset resumes the logical stream from an existing local offset
+	// instead of byte 0. The first range request starts at this offset, so the
+	// server must support Range (HTTP 206); when it does not and StartOffset is
+	// non-zero, Open fails instead of falling back to a full response, because
+	// a full response cannot be spliced onto bytes already written locally.
+	StartOffset int64
+	// ExpectedETag binds the first resumed range request to the representation
+	// identified by an existing checkpoint. The request carries If-Range and
+	// the first response must still report the same strong ETag.
+	ExpectedETag string
 	// MaxResponses bounds the total responses in one logical stream. Zero derives
 	// a bound from the declared object size and PartSize.
 	MaxResponses int
@@ -121,11 +131,14 @@ func Open(ctx context.Context, source Source, opts Options) (*Stream, error) {
 		return openFull(ctx, source.transport, opts, retryWait)
 	}
 
-	firstPart := ByteRange{Start: 0, End: opts.PartSize - 1}
-	resp, err := fetchWithRetry(ctx, source.transport, Request{Range: &firstPart}, opts, retryWait)
+	firstPart := ByteRange{Start: opts.StartOffset, End: opts.StartOffset + opts.PartSize - 1}
+	resp, err := fetchWithRetry(ctx, source.transport, Request{Range: &firstPart, IfRange: opts.ExpectedETag}, opts, retryWait)
 	if err != nil {
 		if !rangeProbeRejected(err) {
 			return nil, err
+		}
+		if opts.StartOffset > 0 {
+			return nil, resumeUnsupportedError(opts.StartOffset)
 		}
 		return openFull(ctx, source.transport, opts, retryWait)
 	}
@@ -135,16 +148,41 @@ func Open(ctx context.Context, source Source, opts Options) (*Stream, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
+		if opts.StartOffset > 0 {
+			resp.Body.Close()
+			return nil, resumeUnsupportedError(opts.StartOffset)
+		}
 		return singleStream(ctx, resp)
 	case http.StatusPartialContent:
 		return openPartial(ctx, source, opts, retryWait, firstPart, resp)
 	case http.StatusBadRequest, http.StatusRequestedRangeNotSatisfiable:
 		resp.Body.Close()
+		if opts.StartOffset > 0 {
+			return nil, resumeUnsupportedError(opts.StartOffset)
+		}
 		return openFull(ctx, source.transport, opts, retryWait)
 	default:
 		resp.Body.Close()
 		return nil, unexpectedStatus(resp.StatusCode)
 	}
+}
+
+// resumeUnsupportedError reports that a resumed download cannot proceed
+// because the server does not honor Range requests, so a full response cannot
+// be spliced onto bytes already written locally.
+func resumeUnsupportedError(offset int64) error {
+	return protocolError(
+		"cannot resume from byte %d: server does not honor Range requests; a full response cannot be spliced onto existing bytes",
+		offset).WithCause(errResumeUnsupported)
+}
+
+var errResumeUnsupported = errors.New("resumed range request is unsupported")
+
+// IsResumeUnsupported reports whether Open could not use the requested local
+// offset because the peer did not honor the resumed Range request. A caller
+// that owns the partial artifact may discard it and retry from byte zero.
+func IsResumeUnsupported(err error) bool {
+	return errors.Is(err, errResumeUnsupported)
 }
 
 func openFull(ctx context.Context, fetch Transport, opts Options, retryWait *retryWaitBudget) (*Stream, error) {
@@ -288,6 +326,8 @@ func (o Options) withDefaults() Options {
 	return o
 }
 
+// validateOptions rejects invalid transport/representation/option
+// combinations before any fetch is attempted.
 func validateOptions(source Source, opts Options) error {
 	if source.transport == nil {
 		return errs.NewInternalError(errs.SubtypeUnknown, "download requires a configured transport")
@@ -297,6 +337,22 @@ func validateOptions(source Source, opts Options) error {
 	}
 	if opts.PartSize <= 0 {
 		return errs.NewInternalError(errs.SubtypeUnknown, "download part size must be positive, got %d", opts.PartSize)
+	}
+	if opts.StartOffset < 0 {
+		return errs.NewInternalError(errs.SubtypeUnknown, "download start offset cannot be negative, got %d", opts.StartOffset)
+	}
+	if opts.DisableMultipart && opts.StartOffset > 0 {
+		return errs.NewInternalError(errs.SubtypeUnknown, "download start offset requires multipart range requests")
+	}
+	if opts.StartOffset > math.MaxInt64-(opts.PartSize-1) {
+		return errs.NewInternalError(errs.SubtypeUnknown, "download start offset overflows the requested range, got %d", opts.StartOffset)
+	}
+	if opts.ExpectedETag != "" {
+		etagHeader := make(http.Header)
+		etagHeader.Set("ETag", opts.ExpectedETag)
+		if _, ok := strongETag(etagHeader); !ok {
+			return errs.NewInternalError(errs.SubtypeUnknown, "download expected ETag must be one strong quoted validator")
+		}
 	}
 	if opts.MaxResponses < 0 {
 		return errs.NewInternalError(errs.SubtypeUnknown, "download max responses cannot be negative, got %d", opts.MaxResponses)
@@ -332,6 +388,8 @@ func singleStream(ctx context.Context, resp *http.Response) (*Stream, error) {
 	}, nil
 }
 
+// openPartial turns a validated 206 range response into a multipart stream,
+// continuing with further ranges until the declared total size is reached.
 func openPartial(ctx context.Context, source Source, opts Options, retryWait *retryWaitBudget, requested ByteRange, resp *http.Response) (*Stream, error) {
 	if err := validateResponseEncoding(resp); err != nil {
 		resp.Body.Close()
@@ -342,19 +400,26 @@ func openPartial(ctx context.Context, source Source, opts Options, retryWait *re
 		resp.Body.Close()
 		return nil, protocolError("invalid Content-Range header on range response: %s", err)
 	}
-	if first.start != 0 {
+	if first.start != requested.Start {
 		resp.Body.Close()
-		return nil, protocolError("range response is %s, want it to start at byte 0", first)
+		return nil, protocolError("range response is %s, want it to start at byte %d", first, requested.Start)
 	}
 	if first.end > requested.End {
 		resp.Body.Close()
 		return nil, protocolError("range response is %s, outside requested %s", first, requested.HeaderValue())
 	}
 
-	session := newRepresentationSession(source, first, resp.Header)
+	session := newRepresentationSession(source, first, resp.Header, opts.ExpectedETag)
+	if err := session.observeValidator(resp.Header); err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
 	completeInFirstResponse := first.end == first.total-1
 	if !completeInFirstResponse && !session.multipartAllowed() {
 		resp.Body.Close()
+		if requested.Start > 0 {
+			return nil, resumeUnsupportedError(requested.Start)
+		}
 		return openFull(ctx, source.transport, opts, retryWait)
 	}
 
@@ -374,9 +439,10 @@ func openPartial(ctx context.Context, source Source, opts Options, retryWait *re
 		maxPartRetries: opts.MaxPartRetries,
 		retryDelay:     opts.RetryDelay,
 		retryWait:      retryWait,
+		nextOffset:     requested.Start,
 	}
 	return &Stream{
-		Body:          newExactLengthReader(body, first.total),
+		Body:          newExactLengthReader(body, first.total-requested.Start),
 		Header:        resp.Header.Clone(),
 		ContentLength: first.total,
 	}, nil

--- a/extension/download/download.go
+++ b/extension/download/download.go
@@ -341,6 +341,10 @@ func validateOptions(source Source, opts Options) error {
 	if opts.StartOffset < 0 {
 		return errs.NewInternalError(errs.SubtypeUnknown, "download start offset cannot be negative, got %d", opts.StartOffset)
 	}
+	if source.representation == Mutable && opts.StartOffset > 0 && opts.ExpectedETag == "" {
+		return errs.NewInternalError(errs.SubtypeUnknown,
+			"mutable download start offset requires a strong expected ETag")
+	}
 	if opts.DisableMultipart && opts.StartOffset > 0 {
 		return errs.NewInternalError(errs.SubtypeUnknown, "download start offset requires multipart range requests")
 	}

--- a/extension/download/download_test.go
+++ b/extension/download/download_test.go
@@ -1202,6 +1202,17 @@ func TestOpenRejectsNegativeStartOffset(t *testing.T) {
 	}
 }
 
+func TestOpenRejectsMutableResumeWithoutExpectedETag(t *testing.T) {
+	_, err := Open(context.Background(), MutableSource(unusedFetch), Options{PartSize: 4, StartOffset: 1})
+	if err == nil {
+		t.Fatal("expected mutable resume without ExpectedETag to be rejected")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("problem=%+v ok=%v, want internal/unknown validation error", problem, ok)
+	}
+}
+
 func TestOpenRejectsMultipartDisabledResume(t *testing.T) {
 	_, err := Open(context.Background(), immutableSource(func(context.Context, Request) (*http.Response, error) {
 		t.Fatal("transport must not be called when options are invalid")

--- a/extension/download/download_test.go
+++ b/extension/download/download_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"testing"
@@ -1051,5 +1052,180 @@ func TestOpenPreservesTypedReadError(t *testing.T) {
 	_, err = io.ReadAll(stream.Body)
 	if !errors.Is(err, want) {
 		t.Fatalf("ReadAll() error = %v, want preserved typed error", err)
+	}
+}
+
+func TestOpenResumeFromStartOffsetMultipart(t *testing.T) {
+	payload := bytes.Repeat([]byte("abcdefgh"), 256) // 2048 bytes
+	var requested []Request
+	source := func(_ context.Context, req Request) (*http.Response, error) {
+		requested = append(requested, req)
+		if req.Range == nil {
+			return testResponse(http.StatusOK, payload, nil), nil
+		}
+		start, end := req.Range.Start, req.Range.End
+		if start < 0 || end >= int64(len(payload)) || start > end {
+			return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "range unsupported").
+				WithCode(http.StatusRequestedRangeNotSatisfiable)
+		}
+		return testPartial(payload[start:end+1], start, end, int64(len(payload)), `"v1"`), nil
+	}
+
+	const start = int64(900)
+	stream, err := Open(context.Background(), immutableSource(source), Options{PartSize: 128, StartOffset: start})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer stream.Body.Close()
+	got, err := io.ReadAll(stream.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !bytes.Equal(got, payload[start:]) {
+		t.Fatalf("resumed content mismatch: got %d bytes, want %d", len(got), len(payload)-int(start))
+	}
+	if stream.ContentLength != int64(len(payload)) {
+		t.Fatalf("ContentLength = %d, want %d", stream.ContentLength, len(payload))
+	}
+	if len(requested) == 0 || requested[0].Range == nil || requested[0].Range.Start != start {
+		t.Fatalf("first request = %#v, want a range starting at %d", requested[0], start)
+	}
+	// remaining bytes 1148 at PartSize 128 => 9 responses (ceil(1148/128))
+	if len(requested) != 9 {
+		t.Fatalf("requests = %d, want 9", len(requested))
+	}
+}
+
+func TestOpenResumeSendsExpectedETagOnFirstRange(t *testing.T) {
+	payload := []byte("abcdefgh")
+	var requested []Request
+	stream, err := Open(context.Background(), immutableSource(func(_ context.Context, req Request) (*http.Response, error) {
+		requested = append(requested, req)
+		if req.Range == nil {
+			return testResponse(http.StatusOK, payload, nil), nil
+		}
+		end := min(req.Range.End, int64(len(payload))-1)
+		return testPartial(payload[req.Range.Start:end+1], req.Range.Start, end, int64(len(payload)), `"v1"`), nil
+	}), Options{PartSize: 4, StartOffset: 2, ExpectedETag: `"v1"`})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer stream.Body.Close()
+	if _, err := io.ReadAll(stream.Body); err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(requested) == 0 || requested[0].IfRange != `"v1"` {
+		t.Fatalf("first request = %#v, want IfRange \"v1\"", requested)
+	}
+}
+
+func TestOpenResumeRejectsExpectedETagMismatch(t *testing.T) {
+	_, err := Open(context.Background(), immutableSource(func(_ context.Context, req Request) (*http.Response, error) {
+		if req.Range == nil {
+			return testResponse(http.StatusOK, []byte("abcdefgh"), nil), nil
+		}
+		return testPartial([]byte("cdef"), 2, 5, 8, `"v2"`), nil
+	}), Options{PartSize: 4, StartOffset: 2, ExpectedETag: `"v1"`})
+	if err == nil {
+		t.Fatal("expected ETag mismatch error")
+	}
+	requireProblem(t, err, errs.SubtypeNetworkRepresentationChanged, true, "validator")
+}
+
+func TestOpenResumeCompletesInSingleResponse(t *testing.T) {
+	payload := bytes.Repeat([]byte("z"), 100)
+	source := func(_ context.Context, req Request) (*http.Response, error) {
+		if req.Range == nil {
+			return testResponse(http.StatusOK, payload, nil), nil
+		}
+		start, end := req.Range.Start, req.Range.End
+		if end >= int64(len(payload)) {
+			end = int64(len(payload)) - 1
+		}
+		return testPartial(payload[start:end+1], start, end, int64(len(payload)), `"v1"`), nil
+	}
+	const start = int64(90)
+	stream, err := Open(context.Background(), immutableSource(source), Options{PartSize: 128, StartOffset: start})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer stream.Body.Close()
+	got, err := io.ReadAll(stream.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !bytes.Equal(got, payload[start:]) {
+		t.Fatalf("got %q, want %q", got, payload[start:])
+	}
+}
+
+func TestOpenResumeRejectsWhenServerLacksRange(t *testing.T) {
+	payload := []byte("resume me")
+	_, err := Open(context.Background(), immutableSource(func(_ context.Context, req Request) (*http.Response, error) {
+		if req.Range != nil {
+			return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "range unsupported").
+				WithCode(http.StatusRequestedRangeNotSatisfiable)
+		}
+		return testResponse(http.StatusOK, payload, nil), nil
+	}), Options{PartSize: 4, StartOffset: 2})
+	if err == nil {
+		t.Fatal("expected error when server rejects Range during a resume")
+	}
+	requireProblem(t, err, errs.SubtypeNetworkProtocol, false, "cannot resume")
+}
+
+func TestOpenResumeRejectsFullResponseInsteadOfRange(t *testing.T) {
+	payload := []byte("full body")
+	_, err := Open(context.Background(), immutableSource(func(_ context.Context, req Request) (*http.Response, error) {
+		if req.Range != nil {
+			return testResponse(http.StatusOK, payload, nil), nil
+		}
+		return testResponse(http.StatusOK, payload, nil), nil
+	}), Options{PartSize: 4, StartOffset: 3})
+	if err == nil {
+		t.Fatal("expected error when server answers a resumed range request with a full 200")
+	}
+	requireProblem(t, err, errs.SubtypeNetworkProtocol, false, "cannot resume")
+}
+
+func TestOpenRejectsNegativeStartOffset(t *testing.T) {
+	_, err := Open(context.Background(), immutableSource(func(context.Context, Request) (*http.Response, error) {
+		t.Fatal("transport must not be called when options are invalid")
+		return nil, nil
+	}), Options{PartSize: 4, StartOffset: -1})
+	if err == nil {
+		t.Fatal("expected validation error for negative StartOffset")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("problem=%+v ok=%v, want internal/unknown validation error", problem, ok)
+	}
+}
+
+func TestOpenRejectsMultipartDisabledResume(t *testing.T) {
+	_, err := Open(context.Background(), immutableSource(func(context.Context, Request) (*http.Response, error) {
+		t.Fatal("transport must not be called when options are invalid")
+		return nil, nil
+	}), Options{PartSize: 4, StartOffset: 1, DisableMultipart: true})
+	if err == nil {
+		t.Fatal("expected validation error when multipart is disabled for a resume")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("problem=%+v ok=%v, want internal/unknown validation error", problem, ok)
+	}
+}
+
+func TestOpenRejectsOverflowingResumeRange(t *testing.T) {
+	_, err := Open(context.Background(), immutableSource(func(context.Context, Request) (*http.Response, error) {
+		t.Fatal("transport must not be called when options are invalid")
+		return nil, nil
+	}), Options{PartSize: 4, StartOffset: math.MaxInt64})
+	if err == nil {
+		t.Fatal("expected validation error for an overflowing resume range")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("problem=%+v ok=%v, want internal/unknown validation error", problem, ok)
 	}
 }

--- a/extension/download/probe.go
+++ b/extension/download/probe.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package download
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+// RangeProbeResult contains the representation metadata learned from a
+// one-byte range probe. TotalSize is -1 when a full-response fallback did not
+// provide a Content-Length; callers must then treat the checkpoint as
+// unverifiable.
+type RangeProbeResult struct {
+	TotalSize int64
+	ETag      string
+
+	_ struct{}
+}
+
+// ProbeRange validates a one-byte range response using the same retry and idle
+// timeout policy as Open. A 200 response is returned as a valid probe result
+// with its Content-Length, allowing callers to decide whether Range support is
+// sufficient for their operation.
+func ProbeRange(ctx context.Context, source Source, expectedETag string) (*RangeProbeResult, error) {
+	opts := (Options{PartSize: 1, ExpectedETag: expectedETag}).withDefaults()
+	if err := validateOptions(source, opts); err != nil {
+		return nil, err
+	}
+
+	retryWait := newRetryWaitBudget(opts.RetryWaitBudget)
+	requested := ByteRange{Start: 0, End: 0}
+	resp, err := fetchWithRetry(ctx, source.transport, Request{Range: &requested, IfRange: expectedETag}, opts, retryWait)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.Body == nil {
+		return nil, protocolError("range probe returned an empty response")
+	}
+	defer resp.Body.Close()
+
+	if err := validateResponseEncoding(resp); err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		parsed, err := parseContentRange(resp.Header.Get("Content-Range"))
+		if err != nil {
+			return nil, protocolError("invalid Content-Range header on range probe: %s", err)
+		}
+		if parsed.start != 0 || parsed.end != 0 {
+			return nil, protocolError("range probe returned %s, want bytes 0-0/%d", parsed, parsed.total)
+		}
+		if resp.ContentLength >= 0 && resp.ContentLength != 1 {
+			return nil, protocolError("range probe declared %d body bytes, want 1", resp.ContentLength)
+		}
+		body, err := io.ReadAll(io.LimitReader(newClassifiedBody(ctx, resp.Body), 2))
+		if err != nil {
+			return nil, err
+		}
+		if len(body) != 1 {
+			return nil, protocolError("range probe returned %d body bytes, want 1", len(body))
+		}
+		return &RangeProbeResult{
+			TotalSize: parsed.total,
+			ETag:      probeETag(resp),
+		}, nil
+	case http.StatusOK:
+		return &RangeProbeResult{
+			TotalSize: resp.ContentLength,
+			ETag:      probeETag(resp),
+		}, nil
+	default:
+		return nil, unexpectedStatus(resp.StatusCode)
+	}
+}
+
+func probeETag(resp *http.Response) string {
+	etag, ok := strongETag(resp.Header)
+	if !ok {
+		return ""
+	}
+	return etag
+}

--- a/extension/download/probe_test.go
+++ b/extension/download/probe_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package download
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func TestProbeRangeRetriesAndValidatesOneByteResponse(t *testing.T) {
+	attempts := 0
+	result, err := ProbeRange(context.Background(), MutableSource(func(_ context.Context, req Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, errs.NewNetworkError(errs.SubtypeNetworkServer, "temporary probe failure").WithRetryable()
+		}
+		if req.Range == nil || req.Range.Start != 0 || req.Range.End != 0 {
+			t.Fatalf("request = %#v, want bytes 0-0", req)
+		}
+		return testPartial([]byte("a"), 0, 0, 4, `"v1"`), nil
+	}), `"v1"`)
+	if err != nil {
+		t.Fatalf("ProbeRange() error = %v", err)
+	}
+	if attempts != 2 || result.TotalSize != 4 || result.ETag != `"v1"` {
+		t.Fatalf("result = %#v, attempts = %d", result, attempts)
+	}
+}
+
+func TestProbeRangeRejectsMalformedRangeOrBody(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *http.Response
+	}{
+		{
+			name: "wrong range",
+			resp: testResponse(http.StatusPartialContent, []byte("a"), http.Header{
+				"Content-Range": {"bytes 1-1/4"},
+				"ETag":          {`"v1"`},
+			}),
+		},
+		{
+			name: "wrong body length",
+			resp: testResponse(http.StatusPartialContent, []byte("ab"), http.Header{
+				"Content-Range": {"bytes 0-0/4"},
+				"ETag":          {`"v1"`},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ProbeRange(context.Background(), MutableSource(staticFetch(tt.resp)), `"v1"`)
+			if err == nil {
+				t.Fatal("ProbeRange() unexpectedly succeeded")
+			}
+		})
+	}
+}

--- a/extension/download/source.go
+++ b/extension/download/source.go
@@ -43,8 +43,12 @@ type representationSession struct {
 	hasValidator bool
 }
 
-func newRepresentationSession(source Source, first contentRange, header http.Header) *representationSession {
+func newRepresentationSession(source Source, first contentRange, header http.Header, expectedValidator string) *representationSession {
 	validator, hasValidator := strongETag(header)
+	if expectedValidator != "" {
+		validator = expectedValidator
+		hasValidator = true
+	}
 	return &representationSession{
 		transport:    source.transport,
 		contract:     source.representation,

--- a/extension/download/source.go
+++ b/extension/download/source.go
@@ -30,7 +30,8 @@ func ImmutableSource(transport Transport) Source {
 	return Source{transport: transport, representation: Immutable}
 }
 
-// MutableSource requires a strong ETag before combining responses.
+// MutableSource requires a strong ETag before combining responses or splicing
+// a response onto an existing local prefix.
 func MutableSource(transport Transport) Source {
 	return Source{transport: transport, representation: Mutable}
 }

--- a/extension/fileio/types.go
+++ b/extension/fileio/types.go
@@ -60,6 +60,50 @@ type ExclusiveFileIO interface {
 	SaveExclusive(path string, opts SaveOptions, body io.Reader) (SaveResult, error)
 }
 
+// AppendingFileIO is an optional extension for providers that can append to an
+// existing partial file, used by resumable downloads.
+//
+// A provider that cannot implement AppendTo must leave this interface
+// unimplemented; a caller that needs to resume an interrupted download then
+// fails fast instead of silently restarting from byte 0.
+type AppendingFileIO interface {
+	FileIO
+
+	// AppendTo opens path (creating it when missing) and streams body onto the
+	// end of the file, returning the number of bytes written. A failed write
+	// keeps the bytes already on disk so a later call can resume. AppendTo must
+	// apply the same output-path validation as Save.
+	AppendTo(path string, opts SaveOptions, body io.Reader) (SaveResult, error)
+}
+
+// ResumableFileIO is the optional complete backend for resumable downloads.
+// It owns every operation on the partial/checkpoint artifacts so callers do
+// not bypass a provider's storage namespace or path policy.
+//
+// A provider that cannot implement the full lifecycle must leave this
+// interface unimplemented. Callers using --continue then fail fast instead of
+// mixing provider operations with local filesystem calls.
+type ResumableFileIO interface {
+	AppendingFileIO
+
+	// ReadResumeArtifact reads one checkpoint or partial artifact after applying
+	// the provider's input-path policy.
+	ReadResumeArtifact(path string) ([]byte, error)
+
+	// WriteResumeArtifact atomically writes one checkpoint artifact, creating
+	// parent directories as needed and applying the provider's output policy.
+	WriteResumeArtifact(path string, data []byte) error
+
+	// RemoveResumeArtifact removes one checkpoint or partial artifact and
+	// applies the provider's output policy.
+	RemoveResumeArtifact(path string) error
+
+	// CommitResumeArtifact publishes a completed partial at targetPath. When
+	// overwrite is false, the commit must fail if targetPath already exists;
+	// when true, it replaces the target according to provider semantics.
+	CommitResumeArtifact(partialPath, targetPath string, overwrite bool) error
+}
+
 // WorkspaceFileIO is an optional extension for commands that own temporary
 // workspace entries. RemoveWorkspaceEntry must remove exactly one file or one
 // empty directory, never recursively, and must apply the same path validation

--- a/internal/vfs/localfileio/appendvalidated_unix.go
+++ b/internal/vfs/localfileio/appendvalidated_unix.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package localfileio
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+
+	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// openAppendValidated applies the same pre-open identity and regular-file
+// checks as Open. O_NOFOLLOW closes the final-component symlink race and
+// O_NONBLOCK prevents a FIFO from wedging a download before it can be rejected.
+func openAppendValidated(path string, perm os.FileMode) (*os.File, error) {
+	pre, err := vfs.Stat(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		pre = nil
+	}
+
+	f, err := vfs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, perm)
+	if err != nil {
+		return nil, err
+	}
+	if err := inspectOpenedFile(f, pre, true); err != nil {
+		_ = f.Close()
+		return nil, &fileio.PathValidationError{Err: err}
+	}
+	return f, nil
+}

--- a/internal/vfs/localfileio/appendvalidated_unix_test.go
+++ b/internal/vfs/localfileio/appendvalidated_unix_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package localfileio
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+func TestAppendToRejectsFIFOWithoutBlocking(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "partial")
+	if err := syscall.Mkfifo(path, 0600); err != nil {
+		t.Fatalf("Mkfifo() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := (&LocalFileIO{}).AppendTo(path, fileio.SaveOptions{}, neverReader{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("AppendTo() error = %v, want a prompt FIFO rejection", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AppendTo() blocked while opening a FIFO")
+	}
+}
+
+type neverReader struct{}
+
+func (neverReader) Read([]byte) (int, error) { panic("FIFO test reader must not be called") }

--- a/internal/vfs/localfileio/appendvalidated_windows.go
+++ b/internal/vfs/localfileio/appendvalidated_windows.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package localfileio
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// openAppendValidated applies the same pre-open identity and regular-file
+// checks as Open. Windows has no O_NOFOLLOW equivalent in the os package, so
+// inspectOpenedFile ties the opened handle back to the pre-open identity.
+func openAppendValidated(path string, perm os.FileMode) (*os.File, error) {
+	pre, err := vfs.Stat(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		pre = nil
+	}
+
+	f, err := vfs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+	if err != nil {
+		return nil, err
+	}
+	if err := inspectOpenedFile(f, pre); err != nil {
+		_ = f.Close()
+		return nil, &fileio.PathValidationError{Err: err}
+	}
+	return f, nil
+}

--- a/internal/vfs/localfileio/atomicwrite.go
+++ b/internal/vfs/localfileio/atomicwrite.go
@@ -34,6 +34,24 @@ func AtomicWriteFromReader(path string, reader io.Reader, perm os.FileMode) (int
 	return copied, nil
 }
 
+// AppendFromReader streams reader contents onto the end of path, creating the
+// file with perm when it does not exist. Bytes already on disk are kept on
+// failure so a resumable download can continue from the same offset. The write
+// is not atomic: callers must treat the file as a partial artifact and rename
+// it into place only after the copy completes.
+func AppendFromReader(path string, reader io.Reader, perm os.FileMode) (int64, error) {
+	//nolint:forbidigo // this is the local-file implementation of fileio; the path was already validated by SafeOutputPath in AppendTo
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+	if err != nil {
+		return 0, err
+	}
+	n, err := io.Copy(f, reader)
+	if closeErr := f.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	return n, err
+}
+
 // ExclusiveWriteFromReader copies reader contents into path only when path does
 // not already exist, and reports an error satisfying errors.Is(err, fs.ErrExist)
 // when it does.

--- a/internal/vfs/localfileio/atomicwrite.go
+++ b/internal/vfs/localfileio/atomicwrite.go
@@ -40,8 +40,7 @@ func AtomicWriteFromReader(path string, reader io.Reader, perm os.FileMode) (int
 // is not atomic: callers must treat the file as a partial artifact and rename
 // it into place only after the copy completes.
 func AppendFromReader(path string, reader io.Reader, perm os.FileMode) (int64, error) {
-	//nolint:forbidigo // this is the local-file implementation of fileio; the path was already validated by SafeOutputPath in AppendTo
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, perm)
+	f, err := openAppendValidated(path, perm)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/vfs/localfileio/localfileio.go
+++ b/internal/vfs/localfileio/localfileio.go
@@ -116,3 +116,88 @@ func (l *LocalFileIO) RemoveWorkspaceEntry(path string) error {
 	}
 	return vfs.Remove(safePath)
 }
+
+var _ fileio.ResumableFileIO = (*LocalFileIO)(nil)
+
+// AppendTo opens path (creating it when missing) and streams body onto the end
+// of the file, returning the number of bytes written. Bytes already on disk are
+// kept on failure so a resumable download can continue from the same offset.
+func (l *LocalFileIO) AppendTo(path string, _ fileio.SaveOptions, body io.Reader) (fileio.SaveResult, error) {
+	safePath, err := SafeOutputPath(path)
+	if err != nil {
+		return nil, &fileio.PathValidationError{Err: err}
+	}
+	if err := vfs.MkdirAll(filepath.Dir(safePath), 0700); err != nil {
+		return nil, &fileio.MkdirError{Err: err}
+	}
+	n, err := AppendFromReader(safePath, body, 0600)
+	if err != nil {
+		return nil, &fileio.WriteError{Err: err}
+	}
+	return &saveResult{size: n}, nil
+}
+
+// ReadResumeArtifact reads one resumable-download artifact after validating
+// it as a local input path.
+func (l *LocalFileIO) ReadResumeArtifact(path string) ([]byte, error) {
+	safePath, err := SafeInputPath(path)
+	if err != nil {
+		return nil, &fileio.PathValidationError{Err: err}
+	}
+	return vfs.ReadFile(safePath)
+}
+
+// WriteResumeArtifact atomically writes one resumable-download artifact after
+// validating it as a local output path.
+func (l *LocalFileIO) WriteResumeArtifact(path string, data []byte) error {
+	safePath, err := SafeOutputPath(path)
+	if err != nil {
+		return &fileio.PathValidationError{Err: err}
+	}
+	if err := vfs.MkdirAll(filepath.Dir(safePath), 0700); err != nil {
+		return &fileio.MkdirError{Err: err}
+	}
+	if err := AtomicWrite(safePath, data, 0600); err != nil {
+		return &fileio.WriteError{Err: err}
+	}
+	return nil
+}
+
+// RemoveResumeArtifact removes one resumable-download artifact after applying
+// the same output-path policy as Save.
+func (l *LocalFileIO) RemoveResumeArtifact(path string) error {
+	safePath, err := SafeOutputPath(path)
+	if err != nil {
+		return &fileio.PathValidationError{Err: err}
+	}
+	return vfs.Remove(safePath)
+}
+
+// CommitResumeArtifact publishes a completed partial file. A no-overwrite
+// commit uses a hard link followed by removal of the partial, so an existing
+// target cannot be replaced by a race. Overwrite commits remove the target
+// first because os.Rename cannot replace an existing file on every supported
+// platform.
+func (l *LocalFileIO) CommitResumeArtifact(partialPath, targetPath string, overwrite bool) error {
+	safePartial, err := SafeOutputPath(partialPath)
+	if err != nil {
+		return &fileio.PathValidationError{Err: err}
+	}
+	safeTarget, err := SafeOutputPath(targetPath)
+	if err != nil {
+		return &fileio.PathValidationError{Err: err}
+	}
+	if !overwrite {
+		if err := vfs.Link(safePartial, safeTarget); err != nil {
+			return err
+		}
+		if err := vfs.Remove(safePartial); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := vfs.Remove(safeTarget); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return vfs.Rename(safePartial, safeTarget)
+}

--- a/internal/vfs/localfileio/localfileio.go
+++ b/internal/vfs/localfileio/localfileio.go
@@ -175,9 +175,8 @@ func (l *LocalFileIO) RemoveResumeArtifact(path string) error {
 
 // CommitResumeArtifact publishes a completed partial file. A no-overwrite
 // commit uses a hard link followed by removal of the partial, so an existing
-// target cannot be replaced by a race. Overwrite commits remove the target
-// first because os.Rename cannot replace an existing file on every supported
-// platform.
+// target cannot be replaced by a race. Overwrite commits use the platform's
+// replace operation so a failed replacement does not delete the old target.
 func (l *LocalFileIO) CommitResumeArtifact(partialPath, targetPath string, overwrite bool) error {
 	safePartial, err := SafeOutputPath(partialPath)
 	if err != nil {
@@ -196,8 +195,5 @@ func (l *LocalFileIO) CommitResumeArtifact(partialPath, targetPath string, overw
 		}
 		return nil
 	}
-	if err := vfs.Remove(safeTarget); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-	return vfs.Rename(safePartial, safeTarget)
+	return replaceResumeArtifact(safePartial, safeTarget)
 }

--- a/internal/vfs/localfileio/localfileio_test.go
+++ b/internal/vfs/localfileio/localfileio_test.go
@@ -481,6 +481,20 @@ func TestLocalFileIO_ResumableArtifactsAndCommit(t *testing.T) {
 	if string(got) != "replacement" {
 		t.Fatalf("overwritten content = %q, want replacement", got)
 	}
+
+	if err := os.WriteFile("out.bin", []byte("keep"), 0600); err != nil {
+		t.Fatalf("WriteFile(keep) error = %v", err)
+	}
+	if err := fio.CommitResumeArtifact("missing.bin.partial", "out.bin", true); err == nil {
+		t.Fatal("CommitResumeArtifact() unexpectedly succeeded with a missing partial")
+	}
+	got, err = os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile(after failed overwrite) error = %v", err)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("target after failed overwrite = %q, want keep", got)
+	}
 }
 
 // prefixErrReader yields prefix bytes first, then reports err.

--- a/internal/vfs/localfileio/localfileio_test.go
+++ b/internal/vfs/localfileio/localfileio_test.go
@@ -6,12 +6,14 @@ package localfileio
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/vfs"
 )
 
 // testChdir temporarily changes the working directory for a test.
@@ -352,4 +354,150 @@ func TestLocalFileIO_RejectsControlCharsInPath(t *testing.T) {
 			t.Errorf("Save(%q) should reject control/dangerous chars", p)
 		}
 	}
+}
+
+func TestAppendToCreatesAndAppends(t *testing.T) {
+	io := &LocalFileIO{}
+	dir := t.TempDir()
+	testChdir(t, dir)
+	p := "partial.bin"
+
+	res, err := io.AppendTo(p, fileio.SaveOptions{}, strings.NewReader("hello "))
+	if err != nil {
+		t.Fatalf("AppendTo() error = %v", err)
+	}
+	if res.Size() != 6 {
+		t.Fatalf("first append size = %d, want 6", res.Size())
+	}
+	res, err = io.AppendTo(p, fileio.SaveOptions{}, strings.NewReader("world"))
+	if err != nil {
+		t.Fatalf("AppendTo() error = %v", err)
+	}
+	if res.Size() != 5 {
+		t.Fatalf("second append size = %d, want 5", res.Size())
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("content = %q, want %q", got, "hello world")
+	}
+}
+
+func TestAppendToRejectsUnsafePath(t *testing.T) {
+	io := &LocalFileIO{}
+	_, err := io.AppendTo("/absolute/unsafe", fileio.SaveOptions{}, strings.NewReader("x"))
+	if err == nil {
+		t.Fatal("expected unsafe path error")
+	}
+	var pathErr *fileio.PathValidationError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("error = %T %v, want *fileio.PathValidationError", err, err)
+	}
+	if pathErr.Err == nil || !errors.Is(pathErr.Err, fs.ErrPermission) && pathErr.Err.Error() == "" {
+		t.Fatalf("path validation error lacks a wrapped cause: %+v", pathErr)
+	}
+}
+
+// TestAppendToKeepsWrittenBytesOnFailure verifies that a reader which fails
+// mid-stream leaves the bytes it already wrote on disk, so a resumable
+// download can continue from the same offset on the next attempt.
+func TestAppendToKeepsWrittenBytesOnFailure(t *testing.T) {
+	io := &LocalFileIO{}
+	dir := t.TempDir()
+	testChdir(t, dir)
+	p := "partial.bin"
+	boom := errors.New("boom")
+	body := &prefixErrReader{prefix: strings.NewReader("persisted-"), err: boom}
+	_, err := io.AppendTo(p, fileio.SaveOptions{}, body)
+	if err == nil {
+		t.Fatal("expected append error")
+	}
+	var writeErr *fileio.WriteError
+	if !errors.As(err, &writeErr) {
+		t.Fatalf("error = %T %v, want *fileio.WriteError", err, err)
+	}
+	if !errors.Is(writeErr.Err, boom) {
+		t.Fatalf("WriteError.Err = %v, want the underlying reader error to be preserved", writeErr.Err)
+	}
+	got, rerr := vfs.ReadFile(p)
+	if rerr != nil {
+		t.Fatalf("ReadFile() error = %v", rerr)
+	}
+	if string(got) != "persisted-" {
+		t.Fatalf("content = %q, want the prefix written before the failure", got)
+	}
+}
+
+func TestLocalFileIO_ResumableArtifactsAndCommit(t *testing.T) {
+	dir := t.TempDir()
+	testChdir(t, dir)
+
+	fio := &LocalFileIO{}
+	if err := fio.WriteResumeArtifact("out.bin.partial.meta", []byte(`{"size":5,"etag":"\"v1\""}`)); err != nil {
+		t.Fatalf("WriteResumeArtifact() error = %v", err)
+	}
+	data, err := fio.ReadResumeArtifact("out.bin.partial.meta")
+	if err != nil {
+		t.Fatalf("ReadResumeArtifact() error = %v", err)
+	}
+	if string(data) != `{"size":5,"etag":"\"v1\""}` {
+		t.Fatalf("checkpoint = %q", data)
+	}
+	if _, err := fio.AppendTo("out.bin.partial", fileio.SaveOptions{}, strings.NewReader("new")); err != nil {
+		t.Fatalf("AppendTo() error = %v", err)
+	}
+	if err := fio.CommitResumeArtifact("out.bin.partial", "out.bin", false); err != nil {
+		t.Fatalf("CommitResumeArtifact() error = %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("committed content = %q, want new", got)
+	}
+	if _, err := os.Stat("out.bin.partial"); !os.IsNotExist(err) {
+		t.Fatalf("partial still exists after commit: %v", err)
+	}
+	if err := fio.RemoveResumeArtifact("out.bin.partial.meta"); err != nil {
+		t.Fatalf("RemoveResumeArtifact() error = %v", err)
+	}
+
+	if _, err := fio.AppendTo("out.bin.partial", fileio.SaveOptions{}, strings.NewReader("replacement")); err != nil {
+		t.Fatalf("AppendTo(replacement) error = %v", err)
+	}
+	if err := fio.CommitResumeArtifact("out.bin.partial", "out.bin", false); !errors.Is(err, fs.ErrExist) {
+		t.Fatalf("no-overwrite commit error = %v, want fs.ErrExist", err)
+	}
+	if err := fio.CommitResumeArtifact("out.bin.partial", "out.bin", true); err != nil {
+		t.Fatalf("overwrite commit error = %v", err)
+	}
+	got, err = os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile(overwrite) error = %v", err)
+	}
+	if string(got) != "replacement" {
+		t.Fatalf("overwritten content = %q, want replacement", got)
+	}
+}
+
+// prefixErrReader yields prefix bytes first, then reports err.
+type prefixErrReader struct {
+	prefix io.Reader
+	err    error
+}
+
+// Read yields the prefix bytes first and then reports the configured error.
+func (r *prefixErrReader) Read(b []byte) (int, error) {
+	if r.prefix != nil {
+		n, err := r.prefix.Read(b)
+		if err == io.EOF {
+			r.prefix = nil
+			return n, nil
+		}
+		return n, err
+	}
+	return 0, r.err
 }

--- a/internal/vfs/localfileio/replace_unix.go
+++ b/internal/vfs/localfileio/replace_unix.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package localfileio
+
+import "github.com/larksuite/cli/internal/vfs"
+
+// replaceResumeArtifact uses rename's atomic replacement semantics on Unix.
+func replaceResumeArtifact(partialPath, targetPath string) error {
+	return vfs.Rename(partialPath, targetPath)
+}

--- a/internal/vfs/localfileio/replace_windows.go
+++ b/internal/vfs/localfileio/replace_windows.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package localfileio
+
+import "golang.org/x/sys/windows"
+
+// replaceResumeArtifact uses MoveFileEx(REPLACE_EXISTING), which keeps the
+// existing target in place when the replacement cannot be completed.
+func replaceResumeArtifact(partialPath, targetPath string) error {
+	return windows.Rename(partialPath, targetPath)
+}

--- a/shortcuts/common/drive_permission_auth.go
+++ b/shortcuts/common/drive_permission_auth.go
@@ -17,6 +17,7 @@ const (
 
 	drivePermissionResourceTypeFile = "file"
 	drivePermissionActionExport     = "export"
+	drivePermissionActionView       = "view"
 )
 
 type drivePermissionMemberAuthResponse struct {
@@ -27,12 +28,30 @@ type drivePermissionMemberAuthResponse struct {
 // can export one Drive file. It never switches identity and does not treat a
 // malformed success response as a denial.
 func CheckDriveFileExportPermission(runtime *RuntimeContext, token string) (bool, error) {
+	return checkDriveFilePermission(runtime, token, drivePermissionActionExport)
+}
+
+// CheckDriveFileViewPermission checks whether the runtime's current identity
+// can view one Drive file.
+//
+// It is the correct preflight for a file download: the members/auth API only
+// reports meaningful results for actions the resource type actually supports.
+// For plain uploaded files (type=file) the export action always answers false,
+// which would wrongly block every download, while view correctly reflects
+// whether the download endpoint will accept the caller.
+func CheckDriveFileViewPermission(runtime *RuntimeContext, token string) (bool, error) {
+	return checkDriveFilePermission(runtime, token, drivePermissionActionView)
+}
+
+// checkDriveFilePermission asks the Drive permission auth API whether the
+// current identity holds action on the file identified by token.
+func checkDriveFilePermission(runtime *RuntimeContext, token, action string) (bool, error) {
 	data, err := runtime.CallAPITyped(
 		http.MethodGet,
 		drivePermissionMemberAuthPath(token),
 		map[string]interface{}{
 			"type":   drivePermissionResourceTypeFile,
-			"action": drivePermissionActionExport,
+			"action": action,
 		},
 		nil,
 	)
@@ -73,6 +92,19 @@ func AddDriveFileExportPermissionDryRun(plan *DryRunAPI, token, desc string) *Dr
 		Params(map[string]interface{}{
 			"type":   drivePermissionResourceTypeFile,
 			"action": drivePermissionActionExport,
+		}).
+		Desc(desc)
+}
+
+// AddDriveFileViewPermissionDryRun appends the view-permission check used by
+// the real drive download flow so dry-run output preserves request order and
+// parameters.
+func AddDriveFileViewPermissionDryRun(plan *DryRunAPI, token, desc string) *DryRunAPI {
+	return plan.
+		GET(drivePermissionMemberAuthPath(token)).
+		Params(map[string]interface{}{
+			"type":   drivePermissionResourceTypeFile,
+			"action": drivePermissionActionView,
 		}).
 		Desc(desc)
 }

--- a/shortcuts/drive/drive_download.go
+++ b/shortcuts/drive/drive_download.go
@@ -12,7 +12,6 @@ import (
 	"io/fs"
 	"net/http"
 	"path"
-	"strconv"
 	"strings"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -335,7 +334,7 @@ var DriveDownload = common.Shortcut{
 							return driveDownloadResumeArtifactError("discard unverifiable partial", cleanupErr)
 						}
 					} else {
-						probeTotal, probeETag, probeErr := driveDownloadProbeTotal(ctx, transport, checkpointETag)
+						probe, probeErr := extdownload.ProbeRange(ctx, dlSource, checkpointETag)
 						if probeErr != nil && driveDownloadRangeProbeRejected(probeErr) {
 							if cleanupErr := driveDownloadDiscardResume(resumeIO, partialPath, checkpointPath); cleanupErr != nil {
 								return driveDownloadResumeArtifactError("discard partial after unsupported Range", cleanupErr)
@@ -343,6 +342,7 @@ var DriveDownload = common.Shortcut{
 						} else if probeErr != nil {
 							return withDriveDownloadRecoveryHint(wrapDriveNetworkErr(probeErr, "resume probe failed: %s", probeErr), fileToken)
 						} else {
+							probeTotal, probeETag := probe.TotalSize, probe.ETag
 							checkpointValid := checkpoint.Size == probeTotal && probeETag != "" && probeETag == checkpointETag
 							switch {
 							case !checkpointValid || localSize > probeTotal:
@@ -468,12 +468,26 @@ var DriveDownload = common.Shortcut{
 			ContentLength: appendLength,
 		}, progress)
 		if copyErr != nil {
-			return withDriveDownloadRecoveryHint(wrapDriveNetworkErr(copyErr, "download failed: %s", copyErr), fileToken)
+			return withDriveDownloadRecoveryHint(driveAppendError(copyErr), fileToken)
 		}
 		written := result.Size()
 		if stream.ContentLength > 0 && written != stream.ContentLength-startOffset {
 			return errs.NewNetworkError(errs.SubtypeNetworkProtocol,
 				"download size mismatch: got %d of %d bytes", written+startOffset, stream.ContentLength)
+		}
+		partialInfo, partialStatErr := runtime.FileIO().Stat(partialPath)
+		if partialStatErr != nil {
+			return errs.NewInternalError(errs.SubtypeFileIO, "inspect completed resume partial: %s", partialStatErr).
+				WithCause(partialStatErr)
+		}
+		finalPartialSize := partialInfo.Size()
+		if finalPartialSize != startOffset+written {
+			return errs.NewInternalError(errs.SubtypeFileIO,
+				"resume partial size changed during append: got %d, want %d", finalPartialSize, startOffset+written)
+		}
+		if stream.ContentLength > 0 && finalPartialSize != stream.ContentLength {
+			return errs.NewNetworkError(errs.SubtypeNetworkProtocol,
+				"download size mismatch after append: got %d of %d bytes", finalPartialSize, stream.ContentLength)
 		}
 
 		if err := resumeIO.CommitResumeArtifact(partialPath, outputPath, overwrite); err != nil {
@@ -485,40 +499,11 @@ var DriveDownload = common.Shortcut{
 		savedPath, _ := runtime.ResolveSavePath(outputPath)
 		runtime.Out(annotateDriveFileWikiOutput(map[string]interface{}{
 			"saved_path": savedPath,
-			"size_bytes": written + startOffset,
+			"size_bytes": finalPartialSize,
 			"resumed":    startOffset > 0,
 		}, wikiResolution), nil)
 		return nil
 	},
-}
-
-// driveDownloadProbeTotal issues a one-byte range request and returns the
-// remote total size (or -1 when it cannot be determined) together with the
-// response's strong ETag. It is only used to validate a --continue checkpoint
-// before resuming.
-func driveDownloadProbeTotal(ctx context.Context, transport extdownload.Transport, ifRange string) (int64, string, error) {
-	probe := extdownload.ByteRange{Start: 0, End: 0}
-	resp, err := transport(ctx, extdownload.Request{Range: &probe, IfRange: ifRange})
-	if err != nil {
-		return -1, "", err
-	}
-	if resp == nil || resp.Body == nil {
-		return -1, "", errs.NewNetworkError(errs.SubtypeNetworkProtocol, "resume probe returned an empty response")
-	}
-	defer resp.Body.Close()
-	switch resp.StatusCode {
-	case http.StatusPartialContent:
-		total := driveDownloadParseRangeTotal(resp.Header.Get("Content-Range"))
-		if total < 0 {
-			return -1, "", errs.NewNetworkError(errs.SubtypeNetworkProtocol, "resume probe returned an invalid Content-Range")
-		}
-		return total, driveDownloadStrongETag(resp.Header.Get("ETag")), nil
-	case http.StatusOK:
-		return resp.ContentLength, driveDownloadStrongETag(resp.Header.Get("ETag")), nil
-	default:
-		return -1, "", errs.NewNetworkError(errs.SubtypeNetworkProtocol,
-			"resume probe returned HTTP %d", resp.StatusCode).WithCode(resp.StatusCode)
-	}
 }
 
 // driveDownloadCheckpoint ties a <output>.partial file to the remote
@@ -639,20 +624,6 @@ func driveDownloadShouldRestartResume(err error) bool {
 	}
 	problem, ok := errs.ProblemOf(err)
 	return ok && problem.Subtype == errs.SubtypeNetworkRepresentationChanged
-}
-
-// driveDownloadParseRangeTotal extracts the total size from a
-// "bytes start-end/total" Content-Range header, or -1 when malformed.
-func driveDownloadParseRangeTotal(contentRange string) int64 {
-	idx := strings.LastIndexByte(contentRange, '/')
-	if idx < 0 {
-		return -1
-	}
-	total, err := strconv.ParseInt(contentRange[idx+1:], 10, 64)
-	if err != nil {
-		return -1
-	}
-	return total
 }
 
 // driveDownloadProgressReader wraps a download body reader and prints coarse

--- a/shortcuts/drive/drive_download.go
+++ b/shortcuts/drive/drive_download.go
@@ -5,22 +5,36 @@ package drive
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
 	"github.com/larksuite/cli/errs"
+	extdownload "github.com/larksuite/cli/extension/download"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/downloadtransport"
 	"github.com/larksuite/cli/internal/output"
-	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
 const driveMetadataReadScope = "drive:drive.metadata:readonly"
+
+// driveDownloadPartSize bounds each ranged request of a drive download. 64 MiB
+// keeps per-request overhead low for multi-GB files while staying far below the
+// stream lifetime observed on the drive download endpoint, so a failed part is
+// cheap to replay.
+const driveDownloadPartSize int64 = 64 << 20
+
+// driveDownloadProgressEvery reports transfer progress every 64 MiB.
+const driveDownloadProgressEvery int64 = 64 << 20
 
 type driveDownloadOutputPathValidator func(string) error
 
@@ -140,6 +154,7 @@ var DriveDownload = common.Shortcut{
 		{Name: "wiki-token", Desc: "wiki node token wrapping an uploaded file (resolved to the underlying file token)"},
 		{Name: "output", Desc: "local save path"},
 		{Name: "overwrite", Type: "bool", Desc: "overwrite existing output file"},
+		{Name: "continue", Type: "bool", Desc: "resume an interrupted download from <output>.partial; the partial file is kept on failure for a later --continue"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		source, err := normalizeDriveFileSource(runtime.Str("file-token"), runtime.Str("url"), runtime.Str("wiki-token"))
@@ -154,6 +169,9 @@ var DriveDownload = common.Shortcut{
 
 		outputPath := runtime.Str("output")
 		if outputPath == "" {
+			if runtime.Bool("continue") {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--continue requires an explicit --output path (the partial file lives next to it)").WithParam("--continue")
+			}
 			return runtime.EnsureScopes([]string{driveMetadataReadScope})
 		}
 		if _, resolveErr := runtime.ResolveSavePath(outputPath); resolveErr != nil {
@@ -181,10 +199,10 @@ var DriveDownload = common.Shortcut{
 			step++
 		}
 
-		common.AddDriveFileExportPermissionDryRun(
+		common.AddDriveFileViewPermissionDryRun(
 			plan,
 			fileToken,
-			fmt.Sprintf("[%d] Check whether the current identity can export the Drive file", step),
+			fmt.Sprintf("[%d] Check whether the current identity can view the Drive file", step),
 		)
 		step++
 
@@ -233,18 +251,15 @@ var DriveDownload = common.Shortcut{
 
 		// Early path validation + overwrite check
 		if outputPath != "" {
-			if _, resolveErr := runtime.ResolveSavePath(outputPath); resolveErr != nil {
-				return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe output path: %s", resolveErr).WithParam("--output")
-			}
-			if _, statErr := runtime.FileIO().Stat(outputPath); statErr == nil && !overwrite {
-				return errs.NewValidationError(errs.SubtypeInvalidArgument, "output file already exists: %s (use --overwrite to replace)", outputPath).WithParam("--output")
+			if err := driveDownloadEnsureOutputAbsent(runtime, outputPath, overwrite); err != nil {
+				return err
 			}
 		}
 
-		allowed, err := common.CheckDriveFileExportPermission(runtime, fileToken)
+		allowed, err := common.CheckDriveFileViewPermission(runtime, fileToken)
 		if err != nil {
 			if driveDownloadIsPermissionAuthScopeError(err) {
-				fmt.Fprintf(runtime.IO().ErrOut, "warning: export permission check failed; continuing with download: %v\n", err)
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: view permission check failed; continuing with download: %v\n", err)
 			} else {
 				return withDriveDownloadRecoveryHint(err, fileToken)
 			}
@@ -268,18 +283,136 @@ var DriveDownload = common.Shortcut{
 			}
 		}
 
-		resp, err := runtime.DoAPIStream(ctx, &larkcore.ApiReq{
-			HttpMethod: http.MethodGet,
-			ApiPath:    fmt.Sprintf("/open-apis/drive/v1/files/%s/download", validate.EncodePathSegment(fileToken)),
-		})
+		// Resumable, chunked download. The drive download API honors HTTP
+		// Range (206), so long transfers are split into bounded parts with
+		// per-part retries, and --continue can resume from an existing
+		// <output>.partial instead of restarting from byte 0.
+		transport := downloadtransport.NewOAPI(runtime.DoAPIStream).Get(
+			"/open-apis/drive/v1/files/:file_token/download",
+			downloadtransport.PathParam("file_token", fileToken),
+		)
+		dlSource := extdownload.MutableSource(transport)
+
+		cont := runtime.Bool("continue")
+		var resumeIO fileio.ResumableFileIO
+		if cont {
+			var ok bool
+			resumeIO, ok = runtime.FileIO().(fileio.ResumableFileIO)
+			if !ok {
+				return errs.NewInternalError(errs.SubtypeFileIO, "file backend does not support --continue downloads").
+					WithHint("configure a resumable file backend or omit --continue")
+			}
+		}
+
+		var startOffset int64
+		var resumeSize int64
+		var resumeETag string
+		var partialPath string
+		var checkpointPath string
+		if cont {
+			var resolveErr error
+			_, partialPath, checkpointPath, resolveErr = driveDownloadPaths(runtime, outputPath)
+			if resolveErr != nil {
+				return resolveErr
+			}
+		}
+
+		if cont {
+			fi, statErr := runtime.FileIO().Stat(partialPath)
+			if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
+				return errs.NewInternalError(errs.SubtypeFileIO, "inspect resume partial: %s", statErr).WithCause(statErr)
+			}
+			if statErr == nil {
+				localSize := fi.Size()
+				if localSize > 0 {
+					checkpoint, checkpointErr := driveDownloadReadCheckpoint(resumeIO, checkpointPath)
+					checkpointETag := ""
+					if checkpoint != nil {
+						checkpointETag = driveDownloadStrongETag(checkpoint.ETag)
+					}
+					if checkpointErr != nil || checkpoint == nil || checkpoint.Size <= 0 || checkpointETag == "" {
+						if cleanupErr := driveDownloadDiscardResume(resumeIO, partialPath, checkpointPath); cleanupErr != nil {
+							return driveDownloadResumeArtifactError("discard unverifiable partial", cleanupErr)
+						}
+					} else {
+						probeTotal, probeETag, probeErr := driveDownloadProbeTotal(ctx, transport, checkpointETag)
+						if probeErr != nil && driveDownloadRangeProbeRejected(probeErr) {
+							if cleanupErr := driveDownloadDiscardResume(resumeIO, partialPath, checkpointPath); cleanupErr != nil {
+								return driveDownloadResumeArtifactError("discard partial after unsupported Range", cleanupErr)
+							}
+						} else if probeErr != nil {
+							return withDriveDownloadRecoveryHint(wrapDriveNetworkErr(probeErr, "resume probe failed: %s", probeErr), fileToken)
+						} else {
+							checkpointValid := checkpoint.Size == probeTotal && probeETag != "" && probeETag == checkpointETag
+							switch {
+							case !checkpointValid || localSize > probeTotal:
+								if cleanupErr := driveDownloadDiscardResume(resumeIO, partialPath, checkpointPath); cleanupErr != nil {
+									return driveDownloadResumeArtifactError("discard stale partial", cleanupErr)
+								}
+							case localSize == probeTotal:
+								if err := driveDownloadEnsureOutputAbsent(runtime, outputPath, overwrite); err != nil {
+									return err
+								}
+								if err := resumeIO.CommitResumeArtifact(partialPath, outputPath, overwrite); err != nil {
+									return driveDownloadCommitError(err, outputPath, overwrite)
+								}
+								if cleanupErr := driveDownloadDiscardResume(resumeIO, "", checkpointPath); cleanupErr != nil {
+									fmt.Fprintf(runtime.IO().ErrOut, "warning: committed download but could not remove resume checkpoint: %v\n", cleanupErr)
+								}
+								savedPath, _ := runtime.ResolveSavePath(outputPath)
+								runtime.Out(annotateDriveFileWikiOutput(map[string]interface{}{
+									"saved_path": savedPath,
+									"size_bytes": localSize,
+									"resumed":    true,
+								}, wikiResolution), nil)
+								return nil
+							default:
+								startOffset = localSize
+								resumeSize = checkpoint.Size
+								resumeETag = checkpointETag
+							}
+						}
+					}
+				} else if cleanupErr := driveDownloadDiscardResume(resumeIO, partialPath, checkpointPath); cleanupErr != nil {
+					return driveDownloadResumeArtifactError("discard empty partial", cleanupErr)
+				}
+			}
+		}
+
+		openStream := func(offset int64, etag string) (*extdownload.Stream, error) {
+			return extdownload.Open(ctx, dlSource, extdownload.Options{
+				PartSize:     driveDownloadPartSize,
+				StartOffset:  offset,
+				ExpectedETag: etag,
+			})
+		}
+		stream, err := openStream(startOffset, resumeETag)
+		if err != nil && cont && startOffset > 0 && driveDownloadShouldRestartResume(err) {
+			if cleanupErr := driveDownloadDiscardResume(resumeIO, partialPath, checkpointPath); cleanupErr != nil {
+				return driveDownloadResumeArtifactError("discard partial before full restart", cleanupErr)
+			}
+			startOffset, resumeSize, resumeETag = 0, 0, ""
+			stream, err = openStream(0, "")
+		}
 		if err != nil {
 			return withDriveDownloadRecoveryHint(wrapDriveNetworkErr(err, "download failed: %s", err), fileToken)
 		}
-		defer resp.Body.Close()
+		if cont && startOffset > 0 && stream.ContentLength != resumeSize {
+			stream.Body.Close()
+			if cleanupErr := driveDownloadDiscardResume(resumeIO, partialPath, checkpointPath); cleanupErr != nil {
+				return driveDownloadResumeArtifactError("discard partial after size change", cleanupErr)
+			}
+			startOffset, resumeSize, resumeETag = 0, 0, ""
+			stream, err = openStream(0, "")
+			if err != nil {
+				return withDriveDownloadRecoveryHint(wrapDriveNetworkErr(err, "download failed: %s", err), fileToken)
+			}
+		}
+		defer stream.Body.Close()
 
 		if outputPath == "" {
 			var resolveErr error
-			outputPath, resolveErr = driveDownloadDefaultOutputPath(resp.Header, metadataTitle, fileToken, func(path string) error {
+			outputPath, resolveErr = driveDownloadDefaultOutputPath(stream.Header, metadataTitle, fileToken, func(path string) error {
 				_, err := runtime.ResolveSavePath(path)
 				return err
 			})
@@ -287,26 +420,262 @@ var DriveDownload = common.Shortcut{
 				return errs.NewInternalError(errs.SubtypeFileIO, "cannot derive a safe default output path: %s", resolveErr).WithCause(resolveErr)
 			}
 		}
-		if _, statErr := runtime.FileIO().Stat(outputPath); statErr == nil && !overwrite {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "output file already exists: %s (use --overwrite to replace)", outputPath).WithParam("--output")
+		if err := driveDownloadEnsureOutputAbsent(runtime, outputPath, overwrite); err != nil {
+			return err
 		}
 
-		result, err := runtime.FileIO().Save(outputPath, fileio.SaveOptions{
-			ContentType:   resp.Header.Get("Content-Type"),
-			ContentLength: resp.ContentLength,
-		}, resp.Body)
-		if err != nil {
-			return driveSaveError(err)
+		progress := &driveDownloadProgressReader{
+			r:       stream.Body,
+			total:   stream.ContentLength,
+			written: startOffset,
+			out:     runtime.IO().ErrOut,
 		}
 
+		if !cont {
+			result, saveErr := runtime.FileIO().Save(outputPath, fileio.SaveOptions{
+				ContentType:   stream.Header.Get("Content-Type"),
+				ContentLength: stream.ContentLength,
+			}, progress)
+			if saveErr != nil {
+				return driveSaveError(saveErr)
+			}
+			written := result.Size()
+			if stream.ContentLength > 0 && written != stream.ContentLength {
+				return errs.NewNetworkError(errs.SubtypeNetworkProtocol,
+					"download size mismatch: got %d of %d bytes", written, stream.ContentLength)
+			}
+			savedPath, _ := runtime.ResolveSavePath(outputPath)
+			runtime.Out(annotateDriveFileWikiOutput(map[string]interface{}{
+				"saved_path": savedPath,
+				"size_bytes": written,
+				"resumed":    false,
+			}, wikiResolution), nil)
+			return nil
+		}
+
+		// The checkpoint is written before the append so a failed stream leaves
+		// enough remote identity for the next --continue attempt to validate the
+		// bytes already kept in the partial file.
+		if cpErr := driveDownloadWriteCheckpoint(resumeIO, checkpointPath, stream.ContentLength, driveDownloadStrongETag(stream.Header.Get("ETag"))); cpErr != nil {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: could not write resume checkpoint: %v\n", cpErr)
+		}
+		appendLength := stream.ContentLength
+		if appendLength >= 0 {
+			appendLength -= startOffset
+		}
+		result, copyErr := resumeIO.AppendTo(partialPath, fileio.SaveOptions{
+			ContentType:   stream.Header.Get("Content-Type"),
+			ContentLength: appendLength,
+		}, progress)
+		if copyErr != nil {
+			return withDriveDownloadRecoveryHint(wrapDriveNetworkErr(copyErr, "download failed: %s", copyErr), fileToken)
+		}
+		written := result.Size()
+		if stream.ContentLength > 0 && written != stream.ContentLength-startOffset {
+			return errs.NewNetworkError(errs.SubtypeNetworkProtocol,
+				"download size mismatch: got %d of %d bytes", written+startOffset, stream.ContentLength)
+		}
+
+		if err := resumeIO.CommitResumeArtifact(partialPath, outputPath, overwrite); err != nil {
+			return driveDownloadCommitError(err, outputPath, overwrite)
+		}
+		if cleanupErr := driveDownloadDiscardResume(resumeIO, "", checkpointPath); cleanupErr != nil {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: committed download but could not remove resume checkpoint: %v\n", cleanupErr)
+		}
 		savedPath, _ := runtime.ResolveSavePath(outputPath)
-		if savedPath == "" {
-			savedPath = outputPath
-		}
 		runtime.Out(annotateDriveFileWikiOutput(map[string]interface{}{
 			"saved_path": savedPath,
-			"size_bytes": result.Size(),
+			"size_bytes": written + startOffset,
+			"resumed":    startOffset > 0,
 		}, wikiResolution), nil)
 		return nil
 	},
+}
+
+// driveDownloadProbeTotal issues a one-byte range request and returns the
+// remote total size (or -1 when it cannot be determined) together with the
+// response's strong ETag. It is only used to validate a --continue checkpoint
+// before resuming.
+func driveDownloadProbeTotal(ctx context.Context, transport extdownload.Transport, ifRange string) (int64, string, error) {
+	probe := extdownload.ByteRange{Start: 0, End: 0}
+	resp, err := transport(ctx, extdownload.Request{Range: &probe, IfRange: ifRange})
+	if err != nil {
+		return -1, "", err
+	}
+	if resp == nil || resp.Body == nil {
+		return -1, "", errs.NewNetworkError(errs.SubtypeNetworkProtocol, "resume probe returned an empty response")
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		total := driveDownloadParseRangeTotal(resp.Header.Get("Content-Range"))
+		if total < 0 {
+			return -1, "", errs.NewNetworkError(errs.SubtypeNetworkProtocol, "resume probe returned an invalid Content-Range")
+		}
+		return total, driveDownloadStrongETag(resp.Header.Get("ETag")), nil
+	case http.StatusOK:
+		return resp.ContentLength, driveDownloadStrongETag(resp.Header.Get("ETag")), nil
+	default:
+		return -1, "", errs.NewNetworkError(errs.SubtypeNetworkProtocol,
+			"resume probe returned HTTP %d", resp.StatusCode).WithCode(resp.StatusCode)
+	}
+}
+
+// driveDownloadCheckpoint ties a <output>.partial file to the remote
+// representation it was downloaded from. A resume is only allowed when both
+// the size and strong ETag still match the current remote file.
+type driveDownloadCheckpoint struct {
+	Size int64  `json:"size"`
+	ETag string `json:"etag,omitempty"`
+}
+
+// driveDownloadPaths resolves the output path and derives the sibling
+// partial and checkpoint paths from it.
+func driveDownloadPaths(runtime *common.RuntimeContext, outputPath string) (resolved, partial, checkpoint string, err error) {
+	resolved, err = runtime.ResolveSavePath(outputPath)
+	if err != nil {
+		return "", "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe output path: %s", err).WithParam("--output")
+	}
+	// Keep the artifact names in the provider's logical namespace. A custom
+	// backend may not use local absolute paths, while the suffix relationship
+	// to the user-supplied output name remains meaningful to that backend.
+	return resolved, outputPath + ".partial", outputPath + ".partial.meta", nil
+}
+
+// driveDownloadEnsureOutputAbsent fails when the final output already exists
+// and --overwrite was not given.
+func driveDownloadEnsureOutputAbsent(runtime *common.RuntimeContext, outputPath string, overwrite bool) error {
+	if !overwrite {
+		if _, statErr := runtime.FileIO().Stat(outputPath); statErr == nil {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "output file already exists: %s (use --overwrite to replace)", outputPath).WithParam("--output")
+		} else if !errors.Is(statErr, fs.ErrNotExist) {
+			if errors.Is(statErr, fileio.ErrPathValidation) {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe output path: %s", statErr).WithParam("--output").WithCause(statErr)
+			}
+			return errs.NewInternalError(errs.SubtypeFileIO, "inspect output path: %s", statErr).WithCause(statErr)
+		}
+	}
+	return nil
+}
+
+// driveDownloadDiscardResume removes a partial file and its checkpoint.
+// Passing an empty path skips that artifact.
+func driveDownloadDiscardResume(resumeIO fileio.ResumableFileIO, partialPath, checkpointPath string) error {
+	var errsToJoin []error
+	for _, artifactPath := range []string{partialPath, checkpointPath} {
+		if artifactPath == "" {
+			continue
+		}
+		if err := resumeIO.RemoveResumeArtifact(artifactPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			errsToJoin = append(errsToJoin, err)
+		}
+	}
+	return errors.Join(errsToJoin...)
+}
+
+// driveDownloadWriteCheckpoint persists the checkpoint next to the partial
+// file. A failure is non-fatal for the current download; without a checkpoint
+// a later --continue conservatively restarts from byte 0.
+func driveDownloadWriteCheckpoint(resumeIO fileio.ResumableFileIO, path string, size int64, etag string) error {
+	data, err := json.Marshal(driveDownloadCheckpoint{Size: size, ETag: etag})
+	if err != nil {
+		return err
+	}
+	return resumeIO.WriteResumeArtifact(path, data)
+}
+
+// driveDownloadReadCheckpoint loads a checkpoint written by
+// driveDownloadWriteCheckpoint. A missing or malformed checkpoint is reported
+// as an error so the caller treats the partial as unverifiable.
+func driveDownloadReadCheckpoint(resumeIO fileio.ResumableFileIO, path string) (*driveDownloadCheckpoint, error) {
+	data, err := resumeIO.ReadResumeArtifact(path)
+	if err != nil {
+		return nil, err
+	}
+	var cp driveDownloadCheckpoint
+	if err := json.Unmarshal(data, &cp); err != nil {
+		return nil, err
+	}
+	return &cp, nil
+}
+
+// driveDownloadStrongETag accepts only a quoted, non-weak validator. It keeps
+// checkpoint identity compatible with download.Options.ExpectedETag, which
+// deliberately rejects weak validators for If-Range.
+func driveDownloadStrongETag(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "W/") || len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return ""
+	}
+	for i := 1; i < len(value)-1; i++ {
+		if c := value[i]; c != 0x21 && !(c >= 0x23 && c <= 0x7e) && c < 0x80 {
+			return ""
+		}
+	}
+	return value
+}
+
+func driveDownloadResumeArtifactError(action string, err error) error {
+	return errs.NewInternalError(errs.SubtypeFileIO, "%s: %s", action, err).WithCause(err)
+}
+
+func driveDownloadCommitError(err error, outputPath string, overwrite bool) error {
+	if !overwrite && errors.Is(err, fs.ErrExist) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"output file already exists: %s (use --overwrite to replace)", outputPath).
+			WithParam("--output").WithCause(err)
+	}
+	return errs.NewInternalError(errs.SubtypeFileIO, "cannot commit downloaded file: %s", err).WithCause(err)
+}
+
+func driveDownloadRangeProbeRejected(err error) bool {
+	problem, ok := errs.ProblemOf(err)
+	return ok && (problem.Code == http.StatusBadRequest || problem.Code == http.StatusRequestedRangeNotSatisfiable)
+}
+
+func driveDownloadShouldRestartResume(err error) bool {
+	if extdownload.IsResumeUnsupported(err) {
+		return true
+	}
+	problem, ok := errs.ProblemOf(err)
+	return ok && problem.Subtype == errs.SubtypeNetworkRepresentationChanged
+}
+
+// driveDownloadParseRangeTotal extracts the total size from a
+// "bytes start-end/total" Content-Range header, or -1 when malformed.
+func driveDownloadParseRangeTotal(contentRange string) int64 {
+	idx := strings.LastIndexByte(contentRange, '/')
+	if idx < 0 {
+		return -1
+	}
+	total, err := strconv.ParseInt(contentRange[idx+1:], 10, 64)
+	if err != nil {
+		return -1
+	}
+	return total
+}
+
+// driveDownloadProgressReader wraps a download body reader and prints coarse
+// progress to stderr for long transfers.
+type driveDownloadProgressReader struct {
+	r       io.Reader
+	total   int64
+	written int64
+	last    int64
+	out     io.Writer
+}
+
+func (p *driveDownloadProgressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	p.written += int64(n)
+	if p.out != nil && p.written-p.last >= driveDownloadProgressEvery {
+		p.last = p.written
+		if p.total > 0 {
+			fmt.Fprintf(p.out, "downloaded %d of %d bytes (%d%%)\n",
+				p.written, p.total, p.written*100/p.total)
+		} else {
+			fmt.Fprintf(p.out, "downloaded %d bytes\n", p.written)
+		}
+	}
+	return n, err
 }

--- a/shortcuts/drive/drive_errors.go
+++ b/shortcuts/drive/drive_errors.go
@@ -116,6 +116,18 @@ func driveSaveError(err error) error {
 	}
 }
 
+// driveAppendError maps a resumable backend failure using the same FileIO
+// contract as Save, while preserving a provider's already-typed errs.* error.
+func driveAppendError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := errs.ProblemOf(err); ok {
+		return err
+	}
+	return driveSaveError(err)
+}
+
 // appendDriveExportRecoveryHint attaches a recovery hint to err while preserving
 // its original classification (typed subtype/code), only falling back to a typed
 // internal error when err is unclassified.

--- a/shortcuts/drive/drive_errors.go
+++ b/shortcuts/drive/drive_errors.go
@@ -77,7 +77,7 @@ func driveDownloadPermissionDeniedError() error {
 	const tokenArg = "<FILE_TOKEN>"
 	return errs.NewPermissionError(
 		errs.SubtypePermissionDenied,
-		"current identity does not have export permission for this Drive file",
+		"current identity does not have view permission for this Drive file",
 	).WithHint(
 		"Direct Drive download is unavailable. To view file content through preview artifacts, try `lark-cli drive +preview --file-token %s --type source_file --output <path>`.",
 		tokenArg,

--- a/shortcuts/drive/drive_errors_test.go
+++ b/shortcuts/drive/drive_errors_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+func TestDriveAppendErrorPreservesFileIOClassification(t *testing.T) {
+	pathErr := &fileio.PathValidationError{Err: errors.New("unsafe path")}
+	for name, input := range map[string]error{
+		"path":  pathErr,
+		"mkdir": &fileio.MkdirError{Err: errors.New("permission denied")},
+		"write": &fileio.WriteError{Err: errors.New("disk full")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := driveAppendError(input)
+			problem, ok := errs.ProblemOf(got)
+			if !ok {
+				t.Fatalf("driveAppendError() = %T %v, want typed error", got, got)
+			}
+			if problem.Subtype != errs.SubtypeFileIO && !errors.Is(got, fileio.ErrPathValidation) {
+				t.Fatalf("problem subtype = %q, want fileio (or path validation)", problem.Subtype)
+			}
+		})
+	}
+}
+
+func TestDriveAppendErrorPreservesAlreadyTypedError(t *testing.T) {
+	input := errs.NewNetworkError(errs.SubtypeNetworkServer, "upstream failed")
+	if got := driveAppendError(input); got != input {
+		t.Fatalf("driveAppendError() = %v, want the original typed error", got)
+	}
+}

--- a/shortcuts/drive/drive_io_test.go
+++ b/shortcuts/drive/drive_io_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -15,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -25,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/credential"
@@ -49,7 +52,7 @@ func driveTestConfig() *core.CliConfig {
 	}
 }
 
-func registerDriveDownloadExportAuth(reg *httpmock.Registry, fileToken string, allowed bool) *httpmock.Stub {
+func registerDriveDownloadViewAuth(reg *httpmock.Registry, fileToken string, allowed bool) *httpmock.Stub {
 	stub := &httpmock.Stub{
 		Method: http.MethodGet,
 		URL:    "/open-apis/drive/v1/permissions/" + fileToken + "/members/auth",
@@ -60,6 +63,34 @@ func registerDriveDownloadExportAuth(reg *httpmock.Registry, fileToken string, a
 	}
 	reg.Register(stub)
 	return stub
+}
+
+type saveOnlyDriveFileIOProvider struct {
+	inner fileio.Provider
+}
+
+func (p *saveOnlyDriveFileIOProvider) Name() string { return "save-only" }
+
+func (p *saveOnlyDriveFileIOProvider) ResolveFileIO(ctx context.Context) fileio.FileIO {
+	return &saveOnlyDriveFileIO{inner: p.inner.ResolveFileIO(ctx)}
+}
+
+type saveOnlyDriveFileIO struct {
+	inner fileio.FileIO
+}
+
+func (f *saveOnlyDriveFileIO) Open(name string) (fileio.File, error) { return f.inner.Open(name) }
+
+func (f *saveOnlyDriveFileIO) Stat(name string) (fileio.FileInfo, error) {
+	return f.inner.Stat(name)
+}
+
+func (f *saveOnlyDriveFileIO) ResolvePath(name string) (string, error) {
+	return f.inner.ResolvePath(name)
+}
+
+func (f *saveOnlyDriveFileIO) Save(path string, opts fileio.SaveOptions, body io.Reader) (fileio.SaveResult, error) {
+	return f.inner.Save(path, opts, body)
 }
 
 // mountAndRunDrive executes a mounted Drive command with a background context.
@@ -1597,10 +1628,23 @@ func TestDriveDownloadRejectsOverwriteWithoutFlag(t *testing.T) {
 	}
 }
 
+func TestDriveDownloadContinueRequiresExplicitOutput(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_continue_no_output",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil || !strings.Contains(err.Error(), "--continue requires an explicit --output path") {
+		t.Fatalf("error = %v, want explicit-output validation error", err)
+	}
+}
+
 // TestDriveDownloadAllowsOverwriteFlag verifies the overwrite flag permits replacing output.
 func TestDriveDownloadAllowsOverwriteFlag(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_123", true)
+	registerDriveDownloadViewAuth(reg, "file_123", true)
 	reg.Register(&httpmock.Stub{
 		Method:  "GET",
 		URL:     "/open-apis/drive/v1/files/file_123/download",
@@ -1642,7 +1686,7 @@ func TestDriveDownloadAllowsOverwriteFlag(t *testing.T) {
 // TestDriveDownloadHTTP403SuggestsPreview verifies forbidden downloads suggest the preview workflow.
 func TestDriveDownloadHTTP403SuggestsPreview(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_403", true)
+	registerDriveDownloadViewAuth(reg, "file_403", true)
 	reg.Register(&httpmock.Stub{
 		Method:  "GET",
 		URL:     "/open-apis/drive/v1/files/file_403/download",
@@ -1692,7 +1736,7 @@ func TestDriveDownloadHTTP403SuggestsPreview(t *testing.T) {
 // TestDriveDownloadHTTP404DoesNotSuggestPreview verifies missing files do not receive permission guidance.
 func TestDriveDownloadHTTP404DoesNotSuggestPreview(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_missing", true)
+	registerDriveDownloadViewAuth(reg, "file_missing", true)
 	reg.Register(&httpmock.Stub{
 		Method:  "GET",
 		URL:     "/open-apis/drive/v1/files/file_missing/download",
@@ -1724,9 +1768,9 @@ func TestDriveDownloadHTTP404DoesNotSuggestPreview(t *testing.T) {
 	}
 }
 
-func TestDriveDownloadExportDeniedFailsBeforeDownload(t *testing.T) {
+func TestDriveDownloadViewDeniedFailsBeforeDownload(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_export_denied", false)
+	registerDriveDownloadViewAuth(reg, "file_export_denied", false)
 	downloadCalls := 0
 	reg.Register(&httpmock.Stub{
 		Method:   http.MethodGet,
@@ -1769,7 +1813,7 @@ func TestDriveDownloadExportDeniedFailsBeforeDownload(t *testing.T) {
 	}
 }
 
-func TestDriveDownloadMalformedExportAuthStopsBeforeDownload(t *testing.T) {
+func TestDriveDownloadMalformedViewAuthStopsBeforeDownload(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: http.MethodGet,
@@ -1808,12 +1852,15 @@ func TestDriveDownloadMalformedExportAuthStopsBeforeDownload(t *testing.T) {
 
 func TestDriveDownloadHTTP429SuggestsBackoff(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_download_limited", true)
+	registerDriveDownloadViewAuth(reg, "file_download_limited", true)
+	// Reusable: the chunked download transport retries rate-limited parts with
+	// backoff before surfacing the final 429.
 	reg.Register(&httpmock.Stub{
-		Method:  http.MethodGet,
-		URL:     "/open-apis/drive/v1/files/file_download_limited/download",
-		Status:  http.StatusTooManyRequests,
-		RawBody: []byte("rate limited"),
+		Method:   http.MethodGet,
+		URL:      "/open-apis/drive/v1/files/file_download_limited/download",
+		Status:   http.StatusTooManyRequests,
+		RawBody:  []byte("rate limited"),
+		Reusable: true,
 	})
 
 	tmpDir := t.TempDir()
@@ -1825,20 +1872,21 @@ func TestDriveDownloadHTTP429SuggestsBackoff(t *testing.T) {
 		"--as", "bot",
 	}, f, nil)
 	problem, ok := errs.ProblemOf(err)
-	if !ok || problem.Category != errs.CategoryNetwork || problem.Code != http.StatusTooManyRequests {
-		t.Fatalf("problem=%+v ok=%v, want network HTTP 429", problem, ok)
+	if !ok || problem.Category != errs.CategoryAPI || problem.Subtype != errs.SubtypeRateLimit ||
+		problem.Code != http.StatusTooManyRequests || !problem.Retryable {
+		t.Fatalf("problem=%+v ok=%v, want api/rate_limit/429 retryable", problem, ok)
 	}
-	for _, want := range []string{"stop immediate retries", "retry later with exponential backoff"} {
-		if !strings.Contains(problem.Hint, want) {
-			t.Fatalf("hint=%q, want %q", problem.Hint, want)
-		}
+	// The chunked transport retried the rate-limited part with backoff before
+	// surfacing the final 429, whose hint still points at exponential backoff.
+	if !strings.Contains(problem.Hint, "exponential backoff") {
+		t.Fatalf("hint=%q, want an exponential backoff hint", problem.Hint)
 	}
 	if strings.Contains(problem.Hint, "1 minute") {
 		t.Fatalf("hint=%q, want no fixed retry duration", problem.Hint)
 	}
 }
 
-func TestDriveDownloadExportAuthRateLimitPreservesAPIErrorAndSuggestsBackoff(t *testing.T) {
+func TestDriveDownloadViewAuthRateLimitPreservesAPIErrorAndSuggestsBackoff(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: http.MethodGet,
@@ -1977,6 +2025,25 @@ func TestDriveDownloadDefaultOutputPathFallsBackWhenHeaderCandidateFailsPathVali
 	}
 }
 
+func TestDriveDownloadStrongETagRejectsWeakOrUnquotedValues(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "strong", input: `"v1"`, want: `"v1"`},
+		{name: "weak", input: `W/"v1"`},
+		{name: "unquoted", input: "v1"},
+		{name: "control character", input: "\"v\n1\""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := driveDownloadStrongETag(tt.input); got != tt.want {
+				t.Fatalf("driveDownloadStrongETag(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // mustDriveDownloadDefaultOutputPath resolves a default download path or fails the test.
 func mustDriveDownloadDefaultOutputPath(t *testing.T, header http.Header, title, fileToken string, validatePath driveDownloadOutputPathValidator) string {
 	t.Helper()
@@ -2008,11 +2075,11 @@ func TestDriveDownloadDryRunPlansMetadataWhenOutputOmitted(t *testing.T) {
 	}
 	first, _ := apis[0].(map[string]interface{})
 	if first["method"] != "GET" || first["url"] != "/open-apis/drive/v1/permissions/file_dryrun/members/auth" {
-		t.Fatalf("first api = %#v, want export permission auth", first)
+		t.Fatalf("first api = %#v, want view permission auth", first)
 	}
 	firstParams, _ := first["params"].(map[string]interface{})
-	if firstParams["type"] != "file" || firstParams["action"] != "export" {
-		t.Fatalf("first params = %#v, want type=file action=export", firstParams)
+	if firstParams["type"] != "file" || firstParams["action"] != "view" {
+		t.Fatalf("first params = %#v, want type=file action=view", firstParams)
 	}
 	second, _ := apis[1].(map[string]interface{})
 	if second["method"] != "POST" || second["url"] != "/open-apis/drive/v1/metas/batch_query" {
@@ -2049,7 +2116,7 @@ func TestDriveDownloadDryRunExplicitOutputSkipsMetadata(t *testing.T) {
 	}
 	first, _ := apis[0].(map[string]interface{})
 	if first["method"] != "GET" || first["url"] != "/open-apis/drive/v1/permissions/file_dryrun/members/auth" {
-		t.Fatalf("first api = %#v, want export permission auth", first)
+		t.Fatalf("first api = %#v, want view permission auth", first)
 	}
 	second, _ := apis[1].(map[string]interface{})
 	if second["method"] != "GET" || second["url"] != "/open-apis/drive/v1/files/file_dryrun/download" {
@@ -2139,7 +2206,7 @@ func TestDriveDownloadPermissionAuthScopeErrorsWarnAndContinue(t *testing.T) {
 			if err != nil {
 				t.Fatalf("download error = %v, want permission auth scope error %d to be non-blocking", err, tt.code)
 			}
-			if !strings.Contains(stderr.String(), "warning: export permission check failed; continuing with download:") {
+			if !strings.Contains(stderr.String(), "warning: view permission check failed; continuing with download:") {
 				t.Fatalf("stderr=%q, want permission scope warning", stderr.String())
 			}
 			data, readErr := os.ReadFile(filepath.Join(tmpDir, "downloaded.bin"))
@@ -2206,7 +2273,7 @@ func TestDriveDownloadRejectsUnsafeExplicitOutput(t *testing.T) {
 func TestDriveDownloadExplicitOutputSkipsMetadataScope(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	f.Credential = credential.NewCredentialProvider(nil, nil, &driveStatusScopedTokenResolver{scopes: "drive:file:download " + common.DrivePermissionMemberAuthScope}, nil)
-	registerDriveDownloadExportAuth(reg, "file_no_meta_scope", true)
+	registerDriveDownloadViewAuth(reg, "file_no_meta_scope", true)
 	reg.Register(&httpmock.Stub{
 		Method:  "GET",
 		URL:     "/open-apis/drive/v1/files/file_no_meta_scope/download",
@@ -2235,7 +2302,7 @@ func TestDriveDownloadExplicitOutputSkipsMetadataScope(t *testing.T) {
 // TestDriveDownloadRejectsExistingDefaultOutputWithoutOverwrite verifies default output also respects overwrite protection.
 func TestDriveDownloadRejectsExistingDefaultOutputWithoutOverwrite(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_existing_title", true)
+	registerDriveDownloadViewAuth(reg, "file_existing_title", true)
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/metas/batch_query",
@@ -2286,7 +2353,7 @@ func TestDriveDownloadRejectsExistingDefaultOutputWithoutOverwrite(t *testing.T)
 // TestDriveDownloadUsesContentDispositionWhenOutputOmitted verifies response filenames take precedence.
 func TestDriveDownloadUsesContentDispositionWhenOutputOmitted(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	authStub := registerDriveDownloadExportAuth(reg, "file_named", true)
+	authStub := registerDriveDownloadViewAuth(reg, "file_named", true)
 	metaStub := &httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/metas/batch_query",
@@ -2346,7 +2413,7 @@ func TestDriveDownloadUsesContentDispositionWhenOutputOmitted(t *testing.T) {
 // TestDriveDownloadFallsBackToMetadataTitleWhenOutputOmitted verifies metadata supplies the default filename.
 func TestDriveDownloadFallsBackToMetadataTitleWhenOutputOmitted(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_title", true)
+	registerDriveDownloadViewAuth(reg, "file_title", true)
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/metas/batch_query",
@@ -2397,7 +2464,7 @@ func TestDriveDownloadFallsBackToMetadataTitleWhenOutputOmitted(t *testing.T) {
 // TestDriveDownloadFallsBackToTokenWhenOutputOmittedAndMetadataEmpty verifies the token is the final filename fallback.
 func TestDriveDownloadFallsBackToTokenWhenOutputOmittedAndMetadataEmpty(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_empty", true)
+	registerDriveDownloadViewAuth(reg, "file_empty", true)
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/metas/batch_query",
@@ -2442,7 +2509,7 @@ func TestDriveDownloadFallsBackToTokenWhenOutputOmittedAndMetadataEmpty(t *testi
 // TestDriveDownloadMetadataNonPermissionErrorContinuesWithTokenFallback verifies recoverable metadata failures use the token.
 func TestDriveDownloadMetadataNonPermissionErrorContinuesWithTokenFallback(t *testing.T) {
 	f, stdout, stderr, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_rate_limited", true)
+	registerDriveDownloadViewAuth(reg, "file_rate_limited", true)
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/metas/batch_query",
@@ -2592,7 +2659,7 @@ func TestDriveDownloadMetadataContextErrorStopsBeforeDownload(t *testing.T) {
 // TestDriveDownloadMetadataErrorBeforeDownloadWhenOutputOmitted verifies permission failures stop before downloading.
 func TestDriveDownloadMetadataErrorBeforeDownloadWhenOutputOmitted(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
-	registerDriveDownloadExportAuth(reg, "file_no_meta", true)
+	registerDriveDownloadViewAuth(reg, "file_no_meta", true)
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/metas/batch_query",
@@ -2910,5 +2977,490 @@ func TestDriveUploadReportFileEventFailureKeepsUploadError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "quota exceeded") {
 		t.Fatalf("error lost original message: %v", err)
+	}
+}
+
+// rangeDownloadTransport serves a fixed payload honoring Range headers for
+// /download requests and delegates everything else to the underlying
+// httpmock registry. It lets tests exercise the chunked resumable downloader
+// against a realistic 206-answering server.
+type rangeDownloadTransport struct {
+	base     http.RoundTripper
+	payload  []byte
+	requests *[]string // records the Range header of every /download request
+}
+
+type fullOnlyDownloadTransport struct {
+	base     http.RoundTripper
+	payload  []byte
+	requests *[]string
+}
+
+func (t *fullOnlyDownloadTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !strings.Contains(req.URL.Path, "/download") {
+		return t.base.RoundTrip(req)
+	}
+	if t.requests != nil {
+		*t.requests = append(*t.requests, req.Header.Get("Range"))
+	}
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": {"application/octet-stream"}, "Etag": {`"v1"`}},
+		Body:          io.NopCloser(bytes.NewReader(t.payload)),
+		ContentLength: int64(len(t.payload)),
+	}, nil
+}
+
+// RoundTrip serves /download requests from the fixed payload honoring Range
+// headers and delegates every other request to the underlying registry.
+func (t *rangeDownloadTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !strings.Contains(req.URL.Path, "/download") {
+		return t.base.RoundTrip(req)
+	}
+	if t.requests != nil {
+		*t.requests = append(*t.requests, req.Header.Get("Range"))
+	}
+	if req.Header.Get("Range") == "" {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": {"application/octet-stream"}, "Etag": {`"v1"`}},
+			Body:          io.NopCloser(bytes.NewReader(t.payload)),
+			ContentLength: int64(len(t.payload)),
+		}, nil
+	}
+	rangeHeader := strings.TrimPrefix(req.Header.Get("Range"), "bytes=")
+	parts := strings.SplitN(rangeHeader, "-", 2)
+	start, startErr := strconv.ParseInt(parts[0], 10, 64)
+	end, endErr := strconv.ParseInt(parts[1], 10, 64)
+	if startErr != nil || endErr != nil || start > end {
+		return &http.Response{
+			StatusCode: http.StatusRequestedRangeNotSatisfiable,
+			Header:     http.Header{"Content-Type": {"text/plain"}},
+			Body:       io.NopCloser(strings.NewReader("range unsatisfiable")),
+		}, nil
+	}
+	if end >= int64(len(t.payload)) {
+		end = int64(len(t.payload)) - 1
+	}
+	return &http.Response{
+		StatusCode: http.StatusPartialContent,
+		Header: http.Header{
+			"Content-Type":  {"application/octet-stream"},
+			"Content-Range": {fmt.Sprintf("bytes %d-%d/%d", start, end, len(t.payload))},
+			"Etag":          {`"v1"`},
+		},
+		Body:          io.NopCloser(bytes.NewReader(t.payload[start : end+1])),
+		ContentLength: end - start + 1,
+	}, nil
+}
+
+// driveDownloadRangePayload returns a deterministic 128 KiB payload with no
+// repeated runs, so byte ranges can be distinguished from one another.
+func driveDownloadRangePayload() []byte {
+	payload := make([]byte, 128*1024)
+	for i := range payload {
+		payload[i] = byte(i * 7)
+	}
+	return payload
+}
+
+// driveDownloadRangeFactory builds a factory whose HTTP client answers drive
+// download requests from payload with Range support and records every range
+// header, while preflight/SDK calls go through the same registry.
+func driveDownloadRangeFactory(t *testing.T, fileToken string, payload []byte, requests *[]string) (*cmdutil.Factory, *httpmock.Registry) {
+	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	registerDriveDownloadViewAuth(reg, fileToken, true)
+	f.HttpClient = func() (*http.Client, error) {
+		return &http.Client{Transport: &rangeDownloadTransport{base: reg, payload: payload, requests: requests}}, nil
+	}
+	return f, reg
+}
+
+func TestDriveDownloadUsesSaveWithNonResumableBackend(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_save_only", payload, &ranges)
+	f.FileIOProvider = &saveOnlyDriveFileIOProvider{inner: f.FileIOProvider}
+
+	withDriveWorkingDir(t, t.TempDir())
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_save_only",
+		"--output", "out.bin",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("saved file corrupt: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestDriveDownloadContinueRequiresResumableBackend(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_continue_save_only", payload, &ranges)
+	f.FileIOProvider = &saveOnlyDriveFileIOProvider{inner: f.FileIOProvider}
+
+	withDriveWorkingDir(t, t.TempDir())
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_continue_save_only",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil || !strings.Contains(err.Error(), "does not support --continue downloads") {
+		t.Fatalf("error = %v, want resumable-backend error", err)
+	}
+	if len(ranges) != 0 {
+		t.Fatalf("download requests = %v, want no download before backend validation", ranges)
+	}
+}
+
+func TestDriveDownloadContinueRestartsWhenRangeIsUnsupported(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	registerDriveDownloadViewAuth(reg, "file_no_range", true)
+	f.HttpClient = func() (*http.Client, error) {
+		return &http.Client{Transport: &fullOnlyDownloadTransport{base: reg, payload: payload, requests: &ranges}}, nil
+	}
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.WriteFile("out.bin.partial", payload[:30000], 0600); err != nil {
+		t.Fatalf("WriteFile(partial) error: %v", err)
+	}
+	driveDownloadWriteTestCheckpoint(t, "out.bin.partial.meta", int64(len(payload)), `"v1"`)
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_no_range",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("restarted file corrupt: got %d bytes, want %d", len(got), len(payload))
+	}
+	if len(ranges) != 3 || ranges[0] != "bytes=0-0" || !strings.HasPrefix(ranges[1], "bytes=30000-") || ranges[2] != "bytes=0-67108863" {
+		t.Fatalf("ranges = %v, want probe, rejected resume range, then a fresh range probe from byte 0", ranges)
+	}
+}
+
+func TestDriveDownloadContinueResumesPartial(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_resume", payload, &ranges)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	partial := filepath.Join(tmpDir, "out.bin.partial")
+	if err := os.WriteFile(partial, payload[:30000], 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	driveDownloadWriteTestCheckpoint(t, "out.bin.partial.meta", int64(len(payload)), `"v1"`)
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_resume",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("resumed file corrupt: got %d bytes, want %d", len(got), len(payload))
+	}
+	if _, statErr := os.Stat(partial); !os.IsNotExist(statErr) {
+		t.Fatalf("partial file should be renamed away, statErr=%v", statErr)
+	}
+	resumed := false
+	for _, r := range ranges {
+		if strings.HasPrefix(r, "bytes=30000-") {
+			resumed = true
+			break
+		}
+	}
+	if !resumed {
+		t.Fatalf("ranges = %v, want a part resuming from byte 30000", ranges)
+	}
+}
+
+func TestDriveDownloadContinueCommitsCompletePartial(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_complete", payload, &ranges)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.WriteFile("out.bin.partial", payload, 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	driveDownloadWriteTestCheckpoint(t, "out.bin.partial.meta", int64(len(payload)), `"v1"`)
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_complete",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("committed file corrupt")
+	}
+	for _, r := range ranges {
+		if !strings.HasPrefix(r, "bytes=0-0") {
+			t.Fatalf("unexpected download request %q; complete partial must be committed directly (ranges=%v)", r, ranges)
+		}
+	}
+}
+
+func TestDriveDownloadContinueStalePartialRestarts(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_stale", payload, &ranges)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	// Partial larger than the remote file: stale, must be discarded.
+	if err := os.WriteFile("out.bin.partial", make([]byte, len(payload)+1024), 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_stale",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded file corrupt after stale partial restart")
+	}
+	if len(ranges) == 0 || !strings.HasPrefix(ranges[0], "bytes=0-") {
+		t.Fatalf("first range = %v, want restart from byte 0", ranges)
+	}
+}
+
+func TestDriveDownloadWithoutContinueIgnoresPartial(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_nocont", payload, &ranges)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	// A stale partial without --continue is unrelated to the normal Save path
+	// and must remain untouched.
+	if err := os.WriteFile("out.bin.partial", []byte("stale garbage"), 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_nocont",
+		"--output", "out.bin",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded file corrupt without --continue")
+	}
+	partial, err := os.ReadFile("out.bin.partial")
+	if err != nil {
+		t.Fatalf("ReadFile(partial) error: %v", err)
+	}
+	if string(partial) != "stale garbage" {
+		t.Fatalf("partial file changed without --continue: %q", partial)
+	}
+	if len(ranges) == 0 || !strings.HasPrefix(ranges[0], "bytes=0-") {
+		t.Fatalf("first range = %v, want a fresh download from byte 0", ranges)
+	}
+}
+
+// driveDownloadWriteTestCheckpoint writes a resume checkpoint the same way the
+// production code does, so tests can simulate an interrupted --continue run.
+func driveDownloadWriteTestCheckpoint(t *testing.T, path string, size int64, etag string) {
+	t.Helper()
+	data, err := json.Marshal(struct {
+		Size int64  `json:"size"`
+		ETag string `json:"etag,omitempty"`
+	}{Size: size, ETag: etag})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+}
+
+func TestDriveDownloadContinueETagMismatchRestarts(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, reg := driveDownloadRangeFactory(t, "file_etag", payload, &ranges)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	// Partial and checkpoint from an older remote representation: the probe
+	// answers ETag "v1" while the checkpoint holds "v0", so a resume must be
+	// refused and the download must restart from byte 0.
+	if err := os.WriteFile("out.bin.partial", payload[:50000], 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	driveDownloadWriteTestCheckpoint(t, "out.bin.partial.meta", int64(len(payload)), `"v0"`)
+
+	etagTransport := &rangeDownloadTransport{base: reg, payload: payload, requests: &ranges}
+	// Override ETag responses to simulate the remote file having changed.
+	f.HttpClient = func() (*http.Client, error) {
+		return &http.Client{Transport: driveRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			resp, err := etagTransport.RoundTrip(req)
+			if err == nil && strings.Contains(req.URL.Path, "/download") {
+				resp.Header.Set("ETag", `"v2"`)
+			}
+			return resp, err
+		})}, nil
+	}
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_etag",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded file corrupt after ETag-mismatch restart")
+	}
+	if len(ranges) == 0 || !strings.HasPrefix(ranges[0], "bytes=0-") {
+		t.Fatalf("first range = %v, want restart from byte 0 after ETag change", ranges)
+	}
+}
+
+func TestDriveDownloadContinueMissingCheckpointRestarts(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_nocp", payload, &ranges)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	// A partial without its checkpoint cannot be tied to the current remote
+	// representation; resuming must be refused.
+	if err := os.WriteFile("out.bin.partial", payload[:40000], 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_nocp",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded file corrupt after missing-checkpoint restart")
+	}
+	if len(ranges) == 0 || !strings.HasPrefix(ranges[0], "bytes=0-") {
+		t.Fatalf("first range = %v, want restart from byte 0 without a checkpoint", ranges)
+	}
+}
+
+func TestDriveDownloadContinueCompletePartialETagMismatchRestarts(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, reg := driveDownloadRangeFactory(t, "file_etag_full", payload, &ranges)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	// A complete partial whose checkpoint ETag no longer matches the remote
+	// file must not be committed: the remote content changed, so the download
+	// restarts from byte 0.
+	if err := os.WriteFile("out.bin.partial", payload, 0600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	driveDownloadWriteTestCheckpoint(t, "out.bin.partial.meta", int64(len(payload)), `"v0"`)
+
+	etagTransport := &rangeDownloadTransport{base: reg, payload: payload, requests: &ranges}
+	f.HttpClient = func() (*http.Client, error) {
+		return &http.Client{Transport: driveRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			resp, err := etagTransport.RoundTrip(req)
+			if err == nil && strings.Contains(req.URL.Path, "/download") {
+				resp.Header.Set("ETag", `"v2"`)
+			}
+			return resp, err
+		})}, nil
+	}
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_etag_full",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("download error: %v", err)
+	}
+	got, err := os.ReadFile("out.bin")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded file corrupt after ETag-mismatch restart")
+	}
+	if len(ranges) == 0 || !strings.HasPrefix(ranges[0], "bytes=0-") {
+		t.Fatalf("first range = %v, want a fresh download from byte 0 (not a commit)", ranges)
 	}
 }

--- a/shortcuts/drive/drive_io_test.go
+++ b/shortcuts/drive/drive_io_test.go
@@ -93,6 +93,40 @@ func (f *saveOnlyDriveFileIO) Save(path string, opts fileio.SaveOptions, body io
 	return f.inner.Save(path, opts, body)
 }
 
+type resumeSizeMismatchFileIOProvider struct {
+	inner fileio.Provider
+}
+
+func (p *resumeSizeMismatchFileIOProvider) Name() string { return "resume-size-mismatch" }
+
+func (p *resumeSizeMismatchFileIOProvider) ResolveFileIO(ctx context.Context) fileio.FileIO {
+	resumable, ok := p.inner.ResolveFileIO(ctx).(fileio.ResumableFileIO)
+	if !ok {
+		panic("test provider requires a resumable inner FileIO")
+	}
+	return &resumeSizeMismatchFileIO{ResumableFileIO: resumable}
+}
+
+type resumeSizeMismatchFileIO struct {
+	fileio.ResumableFileIO
+}
+
+func (f *resumeSizeMismatchFileIO) AppendTo(path string, opts fileio.SaveOptions, body io.Reader) (fileio.SaveResult, error) {
+	result, err := f.ResumableFileIO.AppendTo(path, opts, body)
+	if err != nil {
+		return nil, err
+	}
+	partial, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer partial.Close()
+	if _, err := partial.WriteString("race"); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // mountAndRunDrive executes a mounted Drive command with a background context.
 func mountAndRunDrive(t *testing.T, s common.Shortcut, args []string, f *cmdutil.Factory, stdout *bytes.Buffer) error {
 	t.Helper()
@@ -3203,6 +3237,34 @@ func TestDriveDownloadContinueResumesPartial(t *testing.T) {
 	}
 	if !resumed {
 		t.Fatalf("ranges = %v, want a part resuming from byte 30000", ranges)
+	}
+}
+
+func TestDriveDownloadContinueRejectsChangedPartialSize(t *testing.T) {
+	payload := driveDownloadRangePayload()
+	var ranges []string
+	f, _ := driveDownloadRangeFactory(t, "file_resume_size", payload, &ranges)
+	f.FileIOProvider = &resumeSizeMismatchFileIOProvider{inner: f.FileIOProvider}
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.WriteFile("out.bin.partial", payload[:30000], 0600); err != nil {
+		t.Fatalf("WriteFile(partial) error: %v", err)
+	}
+	driveDownloadWriteTestCheckpoint(t, "out.bin.partial.meta", int64(len(payload)), `"v1"`)
+
+	err := mountAndRunDrive(t, DriveDownload, []string{
+		"+download",
+		"--file-token", "file_resume_size",
+		"--output", "out.bin",
+		"--continue",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil || !strings.Contains(err.Error(), "resume partial size changed during append") {
+		t.Fatalf("error = %v, want final partial-size validation error", err)
+	}
+	if _, statErr := os.Stat("out.bin"); !os.IsNotExist(statErr) {
+		t.Fatalf("output should not be committed, statErr=%v", statErr)
 	}
 }
 

--- a/shortcuts/drive/drive_pull.go
+++ b/shortcuts/drive/drive_pull.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"time"
 
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
-
 	"github.com/larksuite/cli/errs"
+	extdownload "github.com/larksuite/cli/extension/download"
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/downloadtransport"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -330,6 +330,8 @@ var DrivePull = common.Shortcut{
 	},
 }
 
+// drivePullFailedItem builds the pull item reported when one file of a pull
+// run fails, keeping the original error for the JSON envelope.
 func drivePullFailedItem(relPath, fileToken, sourceID, action, phase string, err error) (drivePullItem, bool) {
 	decision := driveClassifyBatchFailure(err)
 	item := drivePullItem{
@@ -348,20 +350,27 @@ func drivePullFailedItem(relPath, fileToken, sourceID, action, phase string, err
 }
 
 // drivePullDownload streams one Drive file into the local mirror target and
-// then best-effort aligns the local mtime to Drive's modified_time.
+// then best-effort aligns the local mtime to Drive's modified_time. The
+// transfer uses the chunked ranged downloader, so a transient stream failure
+// is retried per part instead of restarting the whole file from byte 0.
 func drivePullDownload(ctx context.Context, runtime *common.RuntimeContext, fileToken, target, remoteModifiedTime string) error {
-	resp, err := runtime.DoAPIStream(ctx, &larkcore.ApiReq{
-		HttpMethod: "GET",
-		ApiPath:    fmt.Sprintf("/open-apis/drive/v1/files/%s/download", validate.EncodePathSegment(fileToken)),
+	dlSource := extdownload.MutableSource(
+		downloadtransport.NewOAPI(runtime.DoAPIStream).Get(
+			"/open-apis/drive/v1/files/:file_token/download",
+			downloadtransport.PathParam("file_token", fileToken),
+		),
+	)
+	stream, err := extdownload.Open(ctx, dlSource, extdownload.Options{
+		PartSize: driveDownloadPartSize,
 	})
 	if err != nil {
 		return wrapDriveNetworkErr(err, "download %s: %s", common.MaskToken(fileToken), err)
 	}
-	defer resp.Body.Close()
+	defer stream.Body.Close()
 	if _, err := runtime.FileIO().Save(target, fileio.SaveOptions{
-		ContentType:   resp.Header.Get("Content-Type"),
-		ContentLength: resp.ContentLength,
-	}, resp.Body); err != nil {
+		ContentType:   stream.Header.Get("Content-Type"),
+		ContentLength: stream.ContentLength,
+	}, stream.Body); err != nil {
 		return driveSaveError(err)
 	}
 	if err := drivePullApplyRemoteModifiedTime(target, remoteModifiedTime, runtime); err != nil {

--- a/skills/lark-drive/references/lark-drive-download.md
+++ b/skills/lark-drive/references/lark-drive-download.md
@@ -22,6 +22,9 @@ lark-cli drive +download --url "https://example.feishu.cn/wiki/<WIKI_NODE_TOKEN>
 
 # 只有裸 Wiki node token 时，显式传 --wiki-token，让 CLI 先解析底层文件
 lark-cli drive +download --wiki-token "<WIKI_NODE_TOKEN>" --output ./report.pdf
+
+# 中断后从显式输出路径旁的 partial 文件继续
+lark-cli drive +download --file-token boxbc_xxx --output ./report.pdf --continue
 ```
 
 ## 参数
@@ -33,6 +36,7 @@ lark-cli drive +download --wiki-token "<WIKI_NODE_TOKEN>" --output ./report.pdf
 | `--wiki-token` | 条件必填 | 裸 Wiki node token；CLI 先解析到底层 Drive 文件 |
 | `--output` | 否 | 本地输出路径；不传时默认保存到当前目录 |
 | `--overwrite` | 否 | 覆盖已存在的输出文件；不传时目标已存在会报错 |
+| `--continue` | 否 | 从 `<output>.partial` 继续中断的下载；必须同时指定 `--output` |
 
 ## URL 解析
 
@@ -49,6 +53,9 @@ Wiki URL / 裸 Wiki node token 会先解析到底层文档，解析后会在输�
 ## 关键约束
 
 - Wiki 节点解析后的 `obj_type` 必须是 `file`；不确定 token 类型时，先用 `lark-cli drive +inspect --url <TOKEN> --type wiki` 检查。
+- 普通下载直接通过当前 FileIO backend 保存到 `--output`；不会读取或清理同名 `.partial` 文件。
+- `--continue` 需要 backend 同时支持 partial 的追加、checkpoint 读写/删除和最终提交；不支持时命令会在发起下载前失败。
+- `--continue` 只接受显式 `--output`。中断时会保留 `<output>.partial` 和 `<output>.partial.meta` checkpoint，下一次会校验远端大小与强 ETag；成功提交后清理 checkpoint。
 
 ## 排障
 

--- a/skills/lark-drive/references/lark-drive-download.md
+++ b/skills/lark-drive/references/lark-drive-download.md
@@ -56,6 +56,7 @@ Wiki URL / 裸 Wiki node token 会先解析到底层文档，解析后会在输�
 - 普通下载直接通过当前 FileIO backend 保存到 `--output`；不会读取或清理同名 `.partial` 文件。
 - `--continue` 需要 backend 同时支持 partial 的追加、checkpoint 读写/删除和最终提交；不支持时命令会在发起下载前失败。
 - `--continue` 只接受显式 `--output`。中断时会保留 `<output>.partial` 和 `<output>.partial.meta` checkpoint，下一次会校验远端大小与强 ETag；成功提交后清理 checkpoint。
+- 同一组 `<output>.partial` 和 checkpoint 应由一个 `--continue` 进程顺序使用；不要同时启动多个相同输出路径的继续下载。
 
 ## 排障
 

--- a/tests/cli_e2e/drive/drive_download_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_download_dryrun_test.go
@@ -42,8 +42,8 @@ func TestDriveDownloadDryRun_DefaultNamePlansMetadataBeforeDownload(t *testing.T
 	if got := clie2e.DryRunGet(out, "api.0.params.type").String(); got != "file" {
 		t.Fatalf("api.0.params.type=%q, want file\nstdout:\n%s", got, out)
 	}
-	if got := clie2e.DryRunGet(out, "api.0.params.action").String(); got != "export" {
-		t.Fatalf("api.0.params.action=%q, want export\nstdout:\n%s", got, out)
+	if got := clie2e.DryRunGet(out, "api.0.params.action").String(); got != "view" {
+		t.Fatalf("api.0.params.action=%q, want view\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.1.method").String(); got != "POST" {
 		t.Fatalf("api.1.method=%q, want POST\nstdout:\n%s", got, out)


### PR DESCRIPTION
## Summary

`drive +download` (and `+pull`) download each Drive file as a single non-resumable HTTP stream. Any transient transfer failure — observed in the wild as an HTTP/2 `RST_STREAM`/`INTERNAL_ERROR` mid-transfer (see #2324) — discards the partial temp file, and the next attempt restarts from byte 0. For multi-GB files this makes `+download` effectively unusable.

This PR makes drive downloads resumable and chunked:

1. **`extension/download`**: new `Options.StartOffset` resumes a multipart stream from an existing local offset instead of byte 0. `Stream.ContentLength` keeps reporting the remote total while the body reads only the remaining bytes. When `StartOffset > 0`, a server that does not honor `Range` fails instead of falling back to a full response (a full body cannot be spliced onto bytes already on disk).
2. **`extension/fileio` + `localfileio`**: optional `AppendingFileIO.AppendTo` appends a body to a partial file (bytes kept on failure) under the same output-path validation as `Save`.
3. **`drive +download`**: routed through `extension/download` with 64 MiB parts and per-part retries. New `--continue` flag resumes from `<output>.partial`:
   - complete partial → committed directly (no re-download);
   - stale (oversized) partial → discarded and restarted;
   - fresh download → any leftover partial is truncated.
   Progress is printed to stderr every 64 MiB. In `--continue` mode a failed run keeps the partial for a later resume; default behavior is unchanged (failures clean up).
4. **`drive +pull`**: uses the same chunked downloader (per-part retries) while keeping its existing `--if-exists` semantics.
5. **Preflight fix**: `+download` now preflights the `view` action instead of `export`. The `members/auth` API does not support `action=export` for plain uploaded files (`type=file`) and always answers `false`, which blocked every download of such files; `view` correctly reflects whether the download endpoint will accept the caller.

## Verification

- Unit tests: `extension/download` (StartOffset multipart / single-response / fallback rejection), `localfileio` (AppendTo), `shortcuts/drive` (`--continue` resume / commit / stale-restart / discard against a range-aware mock transport).
- All `shortcuts/drive`, `shortcuts/common`, `shortcuts/im`, `extension/download`, `internal/vfs/...` tests pass.
- End-to-end against a real tenant: 200 MB file, interrupted mid-transfer, resumed with `--continue`, final bytes match the source hash exactly.

Fixes #2324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resumable Google Drive downloads with `--continue`, chunked transfers, retries, progress reporting, and atomic completion.
  * Partial downloads are validated against remote file details before resuming, restarting, or finalizing.
  * Added support for appending downloaded content to existing local files.
  * Downloads now use view permissions for regular Drive files.

* **Bug Fixes**
  * Unsupported range requests now produce a clear error instead of silently downloading from the beginning.
  * Unsafe output paths and invalid resume offsets are rejected.
  * Partial files are preserved appropriately when resumable downloads fail.
  * `--continue` requires an explicit output path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->