### PR TITLE
fix(mail): complete rule reorder ids

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -370,7 +370,7 @@ var MailRuleReorder = common.Shortcut{
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule ID order. Missing current rules are appended in their current relative order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1631,10 +1631,11 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
+		target, err := completeRuleOrder(ids, currentIDs)
+		if err != nil {
 			return nil, err
 		}
-		return ids, nil
+		return target, nil
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1653,23 +1654,32 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 	}
 }
 
-func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
+func completeRuleOrder(requested, current []string) ([]string, error) {
+	if len(requested) == 0 {
+		return nil, mailValidationParamError("--rule-ids", "--rule-ids must contain at least one rule id")
 	}
-	want := make(map[string]int, len(current))
+	want := make(map[string]struct{}, len(current))
 	for _, id := range current {
-		want[id]++
+		want[id] = struct{}{}
 	}
-	for _, id := range target {
-		want[id]--
+	seen := make(map[string]struct{}, len(requested))
+	target := make([]string, 0, len(current))
+	for _, id := range requested {
+		if _, ok := want[id]; !ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains unknown rule id %s; run +rule-list first", id)
+		}
+		if _, ok := seen[id]; ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
+		}
+		seen[id] = struct{}{}
+		target = append(target, id)
 	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+	for _, id := range current {
+		if _, ok := seen[id]; !ok {
+			target = append(target, id)
 		}
 	}
-	return nil
+	return target, nil
 }
 
 func normalizeRuleIDs(ids []string) []string {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1165,6 +1165,27 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
 	})
 
+	t.Run("partial order fills missing current rules", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+			mailRuleTestRawRule("d", "D"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b,d")
+	})
+
 	t.Run("move to bottom", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
@@ -1224,6 +1245,43 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		}
 		assertRuleIDsBody(t, post.CapturedBody, "b,c,a")
 	})
+}
+
+func TestMailRuleReorderRejectsInvalidPartialRuleIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ids  string
+		want string
+	}{
+		{name: "unknown", ids: "c,a", want: "unknown rule id c"},
+		{name: "duplicate", ids: "a,a", want: "duplicate rule id a"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, reg := mailShortcutTestFactory(t)
+			reg.Register(mailRuleListStub(
+				mailRuleTestRawRule("a", "A"),
+				mailRuleTestRawRule("b", "B"),
+			))
+			post := &httpmock.Stub{
+				Method:   "POST",
+				URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+				Optional: true,
+				Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+			}
+			reg.Register(post)
+
+			err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", tc.ids, "--format", "json"}, f, stdout)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+			if len(post.CapturedBodies) != 0 {
+				t.Fatalf("POST should not be sent after invalid rule ids, captured %d request(s)", len(post.CapturedBodies))
+			}
+		})
+	}
 }
 
 func TestMailRuleUpdateReplacesUnknownConditionCollection(t *testing.T) {
@@ -1488,11 +1546,14 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 }
 
 func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+	if got, err := completeRuleOrder([]string{"a"}, []string{"a", "b"}); err != nil || strings.Join(got, ",") != "a,b" {
+		t.Fatalf("completeRuleOrder partial = %v, %v; want a,b", got, err)
 	}
-	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected duplicate mismatch error")
+	if _, err := completeRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected duplicate rule id error")
+	}
+	if _, err := completeRuleOrder([]string{"z"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected unknown rule id error")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1527,14 +1588,14 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			want: "is not in current rule order",
 		},
 		{
-			name: "full mismatch",
+			name: "full unknown rule",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
+			want: "unknown rule id z",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "unknown rule id") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)

--- a/skills/lark-mail/references/lark-mail-rules.md
+++ b/skills/lark-mail/references/lark-mail-rules.md
@@ -39,7 +39,7 @@ lark-cli mail +rule-enable --as user --rule-id "<rule_id>"
 lark-cli mail +rule-delete --as user --rule-id "<rule_id>" --dry-run
 lark-cli mail +rule-delete --as user --rule-id "<rule_id>" --yes
 
-# 调整顺序：完整顺序或单条移动二选一
+# 调整顺序：指定顺序或单条移动二选一；--rule-ids 不完整时会自动补齐其他当前规则
 lark-cli mail +rule-reorder --as user --rule-ids "<rule_id_1>,<rule_id_2>,<rule_id_3>"
 lark-cli mail +rule-reorder --as user --move-rule-id "<rule_id_3>" --before-rule-id "<rule_id_1>"
 ```


### PR DESCRIPTION
## Summary
- Complete partial mail rule reorder input with the remaining current rule IDs before calling reorder
- Keep full-order and move-mode behavior intact
- Update mail rule docs and tests for partial reorder input

## Tests
- go test ./shortcuts/mail
- make fmt-check
- make vet

Remote Go UT was not triggered because this GitHub repo has no .codebase/pipelines config for the Bits remote unit-test runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The mail rule reorder shortcut now accepts partial rule ID lists and automatically preserves omitted rules in their current order.
  * Unknown or duplicate rule IDs are rejected before any changes are submitted.

* **Documentation**
  * Updated guidance clarifies the supported partial-order behavior for mail rule reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->