### PR TITLE
feat(mail): use default send-as identity in shortcuts

### DIFF
--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -388,10 +388,10 @@ type composeIdentity struct {
 // a failed or malformed settings response falls back to the old primary-email
 // lookup so the new dependency cannot block existing commands.
 func resolveComposeIdentity(runtime *common.RuntimeContext, mailboxID string, scenario composeScenario, originalTo, originalCC []string) composeIdentity {
-	if from := strings.TrimSpace(runtime.Str("from")); from != "" {
+	if from := runtime.Str("from"); from != "" {
 		return composeIdentity{Email: from}
 	}
-	if mailbox := strings.TrimSpace(runtime.Str("mailbox")); mailbox != "" && mailbox != "me" {
+	if mailbox := runtime.Str("mailbox"); mailbox != "" && mailbox != "me" {
 		return composeIdentity{Email: mailbox}
 	}
 
@@ -439,7 +439,7 @@ func composeFallbackName(runtime *common.RuntimeContext) string {
 	if runtime == nil || runtime.Config == nil {
 		return ""
 	}
-	return strings.TrimSpace(runtime.Config.UserName)
+	return runtime.Config.UserName
 }
 
 func withComposeFallbackName(identity composeIdentity, runtime *common.RuntimeContext) composeIdentity {
@@ -471,8 +471,8 @@ func parseSendAsIdentities(data map[string]interface{}) ([]composeIdentity, bool
 		}
 		isDefault, _ := entry["is_default"].(bool)
 		identities = append(identities, composeIdentity{
-			Email:     strings.TrimSpace(strVal(entry["email_address"])),
-			Name:      strings.TrimSpace(strVal(entry["name"])),
+			Email:     strVal(entry["email_address"]),
+			Name:      strVal(entry["name"]),
 			IsDefault: isDefault,
 		})
 	}

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -368,6 +368,153 @@ func resolveComposeSenderEmail(runtime *common.RuntimeContext) string {
 	return email
 }
 
+type composeScenario int
+
+const (
+	composeScenarioNew composeScenario = iota
+	composeScenarioReply
+)
+
+type composeIdentity struct {
+	Email      string
+	Name       string
+	IsDefault  bool
+	SelfEmails []string
+}
+
+// resolveComposeIdentity selects the From identity for one compose command.
+// Explicit flags preserve their historical behavior and avoid any additional
+// API call. Automatic selection uses settings/send_as when it is trustworthy;
+// a failed or malformed settings response falls back to the old primary-email
+// lookup so the new dependency cannot block existing commands.
+func resolveComposeIdentity(runtime *common.RuntimeContext, mailboxID string, scenario composeScenario, originalTo, originalCC []string) composeIdentity {
+	if from := strings.TrimSpace(runtime.Str("from")); from != "" {
+		return composeIdentity{Email: from}
+	}
+	if mailbox := strings.TrimSpace(runtime.Str("mailbox")); mailbox != "" && mailbox != "me" {
+		return composeIdentity{Email: mailbox}
+	}
+
+	legacy := func() composeIdentity {
+		email, _ := fetchMailboxPrimaryEmail(runtime, "me")
+		return composeIdentity{Email: email}
+	}
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "settings", "send_as"), nil, nil)
+	if err != nil {
+		return legacy()
+	}
+	identities, ok := parseSendAsIdentities(data)
+	if !ok {
+		return legacy()
+	}
+
+	primaryEmail, _ := fetchMailboxPrimaryEmail(runtime, "me")
+	primary := composeIdentity{Email: primaryEmail, Name: composeFallbackName(runtime)}
+	selfEmails := make([]string, 0, len(identities)+1)
+	for _, identity := range identities {
+		if strings.TrimSpace(identity.Email) != "" {
+			selfEmails = append(selfEmails, identity.Email)
+		}
+	}
+	if strings.TrimSpace(primary.Email) != "" {
+		selfEmails = append(selfEmails, primary.Email)
+	}
+	if scenario == composeScenarioReply {
+		if identity, found := firstMatchingComposeIdentity(originalTo, originalCC, identities, primary); found {
+			identity = withComposeFallbackName(identity, runtime)
+			identity.SelfEmails = selfEmails
+			return identity
+		}
+	}
+	if identity, found := uniqueDefaultComposeIdentity(identities); found {
+		identity = withComposeFallbackName(identity, runtime)
+		identity.SelfEmails = selfEmails
+		return identity
+	}
+	primary.SelfEmails = selfEmails
+	return primary
+}
+
+func composeFallbackName(runtime *common.RuntimeContext) string {
+	if runtime == nil || runtime.Config == nil {
+		return ""
+	}
+	return strings.TrimSpace(runtime.Config.UserName)
+}
+
+func withComposeFallbackName(identity composeIdentity, runtime *common.RuntimeContext) composeIdentity {
+	if strings.TrimSpace(identity.Name) == "" {
+		identity.Name = composeFallbackName(runtime)
+	}
+	return identity
+}
+
+func parseSendAsIdentities(data map[string]interface{}) ([]composeIdentity, bool) {
+	raw, exists := data["sendable_addresses"]
+	if !exists {
+		if nested, ok := data["data"].(map[string]interface{}); ok {
+			raw, exists = nested["sendable_addresses"]
+		}
+	}
+	if !exists {
+		return nil, false
+	}
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	identities := make([]composeIdentity, 0, len(items))
+	for _, item := range items {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		isDefault, _ := entry["is_default"].(bool)
+		identities = append(identities, composeIdentity{
+			Email:     strings.TrimSpace(strVal(entry["email_address"])),
+			Name:      strings.TrimSpace(strVal(entry["name"])),
+			IsDefault: isDefault,
+		})
+	}
+	return identities, true
+}
+
+func uniqueDefaultComposeIdentity(identities []composeIdentity) (composeIdentity, bool) {
+	var selected composeIdentity
+	count := 0
+	for _, identity := range identities {
+		if identity.IsDefault {
+			count++
+			selected = identity
+		}
+	}
+	return selected, count == 1 && strings.TrimSpace(selected.Email) != ""
+}
+
+func firstMatchingComposeIdentity(originalTo, originalCC []string, identities []composeIdentity, primary composeIdentity) (composeIdentity, bool) {
+	byEmail := make(map[string]composeIdentity, len(identities)+1)
+	for _, identity := range identities {
+		key := strings.ToLower(strings.TrimSpace(identity.Email))
+		if key != "" {
+			if _, exists := byEmail[key]; !exists {
+				byEmail[key] = identity
+			}
+		}
+	}
+	if key := strings.ToLower(strings.TrimSpace(primary.Email)); key != "" {
+		if _, exists := byEmail[key]; !exists {
+			byEmail[key] = primary
+		}
+	}
+	for _, address := range append(append([]string(nil), originalTo...), originalCC...) {
+		key := strings.ToLower(strings.TrimSpace(address))
+		if identity, exists := byEmail[key]; exists {
+			return identity, true
+		}
+	}
+	return composeIdentity{}, false
+}
+
 // fetchSelfEmailSet returns a set of addresses to exclude as "self" in
 // reply-all. It always tries profile("me"); when mailboxID or senderEmail
 // differ from "me", those are added to the set as well so that shared-

--- a/shortcuts/mail/mail_compose_identity_test.go
+++ b/shortcuts/mail/mail_compose_identity_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+func TestResolveComposeIdentityExplicitPrecedence(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("from", "", "")
+	cmd.Flags().String("mailbox", "", "")
+	_ = cmd.Flags().Set("from", "from@example.com")
+	_ = cmd.Flags().Set("mailbox", "mailbox@example.com")
+
+	got := resolveComposeIdentity(&common.RuntimeContext{Cmd: cmd}, "mailbox@example.com", composeScenarioNew, nil, nil)
+	if got.Email != "from@example.com" {
+		t.Fatalf("resolveComposeIdentity() email = %q, want explicit --from", got.Email)
+	}
+}
+
+func TestUniqueDefaultComposeIdentityRequiresOneNonEmptyMarker(t *testing.T) {
+	tests := []struct {
+		name       string
+		identities []composeIdentity
+		wantEmail  string
+		wantOK     bool
+	}{
+		{name: "one", identities: []composeIdentity{{Email: "first@example.com"}, {Email: "default@example.com", IsDefault: true}}, wantEmail: "default@example.com", wantOK: true},
+		{name: "none", identities: []composeIdentity{{Email: "first@example.com"}}},
+		{name: "multiple", identities: []composeIdentity{{Email: "one@example.com", IsDefault: true}, {Email: "two@example.com", IsDefault: true}}},
+		{name: "empty default", identities: []composeIdentity{{Email: " ", IsDefault: true}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := uniqueDefaultComposeIdentity(tt.identities)
+			if ok != tt.wantOK || got.Email != tt.wantEmail {
+				t.Fatalf("uniqueDefaultComposeIdentity() = (%q, %v), want (%q, %v)", got.Email, ok, tt.wantEmail, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestFirstMatchingComposeIdentityUsesToBeforeCCAndNormalizes(t *testing.T) {
+	identities := []composeIdentity{
+		{Email: "Alias@Example.com", Name: "Alias"},
+		{Email: "cc@example.com", Name: "CC"},
+	}
+	got, ok := firstMatchingComposeIdentity(
+		[]string{"other@example.com", " alias@example.COM "},
+		[]string{"cc@example.com"},
+		identities,
+		composeIdentity{Email: "primary@example.com", Name: "Primary"},
+	)
+	if !ok || got.Email != "Alias@Example.com" || got.Name != "Alias" {
+		t.Fatalf("firstMatchingComposeIdentity() = %#v, %v", got, ok)
+	}
+}
+
+func TestMailSendUsesDefaultSendAsAddressAndName(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/settings/send_as",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []interface{}{
+					map[string]interface{}{"email_address": "first@example.com", "name": "First"},
+					map[string]interface{}{"email_address": "alias@example.com", "name": "Default Alias", "is_default": true},
+				},
+			},
+		},
+	})
+	registerMailboxProfileMock(reg)
+	draftStub := registerDraftCreateCapture(reg)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send", "--to", "recipient@example.com", "--subject", "subject", "--body", "body", "--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("MailSend.Execute() error = %v", err)
+	}
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if !strings.Contains(eml, "From: Default Alias <alias@example.com>") {
+		t.Fatalf("default send-as identity not used in EML:\n%s", eml)
+	}
+}
+
+func TestMailSendDoesNotUseFirstAddressWithoutTrustedDefault(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/settings/send_as",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []interface{}{
+					map[string]interface{}{"email_address": "first@example.com", "name": "First"},
+					map[string]interface{}{"email_address": "other@example.com", "name": "Other"},
+				},
+			},
+		},
+	})
+	registerMailboxProfileMock(reg)
+	draftStub := registerDraftCreateCapture(reg)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send", "--to", "recipient@example.com", "--subject", "subject", "--body", "body", "--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("MailSend.Execute() error = %v", err)
+	}
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if strings.Contains(eml, "first@example.com") || !strings.Contains(eml, "sender@example.com") {
+		t.Fatalf("untrusted first send-as address was selected:\n%s", eml)
+	}
+}
+
+func TestMailSendSettingsFailureUsesLegacyPrimaryAddress(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	registerMailboxProfileMock(reg)
+	draftStub := registerDraftCreateCapture(reg)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send", "--to", "recipient@example.com", "--subject", "subject", "--body", "body", "--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("MailSend.Execute() error = %v", err)
+	}
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if !strings.Contains(eml, "From: <sender@example.com>") {
+		t.Fatalf("settings failure did not preserve the legacy primary sender:\n%s", eml)
+	}
+}
+
+func TestMailReplyUsesFirstMatchingOriginalRecipientIdentity(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubSourceMessageHTML(reg, `<p>Original</p>`)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/settings/send_as",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []interface{}{
+					map[string]interface{}{"email_address": "default@example.com", "name": "Default", "is_default": true},
+					map[string]interface{}{"email_address": "me@example.com", "name": "Original Recipient"},
+				},
+			},
+		},
+	})
+	draftStub := registerDraftCreateCapture(reg)
+
+	err := runMountedMailShortcut(t, MailReply, []string{
+		"+reply", "--message-id", "msg_w1", "--body", "reply", "--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("MailReply.Execute() error = %v", err)
+	}
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if !strings.Contains(eml, "From: Original Recipient <me@example.com>") {
+		t.Fatalf("original recipient identity not used in reply EML:\n%s", eml)
+	}
+}
+
+func registerDraftCreateCapture(reg *httpmock.Registry) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "d_identity"},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}

--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -69,7 +69,8 @@ var MailDraftCreate = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
-		api = api.GET(mailboxPath(mailboxID, "profile")).
+		api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
 				"raw": "<base64url-EML>",
@@ -183,7 +184,8 @@ var MailDraftCreate = common.Shortcut{
 		}
 		signatureID := runtime.Str("signature-id")
 		noSignature := runtime.Bool("no-signature")
-		senderEmail := resolveComposeSenderEmail(runtime)
+		sender := resolveComposeIdentity(runtime, mailboxID, composeScenarioNew, nil, nil)
+		senderEmail := sender.Email
 		// Auto-resolve default signature when neither --no-signature nor --signature-id is set.
 		if noSignature {
 			signatureID = ""
@@ -196,7 +198,7 @@ var MailDraftCreate = common.Shortcut{
 			return err
 		}
 		rawEML, lintApplied, lintBlocked, err := buildRawEMLForDraftCreate(ctx, runtime, input, sigResult, priority,
-			templateLargeAttachmentIDs, mailboxID, templateID, templateInlineAttachments, templateSmallAttachments, senderEmail)
+			templateLargeAttachmentIDs, mailboxID, templateID, templateInlineAttachments, templateSmallAttachments, senderEmail, sender.Name)
 		if err != nil {
 			return err
 		}
@@ -253,6 +255,7 @@ func buildRawEMLForDraftCreate(
 	templateInlineAttachments []templateInlineRef,
 	templateSmallAttachments []templateAttachmentRef,
 	senderEmailHint string,
+	senderNameHints ...string,
 ) (rawEMLOut string, lintApplied, lintBlocked []lint.Finding, err error) {
 	// Initialise lint findings as empty (non-nil) slices so callers can
 	// surface them through the envelope unconditionally even on the
@@ -262,6 +265,10 @@ func buildRawEMLForDraftCreate(
 	// Use the pre-resolved senderEmail when available (avoids a duplicate
 	// profile API call when Execute already fetched it for auto-resolve).
 	senderEmail := senderEmailHint
+	senderName := ""
+	if len(senderNameHints) > 0 {
+		senderName = senderNameHints[0]
+	}
 	if senderEmail == "" {
 		senderEmail = resolveComposeSenderEmail(runtime)
 	}
@@ -280,7 +287,7 @@ func buildRawEMLForDraftCreate(
 		bld = bld.ToAddrs(parseNetAddrs(input.To))
 	}
 	if senderEmail != "" {
-		bld = bld.From("", senderEmail)
+		bld = bld.From(senderName, senderEmail)
 	}
 	// senderEmail non-emptiness is already enforced above (L140); the flag-
 	// driven guard here only exists to make the relationship explicit to

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -64,6 +64,7 @@ var MailForward = common.Shortcut{
 				Desc("Fetch template to merge with forward compose flags.")
 		}
 		api = api.GET(mailboxPath(mailboxID, "messages", messageId)).
+			GET(mailboxPath(mailboxID, "settings", "send_as")).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{"raw": "<base64url-EML>", "_to": to})
@@ -138,7 +139,8 @@ var MailForward = common.Shortcut{
 		}
 		orig := sourceMsg.Original
 
-		resolvedSender := resolveComposeSenderEmail(runtime)
+		sender := resolveComposeIdentity(runtime, mailboxID, composeScenarioReply, orig.toAddresses, orig.ccAddresses)
+		resolvedSender := sender.Email
 		// Check --request-receipt BEFORE the orig.headTo fallback below:
 		// the receipt's Disposition-Notification-To must point to an address
 		// the caller explicitly controls, not to a fallback picked from the
@@ -237,7 +239,7 @@ var MailForward = common.Shortcut{
 			Subject(subjectLine).
 			ToAddrs(parseNetAddrs(to))
 		if senderEmail != "" {
-			bld = bld.From("", senderEmail)
+			bld = bld.From(sender.Name, senderEmail)
 		}
 		// Note: requireSenderForRequestReceipt already ran above against
 		// resolvedSender (pre-fallback). When --request-receipt is set we

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -60,6 +60,7 @@ var MailReply = common.Shortcut{
 				Desc("Fetch template to merge with reply-derived recipients / body.")
 		}
 		api = api.GET(mailboxPath(mailboxID, "messages", messageId)).
+			GET(mailboxPath(mailboxID, "settings", "send_as")).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{"raw": "<base64url-EML>"})
@@ -138,7 +139,8 @@ var MailReply = common.Shortcut{
 		orig := sourceMsg.Original
 		stripLargeAttachmentCard(&orig)
 
-		resolvedSender := resolveComposeSenderEmail(runtime)
+		sender := resolveComposeIdentity(runtime, mailboxID, composeScenarioReply, orig.toAddresses, orig.ccAddresses)
+		resolvedSender := sender.Email
 		// Check --request-receipt BEFORE the orig.headTo fallback below:
 		// the receipt's Disposition-Notification-To must point to an address
 		// the caller explicitly controls, not to a fallback picked from the
@@ -250,7 +252,7 @@ var MailReply = common.Shortcut{
 			Subject(subjectLine).
 			ToAddrs(parseNetAddrs(replyTo))
 		if senderEmail != "" {
-			bld = bld.From("", senderEmail)
+			bld = bld.From(sender.Name, senderEmail)
 		}
 		// Note: requireSenderForRequestReceipt already ran above against
 		// resolvedSender (pre-fallback). When --request-receipt is set we

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -61,6 +61,7 @@ var MailReplyAll = common.Shortcut{
 				Desc("Fetch template to merge with reply-all-derived recipients / body.")
 		}
 		api = api.GET(mailboxPath(mailboxID, "messages", messageId)).
+			GET(mailboxPath(mailboxID, "settings", "send_as")).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{"raw": "<base64url-EML>"})
@@ -140,7 +141,8 @@ var MailReplyAll = common.Shortcut{
 		orig := sourceMsg.Original
 		stripLargeAttachmentCard(&orig)
 
-		resolvedSender := resolveComposeSenderEmail(runtime)
+		sender := resolveComposeIdentity(runtime, mailboxID, composeScenarioReply, orig.toAddresses, orig.ccAddresses)
+		resolvedSender := sender.Email
 		// Check --request-receipt BEFORE the orig.headTo fallback below:
 		// the receipt's Disposition-Notification-To must point to an address
 		// the caller explicitly controls, not to a fallback picked from the
@@ -173,6 +175,9 @@ var MailReplyAll = common.Shortcut{
 			}
 		}
 		selfEmails := fetchSelfEmailSet(runtime, mailboxID)
+		for _, email := range sender.SelfEmails {
+			selfEmails[strings.ToLower(strings.TrimSpace(email))] = true
+		}
 		excluded := buildExcludeSet(selfEmails, removeList)
 		replyToAddr := orig.replyTo
 		if replyToAddr == "" {
@@ -259,7 +264,7 @@ var MailReplyAll = common.Shortcut{
 			Subject(subjectLine).
 			ToAddrs(parseNetAddrs(toList))
 		if senderEmail != "" {
-			bld = bld.From("", senderEmail)
+			bld = bld.From(sender.Name, senderEmail)
 		}
 		// Note: requireSenderForRequestReceipt already ran above against
 		// resolvedSender (pre-fallback). When --request-receipt is set we

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -58,7 +58,8 @@ var MailSend = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
-		api = api.GET(mailboxPath(mailboxID, "profile")).
+		api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
 				"raw": "<base64url-EML>",
@@ -137,7 +138,8 @@ var MailSend = common.Shortcut{
 		confirmSend := runtime.Bool("confirm-send")
 		sendTime := runtime.Str("send-time")
 
-		senderEmail := resolveComposeSenderEmail(runtime)
+		sender := resolveComposeIdentity(runtime, resolveComposeMailboxID(runtime), composeScenarioNew, nil, nil)
+		senderEmail := sender.Email
 		signatureID := runtime.Str("signature-id")
 		priority, err := parsePriority(runtime.Str("priority"))
 		if err != nil {
@@ -214,7 +216,7 @@ var MailSend = common.Shortcut{
 			Subject(subject).
 			ToAddrs(parseNetAddrs(to))
 		if senderEmail != "" {
-			bld = bld.From("", senderEmail)
+			bld = bld.From(sender.Name, senderEmail)
 		}
 		if err := requireSenderForRequestReceipt(runtime, senderEmail); err != nil {
 			return err

--- a/shortcuts/mail/mail_send_receipt.go
+++ b/shortcuts/mail/mail_send_receipt.go
@@ -95,6 +95,7 @@ var MailSendReceipt = common.Shortcut{
 			Desc("Send read receipt: fetch the original message → verify the READ_RECEIPT_REQUEST label is present → build a reply with subject \"已读回执：<original>\" (zh) or \"Read receipt: <original>\" (en) picked by CJK detection on the original subject, In-Reply-To / References threading, and X-Lark-Read-Receipt-Mail: 1 → create draft and send. The backend extracts the private header, sets BodyExtra.IsReadReceiptMail, and DraftSend applies the READ_RECEIPT_SENT label to the outgoing message.").
 			GET(mailboxPath(mailboxID, "messages", messageID)).
 			Params(map[string]interface{}{"format": messageGetFormat(false)}).
+			GET(mailboxPath(mailboxID, "settings", "send_as")).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{"raw": "<base64url-EML>"}).
@@ -130,7 +131,10 @@ var MailSendReceipt = common.Shortcut{
 			return mailFailedPreconditionError("original message %s has no sender address; cannot address receipt", messageID)
 		}
 
-		senderEmail := resolveComposeSenderEmail(runtime)
+		originalTo := toAddressEmailList(toAddressList(msg["to"]))
+		originalCC := toAddressEmailList(toAddressList(msg["cc"]))
+		sender := resolveComposeIdentity(runtime, mailboxID, composeScenarioReply, originalTo, originalCC)
+		senderEmail := sender.Email
 		if senderEmail == "" {
 			return mailValidationParamError("--from", "unable to determine sender email; please specify --from explicitly")
 		}
@@ -142,7 +146,7 @@ var MailSendReceipt = common.Shortcut{
 
 		bld := emlbuilder.New().WithFileIO(runtime.FileIO()).
 			Subject(buildReceiptSubject(origSubject)).
-			From("", senderEmail).
+			From(sender.Name, senderEmail).
 			To("", origFromEmail).
 			TextBody([]byte(textBody)).
 			HTMLBody([]byte(htmlBody)).


### PR DESCRIPTION
## Summary

- resolve send-as identities once per shortcut invocation
- preserve explicit from/mailbox precedence
- prefer original-recipient identity for reply-like flows, then the unique default identity
- retain legacy behavior when send-as settings cannot be read

## Validation

Focused mail shortcut tests were added; full CI runs in the repository pipeline.