### PR TITLE
fix: list workspace entity page_size 上限调整为 30

### DIFF
--- a/shortcuts/base/app_ops.go
+++ b/shortcuts/base/app_ops.go
@@ -521,7 +521,7 @@ func validateListBaseWorkspace(runtime *common.RuntimeContext) error {
 	}
 	pageToken := ""
 	for {
-		params := map[string]interface{}{"page_size": 100, "entity_type": "base"}
+		params := map[string]interface{}{"page_size": 30, "entity_type": "base"}
 		if pageToken != "" {
 			params["page_token"] = pageToken
 		}

--- a/shortcuts/base/app_test.go
+++ b/shortcuts/base/app_test.go
@@ -17,8 +17,8 @@ func TestDryRunWorkspaceOps(t *testing.T) {
 	createRT := newBaseTestRuntime(map[string]string{"name": "Growth"}, nil, nil)
 	assertDryRunContains(t, dryRunWorkspaceCreate(ctx, createRT), "POST /open-apis/base/v3/workspaces", `"name":"Growth"`)
 
-	listRT := newBaseTestRuntime(map[string]string{"workspace-token": "ws_x", "type": "BaseApp"}, nil, map[string]int{"page-size": 50})
-	assertDryRunContains(t, dryRunWorkspaceEntityList(ctx, listRT), "GET /open-apis/base/v3/workspaces/ws_x/entities", "page_size=50", "entity_type=baseapp")
+	listRT := newBaseTestRuntime(map[string]string{"workspace-token": "ws_x", "type": "BaseApp"}, nil, map[string]int{"page-size": 30})
+	assertDryRunContains(t, dryRunWorkspaceEntityList(ctx, listRT), "GET /open-apis/base/v3/workspaces/ws_x/entities", "page_size=30", "entity_type=baseapp")
 
 	moveInRT := newBaseTestRuntime(map[string]string{"workspace-token": "ws_x", "entity-token": "bascn_1"}, nil, nil)
 	assertDryRunContains(t, dryRunWorkspaceMoveIn(ctx, moveInRT), "POST /open-apis/base/v3/workspaces/ws_x/move_in", `"entity_token":"bascn_1"`)

--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -374,7 +374,7 @@ func TestBaseAppBlockUpdateRejectsListBaseOutsideWorkspace(t *testing.T) {
 	})
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/base/v3/workspaces/ws_x/entities?entity_type=base&page_size=100",
+		URL:    "/open-apis/base/v3/workspaces/ws_x/entities?entity_type=base&page_size=30",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{"items": []interface{}{}, "has_more": false},
@@ -433,7 +433,7 @@ func TestBaseAppBlockCreateUsesWorkspaceIDAsWorkspaceToken(t *testing.T) {
 	})
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/base/v3/workspaces/ws_x/entities?entity_type=base&page_size=100",
+		URL:    "/open-apis/base/v3/workspaces/ws_x/entities?entity_type=base&page_size=30",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{

--- a/shortcuts/base/workspace_entity_list.go
+++ b/shortcuts/base/workspace_entity_list.go
@@ -19,14 +19,14 @@ var BaseWorkspaceEntityList = common.Shortcut{
 	Flags: []common.Flag{
 		workspaceTokenFlag(true),
 		{Name: "type", Desc: "filter by entity type: base|baseapp; omit to list both", Enum: entityTypeValues},
-		{Name: "page-size", Type: "int", Default: "100", Desc: "page size, range 1-100"},
+		{Name: "page-size", Type: "int", Default: "30", Desc: "page size, range 1-30"},
 		{Name: "page-token", Desc: "pagination token"},
 	},
 	Tips: []string{
 		"lark-cli base +workspace-entity-list --workspace-token <workspace_token> --type baseapp",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 100); err != nil {
+		if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 30, 1, 30); err != nil {
 			return err
 		}
 		_, err := normalizeEntityType(runtime.Str("type"))

--- a/skills/lark-base/references/lark-base-app.md
+++ b/skills/lark-base/references/lark-base-app.md
@@ -23,7 +23,7 @@
 当前 CLI 只支持用 `+workspace-move-in` 把 Base 或 BaseApp 移入 Workspace，不支持从 Workspace 移出或移除资源，也没有 `workspace move-out` / `workspace remove` 命令。这类请求必须先完成只读定位，再说明限制并停止，顺序不可调换：
 
 1. Workspace URL 含 `/base/workspace/<workspace_token>` 时，提取其中的真实 `workspace_token`，不要把完整 URL 当作命令参数。
-2. 在同一轮立即执行 `lark-cli base +workspace-entity-list --workspace-token <workspace_token> --page-size 100 --as user`；若 `has_more=true`，继续分页直到完整。该查询是必要的只读定位步骤，不要把它留成等待用户再次选择的可选项，也不要用 `--help` 代替真实查询。
+2. 在同一轮立即执行 `lark-cli base +workspace-entity-list --workspace-token <workspace_token> --page-size 30 --as user`；若 `has_more=true`，继续分页直到完整。该查询是必要的只读定位步骤，不要把它留成等待用户再次选择的可选项，也不要用 `--help` 代替真实查询。
 3. 用服务端返回的 `entities[].name`、`entity_type`、`token` 和 `url` 忠实判断目标。名称完全匹配时报告真实对象；没有完全匹配时明确说明不存在精确同名实体，并原样列出可能相关的候选。不得自动去掉或补齐前后缀，也不得仅凭名称相似就声称已经定位目标。用户直接给出 token 时仍要忠实报告该 token 对应的实际名称。
 4. 定位结果报告完后，明确说明当前 CLI 无法执行 Workspace 移出/移除，并停止，不要发起任何写请求。用户在任一步骤中取消时立即停止，取消后不再调用工具。
 
@@ -55,7 +55,7 @@ lark-cli base +app-get --app-token <app_token>
   lark-cli base +workspace-entity-list \
     --workspace-token <workspace_token> \
     --type baseapp \
-    --page-size 100
+    --page-size 30
   ```
 
 - 响应中的 `pages` 是页面摘要。

--- a/tests/cli_e2e/base/base_app_workflow_test.go
+++ b/tests/cli_e2e/base/base_app_workflow_test.go
@@ -49,7 +49,7 @@ func TestBaseAppWorkflow(t *testing.T) {
 		}
 	})
 
-	workspaceList, err := runBaseAppLive(ctx, "base", "+workspace-entity-list", "--workspace-token", workspaceToken, "--page-size", "100")
+	workspaceList, err := runBaseAppLive(ctx, "base", "+workspace-entity-list", "--workspace-token", workspaceToken, "--page-size", "30")
 	require.NoError(t, err)
 	workspaceList.AssertExitCode(t, 0)
 	workspaceList.AssertStdoutStatus(t, true)


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated the workspace entity list command to use a default page size of 30 items.
  * Limited the supported page size to a maximum of 30 items.
  * Updated workspace entity lookups and examples to reflect the new page-size limit.
  * Pagination through all available results remains supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->