### PR TITLE
fix(im): label unavailable deleted message content

### DIFF
--- a/shortcuts/im/convert_lib/content_convert.go
+++ b/shortcuts/im/convert_lib/content_convert.go
@@ -188,16 +188,25 @@ func formatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 	rawContent := ""
 	if body, ok := m["body"].(map[string]interface{}); ok {
 		rawContent, _ = body["content"].(string)
-		content = ConvertBodyContent(msgType, &ConvertContext{
-			RawContent:           rawContent,
-			MentionMap:           BuildMentionKeyMap(mentions),
-			Mentions:             mentions,
-			MessageID:            messageId,
-			Runtime:              runtime,
-			SenderNames:          nameCache,
-			MergeForwardSubItems: mergePrefetch,
-			FolderChildren:       folderPrefetch,
-		})
+		deletedContentUnavailable := false
+		if deleted {
+			parsedContent, parseErr := ParseJSONObject(rawContent)
+			deletedContentUnavailable = parseErr != nil || parsedContent == nil
+		}
+		if deletedContentUnavailable {
+			content = "[deleted]"
+		} else {
+			content = ConvertBodyContent(msgType, &ConvertContext{
+				RawContent:           rawContent,
+				MentionMap:           BuildMentionKeyMap(mentions),
+				Mentions:             mentions,
+				MessageID:            messageId,
+				Runtime:              runtime,
+				SenderNames:          nameCache,
+				MergeForwardSubItems: mergePrefetch,
+				FolderChildren:       folderPrefetch,
+			})
+		}
 	}
 
 	msg := map[string]interface{}{

--- a/shortcuts/im/convert_lib/content_convert.go
+++ b/shortcuts/im/convert_lib/content_convert.go
@@ -188,25 +188,25 @@ func formatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 	rawContent := ""
 	if body, ok := m["body"].(map[string]interface{}); ok {
 		rawContent, _ = body["content"].(string)
-		deletedContentUnavailable := false
-		if deleted {
-			parsedContent, parseErr := ParseJSONObject(rawContent)
-			deletedContentUnavailable = parseErr != nil || parsedContent == nil
-		}
-		if deletedContentUnavailable {
-			content = "[deleted]"
-		} else {
-			content = ConvertBodyContent(msgType, &ConvertContext{
-				RawContent:           rawContent,
-				MentionMap:           BuildMentionKeyMap(mentions),
-				Mentions:             mentions,
-				MessageID:            messageId,
-				Runtime:              runtime,
-				SenderNames:          nameCache,
-				MergeForwardSubItems: mergePrefetch,
-				FolderChildren:       folderPrefetch,
-			})
-		}
+	}
+	deletedContentUnavailable := false
+	if deleted {
+		parsedContent, parseErr := ParseJSONObject(rawContent)
+		deletedContentUnavailable = parseErr != nil || parsedContent == nil
+	}
+	if deletedContentUnavailable {
+		content = "[deleted]"
+	} else {
+		content = ConvertBodyContent(msgType, &ConvertContext{
+			RawContent:           rawContent,
+			MentionMap:           BuildMentionKeyMap(mentions),
+			Mentions:             mentions,
+			MessageID:            messageId,
+			Runtime:              runtime,
+			SenderNames:          nameCache,
+			MergeForwardSubItems: mergePrefetch,
+			FolderChildren:       folderPrefetch,
+		})
 	}
 
 	msg := map[string]interface{}{

--- a/shortcuts/im/convert_lib/content_media_misc_test.go
+++ b/shortcuts/im/convert_lib/content_media_misc_test.go
@@ -95,6 +95,33 @@ func TestFormatMessageItem(t *testing.T) {
 	}
 }
 
+func TestFormatMessageItemDeletedUnavailableContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawContent string
+	}{
+		{name: "invalid json", rawContent: `{invalid`},
+		{name: "null json", rawContent: `null`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"msg_type":    "post",
+				"message_id":  "om_deleted",
+				"deleted":     true,
+				"create_time": "1710500000",
+				"body":        map[string]interface{}{"content": tt.rawContent},
+			}
+
+			got := FormatMessageItem(raw, nil)
+			if got["content"] != "[deleted]" {
+				t.Fatalf("FormatMessageItem() content = %#v, want %q", got["content"], "[deleted]")
+			}
+		})
+	}
+}
+
 func TestFormatMessageItem_UpdateTime_Present(t *testing.T) {
 	raw := map[string]interface{}{
 		"msg_type":    "text",

--- a/shortcuts/im/convert_lib/content_media_misc_test.go
+++ b/shortcuts/im/convert_lib/content_media_misc_test.go
@@ -97,11 +97,12 @@ func TestFormatMessageItem(t *testing.T) {
 
 func TestFormatMessageItemDeletedUnavailableContent(t *testing.T) {
 	tests := []struct {
-		name       string
-		rawContent string
+		name string
+		body interface{}
 	}{
-		{name: "invalid json", rawContent: `{invalid`},
-		{name: "null json", rawContent: `null`},
+		{name: "invalid json", body: map[string]interface{}{"content": `{invalid`}},
+		{name: "null json", body: map[string]interface{}{"content": `null`}},
+		{name: "null body", body: nil},
 	}
 
 	for _, tt := range tests {
@@ -111,7 +112,7 @@ func TestFormatMessageItemDeletedUnavailableContent(t *testing.T) {
 				"message_id":  "om_deleted",
 				"deleted":     true,
 				"create_time": "1710500000",
-				"body":        map[string]interface{}{"content": tt.rawContent},
+				"body":        tt.body,
 			}
 
 			got := FormatMessageItem(raw, nil)


### PR DESCRIPTION
## Summary
A recalled rich-text message can have a body that is no longer valid JSON. The formatter currently reports this as an invalid rich-text payload even though the deleted flag already identifies the actual state.

## Changes
- Render unavailable content as [deleted] when the message is marked deleted and its body is invalid or null
- Preserve existing conversion for active messages and deleted messages whose bodies remain valid
- Add focused regression coverage for invalid and null recalled content

## Test Plan
- [x] Unit tests pass: make unit-test
- [x] Static checks pass: make vet and make fmt-check
- [x] IM package tests pass: go test ./shortcuts/im/... -count=1
- [x] Quality gate passes: QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate
- [x] Manual local verification confirms im +messages-mget renders a recalled post as [deleted] while preserving a neighboring active post

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deleted messages when their content is unavailable, invalid, or missing.
  * Displays `[deleted]` instead of exposing malformed or unavailable message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->