### PR TITLE
fix(base): verify null numeric record-list cells

### DIFF
--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -2853,7 +2853,7 @@ func TestBaseRecordExecuteReadCreateDelete(t *testing.T) {
 			t.Fatalf("stdout=%s", got)
 		}
 		body := string(batchStub.CapturedBody)
-		if !strings.Contains(body, `"record_id_list":["rec_1"]`) || !strings.Contains(body, `"select_fields":["Cost"]`) {
+		if !strings.Contains(body, `"record_id_list":["rec_1"]`) || !strings.Contains(body, `"select_fields":["fld_cost"]`) {
 			t.Fatalf("batch_get body=%s", body)
 		}
 	})

--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -2810,6 +2810,54 @@ func TestBaseRecordExecuteReadCreateDelete(t *testing.T) {
 		}
 	})
 
+	t.Run("list repairs a silently missing number cell with batch get", func(t *testing.T) {
+		factory, stdout, reg := newExecuteFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "GET",
+			URL:    "field_id=Name&field_id=Cost&limit=1&offset=0",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"fields":          []interface{}{"Name", "Cost"},
+					"field_id_list":   []interface{}{"fld_name", "fld_cost"},
+					"field_type_list": []interface{}{"text", "number"},
+					"record_id_list":  []interface{}{"rec_1"},
+					"data":            []interface{}{[]interface{}{"Alice", nil}},
+					"rev":             42,
+				},
+			},
+		})
+		batchStub := &httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/base/v3/bases/app_x/tables/tbl_x/records/batch_get",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"fields":          []interface{}{"Cost"},
+					"field_id_list":   []interface{}{"fld_cost"},
+					"field_type_list": []interface{}{"number"},
+					"record_id_list":  []interface{}{"rec_1"},
+					"data":            []interface{}{[]interface{}{500}},
+					"rev":             42,
+				},
+			},
+		}
+		reg.Register(batchStub)
+		if err := runShortcut(t, BaseRecordList, []string{
+			"+record-list", "--base-token", "app_x", "--table-id", "tbl_x", "--limit", "1",
+			"--field-id", "Name", "--field-id", "Cost", "--format", "json",
+		}, factory, stdout); err != nil {
+			t.Fatalf("err=%v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `500`) || strings.Contains(got, `null`) {
+			t.Fatalf("stdout=%s", got)
+		}
+		body := string(batchStub.CapturedBody)
+		if !strings.Contains(body, `"record_id_list":["rec_1"]`) || !strings.Contains(body, `"select_fields":["Cost"]`) {
+			t.Fatalf("batch_get body=%s", body)
+		}
+	})
+
 	t.Run("list json alias", func(t *testing.T) {
 		factory, stdout, reg := newExecuteFactory(t)
 		reg.Register(&httpmock.Stub{

--- a/shortcuts/base/record_export.go
+++ b/shortcuts/base/record_export.go
@@ -236,9 +236,7 @@ func executeRecordListNDJSON(
 		params := cloneMap(baseParams)
 		params["offset"] = currentOffset
 		params["limit"] = pageLimit
-		data, err := baseV3Call(runtime, "GET", baseV3Path(
-			"bases", runtime.Str("base-token"), "tables", baseTableID(runtime), "records",
-		), params, nil)
+		data, err := listRecordsVerified(runtime, params)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/base/record_list_consistency.go
+++ b/shortcuts/base/record_list_consistency.go
@@ -36,8 +36,11 @@ func listRecordsVerified(runtime *common.RuntimeContext, params map[string]inter
 }
 
 func verifyNullNumberCells(runtime *common.RuntimeContext, data map[string]interface{}) (map[string]interface{}, error) {
-	matrix, ok := parseListVerificationMatrix(data)
-	if !ok {
+	matrix, complete, err := parseListVerificationMatrix(data)
+	if err != nil {
+		return nil, err
+	}
+	if !complete {
 		// Keep legacy JSON/Markdown behavior for old response shapes. NDJSON has
 		// its own strict matrix parser and will reject malformed responses later.
 		return data, nil
@@ -49,7 +52,7 @@ func verifyNullNumberCells(runtime *common.RuntimeContext, data map[string]inter
 	}
 	numberColumns := make([]numberColumn, 0, len(matrix.fieldTypes))
 	for index, fieldType := range matrix.fieldTypes {
-		if fieldType == "number" {
+		if fieldType == "number" || fieldType == "currency" {
 			numberColumns = append(numberColumns, numberColumn{index: index, fieldID: matrix.fieldIDs[index]})
 		}
 	}
@@ -123,14 +126,17 @@ func verifyNullNumberCells(runtime *common.RuntimeContext, data map[string]inter
 	return data, nil
 }
 
-func parseListVerificationMatrix(data map[string]interface{}) (*recordVerificationMatrix, bool) {
+func parseListVerificationMatrix(data map[string]interface{}) (*recordVerificationMatrix, bool, error) {
 	for _, key := range []string{"fields", "field_id_list", "field_type_list", "record_id_list", "data"} {
 		if _, exists := data[key]; !exists {
-			return nil, false
+			return nil, false, nil
 		}
 	}
 	matrix, err := parseRecordVerificationMatrix(data, true)
-	return matrix, err == nil
+	if err != nil {
+		return nil, true, err
+	}
+	return matrix, true, nil
 }
 
 func parseRecordVerificationMatrix(data map[string]interface{}, requireFieldTypes bool) (*recordVerificationMatrix, error) {

--- a/shortcuts/base/record_list_consistency.go
+++ b/shortcuts/base/record_list_consistency.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"fmt"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// listRecordsVerified reads one record-list page and rechecks ambiguous null
+// number cells through records/batch_get. The list matrix endpoint can
+// occasionally return a null for a populated number cell without reporting an
+// error. A null is otherwise indistinguishable from an intentionally empty
+// cell, so the independent ID-based read is the narrowest reliable check.
+func listRecordsVerified(runtime *common.RuntimeContext, params map[string]interface{}) (map[string]interface{}, error) {
+	path := baseV3Path("bases", runtime.Str("base-token"), "tables", baseTableID(runtime), "records")
+	data, err := baseV3Call(runtime, "GET", path, params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return verifyNullNumberCells(runtime, data)
+}
+
+func verifyNullNumberCells(runtime *common.RuntimeContext, data map[string]interface{}) (map[string]interface{}, error) {
+	fields, fieldsOK := interfaceStrings(data["fields"])
+	fieldTypes, typesOK := interfaceStrings(data["field_type_list"])
+	recordIDs, recordsOK := interfaceStrings(data["record_id_list"])
+	rows, rowsOK := data["data"].([]interface{})
+	if !fieldsOK || !typesOK || !recordsOK || !rowsOK || len(fields) != len(fieldTypes) || len(recordIDs) != len(rows) {
+		// Keep legacy JSON/Markdown behavior for old response shapes. NDJSON has
+		// its own strict matrix parser and will reject malformed responses later.
+		return data, nil
+	}
+
+	numberIndexes := make([]int, 0, len(fieldTypes))
+	numberFields := make([]string, 0, len(fieldTypes))
+	for index, fieldType := range fieldTypes {
+		if fieldType == "number" {
+			numberIndexes = append(numberIndexes, index)
+			numberFields = append(numberFields, fields[index])
+		}
+	}
+	if len(numberIndexes) == 0 {
+		return data, nil
+	}
+
+	affected := make([]string, 0, len(rows))
+	affectedSet := make(map[string]bool, len(rows))
+	for rowIndex, rawRow := range rows {
+		row, ok := rawRow.([]interface{})
+		if !ok || len(row) != len(fields) {
+			continue
+		}
+		for _, columnIndex := range numberIndexes {
+			if row[columnIndex] == nil {
+				affected = append(affected, recordIDs[rowIndex])
+				affectedSet[recordIDs[rowIndex]] = true
+				break
+			}
+		}
+	}
+	if len(affected) == 0 {
+		return data, nil
+	}
+
+	verified := make(map[string]map[string]interface{}, len(affected))
+	path := baseV3Path("bases", runtime.Str("base-token"), "tables", baseTableID(runtime), "records", "batch_get")
+	for recordStart := 0; recordStart < len(affected); recordStart += maxRecordSelectionCount {
+		recordEnd := min(recordStart+maxRecordSelectionCount, len(affected))
+		for fieldStart := 0; fieldStart < len(numberFields); fieldStart += maxBatchGetSelectFieldCount {
+			fieldEnd := min(fieldStart+maxBatchGetSelectFieldCount, len(numberFields))
+			selection := recordSelection{
+				recordIDs:    affected[recordStart:recordEnd],
+				selectFields: numberFields[fieldStart:fieldEnd],
+			}
+			result, callErr := baseV3Raw(runtime, "POST", path, nil, recordGetBatchBody(selection))
+			batch, callErr := handleBaseAPIResult(result, callErr, "verify record-list number cells")
+			if callErr != nil {
+				return nil, callErr
+			}
+			if err := requireSameRecordRevision(data, batch); err != nil {
+				return nil, err
+			}
+			if err := collectVerifiedNumberCells(verified, batch); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for rowIndex, rawRow := range rows {
+		if !affectedSet[recordIDs[rowIndex]] {
+			continue
+		}
+		row, ok := rawRow.([]interface{})
+		if !ok || len(row) != len(fields) {
+			continue
+		}
+		values := verified[recordIDs[rowIndex]]
+		for _, columnIndex := range numberIndexes {
+			if row[columnIndex] == nil && values[fields[columnIndex]] != nil {
+				row[columnIndex] = values[fields[columnIndex]]
+			}
+		}
+	}
+	return data, nil
+}
+
+func interfaceStrings(value interface{}) ([]string, bool) {
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, len(items))
+	for index, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		out[index] = text
+	}
+	return out, true
+}
+
+func requireSameRecordRevision(listData, batchData map[string]interface{}) error {
+	listRev, listHasRev := listData["rev"]
+	batchRev, batchHasRev := batchData["rev"]
+	if !listHasRev || !batchHasRev || fmt.Sprint(listRev) == fmt.Sprint(batchRev) {
+		return nil
+	}
+	return errs.NewInternalError(
+		errs.SubtypeInvalidResponse,
+		"record table changed while verifying list results (list rev %v, verification rev %v)", listRev, batchRev,
+	).WithHint("Retry +record-list so the result comes from one table revision.")
+}
+
+func collectVerifiedNumberCells(dst map[string]map[string]interface{}, data map[string]interface{}) error {
+	fields, fieldsOK := interfaceStrings(data["fields"])
+	recordIDs, recordsOK := interfaceStrings(data["record_id_list"])
+	rows, rowsOK := data["data"].([]interface{})
+	if !fieldsOK || !recordsOK || !rowsOK || len(recordIDs) != len(rows) {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "record-list verification returned a malformed matrix")
+	}
+	for rowIndex, rawRow := range rows {
+		row, ok := rawRow.([]interface{})
+		if !ok || len(row) != len(fields) {
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "record-list verification returned a malformed row")
+		}
+		values := dst[recordIDs[rowIndex]]
+		if values == nil {
+			values = make(map[string]interface{}, len(fields))
+			dst[recordIDs[rowIndex]] = values
+		}
+		for columnIndex, field := range fields {
+			values[field] = row[columnIndex]
+		}
+	}
+	return nil
+}

--- a/shortcuts/base/record_list_consistency.go
+++ b/shortcuts/base/record_list_consistency.go
@@ -10,6 +10,17 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
+type recordVerificationMatrix struct {
+	fields         []string
+	fieldIDs       []string
+	fieldTypes     []string
+	recordIDs      []string
+	rows           [][]interface{}
+	recordNotFound map[string]bool
+	rev            interface{}
+	hasRev         bool
+}
+
 // listRecordsVerified reads one record-list page and rechecks ambiguous null
 // number cells through records/batch_get. The list matrix endpoint can
 // occasionally return a null for a populated number cell without reporting an
@@ -25,40 +36,43 @@ func listRecordsVerified(runtime *common.RuntimeContext, params map[string]inter
 }
 
 func verifyNullNumberCells(runtime *common.RuntimeContext, data map[string]interface{}) (map[string]interface{}, error) {
-	fields, fieldsOK := interfaceStrings(data["fields"])
-	fieldTypes, typesOK := interfaceStrings(data["field_type_list"])
-	recordIDs, recordsOK := interfaceStrings(data["record_id_list"])
-	rows, rowsOK := data["data"].([]interface{})
-	if !fieldsOK || !typesOK || !recordsOK || !rowsOK || len(fields) != len(fieldTypes) || len(recordIDs) != len(rows) {
+	matrix, ok := parseListVerificationMatrix(data)
+	if !ok {
 		// Keep legacy JSON/Markdown behavior for old response shapes. NDJSON has
 		// its own strict matrix parser and will reject malformed responses later.
 		return data, nil
 	}
 
-	numberIndexes := make([]int, 0, len(fieldTypes))
-	numberFields := make([]string, 0, len(fieldTypes))
-	for index, fieldType := range fieldTypes {
+	type numberColumn struct {
+		index   int
+		fieldID string
+	}
+	numberColumns := make([]numberColumn, 0, len(matrix.fieldTypes))
+	for index, fieldType := range matrix.fieldTypes {
 		if fieldType == "number" {
-			numberIndexes = append(numberIndexes, index)
-			numberFields = append(numberFields, fields[index])
+			numberColumns = append(numberColumns, numberColumn{index: index, fieldID: matrix.fieldIDs[index]})
 		}
 	}
-	if len(numberIndexes) == 0 {
+	if len(numberColumns) == 0 {
 		return data, nil
 	}
 
-	affected := make([]string, 0, len(rows))
-	affectedSet := make(map[string]bool, len(rows))
-	for rowIndex, rawRow := range rows {
-		row, ok := rawRow.([]interface{})
-		if !ok || len(row) != len(fields) {
-			continue
-		}
-		for _, columnIndex := range numberIndexes {
-			if row[columnIndex] == nil {
-				affected = append(affected, recordIDs[rowIndex])
-				affectedSet[recordIDs[rowIndex]] = true
-				break
+	affected := make([]string, 0, len(matrix.rows))
+	affectedSet := make(map[string]bool, len(matrix.rows))
+	ambiguousFields := make([]string, 0, len(numberColumns))
+	ambiguousFieldSet := make(map[string]bool, len(numberColumns))
+	for rowIndex, row := range matrix.rows {
+		for _, column := range numberColumns {
+			if row[column.index] != nil {
+				continue
+			}
+			if !affectedSet[matrix.recordIDs[rowIndex]] {
+				affected = append(affected, matrix.recordIDs[rowIndex])
+				affectedSet[matrix.recordIDs[rowIndex]] = true
+			}
+			if !ambiguousFieldSet[column.fieldID] {
+				ambiguousFields = append(ambiguousFields, column.fieldID)
+				ambiguousFieldSet[column.fieldID] = true
 			}
 		}
 	}
@@ -70,42 +84,95 @@ func verifyNullNumberCells(runtime *common.RuntimeContext, data map[string]inter
 	path := baseV3Path("bases", runtime.Str("base-token"), "tables", baseTableID(runtime), "records", "batch_get")
 	for recordStart := 0; recordStart < len(affected); recordStart += maxRecordSelectionCount {
 		recordEnd := min(recordStart+maxRecordSelectionCount, len(affected))
-		for fieldStart := 0; fieldStart < len(numberFields); fieldStart += maxBatchGetSelectFieldCount {
-			fieldEnd := min(fieldStart+maxBatchGetSelectFieldCount, len(numberFields))
+		for fieldStart := 0; fieldStart < len(ambiguousFields); fieldStart += maxBatchGetSelectFieldCount {
+			fieldEnd := min(fieldStart+maxBatchGetSelectFieldCount, len(ambiguousFields))
 			selection := recordSelection{
 				recordIDs:    affected[recordStart:recordEnd],
-				selectFields: numberFields[fieldStart:fieldEnd],
+				selectFields: ambiguousFields[fieldStart:fieldEnd],
 			}
 			result, callErr := baseV3Raw(runtime, "POST", path, nil, recordGetBatchBody(selection))
 			batch, callErr := handleBaseAPIResult(result, callErr, "verify record-list number cells")
 			if callErr != nil {
 				return nil, callErr
 			}
-			if err := requireSameRecordRevision(data, batch); err != nil {
+			batchMatrix, parseErr := parseRecordVerificationMatrix(batch, false)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			if err := requireSameRecordRevision(matrix, batchMatrix); err != nil {
 				return nil, err
 			}
-			if err := collectVerifiedNumberCells(verified, batch); err != nil {
+			if err := collectVerifiedNumberCells(verified, batchMatrix, selection); err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	for rowIndex, rawRow := range rows {
-		if !affectedSet[recordIDs[rowIndex]] {
+	for rowIndex, row := range matrix.rows {
+		if !affectedSet[matrix.recordIDs[rowIndex]] {
 			continue
 		}
-		row, ok := rawRow.([]interface{})
-		if !ok || len(row) != len(fields) {
-			continue
-		}
-		values := verified[recordIDs[rowIndex]]
-		for _, columnIndex := range numberIndexes {
-			if row[columnIndex] == nil && values[fields[columnIndex]] != nil {
-				row[columnIndex] = values[fields[columnIndex]]
+		values := verified[matrix.recordIDs[rowIndex]]
+		for _, column := range numberColumns {
+			value, exists := values[column.fieldID]
+			if row[column.index] == nil && exists && value != nil {
+				row[column.index] = value
 			}
 		}
 	}
 	return data, nil
+}
+
+func parseListVerificationMatrix(data map[string]interface{}) (*recordVerificationMatrix, bool) {
+	for _, key := range []string{"fields", "field_id_list", "field_type_list", "record_id_list", "data"} {
+		if _, exists := data[key]; !exists {
+			return nil, false
+		}
+	}
+	matrix, err := parseRecordVerificationMatrix(data, true)
+	return matrix, err == nil
+}
+
+func parseRecordVerificationMatrix(data map[string]interface{}, requireFieldTypes bool) (*recordVerificationMatrix, error) {
+	fields, fieldsOK := interfaceStrings(data["fields"])
+	fieldIDs, fieldIDsOK := interfaceStrings(data["field_id_list"])
+	recordIDs, recordsOK := interfaceStrings(data["record_id_list"])
+	rawRows, rowsOK := data["data"].([]interface{})
+	if !fieldsOK || !fieldIDsOK || !recordsOK || !rowsOK || len(fields) != len(fieldIDs) || len(recordIDs) != len(rawRows) {
+		return nil, invalidRecordVerificationMatrix("matrix dimensions do not match")
+	}
+	fieldTypes := make([]string, len(fields))
+	if requireFieldTypes {
+		var typesOK bool
+		fieldTypes, typesOK = interfaceStrings(data["field_type_list"])
+		if !typesOK || len(fields) != len(fieldTypes) {
+			return nil, invalidRecordVerificationMatrix("field metadata dimensions do not match")
+		}
+	}
+	rows := make([][]interface{}, len(rawRows))
+	for rowIndex, rawRow := range rawRows {
+		row, ok := rawRow.([]interface{})
+		if !ok || len(row) != len(fields) {
+			return nil, invalidRecordVerificationMatrix("row %d does not match the field count", rowIndex+1)
+		}
+		rows[rowIndex] = row
+	}
+	recordNotFound := map[string]bool{}
+	if raw, exists := data["record_not_found"]; exists && raw != nil {
+		items, ok := interfaceStrings(raw)
+		if !ok {
+			return nil, invalidRecordVerificationMatrix("record_not_found is not a string array")
+		}
+		for _, recordID := range items {
+			recordNotFound[recordID] = true
+		}
+	}
+	rev, hasRev := data["rev"]
+	return &recordVerificationMatrix{
+		fields: fields, fieldIDs: fieldIDs, fieldTypes: fieldTypes,
+		recordIDs: recordIDs, rows: rows, recordNotFound: recordNotFound,
+		rev: rev, hasRev: hasRev,
+	}, nil
 }
 
 func interfaceStrings(value interface{}) ([]string, bool) {
@@ -124,38 +191,60 @@ func interfaceStrings(value interface{}) ([]string, bool) {
 	return out, true
 }
 
-func requireSameRecordRevision(listData, batchData map[string]interface{}) error {
-	listRev, listHasRev := listData["rev"]
-	batchRev, batchHasRev := batchData["rev"]
-	if !listHasRev || !batchHasRev || fmt.Sprint(listRev) == fmt.Sprint(batchRev) {
+func requireSameRecordRevision(listMatrix, batchMatrix *recordVerificationMatrix) error {
+	if !listMatrix.hasRev || !batchMatrix.hasRev || fmt.Sprint(listMatrix.rev) == fmt.Sprint(batchMatrix.rev) {
 		return nil
 	}
 	return errs.NewInternalError(
 		errs.SubtypeInvalidResponse,
-		"record table changed while verifying list results (list rev %v, verification rev %v)", listRev, batchRev,
+		"record table changed while verifying list results (list rev %v, verification rev %v)", listMatrix.rev, batchMatrix.rev,
 	).WithHint("Retry +record-list so the result comes from one table revision.")
 }
 
-func collectVerifiedNumberCells(dst map[string]map[string]interface{}, data map[string]interface{}) error {
-	fields, fieldsOK := interfaceStrings(data["fields"])
-	recordIDs, recordsOK := interfaceStrings(data["record_id_list"])
-	rows, rowsOK := data["data"].([]interface{})
-	if !fieldsOK || !recordsOK || !rowsOK || len(recordIDs) != len(rows) {
-		return errs.NewInternalError(errs.SubtypeInvalidResponse, "record-list verification returned a malformed matrix")
+func collectVerifiedNumberCells(dst map[string]map[string]interface{}, matrix *recordVerificationMatrix, selection recordSelection) error {
+	fieldIndexes := make(map[string]int, len(matrix.fieldIDs))
+	for index, fieldID := range matrix.fieldIDs {
+		if _, duplicate := fieldIndexes[fieldID]; duplicate {
+			return invalidRecordVerificationMatrix("duplicate field id %q", fieldID)
+		}
+		fieldIndexes[fieldID] = index
 	}
-	for rowIndex, rawRow := range rows {
-		row, ok := rawRow.([]interface{})
-		if !ok || len(row) != len(fields) {
-			return errs.NewInternalError(errs.SubtypeInvalidResponse, "record-list verification returned a malformed row")
+	for _, fieldID := range selection.selectFields {
+		if _, exists := fieldIndexes[fieldID]; !exists {
+			return invalidRecordVerificationMatrix("requested field %q is missing", fieldID)
 		}
-		values := dst[recordIDs[rowIndex]]
+	}
+	recordIndexes := make(map[string]int, len(matrix.recordIDs))
+	for index, recordID := range matrix.recordIDs {
+		if _, duplicate := recordIndexes[recordID]; duplicate {
+			return invalidRecordVerificationMatrix("duplicate record id %q", recordID)
+		}
+		recordIndexes[recordID] = index
+	}
+	for _, recordID := range selection.recordIDs {
+		if matrix.recordNotFound[recordID] {
+			return invalidRecordVerificationMatrix("requested record %q was not found", recordID)
+		}
+		rowIndex, exists := recordIndexes[recordID]
+		if !exists {
+			return invalidRecordVerificationMatrix("requested record %q is missing", recordID)
+		}
+		values := dst[recordID]
 		if values == nil {
-			values = make(map[string]interface{}, len(fields))
-			dst[recordIDs[rowIndex]] = values
+			values = make(map[string]interface{}, len(selection.selectFields))
+			dst[recordID] = values
 		}
-		for columnIndex, field := range fields {
-			values[field] = row[columnIndex]
+		for _, fieldID := range selection.selectFields {
+			values[fieldID] = matrix.rows[rowIndex][fieldIndexes[fieldID]]
 		}
 	}
 	return nil
+}
+
+func invalidRecordVerificationMatrix(format string, args ...interface{}) error {
+	return errs.NewInternalError(
+		errs.SubtypeInvalidResponse,
+		"record-list verification returned a malformed matrix: "+format,
+		args...,
+	)
 }

--- a/shortcuts/base/record_list_consistency_test.go
+++ b/shortcuts/base/record_list_consistency_test.go
@@ -70,6 +70,77 @@ func TestRecordListNumberVerification(t *testing.T) {
 		}
 	})
 
+	t.Run("repairs a silently missing currency cell", func(t *testing.T) {
+		factory, stdout, registry := newExecuteFactory(t)
+		registry.Register(recordListVerificationListStub(map[string]interface{}{
+			"fields":          []interface{}{"Amount"},
+			"field_id_list":   []interface{}{"fld_amount"},
+			"field_type_list": []interface{}{"currency"},
+			"record_id_list":  []interface{}{"rec_1"},
+			"data":            []interface{}{[]interface{}{nil}},
+			"rev":             42,
+		}))
+		batchStub := recordListVerificationBatchStub(map[string]interface{}{
+			"fields":         []interface{}{"Amount"},
+			"field_id_list":  []interface{}{"fld_amount"},
+			"record_id_list": []interface{}{"rec_1"},
+			"data":           []interface{}{[]interface{}{35}},
+			"rev":            42,
+		})
+		registry.Register(batchStub)
+
+		if err := runShortcut(t, BaseRecordList, recordListVerificationArgs(), factory, stdout); err != nil {
+			t.Fatalf("runShortcut() error = %v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `35`) || strings.Contains(got, `null`) {
+			t.Fatalf("stdout = %s", got)
+		}
+		if body := string(batchStub.CapturedBody); !strings.Contains(body, `"select_fields":["fld_amount"]`) {
+			t.Fatalf("batch_get body = %s", body)
+		}
+	})
+
+	t.Run("rejects a malformed complete list matrix", func(t *testing.T) {
+		factory, stdout, registry := newExecuteFactory(t)
+		registry.Register(recordListVerificationListStub(map[string]interface{}{
+			"fields":          []interface{}{"Cost"},
+			"field_id_list":   []interface{}{"fld_cost"},
+			"field_type_list": []interface{}{"number"},
+			"record_id_list":  []interface{}{"rec_1"},
+			"data":            []interface{}{[]interface{}{}},
+			"rev":             42,
+		}))
+
+		err := runShortcut(t, BaseRecordList, recordListVerificationArgs(), factory, stdout)
+		if err == nil || !strings.Contains(err.Error(), "row 1 does not match the field count") {
+			t.Fatalf("error = %v", err)
+		}
+		problem, ok := errs.ProblemOf(err)
+		if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeInvalidResponse {
+			t.Fatalf("problem = %#v", problem)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("stdout = %s", stdout.String())
+		}
+	})
+
+	t.Run("preserves a legacy list matrix missing field IDs", func(t *testing.T) {
+		factory, stdout, registry := newExecuteFactory(t)
+		registry.Register(recordListVerificationListStub(map[string]interface{}{
+			"fields":          []interface{}{"Cost"},
+			"field_type_list": []interface{}{"number"},
+			"record_id_list":  []interface{}{"rec_1"},
+			"data":            []interface{}{[]interface{}{nil}},
+		}))
+
+		if err := runShortcut(t, BaseRecordList, recordListVerificationArgs(), factory, stdout); err != nil {
+			t.Fatalf("runShortcut() error = %v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `null`) {
+			t.Fatalf("stdout = %s", got)
+		}
+	})
+
 	for _, test := range []struct {
 		name      string
 		batchData map[string]interface{}

--- a/shortcuts/base/record_list_consistency_test.go
+++ b/shortcuts/base/record_list_consistency_test.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestRecordListNumberVerification(t *testing.T) {
+	t.Run("preserves a legitimate null and requests only ambiguous field IDs", func(t *testing.T) {
+		factory, stdout, registry := newExecuteFactory(t)
+		registry.Register(recordListVerificationListStub(map[string]interface{}{
+			"fields":          []interface{}{"Cost", "Stable"},
+			"field_id_list":   []interface{}{"fld_cost", "fld_stable"},
+			"field_type_list": []interface{}{"number", "number"},
+			"record_id_list":  []interface{}{"rec_1"},
+			"data":            []interface{}{[]interface{}{nil, 7}},
+			"rev":             42,
+		}))
+		batchStub := recordListVerificationBatchStub(map[string]interface{}{
+			"fields":         []interface{}{"Cost"},
+			"field_id_list":  []interface{}{"fld_cost"},
+			"record_id_list": []interface{}{"rec_1"},
+			"data":           []interface{}{[]interface{}{nil}},
+			"rev":            42,
+		})
+		registry.Register(batchStub)
+
+		err := runShortcut(t, BaseRecordList, recordListVerificationArgs(), factory, stdout)
+		if err != nil {
+			t.Fatalf("runShortcut() error = %v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `null`) || !strings.Contains(got, `7`) {
+			t.Fatalf("stdout = %s", got)
+		}
+		body := string(batchStub.CapturedBody)
+		if !strings.Contains(body, `"select_fields":["fld_cost"]`) || strings.Contains(body, `fld_stable`) {
+			t.Fatalf("batch_get body = %s", body)
+		}
+	})
+
+	t.Run("accepts legacy responses without revisions", func(t *testing.T) {
+		factory, stdout, registry := newExecuteFactory(t)
+		registry.Register(recordListVerificationListStub(map[string]interface{}{
+			"fields":          []interface{}{"Cost"},
+			"field_id_list":   []interface{}{"fld_cost"},
+			"field_type_list": []interface{}{"number"},
+			"record_id_list":  []interface{}{"rec_1"},
+			"data":            []interface{}{[]interface{}{nil}},
+		}))
+		registry.Register(recordListVerificationBatchStub(map[string]interface{}{
+			"fields":         []interface{}{"Cost"},
+			"field_id_list":  []interface{}{"fld_cost"},
+			"record_id_list": []interface{}{"rec_1"},
+			"data":           []interface{}{[]interface{}{500}},
+		}))
+
+		if err := runShortcut(t, BaseRecordList, recordListVerificationArgs(), factory, stdout); err != nil {
+			t.Fatalf("runShortcut() error = %v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `500`) || strings.Contains(got, `null`) {
+			t.Fatalf("stdout = %s", got)
+		}
+	})
+
+	for _, test := range []struct {
+		name      string
+		batchData map[string]interface{}
+		want      string
+	}{
+		{
+			name: "rejects a missing requested field",
+			batchData: map[string]interface{}{
+				"fields":         []interface{}{"Other"},
+				"field_id_list":  []interface{}{"fld_other"},
+				"record_id_list": []interface{}{"rec_1"},
+				"data":           []interface{}{[]interface{}{500}},
+				"rev":            42,
+			},
+			want: "requested field",
+		},
+		{
+			name: "rejects a missing requested record",
+			batchData: map[string]interface{}{
+				"fields":         []interface{}{"Cost"},
+				"field_id_list":  []interface{}{"fld_cost"},
+				"record_id_list": []interface{}{},
+				"data":           []interface{}{},
+				"rev":            42,
+			},
+			want: "requested record",
+		},
+		{
+			name: "rejects record_not_found",
+			batchData: map[string]interface{}{
+				"fields":           []interface{}{"Cost"},
+				"field_id_list":    []interface{}{"fld_cost"},
+				"record_id_list":   []interface{}{"rec_1"},
+				"data":             []interface{}{[]interface{}{nil}},
+				"record_not_found": []interface{}{"rec_1"},
+				"rev":              42,
+			},
+			want: "was not found",
+		},
+		{
+			name: "rejects a changed table revision",
+			batchData: map[string]interface{}{
+				"fields":         []interface{}{"Cost"},
+				"field_id_list":  []interface{}{"fld_cost"},
+				"record_id_list": []interface{}{"rec_1"},
+				"data":           []interface{}{[]interface{}{500}},
+				"rev":            43,
+			},
+			want: "table changed",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			factory, stdout, registry := newExecuteFactory(t)
+			registry.Register(recordListVerificationListStub(map[string]interface{}{
+				"fields":          []interface{}{"Cost"},
+				"field_id_list":   []interface{}{"fld_cost"},
+				"field_type_list": []interface{}{"number"},
+				"record_id_list":  []interface{}{"rec_1"},
+				"data":            []interface{}{[]interface{}{nil}},
+				"rev":             42,
+			}))
+			registry.Register(recordListVerificationBatchStub(test.batchData))
+
+			err := runShortcut(t, BaseRecordList, recordListVerificationArgs(), factory, stdout)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryInternal || problem.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("problem = %#v", problem)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRecordListNumberVerificationBatchesAtRecordLimit(t *testing.T) {
+	dir := t.TempDir()
+	withBaseWorkingDir(t, dir)
+	factory, stdout, registry := newExecuteFactory(t)
+	recordIDs := make([]interface{}, maxRecordSelectionCount+1)
+	rows := make([]interface{}, len(recordIDs))
+	firstBatchRecordIDs := make([]interface{}, maxRecordSelectionCount)
+	firstBatchRows := make([]interface{}, maxRecordSelectionCount)
+	for index := range recordIDs {
+		recordID := fmt.Sprintf("rec_%03d", index)
+		recordIDs[index] = recordID
+		rows[index] = []interface{}{nil}
+		if index < maxRecordSelectionCount {
+			firstBatchRecordIDs[index] = recordID
+			firstBatchRows[index] = []interface{}{nil}
+		}
+	}
+	registry.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "limit=201&offset=0",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"timezone":        "UTC",
+			"fields":          []interface{}{"Cost"},
+			"field_id_list":   []interface{}{"fld_cost"},
+			"field_type_list": []interface{}{"number"},
+			"record_id_list":  recordIDs,
+			"data":            rows,
+			"has_more":        false,
+			"rev":             42,
+		}},
+	})
+	firstBatch := recordListVerificationBatchStub(map[string]interface{}{
+		"fields":         []interface{}{"Cost"},
+		"field_id_list":  []interface{}{"fld_cost"},
+		"record_id_list": firstBatchRecordIDs,
+		"data":           firstBatchRows,
+		"rev":            42,
+	})
+	firstBatch.BodyFilter = batchRecordCountFilter(maxRecordSelectionCount)
+	registry.Register(firstBatch)
+	secondBatch := recordListVerificationBatchStub(map[string]interface{}{
+		"fields":         []interface{}{"Cost"},
+		"field_id_list":  []interface{}{"fld_cost"},
+		"record_id_list": []interface{}{"rec_200"},
+		"data":           []interface{}{[]interface{}{nil}},
+		"rev":            42,
+	})
+	secondBatch.BodyFilter = batchRecordCountFilter(1)
+	registry.Register(secondBatch)
+
+	err := runShortcut(t, BaseRecordList, []string{
+		"+record-list", "--base-token", "app_x", "--table-id", "tbl_x",
+		"--limit", "201", "--output", "verified.ndjson", "--minimal-stdout",
+	}, factory, stdout)
+	if err != nil {
+		t.Fatalf("runShortcut() error = %v", err)
+	}
+	if len(firstBatch.CapturedBodies) != 1 || len(secondBatch.CapturedBodies) != 1 {
+		t.Fatalf("batch calls = %d, %d", len(firstBatch.CapturedBodies), len(secondBatch.CapturedBodies))
+	}
+}
+
+func TestRecordListNumberVerificationBatchesAtFieldLimit(t *testing.T) {
+	factory, stdout, registry := newExecuteFactory(t)
+	fieldCount := maxBatchGetSelectFieldCount + 1
+	fields := make([]interface{}, fieldCount)
+	fieldIDs := make([]interface{}, fieldCount)
+	fieldTypes := make([]interface{}, fieldCount)
+	row := make([]interface{}, fieldCount)
+	for index := 0; index < fieldCount; index++ {
+		fields[index] = fmt.Sprintf("Cost %03d", index)
+		fieldIDs[index] = fmt.Sprintf("fld_%03d", index)
+		fieldTypes[index] = "number"
+	}
+	registry.Register(recordListVerificationListStub(map[string]interface{}{
+		"fields":          fields,
+		"field_id_list":   fieldIDs,
+		"field_type_list": fieldTypes,
+		"record_id_list":  []interface{}{"rec_1"},
+		"data":            []interface{}{row},
+		"rev":             42,
+	}))
+	firstBatch := recordListVerificationBatchStub(verificationFieldBatchData(fields[:maxBatchGetSelectFieldCount], fieldIDs[:maxBatchGetSelectFieldCount]))
+	firstBatch.BodyFilter = batchFieldCountFilter(maxBatchGetSelectFieldCount)
+	registry.Register(firstBatch)
+	secondBatch := recordListVerificationBatchStub(verificationFieldBatchData(fields[maxBatchGetSelectFieldCount:], fieldIDs[maxBatchGetSelectFieldCount:]))
+	secondBatch.BodyFilter = batchFieldCountFilter(1)
+	registry.Register(secondBatch)
+
+	if err := runShortcut(t, BaseRecordList, recordListVerificationArgs(), factory, stdout); err != nil {
+		t.Fatalf("runShortcut() error = %v", err)
+	}
+	if len(firstBatch.CapturedBodies) != 1 || len(secondBatch.CapturedBodies) != 1 {
+		t.Fatalf("batch calls = %d, %d", len(firstBatch.CapturedBodies), len(secondBatch.CapturedBodies))
+	}
+}
+
+func verificationFieldBatchData(fields, fieldIDs []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"fields":         fields,
+		"field_id_list":  fieldIDs,
+		"record_id_list": []interface{}{"rec_1"},
+		"data":           []interface{}{make([]interface{}, len(fields))},
+		"rev":            42,
+	}
+}
+
+func batchRecordCountFilter(want int) func([]byte) bool {
+	return func(body []byte) bool {
+		var request struct {
+			RecordIDs []string `json:"record_id_list"`
+		}
+		return json.Unmarshal(body, &request) == nil && len(request.RecordIDs) == want
+	}
+}
+
+func batchFieldCountFilter(want int) func([]byte) bool {
+	return func(body []byte) bool {
+		var request struct {
+			SelectFields []string `json:"select_fields"`
+		}
+		return json.Unmarshal(body, &request) == nil && len(request.SelectFields) == want
+	}
+}
+
+func recordListVerificationArgs() []string {
+	return []string{
+		"+record-list", "--base-token", "app_x", "--table-id", "tbl_x",
+		"--limit", "1", "--format", "json",
+	}
+}
+
+func recordListVerificationListStub(data map[string]interface{}) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "GET",
+		URL:    "limit=1&offset=0",
+		Body:   map[string]interface{}{"code": 0, "data": data},
+	}
+}
+
+func recordListVerificationBatchStub(data map[string]interface{}) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/base/v3/bases/app_x/tables/tbl_x/records/batch_get",
+		Body:   map[string]interface{}{"code": 0, "data": data},
+	}
+}

--- a/shortcuts/base/record_ops.go
+++ b/shortcuts/base/record_ops.go
@@ -573,7 +573,7 @@ func executeRecordList(runtime *common.RuntimeContext) error {
 	}
 	params["offset"] = offset
 	params["limit"] = limit
-	data, err := baseV3Call(runtime, "GET", baseV3Path("bases", runtime.Str("base-token"), "tables", baseTableID(runtime), "records"), params, nil)
+	data, err := listRecordsVerified(runtime, params)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A rare matrix response from `base +record-list` can contain `null` for a populated Number/Currency cell while the record batch-get endpoint returns the stored value. Because the command currently accepts the matrix response as-is, downstream totals can be silently understated.

This change treats null numeric cells as ambiguous and verifies only those cells through `records/batch_get`. It reconciles by stable field ID, keeps confirmed legal nulls unchanged, and returns a typed `invalid_response` error when verification omits a record/field, reports `record_not_found`, or returns a conflicting revision. Verification is chunked to the API's 200-record and 100-field limits. Responses that do not expose revisions remain compatible; when both endpoints expose revisions, they must match.

Validation:
- `go test ./shortcuts/base/...`
- `make fmt-check`
- `make vet`
- `make unit-test`
- `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- Live read-only smoke test against a 357-row table: both pages returned the same revision and a known populated currency cell returned its stored value


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `record-list` reliability by recovering missing numeric and currency values that may appear as `null`.
  * Preserved legitimate `null` values while validating and restoring silently missing number cells.
  * Added safeguards for incomplete, malformed, or inconsistent record responses.
  * Improved handling of large result sets by validating and repairing missing values in batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->