### PR TITLE
docs: improve option update guidance

### DIFF
--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark-base
-version: 1.2.21
+version: 1.2.22
 description: "飞书多维表格（Base）操作：建表、字段、记录、视图、统计、公式/lookup、表单、仪表盘、应用模式（BaseApp/AppMode 页面与组件）、Workspace 目录、workflow、角色权限、模板中心（多维表格模板分类/列表/搜索）；遇到 Base/多维表格/bitable、BaseApp/AppMode、/base/ 或 /app/ 链接时使用。BaseApp 不走 lark-apps；文件导入/导出转 lark-drive，认证/授权转 lark-shared。"
 metadata:
   requires:
@@ -83,6 +83,8 @@ Table 下的大多数更新通过异步链路生效，接口成功返回后立�
 Field 定义列 schema。`field_id` 是稳定列标识，`name` 是可修改的展示名称；Formula、Lookup、Link、Select 等属于 Field 类型或能力。
 
 **读取 Field：** `+field-list` / `+field-get` / `+field-search-options`。**写入 Field：** 已有 Table 中创建多个字段时，优先向一次 `+field-create --json` 传字段对象数组；单字段更新和删除用 `+field-update` / `+field-delete`。创建和更新分别读取 [field-create](references/lark-base-field-create.md) / [field-update](references/lark-base-field-update.md)，由命令文档继续路由 Field JSON、Formula 和 Lookup 协议。`字段插件` 用于扩展基础字段能力：按同一行其他字段内容触发 LLM 生成，并写回已有目标字段；当前已确认目标字段支持文本、单选、数字，配置或触发前先读 [field-extension](references/lark-base-field-extension.md)。
+
+> **Select 选项完整性是强制约束：** 查询单选或多选字段的选项必须使用 `+field-search-options`；这是分页接口，必须持续翻页直到取得全部选项。`+field-get` 返回的 `options` 可能只是前一部分，必须检查 `remaining_options_count`，不得把 `len(options)` 当作选项总数；只要 `remaining_options_count > 0`，当前 `options` 就不能作为 `+field-update` 的覆盖基线。使用 `+field-update` 增加、删除或更新选项时，必须先通过 `+field-search-options` 分页取得完整选项集，在完整集合上完成变换得到最终选项集，再把最终结果交给全量覆盖的 `+field-update`。禁止用 `+field-get` 返回的不完整 `options` 拼接新选项后直接更新字段。
 
 ### Record
 

--- a/skills/lark-base/references/lark-base-field-update.md
+++ b/skills/lark-base/references/lark-base-field-update.md
@@ -4,6 +4,8 @@
 
 更新一个已有字段。
 
+> **Select 选项更新特别警告：** `+field-get` 返回的 `options` 可能不完整。增加、删除或更新单选/多选选项时，禁止直接基于 `+field-get.options` 构造更新 payload；必须先用分页接口 `+field-search-options` 取得全部选项，再生成最终选项集并执行全量覆盖。
+
 ## 推荐命令
 
 ```bash
@@ -28,6 +30,22 @@ lark-cli base +field-update \
 
 > 这是**高风险写入操作**。`+field-update` 使用 `PUT` 全量字段定义语义；改变字段类型或关键配置可能影响整列已有数据的解释、展示或可用性。CLI 层要求显式传 `--yes`；如果用户已经明确目标和期望更新，可直接执行并带上 `--yes`。
 
+## Select 选项更新强制流程
+
+单选或多选字段的选项操作必须遵守以下完整性约束：
+
+1. **选项查询必须使用 `+field-search-options`。** 该命令是分页接口；从第一页开始，使用 `--limit` / `--offset` 持续读取，直到接口明确没有后续页，才能得到可用于写入的完整选项集。查询某个选项是否存在时也使用该命令，不要只检查 `+field-get.options`。
+2. **`+field-get.options` 不保证完整。** `+field-get` 用于读取字段名称、类型和其他字段配置；其响应中的 `options` 可能只返回前一部分。必须检查 `remaining_options_count`：只要该值大于 `0`，就表示仍有选项未返回，禁止把当前 `options` 当作全集，也禁止用 `len(options)` 声称字段的选项总数。
+3. **先收齐、再变换、最后覆盖。** `+field-update` 是全量 `PUT`。增加、删除或更新选项时，先用 `+field-search-options` 分页收齐全部现有选项；然后在完整集合上执行增加、删除、重命名、颜色调整等目标变换，得到最终选项集；最后把这个最终选项集放入完整字段定义并调用 `+field-update --yes`。
+4. **完整性无法证明就停止写入。** 任一分页读取失败、提前终止或无法确认已经读取全部选项时，不得执行 `+field-update`。应说明当前结果不完整并继续补齐读取；无法补齐时如实报告，不能用部分选项覆盖字段。
+
+```text
+field-get（字段其他配置，并检查 remaining_options_count）
+    + field-search-options（offset=0 开始，分页拉取全部选项）
+    + 在完整选项集上增加 / 删除 / 更新
+    + field-update（提交最终完整字段定义，全量 PUT）
+```
+
 ## API 入参详情
 
 **HTTP 方法和路径：**
@@ -42,7 +60,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 - 更新语义是 override 式的完整覆盖 `PUT`，不是 partial update；先读取当前定义，再提交整个字段需要保留的可写配置，不要只传零散片段。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接。
 - 需要字段默认值时传 `default_value`，直接使用字段对应 CellValue；传 `null` 清空。完整规则见 [Field Schema](lark-base-field-schema.md)。
-- `select` 更新时：`options` 仍按对象数组传，避免混入无效字段。
+- `select` 更新时：`options` 仍按对象数组传，避免混入无效字段；该数组必须来自上方流程收齐并变换后的最终完整选项集，不能直接使用 `+field-get.options`。
 - `link` 更新限制：
   - 不能把非 `link` 字段改成 `link`，也不能把 `link` 改成非 `link`。
   - 现有 `link` 字段的 `bidirectional` 不能改。
@@ -72,7 +90,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 ## 工作流
 
 
-1. 先用 `+field-get` 读取当前定义，只改变目标属性，并把需要保留的其他可写配置完整写回。
+1. 先用 `+field-get` 读取当前字段名称、类型和其他配置，并检查 `remaining_options_count`。若操作 Select 选项，再按“Select 选项更新强制流程”使用 `+field-search-options` 分页读取全部选项；只改变目标属性，并把需要保留的其他可写配置与最终完整选项集一并写回。
 2. `formula/lookup` 类型更新前先阅读对应指南。
 3. 如果这次更新会改变字段 `type`，先按下方“字段类型变更规则”判断能否执行。如果不修改 `type`，大多数场景都相对安全。
 
@@ -140,6 +158,8 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 ## 坑点
 
 - ⚠️ 这是全量字段属性更新语义，不是 patch。
+- ⚠️ Select 选项必须通过 `+field-search-options` 分页读取完整；`+field-get.options` 可能不全，必须检查 `remaining_options_count`。
+- ⚠️ 增加、删除或更新选项必须在完整选项集上生成最终结果后再全量覆盖；分页未完成时禁止调用 `+field-update`。
 - ⚠️ 这是高风险写入操作，执行时必须带 `--yes`。
 - ⚠️ 当 `type` 是 `formula` 或 `lookup` 时，先阅读对应指南再执行。
 


### PR DESCRIPTION
## Summary
Improve option update guidance.

## Changes
- Refine the Base skill guidance for updating options.

## Test Plan
- [x] Skill format check
- [x] `git diff --check`
- [ ] `make quality-gate` (blocked locally by Go 1.19.3; the project requires Go 1.23.0)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Lark Base guidance for managing single- and multi-select field options.
  - Select options must now be fully retrieved through paginated search before updates.
  - Added checks to confirm all options were retrieved before making changes.
  - Updates must be calculated from the complete option set and applied as a full replacement; incomplete data must not be used as a baseline.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->