### PR TITLE
fix(output): preserve nil containers during format conversion

### DIFF
--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -54,12 +54,18 @@ func toGeneric(v interface{}) interface{} {
 	case nil:
 		return nil
 	case map[string]interface{}:
+		if value == nil {
+			return value
+		}
 		out := make(map[string]interface{}, len(value))
 		for key, item := range value {
 			out[key] = toGeneric(item)
 		}
 		return out
 	case []interface{}:
+		if value == nil {
+			return value
+		}
 		out := make([]interface{}, len(value))
 		for index, item := range value {
 			out[index] = toGeneric(item)

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -28,6 +28,72 @@ func TestFormatValue_JSON(t *testing.T) {
 	}
 }
 
+func TestWriteFormattedJSONPreservesNullContainers(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		data interface{}
+		want string
+	}{
+		{name: "nil map", data: map[string]interface{}(nil), want: "null"},
+		{name: "nil slice", data: []interface{}(nil), want: "null"},
+		{name: "empty map", data: map[string]interface{}{}, want: "{}"},
+		{name: "empty slice", data: []interface{}{}, want: "[]"},
+		{
+			name: "nested map values",
+			data: map[string]interface{}{
+				"map":   map[string]interface{}(nil),
+				"slice": []interface{}(nil),
+			},
+			want: `{"map":null,"slice":null}`,
+		},
+		{
+			name: "nested slice values",
+			data: []interface{}{map[string]interface{}(nil), []interface{}(nil)},
+			want: `[null,null]`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteFormatted(&buf, tt.data, FormatJSON); err != nil {
+				t.Fatalf("WriteFormatted() error = %v", err)
+			}
+			var compact bytes.Buffer
+			if err := json.Compact(&compact, buf.Bytes()); err != nil {
+				t.Fatalf("invalid JSON output: %v", err)
+			}
+			if got := compact.String(); got != tt.want {
+				t.Fatalf("JSON output = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteFormattedNDJSONPreservesRecordWithNullSlice(t *testing.T) {
+	data := map[string]interface{}{
+		"name": "Alice",
+		"tags": []interface{}(nil),
+	}
+	var buf bytes.Buffer
+	if err := WriteFormatted(&buf, data, FormatNDJSON); err != nil {
+		t.Fatalf("WriteFormatted() error = %v", err)
+	}
+	if got, want := buf.String(), "{\"name\":\"Alice\",\"tags\":null}\n"; got != want {
+		t.Fatalf("NDJSON output = %q, want %q", got, want)
+	}
+}
+
+func TestWriteFormattedNDJSONEmptySlices(t *testing.T) {
+	for _, data := range [][]interface{}{nil, {}} {
+		var buf bytes.Buffer
+		if err := WriteFormatted(&buf, data, FormatNDJSON); err != nil {
+			t.Fatalf("WriteFormatted() error = %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("empty slice should emit no records, got %q", buf.String())
+		}
+	}
+}
+
 func TestFormatValue_NDJSON(t *testing.T) {
 	data := map[string]interface{}{
 		"data": map[string]interface{}{


### PR DESCRIPTION
## Summary

Recursive format conversion turns nil maps and slices into empty containers, changing JSON `null` values to `{}` or `[]`. For example, an NDJSON record with a nil `tags` slice is then mistaken for an empty list and produces no output. Preserve nil containers before allocating their normalized copies.

## Changes

- Keep nil generic maps and slices intact during conversion.
- Cover top-level and nested JSON null values, retain NDJSON records with null fields, and preserve the existing empty-list behavior.

## Test Plan

- Confirmed the regression tests fail before the fix, including the dropped NDJSON record.
- `GOTOOLCHAIN=go1.23.12 make unit-test` (including race checks).
- `make vet`, `make fmt-check`, custom lint tests, PR-scoped source guards, golangci-lint v2.1.6, and the required dependency license check.
- `go mod tidy` leaves `go.mod` and `go.sum` unchanged; `git diff --check` passes.

The local Go 1.26.1 race run crashed during runtime startup; the unit suite was rerun with the project's supported Go 1.23.12 toolchain. No live API calls are needed for this formatter fix.

## Related Issues

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved `null` values when formatting nil maps and slices.
  - Ensured empty containers continue to serialize as `{}` or `[]`, including nested values.
  - Preserved `null` fields in newline-delimited JSON output.
  - Prevented output records from being generated for nil or empty top-level slices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->