### PR TITLE
fix(mail): support partial rule reorder

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -370,7 +370,7 @@ var MailRuleReorder = common.Shortcut{
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule ID order. Omitted current rules are appended in their current order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1631,10 +1631,11 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
+		target, err := completeRuleOrder(ids, currentIDs)
+		if err != nil {
 			return nil, err
 		}
-		return ids, nil
+		return target, nil
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1653,23 +1654,29 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 	}
 }
 
-func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
-	}
-	want := make(map[string]int, len(current))
+func completeRuleOrder(provided, current []string) ([]string, error) {
+	currentSet := make(map[string]bool, len(current))
 	for _, id := range current {
-		want[id]++
+		currentSet[id] = true
 	}
-	for _, id := range target {
-		want[id]--
+	target := make([]string, 0, len(current))
+	seen := make(map[string]bool, len(provided))
+	for _, id := range provided {
+		if seen[id] {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
+		}
+		if !currentSet[id] {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first", id)
+		}
+		seen[id] = true
+		target = append(target, id)
 	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+	for _, id := range current {
+		if !seen[id] {
+			target = append(target, id)
 		}
 	}
-	return nil
+	return target, nil
 }
 
 func normalizeRuleIDs(ids []string) []string {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1511,10 +1511,14 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 	if got, err := completeRuleOrder([]string{"a"}, []string{"a", "b"}); err != nil || !reflect.DeepEqual(got, []string{"a", "b"}) {
 		t.Fatalf("complete partial order = %v, %v", got, err)
 	}
-	if _, err := completeRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
+	if _, err := completeRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err != nil {
+		assertMailRuleValidationParam(t, err, "--rule-ids")
+	} else {
 		t.Fatal("expected duplicate rule id error")
 	}
-	if _, err := completeRuleOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil {
+	if _, err := completeRuleOrder([]string{"a", "z"}, []string{"a", "b"}); err != nil {
+		assertMailRuleValidationParam(t, err, "--rule-ids")
+	} else {
 		t.Fatal("expected unknown rule id error")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
@@ -1573,6 +1577,17 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func assertMailRuleValidationParam(t *testing.T, err error, wantParam string) {
+	t.Helper()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *errs.ValidationError: %v", err, err)
+	}
+	if validationErr.Param != wantParam {
+		t.Fatalf("validation param = %q, want %q", validationErr.Param, wantParam)
 	}
 }
 

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1165,6 +1165,26 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
 	})
 
+	t.Run("partial order appends omitted rules in current order", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b")
+	})
+
 	t.Run("move to bottom", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
@@ -1488,11 +1508,14 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 }
 
 func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+	if got, err := completeRuleOrder([]string{"a"}, []string{"a", "b"}); err != nil || !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("complete partial order = %v, %v", got, err)
 	}
-	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected duplicate mismatch error")
+	if _, err := completeRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected duplicate rule id error")
+	}
+	if _, err := completeRuleOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected unknown rule id error")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1531,10 +1554,15 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
 			want: "mismatch",
 		},
+		{
+			name: "full duplicate",
+			args: []string{"+rule-reorder", "--rule-ids", "a,a"},
+			want: "duplicate",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") || strings.Contains(tc.want, "duplicate") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)


### PR DESCRIPTION
## Summary
- accept partial --rule-ids for mail rule reorder
- append omitted current rule IDs in list order before calling reorder
- preserve validation for duplicate and unknown IDs

## Tests
- go test ./shortcuts/mail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail rules can now be reordered by specifying only the rules that should move; omitted rules remain in their existing order.
  * Duplicate or unknown rule IDs are rejected with validation errors.

* **Documentation**
  * Updated the reorder shortcut’s help text to reflect partial-order behavior.

* **Tests**
  * Added coverage for partial ordering, automatic completion, duplicate IDs, unknown IDs, and validation error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->