### PR TITLE
fix(base): make table and field lists fetch all items

### DIFF
--- a/shortcuts/base/base_dryrun_ops_test.go
+++ b/shortcuts/base/base_dryrun_ops_test.go
@@ -42,6 +42,28 @@ func TestDryRunTableOps(t *testing.T) {
 	assertDryRunContains(t, dryRunTableDelete(ctx, rt), "DELETE /open-apis/base/v3/bases/app_x/tables/tbl_1")
 }
 
+func TestBaseTableAndFieldListDryRunDefaultsToMaximumPageSize(t *testing.T) {
+	factory, stdout, _ := newExecuteFactory(t)
+
+	if err := runShortcut(t, BaseTableList, []string{
+		"+table-list", "--base-token", "app_x", "--dry-run", "--format", "pretty",
+	}, factory, stdout); err != nil {
+		t.Fatalf("table list dry-run err=%v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "limit=500") || !strings.Contains(got, "offset=0") {
+		t.Fatalf("table list dry-run=%s", got)
+	}
+
+	if err := runShortcut(t, BaseFieldList, []string{
+		"+field-list", "--base-token", "app_x", "--table-id", "tbl_x", "--dry-run", "--format", "pretty",
+	}, factory, stdout); err != nil {
+		t.Fatalf("field list dry-run err=%v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "limit=500") || !strings.Contains(got, "offset=0") {
+		t.Fatalf("field list dry-run=%s", got)
+	}
+}
+
 func TestDryRunTemplateCenterOps(t *testing.T) {
 	ctx := context.Background()
 

--- a/shortcuts/base/base_dryrun_ops_test.go
+++ b/shortcuts/base/base_dryrun_ops_test.go
@@ -50,7 +50,7 @@ func TestBaseTableAndFieldListDryRunDefaultsToMaximumPageSize(t *testing.T) {
 	}, factory, stdout); err != nil {
 		t.Fatalf("table list dry-run err=%v", err)
 	}
-	if got := stdout.String(); !strings.Contains(got, "limit=500") || !strings.Contains(got, "offset=0") {
+	if got := stdout.String(); !strings.Contains(got, "limit=300") || !strings.Contains(got, "offset=0") {
 		t.Fatalf("table list dry-run=%s", got)
 	}
 
@@ -59,7 +59,7 @@ func TestBaseTableAndFieldListDryRunDefaultsToMaximumPageSize(t *testing.T) {
 	}, factory, stdout); err != nil {
 		t.Fatalf("field list dry-run err=%v", err)
 	}
-	if got := stdout.String(); !strings.Contains(got, "limit=500") || !strings.Contains(got, "offset=0") {
+	if got := stdout.String(); !strings.Contains(got, "limit=300") || !strings.Contains(got, "offset=0") {
 		t.Fatalf("field list dry-run=%s", got)
 	}
 }

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -620,10 +620,8 @@ func TestBasePaginationHelpShowsDefaults(t *testing.T) {
 		defaultVal string
 		help       string
 	}{
-		{name: "table list", shortcut: BaseTableList, flag: "limit", defaultVal: "50", help: "pagination size, range 1-100"},
 		{name: "template list", shortcut: BaseTemplateList, flag: "limit", defaultVal: "10", help: "pagination size, range 1-100"},
 		{name: "template search", shortcut: BaseTemplateSearch, flag: "limit", defaultVal: "10", help: "pagination size, range 1-100"},
-		{name: "field list", shortcut: BaseFieldList, flag: "limit", defaultVal: "100", help: "pagination size, range 1-200"},
 		{name: "field search options", shortcut: BaseFieldSearchOptions, flag: "limit", defaultVal: "30", help: "pagination size, range 1-200"},
 		{name: "record list", shortcut: BaseRecordList, flag: "limit", defaultVal: "100", help: "maximum records to return; range 1-200, or 1-2000 for ndjson"},
 		{name: "view list", shortcut: BaseViewList, flag: "limit", defaultVal: "100", help: "pagination size, range 1-200"},
@@ -655,6 +653,41 @@ func TestBasePaginationHelpShowsDefaults(t *testing.T) {
 			}
 			if got := strings.Count(help, "default "+tt.defaultVal); got != 1 {
 				t.Fatalf("flag help default %s count=%d, want 1:\n%s", tt.defaultVal, got, help)
+			}
+		})
+	}
+}
+
+func TestBaseTableAndFieldListPaginationFlagsAreHiddenCompatibilityInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		shortcut common.Shortcut
+		defaults map[string]string
+	}{
+		{name: "table list", shortcut: BaseTableList, defaults: map[string]string{"offset": "0", "limit": "500"}},
+		{name: "field list", shortcut: BaseFieldList, defaults: map[string]string{"offset": "0", "limit": "500"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := &cobra.Command{Use: "base"}
+			tt.shortcut.Mount(parent, &cmdutil.Factory{})
+			cmd := parent.Commands()[0]
+			help := cmd.Flags().FlagUsages()
+			for name, wantDefault := range tt.defaults {
+				flag := cmd.Flags().Lookup(name)
+				if flag == nil {
+					t.Fatalf("flag --%s missing", name)
+				}
+				if !flag.Hidden {
+					t.Fatalf("flag --%s should be hidden", name)
+				}
+				if flag.DefValue != wantDefault {
+					t.Fatalf("--%s default=%q, want %q", name, flag.DefValue, wantDefault)
+				}
+				if strings.Contains(help, "--"+name) {
+					t.Fatalf("hidden flag --%s leaked into help:\n%s", name, help)
+				}
 			}
 		})
 	}
@@ -1730,7 +1763,7 @@ func TestBasePaginationValidationRejectsOutOfRange(t *testing.T) {
 		{
 			name:     "table list",
 			shortcut: BaseTableList,
-			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"limit": 101}),
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"limit": 501}),
 			param:    "--limit",
 		},
 		{
@@ -1748,7 +1781,7 @@ func TestBasePaginationValidationRejectsOutOfRange(t *testing.T) {
 		{
 			name:     "field list",
 			shortcut: BaseFieldList,
-			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"limit": 201}),
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"limit": 501}),
 			param:    "--limit",
 		},
 		{

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -664,8 +664,8 @@ func TestBaseTableAndFieldListPaginationFlagsAreHiddenCompatibilityInputs(t *tes
 		shortcut common.Shortcut
 		defaults map[string]string
 	}{
-		{name: "table list", shortcut: BaseTableList, defaults: map[string]string{"offset": "0", "limit": "500"}},
-		{name: "field list", shortcut: BaseFieldList, defaults: map[string]string{"offset": "0", "limit": "500"}},
+		{name: "table list", shortcut: BaseTableList, defaults: map[string]string{"offset": "0", "limit": "300"}},
+		{name: "field list", shortcut: BaseFieldList, defaults: map[string]string{"offset": "0", "limit": "300"}},
 	}
 
 	for _, tt := range tests {
@@ -1763,7 +1763,7 @@ func TestBasePaginationValidationRejectsOutOfRange(t *testing.T) {
 		{
 			name:     "table list",
 			shortcut: BaseTableList,
-			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"limit": 501}),
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"limit": 301}),
 			param:    "--limit",
 		},
 		{
@@ -1781,7 +1781,7 @@ func TestBasePaginationValidationRejectsOutOfRange(t *testing.T) {
 		{
 			name:     "field list",
 			shortcut: BaseFieldList,
-			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"limit": 501}),
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"limit": 301}),
 			param:    "--limit",
 		},
 		{

--- a/shortcuts/base/field_list.go
+++ b/shortcuts/base/field_list.go
@@ -12,7 +12,7 @@ import (
 var BaseFieldList = common.Shortcut{
 	Service:     "base",
 	Command:     "+field-list",
-	Description: "List fields in a table",
+	Description: "List all fields in a table",
 	Risk:        "read",
 	Scopes:      []string{"base:field:read"},
 	AuthTypes:   authTypes(),
@@ -20,10 +20,10 @@ var BaseFieldList = common.Shortcut{
 		baseTokenFlag(true),
 		tableRefFlag(true),
 		{Name: "offset", Type: "int", Default: "0", Desc: "legacy pagination offset; hidden for compatibility", Hidden: true},
-		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "500", Desc: "legacy pagination size, range 1-500; hidden for compatibility", Hidden: true},
+		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "300", Desc: "legacy pagination size, range 1-300; hidden for compatibility", Hidden: true},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		_, err := common.ValidatePageSizeTyped(runtime, "limit", 500, 1, 500)
+		_, err := common.ValidatePageSizeTyped(runtime, "limit", 300, 1, 300)
 		return err
 	},
 	DryRun: dryRunFieldList,

--- a/shortcuts/base/field_list.go
+++ b/shortcuts/base/field_list.go
@@ -19,11 +19,11 @@ var BaseFieldList = common.Shortcut{
 	Flags: []common.Flag{
 		baseTokenFlag(true),
 		tableRefFlag(true),
-		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
-		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "100", Desc: "pagination size, range 1-200"},
+		{Name: "offset", Type: "int", Default: "0", Desc: "legacy pagination offset; hidden for compatibility", Hidden: true},
+		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "500", Desc: "legacy pagination size, range 1-500; hidden for compatibility", Hidden: true},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		_, err := common.ValidatePageSizeTyped(runtime, "limit", 100, 1, 200)
+		_, err := common.ValidatePageSizeTyped(runtime, "limit", 500, 1, 500)
 		return err
 	},
 	DryRun: dryRunFieldList,

--- a/shortcuts/base/table_list.go
+++ b/shortcuts/base/table_list.go
@@ -12,17 +12,17 @@ import (
 var BaseTableList = common.Shortcut{
 	Service:     "base",
 	Command:     "+table-list",
-	Description: "List tables in a base",
+	Description: "List all tables in a base",
 	Risk:        "read",
 	Scopes:      []string{"base:table:read"},
 	AuthTypes:   authTypes(),
 	Flags: []common.Flag{
 		baseTokenFlag(true),
 		{Name: "offset", Type: "int", Default: "0", Desc: "legacy pagination offset; hidden for compatibility", Hidden: true},
-		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "500", Desc: "legacy pagination size, range 1-500; hidden for compatibility", Hidden: true},
+		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "300", Desc: "legacy pagination size, range 1-300; hidden for compatibility", Hidden: true},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		_, err := common.ValidatePageSizeTyped(runtime, "limit", 500, 1, 500)
+		_, err := common.ValidatePageSizeTyped(runtime, "limit", 300, 1, 300)
 		return err
 	},
 	DryRun: dryRunTableList,

--- a/shortcuts/base/table_list.go
+++ b/shortcuts/base/table_list.go
@@ -18,11 +18,11 @@ var BaseTableList = common.Shortcut{
 	AuthTypes:   authTypes(),
 	Flags: []common.Flag{
 		baseTokenFlag(true),
-		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
-		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "50", Desc: "pagination size, range 1-100"},
+		{Name: "offset", Type: "int", Default: "0", Desc: "legacy pagination offset; hidden for compatibility", Hidden: true},
+		{Name: "limit", Aliases: []string{"page-size"}, Type: "int", Default: "500", Desc: "legacy pagination size, range 1-500; hidden for compatibility", Hidden: true},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		_, err := common.ValidatePageSizeTyped(runtime, "limit", 50, 1, 100)
+		_, err := common.ValidatePageSizeTyped(runtime, "limit", 500, 1, 500)
 		return err
 	},
 	DryRun: dryRunTableList,

--- a/tests/cli_e2e/base/base_limit_dryrun_test.go
+++ b/tests/cli_e2e/base/base_limit_dryrun_test.go
@@ -23,7 +23,7 @@ func TestBaseListDryRunRejectsOutOfRangeLimit(t *testing.T) {
 		Args: []string{
 			"base", "+table-list",
 			"--base-token", "app_x",
-			"--limit", "101",
+			"--limit", "301",
 			"--dry-run",
 		},
 		DefaultAs: "bot",
@@ -34,7 +34,7 @@ func TestBaseListDryRunRejectsOutOfRangeLimit(t *testing.T) {
 	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
 	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
 	require.Equal(t, "--limit", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
-	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "must be between 1 and 100")
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "must be between 1 and 300")
 	require.Empty(t, result.Stdout)
 }
 
@@ -92,11 +92,11 @@ func TestBaseListDryRunAttributesValidationToPageSizeAlias(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 	result, err := clie2e.RunCmd(ctx, clie2e.Request{
-		Args:      []string{"base", "+table-list", "--base-token", "app_x", "--page-size", "101", "--dry-run"},
+		Args:      []string{"base", "+table-list", "--base-token", "app_x", "--page-size", "301", "--dry-run"},
 		DefaultAs: "bot",
 	})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 2)
 	require.Equal(t, "--page-size", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
-	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "must be between 1 and 100")
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "must be between 1 and 300")
 }


### PR DESCRIPTION
## Summary

- Make `+table-list` and `+field-list` describe their all-items behavior and default to a 300-item request.
- Cap both compatibility pagination parameters at the current product capacity of 300 (`1-300`).
- Hide `offset` and `limit` from normal help while preserving explicit legacy flag compatibility.
- Add regression coverage for hidden flags, defaults, validation, and dry-run requests.

## Validation

- `go test ./shortcuts/base -count=1`
- Live read-only API probes: table and field list accept `limit=300`; the service endpoint itself accepts up to 500 and rejects 1000 with `param limit must be between 1 and 500`. The CLI intentionally caps at 300 to match the current single-Base/table capacity.
- `make build` is currently blocked on the public base branch by pre-existing missing `isOfficeSpreadsheet` / `officePrefixes` symbols in `shortcuts/sheets/lark_sheet_workbook.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Increased the default page size for table and field listings to 300 items.
  - Updated table and field list commands to clearly indicate that they return all available entries.
  - Preserved legacy pagination options for compatibility while keeping them hidden from standard command help.
  - Expanded the accepted page-size range to support values from 1 to 300, with clearer validation for larger values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->