### PR TITLE
Support repeatable list flags in mail shortcuts

### DIFF
--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -368,6 +368,49 @@ func resolveComposeSenderEmail(runtime *common.RuntimeContext) string {
 	return email
 }
 
+// validateComposeSenderForMailbox verifies that an explicitly selected From
+// address is one of the addresses the target mailbox is allowed to send as.
+// The check is intentionally performed before drafts.create: accepting an
+// arbitrary From header and relying on the send endpoint to reject it would
+// still leave an unauthorized draft behind.
+//
+// Commands that omit --from keep their existing mailbox/profile resolution.
+// This preserves the default "me" path and shared-mailbox owner path while
+// still allowing aliases and mail groups returned by settings.send_as.
+func validateComposeSenderForMailbox(runtime *common.RuntimeContext, mailboxID string) error {
+	from := strings.TrimSpace(runtime.Str("from"))
+	if from == "" {
+		return nil
+	}
+	explicitMailbox := strings.TrimSpace(runtime.Str("mailbox"))
+	if explicitMailbox == "" || strings.EqualFold(explicitMailbox, from) {
+		return nil
+	}
+	if mailboxID == "" {
+		mailboxID = "me"
+	}
+
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "settings", "send_as"), nil, nil)
+	if err != nil {
+		return mailDecorateProblemMessage(err, "failed to validate --from for mailbox %s", mailboxID)
+	}
+	addrs, _ := data["sendable_addresses"].([]interface{})
+	for _, raw := range addrs {
+		addr, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		email, _ := addr["email_address"].(string)
+		if strings.EqualFold(strings.TrimSpace(email), from) {
+			return nil
+		}
+	}
+
+	return mailValidationParamError("--from",
+		"--from %q is not a sendable address for mailbox %q; query mail user_mailbox.settings send_as for the allowed addresses",
+		from, mailboxID)
+}
+
 // fetchSelfEmailSet returns a set of addresses to exclude as "self" in
 // reply-all. It always tries profile("me"); when mailboxID or senderEmail
 // differ from "me", those are added to the set as well so that shared-

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -2293,6 +2293,44 @@ func normalizeRecipientFlagValues(values []string) string {
 	return strings.Join(parts, ", ")
 }
 
+// validateRecipientFlagValues validates every repeated recipient flag
+// occurrence before Execute can perform any remote or upload side effects.
+// The existing normalization remains deliberately separate so dry-run and
+// Execute continue to preserve the original ordering and display names.
+func validateRecipientFlagValues(flagName string, values []string) error {
+	for occurrence, raw := range values {
+		parts := splitAddressList(raw)
+		foundAddress := false
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			foundAddress = true
+			if _, err := netmail.ParseAddress(part); err != nil {
+				return mailValidationParamError(flagName,
+					"%s occurrence %d: invalid recipient address %q: %v",
+					flagName, occurrence+1, part, err).WithCause(err)
+			}
+		}
+		if !foundAddress {
+			return mailValidationParamError(flagName,
+				"%s occurrence %d: recipient address must not be empty",
+				flagName, occurrence+1)
+		}
+	}
+	return nil
+}
+
+func validateRepeatedRecipientFlags(runtime *common.RuntimeContext) error {
+	for _, name := range []string{"to", "cc", "bcc"} {
+		if err := validateRecipientFlagValues("--"+name, runtime.StrArray(name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func normalizeCommaListFlagValues(values []string) []string {
 	var out []string
 	for _, raw := range values {

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -2307,8 +2307,11 @@ func normalizeCommaFlagValues(values []string) string {
 
 func normalizeInlineFlagValues(values []string) (string, error) {
 	var all []InlineSpec
-	for _, raw := range values {
-		specs, err := parseInlineSpecs(raw)
+	for i, raw := range values {
+		if strings.TrimSpace(raw) == "" {
+			return "", mailValidationParamError("--inline", "--inline occurrence %d: value must not be empty", i+1)
+		}
+		specs, err := parseInlineSpecsOccurrence(raw, i+1)
 		if err != nil {
 			return "", err
 		}
@@ -2341,37 +2344,46 @@ func countInlineSpecsForLog(values []string) int {
 }
 
 // parseInlineSpecs parses one --inline flag value as either a JSON array or a
-// single JSON object. Returns an empty slice when raw is empty.
+// single JSON object. Returns an empty slice when raw is empty because an
+// empty normalized value represents an omitted --inline flag.
 func parseInlineSpecs(raw string) ([]InlineSpec, error) {
+	return parseInlineSpecsOccurrence(raw, 0)
+}
+
+func parseInlineSpecsOccurrence(raw string, occurrence int) ([]InlineSpec, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil, nil
 	}
+	prefix := ""
+	if occurrence > 0 {
+		prefix = fmt.Sprintf("--inline occurrence %d: ", occurrence)
+	}
 	if raw == "null" {
-		return nil, nil
+		return nil, mailValidationParamError("--inline", "%s--inline must be a JSON object or array, not null", prefix)
 	}
 	var specs []InlineSpec
 	switch raw[0] {
 	case '{':
 		var spec InlineSpec
 		if err := json.Unmarshal([]byte(raw), &spec); err != nil {
-			return nil, mailValidationParamError("--inline", "--inline must be a JSON object or array, e.g. '{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}' or '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]': %v", err).WithCause(err)
+			return nil, mailValidationParamError("--inline", "%s--inline must be a JSON object or array, e.g. '{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}' or '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]': %v", prefix, err).WithCause(err)
 		}
 		specs = []InlineSpec{spec}
 	case '[':
 		if err := json.Unmarshal([]byte(raw), &specs); err != nil {
-			return nil, mailValidationParamError("--inline", "--inline must be a JSON object or array, e.g. '{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}' or '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]': %v", err).WithCause(err)
+			return nil, mailValidationParamError("--inline", "%s--inline must be a JSON object or array, e.g. '{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}' or '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]': %v", prefix, err).WithCause(err)
 		}
 	default:
-		return nil, mailValidationParamError("--inline", "--inline must be a JSON object or array, e.g. '{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}' or '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]'")
+		return nil, mailValidationParamError("--inline", "%s--inline must be a JSON object or array, e.g. '{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}' or '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]'", prefix)
 	}
 	for i, s := range specs {
 		cid := normalizeInlineCID(s.CID)
 		if cid == "" {
-			return nil, mailValidationParamError("--inline", "--inline entry %d: \"cid\" must not be empty", i)
+			return nil, mailValidationParamError("--inline", "%s--inline entry %d: \"cid\" must not be empty", prefix, i+1)
 		}
 		if strings.TrimSpace(s.FilePath) == "" {
-			return nil, mailValidationParamError("--inline", "--inline entry %d: \"file_path\" must not be empty", i)
+			return nil, mailValidationParamError("--inline", "%s--inline entry %d: \"file_path\" must not be empty", prefix, i+1)
 		}
 		specs[i].CID = cid
 	}

--- a/shortcuts/mail/large_attachment.go
+++ b/shortcuts/mail/large_attachment.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -135,6 +136,51 @@ func statAttachmentFiles(fio fileio.FileIO, paths []string) ([]attachmentFile, e
 		})
 	}
 	return files, nil
+}
+
+// validateRepeatedAttachmentFlagFiles preflights every path while the raw
+// occurrence boundary is still available, so failures can identify the exact
+// --attach occurrence instead of reporting only the flattened path.
+func validateRepeatedAttachmentFlagFiles(fio fileio.FileIO, values []string) error {
+	for i, raw := range values {
+		if err := validateRepeatedFileFlagOccurrence(fio, "--attach", i+1, splitByComma(raw)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRepeatedInlineFlagFiles(fio fileio.FileIO, values []string) error {
+	for i, raw := range values {
+		specs, err := parseInlineSpecsOccurrence(raw, i+1)
+		if err != nil {
+			return err
+		}
+		if err := validateRepeatedFileFlagOccurrence(fio, "--inline", i+1, inlineSpecFilePaths(specs)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRepeatedFileFlagOccurrence(fio fileio.FileIO, flagName string, occurrence int, paths []string) error {
+	for _, path := range paths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		name := filepath.Base(path)
+		if err := filecheck.CheckBlockedExtension(name); err != nil {
+			return mailValidationParamError(flagName, "%s occurrence %d: %v", flagName, occurrence, err).WithCause(err)
+		}
+		if _, err := fio.Stat(path); err != nil {
+			reason := "cannot read file"
+			if errors.Is(err, fileio.ErrPathValidation) {
+				reason = "unsafe file path"
+			}
+			return mailValidationParamError(flagName, "%s occurrence %d: %s: %v", flagName, occurrence, reason, err).WithCause(err)
+		}
+	}
+	return nil
 }
 
 // uploadLargeAttachments uploads oversized files to the mail attachment storage

--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -69,6 +69,10 @@ var MailDraftCreate = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
+		if from, mailbox := strings.TrimSpace(runtime.Str("from")), strings.TrimSpace(runtime.Str("mailbox")); from != "" && mailbox != "" && !strings.EqualFold(from, mailbox) {
+			api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+				Desc("Verify that --from is a sendable address for the target mailbox before creating a draft.")
+		}
 		api = api.GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
@@ -133,6 +137,9 @@ var MailDraftCreate = common.Shortcut{
 			return err
 		}
 		mailboxID := resolveComposeMailboxID(runtime)
+		if err := validateComposeSenderForMailbox(runtime, mailboxID); err != nil {
+			return err
+		}
 		body, bErr := resolveBodyFromFlags(runtime)
 		if bErr != nil {
 			return bErr

--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -42,17 +42,17 @@ var MailDraftCreate = common.Shortcut{
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "to", Type: "string_array", Desc: "Optional. To recipient email address. Repeat --to once per recipient; quote each value. Display-name format is supported. When omitted, the draft is created without recipients (they can be added later via +draft-edit)."},
+		{Name: "to", Type: "string_array", Desc: "Optional. To recipient list. Repeat --to or pass a comma-separated list in one occurrence; quoted display-name commas are preserved. When omitted, the draft is created without recipients."},
 		{Name: "subject", Desc: "Final draft subject. Pass the full subject you want to appear in the draft. Required unless --template-id supplies a non-empty subject."},
 		{Name: "body", Desc: "Full email body. Prefer HTML for rich formatting (bold, lists, links); plain text is also supported. Body type is auto-detected. Use --plain-text to force plain-text mode. Mutually exclusive with --body-file. Required unless --template-id supplies a non-empty body."},
 		bodyFileFlag,
 		{Name: "from", Desc: "Optional. Sender email address for the From header. When using an alias (send_as) address, set this to the alias and use --mailbox for the owning mailbox. If omitted, the mailbox's primary address is used."},
 		{Name: "mailbox", Desc: "Optional. Mailbox email address that owns the draft (default: falls back to --from, then me). Use this when the sender (--from) differs from the mailbox, e.g. sending via an alias or send_as address."},
-		{Name: "cc", Type: "string_array", Desc: "Optional. Cc recipient email address. Repeat --cc once per recipient; quote each value. Display-name format is supported."},
-		{Name: "bcc", Type: "string_array", Desc: "Optional. Bcc recipient email address. Repeat --bcc once per recipient; quote each value. Display-name format is supported."},
+		{Name: "cc", Type: "string_array", Desc: "Optional. Cc recipient list. Repeat --cc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "bcc", Type: "string_array", Desc: "Optional. Bcc recipient list. Repeat --bcc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
 		{Name: "plain-text", Type: "bool", Desc: "Force plain-text mode, ignoring HTML auto-detection. Cannot be used with --inline."},
-		{Name: "attach", Type: "string_array", Desc: "Optional. Regular attachment file path, relative path only. Repeat --attach once per file; quote each value. Each path must point to a readable local file."},
-		{Name: "inline", Type: "string_array", Desc: "Optional. Inline image as one JSON object. Repeat --inline once per image; quote each value. Example value: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique, e.g. a random hex string. Cannot be used with --plain-text."},
+		{Name: "attach", Type: "string_array", Desc: "Optional. Regular attachment path, relative path only. Repeat --attach or pass comma-separated paths in one occurrence; input order is preserved."},
+		{Name: "inline", Type: "string_array", Desc: "Optional. Inline images as a JSON object or array per --inline occurrence; repeat to append in order. Values are not comma-split. file_path must be relative and CID unique. Cannot be used with --plain-text."},
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
@@ -81,6 +81,12 @@ var MailDraftCreate = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
+			return err
+		}
+		if err := validateRepeatedInlineFlagFiles(runtime.FileIO(), runtime.StrArray("inline")); err != nil {
+			return err
+		}
 		attach := normalizeCommaFlagValues(runtime.StrArray("attach"))
 		inline, err := normalizeInlineFlagValues(runtime.StrArray("inline"))
 		if err != nil {

--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -81,6 +81,9 @@ var MailDraftCreate = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedRecipientFlags(runtime); err != nil {
+			return err
+		}
 		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
 			return err
 		}

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -73,6 +73,9 @@ var MailForward = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedRecipientFlags(runtime); err != nil {
+			return err
+		}
 		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
 			return err
 		}

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -63,6 +63,10 @@ var MailForward = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with forward compose flags.")
 		}
+		if from, mailbox := strings.TrimSpace(runtime.Str("from")), strings.TrimSpace(runtime.Str("mailbox")); from != "" && mailbox != "" && !strings.EqualFold(from, mailbox) {
+			api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+				Desc("Verify that --from is a sendable address for the target mailbox before creating a draft.")
+		}
 		api = api.GET(mailboxPath(mailboxID, "messages", messageId)).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
@@ -149,6 +153,9 @@ var MailForward = common.Shortcut{
 		}
 
 		mailboxID := resolveComposeMailboxID(runtime)
+		if err := validateComposeSenderForMailbox(runtime, mailboxID); err != nil {
+			return err
+		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
 			return mailDecorateProblemMessage(err, "failed to fetch original message")

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -29,16 +29,16 @@ var MailForward = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "message-id", Desc: "Required. Message ID to forward", Required: true},
-		{Name: "to", Type: "string_array", Desc: "Recipient email address. Repeat --to once per recipient; quote each value. Display-name format is supported."},
+		{Name: "to", Type: "string_array", Desc: "Recipient list. Repeat --to or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
 		{Name: "body", Desc: "Body prepended before the forwarded message. Prefer HTML for rich formatting; plain text is also supported. Body type is auto-detected from the forward body and the original message. Use --plain-text to force plain-text mode. Mutually exclusive with --body-file."},
 		bodyFileFlag,
 		{Name: "from", Desc: "Sender email address for the From header. When using an alias (send_as) address, set this to the alias and use --mailbox for the owning mailbox. Defaults to the mailbox's primary address."},
 		{Name: "mailbox", Desc: "Mailbox email address that owns the draft (default: falls back to --from, then me). Use this when the sender (--from) differs from the mailbox, e.g. sending via an alias or send_as address."},
-		{Name: "cc", Type: "string_array", Desc: "CC email address. Repeat --cc once per recipient; quote each value. Display-name format is supported."},
-		{Name: "bcc", Type: "string_array", Desc: "BCC email address. Repeat --bcc once per recipient; quote each value. Display-name format is supported."},
+		{Name: "cc", Type: "string_array", Desc: "CC list. Repeat --cc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "bcc", Type: "string_array", Desc: "BCC list. Repeat --bcc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
 		{Name: "plain-text", Type: "bool", Desc: "Force plain-text mode, ignoring all HTML auto-detection. Cannot be used with --inline."},
-		{Name: "attach", Type: "string_array", Desc: "Attachment file path, appended after original attachments (relative path only). Repeat --attach once per file; quote each value."},
-		{Name: "inline", Type: "string_array", Desc: "Inline image as one JSON object. Repeat --inline once per image; quote each value. Example value: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique, e.g. a random hex string. Cannot be used with --plain-text."},
+		{Name: "attach", Type: "string_array", Desc: "Attachment path appended after original attachments (relative path only). Repeat --attach or pass comma-separated paths in one occurrence; input order is preserved."},
+		{Name: "inline", Type: "string_array", Desc: "Inline images as a JSON object or array per --inline occurrence; repeat to append in order. Values are not comma-split. file_path must be relative and CID unique. Cannot be used with --plain-text."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the forward immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
 		{Name: "send-time", Desc: "Scheduled send time as a Unix timestamp in seconds. Must be at least 5 minutes in the future. Use with --confirm-send to schedule the email."},
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
@@ -73,6 +73,12 @@ var MailForward = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
+			return err
+		}
+		if err := validateRepeatedInlineFlagFiles(runtime.FileIO(), runtime.StrArray("inline")); err != nil {
+			return err
+		}
 		to := normalizeRecipientFlagValues(runtime.StrArray("to"))
 		cc := normalizeRecipientFlagValues(runtime.StrArray("cc"))
 		bcc := normalizeRecipientFlagValues(runtime.StrArray("bcc"))

--- a/shortcuts/mail/mail_repeatable_flags_test.go
+++ b/shortcuts/mail/mail_repeatable_flags_test.go
@@ -56,6 +56,29 @@ func TestNormalizeRecipientFlagsPreservesUnicodeDisplayNameSemantics(t *testing.
 	}
 }
 
+func TestValidateRecipientFlagValuesReportsInvalidOccurrence(t *testing.T) {
+	err := validateRecipientFlagValues("--to", []string{
+		`"Doe, John" <john@example.com>,jane@example.com`,
+		`invalid-address`,
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error type = %T, want *errs.ValidationError: %v", err, err)
+	}
+	if ve.Category != errs.CategoryValidation || ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("validation problem = %s/%s, want validation/invalid_argument", ve.Category, ve.Subtype)
+	}
+	if ve.Param != "--to" {
+		t.Fatalf("validation param = %q, want --to", ve.Param)
+	}
+	if !strings.Contains(err.Error(), "--to occurrence 2") {
+		t.Fatalf("error = %v, want flag name and 1-based occurrence", err)
+	}
+}
+
 func TestMailboxLongUnicodeDisplayNameSplitsEncodedWords(t *testing.T) {
 	name := strings.Repeat("测试用户", 20)
 	got := (Mailbox{Name: name, Email: "long@example.com"}).String()
@@ -320,6 +343,45 @@ func TestMailRepeatableAttachmentInvalidLaterOccurrenceReportsIndex(t *testing.T
 				t.Fatalf("error = %v, want occurrence 2", err)
 			}
 		})
+	}
+}
+
+func TestMailRepeatableRecipientInvalidLaterOccurrenceFailsBeforeSideEffects(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{name: "send", shortcut: MailSend, args: []string{"+send", "--subject", "subject", "--body", "<p>body</p>"}},
+		{name: "draft-create", shortcut: MailDraftCreate, args: []string{"+draft-create", "--subject", "subject", "--body", "<p>body</p>"}},
+		{name: "reply", shortcut: MailReply, args: []string{"+reply", "--message-id", "m1", "--body", "<p>body</p>"}},
+		{name: "reply-all", shortcut: MailReplyAll, args: []string{"+reply-all", "--message-id", "m1", "--body", "<p>body</p>"}},
+		{name: "forward", shortcut: MailForward, args: []string{"+forward", "--message-id", "m1"}},
+		{name: "template-create", shortcut: MailTemplateCreate, args: []string{"+template-create", "--name", "template", "--template-content", `<p>body</p>`}},
+	} {
+		for _, flagName := range []string{"to", "cc", "bcc"} {
+			t.Run(tc.name+"/"+flagName, func(t *testing.T) {
+				f, stdout, _, _ := mailShortcutTestFactory(t)
+				args := append(append([]string(nil), tc.args...),
+					"--"+flagName, `"Doe, John" <john@example.com>`,
+					"--"+flagName, "invalid-address")
+				err := runMountedMailShortcut(t, tc.shortcut, args, f, stdout)
+				if err == nil {
+					t.Fatal("expected validation error")
+				}
+				var ve *errs.ValidationError
+				if !errors.As(err, &ve) {
+					t.Fatalf("error type = %T, want *errs.ValidationError: %v", err, err)
+				}
+				wantParam := "--" + flagName
+				if ve.Category != errs.CategoryValidation || ve.Subtype != errs.SubtypeInvalidArgument || ve.Param != wantParam {
+					t.Fatalf("validation problem = %s/%s param=%q, want validation/invalid_argument param=%q", ve.Category, ve.Subtype, ve.Param, wantParam)
+				}
+				if !strings.Contains(err.Error(), wantParam+" occurrence 2") {
+					t.Fatalf("error = %v, want flag name and occurrence 2", err)
+				}
+			})
+		}
 	}
 }
 

--- a/shortcuts/mail/mail_repeatable_flags_test.go
+++ b/shortcuts/mail/mail_repeatable_flags_test.go
@@ -5,6 +5,7 @@ package mail
 
 import (
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -135,13 +136,37 @@ func TestNormalizeRepeatedInlineFlagsAllowsDuplicateCIDForCompatibility(t *testi
 	}
 }
 
-func TestParseInlineSpecsNullIsEmptyForCompatibility(t *testing.T) {
-	specs, err := parseInlineSpecs(`null`)
-	if err != nil {
-		t.Fatalf("parseInlineSpecs(null) error = %v", err)
+func TestNormalizeRepeatedInlineFlagsReportsOccurrence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: ""},
+		{name: "null", raw: `null`},
+		{name: "scalar", raw: `42`},
+		{name: "empty object", raw: `{}`},
+		{name: "bad json", raw: `{`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := normalizeInlineFlagValues([]string{`[]`, tc.raw})
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			assertInlineValidationError(t, err)
+			if !strings.Contains(err.Error(), "occurrence 2") {
+				t.Fatalf("error = %v, want 1-based occurrence", err)
+			}
+		})
 	}
-	if len(specs) != 0 {
-		t.Fatalf("parseInlineSpecs(null) = %#v, want empty", specs)
+}
+
+func TestNormalizeRepeatedInlineFlagsAllowsEmptyArray(t *testing.T) {
+	raw, err := normalizeInlineFlagValues([]string{`[]`})
+	if err != nil {
+		t.Fatalf("normalizeInlineFlagValues([]) error = %v", err)
+	}
+	if raw != "" {
+		t.Fatalf("normalizeInlineFlagValues([]) = %q, want empty normalized value", raw)
 	}
 }
 
@@ -226,6 +251,73 @@ func TestMailRepeatableFlagTypes(t *testing.T) {
 			}
 			for _, name := range tc.strings {
 				assertFlagType(t, cmd, name, "string")
+			}
+		})
+	}
+}
+
+func TestMailRepeatableInlineInvalidLaterOccurrenceFailsBeforeSideEffects(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{name: "send", shortcut: MailSend, args: []string{"+send", "--to", "a@example.com", "--subject", "subject", "--body", "<p>body</p>"}},
+		{name: "draft-create", shortcut: MailDraftCreate, args: []string{"+draft-create", "--subject", "subject", "--body", "<p>body</p>"}},
+		{name: "reply", shortcut: MailReply, args: []string{"+reply", "--message-id", "m1", "--body", "<p>body</p>"}},
+		{name: "reply-all", shortcut: MailReplyAll, args: []string{"+reply-all", "--message-id", "m1", "--body", "<p>body</p>"}},
+		{name: "forward", shortcut: MailForward, args: []string{"+forward", "--message-id", "m1", "--to", "a@example.com"}},
+		{name: "template-create", shortcut: MailTemplateCreate, args: []string{"+template-create", "--name", "template", "--template-content", `<p>body</p>`}},
+		{name: "template-update", shortcut: MailTemplateUpdate, args: []string{"+template-update", "--template-id", "1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			args := append(append([]string(nil), tc.args...), "--inline", `[]`, "--inline", `null`)
+			err := runMountedMailShortcut(t, tc.shortcut, args, f, stdout)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			assertInlineValidationError(t, err)
+			if !strings.Contains(err.Error(), "occurrence 2") {
+				t.Fatalf("error = %v, want occurrence 2", err)
+			}
+		})
+	}
+}
+
+func TestMailRepeatableAttachmentInvalidLaterOccurrenceReportsIndex(t *testing.T) {
+	chdirTemp(t)
+	if err := os.WriteFile("ok.txt", []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{name: "send", shortcut: MailSend, args: []string{"+send", "--to", "a@example.com", "--subject", "subject", "--body", "body"}},
+		{name: "draft-create", shortcut: MailDraftCreate, args: []string{"+draft-create", "--subject", "subject", "--body", "body"}},
+		{name: "reply", shortcut: MailReply, args: []string{"+reply", "--message-id", "m1", "--body", "body"}},
+		{name: "reply-all", shortcut: MailReplyAll, args: []string{"+reply-all", "--message-id", "m1", "--body", "body"}},
+		{name: "forward", shortcut: MailForward, args: []string{"+forward", "--message-id", "m1", "--to", "a@example.com"}},
+		{name: "template-create", shortcut: MailTemplateCreate, args: []string{"+template-create", "--name", "template"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			args := append(append([]string(nil), tc.args...), "--attach", "ok.txt", "--attach", "missing.txt")
+			err := runMountedMailShortcut(t, tc.shortcut, args, f, stdout)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			var ve *errs.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("error type = %T, want *errs.ValidationError: %v", err, err)
+			}
+			if ve.Param != "--attach" {
+				t.Fatalf("validation param = %q, want --attach", ve.Param)
+			}
+			if !strings.Contains(err.Error(), "occurrence 2") {
+				t.Fatalf("error = %v, want occurrence 2", err)
 			}
 		})
 	}

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -59,6 +59,10 @@ var MailReply = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with reply-derived recipients / body.")
 		}
+		if from, mailbox := strings.TrimSpace(runtime.Str("from")), strings.TrimSpace(runtime.Str("mailbox")); from != "" && mailbox != "" && !strings.EqualFold(from, mailbox) {
+			api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+				Desc("Verify that --from is a sendable address for the target mailbox before creating a draft.")
+		}
 		api = api.GET(mailboxPath(mailboxID, "messages", messageId)).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
@@ -148,6 +152,9 @@ var MailReply = common.Shortcut{
 		}
 
 		mailboxID := resolveComposeMailboxID(runtime)
+		if err := validateComposeSenderForMailbox(runtime, mailboxID); err != nil {
+			return err
+		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
 			return mailDecorateProblemMessage(err, "failed to fetch original message")

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -30,12 +30,12 @@ var MailReply = common.Shortcut{
 		bodyFileFlag,
 		{Name: "from", Desc: "Sender email address for the From header. When using an alias (send_as) address, set this to the alias and use --mailbox for the owning mailbox. Defaults to the mailbox's primary address."},
 		{Name: "mailbox", Desc: "Mailbox email address that owns the draft (default: falls back to --from, then me). Use this when the sender (--from) differs from the mailbox, e.g. sending via an alias or send_as address."},
-		{Name: "to", Type: "string_array", Desc: "Additional To address. Repeat --to once per recipient; quote each value; appended to the original sender's address."},
-		{Name: "cc", Type: "string_array", Desc: "Additional CC email address. Repeat --cc once per recipient; quote each value."},
-		{Name: "bcc", Type: "string_array", Desc: "BCC email address. Repeat --bcc once per recipient; quote each value."},
+		{Name: "to", Type: "string_array", Desc: "Additional To list, appended to the original sender. Repeat --to or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "cc", Type: "string_array", Desc: "Additional CC list. Repeat --cc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "bcc", Type: "string_array", Desc: "BCC list. Repeat --bcc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
 		{Name: "plain-text", Type: "bool", Desc: "Force plain-text mode, ignoring all HTML auto-detection. Cannot be used with --inline."},
-		{Name: "attach", Type: "string_array", Desc: "Attachment file path, relative path only. Repeat --attach once per file; quote each value."},
-		{Name: "inline", Type: "string_array", Desc: "Inline image as one JSON object. Repeat --inline once per image; quote each value. Example value: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique, e.g. a random hex string. Cannot be used with --plain-text."},
+		{Name: "attach", Type: "string_array", Desc: "Attachment path, relative path only. Repeat --attach or pass comma-separated paths in one occurrence; input order is preserved."},
+		{Name: "inline", Type: "string_array", Desc: "Inline images as a JSON object or array per --inline occurrence; repeat to append in order. Values are not comma-split. file_path must be relative and CID unique. Cannot be used with --plain-text."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the reply immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
 		{Name: "send-time", Desc: "Scheduled send time as a Unix timestamp in seconds. Must be at least 5 minutes in the future. Use with --confirm-send to schedule the email."},
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
@@ -69,6 +69,12 @@ var MailReply = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
+			return err
+		}
+		if err := validateRepeatedInlineFlagFiles(runtime.FileIO(), runtime.StrArray("inline")); err != nil {
+			return err
+		}
 		attach := normalizeCommaFlagValues(runtime.StrArray("attach"))
 		inline, err := normalizeInlineFlagValues(runtime.StrArray("inline"))
 		if err != nil {

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -69,6 +69,9 @@ var MailReply = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedRecipientFlags(runtime); err != nil {
+			return err
+		}
 		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
 			return err
 		}

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -70,6 +70,9 @@ var MailReplyAll = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedRecipientFlags(runtime); err != nil {
+			return err
+		}
 		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
 			return err
 		}

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -30,13 +30,13 @@ var MailReplyAll = common.Shortcut{
 		bodyFileFlag,
 		{Name: "from", Desc: "Sender email address for the From header. When using an alias (send_as) address, set this to the alias and use --mailbox for the owning mailbox. Defaults to the mailbox's primary address."},
 		{Name: "mailbox", Desc: "Mailbox email address that owns the draft (default: falls back to --from, then me). Use this when the sender (--from) differs from the mailbox, e.g. sending via an alias or send_as address."},
-		{Name: "to", Type: "string_array", Desc: "Additional To address. Repeat --to once per recipient; quote each value; appended to original recipients."},
-		{Name: "cc", Type: "string_array", Desc: "Additional CC email address. Repeat --cc once per recipient; quote each value."},
-		{Name: "bcc", Type: "string_array", Desc: "BCC email address. Repeat --bcc once per recipient; quote each value."},
-		{Name: "remove", Type: "string_array", Desc: "Address to exclude from the outgoing reply. Repeat --remove once per address; quote each value."},
+		{Name: "to", Type: "string_array", Desc: "Additional To list, appended to original recipients. Repeat --to or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "cc", Type: "string_array", Desc: "Additional CC list. Repeat --cc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "bcc", Type: "string_array", Desc: "BCC list. Repeat --bcc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "remove", Type: "string_array", Desc: "Addresses to exclude from the outgoing reply. Repeat --remove or pass a comma-separated list in one occurrence; input order is preserved."},
 		{Name: "plain-text", Type: "bool", Desc: "Force plain-text mode, ignoring all HTML auto-detection. Cannot be used with --inline."},
-		{Name: "attach", Type: "string_array", Desc: "Attachment file path, relative path only. Repeat --attach once per file; quote each value."},
-		{Name: "inline", Type: "string_array", Desc: "Inline image as one JSON object. Repeat --inline once per image; quote each value. Example value: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique, e.g. a random hex string. Cannot be used with --plain-text."},
+		{Name: "attach", Type: "string_array", Desc: "Attachment path, relative path only. Repeat --attach or pass comma-separated paths in one occurrence; input order is preserved."},
+		{Name: "inline", Type: "string_array", Desc: "Inline images as a JSON object or array per --inline occurrence; repeat to append in order. Values are not comma-split. file_path must be relative and CID unique. Cannot be used with --plain-text."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the reply immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
 		{Name: "send-time", Desc: "Scheduled send time as a Unix timestamp in seconds. Must be at least 5 minutes in the future. Use with --confirm-send to schedule the email."},
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
@@ -70,6 +70,12 @@ var MailReplyAll = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
+			return err
+		}
+		if err := validateRepeatedInlineFlagFiles(runtime.FileIO(), runtime.StrArray("inline")); err != nil {
+			return err
+		}
 		attach := normalizeCommaFlagValues(runtime.StrArray("attach"))
 		inline, err := normalizeInlineFlagValues(runtime.StrArray("inline"))
 		if err != nil {

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -60,6 +60,10 @@ var MailReplyAll = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with reply-all-derived recipients / body.")
 		}
+		if from, mailbox := strings.TrimSpace(runtime.Str("from")), strings.TrimSpace(runtime.Str("mailbox")); from != "" && mailbox != "" && !strings.EqualFold(from, mailbox) {
+			api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+				Desc("Verify that --from is a sendable address for the target mailbox before creating a draft.")
+		}
 		api = api.GET(mailboxPath(mailboxID, "messages", messageId)).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
@@ -150,6 +154,9 @@ var MailReplyAll = common.Shortcut{
 		}
 
 		mailboxID := resolveComposeMailboxID(runtime)
+		if err := validateComposeSenderForMailbox(runtime, mailboxID); err != nil {
+			return err
+		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
 			return mailDecorateProblemMessage(err, "failed to fetch original message")

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -58,6 +58,10 @@ var MailSend = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
+		if from, mailbox := strings.TrimSpace(runtime.Str("from")), strings.TrimSpace(runtime.Str("mailbox")); from != "" && mailbox != "" && !strings.EqualFold(from, mailbox) {
+			api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+				Desc("Verify that --from is a sendable address for the target mailbox before creating a draft.")
+		}
 		api = api.GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
@@ -165,6 +169,9 @@ var MailSend = common.Shortcut{
 		}
 
 		mailboxID := resolveComposeMailboxID(runtime)
+		if err := validateComposeSenderForMailbox(runtime, mailboxID); err != nil {
+			return err
+		}
 
 		// Auto-resolve default signature when neither --no-signature nor --signature-id is set.
 		noSignature := runtime.Bool("no-signature")

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -24,17 +24,17 @@ var MailSend = common.Shortcut{
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "to", Type: "string_array", Desc: "Recipient email address. Repeat --to once per recipient; quote each value. Display-name format is supported."},
+		{Name: "to", Type: "string_array", Desc: "Recipient email address list. Repeat --to or pass a comma-separated list in one occurrence; quote display names such as \"Doe, John\" <john@example.com>. Input order is preserved."},
 		{Name: "subject", Desc: "Email subject. Required unless --template-id supplies a non-empty subject."},
 		{Name: "body", Desc: "Email body. Prefer HTML for rich formatting (bold, lists, links); plain text is also supported. Body type is auto-detected. Use --plain-text to force plain-text mode. Mutually exclusive with --body-file. Required unless --template-id supplies a non-empty body."},
 		bodyFileFlag,
 		{Name: "from", Desc: "Sender email address for the From header. When using an alias (send_as) address, set this to the alias and use --mailbox for the owning mailbox. Defaults to the mailbox's primary address."},
 		{Name: "mailbox", Desc: "Mailbox email address that owns the draft (default: falls back to --from, then me). Use this when the sender (--from) differs from the mailbox, e.g. sending via an alias or send_as address."},
-		{Name: "cc", Type: "string_array", Desc: "CC email address. Repeat --cc once per recipient; quote each value. Display-name format is supported."},
-		{Name: "bcc", Type: "string_array", Desc: "BCC email address. Repeat --bcc once per recipient; quote each value. Display-name format is supported."},
+		{Name: "cc", Type: "string_array", Desc: "CC email address list. Repeat --cc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved. Input order is preserved."},
+		{Name: "bcc", Type: "string_array", Desc: "BCC email address list. Repeat --bcc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved. Input order is preserved."},
 		{Name: "plain-text", Type: "bool", Desc: "Force plain-text mode, ignoring HTML auto-detection. Cannot be used with --inline."},
-		{Name: "attach", Type: "string_array", Desc: "Attachment file path, relative path only. Repeat --attach once per file; quote each value."},
-		{Name: "inline", Type: "string_array", Desc: "Inline image as one JSON object. Repeat --inline once per image; quote each value. Example value: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique, e.g. a random hex string. Cannot be used with --plain-text."},
+		{Name: "attach", Type: "string_array", Desc: "Attachment file path, relative path only. Repeat --attach or pass comma-separated paths in one occurrence; input order is preserved."},
+		{Name: "inline", Type: "string_array", Desc: "Inline images as a JSON object or array per --inline occurrence; repeat to append in order. Values are not comma-split. Example: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique. Cannot be used with --plain-text."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the email immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
 		{Name: "send-time", Desc: "Scheduled send time as a Unix timestamp in seconds. Must be at least 5 minutes in the future. Use with --confirm-send to schedule the email."},
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
@@ -73,6 +73,12 @@ var MailSend = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
+			return err
+		}
+		if err := validateRepeatedInlineFlagFiles(runtime.FileIO(), runtime.StrArray("inline")); err != nil {
+			return err
+		}
 		to := normalizeRecipientFlagValues(runtime.StrArray("to"))
 		cc := normalizeRecipientFlagValues(runtime.StrArray("cc"))
 		bcc := normalizeRecipientFlagValues(runtime.StrArray("bcc"))

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -73,6 +73,9 @@ var MailSend = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedRecipientFlags(runtime); err != nil {
+			return err
+		}
 		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
 			return err
 		}

--- a/shortcuts/mail/mail_send_confirm_output_test.go
+++ b/shortcuts/mail/mail_send_confirm_output_test.go
@@ -217,6 +217,90 @@ func TestMailSendSaveDraftOutputsReference(t *testing.T) {
 	}
 }
 
+func TestMailSendRejectsFromOutsideTargetMailboxBeforeCreatingDraft(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/owner@example.com/settings/send_as",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []interface{}{
+					map[string]interface{}{"email_address": "owner@example.com", "name": "Owner"},
+					map[string]interface{}{"email_address": "alias@example.com", "name": "Alias"},
+				},
+			},
+		},
+	})
+	draftStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/owner@example.com/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "must_not_be_created"},
+		},
+	}
+	reg.Register(draftStub)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "owner@example.com",
+		"--from", "outsider@example.com",
+		"--to", "alice@example.com",
+		"--subject", "identity isolation",
+		"--body", "must not create a draft",
+		"--no-signature",
+	}, f, stdout)
+	assertValidationError(t, err, "is not a sendable address")
+	if len(draftStub.CapturedBody) != 0 {
+		t.Fatalf("drafts.create must not run for an unauthorized --from, captured body: %s", draftStub.CapturedBody)
+	}
+}
+
+func TestMailSendAllowsSendAsAddressForTargetMailbox(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/owner@example.com/settings/send_as",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []interface{}{
+					map[string]interface{}{"email_address": "owner@example.com", "name": "Owner"},
+					map[string]interface{}{"email_address": "alias@example.com", "name": "Alias"},
+				},
+			},
+		},
+	})
+	draftStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/owner@example.com/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_alias"},
+		},
+	}
+	reg.Register(draftStub)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "owner@example.com",
+		"--from", "ALIAS@example.com",
+		"--to", "alice@example.com",
+		"--subject", "authorized alias",
+		"--body", "save this draft",
+		"--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("authorized send_as address was rejected: %v", err)
+	}
+	if len(draftStub.CapturedBody) == 0 {
+		t.Fatal("expected drafts.create for an authorized send_as address")
+	}
+}
+
 func TestMailSend_WithCalendarEventEmbedded(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
 

--- a/shortcuts/mail/mail_template_create.go
+++ b/shortcuts/mail/mail_template_create.go
@@ -27,11 +27,11 @@ var MailTemplateCreate = common.Shortcut{
 		{Name: "template-content", Desc: "Template body content. Prefer HTML. Referenced local images (<img src=\"./file.png\">) are auto-uploaded to Drive and rewritten to cid: refs."},
 		{Name: "template-content-file", Desc: "Optional. Path to a file whose contents become --template-content. Relative path only. Mutually exclusive with --template-content."},
 		{Name: "plain-text", Type: "bool", Desc: "Mark the template as plain-text mode (is_plain_text_mode=true). Cannot be used with --inline; use only for pure plain-text templates."},
-		{Name: "to", Type: "string_array", Desc: "Optional. Default To recipient email address. Repeat --to once per recipient; quote each value. Display-name format is supported."},
-		{Name: "cc", Type: "string_array", Desc: "Optional. Default Cc recipient email address. Repeat --cc once per recipient; quote each value."},
-		{Name: "bcc", Type: "string_array", Desc: "Optional. Default Bcc recipient email address. Repeat --bcc once per recipient; quote each value."},
-		{Name: "attach", Type: "string_array", Desc: "Optional. Non-inline attachment file path, relative path only. Repeat --attach once per file; order is preserved for LARGE/SMALL classification."},
-		{Name: "inline", Type: "string_array", Desc: "Optional. Inline image as one JSON object. Repeat --inline once per image; quote each value. Example value: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique, e.g. a random hex string."},
+		{Name: "to", Type: "string_array", Desc: "Optional. Default To list. Repeat --to or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "cc", Type: "string_array", Desc: "Optional. Default Cc list. Repeat --cc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "bcc", Type: "string_array", Desc: "Optional. Default Bcc list. Repeat --bcc or pass a comma-separated list in one occurrence; quoted display-name commas are preserved."},
+		{Name: "attach", Type: "string_array", Desc: "Optional. Non-inline attachment path, relative path only. Repeat --attach or pass comma-separated paths in one occurrence; input order is preserved."},
+		{Name: "inline", Type: "string_array", Desc: "Optional. Inline images as a JSON object or array per --inline occurrence; repeat to append in order. Values are not comma-split. file_path must be relative and CID unique."},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		mailboxID := resolveComposeMailboxID(runtime)
@@ -143,6 +143,12 @@ var MailTemplateCreate = common.Shortcut{
 			return mailFailedPreconditionError("template content exceeds %d MB (got %.1f MB)",
 				maxTemplateContentBytes/(1024*1024),
 				float64(len(content))/1024/1024)
+		}
+		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
+			return err
+		}
+		if err := validateRepeatedInlineFlagFiles(runtime.FileIO(), runtime.StrArray("inline")); err != nil {
+			return err
 		}
 
 		rewritten, atts, err := buildTemplatePayloadFromFlags(

--- a/shortcuts/mail/mail_template_create.go
+++ b/shortcuts/mail/mail_template_create.go
@@ -78,6 +78,9 @@ var MailTemplateCreate = common.Shortcut{
 		return api
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateRepeatedRecipientFlags(runtime); err != nil {
+			return err
+		}
 		if err := validateBotMailboxNotMe(runtime); err != nil {
 			return err
 		}

--- a/shortcuts/mail/mail_template_update.go
+++ b/shortcuts/mail/mail_template_update.go
@@ -33,10 +33,10 @@ var MailTemplateUpdate = common.Shortcut{
 		{Name: "set-template-content-file", Desc: "Replace template body content with the contents of a file (relative path only). Mutually exclusive with --set-template-content."},
 		{Name: "set-plain-text", Type: "bool", Desc: "Set is_plain_text_mode=true."},
 		{Name: "set-to", Desc: "Replace the To recipient list. Separate multiple addresses with commas. Pass --set-to=\"\" to clear the list."},
-		{Name: "set-cc", Desc: "Replace the Cc recipient list. Pass --set-cc=\"\" to clear the list."},
-		{Name: "set-bcc", Desc: "Replace the Bcc recipient list. Pass --set-bcc=\"\" to clear the list."},
-		{Name: "attach", Type: "string_array", Desc: "Additional non-inline attachment file path. Repeat --attach once per file; each file is uploaded to Drive and appended in flag order."},
-		{Name: "inline", Type: "string_array", Desc: "Additional inline image as one JSON object. Repeat --inline once per image; quote each value. Example value: '{\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}'. file_path must be relative. Reference it from HTML as <img src=\"cid:<unique-id>\">. CID must be unique, e.g. a random hex string."},
+		{Name: "set-cc", Desc: "Replace the complete Cc recipient list with this single flag value; separate multiple addresses with commas. Pass --set-cc=\"\" to clear the list."},
+		{Name: "set-bcc", Desc: "Replace the complete Bcc recipient list with this single flag value; separate multiple addresses with commas. Pass --set-bcc=\"\" to clear the list."},
+		{Name: "attach", Type: "string_array", Desc: "Additional non-inline attachment path. Repeat --attach or pass comma-separated paths in one occurrence; files are uploaded and appended in input order."},
+		{Name: "inline", Type: "string_array", Desc: "Additional inline images as a JSON object or array per --inline occurrence; repeat to append in order. Values are not comma-split. file_path must be relative and CID unique."},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		if runtime.Bool("print-patch-template") {
@@ -225,6 +225,12 @@ var MailTemplateUpdate = common.Shortcut{
 		}
 		retainedAttachments := templateAttachmentsForFinalContent(tpl.TemplateContent, tpl.Attachments, contentChanged)
 		if err := validateTemplateInlineUpdate(tpl.TemplateContent, retainedAttachments, inlineSpecs, contentChanged); err != nil {
+			return err
+		}
+		if err := validateRepeatedAttachmentFlagFiles(runtime.FileIO(), runtime.StrArray("attach")); err != nil {
+			return err
+		}
+		if err := validateRepeatedInlineFlagFiles(runtime.FileIO(), runtime.StrArray("inline")); err != nil {
 			return err
 		}
 

--- a/skills/lark-mail/references/lark-mail-draft-create.md
+++ b/skills/lark-mail/references/lark-mail-draft-create.md
@@ -44,17 +44,17 @@ lark-cli mail +draft-create --to 'alice@example.com' --subject '测试' --body '
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--to '<email>'` | 否 | 完整收件人列表。多个收件人请重复传 `--to`，每次只放一个地址，参数值用单引号包住。支持 `Alice <alice@example.com>` 格式。省略时草稿不带收件人（之后可通过 `+draft-edit` 添加） |
+| `--to '<email-list>'` | 否 | 完整收件人列表；支持重复 flag 和单次逗号列表，带逗号的 display-name 需加双引号。省略时草稿不带收件人 |
 | `--subject <text>` | 是 | 草稿主题 |
 | `--body <text>` | 二选一 | 邮件正文。推荐使用 HTML 获得富文本排版；也支持纯文本（自动检测）。使用 `--plain-text` 可强制纯文本模式。支持 `<img src="./local.png" />` 相对路径自动解析为内嵌图片（仅支持相对路径，不支持绝对路径）。与 `--body-file` 互斥 |
 | `--body-file <path>` | 二选一 | 从文件读取邮件正文 HTML（相对路径，仅限 cwd 子树）。与 `--body` 互斥。文件大小上限 32 MB |
 | `--from <email>` | 否 | 发件人邮箱地址（EML From 头）。使用别名（send_as）发信时，设为别名地址并配合 `--mailbox` 指定所属邮箱。省略时使用邮箱主地址 |
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用，如通过别名或 send_as 地址发信。可通过 `accessible_mailboxes` 查询可用邮箱 |
-| `--cc '<email>'` | 否 | 完整抄送列表。多个抄送请重复传 `--cc`，每次只放一个地址，参数值用单引号包住 |
-| `--bcc '<email>'` | 否 | 完整密送列表。多个密送请重复传 `--bcc`，每次只放一个地址，参数值用单引号包住。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
+| `--cc '<email-list>'` | 否 | 完整抄送列表；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
+| `--bcc '<email-list>'` | 否 | 完整密送列表；支持重复 flag 和单次逗号列表。与 `--event-*` 不兼容 |
 | `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用。纯文本模式下也会自动追加纯文本签名（HTML 签名经 `PlainTextFromHTML` 转换，内联图片丢弃） |
-| `--attach '<path>'` | 否 | 附件文件路径。多个附件请重复传 `--attach`，每次只放一个相对路径，参数值用单引号包住；按传入顺序追加。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
-| `--inline '<json>'` | 否 | 高级用法：手动指定内嵌图片 CID 映射。多个 inline 图片请重复传 `--inline`，每次只放一个 JSON object，并用单引号包住：`'{"cid":"mycid","file_path":"./logo.png"}'`。`file_path` 必须是相对路径；CID 应唯一，例如随机十六进制字符串；在 body 中用 `<img src="cid:mycid">` 引用。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。不可与 `--plain-text` 同时使用 |
+| `--attach '<path-list>'` | 否 | 附件路径；支持重复 flag 和单次逗号列表，按输入顺序追加；单个文件上限 3 GB |
+| `--inline '<json>'` | 否 | 每次值为一个 JSON object 或 array，可重复传并按顺序合并，不按逗号切分。`file_path` 必须是相对路径且 CID 应唯一；不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。与 `--no-signature` 互斥 |
 | `--no-signature` | 否 | 跳过默认签名自动追加。与 `--signature-id` 互斥，同时使用时返回参数校验错误（退出码 2） |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |

--- a/skills/lark-mail/references/lark-mail-forward.md
+++ b/skills/lark-mail/references/lark-mail-forward.md
@@ -61,16 +61,16 @@ lark-cli mail +forward --message-id <邮件ID> --to 'alice@example.com' --dry-ru
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `--message-id <id>` | 是 | 被转发的邮件 ID |
-| `--to '<email>'` | 是 | 收件人邮箱。多个收件人请重复传 `--to`，每次只放一个地址，参数值用单引号包住 |
+| `--to '<email-list>'` | 是 | 收件人列表；支持重复 flag 和单次逗号列表，带逗号的 display-name 需加双引号 |
 | `--body <text>` | 否 | 转发时附加的说明文字。推荐使用 HTML 获得富文本排版；也支持纯文本。根据转发正文和原邮件正文自动检测 HTML。使用 `--plain-text` 可强制纯文本模式。支持 `<img src="./local.png" />` 相对路径自动解析为内嵌图片（仅支持相对路径，不支持绝对路径）。与 `--body-file` 互斥 |
 | `--body-file <path>` | 否 | 从文件读取转发说明 HTML（相对路径，仅限 cwd 子树）。与 `--body` 互斥。文件大小上限 32 MB |
 | `--from <email>` | 否 | 发件人邮箱地址（EML From 头）。使用别名（send_as）发信时，设为别名地址并配合 `--mailbox` 指定所属邮箱。默认读取邮箱主地址 |
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
-| `--cc '<email>'` | 否 | 抄送邮箱。多个抄送请重复传 `--cc`，每次只放一个地址，参数值用单引号包住 |
-| `--bcc '<email>'` | 否 | 密送邮箱。多个密送请重复传 `--bcc`，每次只放一个地址，参数值用单引号包住。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
+| `--cc '<email-list>'` | 否 | 抄送列表；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
+| `--bcc '<email-list>'` | 否 | 密送列表；支持重复 flag 和单次逗号列表。与 `--event-*` 不兼容 |
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用。纯文本模式下也会自动追加纯文本签名（HTML 签名经 `PlainTextFromHTML` 转换，内联图片丢弃） |
-| `--attach '<path>'` | 否 | 附件文件路径。多个附件请重复传 `--attach`，每次只放一个相对路径，参数值用单引号包住；按传入顺序追加在原邮件附件之后。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
-| `--inline '<json>'` | 否 | 高级用法：手动指定内嵌图片 CID 映射。多个 inline 图片请重复传 `--inline`，每次只放一个 JSON object，并用单引号包住：`'{"cid":"mycid","file_path":"./logo.png"}'`。`file_path` 必须是相对路径；CID 应唯一，例如随机十六进制字符串；在 body 中用 `<img src="cid:mycid">` 引用。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。不可与 `--plain-text` 同时使用 |
+| `--attach '<path-list>'` | 否 | 附件路径；支持重复 flag 和单次逗号列表，按输入顺序追加在原邮件附件之后；单个文件上限 3 GB |
+| `--inline '<json>'` | 否 | 每次值为一个 JSON object 或 array，可重复传并按顺序合并，不按逗号切分。`file_path` 必须是相对路径且 CID 应唯一；不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到转发正文与引用块之间。运行 `mail +signature` 查看可用签名。与 `--no-signature` 互斥 |
 | `--no-signature` | 否 | 跳过默认签名自动追加。与 `--signature-id` 互斥，同时使用时返回参数校验错误（退出码 2） |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |

--- a/skills/lark-mail/references/lark-mail-reply-all.md
+++ b/skills/lark-mail/references/lark-mail-reply-all.md
@@ -68,13 +68,13 @@ lark-cli mail +reply-all --message-id <邮件ID> --body '测试' --dry-run
 | `--body-file <path>` | 二选一 | 从文件读取回复正文 HTML（相对路径，仅限 cwd 子树）。与 `--body` 互斥。文件大小上限 32 MB |
 | `--from <email>` | 否 | 发件人邮箱地址（EML From 头）。使用别名（send_as）发信时，设为别名地址并配合 `--mailbox` 指定所属邮箱。默认读取邮箱主地址 |
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
-| `--to '<email>'` | 否 | 额外收件人。多个额外收件人请重复传 `--to`，每次只放一个地址，参数值用单引号包住；追加到自动聚合结果 |
-| `--cc '<email>'` | 否 | 额外抄送。多个抄送请重复传 `--cc`，每次只放一个地址，参数值用单引号包住 |
-| `--bcc '<email>'` | 否 | 密送邮箱。多个密送请重复传 `--bcc`，每次只放一个地址，参数值用单引号包住。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
-| `--remove '<email>'` | 否 | 从自动聚合结果中排除的邮箱。多个排除地址请重复传 `--remove`，每次只放一个地址，参数值用单引号包住；按传入顺序处理 |
+| `--to '<email-list>'` | 否 | 额外收件人；支持重复 flag 和单次逗号列表，按顺序追加到自动聚合结果 |
+| `--cc '<email-list>'` | 否 | 额外抄送；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
+| `--bcc '<email-list>'` | 否 | 密送列表；支持重复 flag 和单次逗号列表。与 `--event-*` 不兼容 |
+| `--remove '<email-list>'` | 否 | 从自动聚合结果中排除的邮箱；支持重复 flag 和单次逗号列表，按输入顺序处理 |
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用。纯文本模式下也会自动追加纯文本签名（HTML 签名经 `PlainTextFromHTML` 转换，内联图片丢弃） |
-| `--attach '<path>'` | 否 | 附件文件路径。多个附件请重复传 `--attach`，每次只放一个相对路径，参数值用单引号包住；按传入顺序追加。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
-| `--inline '<json>'` | 否 | 高级用法：手动指定内嵌图片 CID 映射。多个 inline 图片请重复传 `--inline`，每次只放一个 JSON object，并用单引号包住：`'{"cid":"mycid","file_path":"./logo.png"}'`。`file_path` 必须是相对路径；CID 应唯一，例如随机十六进制字符串；在 body 中用 `<img src="cid:mycid">` 引用。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。不可与 `--plain-text` 同时使用 |
+| `--attach '<path-list>'` | 否 | 附件路径；支持重复 flag 和单次逗号列表，按输入顺序追加；单个文件上限 3 GB |
+| `--inline '<json>'` | 否 | 每次值为一个 JSON object 或 array，可重复传并按顺序合并，不按逗号切分。`file_path` 必须是相对路径且 CID 应唯一；不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到回复正文与引用块之间。运行 `mail +signature` 查看可用签名。与 `--no-signature` 互斥 |
 | `--no-signature` | 否 | 跳过默认签名自动追加。与 `--signature-id` 互斥，同时使用时返回参数校验错误（退出码 2） |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |

--- a/skills/lark-mail/references/lark-mail-reply.md
+++ b/skills/lark-mail/references/lark-mail-reply.md
@@ -72,12 +72,12 @@ lark-cli mail +reply --message-id <邮件ID> --body '<p>测试</p>' --dry-run
 | `--body-file <path>` | 二选一 | 从文件读取回复正文 HTML（相对路径，仅限 cwd 子树）。与 `--body` 互斥。文件大小上限 32 MB |
 | `--from <email>` | 否 | 发件人邮箱地址（EML From 头）。使用别名（send_as）发信时，设为别名地址并配合 `--mailbox` 指定所属邮箱。默认读取邮箱主地址 |
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
-| `--to '<email>'` | 否 | 额外收件人。多个额外收件人请重复传 `--to`，每次只放一个地址，参数值用单引号包住；追加到原发件人 |
-| `--cc '<email>'` | 否 | 抄送邮箱。多个抄送请重复传 `--cc`，每次只放一个地址，参数值用单引号包住 |
-| `--bcc '<email>'` | 否 | 密送邮箱。多个密送请重复传 `--bcc`，每次只放一个地址，参数值用单引号包住。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
+| `--to '<email-list>'` | 否 | 额外收件人；支持重复 flag 和单次逗号列表，按顺序追加到原发件人 |
+| `--cc '<email-list>'` | 否 | 抄送列表；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
+| `--bcc '<email-list>'` | 否 | 密送列表；支持重复 flag 和单次逗号列表。与 `--event-*` 不兼容 |
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用。纯文本模式下也会自动追加纯文本签名（HTML 签名经 `PlainTextFromHTML` 转换，内联图片丢弃） |
-| `--attach '<path>'` | 否 | 附件文件路径。多个附件请重复传 `--attach`，每次只放一个相对路径，参数值用单引号包住；按传入顺序追加。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
-| `--inline '<json>'` | 否 | 高级用法：手动指定内嵌图片 CID 映射。多个 inline 图片请重复传 `--inline`，每次只放一个 JSON object，并用单引号包住：`'{"cid":"mycid","file_path":"./logo.png"}'`。`file_path` 必须是相对路径；CID 应唯一，例如随机十六进制字符串；在 body 中用 `<img src="cid:mycid">` 引用。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。不可与 `--plain-text` 同时使用 |
+| `--attach '<path-list>'` | 否 | 附件路径；支持重复 flag 和单次逗号列表，按输入顺序追加；单个文件上限 3 GB |
+| `--inline '<json>'` | 否 | 每次值为一个 JSON object 或 array，可重复传并按顺序合并，不按逗号切分。`file_path` 必须是相对路径且 CID 应唯一；不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到回复正文与引用块之间。运行 `mail +signature` 查看可用签名。与 `--no-signature` 互斥 |
 | `--no-signature` | 否 | 跳过默认签名自动追加。与 `--signature-id` 互斥，同时使用时返回参数校验错误（退出码 2） |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -61,23 +61,29 @@ lark-cli mail +send --to 'alice@example.com' --subject '确认' --body '收到�
 
 # Dry Run（仅打印请求，不执行）
 lark-cli mail +send --to 'alice@example.com' --subject '测试' --body '<p>test</p>' --dry-run
+
+# 推荐：重复 flag（每次 occurrence 保持原样和顺序）
+lark-cli mail +send --to 'alice@example.com' --to '"Doe, John" <john@example.com>' --subject '资料' --body '<p><img src="cid:hero"></p>' --attach './a.pdf' --attach './b.pdf' --inline '{"cid":"hero","file_path":"./hero.png"}'
+
+# 兼容旧写法：单次 flag 内仍可放逗号列表；inline 仍可传 JSON array
+lark-cli mail +send --to 'alice@example.com,bob@example.com' --subject '资料' --body '<p><img src="cid:hero"></p>' --attach './a.pdf,./b.pdf' --inline '[{"cid":"hero","file_path":"./hero.png"}]'
 ```
 
 ## 参数
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--to '<email>'` | 是 | 收件人邮箱。多个收件人请重复传 `--to`，每次只放一个地址，参数值用单引号包住 |
+| `--to '<email-list>'` | 是 | 收件人列表。可重复传 `--to`，也兼容单次逗号列表；带逗号的 display-name 请写成 `"Doe, John" <john@example.com>`，输入顺序保持不变 |
 | `--subject <text>` | 是 | 邮件主题 |
 | `--body <text>` | 二选一 | 邮件正文。推荐使用 HTML 获得富文本排版；也支持纯文本（自动检测）。使用 `--plain-text` 可强制纯文本模式。支持 `<img src="./local.png" />` 相对路径自动解析为内嵌图片（仅支持相对路径，不支持绝对路径）。与 `--body-file` 互斥 |
 | `--body-file <path>` | 二选一 | 从文件读取邮件正文 HTML（相对路径，仅限 cwd 子树）。与 `--body` 互斥。文件大小上限 32 MB |
 | `--from <email>` | 否 | 发件人邮箱地址（EML From 头）。使用别名（send_as）发信时，设为别名地址并配合 `--mailbox` 指定所属邮箱。默认读取邮箱主地址 |
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
-| `--cc '<email>'` | 否 | 抄送邮箱。多个抄送请重复传 `--cc`，每次只放一个地址，参数值用单引号包住 |
-| `--bcc '<email>'` | 否 | 密送邮箱。多个密送请重复传 `--bcc`，每次只放一个地址，参数值用单引号包住 |
+| `--cc '<email-list>'` | 否 | 抄送列表；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
+| `--bcc '<email-list>'` | 否 | 密送列表；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
 | `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用。纯文本模式下也会自动追加纯文本签名（HTML 签名经 `PlainTextFromHTML` 转换，内联图片丢弃） |
-| `--attach '<path>'` | 否 | 附件文件路径。多个附件请重复传 `--attach`，每次只放一个相对路径，参数值用单引号包住；按传入顺序追加。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
-| `--inline '<json>'` | 否 | 高级用法：手动指定内嵌图片 CID 映射。多个 inline 图片请重复传 `--inline`，每次只放一个 JSON object，并用单引号包住：`'{"cid":"mycid","file_path":"./logo.png"}'`。`file_path` 必须是相对路径；CID 应唯一，例如随机十六进制字符串；在 body 中用 `<img src="cid:mycid">` 引用。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。不可与 `--plain-text` 同时使用 |
+| `--attach '<path-list>'` | 否 | 附件路径；支持重复 flag 和单次逗号列表，按输入顺序追加。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件，单个文件上限 3 GB |
+| `--inline '<json>'` | 否 | 每次值为一个 JSON object 或 array，可重复传并按顺序合并，不按逗号切分。`file_path` 必须是相对路径且 CID 应唯一；不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。与 `--no-signature` 互斥 |
 | `--no-signature` | 否 | 跳过默认签名自动追加。与 `--signature-id` 互斥，同时使用时返回参数校验错误（退出码 2） |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |

--- a/skills/lark-mail/references/lark-mail-template-create.md
+++ b/skills/lark-mail/references/lark-mail-template-create.md
@@ -50,11 +50,11 @@ lark-cli mail +template-create --as user \
 | `--template-content <html>` | 否* | 模板正文。HTML 首选；支持 `<img src="./local.png" />` 相对路径自动上传到 Drive 并改写为 `cid:` |
 | `--template-content-file <path>` | 否* | 从文件加载正文内容；与 `--template-content` 互斥 |
 | `--plain-text` | 否 | 标记为纯文本模式（`is_plain_text_mode=true`）。不可与 `--inline` 同时使用；`+send --template-id` 套用时会走 plain-text 正文拼接 |
-| `--to '<email>'` | 否 | 默认收件人列表。多个默认收件人请重复传 `--to`，每次只放一个地址，参数值用单引号包住。支持 `Name <email>` 格式 |
-| `--cc '<email>'` | 否 | 默认抄送。多个抄送请重复传 `--cc`，每次只放一个地址，参数值用单引号包住 |
-| `--bcc '<email>'` | 否 | 默认密送。多个密送请重复传 `--bcc`，每次只放一个地址，参数值用单引号包住 |
-| `--attach '<path>'` | 否 | 非 inline 附件路径。多个附件请重复传 `--attach`，每次只放一个相对路径，参数值用单引号包住；每个文件按传入顺序上传到 Drive |
-| `--inline '<json>'` | 否 | 手动指定 inline 图片 CID 映射。多个 inline 图片请重复传 `--inline`，每次只放一个 JSON object，并用单引号包住：`'{"cid":"mycid","file_path":"./logo.png"}'`。`file_path` 必须是相对路径；CID 应唯一，例如随机十六进制字符串；在模板正文中用 `<img src="cid:mycid">` 引用 |
+| `--to '<email-list>'` | 否 | 默认收件人列表；支持重复 flag 和单次逗号列表，带逗号的 display-name 需加双引号 |
+| `--cc '<email-list>'` | 否 | 默认抄送；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
+| `--bcc '<email-list>'` | 否 | 默认密送；支持重复 flag 和单次逗号列表，输入顺序保持不变 |
+| `--attach '<path-list>'` | 否 | 非 inline 附件路径；支持重复 flag 和单次逗号列表，按输入顺序上传到 Drive |
+| `--inline '<json>'` | 否 | 每次值为一个 JSON object 或 array，可重复传并按顺序合并，不按逗号切分。`file_path` 必须是相对路径且 CID 应唯一 |
 | `--mailbox <email>` | 否 | 所属邮箱，默认 `me`（当前用户主邮箱） |
 | `--dry-run` | 否 | 仅打印计划中的 API 调用链，不真实执行 |
 

--- a/skills/lark-mail/references/lark-mail-template-update.md
+++ b/skills/lark-mail/references/lark-mail-template-update.md
@@ -70,8 +70,8 @@ lark-cli mail +template-update --as user --template-id 712345 \
 | `--set-to <emails>` | 用单次参数值替换默认收件人列表；多个地址仍在该值内用逗号分隔，传 `--set-to=""` 可清空 |
 | `--set-cc <emails>` | 用单次参数值替换默认抄送；多个地址仍在该值内用逗号分隔，传 `--set-cc=""` 可清空 |
 | `--set-bcc <emails>` | 用单次参数值替换默认密送；多个地址仍在该值内用逗号分隔，传 `--set-bcc=""` 可清空 |
-| `--attach '<path>'` | 追加非 inline 附件，不替换已有附件。多个附件请重复传 `--attach`，每次只放一个相对路径，参数值用单引号包住；按传入顺序上传 |
-| `--inline '<json>'` | 追加 inline 图片，不替换已有附件。多个 inline 图片请重复传 `--inline`，每次只放一个 JSON object，并用单引号包住：`'{"cid":"mycid","file_path":"./logo.png"}'`；`file_path` 必须是相对路径；CID 应唯一，例如随机十六进制字符串；在模板正文中用 `<img src="cid:mycid">` 引用；最终模板为纯文本模式时会被拒绝 |
+| `--attach '<path-list>'` | 追加非 inline 附件，不替换已有附件；支持重复 flag 和单次逗号列表，按输入顺序上传 |
+| `--inline '<json>'` | 追加 inline 图片，不替换已有附件；每次值为一个 JSON object 或 array，可重复传并按顺序合并，不按逗号切分；最终模板为纯文本模式时会被拒绝 |
 
 ### 结构化 patch
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail commands support comma-separated recipient and attachment lists alongside repeated flags.
  * Inline content accepts JSON objects or arrays merged in input order.
* **Bug Fixes**
  * Recipient, attachment, and inline values are validated before processing.
  * Invalid, empty, missing, or inaccessible values now produce occurrence-specific errors.
  * Sender addresses are verified against the target mailbox’s allowed send-as addresses before drafts or messages are created.
* **Documentation**
  * Updated command help and reference documentation to clarify input formats, ordering, quoting, and inline content behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->