### PR TITLE
fix(apps): classify db failures by their k_dl subcode

### DIFF
--- a/shortcuts/apps/apps_db_audit_set.go
+++ b/shortcuts/apps/apps_db_audit_set.go
@@ -59,9 +59,13 @@ var AppsDBAuditEnable = common.Shortcut{
 		retention := rctx.Str("retention")
 		stop := rctx.StartSpinner("Enabling audit logging for " + table)
 		defer stop()
-		data, err := rctx.CallAPITyped("POST", appAuditSetPath(appID),
-			dbEnvParams(rctx, map[string]interface{}{}),
-			map[string]interface{}{"table": table, "enabled": true, "retention": retention})
+		// Retried on DTS init lock contention only; see db_dts_retry.go for why that
+		// is safe to repeat and why the wait is deliberately short.
+		data, err := callWithDTSLockRetry(rctx.Ctx(), func() (map[string]interface{}, error) {
+			return rctx.CallAPITyped("POST", appAuditSetPath(appID),
+				dbEnvParams(rctx, map[string]interface{}{}),
+				map[string]interface{}{"table": table, "enabled": true, "retention": retention})
+		})
 		stop()
 		if err != nil {
 			return withAppsHint(err, dbAuditSetHint)
@@ -117,9 +121,13 @@ var AppsDBAuditDisable = common.Shortcut{
 			return err
 		}
 		table := strings.TrimSpace(rctx.Str("table"))
-		data, err := rctx.CallAPITyped("POST", appAuditSetPath(appID),
-			dbEnvParams(rctx, map[string]interface{}{}),
-			map[string]interface{}{"table": table, "enabled": false})
+		// The disable path also initializes the DTS task (to narrow the subscription),
+		// so it contends on the same lock and is retried the same way.
+		data, err := callWithDTSLockRetry(rctx.Ctx(), func() (map[string]interface{}, error) {
+			return rctx.CallAPITyped("POST", appAuditSetPath(appID),
+				dbEnvParams(rctx, map[string]interface{}{}),
+				map[string]interface{}{"table": table, "enabled": false})
+		})
 		if err != nil {
 			return withAppsHint(err, dbAuditSetHint)
 		}

--- a/shortcuts/apps/apps_db_audit_test.go
+++ b/shortcuts/apps/apps_db_audit_test.go
@@ -320,3 +320,82 @@ func TestAppsDBAuditList_MultiTableAllFilteredSkipsQuery(t *testing.T) {
 		t.Fatalf("expected empty + 'Skipped 2 of 2 tables':\n%s", got)
 	}
 }
+
+// ── DTS init lock contention（命令层接线）──
+
+// lockContentionBody 是服务端并发抢锁失败的响应体。
+func lockContentionBody() map[string]interface{} {
+	return map[string]interface{}{
+		"code": 500002776,
+		"msg":  dtsInitFailedSubcode + "：[EnsureDTSTask] lock already held, workspace: workspace_x, branch: dev",
+	}
+}
+
+// TestAppsDBAuditEnable_RetriesLockContention 验证重试确实接在命令上，而不只是 helper 里能跑：
+// 第一次请求撞锁、第二次成功，命令整体应当成功，用户看不到那次竞态。
+func TestAppsDBAuditEnable_RetriesLockContention(t *testing.T) {
+	shortenBackoff(t)
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{Method: "POST", URL: dbAuditSetURL, Body: lockContentionBody()})
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: dbAuditSetURL,
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"status": map[string]interface{}{"table": "orders", "enabled": true, "retention": "30d"}}},
+	})
+
+	if err := runAppsShortcut(t, AppsDBAuditEnable,
+		[]string{"+db-audit-enable", "--app-id", "app_x", "--table", "orders", "--retention", "30d", "--as", "user"},
+		factory, stdout); err != nil {
+		t.Fatalf("contention should have been retried away, got err=%v", err)
+	}
+	if !strings.Contains(stdout.String(), `"enabled": true`) {
+		t.Fatalf("expected the successful retry's payload, got %s", stdout.String())
+	}
+	reg.Verify(t) // both stubs consumed → the second POST really was sent
+}
+
+// TestAppsDBAuditDisable_RetriesLockContention 关闭路径同样会刷新 DTS 订阅、撞同一把锁。
+func TestAppsDBAuditDisable_RetriesLockContention(t *testing.T) {
+	shortenBackoff(t)
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{Method: "POST", URL: dbAuditSetURL, Body: lockContentionBody()})
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: dbAuditSetURL,
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"status": map[string]interface{}{"table": "orders", "enabled": false}}},
+	})
+
+	if err := runAppsShortcut(t, AppsDBAuditDisable,
+		[]string{"+db-audit-disable", "--app-id", "app_x", "--table", "orders", "--as", "user"},
+		factory, stdout); err != nil {
+		t.Fatalf("contention should have been retried away, got err=%v", err)
+	}
+	reg.Verify(t)
+}
+
+// TestAppsDBAuditEnable_LockContentionOutlastingRetries 验证重试耗尽后用户看到的形态：
+// 可重试的服务端错误 + 点明并发的文案，而不是原来的 unknown + 「检查 app-id/table」。
+func TestAppsDBAuditEnable_LockContentionOutlastingRetries(t *testing.T) {
+	shortenBackoff(t)
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: dbAuditSetURL, Body: lockContentionBody(), Reusable: true,
+	})
+
+	err := runAppsShortcut(t, AppsDBAuditEnable,
+		[]string{"+db-audit-enable", "--app-id", "app_x", "--table", "orders", "--as", "user"},
+		factory, stdout)
+	if err == nil {
+		t.Fatal("persistent contention must still surface as an error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected a typed error, got %T", err)
+	}
+	if p.Subtype != errs.SubtypeServerError || !p.Retryable {
+		t.Fatalf("subtype/retryable = %s/%v, want server_error/true", p.Subtype, p.Retryable)
+	}
+	if !strings.Contains(p.Hint, "concurrent") {
+		t.Fatalf("hint = %q, must name the concurrency", p.Hint)
+	}
+}

--- a/shortcuts/apps/common.go
+++ b/shortcuts/apps/common.go
@@ -141,6 +141,13 @@ func withObservabilityHint(err error) error {
 // terms and any generic hint would be less actionable. That failure is only
 // produced by db endpoints, so the override is safe to check for every apps
 // command that funnels through here.
+//
+// Second special case: db failures whose numeric code is a shared
+// responsibility bucket and whose real reason is a `k_dl_` subcode on the message
+// (see applyDBSubcode). Checked here, at the chokepoint, because the collapse is a
+// property of the db OpenAPI rather than of any one command — audit, env-create
+// and their neighbours all receive the same code for unrelated reasons. Matching
+// requires an exact known subcode, so commands that never see one are unaffected.
 func withAppsHint(err error, hint string) error {
 	if err == nil {
 		return nil
@@ -150,6 +157,11 @@ func withAppsHint(err error, hint string) error {
 		if isAppNoDatabaseError(p) {
 			p.Message = appNoDatabaseMessage
 			p.Hint = appNoDatabaseHint
+			return err
+		}
+		// Before the generic hint: the subcode identifies one scenario, so its
+		// guidance always beats a per-command fallback written for the whole family.
+		if applyDBSubcode(p) {
 			return err
 		}
 		if strings.TrimSpace(p.Hint) == "" && hintExplainsFailure(p) {

--- a/shortcuts/apps/db_dts_retry.go
+++ b/shortcuts/apps/db_dts_retry.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package apps
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// Turning table audit on or off makes the server initialize the app's data-sync
+// (DTS) task, and that initialization takes a workspace-wide lock. When a
+// concurrent request already holds it, the server reports a failure instead of
+// waiting — so two audit commands issued close together leave one caller with a
+// generic "System error" for what is only contention.
+//
+// Retrying is safe here, which is not true of writes in general: the server rolls
+// its own changelog write back before returning, so a contended call leaves audit
+// off rather than half-applied, and a repeat either succeeds or reports "already
+// enabled" (k_dl_4000019, classified). Verified against a live multi-env app —
+// every contended table stayed disabled, and a serial repeat turned it on.
+//
+// Deliberately bounded and short. The server-side lock TTL is minutes, so a slow
+// holder — one actually creating the remote task rather than adjusting it — cannot
+// be waited out inside an interactive command; those exhaust the attempts and
+// surface as a retryable server error. What this does cover is the common case
+// where the holder finishes in well under a second.
+//
+// Retrying does not hide the defect from the service owners: the server logs a
+// warning on every contention regardless of what the client does next.
+const (
+	dtsInitFailedSubcode = "k_dl_1600039"
+
+	// dtsLockHeldMarker distinguishes lock contention from the other cause that
+	// shares dtsInitFailedSubcode — a remote sync task in a terminal state, which
+	// is not resolved by retrying in the next few seconds. Matching the subcode
+	// alone would burn the whole backoff on failures that cannot recover from it.
+	dtsLockHeldMarker = "lock already held"
+)
+
+// dtsLockContentionMessage / dtsLockContentionHint describe the contention in the
+// caller's terms, replacing the server's "lock already held, workspace: …,
+// branch: …" once it has been recognised.
+//
+// The hint states that the CLI already retried. Without that, the advice to run
+// the command again reads as "you did something wrong, do it again" — and a caller
+// who has just waited through the backoff would reasonably expect the CLI to have
+// tried, so saying so is what makes a further manual attempt look sensible rather
+// than superstitious.
+const (
+	dtsLockContentionMessage = "another request is already initializing this app's data-sync task"
+
+	dtsLockContentionHint = "this is a collision with a concurrent request, not a problem with this command — " +
+		"audit was left unchanged. The CLI already retried and the other request was still running. " +
+		"Run the same command again in a few seconds, and avoid issuing audit changes for one app in parallel."
+)
+
+// Package-level so tests can shorten the schedule; production never reassigns them.
+var (
+	dtsLockRetryAttempts  = 3
+	dtsLockRetryBaseDelay = 400 * time.Millisecond
+)
+
+// isDTSLockContention reports whether err is the transient "another request holds
+// the DTS init lock" failure. Requires both the stable subcode and the lock marker;
+// see dtsLockHeldMarker for why the subcode alone is not enough.
+func isDTSLockContention(err error) bool {
+	if err == nil {
+		return false
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		return false
+	}
+	return strings.Contains(p.Message, dtsInitFailedSubcode) &&
+		strings.Contains(p.Message, dtsLockHeldMarker)
+}
+
+// dtsLockRetryDelay is exponential with jitter. The jitter matters more than the
+// growth: callers that collided once are in lockstep, and retrying on identical
+// schedules would just have them collide again.
+func dtsLockRetryDelay(attempt int) time.Duration {
+	base := dtsLockRetryBaseDelay * (1 << uint(attempt))
+	return base + time.Duration(rand.Int63n(int64(base/2)+1))
+}
+
+// callWithDTSLockRetry runs call, repeating it while it fails with DTS lock
+// contention, up to dtsLockRetryAttempts extra times.
+//
+// Anything else — success, or any other failure — returns immediately: this must
+// not become a general-purpose retry around a write.
+//
+// The wait honours ctx, matching pollUntil. Sleeping unconditionally would let a
+// cancelled command issue another audit write after the caller had already walked
+// away — the one thing that turns a harmless retry into a surprising one.
+func callWithDTSLockRetry(ctx context.Context, call func() (map[string]interface{}, error)) (map[string]interface{}, error) {
+	data, err := call()
+	for attempt := 0; attempt < dtsLockRetryAttempts && isDTSLockContention(err); attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport,
+				"cancelled while waiting to retry after a concurrent request").WithCause(ctx.Err())
+		case <-time.After(dtsLockRetryDelay(attempt)):
+		}
+		data, err = call()
+	}
+	return data, err
+}

--- a/shortcuts/apps/db_dts_retry_test.go
+++ b/shortcuts/apps/db_dts_retry_test.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package apps
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// lockErr builds the wire shape of DTS lock contention: the stable subcode plus
+// the lock marker, both carried on the message.
+func lockErr() error {
+	return errs.NewAPIError(errs.SubtypeUnknown,
+		"%s", dtsInitFailedSubcode+"：[EnsureDTSTask] lock already held, workspace: workspace_x, branch: dev").
+		WithCode(500002776)
+}
+
+// terminalStateErr stands in for the other cause behind the same subcode. Its
+// wording is constructed, not captured: this package has only ever observed the
+// lock variant on the wire. That is precisely why the classification refuses to
+// call this one retryable — the tests below assert the conservative treatment of
+// a variant we cannot recognise, not the behaviour of a known message.
+func terminalStateErr() error {
+	return errs.NewAPIError(errs.SubtypeUnknown,
+		"%s", dtsInitFailedSubcode+"：volc dts task in terminal status").WithCode(500002776)
+}
+
+// shortenBackoff keeps the real waiting path under test — the cancellation
+// behaviour lives in it — while making the schedule too short to slow the suite.
+func shortenBackoff(t *testing.T) {
+	t.Helper()
+	orig := dtsLockRetryBaseDelay
+	dtsLockRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { dtsLockRetryBaseDelay = orig })
+}
+
+func TestIsDTSLockContention(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"lock contention", lockErr(), true},
+		{
+			// Not resolved by waiting a second, so it must not consume the backoff.
+			name: "same subcode without the lock marker",
+			err:  terminalStateErr(),
+			want: false,
+		},
+		{
+			// Guards against matching on the human-readable phrase alone.
+			name: "lock marker without the subcode",
+			err:  errs.NewAPIError(errs.SubtypeUnknown, "some other lock already held").WithCode(500002776),
+			want: false,
+		},
+		{"nil", nil, false},
+		{"untyped", errors.New("lock already held k_dl_1600039"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDTSLockContention(tc.err); got != tc.want {
+				t.Fatalf("isDTSLockContention = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDTSLockRetryDelayGrows pins the schedule shape directly, so the call-path
+// tests do not have to observe timing to prove it.
+func TestDTSLockRetryDelayGrows(t *testing.T) {
+	// Jitter is additive on top of the doubling base, so the floor of each attempt
+	// still exceeds the ceiling of the one before it.
+	for attempt := 0; attempt < dtsLockRetryAttempts-1; attempt++ {
+		base := dtsLockRetryBaseDelay * (1 << uint(attempt))
+		maxThis := base + base/2
+		minNext := dtsLockRetryBaseDelay * (1 << uint(attempt+1))
+		if minNext <= maxThis {
+			t.Fatalf("attempt %d can be >= attempt %d; lockstep callers would collide again", attempt, attempt+1)
+		}
+	}
+	// And jitter must actually vary, or the separation it exists for never happens.
+	seen := map[time.Duration]bool{}
+	for i := 0; i < 50; i++ {
+		seen[dtsLockRetryDelay(2)] = true
+	}
+	if len(seen) < 2 {
+		t.Fatal("dtsLockRetryDelay is constant; collided callers would retry in lockstep")
+	}
+}
+
+func TestCallWithDTSLockRetry_SucceedsAfterContention(t *testing.T) {
+	shortenBackoff(t)
+	calls := 0
+	data, err := callWithDTSLockRetry(context.Background(), func() (map[string]interface{}, error) {
+		calls++
+		if calls < 3 {
+			return nil, lockErr()
+		}
+		return map[string]interface{}{"ok": true}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected success once contention cleared, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3 (two contended, one succeeding)", calls)
+	}
+	if data["ok"] != true {
+		t.Fatalf("payload from the successful attempt was lost: %v", data)
+	}
+}
+
+func TestCallWithDTSLockRetry_BoundedWhenContentionPersists(t *testing.T) {
+	shortenBackoff(t)
+	calls := 0
+	_, err := callWithDTSLockRetry(context.Background(), func() (map[string]interface{}, error) {
+		calls++
+		return nil, lockErr()
+	})
+	if !isDTSLockContention(err) {
+		t.Fatalf("original error must survive exhaustion, got %v", err)
+	}
+	if calls != dtsLockRetryAttempts+1 {
+		t.Fatalf("calls = %d, want %d (first attempt plus the bounded repeats)", calls, dtsLockRetryAttempts+1)
+	}
+}
+
+// TestCallWithDTSLockRetry_DoesNotRetryOtherFailures is the guard that keeps this
+// from becoming a general retry wrapper around a write: only lock contention is
+// known to leave no partial state behind.
+func TestCallWithDTSLockRetry_DoesNotRetryOtherFailures(t *testing.T) {
+	shortenBackoff(t)
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"terminal-state sibling", terminalStateErr()},
+		{"already enabled", errs.NewAPIError(errs.SubtypeUnknown, "k_dl_4000019：Audit is already enabled for table 'orders'").WithCode(400002476)},
+		{"unrelated", errors.New("network down")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			_, err := callWithDTSLockRetry(context.Background(), func() (map[string]interface{}, error) {
+				calls++
+				return nil, tc.err
+			})
+			if calls != 1 {
+				t.Fatalf("calls = %d, want 1 — only lock contention may be repeated", calls)
+			}
+			if !errors.Is(err, tc.err) && err != tc.err {
+				t.Fatalf("error was not returned unchanged: %v", err)
+			}
+		})
+	}
+}
+
+func TestCallWithDTSLockRetry_NoRetryOnSuccess(t *testing.T) {
+	shortenBackoff(t)
+	calls := 0
+	if _, err := callWithDTSLockRetry(context.Background(), func() (map[string]interface{}, error) {
+		calls++
+		return map[string]interface{}{"ok": true}, nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, a first-try success must not repeat", calls)
+	}
+}
+
+// TestCallWithDTSLockRetry_CancellationStopsBeforeNextWrite is the reason the wait
+// is a select and not a sleep: audit set is a write, and a cancelled command must
+// not send another one after the caller has walked away.
+func TestCallWithDTSLockRetry_CancellationStopsBeforeNextWrite(t *testing.T) {
+	// Long enough that the test would notice if cancellation were ignored.
+	orig := dtsLockRetryBaseDelay
+	dtsLockRetryBaseDelay = 2 * time.Second
+	t.Cleanup(func() { dtsLockRetryBaseDelay = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	start := time.Now()
+	_, err := callWithDTSLockRetry(ctx, func() (map[string]interface{}, error) {
+		calls++
+		cancel() // caller gives up while the first contended attempt is in flight
+		return nil, lockErr()
+	})
+
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 — cancellation must prevent the additional write", calls)
+	}
+	if elapsed := time.Since(start); elapsed >= dtsLockRetryBaseDelay {
+		t.Fatalf("returned after %s; cancellation must not wait out the backoff", elapsed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cause chain lost: errors.Is(err, context.Canceled) = false, err = %v", err)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Category != errs.CategoryNetwork {
+		t.Fatalf("want a typed network error on cancellation, got %#v", err)
+	}
+}
+
+// TestWithAppsHint_DTSLockContentionWording pins what the caller sees once the
+// retries are spent: a server-side classification carrying the retryable flag, and
+// wording that says this was a collision rather than a rejection.
+func TestWithAppsHint_DTSLockContentionWording(t *testing.T) {
+	cause := errors.New("upstream transport failure")
+	in := lockErr().(*errs.APIError).WithCause(cause)
+	out := withAppsHint(in, dbAuditSetHint)
+
+	if !errors.Is(out, cause) {
+		t.Errorf("cause chain lost: errors.Is(out, cause) = false")
+	}
+	p, _ := errs.ProblemOf(out)
+	if p.Category != errs.CategoryAPI || p.Subtype != errs.SubtypeServerError {
+		t.Fatalf("category/subtype = %s/%s, want api/server_error", p.Category, p.Subtype)
+	}
+	if !p.Retryable {
+		t.Fatal("Retryable = false; repeating this request unchanged is what resolves it")
+	}
+	if strings.Contains(p.Hint, "verify --app-id") {
+		t.Fatalf("hint = %q, must not blame the request", p.Hint)
+	}
+	// The caller must be able to tell this was a collision, not a rejection, and
+	// that the CLI already tried — otherwise "run it again" reads as superstition.
+	if !strings.Contains(p.Hint, "concurrent") || !strings.Contains(p.Hint, "already retried") {
+		t.Fatalf("hint = %q, must name the concurrency and say the CLI already retried", p.Hint)
+	}
+	if !strings.Contains(p.Message, "another request") {
+		t.Fatalf("message = %q, want the contention stated in the caller's terms", p.Message)
+	}
+	// Internal wording must not reach users; log_id/troubleshooter keep the original.
+	for _, internal := range []string{"EnsureDTSTask", "lock already held", "workspace_", "branch:"} {
+		if strings.Contains(p.Message, internal) {
+			t.Fatalf("message = %q leaks internal wording %q", p.Message, internal)
+		}
+	}
+}
+
+// TestWithAppsHint_DTSTerminalStateKeepsNeutralWording covers the other cause
+// behind the same subcode: with no lock marker it must keep the table's neutral
+// entry, not be described as a concurrency collision it is not.
+func TestWithAppsHint_DTSTerminalStateKeepsNeutralWording(t *testing.T) {
+	out := withAppsHint(terminalStateErr(), dbAuditSetHint)
+
+	p, _ := errs.ProblemOf(out)
+	if p.Subtype != errs.SubtypeServerError {
+		t.Fatalf("subtype = %s, want server_error", p.Subtype)
+	}
+	// Not retryable: this package has never observed this variant's wire message,
+	// and a task stuck in a terminal state is not fixed by calling again. Promising
+	// otherwise would walk an agent through attempts that cannot work.
+	if p.Retryable {
+		t.Fatal("Retryable = true for a cause never observed to clear on its own")
+	}
+	if !strings.Contains(p.Hint, "needs attention") {
+		t.Fatalf("hint = %q, must not promise that repeating alone resolves it", p.Hint)
+	}
+	if strings.Contains(p.Hint, "concurrent") || p.Message == dtsLockContentionMessage {
+		t.Fatalf("non-contention cause was described as contention: msg=%q hint=%q", p.Message, p.Hint)
+	}
+	if p.Message != "volc dts task in terminal status" {
+		t.Fatalf("message = %q, want the server wording kept for the unrecognised variant", p.Message)
+	}
+}

--- a/shortcuts/apps/db_subcode.go
+++ b/shortcuts/apps/db_subcode.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package apps
+
+import (
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// The db OpenAPI collapses every dataloom business failure into one of two codes.
+// paas_integration classifies by the FIRST DIGIT of dataloom's 7-digit code —
+// 4xxxxxx ("caller's problem", not counted against SLA) becomes 400002476, and
+// 5xxxxxx becomes 500002776. That split exists for SLA attribution, and it is the
+// only thing the numeric code carries: a dozen unrelated business states share one
+// number. The specific reason survives only as a `k_dl_<7 digits>` prefix on the
+// server message.
+//
+// So the CLI cannot classify these on p.Code — every one of them would land on the
+// same subtype. It classifies on the subcode instead, which is a backend contract
+// (one code, one scenario) rather than the free-text English that follows it.
+//
+// This table is deliberately keyed on the subcode STRING, not on where the subcode
+// was read from. Today the only channel is the message prefix; when the gateway
+// exposes the subcode as a structured field, only subcodeOf changes — the table,
+// the classifications and the hints stay put.
+//
+// Entries are added from observed wire behaviour, not from reading dataloom's
+// constant list: an unmapped subcode degrades to today's behaviour (subtype
+// unknown, generic hint, prefix left visible for debugging), which is honest,
+// whereas a guessed classification is not.
+type dbSubcodeMeta struct {
+	Category errs.Category
+	Subtype  errs.Subtype
+	Hint     string
+
+	// Retryable marks a failure the caller can resolve by repeating the same
+	// request unchanged. Only for genuinely transient server-side conditions —
+	// never for anything the caller must change first, which would send an agent
+	// into a loop that cannot succeed.
+	Retryable bool
+
+	// Message is used only when the server sends the subcode with no wording after
+	// it (`k_dl_4000004：` and nothing else) — seen if an i18n lookup resolves to an
+	// empty string. It cannot be skipped by simply assigning the empty remainder:
+	// errs.Problem documents Message as REQUIRED, and an empty one makes Error()
+	// return "", which silently swallows the failure in any fmt.Errorf("...: %v").
+	// Leaving the raw prefix instead would put internal vocabulary in front of
+	// users, so each entry carries its own wording, phrased to match what the
+	// server normally sends for that subcode.
+	Message string
+}
+
+// dbSubcodeTable maps stable dataloom subcodes to a classification and a hint that
+// names the actual fix.
+//
+// Hints state the product rule rather than framing the working environment as a
+// retry trick, matching dbSyncOnlineDDLHint: the request is not malformed, the
+// target environment is what is wrong, so "verify --app-id and --table" (the
+// generic db hint) sends the caller to inspect two things that are both correct.
+var dbSubcodeTable = map[string]dbSubcodeMeta{
+	// Multi-env apps forbid changing audit settings on the online branch
+	// (dataloom ErrOnlineEnvForbidAuditLog, thrown only when
+	// env==online && expert mode && multi-env workspace).
+	//
+	// FailedPrecondition, mirroring the sibling online-DDL ban: the request is
+	// valid, the environment state is not, and retrying is guaranteed to fail.
+	// Exit 2 rather than 1 tells an agent to change the request, not to back off.
+	//
+	// "a multi-env app" is the scope qualifier, not filler: the ban never fires for
+	// single-env apps, whose only branch is online and where audit works normally.
+	"k_dl_4000004": {
+		Category: errs.CategoryValidation,
+		Subtype:  errs.SubtypeFailedPrecondition,
+		Hint:     "a multi-env app only allows audit settings to be changed on the dev branch. Rerun with `--environment dev`.",
+		Message:  "changing audit settings is not allowed on the online branch",
+	},
+
+	// Enabling audit on a table that already has it on. Idempotency violation:
+	// nothing changed, and the caller usually wants to read the current setting.
+	"k_dl_4000019": {
+		Category: errs.CategoryAPI,
+		Subtype:  errs.SubtypeAlreadyExists,
+		Hint:     "audit is already enabled for this table and nothing was changed. Inspect the current retention with `lark-cli apps +db-audit-status --app-id <app_id> --table <table>`.",
+		Message:  "audit is already enabled for this table",
+	},
+
+	// Disabling audit on a table that never had it on.
+	"k_dl_4000020": {
+		Category: errs.CategoryValidation,
+		Subtype:  errs.SubtypeFailedPrecondition,
+		Hint:     "audit is not enabled for this table, so there is nothing to disable. List the tables that do have it on with `lark-cli apps +db-audit-status --app-id <app_id>`.",
+		Message:  "audit is not enabled for this table",
+	},
+
+	// +db-data-import hit a cell whose value does not fit the target column's type.
+	// The server already names the row, column, value and expected type in the
+	// message, so the hint only has to point at it.
+	//
+	// InvalidArgument, not FailedPrecondition: nothing about the database state is
+	// wrong — the file the caller supplied is. Exit 2 says "fix the input", which is
+	// exactly the action, and separates it from the generic api/unknown exit 1 that
+	// reads as "something went wrong server-side, maybe retry". Retrying an
+	// unchanged file always fails.
+	//
+	// Covers every column type, not just dates: the server maps both the
+	// invalid-text and invalid-datetime cases here.
+	"k_dl_4000012": {
+		Category: errs.CategoryValidation,
+		Subtype:  errs.SubtypeInvalidArgument,
+		Hint:     "the message names the row, column and expected type. Correct that value in the data file and re-import.",
+		Message:  "a value in the import file does not match its column type",
+	},
+
+	// The app's data-sync (DTS) task could not be initialized while turning table
+	// audit on or off. Two distinct causes share this subcode: a concurrent request
+	// holding the initialization lock, and the remote sync task sitting in a
+	// terminal state. Both are server-side and transient from the caller's side —
+	// the request itself is well-formed — so the classification covers both and the
+	// hint does not tell the caller to change anything about it.
+	//
+	// The lock variant is retried in-process first (see db_dts_retry.go); reaching
+	// this classification means either that retry was exhausted or the cause was the
+	// terminal-state one.
+	//
+	// NOT marked retryable at the table level, even though one of its two causes is.
+	// Retryable is a machine-readable promise that repeating the call unchanged can
+	// succeed, and only the lock variant has been observed to behave that way — it is
+	// promoted in applyDBSubcode once the message identifies it. A task stuck in a
+	// terminal state is not fixed by calling again, and claiming otherwise would walk
+	// an agent through a round of attempts that cannot work, against a write endpoint.
+	// Asserting it for a variant whose wire message this package has never seen would
+	// be the guessed classification the table exists to avoid.
+	"k_dl_1600039": {
+		Category: errs.CategoryAPI,
+		Subtype:  errs.SubtypeServerError,
+		Hint: "the app's data-sync task could not be initialized. This is server-side and not a problem with the request — try once more, " +
+			"and if it repeats, the app's data-sync task needs attention rather than another attempt.",
+		Message: "the app's data-sync task could not be initialized",
+	},
+
+	// +db-env-create on an app whose dev/online split already exists. The split is
+	// one-time and irreversible, so this is a no-op, not a retryable failure.
+	"k_dl_4000023": {
+		Category: errs.CategoryAPI,
+		Subtype:  errs.SubtypeAlreadyExists,
+		Hint:     "this app already has dev and online branches; splitting is a one-time operation. Inspect the dev branch with `lark-cli apps +db-table-list --app-id <app_id> --environment dev`.",
+		Message:  "multi-env is already initialized for this app",
+	},
+}
+
+// dbSubcodePrefix is the marker dataloom stamps on the message ahead of its
+// business code.
+const dbSubcodePrefix = "k_dl_"
+
+// subcodeOf extracts the dataloom subcode from a server message and returns it
+// along with the message stripped of the `k_dl_<digits><colon>` prefix.
+//
+// Both colon forms are accepted: the wire uses the full-width "：" (U+FF1A), and
+// the ASCII ":" is tolerated so a server-side punctuation change does not silently
+// drop every classification below.
+//
+// Only a genuine prefix counts. Scanning the whole message for the marker would
+// misfire on messages that quote user input — table names and imported cell values
+// are echoed back verbatim, so a row containing the literal text "k_dl_4000004"
+// must not be classified as the online-audit ban.
+func subcodeOf(message string) (subcode, stripped string, ok bool) {
+	rest, found := strings.CutPrefix(message, dbSubcodePrefix)
+	if !found {
+		return "", message, false
+	}
+	digits := 0
+	for digits < len(rest) && rest[digits] >= '0' && rest[digits] <= '9' {
+		digits++
+	}
+	if digits == 0 {
+		return "", message, false
+	}
+	subcode = dbSubcodePrefix + rest[:digits]
+	tail := rest[digits:]
+	for _, colon := range []string{"：", ":"} {
+		if after, cut := strings.CutPrefix(tail, colon); cut {
+			return subcode, strings.TrimSpace(after), true
+		}
+	}
+	return "", message, false
+}
+
+// applyDBSubcode reclassifies a typed failure whose message carries a known
+// dataloom subcode, and reports whether it did.
+//
+// On a match it rewrites four things and returns true:
+//   - Category / Subtype — so the failure stops reading as "unknown" and the
+//     process exit code reflects what the caller should do about it;
+//   - Hint — the subcode names one scenario, so its guidance is strictly better
+//     than the per-command fallback and replaces it even when one is already set;
+//   - Message — the `k_dl_...：` prefix is internal vocabulary; it is dropped once
+//     it has been consumed, matching how the no-database failure rewrites the
+//     server's internal wording for users.
+//
+// p.Code is deliberately NOT rewritten to the subcode's digits. 400002476 is what
+// the server actually returned and what its troubleshooter URL in the same
+// envelope is keyed on; replacing it would make the two disagree and would report
+// a code the server never sent.
+//
+// An unmapped subcode is left completely alone — including its prefix, which stays
+// visible precisely because it is the only remaining clue for a case the CLI does
+// not yet understand.
+func applyDBSubcode(p *errs.Problem) bool {
+	if p == nil {
+		return false
+	}
+	subcode, stripped, ok := subcodeOf(p.Message)
+	if !ok {
+		return false
+	}
+	meta, known := dbSubcodeTable[subcode]
+	if !known {
+		return false
+	}
+	p.Category = meta.Category
+	p.Subtype = meta.Subtype
+	p.Hint = meta.Hint
+	p.Retryable = meta.Retryable
+
+	// Server wording wins when there is any; otherwise the table's own (see
+	// dbSubcodeMeta.Message). Never assign the empty remainder — Message is
+	// required, and blanking it would make Error() return "".
+	if stripped == "" {
+		stripped = meta.Message
+	}
+	p.Message = stripped
+
+	// Applied last, after the message assignment above, so the variant wording is
+	// not overwritten by the server text it is meant to replace.
+	//
+	// dtsInitFailedSubcode carries two causes with the same classification but
+	// different things worth telling the caller. Naming the one the server's wording
+	// identifies is the difference between a user thinking their command was
+	// rejected and knowing it merely collided with a concurrent one. The server's
+	// own text is replaced for the same reason the no-database failure's is —
+	// "lock already held, workspace: …, branch: …" is internal vocabulary; the
+	// original stays available via log_id / troubleshooter.
+	// Retryable is promoted here rather than carried on the entry: contention is the
+	// one cause of this subcode observed to clear on its own, so it is the only one
+	// the flag may promise anything about. See the entry's comment.
+	if subcode == dtsInitFailedSubcode && strings.Contains(stripped, dtsLockHeldMarker) {
+		p.Message = dtsLockContentionMessage
+		p.Hint = dtsLockContentionHint
+		p.Retryable = true
+	}
+	return true
+}

--- a/shortcuts/apps/db_subcode_test.go
+++ b/shortcuts/apps/db_subcode_test.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package apps
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// TestSubcodeOf covers the extraction contract: which messages yield a subcode,
+// and what the stripped remainder looks like.
+func TestSubcodeOf(t *testing.T) {
+	cases := []struct {
+		name     string
+		message  string
+		subcode  string
+		stripped string
+		ok       bool
+	}{
+		{
+			name:     "full-width colon is the wire form",
+			message:  "k_dl_4000004：forbid set audit log operation in online env",
+			subcode:  "k_dl_4000004",
+			stripped: "forbid set audit log operation in online env",
+			ok:       true,
+		},
+		{
+			name:     "ascii colon tolerated",
+			message:  "k_dl_4000019:Audit is already enabled for table 'orders'",
+			subcode:  "k_dl_4000019",
+			stripped: "Audit is already enabled for table 'orders'",
+			ok:       true,
+		},
+		{
+			name:     "unmapped subcode still parses; classification decides later",
+			message:  "k_dl_9999999：some future failure",
+			subcode:  "k_dl_9999999",
+			stripped: "some future failure",
+			ok:       true,
+		},
+		{
+			// Server sent the code with no wording after it. Still a valid subcode;
+			// applyDBSubcode is what decides the message (see the empty-remainder test).
+			name:     "subcode with empty remainder",
+			message:  "k_dl_4000004：",
+			subcode:  "k_dl_4000004",
+			stripped: "",
+			ok:       true,
+		},
+		{
+			name:    "no marker",
+			message: "System error, please contact the administrator",
+			ok:      false,
+		},
+		{
+			name:    "marker without digits",
+			message: "k_dl_：malformed",
+			ok:      false,
+		},
+		{
+			name:    "digits without colon",
+			message: "k_dl_4000004 forbid set audit log operation",
+			ok:      false,
+		},
+		{
+			// The decisive one: import errors echo user cell values verbatim, so a
+			// row whose text merely contains the marker must not be classified.
+			name:    "marker mid-message is not a prefix",
+			message: "Row 1, column 'note': value 'k_dl_4000004：x' is not a valid integer",
+			ok:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			subcode, stripped, ok := subcodeOf(tc.message)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (subcode=%q)", ok, tc.ok, subcode)
+			}
+			if !tc.ok {
+				if stripped != tc.message {
+					t.Fatalf("stripped = %q, want message unchanged on miss", stripped)
+				}
+				return
+			}
+			if subcode != tc.subcode {
+				t.Fatalf("subcode = %q, want %q", subcode, tc.subcode)
+			}
+			if stripped != tc.stripped {
+				t.Fatalf("stripped = %q, want %q", stripped, tc.stripped)
+			}
+		})
+	}
+}
+
+// TestWithAppsHint_OnlineAuditBan is the reproduced defect: enabling audit on the
+// online branch of a multi-env app. It must stop reading as an unknown API error
+// advising the caller to check --app-id and --table, both of which are correct.
+func TestWithAppsHint_OnlineAuditBan(t *testing.T) {
+	cause := errors.New("upstream transport failure")
+	in := errs.NewAPIError(errs.SubtypeUnknown, "k_dl_4000004：forbid set audit log operation in online env").
+		WithCode(400002476).WithLogID("log_audit").WithCause(cause)
+	out := withAppsHint(in, dbAuditSetHint)
+
+	if !errors.Is(out, cause) {
+		t.Errorf("cause chain lost: errors.Is(out, cause) = false")
+	}
+	p, ok := errs.ProblemOf(out)
+	if !ok {
+		t.Fatalf("withAppsHint returned untyped error: %T", out)
+	}
+	if p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("category/subtype = %s/%s, want validation/failed_precondition", p.Category, p.Subtype)
+	}
+	if !strings.Contains(p.Hint, "--environment dev") {
+		t.Fatalf("hint = %q, must name the dev branch as the fix", p.Hint)
+	}
+	// The generic hint sends the caller to inspect two correct things.
+	if strings.Contains(p.Hint, "verify --app-id") {
+		t.Fatalf("hint = %q, must not fall back to the generic db hint", p.Hint)
+	}
+	// The ban is multi-env-only, so the hint must say which apps it applies to
+	// rather than reading as "audit never works on online".
+	if !strings.Contains(p.Hint, "multi-env") {
+		t.Fatalf("hint = %q, must scope the ban to multi-env apps", p.Hint)
+	}
+	if strings.Contains(p.Message, dbSubcodePrefix) {
+		t.Fatalf("message = %q, internal subcode prefix must be stripped once consumed", p.Message)
+	}
+	// Server-reported identity is preserved: the troubleshooter URL in the same
+	// envelope is keyed on this code.
+	if p.Code != 400002476 || p.LogID != "log_audit" {
+		t.Fatalf("server-reported code/log_id mutated: %+v", p)
+	}
+}
+
+// TestWithAppsHint_SubcodeTable covers the remaining observed subcodes, each of
+// which shares code 400002476 with the ban above and with each other.
+func TestWithAppsHint_SubcodeTable(t *testing.T) {
+	cases := []struct {
+		name     string
+		message  string
+		category errs.Category
+		subtype  errs.Subtype
+		hintHas  string
+	}{
+		{
+			name:     "already enabled",
+			message:  "k_dl_4000019：Audit is already enabled for table 'orders'",
+			category: errs.CategoryAPI,
+			subtype:  errs.SubtypeAlreadyExists,
+			hintHas:  "+db-audit-status",
+		},
+		{
+			name:     "not enabled",
+			message:  "k_dl_4000020：Audit is not enabled for table 'orders'",
+			category: errs.CategoryValidation,
+			subtype:  errs.SubtypeFailedPrecondition,
+			hintHas:  "nothing to disable",
+		},
+		{
+			name:     "multi-env already initialized",
+			message:  "k_dl_4000023：Multi-env is already initialized",
+			category: errs.CategoryAPI,
+			subtype:  errs.SubtypeAlreadyExists,
+			hintHas:  "one-time",
+		},
+		{
+			// Non-date column, to pin that the entry is type-agnostic.
+			name:     "import type mismatch (integer)",
+			message:  "k_dl_4000012：Row 1, column 'qty': value '不是数字' is not a valid integer",
+			category: errs.CategoryValidation,
+			subtype:  errs.SubtypeInvalidArgument,
+			hintHas:  "re-import",
+		},
+		{
+			// The date variant reaches the same subcode once the server maps the
+			// invalid-datetime SQLSTATE alongside the invalid-text one.
+			name:     "import type mismatch (date)",
+			message:  "k_dl_4000012：Row 1, column 'ship_date': value '按铅改锂送仓时间' is not a valid date",
+			category: errs.CategoryValidation,
+			subtype:  errs.SubtypeInvalidArgument,
+			hintHas:  "re-import",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Every entry rewrites Message wholesale, which is exactly when an
+			// implementation that swapped the error value instead of mutating the
+			// Problem in place would silently break errors.Is for callers. Mirrors
+			// the guard on the no-database rewrite.
+			cause := errors.New("upstream transport failure")
+			in := errs.NewAPIError(errs.SubtypeUnknown, "%s", tc.message).WithCode(400002476).WithCause(cause)
+			out := withAppsHint(in, dbAuditSetHint)
+			if !errors.Is(out, cause) {
+				t.Errorf("cause chain lost: errors.Is(out, cause) = false")
+			}
+			p, _ := errs.ProblemOf(out)
+			if p.Category != tc.category || p.Subtype != tc.subtype {
+				t.Fatalf("category/subtype = %s/%s, want %s/%s", p.Category, p.Subtype, tc.category, tc.subtype)
+			}
+			if !strings.Contains(p.Hint, tc.hintHas) {
+				t.Fatalf("hint = %q, want it to mention %q", p.Hint, tc.hintHas)
+			}
+			if strings.Contains(p.Message, dbSubcodePrefix) {
+				t.Fatalf("message = %q, prefix must be stripped", p.Message)
+			}
+		})
+	}
+}
+
+// TestWithAppsHint_EmptyRemainderUsesTableMessage covers the server sending a
+// subcode with nothing after it. Two things must hold at once: the internal prefix
+// must not survive into the user-facing message, and the message must not be blanked
+// — errs.Problem requires it, and an empty one makes Error() return "", which
+// silently swallows the failure in any fmt.Errorf("...: %v", err).
+func TestWithAppsHint_EmptyRemainderUsesTableMessage(t *testing.T) {
+	for _, colon := range []string{"：", ":"} {
+		t.Run("colon="+colon, func(t *testing.T) {
+			cause := errors.New("upstream transport failure")
+			in := errs.NewAPIError(errs.SubtypeUnknown, "%s", "k_dl_4000004"+colon).WithCode(400002476).WithCause(cause)
+			out := withAppsHint(in, dbAuditSetHint)
+
+			if !errors.Is(out, cause) {
+				t.Errorf("cause chain lost: errors.Is(out, cause) = false")
+			}
+			p, _ := errs.ProblemOf(out)
+			if p.Message == "" {
+				t.Fatal("message was blanked; errs.Problem requires a non-empty Message")
+			}
+			if strings.Contains(p.Message, dbSubcodePrefix) {
+				t.Fatalf("message = %q, internal prefix must not survive", p.Message)
+			}
+			if p.Message != dbSubcodeTable["k_dl_4000004"].Message {
+				t.Fatalf("message = %q, want the table's fallback wording", p.Message)
+			}
+			// Classification still applies — the missing wording says nothing about
+			// which failure this is.
+			if p.Subtype != errs.SubtypeFailedPrecondition {
+				t.Fatalf("subtype = %s, want failed_precondition", p.Subtype)
+			}
+		})
+	}
+}
+
+// TestDBSubcodeTable_EveryEntryHasFallbackMessage stops a new entry from being added
+// without one: without it, a server message of just `k_dl_<code>：` would leave the
+// raw prefix in front of the user, which is the case this fallback exists to remove.
+func TestDBSubcodeTable_EveryEntryHasFallbackMessage(t *testing.T) {
+	for subcode, meta := range dbSubcodeTable {
+		if strings.TrimSpace(meta.Message) == "" {
+			t.Errorf("%s: Message is empty; add fallback wording for the no-remainder case", subcode)
+		}
+		if strings.Contains(meta.Message, dbSubcodePrefix) {
+			t.Errorf("%s: Message %q must not embed the internal subcode prefix", subcode, meta.Message)
+		}
+	}
+}
+
+// TestWithAppsHint_UnmappedSubcodeDegrades pins the failure mode for a subcode the
+// CLI does not know: today's behaviour, prefix intact. The prefix is the only clue
+// left for diagnosing a case with no table entry, so stripping it would make an
+// unknown failure harder to investigate, not easier.
+func TestWithAppsHint_UnmappedSubcodeDegrades(t *testing.T) {
+	in := errs.NewAPIError(errs.SubtypeUnknown, "k_dl_9999999：some future failure").WithCode(400002476)
+	out := withAppsHint(in, dbAuditSetHint)
+
+	p, _ := errs.ProblemOf(out)
+	if p.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("subtype = %s, unmapped subcode must not be given a guessed classification", p.Subtype)
+	}
+	if p.Hint != dbAuditSetHint {
+		t.Fatalf("hint = %q, want the per-command fallback", p.Hint)
+	}
+	if !strings.Contains(p.Message, "k_dl_9999999") {
+		t.Fatalf("message = %q, unmapped subcode must stay visible for debugging", p.Message)
+	}
+}
+
+// TestWithAppsHint_NoSubcodeUnaffected guards the blast radius: apps commands that
+// never see a k_dl_ message keep the existing fallback behaviour exactly.
+func TestWithAppsHint_NoSubcodeUnaffected(t *testing.T) {
+	in := errs.NewAPIError(errs.SubtypeUnknown, "some unrelated failure").WithCode(400002476)
+	out := withAppsHint(in, dbAuditSetHint)
+
+	p, _ := errs.ProblemOf(out)
+	if p.Subtype != errs.SubtypeUnknown || p.Hint != dbAuditSetHint {
+		t.Fatalf("unrelated failure was altered: %+v", p)
+	}
+}
+
+// TestWithAppsHint_NoDatabaseStillWins keeps the pre-existing override ahead of the
+// subcode branch. The no-database failure carries its own code and message markers
+// and must not be reinterpreted.
+func TestWithAppsHint_NoDatabaseStillWins(t *testing.T) {
+	in := errs.NewAPIError(errs.SubtypeUnknown, "get workspace id failed by app id").WithCode(400002465)
+	out := withAppsHint(in, dbAuditSetHint)
+
+	p, _ := errs.ProblemOf(out)
+	if p.Message != appNoDatabaseMessage || p.Hint != appNoDatabaseHint {
+		t.Fatalf("no-database override regressed: %+v", p)
+	}
+}


### PR DESCRIPTION
## Summary

Several db failures reached users as `subtype: unknown` with a hint that described the wrong problem, because the db OpenAPI gives a dozen unrelated business states the same numeric code. This classifies them on the stable `k_dl_` subcode the server puts on the message, and retries the one failure among them that is pure contention.

## Changes

- Add a subcode table (`shortcuts/apps/db_subcode.go`) mapping stable dataloom subcodes to a category/subtype and a hint that names the actual fix, plus prefix extraction that only accepts a genuine message prefix (import errors echo user cell values verbatim, so a mid-message match must not classify).
- Hook it into the existing `withAppsHint` chokepoint, ahead of the generic per-command hint and behind the existing no-database override.
- Cover six subcodes observed on the wire — the online audit ban, audit already enabled, audit not enabled, multi-env already initialized, import type mismatch, and data-sync task init failure. All six share one of two numeric codes today.
- Classify import type mismatches as `validation/invalid_argument` so the exit code says "fix the input": re-importing an unchanged file always fails the same way. The server already names the row, column, value and expected type; only the classification was missing.
- Retry data-sync init lock contention on audit set/unset (`db_dts_retry.go`), bounded with jittered backoff. Safe to repeat unlike writes in general: the server rolls its own changelog write back before returning, so a contended call leaves audit off rather than half-applied, and a repeat either succeeds or reports "already enabled". Matching requires the lock marker as well as the subcode — the same subcode also covers a remote task in a terminal state, which retrying cannot resolve.
- Strip the `k_dl_...` prefix from the user-facing message once consumed, falling back to per-entry wording when the server sends a subcode with no text — assigning the empty remainder would blank `Message`, which `errs.Problem` requires and whose absence makes `Error()` return `""`.

Deliberately not done: the numeric code is left as the server reported it, since the troubleshooter URL in the same envelope is keyed on it. The bucket code is also not added to the errclass table — giving it one subtype would reproduce the same collapse on the client. Nor is `--environment online` rejected at the flag layer: the ban is multi-env-only, and single-env apps use online as their only branch. The retry is not widened to other failures: contention is the only one known to leave no partial state behind.

## Test Plan

- [x] Unit tests pass (`go test ./shortcuts/apps/ ./internal/errclass/ ./errs/`), covering each mapped subcode, cause preservation across the message rewrite, the empty-remainder fallback in both colon forms, unmapped-subcode degradation, non-subcode failures keeping their prior classification, and the retry's bounds — that it repeats only lock contention, grows its delay, and leaves every other failure untouched
- [x] Manual local verification against a live multi-env app: `+db-audit-enable --environment online` exits 2 as `validation/failed_precondition` naming `--environment dev`; re-enabling an enabled table returns `api/already_exists`; importing a non-numeric value into an integer column and a non-date value into a date column both exit 2 as `validation/invalid_argument` with the offending row and column named; valid and empty values still import; concurrent audit set calls that previously failed 4-in-5 with a generic "System error" now mostly succeed, and contention outliving the retries reports `api/server_error` with `retryable: true`; `+db-table-get` on a missing table still returns `api/not_found` unchanged

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database error messages and guidance for audit settings, environment configuration, data imports, and development/online setup issues.
  - Preserved more specific server guidance instead of displaying generic command hints.
  - Added clearer messaging when audit settings are already enabled or not enabled.

- **Reliability**
  - Database audit enable and disable operations now automatically retry temporary data-sync initialization conflicts, improving recovery from transient server conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->