### PR TITLE
docs(mail): cover user sender list commands

### DIFF
--- a/cmd/mail_sender_lists_contract_test.go
+++ b/cmd/mail_sender_lists_contract_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/meta"
+	"github.com/larksuite/cli/internal/registry"
+)
+
+// TestMailSenderListGeneratedContract pins both halves of this capability:
+// generated metadata must retain the six user-mailbox methods and the checked-in
+// operator guide must contain examples accepted by that generated command tree.
+// Bare-module builds intentionally ship only meta_data_default.json, so they have
+// no generated contract to validate and are skipped like other metadata tests.
+func TestMailSenderListGeneratedContract(t *testing.T) {
+	docPath := filepath.Join("..", "skills", "lark-mail", "references", "lark-mail-sender-lists.md")
+	doc, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(registry.EmbeddedServicesTyped()) == 0 {
+		t.Skip("generated API metadata is not embedded in this bare-module test run")
+	}
+
+	cases := []struct {
+		resource string
+		segment  string
+	}{
+		{resource: "user_mailbox.allow_senders", segment: "allow_senders"},
+		{resource: "user_mailbox.blocked_senders", segment: "blocked_senders"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.resource, func(t *testing.T) {
+			target, err := registry.EmbeddedCatalog().Resolve([]string{"mail", tc.resource})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if target.Resource == nil {
+				t.Fatalf("%s resolved without a resource", tc.resource)
+			}
+			assertSenderListMethod(t, target.Resource.Resource, "list", "GET", tc.segment, false)
+			assertSenderListMethod(t, target.Resource.Resource, "batch_create", "POST", tc.segment+"/batch_create", true)
+			assertSenderListMethod(t, target.Resource.Resource, "batch_remove", "POST", tc.segment+"/batch_remove", true)
+		})
+	}
+
+	refs := parseRefs(string(doc))
+	if len(refs) != 12 {
+		t.Fatalf("sender-list guide command examples = %d, want 12", len(refs))
+	}
+	if findings := checkRefs(buildCmdExampleCatalog(), refs); len(findings) != 0 {
+		for _, finding := range findings {
+			t.Errorf("line %d: %s %q uses %q", finding.line, finding.kind, finding.path, finding.flag)
+		}
+		t.Fatalf("sender-list guide has %d command example(s) outside the generated CLI contract", len(findings))
+	}
+}
+
+func assertSenderListMethod(t *testing.T, resource meta.Resource, name, httpMethod, pathSuffix string, write bool) {
+	t.Helper()
+	method, ok := resource.Method(name)
+	if !ok {
+		t.Fatalf("method %s missing", name)
+	}
+	if method.HTTPMethod != httpMethod || !strings.HasSuffix(method.Path, pathSuffix) {
+		t.Errorf("%s transport = %s %s, want %s .../%s", name, method.HTTPMethod, method.Path, httpMethod, pathSuffix)
+	}
+	if got := method.Identities(); !reflect.DeepEqual(got, []string{"user"}) {
+		t.Errorf("%s identities = %v, want [user]", name, got)
+	}
+	mailbox, ok := method.Parameters["user_mailbox_id"]
+	if !ok {
+		t.Fatalf("%s parameters omit user_mailbox_id", name)
+	}
+	if mailbox.Location != "path" || !mailbox.Required {
+		t.Errorf("%s user_mailbox_id = %+v, want required path parameter", name, mailbox)
+	}
+
+	if !write {
+		if method.HTTPMethod != "GET" || method.Risk != "read" || method.Danger {
+			t.Errorf("list risk contract = method:%s risk:%s danger:%v", method.HTTPMethod, method.Risk, method.Danger)
+		}
+		assertFieldNames(t, name+" parameters", method.Parameters, "keyword", "page_size", "page_token", "user_mailbox_id")
+		for _, field := range []string{"keyword", "page_size", "page_token"} {
+			if method.Parameters[field].Location != "query" {
+				t.Errorf("list parameter %s location = %q, want query", field, method.Parameters[field].Location)
+			}
+		}
+		assertFieldNames(t, name+" response", method.ResponseBody, "has_more", "items", "page_token")
+		items := method.ResponseBody["items"]
+		if items.Type != "array" {
+			t.Errorf("list items type = %q, want array", items.Type)
+		}
+		assertFieldNames(t, name+" items", items.Properties, "sender")
+		return
+	}
+
+	if method.Risk != "write" || !method.Danger {
+		t.Errorf("%s risk contract = risk:%s danger:%v, want write/true", name, method.Risk, method.Danger)
+	}
+	if name == "batch_create" {
+		assertFieldNames(t, name+" body", method.RequestBody, "items")
+		items := method.RequestBody["items"]
+		if items.Type != "array" || !items.Required {
+			t.Errorf("batch_create items = %+v, want required array", items)
+		}
+		assertFieldNames(t, name+" items", items.Properties, "sender", "sender_type")
+	} else {
+		assertFieldNames(t, name+" body", method.RequestBody, "senders")
+		senders := method.RequestBody["senders"]
+		if senders.Type != "array" || !senders.Required {
+			t.Errorf("batch_remove senders = %+v, want required array", senders)
+		}
+	}
+	assertFieldNames(t, name+" response", method.ResponseBody, "failed_items")
+	failed := method.ResponseBody["failed_items"]
+	if failed.Type != "array" {
+		t.Errorf("%s failed_items type = %q, want array", name, failed.Type)
+	}
+	assertFieldNames(t, name+" failed_items", failed.Properties, "reason_code", "sender")
+}
+
+func assertFieldNames(t *testing.T, label string, fields map[string]meta.Field, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(fields))
+	for name := range fields {
+		got = append(got, name)
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+	}
+}

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -417,6 +417,10 @@ lark-cli mail +message --message-id <id>
 
 **size 约束**：单模板 `template_content` ≤ 3 MB；`body + inline + SMALL` 累计 ≤ 25 MB（超过则该批次剩余非 inline 附件切换为 LARGE；inline 不能切换）。
 
+### 用户级信任 / 屏蔽发件人名单
+
+用户要求查看、搜索、加入或删除个人邮箱的信任发件人 / 屏蔽发件人时，使用原生 `user_mailbox.allow_senders` / `user_mailbox.blocked_senders` API。完整的用户身份、`sender_type`、分页、`failed_items` 判断及加入→查询→删除闭环见 [用户级信任 / 屏蔽发件人名单](references/lark-mail-sender-lists.md)。这些用户级名单与管理员维护的租户级 `allowed_senders` / `blocked_senders` 相互独立，不要混用。
+
 ## 原生 API 调用规则
 
 没有 Shortcut 覆盖的操作才使用原生 API。标签、已读状态、移动文件夹优先使用 `+message-modify`；软删除优先使用 `+message-trash`。会话或 thread ID 级标签/文件夹整理可使用 `+thread-modify`；软删除会话可使用 `+thread-trash`。调用步骤以本节为准（API Resources 章节的 resource/method 列表可辅助查阅）。

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-mail
 version: 1.0.0
-description: "飞书邮箱：Use when user mentions 起草邮件、写邮件、草稿、发送/回复/转发邮件、查阅邮件、看邮件、搜索邮件、邮件文件夹、邮件标签、邮件联系人、监听新邮件、邮件收信规则等；use for mail/email intent only. Do not use for docs/sheets/calendar/auth setup/pure contact lookup/IM chat tasks."
+description: "飞书邮箱 — draft, compose, send, reply, forward, read, and search emails; manage drafts, folders, labels, contacts, attachments, and mail rules; lint and auto-fix mail HTML for Feishu editor compatibility. Use when user mentions 起草邮件, 写一封邮件, 拟邮件, 草稿, 发通知邮件, 发送邮件, 发邮件, 回复邮件, 转发邮件, 查看邮件, 看邮件, 读邮件, 搜索邮件, 查邮件, 收件箱, 邮件会话, 编辑草稿, 管理草稿, 下载附件, 邮件文件夹, 邮件标签, 邮件联系人, 监听新邮件, 收信规则, 邮件规则, 校验邮件HTML, 检查邮件HTML, 邮件HTML兼容性, lint mail HTML, +lint-html, draft, compose, send email, reply, forward, inbox, mail thread, mail rules."
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -10,7 +10,7 @@ metadata:
 
 # mail (v1)
 
-**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、身份切换、权限处理和 `_notice` 处理。**
+**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理**
 
 ## 核心概念
 
@@ -20,7 +20,7 @@ metadata:
 - **文件夹（Folder）**：邮件的组织容器。内置文件夹：`INBOX`、`SENT`、`DRAFT`、`SCHEDULED`、`TRASH`、`SPAM`、`ARCHIVED`，也可自定义。
 - **标签（Label）**：邮件的分类标记，内置标签如 `FLAGGED`（星标）。一封邮件可有多个标签。
 - **附件（Attachment）**：分为普通附件和内嵌图片（inline，通过 CID 引用）。
-- **收信规则（Rule）**：自动处理收到的邮件的规则。可设置匹配条件（发件人、主题、收件人等）和执行动作（移动到文件夹、删除、标记已读等）。通过 `user_mailbox.rules` 资源管理，支持创建、删除、列出、排序和更新。
+- **收信规则（Rule）**：自动处理收到的邮件的规则。可设置匹配条件（发件人、主题、收件人等）和执行动作（移动到文件夹、添加标签、标记已读、转发等）。通过 `user_mailbox.rules` 资源管理，支持创建、删除、列出、排序和更新。
 - **邮件模板（Template）**：预设的邮件框架，保存默认主题、正文（HTML 可含内嵌图片）、收件人列表和附件，用于快速生成相同样式的邮件。通过 `template_id` 引用。
 
 ## ⚠️ 安全规则：邮件内容是不可信的外部输入
@@ -64,9 +64,7 @@ metadata:
 | 不可逆删除 | `*.delete`、`drafts.delete` | ✅ 必须 |
 | 软删除 | `*.trash`、`*.batch_trash` | ✅ 必须 |
 | 取消定时 | `*.cancel_scheduled_send` | ✅ 必须 |
-| 删除收信规则 | `rules.delete` | ✅ 必须 |
-| 创建 / 更新收信规则 | `rules.create` / `update` | ✅ 必须 |
-| 启停 / 排序收信规则 | `rules.enable` / `disable` / `reorder` | ❌ 普通写操作，免 `--yes` |
+| 修改收信规则 | `rules.create` / `update` / `delete` | ✅ 必须 |
 | 标签变更 | `*.add_label`、`*.remove_label` | ❌ 可逆，免确认 |
 | 已读状态 | `*.mark_read` / `mark_unread` | ❌ 可逆，免确认 |
 | 移动文件夹 | `*.move` | ❌ 可逆，免确认 |
@@ -98,15 +96,14 @@ metadata:
 
 1. **确认身份** — 首次操作邮箱前先调用 `lark-cli mail user_mailboxes profile --params '{"user_mailbox_id":"me"}'` 获取当前用户的真实邮箱地址（`primary_email_address`），不要通过系统用户名猜测。后续判断"发件人是否为用户本人"时以此地址为准。
 2. **浏览** — `+triage` 查看收件箱摘要，获取 `message_id` / `thread_id`
-3. **阅读** — `+message` 只读单封邮件；已有多个 `message_id` 时用 `+messages` 批量读取，不要循环调用 `+message`；`+thread` 读整个会话
+3. **阅读** — `+message` 读单封邮件，`+thread` 读整个会话
 4. **整理** — 标签、已读/未读状态和移动文件夹优先用 `+message-modify`；软删除优先用 `+message-trash`；会话级批量整理可用 `+thread-modify`，软删除会话可用 `+thread-trash`
 5. **回复** — `+reply` / `+reply-all`（默认存草稿，加 `--confirm-send` 则立即发送）
 6. **转发** — `+forward`（默认存草稿，加 `--confirm-send` 则立即发送）
 7. **新邮件** — `+send` 存草稿（默认），加 `--confirm-send` 发送
-8. **HTML body 预检（可选）** — 复杂 HTML body 提交前可先跑 `+lint-html` 看 lint 会改 / 删什么；写信路径（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op）已内置 autofix，普通正文不必先跑。详见 [references/lark-mail-html.md](references/lark-mail-html.md) 中的「写入路径内置 HTML lint」章节
-9. **确认投递** — 立即发送后用 `send_status` 查询投递状态，定时发送后在预定时间后再查询；取消定时发送用 `cancel_scheduled_send`
-10. **编辑草稿** — `+draft-edit` 修改已有草稿。正文编辑通过 `--patch-file`：回复/转发草稿用 `set_reply_body` op 保留引用区，普通草稿用 `set_body` op
-11. **已读回执** —
+8. **确认投递** — 立即发送后用 `send_status` 查询投递状态，定时发送后在预定时间后再查询；取消定时发送用 `cancel_scheduled_send`
+9. **编辑草稿** — `+draft-edit` 修改已有草稿。正文编辑通过 `--patch-file`：回复/转发草稿用 `set_reply_body` op 保留引用区，普通草稿用 `set_body` op
+10. **已读回执** —
    - **请求回执（写信侧）**：`--request-receipt` 仅在**用户显式要求**时添加，**不要从 subject / body 内容推断意图**。
    - **响应回执（拉信侧）**：拉信看到 `label_ids` 含 `READ_RECEIPT_REQUEST`（或 `-607`）时，**必须先问用户**是否回执（不要自动回执，涉及隐私）。用户同意 → `+send-receipt` 响应；用户不同意但想消掉提示 → `+decline-receipt` 只清本地标签、不发邮件。
 
@@ -116,27 +113,9 @@ metadata:
 - 若用户需要，再继续帮他修改草稿或执行发送
 - 若本次产出了草稿且不是直接发信，则优先展示草稿打开链接；若当前输出没有链接，则静默处理
 
-## 常用操作速查
+### CRITICAL — 首次使用任何命令前先查 `-h`
 
-- 收件人地址搜索：搜索用户邮箱地址、群邮箱地址、邮件组地址，提供给用户确认。ref: [lark-mail-recipient-search](references/lark-mail-recipient-search.md)
-- 使用公共邮箱发信、使用邮箱别名发信：通过 `--mailbox` 指定邮箱归属，通过 `--from` 指定发件人地址。ref: [lark-mail-send-as](references/lark-mail-send-as.md)
-- 查看发送邮件后的投递状态：发送成功后查看邮件投递状态；也覆盖发送拦截。ref: [lark-mail-send-status](references/lark-mail-send-status.md)
-- 使用邮件模板：区分个人模板和静态 HTML 模板，发信类 shortcut 用 `--template-id` 套用模板。ref: [lark-mail-template](references/lark-mail-template.md)
-- 撤回已发送邮件：撤回邮件并查询异步撤回状态。ref: [lark-mail-recall](references/lark-mail-recall.md)
-- 修改邮件标签/已读状态/文件夹：优先使用 `+message-modify`。ref: [`+message-modify`](references/lark-mail-message-modify.md)
-- 修改会话标签/文件夹：使用 `+thread-modify`。ref: [`+thread-modify`](references/lark-mail-thread-modify.md)
-- 软删除邮件：优先使用 `+message-trash`。ref: [`+message-trash`](references/lark-mail-message-trash.md)
-- 软删除会话：已有 `thread_id` 时可使用 `+thread-trash`。ref: [`+thread-trash`](references/lark-mail-thread-trash.md)
-- 收信规则：查看、创建、更新、删除、启停、排序自动处理收到邮件的规则。ref: [lark-mail-rules](references/lark-mail-rules.md)
-- 分享邮件到 IM：分享邮件或会话到群聊、个人会话。ref: [lark-mail-share-to-chat](references/lark-mail-share-to-chat.md)
-- 发送日程邀请邮件：在邮件中嵌入 `text/calendar` 日程邀请。ref: [lark-mail-calendar-invite](references/lark-mail-calendar-invite.md)
-- 编写复杂 HTML 正文：复杂 HTML、本地图片、安全不确定时读取规范或运行 `+lint-html`；普通正文无需预读。ref: [lark-mail-html](references/lark-mail-html.md)
-- 读取邮件：按场景选择 triage、单封、批量或会话读取。ref: [`+triage`](references/lark-mail-triage.md)、[`+message`](references/lark-mail-message.md)、[`+messages`](references/lark-mail-messages.md)、[`+thread`](references/lark-mail-thread.md)
-- 写信、草稿、回复、转发：先判断新邮件、回复或转发，再决定创建草稿、直接发送或定时发送。命令选择见下方；公共邮箱/别名、发送状态等见相关 ref。
-
-### 参数不确定时先查 `-h`
-
-已有明确示例或已确认 flag 时可直接执行；参数、资源名或 raw API 结构不确定时，先运行 `-h` 查看可用参数，不要猜测参数名称：
+无论是 Shortcut（`+triage`、`+send` 等）还是原生 API，**首次调用前必须先运行 `-h` 查看可用参数**，不要猜测参数名称：
 
 ```bash
 # Shortcut
@@ -147,7 +126,49 @@ lark-cli mail +send -h
 lark-cli mail user_mailbox.messages -h
 ```
 
-`-h` 输出是可用 flag 的权威来源。reference 文档可辅助理解语义，但实际 flag 名称以 `-h` 为准。
+`-h` 输出即可用 flag 的权威来源。reference 文档中的参数表可辅助理解语义，但实际 flag 名称以 `-h` 为准。
+
+### 收件人搜索：查找邮箱地址
+
+当需要查找收件人邮箱地址时，使用联系人搜索接口。支持多种搜索方式，如：
+- **按人名搜索**：如"给张三发邮件" → query="张三"
+- **按邮箱关键词搜索**：如"发到 larkmail 的邮箱" → query="@larkmail"
+- **按群名搜索**：如"发给项目群" → query="项目群"
+
+```bash
+lark-cli mail multi_entity search --as user --data '{"query":"<关键词>"}'
+```
+
+搜索结果包含多种实体类型：
+
+| `type` 值 | `tag` 示例 | 说明 |
+|-----------|-----------|------|
+| `user` / `chatter` | `chatter` | 个人用户 |
+| `enterprise_mail_group` | `mail_group` | 企业邮件组 |
+| `chat` / `group` | `chat_group_tenant` / `chat_group_normal` | 群聊（有群邮件地址） |
+| `external_contact` | `external_contact` | 外部联系人 |
+
+**处理规则：**
+1. 从结果中筛选有 `email` 字段的条目
+2. 无论匹配数量多少，都必须列出候选项供用户确认后再使用（搜索是模糊匹配，单条结果不代表精确命中）。展示尽可能多的字段帮助用户区分：
+   ```text
+   找到以下匹配"张三"的结果：
+   1. 张三 <zhangsan@example.com>
+      类型：user | 部门：研发团队
+   ---
+   找到多个匹配"组"的结果，请选择：
+   1. 团队邮件组 <team@example.com>
+      类型：enterprise_mail_group | 标签：mail_group
+   2. 项目群 <project@example.com>
+      类型：chat | 成员数：50 | 标签：chat_group_normal
+   3. 张群 <zhangqun@example.com>
+      类型：user | 部门：研发团队 | 备注名：张群同学
+   ```
+   可用字段：`name`（名称）、`email`（邮箱）、`department`（部门）、`tag`（标签）、`display_name`（备注名）、`type`（实体类型）、`member_count`（成员数，群类型时展示）。字段为空时省略。
+3. 若无匹配，告知用户未找到，建议换关键词或直接提供邮箱地址
+4. 用户确认后，将 `email` 传入 compose shortcut 的 `--to` / `--cc` / `--bcc` 参数
+
+**注意：** 用户直接提供完整邮箱地址时不需要搜索，直接使用即可。
 
 ### 命令选择：先判断邮件类型，再决定草稿还是发送
 
@@ -158,19 +179,155 @@ lark-cli mail user_mailbox.messages -h
 | **转发** | `+forward` | `+forward --confirm-send` | `+forward --confirm-send --send-time <unix_timestamp>` |
 
 - 有原邮件上下文 → 用 `+reply` / `+reply-all` / `+forward`（默认即草稿），**不要用 `+draft-create`**
-- 当需要查找收件人邮箱地址时，使用联系人搜索接口。ref: [lark-mail-recipient-search](references/lark-mail-recipient-search.md)
 - **发送前必须向用户确认收件人和内容；如有必要，可引导用户去飞书邮件里打开草稿查看详情；用户明确同意后才可执行发送或使用 `--confirm-send`**
-- **发送后必须调用 `send_status` 确认投递状态**；定时发送（`--send-time`）在预定发送时间后再查询。ref: [lark-mail-send-status](references/lark-mail-send-status.md)
-- 公共邮箱/别名发信见 [lark-mail-send-as](references/lark-mail-send-as.md)
-- 发送拦截见 [lark-mail-send-status](references/lark-mail-send-status.md)
+- **发送后必须调用 `send_status` 确认投递状态**；定时发送（`--send-time`）在预定发送时间后再查询，取消定时发送用 `cancel_scheduled_send`（详见下方说明）
 
-### 正文格式与书写规范
+> **定时发送注意事项**：`--send-time` 必须与 `--confirm-send` 配合使用，不能单独使用。`send_time` 为 Unix 时间戳（秒），需至少为当前时间 + 5 分钟。
 
-撰写邮件正文时，**默认使用 HTML 格式**（body 内容会被自动检测）；仅当用户明确要求纯文本或内容极简时，才使用 `--plain-text`。
+### 使用公共邮箱或别名（send_as）发信
+
+当用户需要用非主账号地址发信时，使用 `--mailbox` 指定邮箱、`--from` 指定发件人地址。
+
+- `--mailbox` 传邮箱地址（如 `shared@example.com` 或 `me`），可通过 `accessible_mailboxes` 查询可用值
+- `--from` 传发信地址（别名、邮件组等），可通过 `send_as` 查询可用值
+
+**查询可用邮箱和发信地址：**
+
+```bash
+# 查询可访问的邮箱（主邮箱 + 公共邮箱）
+lark-cli mail user_mailboxes accessible_mailboxes --params '{"user_mailbox_id":"me"}'
+
+# 查询某个邮箱的可用发信地址（主地址、别名、邮件组）
+lark-cli mail user_mailbox.settings send_as --params '{"user_mailbox_id":"me"}'
+```
+
+**公共邮箱发信：**
+
+```bash
+# --mailbox 指定公共邮箱，From 头自动使用该邮箱地址
+lark-cli mail +send --mailbox shared@example.com \
+  --to bob@example.com --subject '通知' --body '<p>你好</p>'
+```
+
+**别名发信：**
+
+```bash
+# --mailbox 指定所属邮箱，--from 指定别名地址
+lark-cli mail +send --mailbox me --from alias@example.com \
+  --to bob@example.com --subject '测试' --body '<p>你好</p>'
+```
+
+不使用公共邮箱或别名时无需指定 `--mailbox`，行为与之前一致。
+
+### 发送后确认投递状态
+
+**立即发送（无 `--send-time`）**：邮件发送成功后（收到 `message_id`），**必须**调用 `send_status` API 查询投递状态并向用户报告：
+
+```bash
+lark-cli mail user_mailbox.messages send_status --params '{"user_mailbox_id":"me","message_id":"<发送返回的 message_id>"}'
+```
+
+返回每个收件人的投递状态（`status`）：1=正在投递, 2=投递失败重试, 3=退信, 4=投递成功, 5=待审批, 6=审批拒绝。向用户简要报告结果，如有异常状态（退信/审批拒绝）需重点提示。
+
+**定时发送（指定了 `--send-time`）**：定时发送不会立即产生 `message_id`，`send_status` 在定时发送成功后会返回"待发送"状态，**不建议在定时发送后立即查询**。可在预定发送时间后再查询。如需取消定时发送：
+
+```bash
+lark-cli mail user_mailbox.drafts cancel_scheduled_send --params '{"user_mailbox_id":"me","draft_id":"<draft_id>"}'
+```
+
+**取消后邮件会变回草稿**，可继续编辑或在之后重新发送。
+
+### 撤回邮件
+
+发送成功后，若响应中包含 `recall_available: true`，说明该邮件支持撤回（24 小时内已投递的邮件）。
+
+**撤回操作：**
+```bash
+lark-cli mail user_mailbox.sent_messages recall --as user \
+  --params '{"user_mailbox_id":"me","message_id":"<message_id>"}'
+```
+
+- 返回 `recall_status: available` 表示撤回请求已受理（异步执行）
+- 返回 `recall_status: unavailable` 表示不可撤回，`recall_restriction_reason` 说明原因
+
+**查询撤回进度：**
+```bash
+lark-cli mail user_mailbox.sent_messages get_recall_detail --as user \
+  --params '{"user_mailbox_id":"me","message_id":"<message_id>"}'
+```
+
+- `recall_status: in_progress` — 撤回进行中，可稍后再查
+- `recall_status: done` — 撤回完成，查看 `recall_result`（`all_success` / `all_fail` / `some_fail`）和每个收件人的详情
+
+**注意：** 撤回是异步操作，`recall` 返回成功仅表示请求已受理，实际结果需通过 `get_recall_detail` 查询。若响应中无 `recall_available` 字段，说明该邮件或应用不支持撤回，不要主动提及撤回。
+
+### 分享邮件到 IM
+
+将邮件以卡片形式分享到飞书群聊或个人会话。
+
+**依赖 Scope：** `mail:user_mailbox.message:readonly`、`im:message`、`im:message.send_as_user`
+
+1. 分享单封邮件到群聊（默认 `--receive-id-type chat_id`）：
+   ```bash
+   lark-cli mail +share-to-chat --message-id <邮件ID> --receive-id oc_xxx
+   ```
+
+2. 分享整个会话到群聊：
+   ```bash
+   lark-cli mail +share-to-chat --thread-id <会话ID> --receive-id oc_xxx
+   ```
+
+3. 通过邮箱分享给个人：
+   ```bash
+   lark-cli mail +share-to-chat --message-id <邮件ID> --receive-id user@example.com --receive-id-type email
+   ```
+
+4. 如果不知道群聊 ID，先搜索：
+   ```bash
+   lark-cli im +chat-search --query "群名关键词"
+   ```
+   从结果中获取 `chat_id`，然后执行分享。
+
+**注意：**
+- 分享需要用户在目标会话中有发消息权限
+- 需要同时授权 mail 和 im 两个域的 scope
+- 分享的卡片包含邮件摘要信息，收件人可点击查看
+
+### 发送日程邀请邮件
+
+在邮件中嵌入日程邀请（`text/calendar`），收件人收信后可直接接受或拒绝日程。`To`/`Cc` 收件人自动成为参会人（ATTENDEE），发件人自动成为组织者（ORGANIZER）。
+
+```bash
+# 发送带日程邀请的新邮件（先保存草稿，确认后发送）
+lark-cli mail +send --as user \
+    --to alice@example.com --cc bob@example.com \
+    --subject '产品评审' \
+    --body '<p>请参加本次产品评审会议。</p>' \
+    --event-summary '产品评审' \
+    --event-start '2026-05-10T14:00+08:00' \
+    --event-end '2026-05-10T15:00+08:00' \
+    --event-location '5F 大会议室' \
+    --confirm-send
+```
+
+**参数说明：**
+- `--event-summary`：日程标题，设置此参数即开启日程邀请模式，需同时设置 `--event-start` 和 `--event-end`
+- `--event-start` / `--event-end`：ISO 8601 格式时间，如 `2026-05-10T14:00+08:00`
+- `--event-location`：可选，日程地点
+
+**约束：**
+- `--event-*` 与 `--send-time`（定时发送）互斥，不可同时使用
+- `Bcc` 收件人不会成为日程参会人；如果邮件同时包含 Bcc 和日程，后端在发送时会拒绝该请求
+
+读取含日程邀请的邮件时，`calendar_event` 字段包含日程详情（`method`、`summary`、`start`、`end`、`organizer`、`attendees` 等）。
+
+### 正文格式：优先使用 HTML
+
+撰写邮件正文时，**默认使用 HTML 格式**（body 内容会被自动检测）。仅当用户明确要求纯文本时，才使用 `--plain-text` 标志强制纯文本模式。
 
 - HTML 支持粗体、列表、链接、段落等富文本排版，收件人阅读体验更好
-- 简单正文直接使用常规 `<p>` / `<ul><li>`；复杂 HTML、本地图片或安全不确定时再读取 [邮件 HTML 写法规范](references/lark-mail-html.md) 或使用 [`+lint-html`](references/lark-mail-lint-html.md)
-- **官方模板库** [`assets/templates/`](assets/templates/) 可供参考
+- 所有发送类命令（`+send`、`+reply`、`+reply-all`、`+forward`、`+draft-create`）都支持自动检测 HTML，可通过 `--plain-text` 强制纯文本
+- 纯文本仅适用于极简内容（如一句话回复 "收到"）
 
 ```bash
 # ✅ 推荐：HTML 格式
@@ -181,9 +338,60 @@ lark-cli mail +send --to alice@example.com --subject '周报' \
 lark-cli mail +reply --message-id <id> --body '收到，谢谢'
 ```
 
+**HTML 写法、风格指引、场景模板请参考两份配套文档：**
+
+- [邮件 HTML 写法指南](references/lark-mail-html.md) — 标签 / class / inline style 速查、飞书原生写法（含风格指引）、完整场景模板（通知 / 周报 / 决策请求）；表格 / 列表 / 字号 / 引用 / 链接 / 内嵌图片标准写法都在这里
+- [`+lint-html` 用法](references/lark-mail-lint-html.md) — 创建草稿前自检 / 修复 AI 输出
+
+### 邮件风格规范
+
+写信时必须遵守的文风底线（详见 [邮件 HTML 写法指南](references/lark-mail-html.md)）：
+
+- **禁机械编号**：用 `<ul>` / `<ol>` 表达列表，不要用 "一、二、三" / "①②③" / "1) 2) 3)"
+- **emoji 克制**：emoji 仅作状态标签（⏰紧急 / ✅完成 / ⚠️风险），不要在正文段落里堆 emoji 装饰
+- **禁冗长 disclaimer**：删除 "希望对您有帮助" / "感谢您的耐心阅读" 等填充语；信息密度优先
+- **标题 ≤ 30 字**：邮件主题 `--subject` 控制在 30 字内，避免被收件箱截断
+- **决策 / 结论前置**：第一段就给结论或决策项，让收件人扫一眼就知道是不是需要他做什么
+- **问候 / 落款不超 1 段**：`Hi 各位 Reviewer，` / `各位同事：` 一句话即可；落款 `[发件人姓名] / [团队] / [日期]` 一行结束
+
+### 严禁手拼 raw EML
+
+> **CRITICAL：严禁手拼 raw EML 直传 `drafts.create`，必须走 compose 5 shortcut（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward`）或 `+draft-edit` 的 body op。**
+
+`emlbuilder` 已内置 RFC 合规处理（base64 / boundary / header folding / 附件 RFC 2231 等），AI **无需自学 RFC**。手拼 raw EML 几乎一定会踩坑（编码错误 / 边界冲突 / 收件端不渲染），且绕开了 lark-cli 的统一安全和兼容性兜底——本仓库的 `+send` / `+draft-create` 等 shortcut 已封装好所有发信细节，AI 只需关注业务字段（收件人 / 主题 / HTML 正文 / 附件路径）即可。
+
+### 写入路径内置 HTML lint
+
+`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op 在调用 `emlbuilder` **之前**会强制对 HTML 正文做 lint：
+
+- 错误（`<script>` / `on*` / `javascript:` URL / `<iframe>` / `<form>` / `<style>` / `<link>` 等）会被**直接删除**
+- 警告（`<font>` / `<center>` / `<marquee>`）会被**自动修复**为飞书原生写法
+- 不允许的 CSS property（`position` / `z-index` / `transform` 等）会从 inline `style` 里删除
+
+默认 envelope 只携带必要字段；加 `--show-lint-details` 后会同时输出两个 Finding 数组（无违规时是空数组），方便调用方调试：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "draft_id": "...",
+    "lint_applied": [
+      {"rule_id": "TAG_FONT_TO_SPAN", "severity": "warning", "tag_or_attr": "font",
+       "excerpt": "<font color=\"red\"...>", "hint": "已替换为 <span style=...>"}
+    ],
+    "original_blocked": [
+      {"rule_id": "TAG_SCRIPT_BLOCKED", "severity": "error", "tag_or_attr": "script",
+       "excerpt": "<script...>", "hint": "已整段删除（XSS 风险）"}
+    ]
+  }
+}
+```
+
+写入路径**没有 `--no-lint` 总开关**——这是本方案的安全契约。如果想预先看 HTML 是否会被改动，先用 [`+lint-html`](references/lark-mail-lint-html.md) 跑一次。
+
 ### 读取邮件：按需控制返回内容
 
-`+message`、`+messages`、`+thread` 默认返回 HTML 正文（`--html=true`）。`+message` 只适合单个 `message_id`；多个已知 `message_id` 请一次性传给 `+messages --message-ids <id1>,<id2>,<id3>`。仅需确认操作结果（如验证标记已读、移动文件夹是否成功）时，用 `--html=false` 跳过 HTML 正文，只返回纯文本，显著减少 token 消耗。
+`+message`、`+messages`、`+thread` 默认返回 HTML 正文（`--html=true`）。仅需确认操作结果（如验证标记已读、移动文件夹是否成功）时，用 `--html=false` 跳过 HTML 正文，只返回纯文本，显著减少 token 消耗。
 
 输出默认为结构化 JSON，可直接读取，无需额外编码转换。
 
@@ -193,14 +401,43 @@ lark-cli mail +message --message-id <id> --html=false
 
 # ✅ 需要阅读完整内容：保持默认
 lark-cli mail +message --message-id <id>
-
-# ✅ 已有多个 message_id：批量读取，避免循环调用 +message
-lark-cli mail +messages --message-ids <id1>,<id2>,<id3> --html=false
 ```
+
+### 邮件模板（`+template-create` / `+template-update` / `--template-id`）
+
+模板的创建 / 更新由专用 shortcut 处理（自动做 Drive 上传 + `<img src>` 改写成 `cid:`）；发信类 shortcut 通过 `--template-id <id>` 套用模板。
+
+**管理模板**：
+
+- [`+template-create`](references/lark-mail-template-create.md) — 创建新模板。`--name` 必填；正文通过 `--template-content` 或 `--template-content-file` 二选一；支持 HTML 内嵌图片自动上传到 Drive。
+- [`+template-update`](references/lark-mail-template-update.md) — 全量替换式更新（**后端无乐观锁，last-write-wins**）。支持 `--inspect`（只读 projection）/ `--print-patch-template`（patch 骨架）/ `--patch-file`（结构化 patch）/ 扁平 `--set-*` flag。
+- 列表 / 获取 / 删除 走原生 API：`lark-cli mail user_mailbox.templates {list|get|delete} ...`。
+
+**套用模板（5 个发信 shortcut）**：`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` 均支持 `--template-id <id>`。`--template-id` 必须是**十进制整数字符串**。
+
+合并规则（与 `lark/desktop` 对齐）：
+
+| # | 场景 | 合并策略 |
+|---|------|----------|
+| Q1 to/cc/bcc | 全部 5 个 shortcut | 用户 `--to/--cc/--bcc` 先覆盖草稿原有值，再与模板 tos/ccs/bccs **无去重追加** |
+| Q2 subject | `+send` / `+draft-create` | 用户 `--subject` > 草稿 subject > 模板 subject |
+|  | `+reply` / `+reply-all` / `+forward` | 用户 `--subject` 覆盖自动 Re:/Fw:；否则保持 Re:/Fw: + 原邮件 subject。**模板 subject 被忽略**（保留会话线索） |
+| Q3 body | `+send` / `+draft-create` | 空草稿 body → 用模板；非空 HTML → `draftBody + <br><br> + tplContent`；非空 plain-text → `\n\n` 拼接 |
+|  | `+reply` / `+reply-all` / `+forward` | 模板内容注入 `<blockquote>` 之前；无 blockquote 则追加；plain-text 模板走 emlbuilder plain-text 追加 |
+| Q4 附件 | 全部 5 个 shortcut | 模板 inline（SMALL）由 CLI 走 `user_mailbox.template.attachments.download_url` 下载后以 MIME part 注入；SMALL 非 inline 同样注入；LARGE（`attachment_type=2`）不下载，只把 `file_key` 放到 `X-Lms-Large-Attachment-Ids` header 让服务端渲染下载卡片 |
+| Q5 cid 冲突 | inline 图片 | cid 由 UUID v4 生成（碰撞概率 ~ 2^-122），不显式检测 |
+
+**Warning**：`+reply` / `+reply-all` + 模板且模板自带 tos/ccs/bccs 时，CLI 在 stderr 打印：`warning: template to/cc/bcc are appended without de-duplication; you may see repeated recipients. Use --to/--cc/--bcc to override, or run +template-update to clear template addresses.`
+
+**size 约束**：单模板 `template_content` ≤ 3 MB；`body + inline + SMALL` 累计 ≤ 25 MB（超过则该批次剩余非 inline 附件切换为 LARGE；inline 不能切换）。
+
+### 用户级信任 / 屏蔽发件人名单
+
+用户要求查看、搜索、加入或删除个人邮箱的信任发件人 / 屏蔽发件人时，使用原生 `user_mailbox.allow_senders` / `user_mailbox.blocked_senders` API。完整的用户身份、`sender_type`、分页、`failed_items` 判断及加入→查询→删除闭环见 [用户级信任 / 屏蔽发件人名单](references/lark-mail-sender-lists.md)。这些用户级名单与管理员维护的租户级 `allowed_senders` / `blocked_senders` 相互独立，不要混用。
 
 ## 原生 API 调用规则
 
-没有 Shortcut 覆盖的操作才使用原生 API。标签、已读状态、移动文件夹优先使用 `+message-modify`；软删除优先使用 `+message-trash`。会话或 thread ID 级标签/文件夹整理可使用 `+thread-modify`；软删除会话可使用 `+thread-trash`。调用步骤以本节为准；资源和 method 用 `lark-cli mail -h` / `lark-cli mail <resource> -h` 发现，不在入口保留完整资源表。
+没有 Shortcut 覆盖的操作才使用原生 API。标签、已读状态、移动文件夹优先使用 `+message-modify`；软删除优先使用 `+message-trash`。会话或 thread ID 级标签/文件夹整理可使用 `+thread-modify`；软删除会话可使用 `+thread-trash`。调用步骤以本节为准（API Resources 章节的 resource/method 列表可辅助查阅）。
 
 ### Step 1 — 用 `-h` 确定要调用的 API（必须，不可跳过）
 
@@ -249,13 +486,9 @@ lark-cli mail <resource> <method> --params '{...}' [--data '{...}']
 **GET — 只有 `--params`**（`parameters` 中有 path + query，无 `requestBody`）：
 
 ```bash
-# schema 中：user_mailbox_id (path, required), page_size (query, required)
-# user_mailbox.threads.list 要求 folder_id / label_id 必须且只能提供一个
-lark-cli mail user_mailbox.threads list \
+# schema 中：user_mailbox_id (path, required), page_size (query, required), folder_id (query, optional)
+lark-cli mail user_mailbox.messages list \
   --params '{"user_mailbox_id":"me","page_size":20,"folder_id":"INBOX"}'
-
-lark-cli mail user_mailbox.threads list \
-  --params '{"user_mailbox_id":"me","page_size":20,"label_id":"FLAGGED"}'
 ```
 
 **POST — `--params` + `--data`**（`parameters` 中有 path，`requestBody` 有 body 字段）：
@@ -279,17 +512,28 @@ Shortcut 是对常用操作的高级封装（`lark-cli mail +<verb> [flags]`）�
 
 | Shortcut | 说明 |
 |----------|------|
-| [`+message`](references/lark-mail-message.md) | Use only when reading full content for one email by one message ID. For multiple message IDs, use `mail +messages`; do not loop `mail +message`. |
-| [`+messages`](references/lark-mail-messages.md) | Use when reading full content for multiple emails by message ID. Accepts comma-separated message IDs; CLI handles more than 20 IDs in batches and merges output. |
+| [`+message`](references/lark-mail-message.md) | Use only when reading full content for one email by one message ID. For multiple message IDs, use mail +messages; do not loop mail +message. Returns normalized body content plus attachments metadata, including inline images. |
+| [`+messages`](references/lark-mail-messages.md) | Use when reading full content for multiple emails by message ID. You may pass more than 20 IDs; the CLI handles them in batches of 20 and merges output while preserving request order. |
+| [`+message-modify`](references/lark-mail-message-modify.md) | Modify existing mail messages by adding/removing label IDs or moving them to a folder. Batches message IDs in groups of 20 and keeps output compact. |
+| [`+message-trash`](references/lark-mail-message-trash.md) | Soft-delete existing mail messages. Batches message IDs in groups of 20 and calls batch_trash sequentially. Requires --yes. |
 | [`+thread`](references/lark-mail-thread.md) | Use when querying a full mail conversation/thread by thread ID. Returns all messages in chronological order, including replies and drafts, with body content and attachments metadata, including inline images. |
-| [`+thread-modify`](references/lark-mail-thread-modify.md) | Modify existing mail threads by adding/removing label IDs or moving them to a folder. Batches thread IDs in groups of 20 and returns success_thread_ids / failed_thread_ids. |
-| [`+thread-trash`](references/lark-mail-thread-trash.md) | Soft-delete existing mail threads. Batches thread IDs in groups of 20 and returns success_thread_ids / failed_thread_ids. Requires --yes. |
+| [`+thread-modify`](references/lark-mail-thread-modify.md) | Modify existing mail threads by adding/removing label IDs or moving them to a folder. Batches thread IDs in groups of 20 and keeps output compact. |
+| [`+thread-trash`](references/lark-mail-thread-trash.md) | Soft-delete existing mail threads. Batches thread IDs in groups of 20 and calls batch_trash sequentially. Requires --yes. |
 | [`+triage`](references/lark-mail-triage.md) | List mail summaries (date/from/subject/message_id). Use --query for full-text search, --filter for exact-match conditions. |
 | [`+watch`](references/lark-mail-watch.md) | Watch for incoming mail events via WebSocket (requires scope mail:event and bot event mail.user_mailbox.event.message_received_v1 added). Run with --print-output-schema to see per-format field reference before parsing output. |
+| [`+rule-list`](references/lark-mail-rule-list.md) | List mailbox rules with semantic aliases, Chinese descriptions, and unknown raw warnings. |
+| [`+rule-get`](references/lark-mail-rule-get.md) | Get one mailbox rule by rule_id by scanning the rules collection when no atomic get is exposed. |
+| [`+rule-create`](references/lark-mail-rule-create.md) | Create a mailbox rule from semantic condition/action aliases; use --dry-run to inspect the raw request. |
+| [`+rule-update`](references/lark-mail-rule-update.md) | Update one mailbox rule by reading the current rule and preserving unspecified fields. |
+| [`+rule-delete`](references/lark-mail-rule-delete.md) | Delete one mailbox rule. Without --yes, the shortcut fetches the target and returns a confirmation summary without deleting. |
+| [`+rule-enable`](references/lark-mail-rule-enable.md) | Enable one mailbox rule while preserving unknown raw conditions/actions. |
+| [`+rule-disable`](references/lark-mail-rule-disable.md) | Disable one mailbox rule while preserving unknown raw conditions/actions. |
+| [`+rule-reorder`](references/lark-mail-rule-reorder.md) | Reorder mailbox rules by full rule_id list or by moving one rule before/after/top/bottom. |
 | [`+reply`](references/lark-mail-reply.md) | Reply to a message and save as draft (default). Use --confirm-send to send immediately after user confirmation. Sets Re: subject, In-Reply-To, and References headers automatically. |
 | [`+reply-all`](references/lark-mail-reply-all.md) | Reply to all recipients and save as draft (default). Use --confirm-send to send immediately after user confirmation. Includes all original To and CC automatically. |
 | [`+send`](references/lark-mail-send.md) | Compose a new email and save as draft (default). Use --confirm-send to send immediately after user confirmation. |
 | [`+draft-create`](references/lark-mail-draft-create.md) | Create a brand-new mail draft from scratch (NOT for reply or forward). For reply drafts use +reply; for forward drafts use +forward. Only use +draft-create when composing a new email with no parent message. |
+| [`+draft-send`](references/lark-mail-draft-send.md) | Send one or more existing mail drafts sequentially. Calls POST /drafts/:draft_id/send for each input ID, isolates per-draft failures, and aggregates the results. Use after the drafts have already been created (via the Lark client, +draft-create, or the drafts.create API). |
 | [`+draft-edit`](references/lark-mail-draft-edit.md) | Use when updating an existing mail draft without sending it. Prefer this shortcut over calling raw drafts.get or drafts.update directly, because it performs draft-safe MIME read/patch/write editing while preserving unchanged structure, attachments, and headers where possible. |
 | [`+forward`](references/lark-mail-forward.md) | Forward a message and save as draft (default). Use --confirm-send to send immediately after user confirmation. Original message block included automatically. |
 | [`+send-receipt`](references/lark-mail-send-receipt.md) | Send a read-receipt reply for an incoming message that requested one (i.e. carries the READ_RECEIPT_REQUEST label). Body is auto-generated (subject / recipient / send time / read time) to match the Lark client's receipt format — callers cannot customize it, matching the industry norm that read-receipt bodies are system-generated templates, not free-form replies. Intended for agent use after the user confirms. |
@@ -298,4 +542,195 @@ Shortcut 是对常用操作的高级封装（`lark-cli mail +<verb> [flags]`）�
 | [`+share-to-chat`](references/lark-mail-share-to-chat.md) | Share an email or thread as a card to a Lark IM chat. |
 | [`+template-create`](references/lark-mail-template-create.md) | Create a personal mail template. Scans HTML <img src> local paths (reusing draft inline-image detection), uploads inline images and non-inline attachments to Drive, rewrites HTML to cid: references, and POSTs a Template payload to mail.user_mailbox.templates.create. |
 | [`+template-update`](references/lark-mail-template-update.md) | Update an existing mail template. Supports --inspect (read-only projection), --print-patch-template (prints a JSON skeleton for --patch-file), and flat flags (--set-subject / --set-name / etc). Internally it GETs the template, applies the patch, rewrites <img> local paths to cid: refs, and PUTs a full-replace update (no optimistic locking: last-write-wins). |
-| [`+lint-html`](references/lark-mail-lint-html.md) | Lint mail HTML body for compatibility / safety / Feishu-native rules. Returns warnings/errors and (default) auto-fixed HTML. Read-only: no draft, no API call. Use this BEFORE creating a draft to preview what the writing-path lint would change, or as a CI gate for static HTML templates. |
+| [`+lint-html`](references/lark-mail-lint-html.md) | Lint mail HTML body for compatibility / safety / Larksuite-native rules. Returns warnings/errors and (always) auto-fixed cleaned_html. Read-only: no draft, no API call. Use this BEFORE creating a draft to preview what the writing-path lint would change. |
+
+## API Resources
+
+```bash
+lark-cli schema mail.<resource>.<method>   # 调用 API 前必须先查看参数结构
+lark-cli mail <resource> <method> [flags] # 调用 API
+```
+
+> **重要**：使用原生 API 时，必须先运行 `schema` 查看 `--data` / `--params` 参数结构，不要猜测字段格式。
+
+### multi_entity
+
+  - `search` — 适用于写信联系人搜索
+
+### user_mailboxes
+
+  - `accessible_mailboxes` — 获取主账号的所有可访问邮箱，包括主邮箱和公共邮箱
+  - `profile` — 用于在用户身份下获取自己的邮箱主地址。当用户没有邮箱时，返回的 primary_email_address 为空。
+  - `search` — 搜索邮件
+
+### user_mailbox.allow_senders
+
+  - `batch_create` — 批量将发件人加入指定用户邮箱的「信任发件人」白名单。支持按邮箱地址 (sender_type=1) 或域名 (sender_type=2) 添加。单次最多 100 项，单用户黑白名单合计最多 2000 项；与黑名单互斥（添加白名单会从黑名单删除对侧记录）。
+  - `batch_remove` — 批量从指定用户邮箱的「信任发件人」白名单中删除发件人。senders 中每项可以是邮箱地址或域名（与添加时一致）。批量删除按字面值哈希匹配，可兼容历史大写数据。单次最多 100 项。
+  - `list` — 列表/搜索指定用户邮箱的「信任发件人」白名单。支持按发件人地址或域名前缀搜索 (keyword)。返回列表按创建时间倒序，使用 page_token + page_size 进行分页。
+
+### user_mailbox.blocked_senders
+
+  - `batch_create` — 批量将发件人加入指定用户邮箱的「屏蔽发件人」黑名单。支持按邮箱地址 (sender_type=1) 或域名 (sender_type=2) 添加。单次最多 100 项，单用户黑白名单合计最多 2000 项；与白名单互斥（添加黑名单会从白名单删除对侧记录）。
+  - `batch_remove` — 批量从指定用户邮箱的「屏蔽发件人」黑名单中删除发件人。senders 中每项可以是邮箱地址或域名（与添加时一致）。批量删除按字面值哈希匹配，可兼容历史大写数据。单次最多 100 项。
+  - `list` — 列表/搜索指定用户邮箱的「屏蔽发件人」黑名单。支持按发件人地址或域名前缀搜索 (keyword)。返回列表按创建时间倒序，使用 page_token + page_size 进行分页。
+
+### user_mailbox.drafts
+
+  - `cancel_scheduled_send` — 取消定时发送
+  - `create` — 创建草稿
+  - `delete` — 删除指定邮箱账户下的单份邮件草稿。注意：对于草稿状态的邮件，只能使用本接口删除，禁止使用 trash_message；被删除的草稿数据无法恢复，请谨慎使用。
+  - `get` — 获取草稿详情
+  - `list` — 拉取草稿列表
+  - `send` — 发送草稿
+  - `update` — 更新草稿
+
+### user_mailbox.event
+
+  - `subscribe` — 订阅收信事件
+  - `subscription` — 查询订阅的收信事件
+  - `unsubscribe` — 取消订阅收信事件
+
+### user_mailbox.folders
+
+  - `create` — 创建邮箱文件夹
+  - `delete` — 删除用户文件夹。删除后文件夹数据无法恢复，请谨慎使用；删除文件夹会将该文件夹下的邮件移至已删除文件夹中。
+  - `get` — 获取指定邮箱账户下的单个邮件文件夹详情
+  - `list` — 列出用户文件夹，可获取文件夹名称、文件夹ID、文件夹下的未读邮件和未读会话数量
+  - `patch` — 更新用户文件夹
+
+### user_mailbox.labels
+
+  - `create` — 根据用户指定的名称、颜色等信息，创建邮件标签
+  - `delete` — 删除用户指定的标签，注意，删除的标签无法恢复
+  - `get` — 根据指定ID，获取邮件标签信息，包括名称、未读数据、颜色等信息
+  - `list` — 列出邮件标签，包括ID、名称、颜色、未读信息等内容
+  - `patch` — 更新邮件标签
+
+### user_mailbox.mail_contacts
+
+  - `create` — 创建邮箱联系人
+  - `delete` — 删除指定的邮箱联系人
+  - `list` — 列出邮箱联系人
+  - `patch` — 更新邮箱联系人
+
+### user_mailbox.message.attachments
+
+  - `download_url` — 获取附件下载链接
+
+### user_mailbox.messages
+
+  - `batch_get` — 通过指定邮件ID，获取对应邮件的标签、文件夹、摘要、正文、html、附件等信息。注意，如需获取摘要、正文、主题或收发件人地址，需要申请对应的字段权限。
+  - `batch_modify` — 本接口提供修改邮件的能力，支持移动邮件的文件夹、给邮件添加和移除标签、标记邮件读和未读、移动邮件至垃圾邮件等能力。不支持移动邮件到已删除文件夹，如需，请使用批量删除邮件接口。
+  - `batch_trash` — 通过指定邮件ID，批量移动邮件到已删除文件夹
+  - `get` — 获取邮件详情
+  - `list` — 根据用户指定的标签或文件夹，列出对应位置下的邮件列表。注意，必须填写folder_id或label_id中的一个字段。
+  - `modify` — 本接口提供修改邮件的能力，支持移动邮件的文件夹、给邮件添加和移除标签、标记邮件已读和未读、移动邮件至垃圾邮件等能力。不支持移动邮件到已删除文件夹，如需删除邮件，请使用删除邮件接口。至少填写add_label_ids、remove_label_ids、add_folder中的一个参数。
+  - `send_status` — 查询邮件发送状态
+  - `trash` — 移动邮件到已删除文件夹。注意，该接口无法删除草稿，如需删除草稿，请使用删除草稿接口
+
+### user_mailbox.rules
+
+  - `create` — 创建收信规则
+  - `delete` — 删除收信规则
+  - `list` — 列出收信规则
+  - `reorder` —
+  - `update` —
+
+### user_mailbox.sent_messages
+
+  - `get_recall_detail` — 查询指定邮件的撤回结果详情，包括整体撤回进度、成功/失败/处理中的收件人数量，以及每个收件人的撤回状态和失败原因。
+  - `recall` — 撤回指定邮件。前置条件：邮件须已投递，且发送时间在 24 小时以内；搬家中的域名不支持撤回。返回说明：若用户或邮件不满足撤回条件，接口仍返回 200，响应体中 recall_status 为 unavailable，recall_restriction_reason 标明具体原因。返回成功仅表示撤回请求已受理，实际撤回结果请调用「查询邮件撤回进度」接口获取。
+
+### user_mailbox.settings
+
+  - `send_as` — 获取账号的所有可发信地址，包括主地址、别名地址、邮件组。可以使用用户地址访问该接口，也可以使用用户有权限的公共邮箱地址访问该接口。
+
+### user_mailbox.template.attachments
+
+  - `download_url` — 获取指定邮件模板下的附件下载链接。用于在已知模板 ID 与附件 ID 的场景下，二次获取附件的有效访问 URL，便于在用户端预览或下载邮件模板中的附件资源。
+
+### user_mailbox.templates
+
+  - `create` — 在指定用户邮箱下创建一份可复用的个人邮件模板。请求时需传入完整的模板对象（含名称、主题、正文、收件信息、附件等），创建成功后返回完整模板内容（含系统生成的 template_id），适用于将常用邮件内容沉淀为模板以便后续快速发送同类型邮件。
+  - `delete` — 永久删除指定用户邮箱下的某个个人邮件模板。删除操作不可恢复，删除后该模板将无法在「列出邮件模板」「获取邮件模板」等接口中再返回，常用于清理已废弃或不再使用的模板。
+  - `get` — 获取指定邮件模板的完整详情，包括模板名称、主题、正文（HTML 或纯文本）、收件人/抄送/密送地址、附件信息等所有字段。常用于编辑模板前回填表单，或在发送邮件场景下读取模板内容做二次填充。
+  - `list` — 列出指定用户邮箱下的全部个人邮件模板基本信息（一次性返回，不分页），常用于在编辑或发送邮件场景下展示可选模板列表。如需获取模板正文与附件等完整字段，请通过获取个人邮件模板详情接口按 `template_id` 查询。
+  - `update` — 以全量替换的方式更新指定邮件模板的所有字段（包括名称、主题、正文、附件、收件信息等）。本接口为「全量更新」语义：请求时需传入完整的模板对象，未携带的字段将被清空。**调用依赖**：如仅修改部分字段，请先调用获取个人邮件模板详情接口拿到完整模板，在本地修改后再传回本接口，以避免漏传字段导致数据丢失。
+
+### user_mailbox.threads
+
+  - `batch_modify` — 本接口提供修改邮件会话的能力，支持移动邮件会话的文件夹、给邮件会话添加和移除标签、标记邮件会话读和未读、移动邮件会话至垃圾邮件等能力。不支持移动邮件会话到已删除文件夹，如需，请使用批量删除邮件会话接口。
+  - `batch_trash` — 通过指定邮件会话ID，批量移动邮件到已删除文件夹
+  - `get` — 通过用户邮箱地址和邮件会话ID，获取该会话下的所有邮件关键信息列表。如需查询主题、正文、摘要、收发件人信息，请申请字段权限。
+  - `list` — 通过指定文件夹或标签，列出对应位置下的邮件会话列表。接口可返回邮件会话ID和会话下最新一封邮件的摘要。folder_id 和 label_id 必须且只能提供一个。
+  - `modify` — 本接口提供修改邮件会话的能力，支持移动邮件会话的文件夹、给邮件会话添加和移除标签、标记邮件会话读和未读、移动邮件会话至垃圾邮件等能力。不支持移动邮件会话到已删除文件夹，如需，请使用删除邮件会话接口。至少填写add_label_ids、remove_label_ids、add_folder中的一个参数。
+  - `trash` — 移动指定的邮件会话到已删除文件夹
+
+## 权限表
+
+| 方法 | 所需 scope |
+|------|-----------|
+| `multi_entity.search` | `mail:user_mailbox:readonly` |
+| `user_mailboxes.accessible_mailboxes` | `mail:user_mailbox:readonly` |
+| `user_mailboxes.profile` | `mail:user_mailbox:readonly` |
+| `user_mailboxes.search` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.allow_senders.batch_create` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.allow_senders.batch_remove` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.allow_senders.list` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.blocked_senders.batch_create` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.blocked_senders.batch_remove` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.blocked_senders.list` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.drafts.cancel_scheduled_send` | `mail:user_mailbox.message:send` |
+| `user_mailbox.drafts.create` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.drafts.delete` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.drafts.get` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.drafts.list` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.drafts.send` | `mail:user_mailbox.message:send` |
+| `user_mailbox.drafts.update` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.event.subscribe` | `mail:event` |
+| `user_mailbox.event.subscription` | `mail:event` |
+| `user_mailbox.event.unsubscribe` | `mail:event` |
+| `user_mailbox.folders.create` | `mail:user_mailbox.folder:write` |
+| `user_mailbox.folders.delete` | `mail:user_mailbox.folder:write` |
+| `user_mailbox.folders.get` | `mail:user_mailbox.folder:read` |
+| `user_mailbox.folders.list` | `mail:user_mailbox.folder:read` |
+| `user_mailbox.folders.patch` | `mail:user_mailbox.folder:write` |
+| `user_mailbox.labels.create` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.labels.delete` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.labels.get` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.labels.list` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.labels.patch` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.mail_contacts.create` | `mail:user_mailbox.mail_contact:write` |
+| `user_mailbox.mail_contacts.delete` | `mail:user_mailbox.mail_contact:write` |
+| `user_mailbox.mail_contacts.list` | `mail:user_mailbox.mail_contact:read` |
+| `user_mailbox.mail_contacts.patch` | `mail:user_mailbox.mail_contact:write` |
+| `user_mailbox.message.attachments.download_url` | `mail:user_mailbox.message.body:read` |
+| `user_mailbox.messages.batch_get` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.messages.batch_modify` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.messages.batch_trash` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.messages.get` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.messages.list` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.messages.modify` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.messages.send_status` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.messages.trash` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.rules.create` | `mail:user_mailbox.rule:write` |
+| `user_mailbox.rules.delete` | `mail:user_mailbox.rule:write` |
+| `user_mailbox.rules.list` | `mail:user_mailbox.rule:read` |
+| `user_mailbox.rules.reorder` | `mail:user_mailbox.rule:write` |
+| `user_mailbox.rules.update` | `mail:user_mailbox.rule:write` |
+| `user_mailbox.sent_messages.get_recall_detail` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.sent_messages.recall` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.settings.send_as` | `mail:user_mailbox:readonly` |
+| `user_mailbox.template.attachments.download_url` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.templates.create` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.templates.delete` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.templates.get` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.templates.list` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.templates.update` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.threads.batch_modify` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.threads.batch_trash` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.threads.get` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.threads.list` | `mail:user_mailbox.message:readonly` |
+| `user_mailbox.threads.modify` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.threads.trash` | `mail:user_mailbox.message:modify` |

--- a/skills/lark-mail/references/lark-mail-sender-lists.md
+++ b/skills/lark-mail/references/lark-mail-sender-lists.md
@@ -1,0 +1,71 @@
+# 用户级信任 / 屏蔽发件人名单
+
+使用原生 Meta API 管理当前用户邮箱的信任发件人（allow list）和屏蔽发件人（block list）。这是**用户级**设置，与管理员维护的租户级 `allowed_senders` / `blocked_senders` 不是同一套数据；不要用其中一套代替另一套。
+
+## 契约与安全约定
+
+- 资源名以当前命令树为准：`user_mailbox.allow_senders`、`user_mailbox.blocked_senders`。两者都只支持用户身份，调用时显式传 `--as user`。
+- `user_mailbox_id`、搜索关键字和分页参数放在 `--params`；批量条目放在 `--data`。首次调用前先运行对应资源的 `-h` 和 method 级 `schema`。
+- `sender_type=1` 表示完整邮箱地址，`sender_type=2` 表示邮箱域名。`batch_create` 是“加入名单”，不是全量替换。
+- `batch_create` / `batch_remove` 是写操作，只能按用户明确指定的名单和条目执行。当前生成命令的风险级别是 `write`，不接受 `--yes`；不要为示例添加命令树不存在的 flag。
+- 批量响应只有 `failed_items`。空数组表示本批次没有逐项失败，**不代表 CLI 获得了真实新增数或删除数**；需要确认最终状态时，写入后用 `list --keyword` 回读。
+- 成功输出保持标准 JSON envelope；OpenAPI 错误保持结构化 stderr envelope 和非零退出码。上游返回 trace 标识时保留在 `error.log_id`，包括搜索缓存未就绪（HTTP 456）等错误；不要把错误响应当成空列表。
+
+## 信任发件人：加入 → 查询 → 删除
+
+```bash
+# 先确认资源、方法和输入结构
+lark-cli mail user_mailbox.allow_senders -h
+lark-cli schema mail.user_mailbox.allow_senders.batch_create
+
+# 加入一个邮箱地址和一个域名
+lark-cli mail user_mailbox.allow_senders batch_create --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"items":[{"sender":"trusted@example.com","sender_type":1},{"sender":"partner.example","sender_type":2}]}'
+
+# 用 keyword 前缀搜索验证；检查 items、has_more 和 page_token
+lark-cli mail user_mailbox.allow_senders list --as user \
+  --params '{"user_mailbox_id":"me","keyword":"trusted@","page_size":20}'
+
+# 删除刚才加入的值
+lark-cli mail user_mailbox.allow_senders batch_remove --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"senders":["trusted@example.com","partner.example"]}'
+```
+
+## 屏蔽发件人：加入 → 查询 → 删除
+
+```bash
+# 先确认资源、方法和输入结构
+lark-cli mail user_mailbox.blocked_senders -h
+lark-cli schema mail.user_mailbox.blocked_senders.batch_create
+
+# 加入一个邮箱地址和一个域名
+lark-cli mail user_mailbox.blocked_senders batch_create --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"items":[{"sender":"spam@example.com","sender_type":1},{"sender":"noise.example","sender_type":2}]}'
+
+# 用 keyword 前缀搜索验证
+lark-cli mail user_mailbox.blocked_senders list --as user \
+  --params '{"user_mailbox_id":"me","keyword":"spam@","page_size":20}'
+
+# 删除刚才加入的值
+lark-cli mail user_mailbox.blocked_senders batch_remove --as user \
+  --params '{"user_mailbox_id":"me"}' \
+  --data '{"senders":["spam@example.com","noise.example"]}'
+```
+
+## 分页与互斥
+
+`list` 返回 `items`、`has_more` 和 opaque `page_token`。单页精确控制时，把上一页的 `page_token` 原样放回 `--params`；遍历全部结果时可用全局 `--page-all`：
+
+```bash
+lark-cli mail user_mailbox.allow_senders list --as user \
+  --params '{"user_mailbox_id":"me","page_size":100,"page_token":"<opaque_page_token>"}'
+
+lark-cli mail user_mailbox.blocked_senders list --as user \
+  --params '{"user_mailbox_id":"me","page_size":100}' \
+  --page-all
+```
+
+同一个 sender 的用户级信任名单和屏蔽名单互斥：加入一侧可能移除另一侧的对应记录。若用户要求切换状态，写入目标名单后应分别查询两侧，确认目标侧存在且对侧不再命中。


### PR DESCRIPTION
Document user mailbox allow/block sender management in the mail skill.

- Add closed-loop examples for listing, searching, adding, and removing allow/block senders.
- Extend generated command-tree contract coverage and mail skill routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for managing user-level trusted and blocked sender lists, including listing, adding, removing, pagination, permissions, and failure handling.
  - Expanded mail skill documentation with recipient search, draft editing, forwarding, templates, sender-list management, API resources, permissions, and updated workflow guidance.
  - Added detailed reference examples and clarified that user-level sender lists are separate from tenant-level lists.

- **Tests**
  - Added automated checks to ensure sender-list documentation examples remain aligned with supported command contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->