### PR TITLE
fix(drive): migrate wiki lookups to node_by_token

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -489,11 +489,21 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 
 	data, err := runtime.CallAPITyped(
 		"GET",
-		"/open-apis/wiki/v2/spaces/get_node",
+		"/open-apis/wiki/v2/spaces/node_by_token",
 		map[string]interface{}{"token": docRef.Token},
 		nil,
 	)
 	if err != nil {
+		if problem, ok := errs.ProblemOf(err); ok {
+			switch problem.Code {
+			case 131012:
+				problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+			case 131013, 131016:
+				problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+			case 131014:
+				problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+			}
+		}
 		return resolvedCommentTarget{}, err
 	}
 
@@ -501,7 +511,7 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 	objType := common.GetString(node, "obj_type")
 	objToken := common.GetString(node, "obj_token")
 	if objType == "" || objToken == "" {
-		return resolvedCommentTarget{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data")
+		return resolvedCommentTarget{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data")
 	}
 	if objType == "slides" && mode == commentModeFull {
 		return resolvedCommentTarget{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but slide comments require --block-id <slide-block-type>!<xml-id>; --full-comment is not applicable", objType)

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -1153,7 +1153,7 @@ func TestSlidesCommentExecuteSuccessWithCompoundBlockID(t *testing.T) {
 func TestSlidesCommentViaWikiResolve(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1236,7 +1236,7 @@ func TestSheetCommentExecuteWithURL(t *testing.T) {
 func TestSheetCommentViaWikiResolve(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1272,7 +1272,7 @@ func TestSheetCommentViaWikiResolve(t *testing.T) {
 func TestSheetCommentViaWikiMissingBlockID(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1537,7 +1537,7 @@ func TestDryRunSheetDirectURL(t *testing.T) {
 func TestDryRunWikiResolvesToSheet(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1563,7 +1563,7 @@ func TestDryRunWikiResolvesToSheet(t *testing.T) {
 func TestDryRunWikiResolvesToDocxFull(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1650,7 +1650,7 @@ func TestDryRunBaseDirectURL(t *testing.T) {
 func TestDryRunWikiResolvesToSlides(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1687,7 +1687,7 @@ func TestDryRunWikiResolvesToSlides(t *testing.T) {
 func TestDryRunWikiSlidesInvalidBlockIDSurfaces(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1721,7 +1721,7 @@ func TestDryRunWikiSlidesInvalidBlockIDSurfaces(t *testing.T) {
 func TestDryRunWikiSlidesResolutionErrorSurfaces(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1835,11 +1835,14 @@ func TestDryRunFileDirectURL(t *testing.T) {
 func TestResolveWikiToDocxFullComment(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
-				"node": map[string]interface{}{"obj_type": "docx", "obj_token": "docxResolved"},
+				"node": map[string]interface{}{
+					"obj_type": "docx", "obj_token": "docxResolved",
+					"node_type": "shortcut", "node_token": "wikiToken", "origin_node_token": "wikiOriginal",
+				},
 			},
 		},
 	})
@@ -1869,7 +1872,7 @@ func TestResolveWikiToBaseComment(t *testing.T) {
 		t.Run(objType, func(t *testing.T) {
 			f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 			reg.Register(&httpmock.Stub{
-				Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+				Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 				Body: map[string]interface{}{
 					"code": 0, "msg": "success",
 					"data": map[string]interface{}{
@@ -1925,7 +1928,7 @@ func TestResolveWikiToBaseRejectsIncompatibleFlags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 			reg.Register(&httpmock.Stub{
-				Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+				Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 				Body: map[string]interface{}{
 					"code": 0, "msg": "success",
 					"data": map[string]interface{}{
@@ -1951,7 +1954,7 @@ func TestResolveWikiToBaseRejectsIncompatibleFlags(t *testing.T) {
 func TestResolveWikiToSlidesFullCommentRejected(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1974,7 +1977,7 @@ func TestResolveWikiToSlidesFullCommentRejected(t *testing.T) {
 func TestResolveWikiIncompleteNodeData(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
-		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{
@@ -1991,6 +1994,7 @@ func TestResolveWikiIncompleteNodeData(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "incomplete node data") {
 		t.Fatalf("expected incomplete node error, got: %v", err)
 	}
+	assertDriveCommentIncompleteNodeError(t, err)
 }
 
 func TestDocOldFormatLocalCommentRejected(t *testing.T) {

--- a/shortcuts/drive/drive_add_reply.go
+++ b/shortcuts/drive/drive_add_reply.go
@@ -191,7 +191,7 @@ func buildDriveAddReplyDryRun(spec driveAddReplySpec) *common.DryRunAPI {
 	if spec.Ref.Type == "wiki" {
 		return common.NewDryRunAPI().
 			Desc("2-step orchestration: resolve wiki -> add reply to comment").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			POST("/open-apis/drive/v1/files/<obj_token from step 1>/comments/:comment_id/replies").

--- a/shortcuts/drive/drive_add_reply_test.go
+++ b/shortcuts/drive/drive_add_reply_test.go
@@ -123,7 +123,7 @@ func TestDriveAddReplyExecuteWikiResolvesToDocx(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -188,7 +188,7 @@ func TestDriveAddReplyWikiResolvesToUnsupported(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",

--- a/shortcuts/drive/drive_batch_query_comments.go
+++ b/shortcuts/drive/drive_batch_query_comments.go
@@ -156,7 +156,7 @@ func buildDriveBatchQueryCommentsDryRun(spec driveBatchQueryCommentsSpec) *commo
 		}
 		return common.NewDryRunAPI().
 			Desc("2-step orchestration: resolve wiki -> batch query comments").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			POST("/open-apis/drive/v1/files/<obj_token from step 1>/comments/batch_query").

--- a/shortcuts/drive/drive_batch_query_comments_test.go
+++ b/shortcuts/drive/drive_batch_query_comments_test.go
@@ -108,7 +108,7 @@ func TestDriveBatchQueryCommentsExecuteWikiWithReaction(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		OnMatch: func(req *http.Request) {
 			if got := req.URL.Query().Get("token"); got != "wikiResource" {
 				t.Errorf("wiki token = %q, want wikiResource", got)
@@ -255,7 +255,7 @@ func TestDriveBatchQueryCommentsWikiResolvesToUnsupported(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -418,8 +418,8 @@ func TestDriveBatchQueryCommentsDryRunWiki(t *testing.T) {
 		t.Fatalf("dry-run api call count = %d, want 2\nstdout:\n%s", len(api), stdout.String())
 	}
 	step1 := mustMapValue(t, api[0], "api[0]")
-	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/get_node") {
-		t.Fatalf("api[0].url = %q, want wiki get_node", got)
+	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/node_by_token") {
+		t.Fatalf("api[0].url = %q, want wiki node_by_token", got)
 	}
 	step2 := mustMapValue(t, api[1], "api[1]")
 	if got := mustStringField(t, step2, "method", "api[1].method"); got != "POST" {

--- a/shortcuts/drive/drive_comment_common.go
+++ b/shortcuts/drive/drive_comment_common.go
@@ -171,7 +171,7 @@ func normalizeDriveCommentType(docType string) string {
 }
 
 // resolveDriveCommentTarget unwraps wiki refs to the underlying document via
-// wiki get_node and validates the resolved type against op.Types.
+// wiki node_by_token and validates the resolved type against op.Types.
 func resolveDriveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, op driveCommentOp, ref driveCommentRef) (driveCommentTarget, error) {
 	if ref.Type != "wiki" {
 		return driveCommentTarget{FileToken: ref.Token, FileType: ref.Type}, nil
@@ -179,11 +179,21 @@ func resolveDriveCommentTarget(ctx context.Context, runtime *common.RuntimeConte
 
 	data, err := runtime.CallAPITyped(
 		"GET",
-		"/open-apis/wiki/v2/spaces/get_node",
+		"/open-apis/wiki/v2/spaces/node_by_token",
 		map[string]interface{}{"token": ref.Token},
 		nil,
 	)
 	if err != nil {
+		if problem, ok := errs.ProblemOf(err); ok {
+			switch problem.Code {
+			case 131012:
+				problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+			case 131013, 131016:
+				problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+			case 131014:
+				problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+			}
+		}
 		return driveCommentTarget{}, err
 	}
 
@@ -191,7 +201,7 @@ func resolveDriveCommentTarget(ctx context.Context, runtime *common.RuntimeConte
 	objType := normalizeDriveCommentType(common.GetString(node, "obj_type"))
 	objToken := common.GetString(node, "obj_token")
 	if objType == "" || objToken == "" {
-		return driveCommentTarget{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data")
+		return driveCommentTarget{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data")
 	}
 	if objType == "wiki" || !op.supports(objType) {
 		return driveCommentTarget{}, errs.NewValidationError(

--- a/shortcuts/drive/drive_comment_common_test.go
+++ b/shortcuts/drive/drive_comment_common_test.go
@@ -47,6 +47,17 @@ func assertDriveCommentAPIError(t *testing.T, err error, wantCode int) {
 	}
 }
 
+func assertDriveCommentIncompleteNodeError(t *testing.T, err error) {
+	t.Helper()
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) || internalErr.Category != errs.CategoryInternal || internalErr.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("expected internal/invalid_response, got %T: %v", err, err)
+	}
+	if cause := errors.Unwrap(err); cause != nil {
+		t.Fatalf("unexpected cause on direct invalid-response error: %v", cause)
+	}
+}
+
 func TestResolveDriveCommentInput(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/drive/drive_copy.go
+++ b/shortcuts/drive/drive_copy.go
@@ -66,7 +66,7 @@ var DriveCopy = common.Shortcut{
 	},
 	Tips: []string{
 		"The source type must match the real file type; the API rejects mismatches.",
-		"A wiki URL or --token with --type wiki is resolved through wiki get_node, then its underlying Drive resource is copied.",
+		"A wiki URL or --token with --type wiki is resolved through wiki node_by_token, then its underlying Drive resource is copied.",
 		"Use `--extra target_type=docx` with a legacy doc source to create the copy as a new-version docx.",
 		"`--folder-token my_space` resolves the caller's My Space root folder automatically; resolution needs the drive:drive.metadata:readonly (or drive:drive) scope.",
 		"In bot mode, the CLI also tries to grant the current CLI user full_access on the new copy; the outcome is reported in the permission_grant output field.",
@@ -253,12 +253,24 @@ func resolveDriveCopyInput(urlInput, tokenInput, explicitType string) (driveCopy
 func resolveDriveCopyWikiResource(ctx context.Context, runtime *common.RuntimeContext, spec driveCopySpec) (driveCopySpec, error) {
 	wikiToken := spec.Ref.Token
 	data, err := driveInspectCallWithRetry(ctx, func() (map[string]interface{}, error) {
-		return runtime.CallAPITyped(
+		data, err := runtime.CallAPITyped(
 			"GET",
-			"/open-apis/wiki/v2/spaces/get_node",
+			"/open-apis/wiki/v2/spaces/node_by_token",
 			map[string]interface{}{"token": wikiToken},
 			nil,
 		)
+		// Classify terminal lookup failures before deciding whether to retry.
+		if problem, ok := errs.ProblemOf(err); ok {
+			switch problem.Code {
+			case 131012:
+				problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+			case 131013, 131016:
+				problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+			case 131014:
+				problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+			}
+		}
+		return data, err
 	})
 	if err != nil {
 		return driveCopySpec{}, driveInspectAnnotateError("resolve_wiki", err)
@@ -270,7 +282,7 @@ func resolveDriveCopyWikiResource(ctx context.Context, runtime *common.RuntimeCo
 	if objType == "" || objToken == "" {
 		return driveCopySpec{}, errs.NewInternalError(
 			errs.SubtypeInvalidResponse,
-			"wiki get_node returned incomplete node data (obj_type=%q, obj_token=%q)",
+			"wiki node_by_token returned incomplete node data (obj_type=%q, obj_token=%q)",
 			objType,
 			objToken,
 		)
@@ -285,7 +297,7 @@ func resolveDriveCopyWikiResource(ctx context.Context, runtime *common.RuntimeCo
 	if err := validate.ResourceName(objToken, spec.Ref.SourceFlag); err != nil {
 		return driveCopySpec{}, errs.NewInternalError(
 			errs.SubtypeInvalidResponse,
-			"wiki get_node returned an unsafe obj_token: %s",
+			"wiki node_by_token returned an unsafe obj_token: %s",
 			err,
 		).WithCause(err)
 	}
@@ -377,7 +389,7 @@ func buildDriveCopyDryRun(spec driveCopySpec) *common.DryRunAPI {
 	if spec.Ref.Type == "wiki" {
 		dry := common.NewDryRunAPI().
 			Desc("Resolve wiki node, then copy its underlying resource into Drive").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve the wiki node to its underlying resource").
 			Params(map[string]interface{}{"token": spec.Ref.Token})
 		folderToken := spec.FolderToken

--- a/shortcuts/drive/drive_copy_test.go
+++ b/shortcuts/drive/drive_copy_test.go
@@ -900,12 +900,15 @@ func TestDriveCopyExecuteWikiSheet(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
 			"data": map[string]interface{}{
-				"node": map[string]interface{}{"obj_type": "sheet", "obj_token": "sheetFromWiki"},
+				"node": map[string]interface{}{
+					"obj_type": "sheet", "obj_token": "sheetFromWiki",
+					"node_type": "shortcut", "node_token": "wikiCopySource", "origin_node_token": "wikiOriginal",
+				},
 			},
 		},
 	})
@@ -950,7 +953,7 @@ func TestDriveCopyWikiRejectsUnsupportedResolvedType(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",

--- a/shortcuts/drive/drive_delete_reply.go
+++ b/shortcuts/drive/drive_delete_reply.go
@@ -113,7 +113,7 @@ func buildDriveDeleteReplyDryRun(spec driveDeleteReplySpec) *common.DryRunAPI {
 	if spec.Ref.Type == "wiki" {
 		return common.NewDryRunAPI().
 			Desc("2-step orchestration: resolve wiki -> delete reply").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			DELETE("/open-apis/drive/v1/files/<obj_token from step 1>/comments/:comment_id/replies/:reply_id").

--- a/shortcuts/drive/drive_delete_reply_test.go
+++ b/shortcuts/drive/drive_delete_reply_test.go
@@ -58,7 +58,7 @@ func TestDriveDeleteReplyExecuteViaWiki(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -201,7 +201,7 @@ func TestDriveDeleteReplyWikiNodeIncompleteResponse(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",

--- a/shortcuts/drive/drive_export.go
+++ b/shortcuts/drive/drive_export.go
@@ -145,7 +145,7 @@ func PlanExportDryRun(runtime *common.RuntimeContext, p ExportParams) *common.Dr
 
 	dry := common.NewDryRunAPI()
 	if source.Type == "wiki" {
-		dry.GET("/open-apis/wiki/v2/spaces/get_node").
+		dry.GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[0] Resolve wiki node to underlying document token").
 			Params(map[string]interface{}{"token": source.Token})
 		spec.Token = "obj_token_from_step_0"

--- a/shortcuts/drive/drive_export_common.go
+++ b/shortcuts/drive/drive_export_common.go
@@ -439,12 +439,24 @@ func resolveDriveExportWikiSource(ctx context.Context, runtime *common.RuntimeCo
 	}
 
 	data, err := driveInspectCallWithRetry(ctx, func() (map[string]interface{}, error) {
-		return runtime.CallAPITyped(
+		data, err := runtime.CallAPITyped(
 			"GET",
-			"/open-apis/wiki/v2/spaces/get_node",
+			"/open-apis/wiki/v2/spaces/node_by_token",
 			map[string]interface{}{"token": wikiToken},
 			nil,
 		)
+		// Classify terminal lookup failures before deciding whether to retry.
+		if problem, ok := errs.ProblemOf(err); ok {
+			switch problem.Code {
+			case 131012:
+				problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+			case 131013, 131016:
+				problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+			case 131014:
+				problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+			}
+		}
+		return data, err
 	})
 	if err != nil {
 		return spec, driveExportWikiResolution{}, err
@@ -454,7 +466,7 @@ func resolveDriveExportWikiSource(ctx context.Context, runtime *common.RuntimeCo
 	objType := normalizeDriveExportDocType(common.GetString(node, "obj_type"))
 	objToken := common.GetString(node, "obj_token")
 	if objType == "" || objToken == "" {
-		return spec, driveExportWikiResolution{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data (obj_type=%q, obj_token=%q)", objType, objToken)
+		return spec, driveExportWikiResolution{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data (obj_type=%q, obj_token=%q)", objType, objToken)
 	}
 	if !isDriveExportDocType(objType) {
 		return spec, driveExportWikiResolution{}, errs.NewValidationError(

--- a/shortcuts/drive/drive_export_test.go
+++ b/shortcuts/drive/drive_export_test.go
@@ -237,6 +237,64 @@ func TestDriveExportMarkdownWritesFile(t *testing.T) {
 	}
 }
 
+func TestDriveExportWikiShortcutMarkdown(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
+		OnMatch: func(req *http.Request) {
+			if req.URL.RawQuery != "token=wikiShortcut" {
+				t.Errorf("lookup query = %q", req.URL.RawQuery)
+			}
+		},
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"node": map[string]interface{}{
+				"node_type": "shortcut", "node_token": "wikiShortcut", "origin_node_token": "wikiOriginal",
+				"obj_type": "docx", "obj_token": "docxOriginal", "title": "Shortcut title",
+			},
+		}},
+	})
+	fetch := &httpmock.Stub{
+		Method: "POST", URL: "/open-apis/docs_ai/v1/documents/docxOriginal/fetch",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"document": map[string]interface{}{"content": "# Original content\n"},
+		}},
+	}
+	reg.Register(fetch)
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"metas": []map[string]interface{}{{"title": "Original title"}},
+		}},
+	})
+	dir := t.TempDir()
+	withDriveWorkingDir(t, dir)
+	err := mountAndRunDrive(t, DriveExport, []string{
+		"+export", "--token", "wikiShortcut", "--doc-type", "wiki", "--file-extension", "markdown", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body := decodeCapturedJSONBody(t, fetch); len(body) != 1 || body["format"] != "markdown" {
+		t.Fatalf("fetch body = %#v", body)
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "Original title.md"))
+	if err != nil || string(content) != "# Original content\n" {
+		t.Fatalf("saved content = %q, error = %v", content, err)
+	}
+	out := decodeDriveEnvelope(t, stdout)
+	if out["token"] != "docxOriginal" || out["doc_type"] != "docx" || out["wiki_token"] != "wikiShortcut" {
+		t.Fatalf("unexpected export target: %#v", out)
+	}
+	node := mustMapValue(t, out["wiki_node"], "wiki_node")
+	if len(node) != 2 || node["obj_token"] != "docxOriginal" || node["obj_type"] != "docx" {
+		t.Fatalf("unexpected wiki_node: %#v", node)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+}
+
 func TestDriveExportMarkdownUsesProvidedFileName(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	fetchStub := &httpmock.Stub{
@@ -643,7 +701,7 @@ func TestDriveExportWikiURLResolvesBeforeAsyncTask(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -729,7 +787,7 @@ func TestDriveExportBareWikiTypeResolvesBeforeAsyncTask(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -868,7 +926,7 @@ func TestDriveExportWikiResolvedTypeMismatch(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{

--- a/shortcuts/drive/drive_import_common.go
+++ b/shortcuts/drive/drive_import_common.go
@@ -295,7 +295,7 @@ func appendDriveImportFolderTokenWikiCheckDryRun(dry *common.DryRunAPI, spec dri
 		return
 	}
 
-	dry.GET("/open-apis/wiki/v2/spaces/get_node").
+	dry.GET("/open-apis/wiki/v2/spaces/node_by_token").
 		Desc("[0] Validate whether --folder-token is a wiki node").
 		Params(map[string]interface{}{"token": folderToken})
 }
@@ -308,7 +308,7 @@ func rejectDriveImportWikiFolderToken(runtime *common.RuntimeContext, folderToke
 
 	data, err := runtime.CallAPITyped(
 		"GET",
-		"/open-apis/wiki/v2/spaces/get_node",
+		"/open-apis/wiki/v2/spaces/node_by_token",
 		map[string]interface{}{"token": folderToken},
 		nil,
 	)

--- a/shortcuts/drive/drive_import_common_test.go
+++ b/shortcuts/drive/drive_import_common_test.go
@@ -439,7 +439,7 @@ func TestDriveImportRejectsWikiFolderToken(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -497,7 +497,7 @@ func TestDriveImportContinuesWhenFolderTokenDoesNotResolveAsWiki(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 1310001,
 			"msg":  "node not found",
@@ -567,7 +567,7 @@ func TestDriveImportWikiProbePermissionFailureRemainsNonBlocking(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 131006,
 			"msg":  "permission denied: node permission denied, user needs read permission.",
@@ -583,6 +583,32 @@ func TestDriveImportWikiProbePermissionFailureRemainsNonBlocking(t *testing.T) {
 
 	if err := rejectDriveImportWikiFolderToken(runtime, "fldcnImportTarget"); err != nil {
 		t.Fatalf("wiki probe permission failure must not block a valid Drive folder token: %v", err)
+	}
+}
+
+func TestDriveImportWikiProbeErrorsRemainNonBlocking(t *testing.T) {
+	for _, code := range []int{131006, 131012, 131013, 131014, 131016} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+			f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+			lookup := &httpmock.Stub{
+				Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
+				Body: map[string]interface{}{"code": code, "msg": "not a readable Wiki node"},
+				OnMatch: func(req *http.Request) {
+					if req.URL.RawQuery != "token=folderTarget" {
+						t.Errorf("lookup query = %q", req.URL.RawQuery)
+					}
+				},
+			}
+			reg.Register(lookup)
+			runtime := common.TestNewRuntimeContextForAPI(context.Background(), &cobra.Command{Use: "drive +import"}, driveTestConfig(), f, core.AsUser)
+			if err := rejectDriveImportWikiFolderToken(runtime, "folderTarget"); err != nil {
+				t.Fatalf("Wiki probe must remain non-blocking: %v", err)
+			}
+			if len(lookup.CapturedBodies) != 1 {
+				t.Fatalf("lookup calls = %d, want 1", len(lookup.CapturedBodies))
+			}
+		})
 	}
 }
 

--- a/shortcuts/drive/drive_inspect.go
+++ b/shortcuts/drive/drive_inspect.go
@@ -21,6 +21,13 @@ const (
 
 var driveInspectAfter = time.After
 
+type driveInspectWikiNode struct {
+	SpaceID   string `json:"space_id"`
+	NodeToken string `json:"node_token"`
+	ObjToken  string `json:"obj_token"`
+	ObjType   string `json:"obj_type"`
+}
+
 var DriveInspect = common.Shortcut{
 	Service:           "drive",
 	Command:           "+inspect",
@@ -58,7 +65,7 @@ var DriveInspect = common.Shortcut{
 
 		if ref.Type == "wiki" {
 			dry.Desc("2-step: inspect wiki node, then batch query metadata")
-			dry.GET("/open-apis/wiki/v2/spaces/get_node").
+			dry.GET("/open-apis/wiki/v2/spaces/node_by_token").
 				Desc("[1] Inspect wiki node to get underlying document").
 				Params(map[string]interface{}{"token": ref.Token})
 			dry.POST("/open-apis/drive/v1/metas/batch_query").
@@ -91,19 +98,31 @@ var DriveInspect = common.Shortcut{
 		docType := ref.Type
 		docToken := ref.Token
 
-		var wikiNode map[string]interface{}
+		var wikiNode *driveInspectWikiNode
 
-		// Step 2: If type is "wiki", unwrap via get_node API.
+		// Step 2: If type is "wiki", resolve its underlying document.
 		if docType == "wiki" {
 			data, err := driveInspectCallWithRetry(
 				ctx,
 				func() (map[string]interface{}, error) {
-					return runtime.CallAPITyped(
+					data, err := runtime.CallAPITyped(
 						"GET",
-						"/open-apis/wiki/v2/spaces/get_node",
+						"/open-apis/wiki/v2/spaces/node_by_token",
 						map[string]interface{}{"token": docToken},
 						nil,
 					)
+					// Classify terminal lookup failures before deciding whether to retry.
+					if problem, ok := errs.ProblemOf(err); ok {
+						switch problem.Code {
+						case 131012:
+							problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+						case 131013, 131016:
+							problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+						case 131014:
+							problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+						}
+					}
+					return data, err
 				},
 			)
 			if err != nil {
@@ -111,25 +130,19 @@ var DriveInspect = common.Shortcut{
 			}
 
 			node := common.GetMap(data, "node")
-			objType := common.GetString(node, "obj_type")
-			objToken := common.GetString(node, "obj_token")
-			spaceID := common.GetString(node, "space_id")
-			nodeToken := common.GetString(node, "node_token")
-
-			if objType == "" || objToken == "" {
-				return errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data (obj_type=%q, obj_token=%q)", objType, objToken)
+			wikiNode = &driveInspectWikiNode{
+				SpaceID:   common.GetString(node, "space_id"),
+				NodeToken: common.GetString(node, "node_token"),
+				ObjToken:  common.GetString(node, "obj_token"),
+				ObjType:   common.GetString(node, "obj_type"),
 			}
 
-			wikiNode = map[string]interface{}{
-				"space_id":   spaceID,
-				"node_token": nodeToken,
-				"obj_token":  objToken,
-				"obj_type":   objType,
+			if wikiNode.ObjType == "" || wikiNode.ObjToken == "" {
+				return errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data (obj_type=%q, obj_token=%q)", wikiNode.ObjType, wikiNode.ObjToken)
 			}
 
-			docType = objType
-			docToken = objToken
-
+			docType = wikiNode.ObjType
+			docToken = wikiNode.ObjToken
 		}
 
 		// Step 3: Call batch_query to verify and get title.
@@ -163,7 +176,7 @@ var DriveInspect = common.Shortcut{
 				fmt.Fprintf(w, "URL:   %s\n", resolvedURL)
 			}
 			if wikiNode != nil {
-				fmt.Fprintf(w, "Wiki:  space_id=%s, node_token=%s\n", wikiNode["space_id"], wikiNode["node_token"])
+				fmt.Fprintf(w, "Wiki:  space_id=%s, node_token=%s\n", wikiNode.SpaceID, wikiNode.NodeToken)
 			}
 		})
 		return nil

--- a/shortcuts/drive/drive_inspect_test.go
+++ b/shortcuts/drive/drive_inspect_test.go
@@ -258,8 +258,8 @@ func TestDriveInspectDryRun_WikiURL(t *testing.T) {
 	if len(got.API) != 2 {
 		t.Fatalf("expected 2 API steps, got %d", len(got.API))
 	}
-	if got.API[0].URL != "/open-apis/wiki/v2/spaces/get_node" {
-		t.Errorf("step 1 URL = %q, want /open-apis/wiki/v2/spaces/get_node", got.API[0].URL)
+	if got.API[0].URL != "/open-apis/wiki/v2/spaces/node_by_token" {
+		t.Errorf("step 1 URL = %q, want /open-apis/wiki/v2/spaces/node_by_token", got.API[0].URL)
 	}
 	// Verify step 1 params contain the wiki token.
 	if got.API[0].Params["token"] != "wikcnABC" {
@@ -430,17 +430,18 @@ func TestDriveInspectExecute_WikiURL(t *testing.T) {
 
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
 				"node": map[string]interface{}{
-					"obj_type":   "docx",
-					"obj_token":  "doxcnUnwrapped",
-					"space_id":   "space123",
-					"node_token": "wikcnNodeToken",
-					"title":      "Wiki Doc",
-					"node_type":  "origin",
+					"obj_type":          "docx",
+					"obj_token":         "doxcnUnwrapped",
+					"space_id":          "space123",
+					"node_token":        "wikcnNodeToken",
+					"title":             "Shortcut title",
+					"node_type":         "shortcut",
+					"origin_node_token": "wikiOriginal",
 				},
 			},
 		},
@@ -484,6 +485,9 @@ func TestDriveInspectExecute_WikiURL(t *testing.T) {
 	if wikiNode["space_id"] != "space123" {
 		t.Errorf("wiki_node.space_id = %v, want space123", wikiNode["space_id"])
 	}
+	if len(wikiNode) != 4 || wikiNode["node_token"] != "wikcnNodeToken" || wikiNode["obj_type"] != "docx" || wikiNode["obj_token"] != "doxcnUnwrapped" {
+		t.Fatalf("unexpected wiki_node projection: %#v", wikiNode)
+	}
 }
 
 func TestDriveInspectExecute_WikiPermissionDeniedUsesTerminalGuidance(t *testing.T) {
@@ -492,7 +496,7 @@ func TestDriveInspectExecute_WikiPermissionDeniedUsesTerminalGuidance(t *testing
 
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code":   131006,
 			"msg":    "permission denied: node permission denied, user needs read permission.",
@@ -529,7 +533,7 @@ func TestDriveInspectExecute_WikiGetNodeIncompleteData(t *testing.T) {
 
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -623,7 +627,7 @@ func TestDriveInspectExecute_RetriesRateLimitOnWikiResolve(t *testing.T) {
 
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 99991400,
 			"msg":  "request trigger frequency limit",
@@ -631,7 +635,7 @@ func TestDriveInspectExecute_RetriesRateLimitOnWikiResolve(t *testing.T) {
 	})
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{

--- a/shortcuts/drive/drive_list_comments.go
+++ b/shortcuts/drive/drive_list_comments.go
@@ -245,11 +245,21 @@ func resolveDriveListCommentsTarget(ctx context.Context, runtime *common.Runtime
 
 	data, err := runtime.CallAPITyped(
 		"GET",
-		"/open-apis/wiki/v2/spaces/get_node",
+		"/open-apis/wiki/v2/spaces/node_by_token",
 		map[string]interface{}{"token": ref.Token},
 		nil,
 	)
 	if err != nil {
+		if problem, ok := errs.ProblemOf(err); ok {
+			switch problem.Code {
+			case 131012:
+				problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+			case 131013, 131016:
+				problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+			case 131014:
+				problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+			}
+		}
 		return driveListCommentsTarget{}, err
 	}
 
@@ -257,7 +267,7 @@ func resolveDriveListCommentsTarget(ctx context.Context, runtime *common.Runtime
 	objType := normalizeDriveListCommentsType(common.GetString(node, "obj_type"))
 	objToken := common.GetString(node, "obj_token")
 	if objType == "" || objToken == "" {
-		return driveListCommentsTarget{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data")
+		return driveListCommentsTarget{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data")
 	}
 	if !driveListCommentsTypeSupported(objType) || objType == "wiki" {
 		return driveListCommentsTarget{}, errs.NewValidationError(
@@ -277,7 +287,7 @@ func buildDriveListCommentsDryRun(spec driveListCommentsSpec) *common.DryRunAPI 
 		}
 		return common.NewDryRunAPI().
 			Desc("2-step orchestration: resolve wiki -> list comments").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			GET("/open-apis/drive/v1/files/<obj_token from step 1>/comments").

--- a/shortcuts/drive/drive_list_comments_test.go
+++ b/shortcuts/drive/drive_list_comments_test.go
@@ -380,7 +380,7 @@ func TestDriveListCommentsExecuteWikiResolvesToDocx(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		OnMatch: func(req *http.Request) {
 			if got := req.URL.Query().Get("token"); got != "wikiResource" {
 				t.Errorf("wiki token = %q, want wikiResource", got)
@@ -393,6 +393,7 @@ func TestDriveListCommentsExecuteWikiResolvesToDocx(t *testing.T) {
 				"node": map[string]interface{}{
 					"obj_type":  "docx",
 					"obj_token": "docxFromWikiResource",
+					"node_type": "shortcut", "node_token": "wikiResource", "origin_node_token": "wikiOriginal",
 				},
 			},
 		},
@@ -449,7 +450,7 @@ func TestDriveListCommentsExecuteWikiRejectsUnsupportedResolvedType(t *testing.T
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",

--- a/shortcuts/drive/drive_list_replies.go
+++ b/shortcuts/drive/drive_list_replies.go
@@ -137,7 +137,7 @@ func buildDriveListRepliesDryRun(spec driveListRepliesSpec) *common.DryRunAPI {
 	if spec.Ref.Type == "wiki" {
 		return common.NewDryRunAPI().
 			Desc("2-step orchestration: resolve wiki -> list comment replies").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			GET("/open-apis/drive/v1/files/<obj_token from step 1>/comments/:comment_id/replies").

--- a/shortcuts/drive/drive_list_replies_test.go
+++ b/shortcuts/drive/drive_list_replies_test.go
@@ -105,7 +105,7 @@ func TestDriveListRepliesExecuteViaWikiToBitable(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -306,7 +306,7 @@ func TestDriveListRepliesWikiNodeIncompleteResponse(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -325,6 +325,7 @@ func TestDriveListRepliesWikiNodeIncompleteResponse(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "incomplete node data") {
 		t.Fatalf("expected incomplete-node error, got %v", err)
 	}
+	assertDriveCommentIncompleteNodeError(t, err)
 }
 
 func TestDriveListRepliesDryRunDirect(t *testing.T) {
@@ -376,8 +377,8 @@ func TestDriveListRepliesDryRunWiki(t *testing.T) {
 		t.Fatalf("dry-run api call count = %d, want 2\nstdout:\n%s", len(api), stdout.String())
 	}
 	step1 := mustMapValue(t, api[0], "api[0]")
-	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/get_node") {
-		t.Fatalf("api[0].url = %q, want wiki get_node", got)
+	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/node_by_token") {
+		t.Fatalf("api[0].url = %q, want wiki node_by_token", got)
 	}
 	step2 := mustMapValue(t, api[1], "api[1]")
 	if got := mustStringField(t, step2, "method", "api[1].method"); got != "GET" {

--- a/shortcuts/drive/drive_react_reply.go
+++ b/shortcuts/drive/drive_react_reply.go
@@ -194,7 +194,7 @@ func buildDriveReactReplyDryRun(spec driveReactReplySpec) *common.DryRunAPI {
 	if spec.Ref.Type == "wiki" {
 		return common.NewDryRunAPI().
 			Desc("2-step orchestration: resolve wiki -> update reply reaction").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			POST("/open-apis/drive/v2/files/<obj_token from step 1>/comments/reaction").

--- a/shortcuts/drive/drive_react_reply_test.go
+++ b/shortcuts/drive/drive_react_reply_test.go
@@ -77,7 +77,7 @@ func TestDriveReactReplyExecuteViaWikiDelete(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -288,7 +288,7 @@ func TestDriveReactReplyWikiNodeIncompleteResponse(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -309,6 +309,7 @@ func TestDriveReactReplyWikiNodeIncompleteResponse(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "incomplete node data") {
 		t.Fatalf("expected incomplete-node error, got %v", err)
 	}
+	assertDriveCommentIncompleteNodeError(t, err)
 }
 
 func TestDriveReactReplyDryRunDirect(t *testing.T) {
@@ -369,8 +370,8 @@ func TestDriveReactReplyDryRunWiki(t *testing.T) {
 		t.Fatalf("dry-run api call count = %d, want 2\nstdout:\n%s", len(api), stdout.String())
 	}
 	step1 := mustMapValue(t, api[0], "api[0]")
-	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/get_node") {
-		t.Fatalf("api[0].url = %q, want wiki get_node", got)
+	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/node_by_token") {
+		t.Fatalf("api[0].url = %q, want wiki node_by_token", got)
 	}
 	step2 := mustMapValue(t, api[1], "api[1]")
 	if got := mustStringField(t, step2, "method", "api[1].method"); got != "POST" {

--- a/shortcuts/drive/drive_resolve_comment.go
+++ b/shortcuts/drive/drive_resolve_comment.go
@@ -147,7 +147,7 @@ func buildDriveCommentSolvedDryRun(cfg driveCommentSolvedConfig, spec driveComme
 	if spec.Ref.Type == "wiki" {
 		return common.NewDryRunAPI().
 			Desc(fmt.Sprintf("2-step orchestration: resolve wiki -> %s comment", cfg.Action)).
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			PATCH("/open-apis/drive/v1/files/<obj_token from step 1>/comments/:comment_id").

--- a/shortcuts/drive/drive_resolve_comment_test.go
+++ b/shortcuts/drive/drive_resolve_comment_test.go
@@ -5,10 +5,12 @@ package drive
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
 )
@@ -69,7 +71,7 @@ func TestDriveRestoreCommentExecuteViaWiki(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -77,6 +79,7 @@ func TestDriveRestoreCommentExecuteViaWiki(t *testing.T) {
 				"node": map[string]interface{}{
 					"obj_type":  "docx",
 					"obj_token": "docxFromWiki",
+					"node_type": "shortcut", "node_token": "wikiResource", "origin_node_token": "wikiOriginal",
 				},
 			},
 		},
@@ -128,7 +131,7 @@ func TestDriveResolveCommentExecuteWikiResolvesToBitable(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -276,7 +279,7 @@ func TestDriveResolveCommentPropagatesWikiResolveError(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 230005,
 			"msg":  "wiki node not found",
@@ -291,6 +294,14 @@ func TestDriveResolveCommentPropagatesWikiResolveError(t *testing.T) {
 	}, f, stdout)
 	if err == nil || !strings.Contains(err.Error(), "wiki node not found") {
 		t.Fatalf("expected wiki resolve error to propagate, got %v", err)
+	}
+	assertDriveCommentAPIError(t, err, 230005)
+	problem, _ := errs.ProblemOf(err)
+	if problem.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("subtype = %q, want %q for unmapped code 230005", problem.Subtype, errs.SubtypeUnknown)
+	}
+	if cause := errors.Unwrap(err); cause != nil {
+		t.Fatalf("unexpected cause on direct API error: %v", cause)
 	}
 }
 

--- a/shortcuts/drive/drive_update_reply.go
+++ b/shortcuts/drive/drive_update_reply.go
@@ -129,7 +129,7 @@ func buildDriveUpdateReplyDryRun(spec driveUpdateReplySpec) *common.DryRunAPI {
 	if spec.Ref.Type == "wiki" {
 		return common.NewDryRunAPI().
 			Desc("2-step orchestration: resolve wiki -> update comment reply").
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET("/open-apis/wiki/v2/spaces/node_by_token").
 			Desc("[1] Resolve wiki node to underlying document").
 			Params(map[string]interface{}{"token": spec.Ref.Token}).
 			PUT("/open-apis/drive/v1/files/<obj_token from step 1>/comments/:comment_id/replies/:reply_id").

--- a/shortcuts/drive/drive_update_reply_test.go
+++ b/shortcuts/drive/drive_update_reply_test.go
@@ -86,7 +86,7 @@ func TestDriveUpdateReplyExecuteViaWiki(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -266,7 +266,7 @@ func TestDriveUpdateReplyWikiNodeIncompleteResponse(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -287,6 +287,7 @@ func TestDriveUpdateReplyWikiNodeIncompleteResponse(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "incomplete node data") {
 		t.Fatalf("expected incomplete-node error, got %v", err)
 	}
+	assertDriveCommentIncompleteNodeError(t, err)
 }
 
 func TestDriveUpdateReplyDryRunDirect(t *testing.T) {
@@ -343,8 +344,8 @@ func TestDriveUpdateReplyDryRunWiki(t *testing.T) {
 		t.Fatalf("dry-run api call count = %d, want 2\nstdout:\n%s", len(api), stdout.String())
 	}
 	step1 := mustMapValue(t, api[0], "api[0]")
-	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/get_node") {
-		t.Fatalf("api[0].url = %q, want wiki get_node", got)
+	if got := mustStringField(t, step1, "url", "api[0].url"); !strings.Contains(got, "/wiki/v2/spaces/node_by_token") {
+		t.Fatalf("api[0].url = %q, want wiki node_by_token", got)
 	}
 	step2 := mustMapValue(t, api[1], "api[1]")
 	if got := mustStringField(t, step2, "method", "api[1].method"); got != "PUT" {

--- a/shortcuts/drive/drive_wiki_lookup_test.go
+++ b/shortcuts/drive/drive_wiki_lookup_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// Exercise each mounted caller: a terminal Wiki lookup failure must keep its
+// metadata, stop before downstream operations, and never be retried.
+func TestDriveWikiLookupTerminalErrors(t *testing.T) {
+	const wikiURL = "https://example.feishu.cn/wiki/wikiLookupToken"
+	const content = `[{"type":"text","text":"test reply"}]`
+	cases := []struct {
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{DriveInspect, []string{"--url", wikiURL}},
+		{DriveCopy, []string{"--url", wikiURL, "--name", "Copy", "--folder-token", "folderTarget"}},
+		{DriveExport, []string{"--url", wikiURL, "--file-extension", "pdf"}},
+		{DriveExport, []string{"--url", wikiURL, "--file-extension", "markdown"}},
+		{DriveAddComment, []string{"--doc", wikiURL, "--content", content}},
+		{DriveListComments, []string{"--url", wikiURL}},
+		{DriveBatchQueryComments, []string{"--url", wikiURL, "--comment-ids", "commentID"}},
+		{DriveResolveComment, []string{"--url", wikiURL, "--comment-id", "commentID"}},
+		{DriveRestoreComment, []string{"--url", wikiURL, "--comment-id", "commentID"}},
+		{DriveListReplies, []string{"--url", wikiURL, "--comment-id", "commentID"}},
+		{DriveAddReply, []string{"--url", wikiURL, "--comment-id", "commentID", "--content", content}},
+		{DriveUpdateReply, []string{"--url", wikiURL, "--comment-id", "commentID", "--reply-id", "replyID", "--content", content}},
+		{DriveDeleteReply, []string{"--url", wikiURL, "--comment-id", "commentID", "--reply-id", "replyID", "--yes"}},
+		{DriveReactReply, []string{"--url", wikiURL, "--reply-id", "replyID", "--emoji", "THUMBSUP", "--action", "add"}},
+	}
+	for _, tc := range cases {
+		for _, identity := range []string{"user", "bot"} {
+			for _, failure := range []struct {
+				code    int
+				subtype errs.Subtype
+			}{
+				{131012, errs.SubtypeNotFound},
+				{131013, errs.SubtypeInvalidParameters},
+				{131014, errs.SubtypeFailedPrecondition},
+				{131016, errs.SubtypeInvalidParameters},
+			} {
+				t.Run(fmt.Sprintf("%s/%s/%d", tc.shortcut.Command, identity, failure.code), func(t *testing.T) {
+					t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+					f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+					lookup := &httpmock.Stub{
+						Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token", Reusable: true,
+						Headers: http.Header{"X-Tt-Logid": []string{"wiki-lookup-log"}},
+						Body:    map[string]interface{}{"code": failure.code, "msg": "lookup rejected"},
+						OnMatch: func(req *http.Request) {
+							if got := req.URL.RawQuery; got != "token=wikiLookupToken" {
+								t.Errorf("lookup query = %q, want token only", got)
+							}
+						},
+					}
+					reg.Register(lookup)
+					// Match any unexpected downstream request, including a write.
+					downstream := &httpmock.Stub{Optional: true, Reusable: true, Body: map[string]interface{}{"code": 1}}
+					reg.Register(downstream)
+					args := append([]string{tc.shortcut.Command, "--as", identity}, tc.args...)
+					err := mountAndRunDrive(t, tc.shortcut, args, f, stdout)
+					problem, ok := errs.ProblemOf(err)
+					if !ok || problem.Category != errs.CategoryAPI || problem.Subtype != failure.subtype || problem.Code != failure.code || problem.Retryable {
+						t.Fatalf("error = %#v (%v), want terminal api/%s/%d", problem, err, failure.subtype, failure.code)
+					}
+					if problem.LogID != "wiki-lookup-log" || !strings.Contains(problem.Message, "lookup rejected") {
+						t.Fatalf("upstream metadata not preserved: %#v", problem)
+					}
+					if len(lookup.CapturedBodies) != 1 || len(downstream.CapturedBodies) != 0 {
+						t.Fatalf("lookup calls = %d, downstream calls = %d", len(lookup.CapturedBodies), len(downstream.CapturedBodies))
+					}
+					if stdout.Len() != 0 {
+						t.Fatalf("unexpected success output: %s", stdout)
+					}
+				})
+			}
+		}
+	}
+}

--- a/shortcuts/sheets/lark_sheet_workbook_import_test.go
+++ b/shortcuts/sheets/lark_sheet_workbook_import_test.go
@@ -5,10 +5,12 @@ package sheets
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/vfs/localfileio"
 )
@@ -151,6 +153,37 @@ func TestWorkbookImport_RejectsUnrecognizedExcel(t *testing.T) {
 
 	_, _, err := runShortcutCapturingErr(t, WorkbookImport, []string{"--file", "./bogus.xls", "--dry-run"})
 	requireValidation(t, err, "neither an OOXML")
+}
+
+func TestWorkbookImport_RejectsWikiFolderBeforeUpload(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	chdirTemp(t)
+	if err := os.WriteFile("data.csv", []byte("a,b\n1,2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lookup := &httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/node_by_token",
+		Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{
+			"node": map[string]interface{}{"node_token": "wikiFolder", "node_type": "shortcut", "obj_token": "docxOriginal"},
+		}},
+	}
+	upload := &httpmock.Stub{Method: "POST", URL: "/open-apis/drive/v1/medias/upload_all", Optional: true}
+	_, err := runShortcutWithStubs(t, WorkbookImport, []string{
+		"--file", "./data.csv", "--folder-token", "wikiFolder", "--as", "user",
+	}, lookup, upload)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Param != "--folder-token" || validationErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("expected folder-token validation error, got %v", err)
+	}
+	if validationErr.Category != errs.CategoryValidation {
+		t.Fatalf("category = %q, want %q", validationErr.Category, errs.CategoryValidation)
+	}
+	if cause := errors.Unwrap(err); cause != nil {
+		t.Fatalf("unexpected cause on direct validation error: %v", cause)
+	}
+	if len(lookup.CapturedBodies) != 1 || len(upload.CapturedBodies) != 0 {
+		t.Fatalf("lookup calls = %d, upload calls = %d", len(lookup.CapturedBodies), len(upload.CapturedBodies))
+	}
 }
 
 // TestWorkbookImport_ExecuteCreatesSheet runs the full upload → create → poll

--- a/tests/cli_e2e/drive/drive_comment_ops_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_comment_ops_dryrun_test.go
@@ -65,7 +65,7 @@ func TestDrive_CommentOpsDryRun(t *testing.T) {
 				"--dry-run",
 			},
 			wantMethod: "GET",
-			wantURL:    "/open-apis/wiki/v2/spaces/get_node",
+			wantURL:    "/open-apis/wiki/v2/spaces/node_by_token",
 			assert: func(t *testing.T, out string) {
 				if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "wikcnE2EComment" {
 					t.Fatalf("wiki token = %q, want wikcnE2EComment\nstdout:\n%s", got, out)
@@ -217,7 +217,7 @@ func TestDrive_CommentOpsDryRun(t *testing.T) {
 				"--dry-run",
 			},
 			wantMethod: "GET",
-			wantURL:    "/open-apis/wiki/v2/spaces/get_node",
+			wantURL:    "/open-apis/wiki/v2/spaces/node_by_token",
 			assert: func(t *testing.T, out string) {
 				if got := clie2e.DryRunGet(out, "api.1.method").String(); got != "GET" {
 					t.Fatalf("api.1.method = %q, want GET\nstdout:\n%s", got, out)
@@ -290,7 +290,7 @@ func TestDrive_CommentOpsDryRun(t *testing.T) {
 				"--dry-run",
 			},
 			wantMethod: "GET",
-			wantURL:    "/open-apis/wiki/v2/spaces/get_node",
+			wantURL:    "/open-apis/wiki/v2/spaces/node_by_token",
 			assert: func(t *testing.T, out string) {
 				if got := clie2e.DryRunGet(out, "api.1.method").String(); got != "POST" {
 					t.Fatalf("api.1.method = %q, want POST\nstdout:\n%s", got, out)

--- a/tests/cli_e2e/drive/drive_copy_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_copy_dryrun_test.go
@@ -142,7 +142,7 @@ func TestDriveCopyDryRun_WikiURLResolvesResourceThenCopiesToDrive(t *testing.T) 
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
 	out := result.Stdout
-	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/node_by_token" {
 		t.Fatalf("api.0.url=%q, want wiki resolver endpoint\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "wikiDryRunCopy" {

--- a/tests/cli_e2e/drive/drive_export_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_export_dryrun_test.go
@@ -84,8 +84,8 @@ func TestDriveExportDryRun_WikiURLPlansResolveBeforeExportTask(t *testing.T) {
 	if got := clie2e.DryRunGet(out, "api.0.method").String(); got != "GET" {
 		t.Fatalf("api.0.method=%q, want GET\nstdout:\n%s", got, out)
 	}
-	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
-		t.Fatalf("api.0.url=%q, want wiki get_node\nstdout:\n%s", got, out)
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/node_by_token" {
+		t.Fatalf("api.0.url=%q, want wiki node_by_token\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "wikiDryRunExport" {
 		t.Fatalf("api.0.params.token=%q, want wiki token\nstdout:\n%s", got, out)
@@ -133,8 +133,8 @@ func TestDriveExportDryRun_WikiTokenTypePlansResolveBeforeExportTask(t *testing.
 	if got := clie2e.DryRunGet(out, "api.0.method").String(); got != "GET" {
 		t.Fatalf("api.0.method=%q, want GET\nstdout:\n%s", got, out)
 	}
-	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
-		t.Fatalf("api.0.url=%q, want wiki get_node\nstdout:\n%s", got, out)
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/node_by_token" {
+		t.Fatalf("api.0.url=%q, want wiki node_by_token\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "wikiDryRunExport" {
 		t.Fatalf("api.0.params.token=%q, want wiki token\nstdout:\n%s", got, out)

--- a/tests/cli_e2e/drive/drive_import_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_import_dryrun_test.go
@@ -43,8 +43,8 @@ func TestDriveImportDryRunFolderTokenWikiProbe(t *testing.T) {
 	if got := clie2e.DryRunGet(out, "api.0.method").String(); got != "GET" {
 		t.Fatalf("data.api.0.method = %q, want GET\nstdout:\n%s", got, out)
 	}
-	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
-		t.Fatalf("data.api.0.url = %q, want wiki get_node\nstdout:\n%s", got, out)
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/node_by_token" {
+		t.Fatalf("data.api.0.url = %q, want wiki node_by_token\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "fldcnImportDryRunTarget" {
 		t.Fatalf("data.api.0.params.token = %q, want fldcnImportDryRunTarget\nstdout:\n%s", got, out)

--- a/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
@@ -101,9 +101,9 @@ func TestDriveInspectDryRun_WikiURL(t *testing.T) {
 
 	require.Equal(t, int64(2), clie2e.DryRunGet(result.Stdout, "api.#").Int(),
 		"expected exactly 2 dry-run API steps for wiki URL, stdout:\n%s", result.Stdout)
-	require.Equal(t, "/open-apis/wiki/v2/spaces/get_node",
+	require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token",
 		clie2e.DryRunGet(result.Stdout, "api.0.url").String(),
-		"expected get_node as first step, stdout:\n%s", result.Stdout)
+		"expected node_by_token as first step, stdout:\n%s", result.Stdout)
 	require.Equal(t, "/open-apis/drive/v1/metas/batch_query",
 		clie2e.DryRunGet(result.Stdout, "api.1.url").String(),
 		"expected batch_query as second step, stdout:\n%s", result.Stdout)

--- a/tests/cli_e2e/drive/drive_list_comments_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_list_comments_dryrun_test.go
@@ -100,8 +100,8 @@ func TestDriveListCommentsDryRun_WikiToken(t *testing.T) {
 	result.AssertExitCode(t, 0)
 
 	out := result.Stdout
-	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
-		t.Fatalf("api.0.url=%q, want wiki get_node\nstdout:\n%s", got, out)
+	if got := clie2e.DryRunGet(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/node_by_token" {
+		t.Fatalf("api.0.url=%q, want wiki node_by_token\nstdout:\n%s", got, out)
 	}
 	if got := clie2e.DryRunGet(out, "api.0.params.token").String(); got != "wikiDryRunCommentList" {
 		t.Fatalf("api.0.params.token=%q, want wikiDryRunCommentList\nstdout:\n%s", got, out)

--- a/tests/cli_e2e/sheets/sheets_workbook_import_dryrun_test.go
+++ b/tests/cli_e2e/sheets/sheets_workbook_import_dryrun_test.go
@@ -19,6 +19,26 @@ import (
 // and poll it with the doc type pinned to "sheet". The shortcut is distinct
 // from generic drive +import because it hard-codes type=sheet and uses --name
 // instead of --file-name.
+func TestSheets_WorkbookImportWikiProbeDryRun(t *testing.T) {
+	setSheetsDryRunEnv(t)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "data.csv"), []byte("a,b\n1,2\n"), 0o644))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"sheets", "+workbook-import", "--file", "data.csv", "--folder-token", "folderTarget", "--dry-run"},
+		DefaultAs: "user", WorkDir: dir,
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	out := result.Stdout
+	require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", clie2e.DryRunGet(out, "api.0.url").String())
+	require.Equal(t, "folderTarget", clie2e.DryRunGet(out, "api.0.params.token").String())
+	require.Equal(t, "GET", clie2e.DryRunGet(out, "api.0.method").String())
+	require.Equal(t, "folderTarget", clie2e.DryRunGet(out, "api.3.body.point.mount_key").String())
+	require.Equal(t, "sheet", clie2e.DryRunGet(out, "api.3.body.type").String())
+}
+
 func TestSheets_WorkbookImportDryRun(t *testing.T) {
 	setSheetsDryRunEnv(t)
 


### PR DESCRIPTION
## Summary
Use `wiki/v2/spaces/node_by_token` for the selected Drive workflows and the shared spreadsheet import preflight. Preserve resolved document targets, shortcut handling, command inputs, and downstream requests while classifying the new terminal lookup errors.

## Changes
- Migrate Wiki lookups in `drive +inspect`, `+copy`, `+export` (including Markdown), `+import`, `+add-comment`, and `+list-comments`.
- Migrate the shared lookup for `+batch-query-comments`, `+resolve-comment`, `+restore-comment`, `+list-replies`, `+add-reply`, `+update-reply`, `+delete-reply`, and `+react-reply`; update their dry-run plans.
- Keep import's Wiki-folder probe non-blocking on lookup errors, including the shared `sheets +workbook-import` path. A document obj_token that resolves to a Wiki node is now rejected before upload when passed as a folder token.
- Update existing tests and add user/bot terminal-error coverage, shortcut target assertions, Markdown file/content checks, and spreadsheet import preflight coverage.

## Test Plan
- [x] Unit tests pass: `make unit-test` (race enabled).
- [x] Drive and Sheets dry-run E2E tests pass using the canonical local build.
- [x] Manual local dry-run verification covers the migrated command flows.
- [x] `make vet`, `make fmt-check`, and `go mod tidy` (module files unchanged).
- [x] PR-scoped golangci-lint, source-contract guards, lint-module tests, license check, and quality gate.

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Drive and Sheets wiki reference handling to use the current node lookup service.
  - Improved error reporting for invalid, missing, or unavailable wiki nodes, marking these failures as non-retryable.
  - Prevented invalid wiki folder shortcuts from proceeding with workbook imports or uploads.
  - Added Markdown export support for wiki shortcut nodes while preserving document metadata.

- **User Experience**
  - Updated dry-run previews to show the current wiki resolution request and workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->