### PR TITLE
fix(docs): migrate wiki lookups to node_by_token

### DIFF
--- a/shortcuts/doc/doc_media_insert.go
+++ b/shortcuts/doc/doc_media_insert.go
@@ -30,6 +30,27 @@ var alignMap = map[string]int{
 	"right":  3,
 }
 
+const docWikiNodeByTokenPath = "/open-apis/wiki/v2/spaces/node_by_token"
+
+type docWikiNode struct {
+	ObjToken string
+	ObjType  string
+}
+
+func docWikiNodeLookupProblem(err error) error {
+	if problem, ok := errs.ProblemOf(err); ok {
+		switch problem.Code {
+		case 131012:
+			problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+		case 131013, 131016:
+			problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+		case 131014:
+			problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+		}
+	}
+	return err
+}
+
 // readClipboardImage is the clipboard read function, swappable in tests to
 // inject synthetic image bytes without depending on the host pasteboard.
 var readClipboardImage = readClipboardImageBytes
@@ -171,7 +192,7 @@ var DocMediaInsert = common.Shortcut{
 			documentID = "<resolved_docx_token>"
 			stepBase = 2
 			d.Desc(fmt.Sprintf("%d-step orchestration: resolve wiki → query root → create block → upload file → bind to block (auto-rollback on failure)", totalSteps)).
-				GET("/open-apis/wiki/v2/spaces/get_node").
+				GET(docWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to docx document").
 				Params(map[string]interface{}{"token": docRef.Token})
 		} else {
@@ -454,25 +475,27 @@ func resolveDocxDocumentID(runtime *common.RuntimeContext, input string) (string
 	case "wiki":
 		data, err := runtime.CallAPITyped(
 			"GET",
-			"/open-apis/wiki/v2/spaces/get_node",
+			docWikiNodeByTokenPath,
 			map[string]interface{}{"token": docRef.Token},
 			nil,
 		)
 		if err != nil {
-			return "", err
+			return "", docWikiNodeLookupProblem(err)
 		}
 
-		node := common.GetMap(data, "node")
-		objType := common.GetString(node, "obj_type")
-		objToken := common.GetString(node, "obj_token")
-		if objType == "" || objToken == "" {
-			return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data")
+		nodeData := common.GetMap(data, "node")
+		node := docWikiNode{
+			ObjToken: common.GetString(nodeData, "obj_token"),
+			ObjType:  common.GetString(nodeData, "obj_type"),
 		}
-		if objType != "docx" {
-			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but this document operation only supports docx documents", objType).WithParam("--doc")
+		if node.ObjType == "" || node.ObjToken == "" {
+			return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data")
+		}
+		if node.ObjType != "docx" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but this document operation only supports docx documents", node.ObjType).WithParam("--doc")
 		}
 
-		return objToken, nil
+		return node.ObjToken, nil
 	default:
 		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "this document operation only supports docx documents").WithParam("--doc")
 	}

--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -156,6 +156,8 @@ func TestDocMediaInsertDryRunWithClipboardUsesPlaceholder(t *testing.T) {
 }
 
 func TestDocMediaInsertDryRunWikiAddsResolveStep(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	f, stdout, _, _ := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-test-app"))
 
 	err := mountAndRunDocs(t, DocMediaInsert, []string{
@@ -170,6 +172,9 @@ func TestDocMediaInsertDryRunWikiAddsResolveStep(t *testing.T) {
 	}
 
 	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/wiki/v2/spaces/node_by_token") {
+		t.Fatalf("dry-run output missing node_by_token resolve endpoint: %s", out)
+	}
 	if !strings.Contains(out, "Resolve wiki node to docx document") {
 		t.Fatalf("dry-run output missing wiki resolve step: %s", out)
 	}
@@ -736,10 +741,12 @@ func TestDocMediaInsertBindFailureReportsUploadedStateAndRollback(t *testing.T) 
 }
 
 func TestDocMediaInsertExecuteResolvesWikiBeforeFileCheck(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	f, _, stderr, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-insert-exec-app"))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
 			"data": map[string]interface{}{
@@ -768,6 +775,81 @@ func TestDocMediaInsertExecuteResolvesWikiBeforeFileCheck(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want no wiki resolution progress", stderr.String())
+	}
+}
+
+func TestDocMediaInsertRejectsWikiResolvingToNonDocxBeforeFileCheck(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, _, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-insert-non-docx-app"))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "mindnote",
+					"obj_token": "mindnoteResolved123",
+				},
+			},
+		},
+	})
+
+	tmpDir := t.TempDir()
+	withDocsWorkingDir(t, tmpDir)
+
+	err := mountAndRunDocs(t, DocMediaInsert, []string{
+		"+media-insert",
+		"--doc", "https://example.larksuite.com/wiki/xxxxxx",
+		"--file", "missing.png",
+		"--as", "bot",
+	}, f, nil)
+	assertValidationContract(t, err, errs.SubtypeInvalidArgument, "--doc")
+	if !strings.Contains(err.Error(), `wiki resolved to "mindnote"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDocMediaInsertClassifiesNodeByTokenErrors(t *testing.T) {
+	for _, tt := range []struct {
+		code    int
+		subtype errs.Subtype
+	}{
+		{code: 131012, subtype: errs.SubtypeNotFound},
+		{code: 131013, subtype: errs.SubtypeInvalidParameters},
+		{code: 131014, subtype: errs.SubtypeFailedPrecondition},
+		{code: 131016, subtype: errs.SubtypeInvalidParameters},
+	} {
+		t.Run(fmt.Sprint(tt.code), func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+			f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-insert-wiki-error-app"))
+			lookup := &httpmock.Stub{
+				Method:  "GET",
+				URL:     "/open-apis/wiki/v2/spaces/node_by_token",
+				Headers: http.Header{"X-Tt-Logid": []string{"docs-wiki-lookup-log"}},
+				Body:    map[string]interface{}{"code": tt.code, "msg": "lookup rejected"},
+			}
+			reg.Register(lookup)
+
+			err := mountAndRunDocs(t, DocMediaInsert, []string{
+				"+media-insert",
+				"--doc", "https://example.larksuite.com/wiki/xxxxxx",
+				"--file", "missing.png",
+				"--as", "bot",
+			}, f, stdout)
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Code != tt.code || problem.Subtype != tt.subtype || problem.Retryable {
+				t.Fatalf("error = %#v (%v), want terminal %s/%d", problem, err, tt.subtype, tt.code)
+			}
+			if problem.LogID != "docs-wiki-lookup-log" || !strings.Contains(problem.Message, "lookup rejected") {
+				t.Fatalf("upstream metadata not preserved: %#v", problem)
+			}
+			if len(lookup.CapturedBodies) != 1 || stdout.Len() != 0 {
+				t.Fatalf("lookup calls = %d, stdout = %q", len(lookup.CapturedBodies), stdout.String())
+			}
+		})
 	}
 }
 

--- a/shortcuts/doc/doc_resource_cover.go
+++ b/shortcuts/doc/doc_resource_cover.go
@@ -72,7 +72,7 @@ var DocResourceDownload = common.Shortcut{
 		d := common.NewDryRunAPI()
 		if docRef.Kind == "wiki" {
 			documentID = "<resolved_docx_token>"
-			d.GET("/open-apis/wiki/v2/spaces/get_node").
+			d.GET(docWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to docx document").
 				Params(map[string]interface{}{"token": docRef.Token})
 		}
@@ -173,7 +173,7 @@ var DocResourceUpdate = common.Shortcut{
 		d := common.NewDryRunAPI()
 		if docRef.Kind == "wiki" {
 			documentID = "<resolved_docx_token>"
-			d.GET("/open-apis/wiki/v2/spaces/get_node").
+			d.GET(docWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to docx document").
 				Params(map[string]interface{}{"token": docRef.Token})
 		}
@@ -267,7 +267,7 @@ var DocResourceDelete = common.Shortcut{
 		d := common.NewDryRunAPI()
 		if docRef.Kind == "wiki" {
 			documentID = "<resolved_docx_token>"
-			d.GET("/open-apis/wiki/v2/spaces/get_node").
+			d.GET(docWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to docx document").
 				Params(map[string]interface{}{"token": docRef.Token})
 		}

--- a/shortcuts/doc/doc_resource_cover_test.go
+++ b/shortcuts/doc/doc_resource_cover_test.go
@@ -399,7 +399,7 @@ func TestDocResourceCoverDryRunsPlanAPIs(t *testing.T) {
 	if len(update.API) != 3 {
 		t.Fatalf("update dry-run API count = %d, want 3", len(update.API))
 	}
-	if got := update.API[0].URL; got != "/open-apis/wiki/v2/spaces/get_node" {
+	if got := update.API[0].URL; got != "/open-apis/wiki/v2/spaces/node_by_token" {
 		t.Fatalf("wiki resolve URL = %q", got)
 	}
 	if got := update.API[1].URL; got != "/open-apis/drive/v1/medias/upload_all" {

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -195,7 +195,7 @@ func dryRunUpdateV2(_ context.Context, runtime *common.RuntimeContext) *common.D
 	dry := common.NewDryRunAPI()
 	if len(resources) > 0 && ref.Kind == "wiki" {
 		documentID = "<resolved_docx_token>"
-		dry.GET("/open-apis/wiki/v2/spaces/get_node").
+		dry.GET(docWikiNodeByTokenPath).
 			Desc("Resolve wiki node to its docx document before writing local resources").
 			Params(map[string]interface{}{"token": ref.Token})
 	}

--- a/shortcuts/doc/local_doc_resources_test.go
+++ b/shortcuts/doc/local_doc_resources_test.go
@@ -1905,7 +1905,7 @@ func TestDocsUpdateLocalResourceWikiDryRunResolvesDocxFirst(t *testing.T) {
 		"content": `<img path="@diagram.png"/>`,
 	})
 	dry := decodeDocDryRun(t, dryRunUpdateV2(context.Background(), runtime))
-	if len(dry.API) < 2 || dry.API[0].URL != "/open-apis/wiki/v2/spaces/get_node" {
+	if len(dry.API) < 2 || dry.API[0].URL != "/open-apis/wiki/v2/spaces/node_by_token" {
 		t.Fatalf("dry-run must resolve wiki first: %#v", dry.API)
 	}
 	if got := dry.API[1].URL; got != "/open-apis/docs_ai/v1/documents/%3Cresolved_docx_token%3E" {

--- a/tests/cli_e2e/docs/docs_wiki_resolution_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_wiki_resolution_dryrun_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocsWikiResourceDryRunsUseNodeByToken(t *testing.T) {
+	setDocsDryRunEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	workDir := t.TempDir()
+	writeLocalResourceFixture(t, workDir, "fixture.png", onePixelPNG)
+	const wikiToken = "wikcnDocsNodeByToken"
+	const wikiURL = "https://example.larksuite.com/wiki/" + wikiToken
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "media insert",
+			args: []string{"docs", "+media-insert", "--doc", wikiURL, "--file", "fixture.png", "--dry-run"},
+		},
+		{
+			name: "resource download",
+			args: []string{"docs", "+resource-download", "--doc", wikiURL, "--output", "cover", "--dry-run"},
+		},
+		{
+			name: "resource update",
+			args: []string{"docs", "+resource-update", "--doc", wikiURL, "--url", "https://93.184.216.34/cover.png", "--dry-run"},
+		},
+		{
+			name: "resource delete",
+			args: []string{"docs", "+resource-delete", "--doc", wikiURL, "--dry-run"},
+		},
+		{
+			name: "update with local image",
+			args: []string{"docs", "+update", "--doc", wikiURL, "--command", "append", "--content", `<img path="@fixture.png"/>`, "--dry-run"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      tt.args,
+				DefaultAs: "bot",
+				WorkDir:   workDir,
+			})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+			require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", clie2e.DryRunGet(result.Stdout, "api.0.url").String(), "stdout:\n%s", result.Stdout)
+			require.Equal(t, wikiToken, clie2e.DryRunGet(result.Stdout, "api.0.params.token").String(), "stdout:\n%s", result.Stdout)
+			require.NotContains(t, result.Stdout, "/open-apis/wiki/v2/spaces/get_node", "stdout:\n%s", result.Stdout)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Migrate the docs shortcuts that resolve Wiki document links from `/wiki/v2/spaces/get_node` to `/wiki/v2/spaces/node_by_token`. The shared resolver continues to require `obj_type=docx` and returns the resolved `obj_token`, while preserving stable error classification for the new endpoint's terminal business codes.

## Changes

- Update `docs +media-insert`, `+resource-download`, `+resource-update`, and `+resource-delete` Wiki resolution.
- Update the local-resource path of `docs +update`; ordinary updates without resources keep their existing request flow.
- Add unit coverage for endpoint selection, non-docx rejection, and terminal error metadata.
- Add dry-run E2E coverage for all five affected command paths.

## Test Plan

- [x] `go test ./shortcuts/doc -count=1`
- [x] `go test ./tests/cli_e2e/docs -run '^TestDocsWikiResourceDryRunsUseNodeByToken$' -count=1`
- [x] `go test ./tests/cli_e2e/docs -run '^TestDocs_DryRunDefaultsToV2OpenAPI$/^update$' -count=1`
- [x] `make fmt-check`
- [x] `make vet`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] Live read-only comparison confirmed matching `obj_type` and `obj_token` resolution for docx and non-docx Wiki nodes.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wiki document resolution across document media, resource, and update workflows to use the current node-by-token endpoint.
  * Improved handling of wiki lookup errors, including clearer classifications and non-retryable failure behavior.
  * Prevented media insertion when a wiki link resolves to a non-Docx document.
* **Tests**
  * Added coverage for wiki resolution, error handling, and dry-run behavior across document commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->