### PR TITLE
Allow partial mail rule reorder IDs

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -370,7 +370,7 @@ var MailRuleReorder = common.Shortcut{
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule IDs in preferred order. Missing IDs keep current order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1608,6 +1608,11 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 	if full == move {
 		return mailValidationError("exactly one of --rule-ids or --move-rule-id is required")
 	}
+	if full {
+		if err := validateRuleIDs(rt.StrSlice("rule-ids")); err != nil {
+			return err
+		}
+	}
 	targets := 0
 	for _, set := range []bool{
 		strings.TrimSpace(rt.Str("before-rule-id")) != "",
@@ -1631,10 +1636,11 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
+		order, err := buildRuleTargetOrderWithPrefix(ids, currentIDs)
+		if err != nil {
 			return nil, err
 		}
-		return ids, nil
+		return order, nil
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1653,23 +1659,53 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 	}
 }
 
-func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
-	}
-	want := make(map[string]int, len(current))
-	for _, id := range current {
-		want[id]++
-	}
-	for _, id := range target {
-		want[id]--
-	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+func validateRuleIDs(ids []string) error {
+	normalized := normalizeRuleIDs(ids)
+	seen := make(map[string]struct{}, len(normalized))
+	dupes := make([]string, 0)
+	for _, id := range normalized {
+		if _, exists := seen[id]; exists {
+			dupes = append(dupes, id)
+			continue
 		}
+		seen[id] = struct{}{}
+	}
+	if len(dupes) > 0 {
+		return mailValidationParamError("--rule-ids", "--rule-ids contains duplicate ids: %s", strings.Join(dupes, ","))
 	}
 	return nil
+}
+
+func buildRuleTargetOrderWithPrefix(ruleIDs, current []string) ([]string, error) {
+	if err := validateRuleIDs(ruleIDs); err != nil {
+		return nil, err
+	}
+	ids := normalizeRuleIDs(ruleIDs)
+	currentSet := make(map[string]struct{}, len(current))
+	for _, id := range current {
+		currentSet[id] = struct{}{}
+	}
+	missing := make([]string, 0)
+	for _, id := range ids {
+		if _, ok := currentSet[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, mailValidationParamError("--rule-ids", "--rule-ids contains ids not in current order: %s", strings.Join(missing, ","))
+	}
+	present := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		present[id] = struct{}{}
+	}
+	order := make([]string, 0, len(current))
+	order = append(order, ids...)
+	for _, id := range current {
+		if _, ok := present[id]; !ok {
+			order = append(order, id)
+		}
+	}
+	return order, nil
 }
 
 func normalizeRuleIDs(ids []string) []string {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1165,6 +1165,26 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
 	})
 
+	t.Run("partial order fills missing ids", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a,c", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "a,c,b")
+	})
+
 	t.Run("move to bottom", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
@@ -1488,11 +1508,11 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 }
 
 func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+	if err := validateRuleIDs([]string{"a", "a"}); err == nil {
+		t.Fatal("expected duplicate ids error")
 	}
-	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected duplicate mismatch error")
+	if _, err := buildRuleTargetOrderWithPrefix([]string{"a", "d"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected unknown ids error")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1527,14 +1547,19 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			want: "is not in current rule order",
 		},
 		{
-			name: "full mismatch",
+			name: "full mismatch with missing",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
+			want: "not in current order",
+		},
+		{
+			name: "rule-ids duplicate",
+			args: []string{"+rule-reorder", "--rule-ids", "a,a"},
+			want: "duplicate",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "missing") || strings.Contains(tc.want, "not in current order") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)
@@ -1545,6 +1570,82 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestBuildRuleTargetOrderWithPrefix(t *testing.T) {
+	order, err := buildRuleTargetOrderWithPrefix([]string{"a", "c"}, []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("buildRuleTargetOrderWithPrefix() error = %v", err)
+	}
+	if strings.Join(order, ",") != "a,c,b" {
+		t.Fatalf("order = %v, want a,c,b", order)
+	}
+
+	if _, err := buildRuleTargetOrderWithPrefix([]string{"a", "a"}, []string{"a", "b", "c"}); err == nil {
+		t.Fatal("expected duplicate error")
+	}
+	if _, err := buildRuleTargetOrderWithPrefix([]string{"a", "z"}, []string{"a", "b", "c"}); err == nil {
+		t.Fatal("expected missing id error")
+	}
+}
+
+func TestMailRuleReorderValidationDoesNotCallAPIs(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	post := &httpmock.Stub{
+		Method:   "POST",
+		URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Optional: true,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		},
+	}
+	reg.Register(post)
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a,a", "--format", "json"}, f, stdout)
+	if err == nil {
+		t.Fatal("expected duplicate validation error")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error = %v, want duplicate", err)
+	}
+	if len(post.CapturedBodies) != 0 {
+		t.Fatalf("reorder should not be called on duplicate ids, captured %d request(s)", len(post.CapturedBodies))
+	}
+}
+
+func TestMailRuleReorderMissingRuleIDsCallsListAndFails(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	list := mailRuleListStub(
+		mailRuleTestRawRule("a", "A"),
+		mailRuleTestRawRule("b", "B"),
+	)
+	list.Optional = true
+	reg.Register(list)
+	post := &httpmock.Stub{
+		Method:   "POST",
+		URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Optional: true,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		},
+	}
+	reg.Register(post)
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a,z", "--format", "json"}, f, stdout)
+	if err == nil {
+		t.Fatal("expected missing rule id error")
+	}
+	if !strings.Contains(err.Error(), "not in current order") {
+		t.Fatalf("error = %v, want missing rule id", err)
+	}
+	if len(list.CapturedBodies) != 1 {
+		t.Fatalf("list should be called exactly once, captured %d request(s)", len(list.CapturedBodies))
+	}
+	if len(post.CapturedBodies) != 0 {
+		t.Fatalf("reorder should not be called on missing rule ids, captured %d request(s)", len(post.CapturedBodies))
 	}
 }
 


### PR DESCRIPTION
Mail rule reordering now accepts a preferred subset of rule IDs and preserves any omitted rules in their existing relative order.

Changes:
- Update the `+rule-reorder --rule-ids` description to reflect partial ordering.
- Validate duplicate IDs before reading the current rule list.
- Reject IDs that are not present in the current mailbox rule order.
- Add coverage for partial ordering, duplicate validation, and missing IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `+rule-reorder` command now accepts a partial list of rule IDs.
  * Listed rules are moved to the front in the specified order, while unlisted rules retain their existing relative order.

* **Bug Fixes**
  * Improved validation reports duplicate or unknown rule IDs before changes are submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->