### PR TITLE
fix(registry): shorten the placeholder app id in catalog examples

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -3,5 +3,3 @@
 9319004abdc3cdb31552abb6ee23ee973a2698eb:internal/registry/catalog/services/im.json:generic-api-key:1189
 f8cd2a7cd3ab6e7deade9e0fc47178eaaed3d9f9:internal/qualitygate/publiccontent/catalog_test.go:generic-api-key:82
 f8cd2a7cd3ab6e7deade9e0fc47178eaaed3d9f9:internal/qualitygate/publiccontent/catalog_test.go:generic-api-key:90
-9319004abdc3cdb31552abb6ee23ee973a2698eb:internal/registry/catalog/services/task.json:lark-bot-app-id:6667
-9319004abdc3cdb31552abb6ee23ee973a2698eb:internal/registry/catalog/services/task.json:lark-bot-app-id:6673

--- a/internal/registry/catalog/manifest.json
+++ b/internal/registry/catalog/manifest.json
@@ -39,9 +39,9 @@
     {
       "name": "im",
       "file": "services/im.json",
-      "revision": 17,
-      "size": 257232,
-      "sha256": "12521681648bcb850dc0570ba229404d5420a7ee4cb55a14f253162968aa465a"
+      "revision": 18,
+      "size": 257214,
+      "sha256": "1d10dab9fb27b26bb2895472c93abb8c7c20a9d02403da3aa02f9f117eb8043d"
     },
     {
       "name": "mail",
@@ -88,9 +88,9 @@
     {
       "name": "task",
       "file": "services/task.json",
-      "revision": 15,
-      "size": 455002,
-      "sha256": "8a67a1c1819e51c9c335ebcf0c8399563b3f1465f96093bb0294e559744ae28e"
+      "revision": 16,
+      "size": 454984,
+      "sha256": "8c78d5c69a3672e99de30097254638b0e283559d1b2ce9ae2e36c4227b80b22e"
     },
     {
       "name": "vc",

--- a/internal/registry/catalog/services/im.json
+++ b/internal/registry/catalog/services/im.json
@@ -2812,7 +2812,7 @@
                       "type": "string",
                       "description": "应用 ID，仅当 member_type=bot 时返回",
                       "required": false,
-                      "example": "cli_a1b2c3d4e5f6g7h8"
+                      "example": "cli_example"
                     },
                     "name": {
                       "type": "string",
@@ -2847,7 +2847,7 @@
                       "type": "string",
                       "description": "应用 ID，仅当 member_type=bot 时返回",
                       "required": false,
-                      "example": "cli_a1b2c3d4e5f6g7h8"
+                      "example": "cli_example"
                     },
                     "name": {
                       "type": "string",

--- a/internal/registry/catalog/services/task.json
+++ b/internal/registry/catalog/services/task.json
@@ -6664,13 +6664,13 @@
               "description": "AI智能体的核心信息对象，包含智能体所属应用的唯一标识与友好名称，用于标识和展示已注册的智能体主体",
               "required": false,
               "ref": "agent",
-              "example": "{\"app_id\":\"cli_a1b2c3d4e5f6g7h8\",\"app_name\":\"企业任务管理助手\"}",
+              "example": "{\"app_id\":\"cli_example\",\"app_name\":\"企业任务管理助手\"}",
               "properties": {
                 "app_id": {
                   "type": "string",
                   "description": "应用唯一标识，用于区分不同应用主体。可通过开放平台应用管理页面获取",
                   "required": false,
-                  "example": "cli_a1b2c3d4e5f6g7h8"
+                  "example": "cli_example"
                 },
                 "app_name": {
                   "type": "string",


### PR DESCRIPTION
## Summary

`main` is red on the push scan for `ad8766b61`. Gitleaks reports four values in the committed catalog: the example app id from the open platform documentation, a public placeholder rather than a credential. What trips the rule is its shape, since `cli_` plus exactly sixteen lowercase alphanumerics is what this repository's own `lark-bot-app-id` pattern looks for.

Shortening it to `cli_example` keeps the examples readable and takes them out of that shape. Four values, two in `im.json` and two in `task.json`.

## Why the branch was green

A `.gitleaksignore` fingerprint is bound to a commit SHA. Squash-merging #2232 moved the same content into a new commit, so every entry stopped matching. Two of the four were never covered by a fingerprint at all and stayed quiet only because the branch's incremental scans no longer reached the commit that introduced them. Fixing the value means the next squash cannot bring the reports back, so the two fingerprints naming these `task.json` values are dropped with them.

## Verification

Local gitleaks v8.18.4 with this repository's own config, same scope as the CI push scan: four reports on `ad8766b61` matching the CI SARIF line for line, none on this commit, and none with `.gitleaksignore` removed entirely. The registry, cmd, service, schema and publiccontent packages pass, and manifest `size` and `sha256` are recomputed so the embedded catalog still validates.

The three remaining fingerprints also name commits absent from `main`'s history and cannot match anything either; worth cleaning up separately.