### PR TITLE
docs: add Windows PATH fallback for AI hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ lark-cli calendar +agenda
 npx @larksuite/cli@latest install
 ```
 
+> **Windows AI hosts:** A global npm install places `lark-cli.cmd` in npm's
+> user-level prefix. Some sandboxed AI hosts do not inherit that directory in
+> `PATH`, even though `lark-cli` works in a regular PowerShell window. If
+> `lark-cli` is not found in the following steps, invoke the installed shim
+> directly with the same arguments:
+>
+> ```powershell
+> $npmPrefix = npm prefix -g
+> & "$npmPrefix\lark-cli.cmd" config init --new
+> ```
+>
+> Use the same resolved shim path with the arguments shown in Steps 3 and 4.
+> Restart the AI host after changing its environment. If it still does not
+> inherit the user-level `PATH`, continue using the resolved shim path.
+
 **Step 2 — Configure app credentials**
 
 > Run this command in the background. It will output an authorization URL — extract it and send it to the user. The command exits automatically after the user completes the setup in the browser.
@@ -132,19 +147,6 @@ lark-cli auth login --recommend
 ```bash
 lark-cli auth status
 ```
-
-> **Windows AI hosts:** A global npm install places `lark-cli.cmd` in npm's
-> user-level prefix. Some sandboxed AI hosts do not inherit that directory in
-> `PATH`, even though `lark-cli` works in a regular PowerShell window. If the
-> verification command is not found, invoke the installed shim directly:
->
-> ```powershell
-> $npmPrefix = npm prefix -g
-> & "$npmPrefix\lark-cli.cmd" auth status
-> ```
->
-> Restart the AI host after changing its environment. If it still does not
-> inherit the user-level `PATH`, use the resolved shim path for later commands.
 
 ## Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ lark-cli auth login --recommend
 lark-cli auth status
 ```
 
+> **Windows AI hosts:** A global npm install places `lark-cli.cmd` in npm's
+> user-level prefix. Some sandboxed AI hosts do not inherit that directory in
+> `PATH`, even though `lark-cli` works in a regular PowerShell window. If the
+> verification command is not found, invoke the installed shim directly:
+>
+> ```powershell
+> $npmPrefix = npm prefix -g
+> & "$npmPrefix\lark-cli.cmd" auth status
+> ```
+>
+> Restart the AI host after changing its environment. If it still does not
+> inherit the user-level `PATH`, use the resolved shim path for later commands.
+
 ## Agent Skills
 
 | Skill                           | Description                                                                                                    |

--- a/README.zh.md
+++ b/README.zh.md
@@ -111,6 +111,20 @@ lark-cli calendar +agenda
 npx @larksuite/cli@latest install
 ```
 
+> **Windows AI 环境：** npm 全局安装会将 `lark-cli.cmd` 放在 npm 的用户级目录中。
+> 部分沙箱化 AI 环境不会继承该目录的 `PATH`，因此即使 `lark-cli` 能在普通
+> PowerShell 中运行，AI 环境仍可能提示找不到命令。如果后续步骤找不到
+> `lark-cli`，请使用相同参数直接调用已安装的命令：
+>
+> ```powershell
+> $npmPrefix = npm prefix -g
+> & "$npmPrefix\lark-cli.cmd" config init --new
+> ```
+>
+> 第 3、4 步请继续使用上面解析出的完整路径，并替换为对应步骤所示参数。
+> 修改环境变量后请重启 AI 应用；如果应用仍不继承用户级 `PATH`，后续命令可继续
+> 使用该完整路径。
+
 **第 2 步 — 配置应用凭证**
 
 > 在后台运行此命令，命令会输出一个授权链接，提取该链接并发送给用户，用户在浏览器中完成配置后命令会自动退出。
@@ -132,18 +146,6 @@ lark-cli auth login --recommend
 ```bash
 lark-cli auth status
 ```
-
-> **Windows AI 环境：** npm 全局安装会将 `lark-cli.cmd` 放在 npm 的用户级目录中。
-> 部分沙箱化 AI 环境不会继承该目录的 `PATH`，因此即使 `lark-cli` 能在普通
-> PowerShell 中运行，AI 环境仍可能提示找不到命令。此时可直接调用已安装的命令：
->
-> ```powershell
-> $npmPrefix = npm prefix -g
-> & "$npmPrefix\lark-cli.cmd" auth status
-> ```
->
-> 修改环境变量后请重启 AI 应用。如果应用仍不继承用户级 `PATH`，后续命令可继续
-> 使用上面解析出的完整路径。
 
 ## Agent Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -133,6 +133,17 @@ lark-cli auth login --recommend
 lark-cli auth status
 ```
 
+> **Windows AI 环境：** npm 全局安装会将 `lark-cli.cmd` 放在 npm 的用户级目录中。
+> 部分沙箱化 AI 环境不会继承该目录的 `PATH`，因此即使 `lark-cli` 能在普通
+> PowerShell 中运行，AI 环境仍可能提示找不到命令。此时可直接调用已安装的命令：
+>
+> ```powershell
+> $npmPrefix = npm prefix -g
+> & "$npmPrefix\lark-cli.cmd" auth status
+> ```
+>
+> 修改环境变量后请重启 AI 应用。如果应用仍不继承用户级 `PATH`，后续命令可继续
+> 使用上面解析出的完整路径。
 
 ## Agent Skills
 


### PR DESCRIPTION
## Summary

Document how to use a global npm installation from Windows AI hosts that do
not inherit npm's user-level PATH.

## Changes

- Explain why `lark-cli` may work in PowerShell but remain unavailable in a
  sandboxed AI host.
- Add a PowerShell fallback that resolves the npm global prefix and invokes
  `lark-cli.cmd` directly.
- Keep the English and Chinese quick-start documentation aligned.

## Test Plan

- [x] `git diff --check`
- [x] Verified both README files remain UTF-8 without BOM and have balanced
      Markdown code fences.
- [x] Verified `npm prefix -g` resolves the global npm directory and the
      resulting `lark-cli.cmd` launches successfully on Windows.

## Related Issues

- Addresses #2626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved Windows troubleshooting guidance in the AI Agent quick-start instructions.
  - Added instructions for resolving and directly invoking the CLI when sandboxed environments do not inherit npm’s global path.
  - Clarified how to reuse the resolved CLI path in subsequent steps or restart the AI host.
  - Updated the guidance in both English and Chinese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->