### PR TITLE
fix(wiki): migrate mutation lookups to node_by_token

### DIFF
--- a/shortcuts/wiki/wiki_move.go
+++ b/shortcuts/wiki/wiki_move.go
@@ -45,10 +45,10 @@ var WikiMove = common.Shortcut{
 	Scopes:      []string{"wiki:node:move", "wiki:node:read", "wiki:space:read"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "node-token", Desc: "wiki node token to move inside Wiki"},
+		{Name: "node-token", Desc: "Wiki node_token or document obj_token to resolve and move inside Wiki"},
 		{Name: "source-space-id", Desc: "source wiki space ID for --node-token; if omitted, it is resolved from the node token"},
 		{Name: "target-space-id", Desc: "target wiki space ID; required for docs-to-wiki, optional for node move when --target-parent-token is set"},
-		{Name: "target-parent-token", Desc: "target parent wiki node token; if omitted for docs-to-wiki, the document is moved to the target space root"},
+		{Name: "target-parent-token", Desc: "target parent Wiki node_token (also accepts document obj_token in node move mode); if omitted for docs-to-wiki, use the target space root"},
 		{Name: "obj-type", Desc: "Drive document type for docs-to-wiki mode", Enum: wikiMoveObjectTypes},
 		{Name: "obj-token", Desc: "Drive document token for docs-to-wiki mode"},
 		{Name: "apply", Type: "bool", Desc: "submit a move request when the caller lacks permission to move the document immediately"},
@@ -227,16 +227,7 @@ type wikiMoveAPI struct {
 }
 
 func (api wikiMoveAPI) GetNode(ctx context.Context, token string) (*wikiNodeRecord, error) {
-	data, err := api.runtime.CallAPITyped(
-		"GET",
-		"/open-apis/wiki/v2/spaces/get_node",
-		map[string]interface{}{"token": token},
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return parseWikiNodeRecord(common.GetMap(data, "node"))
+	return lookupWikiNode(api.runtime, token)
 }
 
 func (api wikiMoveAPI) MoveNode(ctx context.Context, sourceSpaceID string, spec wikiMoveSpec) (*wikiNodeRecord, error) {
@@ -367,37 +358,29 @@ func buildWikiMoveDryRun(spec wikiMoveSpec) *common.DryRunAPI {
 	switch spec.Mode() {
 	case wikiMoveModeNode:
 		step := 1
-		switch {
-		case spec.SourceSpaceID == "" && spec.TargetParentToken != "":
-			dry.Desc("3-step orchestration: resolve source node -> resolve target parent -> move wiki node")
-		case spec.SourceSpaceID == "":
-			dry.Desc("2-step orchestration: resolve source node -> move wiki node")
-		case spec.TargetParentToken != "":
-			dry.Desc("2-step orchestration: resolve target parent -> move wiki node")
-		default:
-			dry.Desc("1-step request: move wiki node")
-		}
+		dry.Desc("Resolve node tokens and spaces, then move the wiki node")
+		dry.GET("/open-apis/wiki/v2/spaces/node_by_token").
+			Desc("[1] Resolve source node and space").
+			Params(map[string]interface{}{"token": spec.NodeToken})
+		step++
 
-		if spec.SourceSpaceID == "" {
-			dry.GET("/open-apis/wiki/v2/spaces/get_node").
-				Desc(fmt.Sprintf("[%d] Resolve source space from node token", step)).
-				Params(map[string]interface{}{"token": spec.NodeToken})
-			step++
-		}
 		if spec.TargetParentToken != "" {
-			dry.GET("/open-apis/wiki/v2/spaces/get_node").
+			dry.GET("/open-apis/wiki/v2/spaces/node_by_token").
 				Desc(fmt.Sprintf("[%d] Resolve target parent node", step)).
 				Params(map[string]interface{}{"token": spec.TargetParentToken})
 			step++
 		}
 
+		body := spec.NodeMoveBody()
+		if spec.TargetParentToken != "" {
+			body["target_parent_token"] = "<resolved_parent_node_token>"
+		}
 		dry.POST(fmt.Sprintf(
-			"/open-apis/wiki/v2/spaces/%s/nodes/%s/move",
+			"/open-apis/wiki/v2/spaces/%s/nodes/<resolved_node_token>/move",
 			dryRunWikiMoveSourceSpaceID(spec),
-			validate.EncodePathSegment(spec.NodeToken),
 		)).
 			Desc(fmt.Sprintf("[%d] Move wiki node", step)).
-			Body(spec.NodeMoveBody())
+			Body(body)
 	case wikiMoveModeDocsToWiki:
 		dry.Desc("2-step orchestration: move Drive document into Wiki -> poll wiki task result when task_id is returned")
 		dry.POST(fmt.Sprintf(
@@ -442,7 +425,7 @@ func runWikiMove(ctx context.Context, client wikiMoveClient, runtime *common.Run
 }
 
 func runWikiNodeMove(ctx context.Context, client wikiMoveClient, spec wikiMoveSpec) (map[string]interface{}, error) {
-	sourceSpaceID, targetSpaceID, err := resolveWikiNodeMoveSpaces(ctx, client, spec)
+	sourceSpaceID, targetSpaceID, err := resolveWikiNodeMoveSpaces(ctx, client, &spec)
 	if err != nil {
 		return nil, err
 	}
@@ -461,21 +444,25 @@ func runWikiNodeMove(ctx context.Context, client wikiMoveClient, spec wikiMoveSp
 	return out, nil
 }
 
-func resolveWikiNodeMoveSpaces(ctx context.Context, client wikiMoveClient, spec wikiMoveSpec) (string, string, error) {
+func resolveWikiNodeMoveSpaces(ctx context.Context, client wikiMoveClient, spec *wikiMoveSpec) (string, string, error) {
 	// Node move requests may start from just a node token and/or a target parent.
 	// Resolve both ends up front so we can fail on space mismatches before sending
 	// the mutation request.
-	sourceSpaceID := spec.SourceSpaceID
-	if sourceSpaceID == "" {
-		sourceNode, err := client.GetNode(ctx, spec.NodeToken)
-		if err != nil {
-			return "", "", err
-		}
-		sourceSpaceID, err = requireWikiNodeSpaceID(sourceNode)
-		if err != nil {
-			return "", "", err
-		}
+	sourceNode, err := client.GetNode(ctx, spec.NodeToken)
+	if err != nil {
+		return "", "", err
 	}
+	sourceSpaceID, err := requireWikiNodeSpaceID(sourceNode)
+	if err != nil {
+		return "", "", err
+	}
+	if sourceNode.NodeToken == "" {
+		return "", "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki source lookup returned no node_token")
+	}
+	if spec.SourceSpaceID != "" && spec.SourceSpaceID != sourceSpaceID {
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--source-space-id does not match the resolved node space").WithParam("--source-space-id")
+	}
+	spec.NodeToken = sourceNode.NodeToken
 
 	targetSpaceID := spec.TargetSpaceID
 	if spec.TargetParentToken != "" {
@@ -487,6 +474,10 @@ func resolveWikiNodeMoveSpaces(ctx context.Context, client wikiMoveClient, spec 
 		if err != nil {
 			return "", "", err
 		}
+		if targetParent.NodeToken == "" {
+			return "", "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki target parent lookup returned no node_token")
+		}
+		spec.TargetParentToken = targetParent.NodeToken
 		if targetSpaceID == "" {
 			targetSpaceID = parentSpaceID
 		} else if targetSpaceID != parentSpaceID {

--- a/shortcuts/wiki/wiki_move_test.go
+++ b/shortcuts/wiki/wiki_move_test.go
@@ -406,13 +406,13 @@ func TestWikiMoveDryRunNodeMoveIncludesResolutionSteps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal dry run: %v", err)
 	}
-	if !bytes.Contains(data, []byte(`"description":"3-step orchestration:`)) {
+	if !bytes.Contains(data, []byte(`"description":"Resolve node tokens and spaces`)) {
 		t.Fatalf("dry run missing 3-step description: %s", string(data))
 	}
-	if !bytes.Contains(data, []byte(`"target_parent_token":"wik_parent"`)) {
+	if !bytes.Contains(data, []byte(`"target_parent_token":"\u003cresolved_parent_node_token\u003e"`)) {
 		t.Fatalf("dry run missing target_parent_token body: %s", string(data))
 	}
-	if !bytes.Contains(data, []byte(`/open-apis/wiki/v2/spaces/\u003cresolved_source_space_id\u003e/nodes/wik_node/move`)) {
+	if !bytes.Contains(data, []byte(`/open-apis/wiki/v2/spaces/\u003cresolved_source_space_id\u003e/nodes/\u003cresolved_node_token\u003e/move`)) {
 		t.Fatalf("dry run missing resolved source placeholder: %s", string(data))
 	}
 }
@@ -464,12 +464,12 @@ func TestResolveWikiNodeMoveSpacesUsesSourceAndTargetLookups(t *testing.T) {
 
 	client := &fakeWikiMoveClient{
 		nodes: map[string]*wikiNodeRecord{
-			"wik_node":   {SpaceID: "space_src"},
-			"wik_parent": {SpaceID: "space_dst"},
+			"wik_node":   {SpaceID: "space_src", NodeToken: "wik_node"},
+			"wik_parent": {SpaceID: "space_dst", NodeToken: "wik_parent"},
 		},
 	}
 
-	sourceSpaceID, targetSpaceID, err := resolveWikiNodeMoveSpaces(context.Background(), client, wikiMoveSpec{
+	sourceSpaceID, targetSpaceID, err := resolveWikiNodeMoveSpaces(context.Background(), client, &wikiMoveSpec{
 		NodeToken:         "wik_node",
 		TargetParentToken: "wik_parent",
 	})
@@ -489,11 +489,12 @@ func TestResolveWikiNodeMoveSpacesRejectsTargetSpaceMismatch(t *testing.T) {
 
 	client := &fakeWikiMoveClient{
 		nodes: map[string]*wikiNodeRecord{
-			"wik_parent": {SpaceID: "space_parent"},
+			"wik_node":   {SpaceID: "space_src", NodeToken: "wik_node"},
+			"wik_parent": {SpaceID: "space_parent", NodeToken: "wik_parent"},
 		},
 	}
 
-	_, _, err := resolveWikiNodeMoveSpaces(context.Background(), client, wikiMoveSpec{
+	_, _, err := resolveWikiNodeMoveSpaces(context.Background(), client, &wikiMoveSpec{
 		NodeToken:         "wik_node",
 		SourceSpaceID:     "space_src",
 		TargetSpaceID:     "space_other",
@@ -509,8 +510,8 @@ func TestRunWikiNodeMoveReturnsResolvedMetadata(t *testing.T) {
 
 	client := &fakeWikiMoveClient{
 		nodes: map[string]*wikiNodeRecord{
-			"wik_node":   {SpaceID: "space_src"},
-			"wik_parent": {SpaceID: "space_dst"},
+			"wik_node":   {SpaceID: "space_src", NodeToken: "wik_node"},
+			"wik_parent": {SpaceID: "space_dst", NodeToken: "wik_parent"},
 		},
 		moveNode: &wikiNodeRecord{
 			SpaceID:         "space_dst",
@@ -551,6 +552,7 @@ func TestRunWikiMoveDispatchesByMode(t *testing.T) {
 	client := &fakeWikiMoveClient{
 		docsResp: &wikiMoveDocsResponse{WikiToken: "wik_ready"},
 		moveNode: &wikiNodeRecord{SpaceID: "space_dst", NodeToken: "wik_node"},
+		nodes:    map[string]*wikiNodeRecord{"wik_node": {SpaceID: "space_src", NodeToken: "wik_node"}},
 	}
 
 	nodeOut, err := runWikiMove(context.Background(), client, runtime, wikiMoveSpec{
@@ -725,21 +727,21 @@ func TestWikiMoveExecuteNodeShortcut(t *testing.T) {
 	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
-				"node": map[string]interface{}{"space_id": "space_src"},
+				"node": map[string]interface{}{"space_id": "space_src", "node_token": "wik_node"},
 			},
 		},
 	})
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
-				"node": map[string]interface{}{"space_id": "space_dst"},
+				"node": map[string]interface{}{"space_id": "space_dst", "node_token": "wik_parent"},
 			},
 		},
 	})

--- a/shortcuts/wiki/wiki_node_create.go
+++ b/shortcuts/wiki/wiki_node_create.go
@@ -64,7 +64,7 @@ var WikiNodeCreate = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "space-id", Desc: "target wiki space ID; use my_library for the personal document library"},
-		{Name: "parent-node-token", Desc: "parent wiki node token; if set, the new node is created under that parent"},
+		{Name: "parent-node-token", Desc: "parent Wiki node_token or document obj_token; the new node is created under the resolved Wiki node"},
 		{Name: "title", Desc: "node title"},
 		{Name: "node-type", Default: wikiNodeTypeOrigin, Desc: "node type", Enum: []string{wikiNodeTypeOrigin, wikiNodeTypeShortcut}},
 		{Name: "obj-type", Default: "docx", Desc: "target object type; file is supported only when --node-type=shortcut", Enum: wikiObjectTypes},
@@ -176,16 +176,7 @@ type wikiNodeCreateAPI struct {
 }
 
 func (api wikiNodeCreateAPI) GetNode(ctx context.Context, token string) (*wikiNodeRecord, error) {
-	data, err := api.runtime.CallAPITyped(
-		"GET",
-		"/open-apis/wiki/v2/spaces/get_node",
-		map[string]interface{}{"token": token},
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return parseWikiNodeRecord(common.GetMap(data, "node"))
+	return lookupWikiNode(api.runtime, token)
 }
 
 func (api wikiNodeCreateAPI) GetSpace(ctx context.Context, spaceID string) (*wikiSpaceRecord, error) {
@@ -292,15 +283,19 @@ func buildWikiNodeCreateDryRun(spec wikiNodeCreateSpec) *common.DryRunAPI {
 	}
 
 	if spec.ParentNodeToken != "" {
-		dry.GET("/open-apis/wiki/v2/spaces/get_node").
+		dry.GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc(fmt.Sprintf("[%d] Resolve parent node space", step)).
 			Params(map[string]interface{}{"token": spec.ParentNodeToken})
 		step++
 	}
 
+	body := spec.RequestBody()
+	if spec.ParentNodeToken != "" {
+		body["parent_node_token"] = "<resolved_parent_node_token>"
+	}
 	dry.POST(fmt.Sprintf("/open-apis/wiki/v2/spaces/%s/nodes", dryRunWikiNodeCreateSpaceID(spec))).
 		Desc(fmt.Sprintf("[%d] Create wiki node", step)).
-		Body(spec.RequestBody())
+		Body(body)
 
 	return dry
 }
@@ -323,6 +318,13 @@ func runWikiNodeCreate(ctx context.Context, client wikiNodeCreateClient, identit
 	resolvedSpace, err := resolveWikiNodeCreateSpace(ctx, client, identity, spec)
 	if err != nil {
 		return nil, err
+	}
+
+	if spec.ParentNodeToken != "" {
+		if resolvedSpace.ParentNode == nil || resolvedSpace.ParentNode.NodeToken == "" {
+			return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki parent lookup returned no node_token")
+		}
+		spec.ParentNodeToken = resolvedSpace.ParentNode.NodeToken
 	}
 
 	var (

--- a/shortcuts/wiki/wiki_node_create_test.go
+++ b/shortcuts/wiki/wiki_node_create_test.go
@@ -449,7 +449,7 @@ func TestWikiNodeCreateDryRunUsesParentNodeWithoutMyLibraryLookup(t *testing.T) 
 	if len(got) != 2 {
 		t.Fatalf("len(dryRun.api) = %d, want 2", len(got))
 	}
-	if got[0].URL != "/open-apis/wiki/v2/spaces/get_node" {
+	if got[0].URL != "/open-apis/wiki/v2/spaces/node_by_token" {
 		t.Fatalf("first dry-run URL = %q, want parent node lookup", got[0].URL)
 	}
 	if got[1].URL != "/open-apis/wiki/v2/spaces/<resolved_space_id>/nodes" {
@@ -475,7 +475,7 @@ func TestWikiNodeCreateDryRunKeepsExplicitSpaceIDWhenParentProvided(t *testing.T
 	if len(got) != 2 {
 		t.Fatalf("len(dryRun.api) = %d, want 2", len(got))
 	}
-	if got[0].URL != "/open-apis/wiki/v2/spaces/get_node" {
+	if got[0].URL != "/open-apis/wiki/v2/spaces/node_by_token" {
 		t.Fatalf("first dry-run URL = %q, want parent node lookup", got[0].URL)
 	}
 	if got[1].URL != "/open-apis/wiki/v2/spaces/space_123/nodes" {
@@ -504,7 +504,7 @@ func TestWikiNodeCreateDryRunShowsMyLibraryLookupWhenExplicitAndParentProvided(t
 	if got[0].URL != "/open-apis/wiki/v2/spaces/my_library" {
 		t.Fatalf("first dry-run URL = %q, want my_library lookup", got[0].URL)
 	}
-	if got[1].URL != "/open-apis/wiki/v2/spaces/get_node" {
+	if got[1].URL != "/open-apis/wiki/v2/spaces/node_by_token" {
 		t.Fatalf("second dry-run URL = %q, want parent node lookup", got[1].URL)
 	}
 	if got[2].URL != "/open-apis/wiki/v2/spaces/<resolved_space_id>/nodes" {

--- a/shortcuts/wiki/wiki_node_delete.go
+++ b/shortcuts/wiki/wiki_node_delete.go
@@ -38,26 +38,24 @@ const (
 // WikiNodeDelete deletes a wiki node (or pulls a cloud doc out of Wiki). The
 // API mirrors +delete-space — synchronous on small deletes, async with a
 // task_id for cascade deletes — so this shortcut shares the async-polling
-// helper. Space ID is optional: when omitted, +node-delete first looks up the
-// node via get_node to resolve the space ID so callers do not have to chain
-// commands.
+// helper. It always resolves the target via node_by_token and infers the space
+// ID when omitted, or validates the supplied space ID.
 var WikiNodeDelete = common.Shortcut{
 	Service:     "wiki",
 	Command:     "+node-delete",
 	Description: "Delete a wiki node, polling the async delete task when needed",
 	Risk:        "high-risk-write",
-	// API spec lists wiki:node:create as the only declared scope for the
-	// delete endpoint. Naming is unfortunate, but the scope-preflight needs
-	// the literal string.
-	Scopes:    []string{"wiki:node:create"},
+	// Deletion requires wiki:node:create; the preceding node_by_token lookup
+	// also requires wiki:node:retrieve, even when --space-id is provided.
+	Scopes:    []string{"wiki:node:create", "wiki:node:retrieve"},
 	AuthTypes: []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "node-token", Desc: "wiki node_token, cloud-doc obj_token, or a Lark URL embedding one of them", Required: true},
 		// Not Required at the cobra level: URL inputs auto-infer obj_type
 		// from the path, and the parser enforces explicit obj_type for raw
 		// tokens. Forcing Cobra Required here breaks the URL ergonomic.
-		{Name: "obj-type", Desc: "token kind; no default — pass explicitly when --node-token is a raw token (URL inputs auto-infer)", Enum: wikiNodeDeleteObjTypes},
-		{Name: "space-id", Desc: "wiki space ID; auto-resolved via get_node when omitted"},
+		{Name: "obj-type", Desc: "deletion token kind: wiki uses the resolved node_token, other types use obj_token; required for raw input (URL inputs auto-infer)", Enum: wikiNodeDeleteObjTypes},
+		{Name: "space-id", Desc: "wiki space ID; auto-resolved via node_by_token when omitted"},
 		{Name: "include-children", Type: "bool", Default: "true", Desc: "cascade delete the subtree (default); pass --include-children=false to lift direct children up to the parent"},
 	},
 	Tips: []string{
@@ -65,7 +63,7 @@ var WikiNodeDelete = common.Shortcut{
 		"This is a high-risk-write command; pass --yes to confirm the deletion.",
 		"--node-token accepts a raw token (wikcnXXX, docxXXX, ...) or a Lark URL like https://feishu.cn/wiki/<token> or https://feishu.cn/docx/<token>; URL paths also imply --obj-type.",
 		"Run +node-get first to confirm space_id / obj_type when in doubt.",
-		"Auto-resolving space_id (when --space-id is omitted) also calls get_node, which needs the wiki:node:retrieve scope; pass --space-id to skip that lookup if your token only carries wiki:node:create.",
+		"Resolving the node also calls node_by_token and requires Wiki node read permission, including when --space-id is provided.",
 		"Async deletes return a task_id; this command polls for a bounded window and then returns a follow-up drive +task_result command.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
@@ -116,7 +114,7 @@ func (spec wikiNodeDeleteSpec) RequestBody() map[string]interface{} {
 // wikiNodeDeleteClient isolates the network operations so business logic can
 // be unit-tested without real HTTP calls. Mirrors wikiDeleteSpaceClient.
 type wikiNodeDeleteClient interface {
-	ResolveNode(ctx context.Context, token, objType string) (*wikiNodeRecord, error)
+	ResolveNode(ctx context.Context, token string) (*wikiNodeRecord, error)
 	DeleteNode(ctx context.Context, spaceID string, spec wikiNodeDeleteSpec) (string, error)
 	GetDeleteNodeTask(ctx context.Context, taskID string) (wikiAsyncTaskStatus, error)
 }
@@ -125,18 +123,8 @@ type wikiNodeDeleteAPI struct {
 	runtime *common.RuntimeContext
 }
 
-func (api wikiNodeDeleteAPI) ResolveNode(ctx context.Context, token, objType string) (*wikiNodeRecord, error) {
-	params := map[string]interface{}{"token": token}
-	// get_node takes obj_type only when the token is an obj_token. For
-	// wiki node_tokens the API rejects an obj_type kwarg, so omit it.
-	if objType != "" && objType != "wiki" {
-		params["obj_type"] = objType
-	}
-	data, err := api.runtime.CallAPITyped("GET", "/open-apis/wiki/v2/spaces/get_node", params, nil)
-	if err != nil {
-		return nil, err
-	}
-	return parseWikiNodeRecord(common.GetMap(data, "node"))
+func (api wikiNodeDeleteAPI) ResolveNode(ctx context.Context, token string) (*wikiNodeRecord, error) {
+	return lookupWikiNode(api.runtime, token)
 }
 
 func (api wikiNodeDeleteAPI) DeleteNode(ctx context.Context, spaceID string, spec wikiNodeDeleteSpec) (string, error) {
@@ -266,33 +254,23 @@ func isValidWikiDeleteObjType(v string) bool {
 
 func buildWikiNodeDeleteDryRun(spec wikiNodeDeleteSpec) *common.DryRunAPI {
 	dry := common.NewDryRunAPI().Desc(
-		"async-aware: delete wiki node -> poll wiki delete-node task when task_id is returned (auto-resolves space_id via get_node when --space-id is omitted)",
+		"async-aware: always resolve the target via node_by_token (requires Wiki node read access, including with --space-id) -> delete wiki node -> poll wiki delete-node task when task_id is returned",
 	)
 
-	if spec.SpaceID == "" {
-		params := map[string]interface{}{"token": spec.NodeToken}
-		if spec.ObjType != "" && spec.ObjType != "wiki" {
-			params["obj_type"] = spec.ObjType
-		}
-		dry.GET("/open-apis/wiki/v2/spaces/get_node").
-			Desc("[1] Resolve space_id via get_node").
-			Params(params)
-		dry.DELETE(fmt.Sprintf(
-			"/open-apis/wiki/v2/spaces/%s/nodes/%s",
-			"<resolved_space_id>",
-			validate.EncodePathSegment(spec.NodeToken),
-		)).
-			Desc("[2] Delete wiki node").
-			Body(spec.RequestBody())
-	} else {
-		dry.DELETE(fmt.Sprintf(
-			"/open-apis/wiki/v2/spaces/%s/nodes/%s",
-			validate.EncodePathSegment(spec.SpaceID),
-			validate.EncodePathSegment(spec.NodeToken),
-		)).
-			Desc("[1] Delete wiki node").
-			Body(spec.RequestBody())
+	dry.GET("/open-apis/wiki/v2/spaces/node_by_token").
+		Desc("[1] Resolve node and space").
+		Params(map[string]interface{}{"token": spec.NodeToken})
+	spaceID := "<resolved_space_id>"
+	if spec.SpaceID != "" {
+		spaceID = validate.EncodePathSegment(spec.SpaceID)
 	}
+	token := "<resolved_node_token>"
+	if spec.ObjType != "wiki" {
+		token = "<resolved_obj_token>"
+	}
+	dry.DELETE(fmt.Sprintf("/open-apis/wiki/v2/spaces/%s/nodes/%s", spaceID, token)).
+		Desc("[2] Delete wiki node").
+		Body(spec.RequestBody())
 
 	dry.GET("/open-apis/wiki/v2/tasks/:task_id").
 		Desc("[N] Poll wiki delete-node task result when async").
@@ -303,7 +281,7 @@ func buildWikiNodeDeleteDryRun(spec wikiNodeDeleteSpec) *common.DryRunAPI {
 }
 
 func runWikiNodeDelete(ctx context.Context, client wikiNodeDeleteClient, runtime *common.RuntimeContext, spec wikiNodeDeleteSpec) (map[string]interface{}, error) {
-	spaceID, err := resolveWikiNodeDeleteSpaceID(ctx, client, runtime, spec)
+	spaceID, err := resolveWikiNodeDeleteSpaceID(ctx, client, &spec)
 	if err != nil {
 		return nil, err
 	}
@@ -357,20 +335,38 @@ func runWikiNodeDelete(ctx context.Context, client wikiNodeDeleteClient, runtime
 	return out, nil
 }
 
-// resolveWikiNodeDeleteSpaceID returns the explicit space_id when the caller
-// supplied one, otherwise resolves it via get_node. The latter saves callers
-// from running +node-get first when they only have a node_token.
-func resolveWikiNodeDeleteSpaceID(ctx context.Context, client wikiNodeDeleteClient, runtime *common.RuntimeContext, spec wikiNodeDeleteSpec) (string, error) {
-	if spec.SpaceID != "" {
-		return spec.SpaceID, nil
-	}
-	node, err := client.ResolveNode(ctx, spec.NodeToken, spec.ObjType)
+// resolveWikiNodeDeleteSpaceID resolves the mutation token and checks any explicit space.
+func resolveWikiNodeDeleteSpaceID(ctx context.Context, client wikiNodeDeleteClient, spec *wikiNodeDeleteSpec) (string, error) {
+	node, err := client.ResolveNode(ctx, spec.NodeToken)
 	if err != nil {
 		return "", err
 	}
 	spaceID, err := requireWikiNodeSpaceID(node)
 	if err != nil {
 		return "", err
+	}
+	if spec.SpaceID != "" && spec.SpaceID != spaceID {
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--space-id does not match the resolved node space").WithParam("--space-id")
+	}
+	if spec.ObjType == "wiki" {
+		if node.NodeToken == "" {
+			return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node lookup returned no node_token")
+		}
+		spec.NodeToken = node.NodeToken
+	} else {
+		// A shortcut's obj_token belongs to its origin document. Converting it
+		// would change the deletion target from the shortcut to that document.
+		if node.NodeType == wikiNodeTypeShortcut {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "deleting a Wiki shortcut requires --obj-type wiki").
+				WithParam("--obj-type").WithHint("Use --obj-type wiki to delete the shortcut itself.")
+		}
+		if node.ObjToken == "" || node.ObjType == "" {
+			return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node lookup returned no obj_token or obj_type")
+		}
+		if spec.ObjType != node.ObjType {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--obj-type does not match the resolved document type").WithParam("--obj-type")
+		}
+		spec.NodeToken = node.ObjToken
 	}
 	return spaceID, nil
 }

--- a/shortcuts/wiki/wiki_node_delete_test.go
+++ b/shortcuts/wiki/wiki_node_delete_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -18,10 +19,68 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
 	"github.com/larksuite/cli/internal/errclass"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+func TestWikiNodeDeleteDeclaredScopes(t *testing.T) {
+	t.Parallel()
+	want := []string{"wiki:node:create", "wiki:node:retrieve"}
+	if !slices.Equal(WikiNodeDelete.Scopes, want) {
+		t.Fatalf("WikiNodeDelete.Scopes = %v, want %v", WikiNodeDelete.Scopes, want)
+	}
+}
+
+func TestWikiNodeDeleteScopePreflight(t *testing.T) {
+	for _, identity := range []string{"user", "bot"} {
+		for _, tt := range []struct {
+			name, granted, missing string
+		}{
+			{"delete only", "wiki:node:create", "wiki:node:retrieve"},
+			{"lookup only", "wiki:node:retrieve", "wiki:node:create"},
+			{"both", "wiki:node:create wiki:node:retrieve", ""},
+		} {
+			t.Run(identity+"/"+tt.name, func(t *testing.T) {
+				t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+				cfg := wikiTestConfig()
+				factory, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+				factory.Credential = credential.NewCredentialProvider(nil, &wikiMoveAccountResolver{cfg: cfg}, &mockWikiMoveTokenResolver{scopes: tt.granted}, nil)
+				if tt.missing == "" {
+					reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token?token=wik_source", Body: map[string]any{
+						"code": 0, "data": map[string]any{"node": map[string]any{"node_token": "wik_source", "space_id": "space_src"}},
+					}})
+					reg.Register(&httpmock.Stub{Method: "DELETE", URL: "/open-apis/wiki/v2/spaces/space_src/nodes/wik_source", Body: map[string]any{"code": 0, "data": map[string]any{}}})
+				}
+				err := mountAndRunWiki(t, WikiNodeDelete, []string{
+					"+node-delete", "--node-token", "wik_source", "--obj-type", "wiki", "--space-id", "space_src", "--yes", "--as", identity,
+				}, factory, stdout)
+				if tt.missing == "" {
+					if err != nil {
+						t.Fatalf("both scopes should allow lookup and deletion: %v", err)
+					}
+					return
+				}
+				// No API stubs are registered: missing scopes must stop before
+				// either lookup or deletion, even with an explicit space ID.
+				var permission *errs.PermissionError
+				if !errors.As(err, &permission) {
+					t.Fatalf("error = %T %v, want PermissionError", err, err)
+				}
+				if permission.Category != errs.CategoryAuthorization || permission.Subtype != errs.SubtypeMissingScope || permission.Identity != identity {
+					t.Fatalf("unexpected permission metadata: %+v", permission)
+				}
+				if !slices.Equal(permission.MissingScopes, []string{tt.missing}) {
+					t.Fatalf("missing scopes = %v, want %s", permission.MissingScopes, tt.missing)
+				}
+				if stdout.Len() != 0 {
+					t.Fatalf("unexpected success output: %s", stdout.String())
+				}
+			})
+		}
+	}
+}
 
 // ── parseWikiNodeDeleteSpec ─────────────────────────────────────────────────
 
@@ -123,15 +182,15 @@ func TestBuildWikiNodeDeleteDryRunWithoutSpaceIDShowsResolve(t *testing.T) {
 	dry := buildWikiNodeDeleteDryRun(spec)
 	got := decodeDryRunAPIs(t, dry)
 	if len(got) != 3 {
-		t.Fatalf("len(dry.api) = %d, want 3 (get_node, delete, task poll)", len(got))
+		t.Fatalf("len(dry.api) = %d, want 3 (node_by_token, delete, task poll)", len(got))
 	}
-	if got[0].URL != "/open-apis/wiki/v2/spaces/get_node" {
-		t.Fatalf("step[0].URL = %q, want get_node", got[0].URL)
+	if got[0].URL != "/open-apis/wiki/v2/spaces/node_by_token" {
+		t.Fatalf("step[0].URL = %q, want node_by_token", got[0].URL)
 	}
-	if got[0].Params["obj_type"] != "docx" || got[0].Params["token"] != "docxXYZ" {
+	if len(got[0].Params) != 1 || got[0].Params["token"] != "docxXYZ" {
 		t.Fatalf("step[0].params = %#v", got[0].Params)
 	}
-	if got[1].URL != "/open-apis/wiki/v2/spaces/<resolved_space_id>/nodes/docxXYZ" {
+	if got[1].URL != "/open-apis/wiki/v2/spaces/<resolved_space_id>/nodes/<resolved_obj_token>" {
 		t.Fatalf("step[1].URL = %q, want delete with placeholder", got[1].URL)
 	}
 	if got[1].Body["obj_type"] != "docx" || got[1].Body["include_children"] != true {
@@ -142,7 +201,7 @@ func TestBuildWikiNodeDeleteDryRunWithoutSpaceIDShowsResolve(t *testing.T) {
 	}
 }
 
-func TestBuildWikiNodeDeleteDryRunWithSpaceIDOmitsResolve(t *testing.T) {
+func TestBuildWikiNodeDeleteDryRunWithSpaceIDResolvesToken(t *testing.T) {
 	t.Parallel()
 
 	spec, err := parseWikiNodeDeleteSpec("wikcnABC", "wiki", "7629741305993170448", false)
@@ -152,14 +211,14 @@ func TestBuildWikiNodeDeleteDryRunWithSpaceIDOmitsResolve(t *testing.T) {
 
 	dry := buildWikiNodeDeleteDryRun(spec)
 	got := decodeDryRunAPIs(t, dry)
-	if len(got) != 2 {
-		t.Fatalf("len(dry.api) = %d, want 2 (delete + task poll) when --space-id supplied", len(got))
+	if len(got) != 3 {
+		t.Fatalf("len(dry.api) = %d, want 3 (lookup + delete + task poll) when --space-id supplied", len(got))
 	}
-	if got[0].Method != "DELETE" || got[0].URL != "/open-apis/wiki/v2/spaces/7629741305993170448/nodes/wikcnABC" {
-		t.Fatalf("step[0] = %+v", got[0])
+	if got[1].Method != "DELETE" || got[1].URL != "/open-apis/wiki/v2/spaces/7629741305993170448/nodes/<resolved_node_token>" {
+		t.Fatalf("step[0] = %+v", got[1])
 	}
-	if got[0].Body["include_children"] != false {
-		t.Fatalf("body include_children = %#v", got[0].Body["include_children"])
+	if got[1].Body["include_children"] != false {
+		t.Fatalf("body include_children = %#v", got[1].Body["include_children"])
 	}
 }
 
@@ -182,7 +241,7 @@ type fakeWikiNodeDeleteClient struct {
 	taskCallArgs []string
 }
 
-func (fake *fakeWikiNodeDeleteClient) ResolveNode(ctx context.Context, token, objType string) (*wikiNodeRecord, error) {
+func (fake *fakeWikiNodeDeleteClient) ResolveNode(ctx context.Context, token string) (*wikiNodeRecord, error) {
 	fake.resolveCalls = append(fake.resolveCalls, token)
 	if fake.resolveErr != nil {
 		return nil, fake.resolveErr
@@ -246,7 +305,7 @@ func TestRunWikiNodeDeleteResolvesSpaceWhenMissing(t *testing.T) {
 
 	runtime, _ := newWikiNodeDeleteRuntime(t, core.AsUser)
 	client := &fakeWikiNodeDeleteClient{
-		resolveNode: &wikiNodeRecord{SpaceID: "space_resolved"},
+		resolveNode: &wikiNodeRecord{SpaceID: "space_resolved", NodeToken: "wikcnABC"},
 	}
 
 	out, err := runWikiNodeDelete(context.Background(), client, runtime, wikiNodeDeleteSpec{
@@ -268,11 +327,11 @@ func TestRunWikiNodeDeleteResolvesSpaceWhenMissing(t *testing.T) {
 	}
 }
 
-func TestRunWikiNodeDeleteSkipsResolveWhenSpaceProvided(t *testing.T) {
+func TestRunWikiNodeDeleteResolvesTokenWhenSpaceProvided(t *testing.T) {
 	t.Parallel()
 
 	runtime, _ := newWikiNodeDeleteRuntime(t, core.AsUser)
-	client := &fakeWikiNodeDeleteClient{}
+	client := &fakeWikiNodeDeleteClient{resolveNode: &wikiNodeRecord{SpaceID: "space_explicit", NodeToken: "wikcnABC"}}
 
 	_, err := runWikiNodeDelete(context.Background(), client, runtime, wikiNodeDeleteSpec{
 		NodeToken: "wikcnABC", ObjType: "wiki", SpaceID: "space_explicit",
@@ -280,8 +339,8 @@ func TestRunWikiNodeDeleteSkipsResolveWhenSpaceProvided(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runWikiNodeDelete() error = %v", err)
 	}
-	if len(client.resolveCalls) != 0 {
-		t.Fatalf("resolveCalls should be empty when --space-id supplied, got %v", client.resolveCalls)
+	if len(client.resolveCalls) != 1 {
+		t.Fatalf("expected token lookup when --space-id supplied, got %v", client.resolveCalls)
 	}
 	if client.deleteCalls[0].SpaceID != "space_explicit" {
 		t.Fatalf("delete used wrong space: %+v", client.deleteCalls)
@@ -293,6 +352,7 @@ func TestRunWikiNodeDeleteAsyncReadyShape(t *testing.T) {
 
 	runtime, stderr := newWikiNodeDeleteRuntime(t, core.AsUser)
 	client := &fakeWikiNodeDeleteClient{
+		resolveNode:  &wikiNodeRecord{SpaceID: "space_123", NodeToken: "wikcnABC"},
 		deleteTaskID: "task_async_node",
 		taskStatuses: []wikiAsyncTaskStatus{{Status: "success"}},
 	}
@@ -316,6 +376,7 @@ func TestRunWikiNodeDeleteAsyncTimeoutReturnsNextCommand(t *testing.T) {
 
 	runtime, _ := newWikiNodeDeleteRuntime(t, core.AsUser)
 	client := &fakeWikiNodeDeleteClient{
+		resolveNode:  &wikiNodeRecord{SpaceID: "space_123", NodeToken: "wikcnABC"},
 		deleteTaskID: "task_async_node",
 		taskStatuses: []wikiAsyncTaskStatus{{Status: "processing"}},
 	}
@@ -340,6 +401,7 @@ func TestRunWikiNodeDeleteAsyncFailureSurfacesReason(t *testing.T) {
 
 	runtime, _ := newWikiNodeDeleteRuntime(t, core.AsUser)
 	client := &fakeWikiNodeDeleteClient{
+		resolveNode:  &wikiNodeRecord{SpaceID: "space_123", NodeToken: "wikcnABC"},
 		deleteTaskID: "task_async_node",
 		taskStatuses: []wikiAsyncTaskStatus{{Status: "failure", StatusMsg: "permission denied"}},
 	}
@@ -441,6 +503,9 @@ func TestWikiNodeDeleteExecuteRequiresYesConfirmation(t *testing.T) {
 func TestWikiNodeDeleteExecuteSync(t *testing.T) {
 	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
 
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"node": map[string]interface{}{"space_id": "space_123", "node_token": "wikcnABC"}},
+	}})
 	deleteStub := &httpmock.Stub{
 		Method: "DELETE",
 		URL:    "/open-apis/wiki/v2/spaces/space_123/nodes/wikcnABC",
@@ -486,7 +551,7 @@ func TestWikiNodeDeleteExecuteResolvesSpaceIDFromURL(t *testing.T) {
 
 	resolveStub := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -522,8 +587,8 @@ func TestWikiNodeDeleteExecuteResolvesSpaceIDFromURL(t *testing.T) {
 		t.Fatalf("mountAndRunWiki() error = %v", err)
 	}
 
-	if !strings.Contains(resolveQuery, "token=docxXYZ") || !strings.Contains(resolveQuery, "obj_type=docx") {
-		t.Fatalf("resolve query = %q, want token+obj_type", resolveQuery)
+	if resolveQuery != "token=docxXYZ" {
+		t.Fatalf("resolve query = %q, want token only", resolveQuery)
 	}
 	data := decodeWikiEnvelope(t, stdout)
 	if data["space_id"] != "space_resolved" || data["obj_type"] != "docx" {
@@ -535,6 +600,9 @@ func TestWikiNodeDeleteExecuteAsyncSuccess(t *testing.T) {
 	withSingleWikiDeleteNodePoll(t)
 
 	factory, stdout, _, reg := cmdutil.TestFactory(t, wikiTestConfig())
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token", Body: map[string]interface{}{
+		"code": 0, "data": map[string]interface{}{"node": map[string]interface{}{"space_id": "space_123", "node_token": "wikcnABC"}},
+	}})
 	reg.Register(&httpmock.Stub{
 		Method: "DELETE",
 		URL:    "/open-apis/wiki/v2/spaces/space_123/nodes/wikcnABC",

--- a/shortcuts/wiki/wiki_node_get.go
+++ b/shortcuts/wiki/wiki_node_get.go
@@ -130,6 +130,7 @@ var WikiNodeGet = common.Shortcut{
 // errors require a changed token, operation, or permission; rate limiting
 // remains retryable only within the bounded backoff guidance below.
 func wikiNodeGetProblem(err error) error {
+	err = wikiNodeLookupProblem(err)
 	p, ok := errs.ProblemOf(err)
 	if !ok {
 		return err
@@ -142,16 +143,10 @@ func wikiNodeGetProblem(err error) error {
 		p.Retryable = false
 		appendWikiProblemHint(err, wikiPermissionDeniedHint())
 	case 131012:
-		p.Subtype = errs.SubtypeNotFound
-		p.Retryable = false
 		appendWikiProblemHint(err, "The Wiki node has been deleted. Do not retry the same node token; rediscover the node or ask for a current Wiki link.")
 	case 131013, 131016:
-		p.Subtype = errs.SubtypeInvalidParameters
-		p.Retryable = false
 		appendWikiProblemHint(err, "The resource token is invalid. Do not retry the same token, switch identity, or reauthorize; check the URL/token and provide a valid wiki node_token, complete raw obj_token, or typed document URL.")
 	case 131014:
-		p.Subtype = errs.SubtypeFailedPrecondition
-		p.Retryable = false
 		appendWikiProblemHint(err, "The document exists but is not mounted in Wiki. Do not retry wiki +node-get with the same document; use the corresponding docs, sheets, base, or drive command, or provide a Wiki URL/node_token.")
 	}
 	return err

--- a/shortcuts/wiki/wiki_node_lookup.go
+++ b/shortcuts/wiki/wiki_node_lookup.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// lookupWikiNode resolves either a Wiki node_token or a document obj_token.
+func lookupWikiNode(runtime *common.RuntimeContext, token string) (*wikiNodeRecord, error) {
+	data, err := runtime.CallAPITyped("GET", "/open-apis/wiki/v2/spaces/node_by_token", map[string]interface{}{"token": token}, nil)
+	if err != nil {
+		return nil, wikiNodeLookupProblem(err)
+	}
+	return parseWikiNodeRecord(common.GetMap(data, "node"))
+}
+
+// These business codes belong to node_by_token regardless of the caller.
+// Command-specific recovery hints stay with the command.
+func wikiNodeLookupProblem(err error) error {
+	if p, ok := errs.ProblemOf(err); ok {
+		switch p.Code {
+		case 131012:
+			p.Subtype, p.Retryable = errs.SubtypeNotFound, false
+		case 131013, 131016:
+			p.Subtype, p.Retryable = errs.SubtypeInvalidParameters, false
+		case 131014:
+			p.Subtype, p.Retryable = errs.SubtypeFailedPrecondition, false
+		}
+	}
+	return err
+}

--- a/shortcuts/wiki/wiki_node_lookup_test.go
+++ b/shortcuts/wiki/wiki_node_lookup_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWikiNodeLookupProblemPreservesUpstreamError(t *testing.T) {
+	for _, code := range []int{131012, 131013, 131014, 131016} {
+		err := errs.NewAPIError(errs.SubtypeUnknown, "upstream message").WithCode(code).
+			WithRetryable().WithLogID("lookup-log").WithHint("upstream hint").WithCause(io.EOF)
+		got := wikiNodeLookupProblem(err)
+		require.Same(t, err, got)
+		require.ErrorIs(t, got, io.EOF)
+		p, ok := errs.ProblemOf(got)
+		require.True(t, ok)
+		require.Equal(t, code, p.Code)
+		require.Equal(t, "lookup-log", p.LogID)
+		require.Equal(t, "upstream hint", p.Hint)
+		require.False(t, p.Retryable)
+	}
+	require.Nil(t, wikiNodeLookupProblem(nil))
+	require.ErrorIs(t, wikiNodeLookupProblem(io.EOF), io.EOF)
+}
+
+// Exercise the mounted commands so failures must stop before the write, and
+// successful lookups must use resolved tokens with the requested mutation type.
+func TestWikiMutationNodeLookup(t *testing.T) {
+	for _, command := range []struct {
+		name         string
+		shortcut     common.Shortcut
+		args         []string
+		token        string
+		method       string
+		path         string
+		body         map[string]interface{}
+		sourceLookup bool
+		spaceParam   string
+	}{
+		{"create infer space", WikiNodeCreate, []string{"+node-create", "--parent-node-token", "wik_input"}, "wik_input", "POST", "/spaces/space_123/nodes", map[string]interface{}{"parent_node_token": "wik_input"}, false, ""},
+		{"create assert space", WikiNodeCreate, []string{"+node-create", "--parent-node-token", "wik_input", "--space-id", "space_123"}, "wik_input", "POST", "/spaces/space_123/nodes", map[string]interface{}{"parent_node_token": "wik_input"}, false, "--space-id"},
+		{"move source", WikiMove, []string{"+move", "--node-token", "wik_input", "--target-space-id", "space_dst"}, "wik_input", "POST", "/spaces/space_123/nodes/wik_input/move", map[string]interface{}{"target_space_id": "space_dst"}, false, ""},
+		{"move parent", WikiMove, []string{"+move", "--node-token", "wik_source", "--source-space-id", "space_src", "--target-parent-token", "wik_input"}, "wik_input", "POST", "/spaces/space_src/nodes/wik_source/move", map[string]interface{}{"target_parent_token": "wik_input"}, true, ""},
+		{"delete wiki", WikiNodeDelete, []string{"+node-delete", "--node-token", "wik_input", "--obj-type", "wiki", "--include-children", "--yes"}, "wik_input", "DELETE", "/spaces/space_123/nodes/wik_input", map[string]interface{}{"obj_type": "wiki", "include_children": true}, false, ""},
+		{"delete document", WikiNodeDelete, []string{"+node-delete", "--node-token", "obj_input", "--obj-type", "docx", "--include-children=false", "--yes"}, "obj_input", "DELETE", "/spaces/space_123/nodes/obj_input", map[string]interface{}{"obj_type": "docx", "include_children": false}, false, ""},
+		{"create document parent", WikiNodeCreate, []string{"+node-create", "--parent-node-token", "obj_input"}, "obj_input", "POST", "/spaces/space_123/nodes", map[string]interface{}{"parent_node_token": "wik_input"}, false, ""},
+		{"create document parent explicit space", WikiNodeCreate, []string{"+node-create", "--parent-node-token", "obj_input", "--space-id", "space_123"}, "obj_input", "POST", "/spaces/space_123/nodes", map[string]interface{}{"parent_node_token": "wik_input"}, false, "--space-id"},
+		{"move document source", WikiMove, []string{"+move", "--node-token", "obj_input", "--target-space-id", "space_dst"}, "obj_input", "POST", "/spaces/space_123/nodes/wik_input/move", map[string]interface{}{"target_space_id": "space_dst"}, false, ""},
+		{"move document source explicit space", WikiMove, []string{"+move", "--node-token", "obj_input", "--source-space-id", "space_123", "--target-space-id", "space_dst"}, "obj_input", "POST", "/spaces/space_123/nodes/wik_input/move", map[string]interface{}{"target_space_id": "space_dst"}, false, "--source-space-id"},
+		{"move parent document", WikiMove, []string{"+move", "--node-token", "wik_source", "--source-space-id", "space_src", "--target-parent-token", "obj_input"}, "obj_input", "POST", "/spaces/space_src/nodes/wik_source/move", map[string]interface{}{"target_parent_token": "wik_input"}, true, ""},
+		{"move parent explicit target space", WikiMove, []string{"+move", "--node-token", "wik_source", "--source-space-id", "space_src", "--target-parent-token", "obj_input", "--target-space-id", "space_123"}, "obj_input", "POST", "/spaces/space_src/nodes/wik_source/move", map[string]interface{}{"target_parent_token": "wik_input", "target_space_id": "space_123"}, true, "--target-space-id"},
+		{"delete document as wiki", WikiNodeDelete, []string{"+node-delete", "--node-token", "obj_input", "--obj-type", "wiki", "--yes"}, "obj_input", "DELETE", "/spaces/space_123/nodes/wik_input", map[string]interface{}{"obj_type": "wiki"}, false, ""},
+		{"delete document as wiki explicit space", WikiNodeDelete, []string{"+node-delete", "--node-token", "obj_input", "--obj-type", "wiki", "--space-id", "space_123", "--yes"}, "obj_input", "DELETE", "/spaces/space_123/nodes/wik_input", map[string]interface{}{"obj_type": "wiki"}, false, "--space-id"},
+		{"delete wiki as document", WikiNodeDelete, []string{"+node-delete", "--node-token", "wik_input", "--obj-type", "docx", "--space-id", "space_123", "--yes"}, "wik_input", "DELETE", "/spaces/space_123/nodes/obj_input", map[string]interface{}{"obj_type": "docx"}, false, "--space-id"},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			for _, scenario := range []struct {
+				name string
+				code int
+			}{
+				{"origin", 0}, {"shortcut", 0}, {"missing identity", 0}, {"wrong type", 0}, {"wrong space", 0},
+				{"invalid parameters", 131002}, {"not found", 131005}, {"forbidden", 131006}, {"deleted", 131012},
+				{"invalid token", 131013}, {"outside Wiki", 131014}, {"short token", 131016},
+			} {
+				t.Run(scenario.name, func(t *testing.T) {
+					t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+					factory, stdout, stderr, reg := cmdutil.TestFactory(t, wikiTestConfig())
+					node := map[string]interface{}{"space_id": "space_123", "node_token": "wik_input", "obj_token": "obj_input", "obj_type": "docx", "node_type": "origin"}
+					response := map[string]interface{}{"code": 0, "data": map[string]interface{}{"node": node}}
+					wantCategory, wantSubtype := errs.CategoryValidation, errs.SubtypeInvalidArgument
+					success := scenario.name == "origin" || scenario.name == "shortcut"
+					if scenario.name == "shortcut" && command.body["obj_type"] == "docx" {
+						success = false
+					}
+					switch scenario.name {
+					case "shortcut":
+						node["node_type"], node["origin_node_token"] = "shortcut", "wik_origin"
+					case "wrong type":
+						if command.body["obj_type"] != "docx" {
+							t.Skip("only document-token deletion specifies the underlying type")
+						}
+						node["obj_type"] = "sheet"
+					case "missing identity":
+						delete(node, "node_token")
+						delete(node, "obj_token")
+						wantCategory, wantSubtype = errs.CategoryInternal, errs.SubtypeInvalidResponse
+					case "wrong space":
+						if command.spaceParam == "" {
+							t.Skip("this case does not assert the lookup's space")
+						}
+						node["space_id"] = "space_other"
+					}
+					code := scenario.code
+					if code != 0 {
+						response = map[string]interface{}{"code": code, "msg": "lookup failed"}
+						wantCategory, wantSubtype = errs.CategoryAPI, errs.SubtypeUnknown
+						switch code {
+						case 131002, 131013, 131016:
+							wantSubtype = errs.SubtypeInvalidParameters
+						case 131005, 131012:
+							wantSubtype = errs.SubtypeNotFound
+						case 131014:
+							wantSubtype = errs.SubtypeFailedPrecondition
+						case 131006:
+							wantCategory, wantSubtype = errs.CategoryAuthorization, errs.SubtypePermissionDenied
+						}
+					}
+					if command.sourceLookup {
+						reg.Register(&httpmock.Stub{Method: "GET", URL: "node_by_token?token=wik_source", Body: map[string]interface{}{
+							"code": 0, "data": map[string]interface{}{"node": map[string]interface{}{"space_id": "space_src", "node_token": "wik_source"}},
+						}})
+					}
+					reg.Register(&httpmock.Stub{
+						Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token", Status: http.StatusOK,
+						Body: response, Headers: http.Header{"X-Tt-Logid": []string{"lookup-log"}},
+						OnMatch: func(req *http.Request) {
+							require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", req.URL.Path)
+							require.Equal(t, "token="+command.token, req.URL.RawQuery)
+						},
+					})
+					write := &httpmock.Stub{
+						Method: command.method, URL: "/open-apis/wiki/v2" + command.path, Optional: !success,
+						OnMatch: func(req *http.Request) {
+							require.True(t, success, "failed lookup must not reach a mutation")
+							require.Equal(t, "/open-apis/wiki/v2"+command.path, req.URL.Path)
+						},
+						Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"node": node}},
+					}
+					reg.Register(write)
+					args := append(append([]string{}, command.args...), "--as", "user")
+					err := mountAndRunWiki(t, command.shortcut, args, factory, stdout)
+					if success {
+						require.NoError(t, err)
+						require.Empty(t, stderr.String())
+						require.Len(t, write.CapturedBodies, 1)
+						body := decodeWikiCapturedJSONBody(t, write)
+						for key, value := range command.body {
+							require.Equal(t, value, body[key], "mutation field %s", key)
+						}
+					} else {
+						require.Error(t, err)
+						p, ok := errs.ProblemOf(err)
+						require.True(t, ok)
+						require.Equal(t, wantCategory, p.Category)
+						require.Equal(t, wantSubtype, p.Subtype)
+						require.Equal(t, code, p.Code)
+						require.False(t, p.Retryable)
+						if code != 0 {
+							require.Equal(t, "lookup-log", p.LogID)
+						}
+						if scenario.name == "wrong space" {
+							var validation *errs.ValidationError
+							require.ErrorAs(t, err, &validation)
+							require.Equal(t, command.spaceParam, validation.Param)
+						}
+						if scenario.name == "wrong type" || (scenario.name == "shortcut" && !success) {
+							var validation *errs.ValidationError
+							require.ErrorAs(t, err, &validation)
+							require.Equal(t, "--obj-type", validation.Param)
+						}
+						require.Empty(t, stdout.String())
+						require.Empty(t, write.CapturedBodies)
+					}
+				})
+			}
+		})
+	}
+}

--- a/skills/lark-wiki/references/lark-wiki-move.md
+++ b/skills/lark-wiki/references/lark-wiki-move.md
@@ -66,7 +66,7 @@ lark-cli wiki +move \
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--node-token` | 条件必填 | 要移动的 Wiki 节点 token。传入后命令进入 `node` 模式 |
+| `--node-token` | 条件必填 | 要移动的 Wiki 节点 token 或文档 obj_token。传入后命令进入 `node` 模式 |
 | `--source-space-id` | 否 | 源知识空间 ID，仅 `node` 模式可用；不传时会根据 `--node-token` 自动解析 |
 | `--target-space-id` | 条件必填 | 目标知识空间 ID。`docs_to_wiki` 模式必填；`node` 模式下如果不传，则必须传 `--target-parent-token` |
 | `--target-parent-token` | 否 | 目标父节点 token。`docs_to_wiki` 不传时表示迁入目标知识空间根目录 |
@@ -87,8 +87,9 @@ lark-cli wiki +move \
 
 ### `node` 模式
 
-- **源空间解析**：如果未传 `--source-space-id`，shortcut 会先调用 `GET /open-apis/wiki/v2/spaces/get_node` 查询 `--node-token`，再读取其 `space_id`
+- **源空间解析**：先调用 `GET /open-apis/wiki/v2/spaces/node_by_token` 解析源节点；未传 `--source-space-id` 时使用查询结果，传入时校验两者一致。
 - **目标父节点解析**：如果传了 `--target-parent-token`，shortcut 会先解析该父节点所属的 `space_id`
+- **节点类型**：源节点和目标父节点接受 Wiki `node_token` 或文档 `obj_token`，实际移动使用查询返回的 `node_token`。
 - **一致性校验**：如果同时传了 `--target-space-id` 和 `--target-parent-token`，shortcut 会校验两者是否属于同一个知识空间；不一致时直接返回验证错误
 - **移动到空间根目录**：如果只传 `--target-space-id`，则表示移动到该知识空间根目录
 

--- a/skills/lark-wiki/references/lark-wiki-node-create.md
+++ b/skills/lark-wiki/references/lark-wiki-node-create.md
@@ -75,7 +75,7 @@ lark-cli wiki +node-create \
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `--space-id` | 否 | 目标知识空间 ID；`user` 身份可传特殊值 `my_library` 表示个人知识库，`bot` 身份不支持该值 |
-| `--parent-node-token` | 否 | 父知识库节点 token；传入后会在该节点下创建新节点 |
+| `--parent-node-token` | 否 | 父知识库节点 token 或文档 obj_token；在解析出的 Wiki 节点下创建新节点 |
 | `--title` | 否 | 节点标题 |
 | `--node-type` | 否 | 节点类型，默认 `origin`；可选值：`origin`、`shortcut` |
 | `--obj-type` | 否 | 节点对应对象类型，默认 `docx`；可选值：`sheet`、`mindnote`、`bitable`、`file`、`docx`、`slides`。`file` 仅支持 `shortcut` 节点 |
@@ -85,7 +85,8 @@ lark-cli wiki +node-create \
 
 - **优先级**：`--space-id` > `--parent-node-token` > `my_library`
 - **显式 space**：传了 `--space-id` 时，shortcut 会直接使用该空间；如果该值是 `my_library`，则仅 `user` 身份可用，并会先调用 `GET /open-apis/wiki/v2/spaces/my_library` 解析成真实 `space_id`
-- **父节点推断**：未传 `--space-id` 但传了 `--parent-node-token` 时，会先调用 `GET /open-apis/wiki/v2/spaces/get_node` 获取父节点，再读取其 `space_id`
+- **父节点推断**：未传 `--space-id` 但传了 `--parent-node-token` 时，会先调用 `GET /open-apis/wiki/v2/spaces/node_by_token` 获取父节点，再读取其 `space_id`
+- **父节点类型**：`--parent-node-token` 接受 Wiki `node_token` 或已挂载到 Wiki 的文档 `obj_token`，创建时使用查询返回的 `node_token`；显式传空间时也会查询并校验父节点空间。
 - **个人知识库回退**：`user` 身份下，如果 `--space-id` 和 `--parent-node-token` 都没传，会自动解析 `my_library`
 - **bot 身份限制**：`bot` 身份既没有“个人知识库”回退语义，也不支持显式传 `--space-id my_library`；请改用真实 `space_id` 或 `--parent-node-token`
 

--- a/skills/lark-wiki/references/lark-wiki-node-delete.md
+++ b/skills/lark-wiki/references/lark-wiki-node-delete.md
@@ -27,11 +27,15 @@ lark-cli wiki +node-delete --node-token <token> --obj-type wiki --dry-run
 | Flag | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `--node-token` | string | **Yes** | — | `node_token`, cloud-doc `obj_token`, or a Lark URL embedding one; URL paths also imply `--obj-type` |
-| `--obj-type` | enum | Conditional | — | Required for a raw token (URL inputs auto-infer). `wiki` = the token is a `node_token`; otherwise the cloud-doc type |
-| `--space-id` | string | No | — | Auto-resolved via `get_node` when omitted (extra lookup; pass it to skip) |
+| `--obj-type` | enum | Conditional | — | Required for a raw token (URL inputs auto-infer). `wiki` uses the resolved `node_token`; other types use the resolved `obj_token` and must match its document type |
+| `--space-id` | string | No | — | Assert the resolved node belongs to this space; inferred when omitted |
 | `--include-children` | bool | No | `true` | Cascade-delete the subtree (default). `--include-children=false` lifts direct children up to the parent |
 | `--yes` | bool | Yes (real delete) | — | Confirm the high-risk operation. Without it the CLI returns `confirmation_required` |
 | `--as` | enum | No | `auto` | Identity `user`/`bot`; wiki is user-centric → pass `--as user` |
+
+The lookup sends only `token`, including when `--space-id` is provided. Deletion uses the resolved token matching `--obj-type`; a document-type mismatch is rejected before deletion.
+
+For a Wiki shortcut, use `--obj-type wiki` to delete the shortcut itself. Other types are rejected because the shortcut's `obj_token` identifies its origin document.
 
 ## Output
 
@@ -57,6 +61,6 @@ Async/timeout adds `task_id`, `timed_out`, and `next_command`.
   - `131011` → the node has delete-approval enabled; apply via the Wiki UI (CLI cannot bypass approval).
   - `131003` → subtree too large to cascade-delete; use `--include-children=false` or delete sub-trees first.
 
-## Required Scope
+## Required Scopes
 
-`wiki:node:create` (the delete endpoint declares this scope). Auto-resolving `space_id` additionally needs `wiki:node:retrieve`; pass `--space-id` to avoid that lookup.
+Both `wiki:node:create` (deletion) and `wiki:node:retrieve` (target lookup) are required, including when `--space-id` is provided. The server also checks access to the target node.

--- a/tests/cli_e2e/wiki/wiki_node_create_dryrun_test.go
+++ b/tests/cli_e2e/wiki/wiki_node_create_dryrun_test.go
@@ -71,12 +71,12 @@ func TestWikiNodeCreateDryRun(t *testing.T) {
 
 		// 2-step: resolve parent node -> create node
 		assert.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, "api.0.method").String())
-		assert.Equal(t, "/open-apis/wiki/v2/spaces/get_node", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
+		assert.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", clie2e.DryRunGet(result.Stdout, "api.0.url").String())
 		assert.Equal(t, "wikcnABC123", clie2e.DryRunGet(result.Stdout, "api.0.params.token").String())
 
 		assert.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.1.method").String())
 		assert.Equal(t, "/open-apis/wiki/v2/spaces/123456/nodes", clie2e.DryRunGet(result.Stdout, "api.1.url").String())
-		assert.Equal(t, "wikcnABC123", clie2e.DryRunGet(result.Stdout, "api.1.body.parent_node_token").String())
+		assert.Equal(t, "<resolved_parent_node_token>", clie2e.DryRunGet(result.Stdout, "api.1.body.parent_node_token").String())
 	})
 
 	t.Run("HappyPath_ShortcutNodeType", func(t *testing.T) {

--- a/tests/cli_e2e/wiki/wiki_node_lookup_dryrun_test.go
+++ b/tests/cli_e2e/wiki/wiki_node_lookup_dryrun_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWikiMutationNodeLookupDryRun(t *testing.T) {
+	setWikiNodeCreateDryRunEnv(t)
+	for _, tt := range []struct {
+		name, method, path string
+		args               []string
+		tokens             []string
+		body               map[string]string
+	}{
+		{"create", "POST", "/open-apis/wiki/v2/spaces/<resolved_space_id>/nodes", []string{"+node-create", "--parent-node-token", "wik_parent"}, []string{"wik_parent"}, map[string]string{"parent_node_token": "<resolved_parent_node_token>"}},
+		{"move", "POST", "/open-apis/wiki/v2/spaces/<resolved_source_space_id>/nodes/<resolved_node_token>/move", []string{"+move", "--node-token", "wik_source", "--target-parent-token", "wik_parent"}, []string{"wik_source", "wik_parent"}, map[string]string{"target_parent_token": "<resolved_parent_node_token>"}},
+		{"delete wiki", "DELETE", "/open-apis/wiki/v2/spaces/<resolved_space_id>/nodes/<resolved_node_token>", []string{"+node-delete", "--node-token", "wik_source", "--obj-type", "wiki"}, []string{"wik_source"}, map[string]string{"obj_type": "wiki"}},
+		{"delete document URL", "DELETE", "/open-apis/wiki/v2/spaces/<resolved_space_id>/nodes/<resolved_obj_token>", []string{"+node-delete", "--node-token", "https://example.com/docx/doc_source"}, []string{"doc_source"}, map[string]string{"obj_type": "docx"}},
+		{"move explicit space", "POST", "/open-apis/wiki/v2/spaces/space_src/nodes/<resolved_node_token>/move", []string{"+move", "--node-token", "doc_source", "--source-space-id", "space_src", "--target-space-id", "space_dst"}, []string{"doc_source"}, map[string]string{"target_space_id": "space_dst"}},
+		{"delete explicit space", "DELETE", "/open-apis/wiki/v2/spaces/space_src/nodes/<resolved_node_token>", []string{"+node-delete", "--node-token", "doc_source", "--obj-type", "wiki", "--space-id", "space_src"}, []string{"doc_source"}, map[string]string{"obj_type": "wiki"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+			args := append([]string{"wiki"}, tt.args...)
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{Args: append(args, "--dry-run"), DefaultAs: "bot"})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+			if tt.method == "DELETE" {
+				description := clie2e.DryRunGet(result.Stdout, "description").String()
+				require.Contains(t, description, "always resolve the target via node_by_token")
+				require.Contains(t, description, "requires Wiki node read access, including with --space-id")
+			}
+			for i, token := range tt.tokens {
+				step := "api." + strconv.Itoa(i)
+				require.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, step+".method").String())
+				require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", clie2e.DryRunGet(result.Stdout, step+".url").String())
+				params := clie2e.DryRunGet(result.Stdout, step+".params").Map()
+				require.Len(t, params, 1)
+				require.Equal(t, token, params["token"].String())
+			}
+			step := "api." + strconv.Itoa(len(tt.tokens))
+			require.Equal(t, tt.method, clie2e.DryRunGet(result.Stdout, step+".method").String())
+			require.Equal(t, tt.path, clie2e.DryRunGet(result.Stdout, step+".url").String())
+			for key, value := range tt.body {
+				require.Equal(t, value, clie2e.DryRunGet(result.Stdout, step+".body."+key).String())
+			}
+		})
+	}
+}

--- a/tests/cli_e2e/wiki/wiki_node_lookup_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_node_lookup_workflow_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestWiki_MutationNodeLookupWorkflow(t *testing.T) {
+	clie2e.SkipWithoutTenantAccessToken(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+	spaceID := getWikiSpace(t, ctx, "my_library").Get("space_id").String()
+	require.NotEmpty(t, spaceID)
+	parent, result, err := createWikiNode(t, t, ctx, spaceID, map[string]any{
+		"node_type": "origin", "obj_type": "docx", "title": "lark-cli-e2e-node-lookup-" + clie2e.GenerateSuffix(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.ExitCode, "%s", result.Stderr)
+	parentToken := parent.Get("node_token").String()
+	target, result, err := createWikiNode(t, t, ctx, spaceID, map[string]any{
+		"node_type": "origin", "obj_type": "docx", "title": "lookup target", "parent_node_token": parentToken,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.ExitCode, "%s", result.Stderr)
+	targetToken := target.Get("node_token").String()
+
+	for _, objType := range []string{"wiki", "docx"} {
+		t.Run("delete by "+objType, func(t *testing.T) {
+			created, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args: []string{"wiki", "+node-create", "--parent-node-token", parent.Get("obj_token").String(), "--title", "lookup child"}, DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			require.Equal(t, 0, created.ExitCode, "%s", created.Stderr)
+			node := gjson.Get(created.Stdout, "data")
+			nodeToken, objToken := node.Get("node_token").String(), node.Get("obj_token").String()
+			require.NotEmpty(t, nodeToken)
+			require.NotEmpty(t, objToken)
+			t.Cleanup(func() {
+				cleanupCtx, cancel := clie2e.CleanupContext()
+				defer cancel()
+				result, err := deleteWikiNodeAndVerify(cleanupCtx, spaceID, nodeToken, "docx")
+				clie2e.ReportCleanupFailure(t, "delete lookup child", result, err)
+			})
+			require.Equal(t, spaceID, node.Get("space_id").String())
+			require.Equal(t, parentToken, node.Get("parent_node_token").String())
+
+			// Compare both lookup APIs on the isolated fixture, including obj_token
+			// resolution used by deletion. The old endpoint remains a supported API.
+			for _, token := range []string{nodeToken, objToken} {
+				var previous gjson.Result
+				for _, endpoint := range []string{"get_node", "node_by_token"} {
+					params := map[string]any{"token": token}
+					if endpoint == "get_node" && token == objToken {
+						params["obj_type"] = "docx"
+					}
+					lookup, err := clie2e.RunCmd(ctx, clie2e.Request{
+						Args: []string{"api", "get", "/open-apis/wiki/v2/spaces/" + endpoint}, Params: params, DefaultAs: "bot",
+					})
+					require.NoError(t, err)
+					require.Equal(t, 0, lookup.ExitCode, "%s", lookup.Stderr)
+					current := gjson.Get(lookup.Stdout, "data.node")
+					require.Equal(t, nodeToken, current.Get("node_token").String())
+					if previous.Exists() {
+						for _, field := range []string{"node_token", "obj_token", "obj_type", "space_id", "parent_node_token", "node_type", "origin_node_token"} {
+							require.Equal(t, previous.Get(field).String(), current.Get(field).String(), field)
+						}
+					}
+					previous = current
+				}
+			}
+
+			// Resolve both source and target, moving only within the isolated tree.
+			moved, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args: []string{"wiki", "+move", "--node-token", objToken, "--target-parent-token", target.Get("obj_token").String()}, DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			require.Equal(t, 0, moved.ExitCode, "%s", moved.Stderr)
+			require.Equal(t, targetToken, gjson.Get(moved.Stdout, "data.parent_node_token").String())
+			require.Equal(t, targetToken, getWikiNode(t, ctx, nodeToken).Get("parent_node_token").String())
+			back, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args: []string{"wiki", "+move", "--node-token", objToken, "--source-space-id", spaceID, "--target-parent-token", parent.Get("obj_token").String()}, DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			require.Equal(t, 0, back.ExitCode, "%s", back.Stderr)
+			require.Equal(t, parentToken, gjson.Get(back.Stdout, "data.parent_node_token").String())
+			require.Equal(t, parentToken, getWikiNode(t, ctx, nodeToken).Get("parent_node_token").String())
+
+			// A shortcut's object token identifies this original document. Reject
+			// converting the shortcut into a document deletion, then delete only
+			// the shortcut and independently verify that the original survives.
+			if objType == "wiki" {
+				shortcut, createdShortcut, err := createWikiNode(t, t, ctx, spaceID, map[string]any{
+					"node_type": "shortcut", "obj_type": "docx", "origin_node_token": nodeToken, "parent_node_token": parentToken,
+				})
+				require.NoError(t, err)
+				require.Equal(t, 0, createdShortcut.ExitCode, "%s", createdShortcut.Stderr)
+				shortcutToken := shortcut.Get("node_token").String()
+				blocked, err := clie2e.RunCmd(ctx, clie2e.Request{
+					Args: []string{"wiki", "+node-delete", "--node-token", shortcutToken, "--obj-type", "docx", "--yes"}, DefaultAs: "bot",
+				})
+				require.NoError(t, err)
+				require.Equal(t, 2, blocked.ExitCode, "%s", blocked.Stderr)
+				require.Equal(t, "--obj-type", gjson.Get(blocked.Stderr, "error.param").String())
+				require.Equal(t, shortcutToken, getWikiNode(t, ctx, shortcutToken).Get("node_token").String())
+				require.Equal(t, nodeToken, getWikiNode(t, ctx, nodeToken).Get("node_token").String())
+				deletedShortcut, err := clie2e.RunCmd(ctx, clie2e.Request{
+					Args: []string{"wiki", "+node-delete", "--node-token", shortcutToken, "--obj-type", "wiki", "--yes"}, DefaultAs: "bot",
+				})
+				require.NoError(t, err)
+				require.Equal(t, 0, deletedShortcut.ExitCode, "%s", deletedShortcut.Stderr)
+				require.NoError(t, waitWikiNodeDeleted(ctx, shortcutToken))
+				require.Equal(t, nodeToken, getWikiNode(t, ctx, nodeToken).Get("node_token").String())
+			}
+			token := objToken
+			if objType == "docx" {
+				token = nodeToken
+			}
+			deleted, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args: []string{"wiki", "+node-delete", "--node-token", token, "--obj-type", objType, "--yes"}, DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			require.Equal(t, 0, deleted.ExitCode, "%s", deleted.Stderr)
+			require.Equal(t, spaceID, gjson.Get(deleted.Stdout, "data.space_id").String())
+			require.Equal(t, objType, gjson.Get(deleted.Stdout, "data.obj_type").String())
+			// Task completion can precede lookup visibility. Poll the new
+			// endpoint itself; unrelated errors must still fail immediately.
+			visibilityCtx, cancel := context.WithTimeout(ctx, wikiDeleteVisibilityTimeout)
+			defer cancel()
+			require.NoError(t, clie2e.WaitForCondition(visibilityCtx, clie2e.WaitOptions{
+				Timeout: wikiDeleteVisibilityTimeout, Interval: wikiDeleteVisibilityPoll,
+			}, func() (bool, error) {
+				missing, err := clie2e.RunCmd(visibilityCtx, clie2e.Request{
+					Args:   []string{"api", "get", "/open-apis/wiki/v2/spaces/node_by_token"},
+					Params: map[string]any{"token": nodeToken}, DefaultAs: "bot",
+				})
+				if err != nil {
+					return false, err
+				}
+				if missing.ExitCode == 0 {
+					require.Equal(t, nodeToken, gjson.Get(missing.Stdout, "data.node.node_token").String())
+					return false, nil
+				}
+				require.Equal(t, 1, missing.ExitCode, "%s", missing.Stderr)
+				require.Contains(t, []int64{131005, 131012}, gjson.Get(missing.Stderr, "error.code").Int())
+				return true, nil
+			}))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Migrate the internal node lookups used by Wiki node creation, node-mode movement, and deletion from `get_node` to `node_by_token`. Resolve accepted Wiki node tokens and document object tokens to the identifiers required by each mutation, while retaining space checks and protecting shortcut targets from accidental deletion.

## Changes
- Use a small Wiki-local lookup helper for parent, source, and deletion lookups. Other domains and document-to-Wiki movement are unchanged.
- Create under the resolved parent node; move the resolved source node to the resolved parent. Explicit source and target spaces are checked against lookup results.
- Delete with the resolved Wiki node token or document object token according to `--obj-type`. Reject document-type deletion of a shortcut so its original document is not deleted. Declare both `wiki:node:create` and `wiki:node:retrieve` for deletion and its mandatory lookup. Preserve confirmation, child handling, and async completion behavior.
- Share the existing `node_by_token` error classifications with mutation callers, preserving node-get recovery hints and upstream error metadata.
- Update dry-run previews and Wiki guidance, and add request/error regression tests plus a self-contained live workflow with independent readback and shortcut protection checks.

## Test Plan
- [x] User/bot scope-preflight regressions: either missing scope stops before API requests; both scopes permit lookup and deletion.
- [x] Wiki package tests, including `go test ./shortcuts/wiki -race -count=1`.
- [x] Focused create/mutation dry-run E2E tests; live E2E package compile check.
- [x] User-identity live verification with isolated fixtures: Wiki/object tokens with inferred/explicit spaces, old/new lookup parity, create/move/delete readback, shortcut protection, child retention/cascade deletion, invalid inputs, and cleanup verification.
- [x] Temporarily reverted seven critical behaviors individually and confirmed the regression tests failed; restored all temporary mutations.
- [x] Canonical build, vet, formatting, skill format check, incremental golangci-lint, and committed-diff source guards.
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate` after committing.
- [x] `go test -C lint ./... -count=1`.
- [x] `go mod tidy` leaves module files unchanged; dependency license check passes.

## Related Issues
- Follow-up to #2665.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Wiki node creation, moving, and deletion accept both Wiki node tokens and document object tokens.
  - Commands resolve tokens and use the appropriate node or document identifier.
  - Dry-run previews show node-resolution steps and resolved-token placeholders.

- **Bug Fixes**
  - Added validation for mismatched spaces, object types, and missing resolution data.
  - Lookup failures are classified consistently and prevent mutation requests.

- **Documentation**
  - Updated guidance on supported tokens, validation behavior, and required access scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
