### PR TITLE
Add batch modify and trash shortcuts for mail threads

### DIFF
--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -280,9 +280,13 @@ func printWatchOutputSchema(runtime *common.RuntimeContext) {
 	fmt.Fprintln(runtime.IO().Out, string(b))
 }
 
-// resolveMailboxID returns the user_mailbox_id from --mailbox flag, defaulting to "me".
+// resolveMailboxID returns the user_mailbox_id from the canonical mailbox flag
+// used by the mounted shortcut, defaulting to "me".
 func resolveMailboxID(runtime *common.RuntimeContext) string {
 	id := runtime.Str("mailbox")
+	if id == "" {
+		id = runtime.Str("mailbox-id")
+	}
 	if id == "" {
 		return "me"
 	}
@@ -2740,7 +2744,7 @@ func buildCalendarBody(runtime *common.RuntimeContext, senderEmail string, toAdd
 // validateBotMailboxNotMe rejects the combination of bot identity with --mailbox me.
 // bot uses tenant access token; "me" cannot be resolved to a user mailbox under TAT.
 func validateBotMailboxNotMe(runtime *common.RuntimeContext) error {
-	if runtime.IsBot() && runtime.Str("mailbox") == "me" {
+	if runtime.IsBot() && resolveMailboxID(runtime) == "me" {
 		return mailValidationParamError("--mailbox",
 			"--as bot does not support --mailbox me: bot identity uses a tenant token and cannot resolve \"me\" to a user mailbox; "+
 				"pass an explicit email address, e.g. --mailbox alice@example.com")

--- a/shortcuts/mail/mail_shortcut_validation_test.go
+++ b/shortcuts/mail/mail_shortcut_validation_test.go
@@ -166,7 +166,7 @@ func TestMailThreadBotExplicitMailboxPassesValidation(t *testing.T) {
 func TestMailThreadModifyBotDefaultMailboxMeReturnsValidationError(t *testing.T) {
 	f, stdout, _, _ := mailShortcutTestFactory(t)
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify", "--as", "bot", "--thread-ids", "thread_xxx", "--add-folder", "archive",
+		"+thread-modify", "--as", "bot", "--thread-id", "thread_xxx", "--add-folder", "archive",
 	}, f, stdout)
 	assertValidationError(t, err, "does not support --mailbox me")
 }
@@ -174,7 +174,7 @@ func TestMailThreadModifyBotDefaultMailboxMeReturnsValidationError(t *testing.T)
 func TestMailThreadModifyBotExplicitMailboxPassesValidation(t *testing.T) {
 	f, stdout, _, _ := mailShortcutTestFactory(t)
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify", "--as", "bot", "--mailbox", "alice@example.com", "--thread-ids", "thread_xxx", "--add-folder", "archive", "--dry-run",
+		"+thread-modify", "--as", "bot", "--mailbox", "alice@example.com", "--thread-id", "thread_xxx", "--add-folder", "archive", "--dry-run",
 	}, f, stdout)
 	assertValidatePasses(t, err)
 }
@@ -182,7 +182,7 @@ func TestMailThreadModifyBotExplicitMailboxPassesValidation(t *testing.T) {
 func TestMailThreadTrashBotDefaultMailboxMeReturnsValidationError(t *testing.T) {
 	f, stdout, _, _ := mailShortcutTestFactory(t)
 	err := runMountedMailShortcut(t, MailThreadTrash, []string{
-		"+thread-trash", "--as", "bot", "--thread-ids", "thread_xxx", "--dry-run",
+		"+thread-trash", "--as", "bot", "--thread-id", "thread_xxx", "--dry-run",
 	}, f, stdout)
 	assertValidationError(t, err, "does not support --mailbox me")
 }
@@ -190,7 +190,7 @@ func TestMailThreadTrashBotDefaultMailboxMeReturnsValidationError(t *testing.T) 
 func TestMailThreadTrashBotExplicitMailboxPassesValidation(t *testing.T) {
 	f, stdout, _, _ := mailShortcutTestFactory(t)
 	err := runMountedMailShortcut(t, MailThreadTrash, []string{
-		"+thread-trash", "--as", "bot", "--mailbox", "alice@example.com", "--thread-ids", "thread_xxx", "--dry-run",
+		"+thread-trash", "--as", "bot", "--mailbox", "alice@example.com", "--thread-id", "thread_xxx", "--dry-run",
 	}, f, stdout)
 	assertValidatePasses(t, err)
 }

--- a/shortcuts/mail/mail_thread_manage.go
+++ b/shortcuts/mail/mail_thread_manage.go
@@ -29,9 +29,9 @@ var MailThreadModify = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "mailbox-id", Aliases: []string{"mailbox"}, Default: "me", Desc: "Mailbox email address that owns the threads (default: me)."},
-		{Name: "thread-id", Aliases: []string{"thread-ids"}, Type: "string_array", Desc: "Required. Thread ID to modify; repeat the flag for multiple threads."},
-		{Name: "add-label-id", Aliases: []string{"add-label-ids"}, Type: "string_slice", Desc: "Label ID to add; repeat the flag for multiple labels."},
-		{Name: "remove-label-id", Aliases: []string{"remove-label-ids"}, Type: "string_slice", Desc: "Label ID to remove; cannot overlap with --add-label-id."},
+		{Name: "thread-id", Type: "string_array", Desc: "Required. Thread ID to modify; repeat the flag for multiple threads."},
+		{Name: "add-label-id", Type: "string_slice", Desc: "Label ID to add; repeat the flag for multiple labels."},
+		{Name: "remove-label-id", Type: "string_slice", Desc: "Label ID to remove; cannot overlap with --add-label-id."},
 		{Name: "folder-id", Aliases: []string{"add-folder"}, Desc: "Folder ID to move threads to."},
 	},
 	Validate: validateThreadModify,
@@ -52,7 +52,7 @@ var MailThreadTrash = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "mailbox-id", Aliases: []string{"mailbox"}, Default: "me", Desc: "Mailbox email address that owns the threads (default: me)."},
-		{Name: "thread-id", Aliases: []string{"thread-ids"}, Type: "string_array", Desc: "Required. Thread ID to soft-delete; repeat the flag for multiple threads."},
+		{Name: "thread-id", Type: "string_array", Desc: "Required. Thread ID to soft-delete; repeat the flag for multiple threads."},
 	},
 	Validate: validateThreadTrash,
 	DryRun:   dryRunThreadTrash,

--- a/shortcuts/mail/mail_thread_manage.go
+++ b/shortcuts/mail/mail_thread_manage.go
@@ -5,11 +5,8 @@ package mail
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -20,73 +17,46 @@ type threadModifyInput struct {
 	FolderID       string
 }
 
-const mailThreadManageBatchSize = 20
-
-type threadManageSummary struct {
-	SuccessThreadIDs []string              `json:"success_thread_ids"`
-	FailedThreadIDs  []threadManageFailure `json:"failed_thread_ids"`
-}
-
-type threadManageFailure struct {
-	ThreadID string `json:"thread_id"`
-	Reason   string `json:"reason"`
-}
-
 // MailThreadModify is the `+thread-modify` shortcut: apply label changes or a
-// folder move to existing mail threads in batches of 20.
+// folder move to existing mail threads in one batch_modify request.
 var MailThreadModify = common.Shortcut{
 	Service:     "mail",
 	Command:     "+thread-modify",
-	Description: "Modify existing mail threads by adding/removing label IDs or moving them to a folder. Batches thread IDs in groups of 20 and keeps output compact.",
+	Description: "Modify existing mail threads by adding/removing label IDs or moving them to a folder in one batch request.",
 	Risk:        "write",
 	Scopes:      []string{"mail:user_mailbox.message:modify"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "mailbox", Default: "me", Desc: "Mailbox email address that owns the threads (default: me)."},
-		{Name: "thread-ids", Type: "string_array", Required: true, Desc: "Thread IDs to modify; comma-separated or repeat the flag."},
-		{Name: "add-label-ids", Type: "string_slice", Desc: "Label IDs to add. System labels unread/important/other/flagged are normalized to upper case."},
-		{Name: "remove-label-ids", Type: "string_slice", Desc: "Label IDs to remove. Cannot overlap with --add-label-ids."},
-		{Name: "add-folder", Desc: "Folder ID to move threads to."},
-		{Name: "folder-id", Hidden: true, Desc: "Compatibility alias for --add-folder."},
+		{Name: "mailbox-id", Aliases: []string{"mailbox"}, Default: "me", Desc: "Mailbox email address that owns the threads (default: me)."},
+		{Name: "thread-id", Aliases: []string{"thread-ids"}, Type: "string_array", Desc: "Required. Thread ID to modify; repeat the flag for multiple threads."},
+		{Name: "add-label-id", Aliases: []string{"add-label-ids"}, Type: "string_slice", Desc: "Label ID to add; repeat the flag for multiple labels."},
+		{Name: "remove-label-id", Aliases: []string{"remove-label-ids"}, Type: "string_slice", Desc: "Label ID to remove; cannot overlap with --add-label-id."},
+		{Name: "folder-id", Aliases: []string{"add-folder"}, Desc: "Folder ID to move threads to."},
 	},
-	Normalize: normalizeThreadModifyCompatibility,
-	Validate:  validateThreadModify,
-	DryRun:    dryRunThreadModify,
-	Execute:   executeThreadModify,
+	Validate: validateThreadModify,
+	DryRun:   dryRunThreadModify,
+	Execute:  executeThreadModify,
 }
 
 // MailThreadTrash is the `+thread-trash` shortcut: soft-delete existing mail
-// threads through the thread batch_trash route. Risk is high-risk-write, so the
+// threads through one batch_trash request. Risk is high-risk-write, so the
 // runner requires --yes before Execute.
 var MailThreadTrash = common.Shortcut{
 	Service:     "mail",
 	Command:     "+thread-trash",
-	Description: "Soft-delete existing mail threads. Batches thread IDs in groups of 20 and calls batch_trash sequentially. Requires --yes.",
+	Description: "Soft-delete existing mail threads in one batch request. Requires --yes.",
 	Risk:        "high-risk-write",
 	Scopes:      []string{"mail:user_mailbox.message:modify"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "mailbox", Default: "me", Desc: "Mailbox email address that owns the threads (default: me)."},
-		{Name: "thread-ids", Type: "string_array", Required: true, Desc: "Thread IDs to soft-delete; comma-separated or repeat the flag."},
+		{Name: "mailbox-id", Aliases: []string{"mailbox"}, Default: "me", Desc: "Mailbox email address that owns the threads (default: me)."},
+		{Name: "thread-id", Aliases: []string{"thread-ids"}, Type: "string_array", Desc: "Required. Thread ID to soft-delete; repeat the flag for multiple threads."},
 	},
 	Validate: validateThreadTrash,
 	DryRun:   dryRunThreadTrash,
 	Execute:  executeThreadTrash,
-}
-
-func normalizeThreadModifyCompatibility(ctx context.Context, flags *common.FlagContext) error {
-	if flags.Changed("add-folder") && flags.Changed("folder-id") {
-		return mailValidationParamError("--folder-id", "--folder-id is a compatibility alias for --add-folder; pass only one of them")
-	}
-	if !flags.Changed("folder-id") {
-		return nil
-	}
-	if _, err := normalizeThreadManageFolderForFlag(flags.Str("folder-id"), "--folder-id"); err != nil {
-		return err
-	}
-	return flags.SetCanonicalFrom("folder-id", "add-folder", flags.Str("folder-id"))
 }
 
 func validateThreadModify(ctx context.Context, rt *common.RuntimeContext) error {
@@ -100,20 +70,10 @@ func validateThreadModify(ctx context.Context, rt *common.RuntimeContext) error 
 func dryRunThreadModify(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
 	mailboxID := resolveMailboxID(rt)
 	input, _ := buildThreadModifyInput(rt)
-	api := common.NewDryRunAPI().
-		Desc("Modify threads sequentially in batches of 20").
-		Set("batch_size", mailThreadManageBatchSize).
-		Set("batches", chunkThreadManageIDs(input.ThreadIDs))
-	for _, batch := range chunkThreadManageIDs(input.ThreadIDs) {
-		api = api.POST(mailboxPath(mailboxID, "threads", "batch_modify")).
-			Body(threadModifyBody(threadModifyInput{
-				ThreadIDs:      batch,
-				AddLabelIDs:    input.AddLabelIDs,
-				RemoveLabelIDs: input.RemoveLabelIDs,
-				FolderID:       input.FolderID,
-			}))
-	}
-	return api
+	return common.NewDryRunAPI().
+		Desc("Modify threads in one batch request").
+		POST(mailboxPath(mailboxID, "threads", "batch_modify")).
+		Body(threadModifyBody(input))
 }
 
 func executeThreadModify(ctx context.Context, rt *common.RuntimeContext) error {
@@ -122,28 +82,11 @@ func executeThreadModify(ctx context.Context, rt *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	summary := threadManageSummary{FailedThreadIDs: []threadManageFailure{}}
-	for _, batch := range chunkThreadManageIDs(input.ThreadIDs) {
-		_, err := rt.CallAPITyped("POST", mailboxPath(mailboxID, "threads", "batch_modify"), nil,
-			threadModifyBody(threadModifyInput{
-				ThreadIDs:      batch,
-				AddLabelIDs:    input.AddLabelIDs,
-				RemoveLabelIDs: input.RemoveLabelIDs,
-				FolderID:       input.FolderID,
-			}))
-		if err != nil {
-			decorated := mailDecorateProblemMessage(err, "failed to modify threads")
-			for _, id := range batch {
-				summary.FailedThreadIDs = append(summary.FailedThreadIDs, threadManageFailure{ThreadID: id, Reason: decorated.Error()})
-			}
-			continue
-		}
-		summary.SuccessThreadIDs = append(summary.SuccessThreadIDs, batch...)
+	data, err := rt.CallAPITyped("POST", mailboxPath(mailboxID, "threads", "batch_modify"), nil, threadModifyBody(input))
+	if err != nil {
+		return err
 	}
-	emitThreadManageSummary(rt, summary)
-	if len(summary.SuccessThreadIDs) == 0 && len(summary.FailedThreadIDs) > 0 {
-		return mailFailedPreconditionError("all thread modify batches failed")
-	}
+	rt.OutFormat(data, nil, nil)
 	return nil
 }
 
@@ -151,72 +94,56 @@ func validateThreadTrash(ctx context.Context, rt *common.RuntimeContext) error {
 	if err := validateBotMailboxNotMe(rt); err != nil {
 		return err
 	}
-	_, err := normalizeThreadManageIDs(rt.StrArray("thread-ids"))
+	_, err := normalizeThreadManageIDs(rt.StrArray("thread-id"))
 	return err
 }
 
 func dryRunThreadTrash(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
 	mailboxID := resolveMailboxID(rt)
-	threadIDs, _ := normalizeThreadManageIDs(rt.StrArray("thread-ids"))
-	api := common.NewDryRunAPI().
-		Desc("Soft-delete threads sequentially in batches of 20").
-		Set("batch_size", mailThreadManageBatchSize).
-		Set("batches", chunkThreadManageIDs(threadIDs))
-	for _, batch := range chunkThreadManageIDs(threadIDs) {
-		api = api.POST(mailboxPath(mailboxID, "threads", "batch_trash")).
-			Body(map[string]interface{}{"thread_ids": batch})
-	}
-	return api
+	threadIDs, _ := normalizeThreadManageIDs(rt.StrArray("thread-id"))
+	return common.NewDryRunAPI().
+		Desc("Soft-delete threads in one batch request").
+		POST(mailboxPath(mailboxID, "threads", "batch_trash")).
+		Body(map[string]interface{}{"thread_ids": threadIDs})
 }
 
 func executeThreadTrash(ctx context.Context, rt *common.RuntimeContext) error {
 	mailboxID := resolveMailboxID(rt)
-	threadIDs, err := normalizeThreadManageIDs(rt.StrArray("thread-ids"))
+	threadIDs, err := normalizeThreadManageIDs(rt.StrArray("thread-id"))
 	if err != nil {
 		return err
 	}
-	summary := threadManageSummary{FailedThreadIDs: []threadManageFailure{}}
-	for _, batch := range chunkThreadManageIDs(threadIDs) {
-		_, err := rt.CallAPITyped("POST", mailboxPath(mailboxID, "threads", "batch_trash"), nil,
-			map[string]interface{}{"thread_ids": batch})
-		if err != nil {
-			decorated := mailDecorateProblemMessage(err, "failed to trash threads")
-			for _, id := range batch {
-				summary.FailedThreadIDs = append(summary.FailedThreadIDs, threadManageFailure{ThreadID: id, Reason: decorated.Error()})
-			}
-			continue
-		}
-		summary.SuccessThreadIDs = append(summary.SuccessThreadIDs, batch...)
+	data, err := rt.CallAPITyped("POST", mailboxPath(mailboxID, "threads", "batch_trash"), nil,
+		map[string]interface{}{"thread_ids": threadIDs})
+	if err != nil {
+		return err
 	}
-	emitThreadManageSummary(rt, summary)
-	if len(summary.SuccessThreadIDs) == 0 && len(summary.FailedThreadIDs) > 0 {
-		return mailFailedPreconditionError("all thread trash batches failed")
-	}
+	rt.OutFormat(data, nil, nil)
 	return nil
 }
 
 func buildThreadModifyInput(rt *common.RuntimeContext) (threadModifyInput, error) {
-	threadIDs, err := normalizeThreadManageIDs(rt.StrArray("thread-ids"))
+	threadIDs, err := normalizeThreadManageIDs(rt.StrArray("thread-id"))
 	if err != nil {
 		return threadModifyInput{}, err
 	}
-	addLabels, err := normalizeThreadManageLabels(rt.StrSlice("add-label-ids"), "--add-label-ids")
+	addLabels, err := normalizeThreadManageLabels(rt.StrSlice("add-label-id"), "--add-label-id")
 	if err != nil {
 		return threadModifyInput{}, err
 	}
-	removeLabels, err := normalizeThreadManageLabels(rt.StrSlice("remove-label-ids"), "--remove-label-ids")
+	removeLabels, err := normalizeThreadManageLabels(rt.StrSlice("remove-label-id"), "--remove-label-id")
 	if err != nil {
 		return threadModifyInput{}, err
 	}
-	if err := validateLabelIntersection(addLabels, removeLabels); err != nil {
+	if err := validateThreadLabelIntersection(addLabels, removeLabels); err != nil {
 		return threadModifyInput{}, err
 	}
-	folderID, err := normalizeThreadManageFolder(rt.Str("add-folder"))
+	folderID, err := normalizeThreadManageFolder(rt.Str("folder-id"))
 	if err != nil {
 		return threadModifyInput{}, err
 	}
 	if len(addLabels) == 0 && len(removeLabels) == 0 && folderID == "" {
-		return threadModifyInput{}, mailValidationParamError("--thread-modify", "provide at least one of --add-label-ids, --remove-label-ids, or --add-folder")
+		return threadModifyInput{}, mailValidationParamError("--thread-modify", "provide at least one of --add-label-id, --remove-label-id, or --folder-id")
 	}
 	return threadModifyInput{
 		ThreadIDs:      threadIDs,
@@ -224,6 +151,19 @@ func buildThreadModifyInput(rt *common.RuntimeContext) (threadModifyInput, error
 		RemoveLabelIDs: removeLabels,
 		FolderID:       folderID,
 	}, nil
+}
+
+func validateThreadLabelIntersection(add, remove []string) error {
+	removeSet := make(map[string]struct{}, len(remove))
+	for _, id := range remove {
+		removeSet[id] = struct{}{}
+	}
+	for _, id := range add {
+		if _, ok := removeSet[id]; ok {
+			return mailValidationParamError("--add-label-id", "label cannot be both added and removed: %s", id)
+		}
+	}
+	return nil
 }
 
 func normalizeThreadManageLabels(raw []string, flagName string) ([]string, error) {
@@ -260,26 +200,26 @@ func normalizeThreadManageLabels(raw []string, flagName string) ([]string, error
 
 func normalizeThreadManageIDs(raw []string) ([]string, error) {
 	if len(raw) == 0 {
-		return nil, mailValidationParamError("--thread-ids", "--thread-ids is required")
+		return nil, mailValidationParamError("--thread-id", "--thread-id is required")
 	}
 	ids := make([]string, 0, len(raw))
 	seen := map[string]struct{}{}
 	for tokenIndex, token := range raw {
 		for _, r := range token {
 			if r == '\n' || r == '\r' || r == '\t' {
-				return nil, mailValidationParamError("--thread-ids", "--thread-ids entry %d (%q): must not contain whitespace or control characters", tokenIndex+1, token)
+				return nil, mailValidationParamError("--thread-id", "--thread-id entry %d (%q): must not contain whitespace or control characters", tokenIndex+1, token)
 			}
 		}
 		for partIndex, part := range strings.Split(token, ",") {
 			if part == "" {
-				return nil, mailValidationParamError("--thread-ids", "--thread-ids contains empty value; remove extra commas or provide valid thread IDs")
+				return nil, mailValidationParamError("--thread-id", "--thread-id contains empty value; remove extra commas or provide valid thread IDs")
 			}
 			id := strings.TrimSpace(part)
 			if id == "" {
-				return nil, mailValidationParamError("--thread-ids", "--thread-ids contains empty value; remove extra commas or provide valid thread IDs")
+				return nil, mailValidationParamError("--thread-id", "--thread-id contains empty value; remove extra commas or provide valid thread IDs")
 			}
 			if id != part {
-				return nil, mailValidationParamError("--thread-ids", "--thread-ids entry %d (%q): must not contain leading or trailing whitespace", partIndex+1, part)
+				return nil, mailValidationParamError("--thread-id", "--thread-id entry %d (%q): must not contain leading or trailing whitespace", partIndex+1, part)
 			}
 			if err := validateThreadManageID(id, partIndex); err != nil {
 				return nil, err
@@ -292,14 +232,14 @@ func normalizeThreadManageIDs(raw []string) ([]string, error) {
 		}
 	}
 	if len(ids) == 0 {
-		return nil, mailValidationParamError("--thread-ids", "--thread-ids must include at least one non-empty thread ID")
+		return nil, mailValidationParamError("--thread-id", "--thread-id must include at least one non-empty thread ID")
 	}
 	return ids, nil
 }
 
 func validateThreadManageID(id string, index int) error {
 	if strings.Trim(id, "0123456789") == "" {
-		return mailValidationParamError("--thread-ids", "--thread-ids entry %d (%q): numeric primary IDs are not supported; pass the Open API thread_id from mail output", index+1, id)
+		return mailValidationParamError("--thread-id", "--thread-id entry %d (%q): numeric primary IDs are not supported; pass the Open API thread_id from mail output", index+1, id)
 	}
 	for _, r := range id {
 		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
@@ -309,14 +249,14 @@ func validateThreadManageID(id string, index int) error {
 		case '+', '/', '=', '_', '-':
 			continue
 		default:
-			return mailValidationParamError("--thread-ids", "--thread-ids entry %d (%q): contains characters outside the Open API thread_id character set", index+1, id)
+			return mailValidationParamError("--thread-id", "--thread-id entry %d (%q): contains characters outside the Open API thread_id character set", index+1, id)
 		}
 	}
 	return nil
 }
 
 func normalizeThreadManageFolder(raw string) (string, error) {
-	return normalizeThreadManageFolderForFlag(raw, "--add-folder")
+	return normalizeThreadManageFolderForFlag(raw, "--folder-id")
 }
 
 func normalizeThreadManageFolderForFlag(raw, flagName string) (string, error) {
@@ -348,29 +288,4 @@ func threadModifyBody(input threadModifyInput) map[string]interface{} {
 		body["add_folder"] = input.FolderID
 	}
 	return body
-}
-
-func chunkThreadManageIDs(ids []string) [][]string {
-	if len(ids) == 0 {
-		return nil
-	}
-	chunks := make([][]string, 0, (len(ids)+mailThreadManageBatchSize-1)/mailThreadManageBatchSize)
-	for start := 0; start < len(ids); start += mailThreadManageBatchSize {
-		end := start + mailThreadManageBatchSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		chunks = append(chunks, ids[start:end])
-	}
-	return chunks
-}
-
-func emitThreadManageSummary(rt *common.RuntimeContext, summary threadManageSummary) {
-	rt.OutFormat(summary, &output.Meta{Count: len(summary.SuccessThreadIDs)}, func(w io.Writer) {
-		fmt.Fprintf(w, "success_thread_ids: %d\n", len(summary.SuccessThreadIDs))
-		fmt.Fprintf(w, "failed_thread_ids: %d\n", len(summary.FailedThreadIDs))
-		for _, item := range summary.FailedThreadIDs {
-			fmt.Fprintf(w, "- %s: %s\n", item.ThreadID, item.Reason)
-		}
-	})
 }

--- a/shortcuts/mail/mail_thread_manage.go
+++ b/shortcuts/mail/mail_thread_manage.go
@@ -60,6 +60,9 @@ var MailThreadTrash = common.Shortcut{
 }
 
 func validateThreadModify(ctx context.Context, rt *common.RuntimeContext) error {
+	if err := validateThreadManageMailbox(rt); err != nil {
+		return err
+	}
 	if err := validateBotMailboxNotMe(rt); err != nil {
 		return err
 	}
@@ -91,11 +94,21 @@ func executeThreadModify(ctx context.Context, rt *common.RuntimeContext) error {
 }
 
 func validateThreadTrash(ctx context.Context, rt *common.RuntimeContext) error {
+	if err := validateThreadManageMailbox(rt); err != nil {
+		return err
+	}
 	if err := validateBotMailboxNotMe(rt); err != nil {
 		return err
 	}
 	_, err := normalizeThreadManageIDs(rt.StrArray("thread-id"))
 	return err
+}
+
+func validateThreadManageMailbox(rt *common.RuntimeContext) error {
+	if strings.TrimSpace(resolveMailboxID(rt)) == "" {
+		return mailValidationParamError("--mailbox-id", "--mailbox-id must not be empty")
+	}
+	return nil
 }
 
 func dryRunThreadTrash(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {

--- a/shortcuts/mail/mail_thread_manage_test.go
+++ b/shortcuts/mail/mail_thread_manage_test.go
@@ -341,9 +341,9 @@ func TestThreadManage_DryRunMailboxPaths(t *testing.T) {
 			shortcut: MailThreadModify,
 			args: []string{
 				"+thread-modify", "--thread-id", threadManageID("1"), "--add-label-id", "UNREAD",
-				"--mailbox-id", "shared+team@example.com", "--dry-run",
+				"--mailbox-id", "shared%team@example.com", "--dry-run",
 			},
-			wantPath: "/user_mailboxes/shared+team@example.com/threads/batch_modify",
+			wantPath: "/user_mailboxes/shared%25team@example.com/threads/batch_modify",
 		},
 		{
 			name:     "trash defaults to me",
@@ -356,9 +356,9 @@ func TestThreadManage_DryRunMailboxPaths(t *testing.T) {
 			shortcut: MailThreadTrash,
 			args: []string{
 				"+thread-trash", "--thread-id", threadManageID("1"),
-				"--mailbox-id", "shared+team@example.com", "--dry-run",
+				"--mailbox-id", "shared%team@example.com", "--dry-run",
 			},
-			wantPath: "/user_mailboxes/shared+team@example.com/threads/batch_trash",
+			wantPath: "/user_mailboxes/shared%25team@example.com/threads/batch_trash",
 		},
 	}
 	for _, test := range tests {

--- a/shortcuts/mail/mail_thread_manage_test.go
+++ b/shortcuts/mail/mail_thread_manage_test.go
@@ -67,8 +67,10 @@ func TestThreadManage_MetadataAndRegistration(t *testing.T) {
 	if flags["thread-id"].Required || flags["thread-id"].Type != "string_array" {
 		t.Errorf("--thread-id = %#v, want validation-owned string_array", flags["thread-id"])
 	}
-	if got := strings.Join(flags["thread-id"].Aliases, ","); got != "thread-ids" {
-		t.Errorf("--thread-id aliases = %q", got)
+	for _, name := range []string{"thread-id", "add-label-id", "remove-label-id"} {
+		if got := flags[name].Aliases; len(got) != 0 {
+			t.Errorf("--%s aliases = %v, want none", name, got)
+		}
 	}
 	if got := strings.Join(flags["folder-id"].Aliases, ","); got != "add-folder" {
 		t.Errorf("--folder-id aliases = %q", got)
@@ -85,21 +87,49 @@ func TestThreadManage_MetadataAndRegistration(t *testing.T) {
 	}
 }
 
-func TestThreadManage_HelpShowsSingularFlags(t *testing.T) {
-	f, stdout, _, _ := mailShortcutTestFactory(t)
-	parent := &cobra.Command{Use: "test"}
-	MailThreadModify.Mount(parent, f)
-	parent.SetOut(stdout)
-	parent.SetErr(stdout)
-	parent.SetArgs([]string{"+thread-modify", "--help"})
-	err := parent.Execute()
-	if err != nil {
-		t.Fatalf("help error: %v", err)
+func TestThreadManage_HelpShowsOnlySingularBatchFlags(t *testing.T) {
+	tests := []struct {
+		shortcut common.Shortcut
+		command  string
+		want     []string
+		forbid   []string
+	}{
+		{
+			shortcut: MailThreadModify,
+			command:  "+thread-modify",
+			want:     []string{"--thread-id", "--add-label-id", "--remove-label-id", "--folder-id", "--mailbox-id"},
+			forbid:   []string{"--thread-ids", "--add-label-ids", "--remove-label-ids"},
+		},
+		{
+			shortcut: MailThreadTrash,
+			command:  "+thread-trash",
+			want:     []string{"--thread-id", "--mailbox-id"},
+			forbid:   []string{"--thread-ids"},
+		},
 	}
-	for _, flag := range []string{"--thread-id", "--add-label-id", "--remove-label-id", "--folder-id", "--mailbox-id"} {
-		if !strings.Contains(stdout.String(), flag) {
-			t.Errorf("help missing %s:\n%s", flag, stdout.String())
-		}
+	for _, test := range tests {
+		t.Run(test.command, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			parent := &cobra.Command{Use: "test"}
+			test.shortcut.Mount(parent, f)
+			parent.SetOut(stdout)
+			parent.SetErr(stdout)
+			parent.SetArgs([]string{test.command, "--help"})
+			if err := parent.Execute(); err != nil {
+				t.Fatalf("help error: %v", err)
+			}
+			help := stdout.String()
+			for _, flag := range test.want {
+				if !strings.Contains(help, flag) {
+					t.Errorf("help missing %s:\n%s", flag, help)
+				}
+			}
+			for _, flag := range test.forbid {
+				if strings.Contains(help, flag) {
+					t.Errorf("help unexpectedly exposes %s:\n%s", flag, help)
+				}
+			}
+		})
 	}
 }
 
@@ -321,18 +351,61 @@ func TestThreadTrash_ConfirmationDryRunAndEmptyResponse(t *testing.T) {
 	}
 }
 
-func TestThreadManage_LegacyAliasesRemainAccepted(t *testing.T) {
+func TestThreadManage_RemainingAliasesStayAccepted(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	post := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify", "--mailbox", "me", "--thread-ids", threadManageID("1"),
-		"--add-label-ids", "unread", "--remove-label-ids", "FLAGGED", "--add-folder", "archive",
+		"+thread-modify", "--mailbox", "me", "--thread-id", threadManageID("1"),
+		"--add-label-id", "unread", "--remove-label-id", "FLAGGED", "--add-folder", "archive",
 	}, f, stdout)
 	if err != nil {
-		t.Fatalf("legacy aliases: %v", err)
+		t.Fatalf("remaining aliases: %v", err)
 	}
 	body := decodeThreadManageBody(t, post)
 	if body["add_folder"] != "ARCHIVED" {
 		t.Fatalf("add_folder = %#v, want ARCHIVED", body["add_folder"])
+	}
+}
+
+func TestThreadManage_RejectsPluralAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+		flag     string
+	}{
+		{
+			name:     "modify thread ids",
+			shortcut: MailThreadModify,
+			args:     []string{"+thread-modify", "--thread-ids", threadManageID("1"), "--folder-id", "archive"},
+			flag:     "--thread-ids",
+		},
+		{
+			name:     "modify add label ids",
+			shortcut: MailThreadModify,
+			args:     []string{"+thread-modify", "--thread-id", threadManageID("1"), "--add-label-ids", "unread"},
+			flag:     "--add-label-ids",
+		},
+		{
+			name:     "modify remove label ids",
+			shortcut: MailThreadModify,
+			args:     []string{"+thread-modify", "--thread-id", threadManageID("1"), "--remove-label-ids", "FLAGGED"},
+			flag:     "--remove-label-ids",
+		},
+		{
+			name:     "trash thread ids",
+			shortcut: MailThreadTrash,
+			args:     []string{"+thread-trash", "--thread-ids", threadManageID("1"), "--dry-run"},
+			flag:     "--thread-ids",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, test.shortcut, test.args, f, stdout)
+			if err == nil || !strings.Contains(err.Error(), "unknown flag: "+test.flag) {
+				t.Fatalf("error = %v, want unknown flag %s", err, test.flag)
+			}
+		})
 	}
 }

--- a/shortcuts/mail/mail_thread_manage_test.go
+++ b/shortcuts/mail/mail_thread_manage_test.go
@@ -282,6 +282,98 @@ func TestThreadModify_DryRunDoesNotCallAPI(t *testing.T) {
 	}
 }
 
+func TestThreadManage_RejectsBlankMailboxBeforeDryRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{
+			name:     "modify",
+			shortcut: MailThreadModify,
+			args: []string{
+				"+thread-modify", "--thread-id", threadManageID("1"),
+				"--add-label-id", "UNREAD", "--mailbox-id", "   ", "--dry-run",
+			},
+		},
+		{
+			name:     "trash",
+			shortcut: MailThreadTrash,
+			args: []string{
+				"+thread-trash", "--thread-id", threadManageID("1"),
+				"--mailbox-id", "   ", "--dry-run",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, test.shortcut, test.args, f, stdout)
+			var validation *errs.ValidationError
+			if !errors.As(err, &validation) {
+				t.Fatalf("error = %T %v, want ValidationError", err, err)
+			}
+			if validation.Param != "--mailbox-id" {
+				t.Fatalf("param = %q, want --mailbox-id", validation.Param)
+			}
+			if strings.Contains(stdout.String(), "/user_mailboxes/") {
+				t.Fatalf("blank mailbox produced a request: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestThreadManage_DryRunMailboxPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+		wantPath string
+	}{
+		{
+			name:     "modify defaults to me",
+			shortcut: MailThreadModify,
+			args:     []string{"+thread-modify", "--thread-id", threadManageID("1"), "--add-label-id", "UNREAD", "--dry-run"},
+			wantPath: "/user_mailboxes/me/threads/batch_modify",
+		},
+		{
+			name:     "modify encodes public mailbox",
+			shortcut: MailThreadModify,
+			args: []string{
+				"+thread-modify", "--thread-id", threadManageID("1"), "--add-label-id", "UNREAD",
+				"--mailbox-id", "shared+team@example.com", "--dry-run",
+			},
+			wantPath: "/user_mailboxes/shared+team@example.com/threads/batch_modify",
+		},
+		{
+			name:     "trash defaults to me",
+			shortcut: MailThreadTrash,
+			args:     []string{"+thread-trash", "--thread-id", threadManageID("1"), "--dry-run"},
+			wantPath: "/user_mailboxes/me/threads/batch_trash",
+		},
+		{
+			name:     "trash encodes public mailbox",
+			shortcut: MailThreadTrash,
+			args: []string{
+				"+thread-trash", "--thread-id", threadManageID("1"),
+				"--mailbox-id", "shared+team@example.com", "--dry-run",
+			},
+			wantPath: "/user_mailboxes/shared+team@example.com/threads/batch_trash",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			if err := runMountedMailShortcut(t, test.shortcut, test.args, f, stdout); err != nil {
+				t.Fatalf("dry-run: %v", err)
+			}
+			if !strings.Contains(stdout.String(), test.wantPath) {
+				t.Fatalf("dry-run missing %q: %s", test.wantPath, stdout.String())
+			}
+		})
+	}
+}
+
 func TestThreadModify_APIFailurePassesThrough(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 1230001, "msg": "bad request"})

--- a/shortcuts/mail/mail_thread_manage_test.go
+++ b/shortcuts/mail/mail_thread_manage_test.go
@@ -5,106 +5,100 @@ package mail
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
 )
 
 func threadManageID(suffix string) string {
 	return "thread_abcdefghijklmnop_" + suffix
 }
 
-func threadManageIDs(count int) []string {
-	ids := make([]string, 0, count)
-	for i := 0; i < count; i++ {
-		ids = append(ids, threadManageID(fmt.Sprintf("%02d", i+1)))
-	}
-	return ids
-}
-
-func stubThreadManagePost(reg *httpmock.Registry, endpoint string, body map[string]interface{}) *httpmock.Stub {
+func stubThreadManagePost(reg *httpmock.Registry, endpoint string, response map[string]interface{}) *httpmock.Stub {
 	stub := &httpmock.Stub{
 		Method: "POST",
 		URL:    "/user_mailboxes/me/threads/" + endpoint,
-		Body:   body,
+		Body:   response,
 	}
 	reg.Register(stub)
 	return stub
 }
 
-func decodeThreadManageSummary(t *testing.T, data map[string]interface{}) ([]interface{}, []interface{}) {
+func decodeThreadManageBody(t *testing.T, stub *httpmock.Stub) map[string]interface{} {
 	t.Helper()
-	success, ok := data["success_thread_ids"].([]interface{})
-	if !ok {
-		t.Fatalf("success_thread_ids = %#v, want array", data["success_thread_ids"])
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
 	}
-	failed, ok := data["failed_thread_ids"].([]interface{})
-	if !ok {
-		t.Fatalf("failed_thread_ids = %#v, want array", data["failed_thread_ids"])
-	}
-	return success, failed
+	return body
 }
 
-func TestThreadModify_Metadata(t *testing.T) {
-	if MailThreadModify.Command != "+thread-modify" {
-		t.Fatalf("Command = %q", MailThreadModify.Command)
-	}
-	if MailThreadModify.Risk != "write" {
-		t.Errorf("Risk = %q, want write", MailThreadModify.Risk)
-	}
-	if strings.Join(MailThreadModify.AuthTypes, ",") != "user,bot" {
-		t.Errorf("AuthTypes = %v, want [user bot]", MailThreadModify.AuthTypes)
-	}
-	if len(MailThreadModify.Scopes) != 1 || MailThreadModify.Scopes[0] != "mail:user_mailbox.message:modify" {
-		t.Errorf("Scopes = %v, want [mail:user_mailbox.message:modify]", MailThreadModify.Scopes)
-	}
-	if len(MailThreadModify.ConditionalScopes) != 0 {
-		t.Errorf("ConditionalScopes = %v, want none", MailThreadModify.ConditionalScopes)
-	}
-	flags := map[string]common.Flag{}
-	for _, fl := range MailThreadModify.Flags {
-		flags[fl.Name] = fl
-	}
-	for _, name := range []string{"mailbox", "thread-ids", "add-label-ids", "remove-label-ids", "add-folder", "folder-id"} {
-		if _, ok := flags[name]; !ok {
-			t.Fatalf("missing --%s flag", name)
+func TestThreadManage_MetadataAndRegistration(t *testing.T) {
+	for _, shortcut := range []common.Shortcut{MailThreadModify, MailThreadTrash} {
+		if strings.Join(shortcut.AuthTypes, ",") != "user,bot" {
+			t.Errorf("%s AuthTypes = %v, want [user bot]", shortcut.Command, shortcut.AuthTypes)
+		}
+		if len(shortcut.Scopes) != 1 || shortcut.Scopes[0] != "mail:user_mailbox.message:modify" {
+			t.Errorf("%s Scopes = %v", shortcut.Command, shortcut.Scopes)
 		}
 	}
-	if flags["thread-ids"].Type != "string_array" || !flags["thread-ids"].Required {
-		t.Errorf("--thread-ids = %#v, want required string_array", flags["thread-ids"])
-	}
-	if got := strings.Join(flags["add-folder"].Aliases, ","); got != "" {
-		t.Errorf("--add-folder aliases = %q, want none", got)
-	}
-	if !flags["folder-id"].Hidden {
-		t.Errorf("--folder-id hidden = false, want true")
-	}
-}
-
-func TestThreadTrash_Metadata(t *testing.T) {
-	if MailThreadTrash.Command != "+thread-trash" {
-		t.Fatalf("Command = %q", MailThreadTrash.Command)
+	if MailThreadModify.Risk != "write" {
+		t.Errorf("modify Risk = %q, want write", MailThreadModify.Risk)
 	}
 	if MailThreadTrash.Risk != "high-risk-write" {
-		t.Errorf("Risk = %q, want high-risk-write", MailThreadTrash.Risk)
+		t.Errorf("trash Risk = %q, want high-risk-write", MailThreadTrash.Risk)
 	}
-	if strings.Join(MailThreadTrash.AuthTypes, ",") != "user,bot" {
-		t.Errorf("AuthTypes = %v, want [user bot]", MailThreadTrash.AuthTypes)
-	}
-}
 
-func TestThreadManage_ShortcutsRegistration(t *testing.T) {
+	flags := map[string]common.Flag{}
+	for _, flag := range MailThreadModify.Flags {
+		flags[flag.Name] = flag
+	}
+	for _, name := range []string{"mailbox-id", "thread-id", "add-label-id", "remove-label-id", "folder-id"} {
+		if _, ok := flags[name]; !ok {
+			t.Fatalf("modify flags missing --%s", name)
+		}
+	}
+	if flags["thread-id"].Required || flags["thread-id"].Type != "string_array" {
+		t.Errorf("--thread-id = %#v, want validation-owned string_array", flags["thread-id"])
+	}
+	if got := strings.Join(flags["thread-id"].Aliases, ","); got != "thread-ids" {
+		t.Errorf("--thread-id aliases = %q", got)
+	}
+	if got := strings.Join(flags["folder-id"].Aliases, ","); got != "add-folder" {
+		t.Errorf("--folder-id aliases = %q", got)
+	}
+
 	commands := map[string]bool{}
 	for _, shortcut := range Shortcuts() {
 		commands[shortcut.Command] = true
 	}
-	for _, want := range []string{"+thread-modify", "+thread-trash"} {
-		if !commands[want] {
-			t.Fatalf("Shortcuts() missing %s", want)
+	for _, command := range []string{"+thread-modify", "+thread-trash"} {
+		if !commands[command] {
+			t.Fatalf("Shortcuts() missing %s", command)
+		}
+	}
+}
+
+func TestThreadManage_HelpShowsSingularFlags(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	parent := &cobra.Command{Use: "test"}
+	MailThreadModify.Mount(parent, f)
+	parent.SetOut(stdout)
+	parent.SetErr(stdout)
+	parent.SetArgs([]string{"+thread-modify", "--help"})
+	err := parent.Execute()
+	if err != nil {
+		t.Fatalf("help error: %v", err)
+	}
+	for _, flag := range []string{"--thread-id", "--add-label-id", "--remove-label-id", "--folder-id", "--mailbox-id"} {
+		if !strings.Contains(stdout.String(), flag) {
+			t.Errorf("help missing %s:\n%s", flag, stdout.String())
 		}
 	}
 }
@@ -112,359 +106,233 @@ func TestThreadManage_ShortcutsRegistration(t *testing.T) {
 func TestThreadManage_NormalizeThreadIDs(t *testing.T) {
 	id1 := threadManageID("1")
 	id2 := threadManageID("2")
-	got, err := normalizeThreadManageIDs([]string{id1 + "," + id2, id1})
+	got, err := normalizeThreadManageIDs([]string{id1, id2, id1})
 	if err != nil {
-		t.Fatalf("normalizeThreadManageIDs returned error: %v", err)
+		t.Fatalf("normalize IDs: %v", err)
 	}
-	if len(got) != 2 || got[0] != id1 || got[1] != id2 {
-		t.Fatalf("ids = %v, want [%s %s]", got, id1, id2)
+	if strings.Join(got, ",") != id1+","+id2 {
+		t.Fatalf("IDs = %v, want stable dedupe", got)
 	}
-	for _, tc := range [][]string{
-		{},
-		{""},
-		{" "},
-		{id1 + ","},
-		{" " + id1},
-		{id1 + "\n" + id2},
-		{"1234567890123456"},
-		{"thread_abcdefghijklmnop!"},
-	} {
-		_, err := normalizeThreadManageIDs(tc)
-		requireMessageManageValidationParam(t, err, "--thread-ids")
-	}
-	withDuplicates := append(threadManageIDs(mailThreadManageBatchSize), threadManageID("01"))
-	got, err = normalizeThreadManageIDs(withDuplicates)
-	if err != nil {
-		t.Fatalf("normalizeThreadManageIDs with duplicate returned error: %v", err)
-	}
-	if len(got) != mailThreadManageBatchSize {
-		t.Fatalf("ids len = %d, want %d after dedupe", len(got), mailThreadManageBatchSize)
+	for _, raw := range [][]string{{}, {""}, {" "}, {id1 + ","}, {" " + id1}, {id1 + "\n" + id2}} {
+		_, err := normalizeThreadManageIDs(raw)
+		requireMessageManageValidationParam(t, err, "--thread-id")
 	}
 }
 
-func TestThreadModify_LabelFolderBodyAndOutputContract(t *testing.T) {
+func TestThreadModify_OneRequestAndRawResponse(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	id1 := threadManageID("1")
 	id2 := threadManageID("2")
-	post := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+	post := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{
+		"code": 0,
+		"data": map[string]interface{}{"request_id": "req_1"},
+	})
 
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
 		"+thread-modify",
-		"--thread-ids", id1 + "," + id2 + "," + id1,
-		"--add-label-ids", "unread,customA",
-		"--remove-label-ids", "FLAGGED",
-		"--add-folder", "archive",
+		"--thread-id", id1,
+		"--thread-id", id2,
+		"--thread-id", id1,
+		"--add-label-id", "unread",
+		"--add-label-id", "customA",
+		"--remove-label-id", "FLAGGED",
+		"--folder-id", "  folderA  ",
 	}, f, stdout)
 	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+		t.Fatalf("execute modify: %v", err)
 	}
-	var body map[string]interface{}
-	if err := json.Unmarshal(post.CapturedBody, &body); err != nil {
-		t.Fatalf("unmarshal captured body: %v", err)
+	if len(post.CapturedBodies) != 1 {
+		t.Fatalf("POST count = %d, want 1", len(post.CapturedBodies))
 	}
-	threadIDs := body["thread_ids"].([]interface{})
-	if len(threadIDs) != 2 || threadIDs[0] != id1 || threadIDs[1] != id2 {
-		t.Fatalf("thread_ids = %#v, want deduped [%s %s]", threadIDs, id1, id2)
+	body := decodeThreadManageBody(t, post)
+	if got := body["thread_ids"].([]interface{}); len(got) != 2 || got[0] != id1 || got[1] != id2 {
+		t.Fatalf("thread_ids = %#v, want stable dedupe", got)
 	}
-	if got := body["add_folder"]; got != "ARCHIVED" {
-		t.Fatalf("add_folder = %v, want ARCHIVED", got)
+	if body["add_folder"] != "folderA" {
+		t.Fatalf("add_folder = %#v, want trimmed folderA", body["add_folder"])
 	}
-	addLabels := body["add_label_ids"].([]interface{})
-	if addLabels[0] != "UNREAD" || addLabels[1] != "customA" {
-		t.Fatalf("add_label_ids = %#v, want [UNREAD customA]", addLabels)
+	if got := body["add_label_ids"].([]interface{}); len(got) != 2 || got[0] != "UNREAD" || got[1] != "customA" {
+		t.Fatalf("add_label_ids = %#v", got)
 	}
-	removeLabels := body["remove_label_ids"].([]interface{})
-	if len(removeLabels) != 1 || removeLabels[0] != "FLAGGED" {
-		t.Fatalf("remove_label_ids = %#v, want [FLAGGED]", removeLabels)
+	if got := body["remove_label_ids"].([]interface{}); len(got) != 1 || got[0] != "FLAGGED" {
+		t.Fatalf("remove_label_ids = %#v", got)
 	}
-
 	data := decodeShortcutEnvelopeData(t, stdout)
-	success, failed := decodeThreadManageSummary(t, data)
-	if len(success) != 2 || success[0] != id1 || success[1] != id2 || len(failed) != 0 {
-		t.Fatalf("summary success=%v failed=%v, want [%s %s]/[]", success, failed, id1, id2)
+	if data["request_id"] != "req_1" {
+		t.Fatalf("data = %#v, want raw downstream data", data)
 	}
-	if _, ok := data["updated_count"]; ok {
-		t.Fatalf("updated_count must not be present: %#v", data)
-	}
-	if _, ok := data["failed_ids"]; ok {
-		t.Fatalf("failed_ids must not be present: %#v", data)
-	}
-	if _, ok := data["submitted_thread_ids"]; ok {
-		t.Fatalf("submitted_thread_ids must not be present: %#v", data)
-	}
-	if _, ok := data["submitted_count"]; ok {
-		t.Fatalf("submitted_count must not be present: %#v", data)
+	for _, synthetic := range []string{"updated_count", "success_thread_ids", "failed_thread_ids"} {
+		if _, ok := data[synthetic]; ok {
+			t.Fatalf("synthetic field %q present in %#v", synthetic, data)
+		}
 	}
 }
 
-func TestThreadModify_FolderIDAliasMapsToAddFolder(t *testing.T) {
+func TestThreadModify_OmitsOptionalFields(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
-	id := threadManageID("alias")
 	post := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
-
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", id,
-		"--folder-id", "archive",
+		"+thread-modify", "--thread-id", threadManageID("1"), "--folder-id", "folderA",
 	}, f, stdout)
 	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+		t.Fatalf("execute modify: %v", err)
 	}
-	var body map[string]interface{}
-	if err := json.Unmarshal(post.CapturedBody, &body); err != nil {
-		t.Fatalf("unmarshal captured body: %v", err)
+	body := decodeThreadManageBody(t, post)
+	if body["add_folder"] != "folderA" {
+		t.Fatalf("add_folder = %#v", body["add_folder"])
 	}
-	if got := body["add_folder"]; got != "ARCHIVED" {
-		t.Fatalf("add_folder = %v, want ARCHIVED", got)
+	for _, omitted := range []string{"add_label_ids", "remove_label_ids"} {
+		if _, ok := body[omitted]; ok {
+			t.Fatalf("body must omit %s: %#v", omitted, body)
+		}
 	}
 }
 
-func TestThreadModify_AddFolderAndFolderIDConflict(t *testing.T) {
-	f, stdout, _, _ := mailShortcutTestFactory(t)
-	id := threadManageID("conflict")
+func TestThreadModify_OmitsFolderWhenNotProvided(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	post := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", id,
-		"--add-folder", "archive",
-		"--folder-id", "folderA",
+		"+thread-modify", "--thread-id", threadManageID("1"), "--add-label-id", "UNREAD",
 	}, f, stdout)
-	requireMessageManageValidationParam(t, err, "--folder-id")
-	if !strings.Contains(err.Error(), "pass only one") {
-		t.Fatalf("error = %v, want pass only one conflict message", err)
+	if err != nil {
+		t.Fatalf("execute modify: %v", err)
+	}
+	body := decodeThreadManageBody(t, post)
+	if _, ok := body["add_folder"]; ok {
+		t.Fatalf("body must omit add_folder: %#v", body)
 	}
 }
 
 func TestThreadModify_Validation(t *testing.T) {
 	f, stdout, _, _ := mailShortcutTestFactory(t)
 	id := threadManageID("1")
-	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", id,
-	}, f, stdout)
-	requireMessageManageValidationParam(t, err, "--thread-modify")
-	if !strings.Contains(err.Error(), "provide at least one") {
-		t.Fatalf("error = %v, want missing action validation", err)
-	}
-
-	err = runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", id,
-		"--add-label-ids", "unread",
-		"--remove-label-ids", "UNREAD",
-	}, f, stdout)
-	requireMessageManageValidationParam(t, err, "--add-label-ids")
-
-	for _, tc := range []struct {
-		name string
-		flag string
+	tests := []struct {
+		name  string
+		args  []string
+		param string
 	}{
-		{name: "add", flag: "--add-label-ids"},
-		{name: "remove", flag: "--remove-label-ids"},
-	} {
-		t.Run("rejects read receipt request label on "+tc.name, func(t *testing.T) {
-			err := runMountedMailShortcut(t, MailThreadModify, []string{
-				"+thread-modify",
-				"--thread-ids", id,
-				tc.flag, "read_receipt_request",
-			}, f, stdout)
-			requireMessageManageValidationParam(t, err, tc.flag)
-			if !strings.Contains(err.Error(), "thread 级别不能管理 `READ_RECEIPT_REQUEST`") {
-				t.Fatalf("error = %v, want thread-level receipt label guidance", err)
+		{name: "missing thread", args: []string{"+thread-modify", "--folder-id", "folderA"}, param: "thread-id"},
+		{name: "missing action", args: []string{"+thread-modify", "--thread-id", id}, param: "thread-modify"},
+		{name: "blank thread", args: []string{"+thread-modify", "--thread-id", " ", "--folder-id", "folderA"}, param: "thread-id"},
+		{name: "blank add label", args: []string{"+thread-modify", "--thread-id", id, "--add-label-id", " "}, param: "add-label-id"},
+		{name: "blank folder", args: []string{"+thread-modify", "--thread-id", id, "--folder-id", " "}, param: "folder-id"},
+		{name: "label conflict", args: []string{"+thread-modify", "--thread-id", id, "--add-label-id", "unread", "--remove-label-id", "UNREAD"}, param: "add-label"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := runMountedMailShortcut(t, MailThreadModify, test.args, f, stdout)
+			var validation *errs.ValidationError
+			if !errors.As(err, &validation) {
+				t.Fatalf("error = %T %v, want ValidationError", err, err)
+			}
+			if !strings.Contains(validation.Param, test.param) {
+				t.Fatalf("param = %q, want %q", validation.Param, test.param)
 			}
 		})
 	}
-
-	err = runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", id,
-		"--folder-id", "trash",
-	}, f, stdout)
-	requireMessageManageValidationParam(t, err, "--folder-id")
-	if !strings.Contains(err.Error(), "use +thread-trash") {
-		t.Fatalf("error = %v, want +thread-trash hint", err)
-	}
 }
 
-func TestThreadModify_BatchesAndAggregatesPartialFailure(t *testing.T) {
+func TestThreadModify_DryRunDoesNotCallAPI(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
-	ids := threadManageIDs(41)
-	first := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
-	second := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 1230001, "msg": "bad request"})
-	third := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
-
+	post := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+	post.Optional = true
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", strings.Join(ids, ","),
-		"--add-folder", "archive",
+		"+thread-modify", "--thread-id", threadManageID("1"), "--add-label-id", "customA", "--dry-run",
 	}, f, stdout)
 	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+		t.Fatalf("dry-run: %v", err)
 	}
-	for idx, stub := range []*httpmock.Stub{first, second, third} {
-		var body map[string]interface{}
-		if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
-			t.Fatalf("batch %d body unmarshal: %v", idx+1, err)
-		}
-		threadIDs := body["thread_ids"].([]interface{})
-		want := []int{20, 20, 1}[idx]
-		if len(threadIDs) != want {
-			t.Fatalf("batch %d size = %d, want %d", idx+1, len(threadIDs), want)
-		}
-		if body["add_folder"] != "ARCHIVED" {
-			t.Fatalf("batch %d add_folder = %v, want ARCHIVED", idx+1, body["add_folder"])
-		}
+	if len(post.CapturedBodies) != 0 {
+		t.Fatalf("dry-run made %d API calls", len(post.CapturedBodies))
 	}
-	success, failed := decodeThreadManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
-	if len(success) != 21 || len(failed) != 20 {
-		t.Fatalf("success=%d failed=%d, want 21/20", len(success), len(failed))
+	for _, want := range []string{"POST", "/user_mailboxes/me/threads/batch_modify", "thread_ids", "add_label_ids"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("dry-run missing %q: %s", want, stdout.String())
+		}
 	}
 }
 
-func TestThreadModify_AllBatchesFailReturnsError(t *testing.T) {
+func TestThreadModify_APIFailurePassesThrough(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
-	id := threadManageID("1")
 	stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 1230001, "msg": "bad request"})
-
 	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", id,
-		"--add-folder", "archive",
+		"+thread-modify", "--thread-id", threadManageID("1"), "--folder-id", "folderA",
 	}, f, stdout)
-	requireMessageManageFailedPrecondition(t, err)
-}
-
-func TestThreadModify_DryRunShowsPostURLAndBody(t *testing.T) {
-	f, stdout, _, _ := mailShortcutTestFactory(t)
-	id1 := threadManageID("1")
-	id2 := threadManageID("2")
-	err := runMountedMailShortcut(t, MailThreadModify, []string{
-		"+thread-modify",
-		"--thread-ids", id1 + "," + id2,
-		"--add-label-ids", "customA",
-		"--add-folder", "folderA",
-		"--dry-run",
-	}, f, stdout)
-	if err != nil {
-		t.Fatalf("dry-run failed: %v", err)
-	}
-	out := stdout.String()
-	for _, want := range []string{
-		`/user_mailboxes/me/threads/batch_modify`,
-		`thread_ids`,
-		`add_label_ids`,
-		`add_folder`,
-		`batch_size`,
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("dry-run output missing %q; got %s", want, out)
-		}
-	}
-	if strings.Contains(out, `validation_api_plan`) {
-		t.Fatalf("dry-run output must not include validation_api_plan; got %s", out)
+	if err == nil || output.ExitCodeOf(err) != output.ExitAPI {
+		t.Fatalf("error = %v, want API error", err)
 	}
 }
 
-func TestThreadTrash_RequiresYesAndBatches(t *testing.T) {
+func TestThreadTrash_OneRequestAndRawResponse(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	id1 := threadManageID("1")
 	id2 := threadManageID("2")
+	post := stubThreadManagePost(reg, "batch_trash", map[string]interface{}{
+		"code": 0,
+		"data": map[string]interface{}{"job_id": "job_1"},
+	})
 	err := runMountedMailShortcut(t, MailThreadTrash, []string{
-		"+thread-trash",
-		"--thread-ids", id1 + "," + id2,
+		"+thread-trash", "--thread-id", id1, "--thread-id", id2, "--thread-id", id1, "--yes",
 	}, f, stdout)
-	if err == nil {
-		t.Fatal("expected confirmation error, got nil")
+	if err != nil {
+		t.Fatalf("execute trash: %v", err)
 	}
-	if code := output.ExitCodeOf(err); code != output.ExitConfirmationRequired {
-		t.Fatalf("exit code = %d, want %d", code, output.ExitConfirmationRequired)
+	if len(post.CapturedBodies) != 1 {
+		t.Fatalf("POST count = %d, want 1", len(post.CapturedBodies))
 	}
+	body := decodeThreadManageBody(t, post)
+	if len(body) != 1 {
+		t.Fatalf("trash body includes modify-only fields: %#v", body)
+	}
+	if got := body["thread_ids"].([]interface{}); len(got) != 2 || got[0] != id1 || got[1] != id2 {
+		t.Fatalf("thread_ids = %#v", got)
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["job_id"] != "job_1" {
+		t.Fatalf("data = %#v, want raw downstream data", data)
+	}
+}
 
+func TestThreadTrash_ConfirmationDryRunAndEmptyResponse(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	id := threadManageID("1")
 	post := stubThreadManagePost(reg, "batch_trash", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
-	err = runMountedMailShortcut(t, MailThreadTrash, []string{
-		"+thread-trash",
-		"--thread-ids", id1 + "," + id2,
-		"--yes",
-	}, f, stdout)
+	post.Optional = true
+
+	err := runMountedMailShortcut(t, MailThreadTrash, []string{"+thread-trash", "--thread-id", id}, f, stdout)
+	if err == nil || output.ExitCodeOf(err) != output.ExitConfirmationRequired {
+		t.Fatalf("error = %v, want confirmation required", err)
+	}
+	err = runMountedMailShortcut(t, MailThreadTrash, []string{"+thread-trash", "--thread-id", id, "--dry-run"}, f, stdout)
 	if err != nil {
-		t.Fatalf("unexpected err with --yes: %v", err)
+		t.Fatalf("dry-run: %v", err)
 	}
-	var body map[string]interface{}
-	if err := json.Unmarshal(post.CapturedBody, &body); err != nil {
-		t.Fatalf("unmarshal captured body: %v", err)
+	if len(post.CapturedBodies) != 0 {
+		t.Fatalf("dry-run made %d API calls", len(post.CapturedBodies))
 	}
-	if got := len(body["thread_ids"].([]interface{})); got != 2 {
-		t.Fatalf("thread_ids len = %d, want 2", got)
+	post.Optional = false
+	err = runMountedMailShortcut(t, MailThreadTrash, []string{"+thread-trash", "--thread-id", id, "--yes"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute trash: %v", err)
 	}
-	success, failed := decodeThreadManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
-	if len(success) != 2 || len(failed) != 0 {
-		t.Fatalf("summary success=%v failed=%v", success, failed)
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if len(data) != 0 {
+		t.Fatalf("empty downstream data gained synthetic fields: %#v", data)
 	}
 }
 
-func TestThreadTrash_AllBatchesFailReturnsError(t *testing.T) {
+func TestThreadManage_LegacyAliasesRemainAccepted(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
-	id := threadManageID("1")
-	stubThreadManagePost(reg, "batch_trash", map[string]interface{}{"code": 1230001, "msg": "bad request"})
-
-	err := runMountedMailShortcut(t, MailThreadTrash, []string{
-		"+thread-trash",
-		"--thread-ids", id,
-		"--yes",
-	}, f, stdout)
-	requireMessageManageFailedPrecondition(t, err)
-}
-
-func TestThreadTrash_BatchesAndAggregatesPartialFailure(t *testing.T) {
-	f, stdout, _, reg := mailShortcutTestFactory(t)
-	ids := threadManageIDs(41)
-	first := stubThreadManagePost(reg, "batch_trash", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
-	second := stubThreadManagePost(reg, "batch_trash", map[string]interface{}{"code": 1230001, "msg": "bad request"})
-	third := stubThreadManagePost(reg, "batch_trash", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
-
-	err := runMountedMailShortcut(t, MailThreadTrash, []string{
-		"+thread-trash",
-		"--thread-ids", strings.Join(ids, ","),
-		"--yes",
+	post := stubThreadManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+	err := runMountedMailShortcut(t, MailThreadModify, []string{
+		"+thread-modify", "--mailbox", "me", "--thread-ids", threadManageID("1"),
+		"--add-label-ids", "unread", "--remove-label-ids", "FLAGGED", "--add-folder", "archive",
 	}, f, stdout)
 	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+		t.Fatalf("legacy aliases: %v", err)
 	}
-	for idx, stub := range []*httpmock.Stub{first, second, third} {
-		var body map[string]interface{}
-		if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
-			t.Fatalf("batch %d body unmarshal: %v", idx+1, err)
-		}
-		threadIDs := body["thread_ids"].([]interface{})
-		want := []int{20, 20, 1}[idx]
-		if len(threadIDs) != want {
-			t.Fatalf("batch %d size = %d, want %d", idx+1, len(threadIDs), want)
-		}
-	}
-	success, failed := decodeThreadManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
-	if len(success) != 21 || len(failed) != 20 {
-		t.Fatalf("success=%d failed=%d, want 21/20", len(success), len(failed))
-	}
-}
-
-func TestThreadTrash_DryRunShowsPostURLAndBody(t *testing.T) {
-	f, stdout, _, _ := mailShortcutTestFactory(t)
-	id := threadManageID("1")
-	err := runMountedMailShortcut(t, MailThreadTrash, []string{
-		"+thread-trash",
-		"--thread-ids", id,
-		"--dry-run",
-	}, f, stdout)
-	if err != nil {
-		t.Fatalf("dry-run failed: %v", err)
-	}
-	out := stdout.String()
-	for _, want := range []string{
-		`/user_mailboxes/me/threads/batch_trash`,
-		`thread_ids`,
-		`batch_size`,
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("dry-run output missing %q; got %s", want, out)
-		}
+	body := decodeThreadManageBody(t, post)
+	if body["add_folder"] != "ARCHIVED" {
+		t.Fatalf("add_folder = %#v, want ARCHIVED", body["add_folder"])
 	}
 }

--- a/skills/lark-mail/references/lark-mail-thread-modify.md
+++ b/skills/lark-mail/references/lark-mail-thread-modify.md
@@ -36,7 +36,7 @@ lark-cli mail +thread-modify --thread-id <thread_id> --add-label-id custom_label
 | `--remove-label-id <id>` | 否 | 要移除的标签 ID；可重复传参，不能与 `--add-label-id` 重复 |
 | `--folder-id <id>` | 否 | 要移动到的文件夹。首尾空白会被移除，并且只映射到请求字段 `add_folder` |
 
-`--add-label-id`、`--remove-label-id`、`--folder-id` 至少传一个。旧拼写 `--thread-ids`、`--add-label-ids`、`--remove-label-ids`、`--add-folder` 和 `--mailbox` 仍作为兼容别名接受。
+`--add-label-id`、`--remove-label-id`、`--folder-id` 至少传一个。`--thread-id`、`--add-label-id`、`--remove-label-id` 只公开单数可重复形式；复数拼写不受支持。`--add-folder` 和 `--mailbox` 仍作为兼容别名接受。
 
 `TRASH` 不允许通过本 shortcut 作为目标文件夹传入。需要软删除会话时，使用 [`mail +thread-trash`](./lark-mail-thread-trash.md)，并在用户确认后加 `--yes` 执行。
 

--- a/skills/lark-mail/references/lark-mail-thread-modify.md
+++ b/skills/lark-mail/references/lark-mail-thread-modify.md
@@ -54,7 +54,7 @@ lark-cli mail +thread-modify --thread-id <thread_id> --add-label-id custom_label
 
 ## 原生 API 适用场景
 
-只有在需要精确复现后端/API 行为做诊断，或需要 shortcut 未暴露的请求结构时，才直接调用 `mail user_mailbox.threads batch_modify`。普通会话整理优先使用本 shortcut，因为它内置了 ID 校验、分批、批量输出和 dry-run 预览。
+只有在需要精确复现后端/API 行为做诊断，或需要 shortcut 未暴露的请求结构时，才直接调用 `mail user_mailbox.threads batch_modify`。普通会话整理优先使用本 shortcut，因为它内置了 ID 校验、稳定去重、字段安全映射和 dry-run 预览。
 
 ## 相关命令
 

--- a/skills/lark-mail/references/lark-mail-thread-modify.md
+++ b/skills/lark-mail/references/lark-mail-thread-modify.md
@@ -8,35 +8,35 @@
 
 ```bash
 # 给多个会话添加未读标签
-lark-cli mail +thread-modify --thread-ids <thread_id1>,<thread_id2> --add-label-ids unread
+lark-cli mail +thread-modify --thread-id <thread_id1> --thread-id <thread_id2> --add-label-id unread
 
 # 移除星标标签
-lark-cli mail +thread-modify --thread-ids <thread_id> --remove-label-ids FLAGGED
+lark-cli mail +thread-modify --thread-id <thread_id> --remove-label-id FLAGGED
 
 # 归档会话
-lark-cli mail +thread-modify --thread-ids <thread_id> --add-folder archive
+lark-cli mail +thread-modify --thread-id <thread_id> --folder-id archive
 
 # 指定公共邮箱或共享邮箱
-lark-cli mail +thread-modify --mailbox shared@example.com --thread-ids <thread_id> --add-folder folder_xxx
+lark-cli mail +thread-modify --mailbox-id shared@example.com --thread-id <thread_id> --folder-id folder_xxx
 
 # 使用 bot 身份时必须显式指定邮箱
-lark-cli mail +thread-modify --as bot --mailbox user@example.com --thread-ids <thread_id> --add-folder archive
+lark-cli mail +thread-modify --as bot --mailbox-id user@example.com --thread-id <thread_id> --folder-id archive
 
 # Dry Run：只预览请求，不执行
-lark-cli mail +thread-modify --thread-ids <thread_id> --add-label-ids custom_label_id --dry-run
+lark-cli mail +thread-modify --thread-id <thread_id> --add-label-id custom_label_id --dry-run
 ```
 
 ## 参数
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--mailbox <email>` | 否 | 会话所属邮箱，默认 `me`；使用 `--as bot` 时必须显式传邮箱地址 |
-| `--thread-ids <ids>` | 是 | 会话 ID 列表，支持逗号分隔和重复传参；超过 20 个时自动分批提交 |
-| `--add-label-ids <ids>` | 否 | 要添加的标签 ID。系统标签可传 `unread` / `important` / `other` / `flagged`；自定义标签传标签 ID |
-| `--remove-label-ids <ids>` | 否 | 要移除的标签 ID。不能与 `--add-label-ids` 传入重复标签 |
-| `--add-folder <id>` | 否 | 要移动到的文件夹。系统文件夹可传 `inbox` / `sent` / `spam` / `archive` / `archived`；自定义文件夹传文件夹 ID |
+| `--mailbox-id <email>` | 否 | 会话所属邮箱，默认 `me`；使用 `--as bot` 时必须显式传邮箱地址 |
+| `--thread-id <id>` | 是 | 会话 ID；可重复传参，CLI 按首次出现顺序去重 |
+| `--add-label-id <id>` | 否 | 要添加的标签 ID；可重复传参。系统标签可传 `unread` / `important` / `other` / `flagged` |
+| `--remove-label-id <id>` | 否 | 要移除的标签 ID；可重复传参，不能与 `--add-label-id` 重复 |
+| `--folder-id <id>` | 否 | 要移动到的文件夹。首尾空白会被移除，并且只映射到请求字段 `add_folder` |
 
-`--add-label-ids`、`--remove-label-ids`、`--add-folder` 至少传一个。
+`--add-label-id`、`--remove-label-id`、`--folder-id` 至少传一个。旧拼写 `--thread-ids`、`--add-label-ids`、`--remove-label-ids`、`--add-folder` 和 `--mailbox` 仍作为兼容别名接受。
 
 `TRASH` 不允许通过本 shortcut 作为目标文件夹传入。需要软删除会话时，使用 [`mail +thread-trash`](./lark-mail-thread-trash.md)，并在用户确认后加 `--yes` 执行。
 
@@ -45,21 +45,12 @@ lark-cli mail +thread-modify --thread-ids <thread_id> --add-label-ids custom_lab
 ## 注意事项
 
 - `thread_id` 必须来自 `+triage`、`+message`、`+thread`、会话列表或搜索等真实查询结果；不要用数字主键或占位符。
-- 命令在本地解析逗号分隔和重复 flag，按首次出现顺序去重，并按 20 个一批提交。
-- 单个 batch 请求失败时，该批次的所有 `thread_id` 都记录为同一个失败原因；后续批次继续执行。
+- 命令在本地按首次出现顺序去重，然后一次调用 `POST /open-apis/mail/v1/user_mailboxes/<mailbox>/threads/batch_modify`。
+- `--folder-id` 未传时省略 `add_folder`；标签集合为空时也省略对应字段。dry-run 只显示规范化后的请求，不访问 API。
 
 ## 返回值
 
-返回示例：
-
-```json
-{
-  "success_thread_ids": ["thread_id1"],
-  "failed_thread_ids": [
-    {"thread_id": "thread_id2", "reason": "api error"}
-  ]
-}
-```
+成功时原样输出 OpenAPI 返回的 `data`。CLI 不根据提交的 ID 数量生成 `updated_count`、逐项成功结果或其他推断字段；空 `data` 保持为空对象。API 报错由统一错误链原样返回，修正 mailbox、ID 或权限后再重试。
 
 ## 原生 API 适用场景
 

--- a/skills/lark-mail/references/lark-mail-thread-trash.md
+++ b/skills/lark-mail/references/lark-mail-thread-trash.md
@@ -10,45 +10,37 @@
 
 ```bash
 # 软删除多个会话
-lark-cli mail +thread-trash --thread-ids <thread_id1>,<thread_id2> --yes
+lark-cli mail +thread-trash --thread-id <thread_id1> --thread-id <thread_id2> --yes
 
 # 指定公共邮箱或共享邮箱
-lark-cli mail +thread-trash --mailbox shared@example.com --thread-ids <thread_id> --yes
+lark-cli mail +thread-trash --mailbox-id shared@example.com --thread-id <thread_id> --yes
 
 # 使用 bot 身份时必须显式指定邮箱
-lark-cli mail +thread-trash --as bot --mailbox user@example.com --thread-ids <thread_id> --yes
+lark-cli mail +thread-trash --as bot --mailbox-id user@example.com --thread-id <thread_id> --yes
 
 # Dry Run：只预览请求，不执行
-lark-cli mail +thread-trash --thread-ids <thread_id1> --thread-ids <thread_id2> --dry-run
+lark-cli mail +thread-trash --thread-id <thread_id1> --thread-id <thread_id2> --dry-run
 ```
 
 ## 参数
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--mailbox <email>` | 否 | 会话所属邮箱，默认 `me`；使用 `--as bot` 时必须显式传邮箱地址 |
-| `--thread-ids <ids>` | 是 | 会话 ID 列表，支持逗号分隔和重复传参；超过 20 个时自动分批提交 |
+| `--mailbox-id <email>` | 否 | 会话所属邮箱，默认 `me`；使用 `--as bot` 时必须显式传邮箱地址 |
+| `--thread-id <id>` | 是 | 会话 ID；可重复传参，CLI 按首次出现顺序去重 |
 | `--yes` | 执行时必填 | 高风险写操作确认。只有用户确认删除预览后才加 |
 
 ## 注意事项
 
 - `thread_id` 必须来自 `+triage`、`+message`、`+thread`、会话列表或搜索等真实查询结果；不要用数字主键或占位符。
 - 软删除属于高风险写操作。先用真实查询结果展示删除预览，包括受影响会话数量和关键邮件摘要；用户确认后再执行并加 `--yes`。
-- 命令在本地解析逗号分隔和重复 flag，按首次出现顺序去重，并按 20 个一批提交。
-- 单个 batch 请求失败时，该批次的所有 `thread_id` 都记录为同一个失败原因；后续批次继续执行。
+- 旧拼写 `--thread-ids` 和 `--mailbox` 仍作为兼容别名接受。
+- 命令在本地按首次出现顺序去重，然后一次调用 `POST /open-apis/mail/v1/user_mailboxes/<mailbox>/threads/batch_trash`；请求体只含 `thread_ids`。
+- dry-run 只显示规范化后的 endpoint 和请求体，绝不会访问 API。
 
 ## 返回值
 
-返回示例：
-
-```json
-{
-  "success_thread_ids": ["thread_id1"],
-  "failed_thread_ids": [
-    {"thread_id": "thread_id2", "reason": "api error"}
-  ]
-}
-```
+成功时原样输出 OpenAPI 返回的 `data`。CLI 不根据提交数量生成 `trashed_count`、逐项成功结果或其他推断字段；空 `data` 保持为空对象。API 报错由统一错误链原样返回。软删除后如需恢复，使用已发布的邮件会话修改/移动能力将对象移出 `TRASH`；不要通过重复 trash 调用猜测状态。
 
 ## 原生 API 适用场景
 

--- a/skills/lark-mail/references/lark-mail-thread-trash.md
+++ b/skills/lark-mail/references/lark-mail-thread-trash.md
@@ -34,7 +34,7 @@ lark-cli mail +thread-trash --thread-id <thread_id1> --thread-id <thread_id2> --
 
 - `thread_id` 必须来自 `+triage`、`+message`、`+thread`、会话列表或搜索等真实查询结果；不要用数字主键或占位符。
 - 软删除属于高风险写操作。先用真实查询结果展示删除预览，包括受影响会话数量和关键邮件摘要；用户确认后再执行并加 `--yes`。
-- 旧拼写 `--thread-ids` 和 `--mailbox` 仍作为兼容别名接受。
+- `--thread-id` 只公开单数可重复形式；复数拼写 `--thread-ids` 不受支持。`--mailbox` 仍作为兼容别名接受。
 - 命令在本地按首次出现顺序去重，然后一次调用 `POST /open-apis/mail/v1/user_mailboxes/<mailbox>/threads/batch_trash`；请求体只含 `thread_ids`。
 - dry-run 只显示规范化后的 endpoint 和请求体，绝不会访问 API。
 

--- a/skills/lark-mail/references/lark-mail-thread-trash.md
+++ b/skills/lark-mail/references/lark-mail-thread-trash.md
@@ -44,7 +44,7 @@ lark-cli mail +thread-trash --thread-id <thread_id1> --thread-id <thread_id2> --
 
 ## 原生 API 适用场景
 
-只有在需要精确复现后端/API 行为做诊断时，才直接调用 `mail user_mailbox.threads batch_trash`。普通会话软删除优先使用本 shortcut，因为它内置了 ID 校验、分批、批量输出、dry-run 预览和 `--yes` 确认。
+只有在需要精确复现后端/API 行为做诊断时，才直接调用 `mail user_mailbox.threads batch_trash`。普通会话软删除优先使用本 shortcut，因为它内置了 ID 校验、稳定去重、dry-run 预览和 `--yes` 确认。
 
 ## 相关命令
 


### PR DESCRIPTION
Adds dedicated mail thread shortcuts for batch label/folder updates and trash operations.

- validates and normalizes thread, label, folder, and mailbox inputs
- maps folder changes to the published thread API contract
- preserves dry-run, error, and response behavior
- documents both shortcuts and adds focused tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updated Features**
  * Thread modification and deletion commands now accept repeatable singular thread and label ID flags, along with folder and mailbox ID flags.
  * Commands submit one request for all selected threads and return the service response directly.
  * Dry-run output shows the normalized endpoint and request body.
  * Mailbox selection and bot-mailbox validation honor mailbox IDs consistently.

* **Documentation**
  * Updated command references and response descriptions to reflect revised flags and behavior.
  * Clarified that plural thread and label flags are unsupported; selected legacy aliases remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->