### PR TITLE
fix(sheets,slides): migrate wiki lookups to node_by_token

### DIFF
--- a/shortcuts/sheets/execute_paths_test.go
+++ b/shortcuts/sheets/execute_paths_test.go
@@ -6,6 +6,7 @@ package sheets
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -112,14 +113,14 @@ func TestExecute_ToolError_KnownSubtypePassthrough(t *testing.T) {
 }
 
 // TestExecute_WikiURLResolvesToSheet covers the two-step wiki path: a /wiki/
-// URL is resolved via get_node to its spreadsheet obj_token, which then feeds
+// URL is resolved via node_by_token to its spreadsheet obj_token, which then feeds
 // the tool invoke. The tool stub is keyed on the resolved obj_token, so the
 // test would fail if the node_token were used unresolved.
 func TestExecute_WikiURLResolvesToSheet(t *testing.T) {
 	t.Parallel()
 	getNode := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -143,6 +144,50 @@ func TestExecute_WikiURLResolvesToSheet(t *testing.T) {
 	}
 }
 
+func TestExecute_WikiURLClassifiesNodeByTokenErrors(t *testing.T) {
+	const wikiToken = "wikTestNODE"
+	for _, tt := range []struct {
+		code    int
+		subtype errs.Subtype
+	}{
+		{code: 131012, subtype: errs.SubtypeNotFound},
+		{code: 131013, subtype: errs.SubtypeInvalidParameters},
+		{code: 131014, subtype: errs.SubtypeFailedPrecondition},
+		{code: 131016, subtype: errs.SubtypeInvalidParameters},
+	} {
+		t.Run(fmt.Sprint(tt.code), func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+			lookup := &httpmock.Stub{
+				Method:  "GET",
+				URL:     "/open-apis/wiki/v2/spaces/node_by_token",
+				Headers: http.Header{"X-Tt-Logid": []string{"sheets-wiki-lookup-log"}},
+				Body:    map[string]interface{}{"code": tt.code, "msg": "lookup rejected"},
+				OnMatch: func(req *http.Request) {
+					if got := req.URL.Query().Get("token"); got != wikiToken {
+						t.Errorf("lookup token = %q, want %q", got, wikiToken)
+					}
+				},
+			}
+			parent, stdout, _, reg := newTestRig(t, WorkbookInfo)
+			reg.Register(lookup)
+			parent.SetArgs([]string{"+workbook-info", "--url", "https://example.feishu.cn/wiki/" + wikiToken})
+
+			err := parent.Execute()
+			problem := requireProblem(t, err, errs.CategoryAPI, tt.subtype, "lookup rejected")
+			if problem.Code != tt.code || problem.Retryable {
+				t.Fatalf("problem = %#v, want terminal code %d", problem, tt.code)
+			}
+			if problem.LogID != "sheets-wiki-lookup-log" {
+				t.Fatalf("log_id = %q, want sheets-wiki-lookup-log", problem.LogID)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("unexpected success output: %s", stdout)
+			}
+		})
+	}
+}
+
 // TestExecute_RevisionGet_WikiURL guards RevisionGet's custom Execute hook:
 // the wiki node token must be resolved before get_workbook_structure runs.
 // TestExecute_CondFormatResultGet_WikiURL guards the condition-format result
@@ -152,7 +197,7 @@ func TestExecute_CondFormatResultGet_WikiURL(t *testing.T) {
 	t.Parallel()
 	getNode := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -211,7 +256,7 @@ func TestExecute_RevisionGet_WikiURL(t *testing.T) {
 	t.Parallel()
 	getNode := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -241,7 +286,7 @@ func TestExecute_WikiURLWrongObjType(t *testing.T) {
 	t.Parallel()
 	getNode := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -258,14 +303,14 @@ func TestExecute_WikiURLWrongObjType(t *testing.T) {
 	requireValidation(t, err, "obj_type")
 }
 
-// TestExecute_WikiURLIncompleteNode treats an incomplete get_node response
+// TestExecute_WikiURLIncompleteNode treats an incomplete node_by_token response
 // (missing obj_type/obj_token) as an internal/server error, not a user --url
 // validation error.
 func TestExecute_WikiURLIncompleteNode(t *testing.T) {
 	t.Parallel()
 	getNode := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",
@@ -277,7 +322,7 @@ func TestExecute_WikiURLIncompleteNode(t *testing.T) {
 	_, err := runShortcutWithStubs(t, WorkbookInfo,
 		[]string{"--url", "https://example.feishu.cn/wiki/wikTestNODE"}, getNode)
 	if err == nil {
-		t.Fatal("want error for incomplete get_node node data")
+		t.Fatal("want error for incomplete node_by_token node data")
 	}
 	var ve *errs.ValidationError
 	if errors.As(err, &ve) {
@@ -294,7 +339,7 @@ func TestExecute_RangeMove_WikiURL(t *testing.T) {
 	t.Parallel()
 	getNode := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"msg":  "success",

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -206,6 +206,13 @@ const (
 	spreadsheetRefWiki  = "wiki"
 )
 
+const sheetsWikiNodeByTokenPath = "/open-apis/wiki/v2/spaces/node_by_token"
+
+type sheetsWikiNode struct {
+	ObjType  string
+	ObjToken string
+}
+
 // spreadsheetRef is a parsed --url / --spreadsheet-token input. A wiki ref holds
 // the still-unresolved wiki node_token; resolveSpreadsheetTokenExec turns it
 // into the real spreadsheet token at Execute time.
@@ -292,7 +299,7 @@ func pathSegmentAfter(path, prefix string) (string, bool) {
 // DryRun.
 //
 // A /wiki/ URL yields the still-unresolved wiki node_token: turning it into the
-// backing spreadsheet token needs a get_node call, which only Execute may make.
+// backing spreadsheet token needs a node_by_token call, which only Execute may make.
 // Validate/DryRun only need a non-empty, control-char-clean token, so the
 // node_token passes through unchanged here; Execute paths call
 // resolveSpreadsheetTokenExec instead.
@@ -306,7 +313,7 @@ func resolveSpreadsheetToken(runtime *common.RuntimeContext) (string, error) {
 
 // resolveSpreadsheetTokenExec is the Execute-time counterpart of
 // resolveSpreadsheetToken: it additionally resolves a /wiki/ URL's node_token to
-// the backing spreadsheet token via wiki get_node, verifying obj_type=sheet.
+// the backing spreadsheet token via wiki node_by_token, verifying obj_type=sheet.
 // Non-wiki inputs make no API call. Use this from every sheets Execute hook and
 // keep resolveSpreadsheetToken in Validate/DryRun so those stay network-free.
 func resolveSpreadsheetTokenExec(runtime *common.RuntimeContext) (string, error) {
@@ -328,21 +335,37 @@ func resolveWikiNodeToSpreadsheetToken(runtime *common.RuntimeContext, nodeToken
 	if err := runtime.EnsureScopes([]string{"wiki:node:read"}); err != nil {
 		return "", err
 	}
-	data, err := runtime.CallAPITyped("GET", "/open-apis/wiki/v2/spaces/get_node",
+	data, err := runtime.CallAPITyped("GET", sheetsWikiNodeByTokenPath,
 		map[string]interface{}{"token": nodeToken}, nil)
 	if err != nil {
-		return "", err
+		return "", sheetsWikiNodeLookupProblem(err)
 	}
-	node := common.GetMap(data, "node")
-	objType := common.GetString(node, "obj_type")
-	objToken := common.GetString(node, "obj_token")
-	if objType == "" || objToken == "" {
-		return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data for %q", nodeToken)
+	nodeData := common.GetMap(data, "node")
+	node := sheetsWikiNode{
+		ObjType:  common.GetString(nodeData, "obj_type"),
+		ObjToken: common.GetString(nodeData, "obj_token"),
 	}
-	if objType != "sheet" {
-		return "", sheetsValidationForFlag("url", "wiki URL resolves to obj_type=%q, but a spreadsheet (obj_type=sheet) is required", objType)
+	if node.ObjType == "" || node.ObjToken == "" {
+		return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data for %q", nodeToken)
 	}
-	return objToken, nil
+	if node.ObjType != "sheet" {
+		return "", sheetsValidationForFlag("url", "wiki URL resolves to obj_type=%q, but a spreadsheet (obj_type=sheet) is required", node.ObjType)
+	}
+	return node.ObjToken, nil
+}
+
+func sheetsWikiNodeLookupProblem(err error) error {
+	if problem, ok := errs.ProblemOf(err); ok {
+		switch problem.Code {
+		case 131012:
+			problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+		case 131013, 131016:
+			problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+		case 131014:
+			problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+		}
+	}
+	return err
 }
 
 // resolveSheetSelector validates the --sheet-id / --sheet-name XOR and

--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -2260,7 +2260,7 @@ var WorkbookExport = common.Shortcut{
 			return err
 		}
 		// workbookExportParams resolves --url network-free (DryRun shares it); a
-		// /wiki/ URL carries a node_token that needs the get_node step only
+		// /wiki/ URL carries a node_token that needs the node_by_token step only
 		// Execute may take, so re-resolve the token here.
 		if p.Token, err = resolveSpreadsheetTokenExec(runtime); err != nil {
 			return err

--- a/shortcuts/sheets/lark_sheet_workbook_export_test.go
+++ b/shortcuts/sheets/lark_sheet_workbook_export_test.go
@@ -264,13 +264,13 @@ func TestWorkbookExport_SuccessLeavesStderrEmpty(t *testing.T) {
 // TestWorkbookExport_LocalOfficeBehindWikiNodeRejected covers the second guard
 // call site: a /wiki/ URL carries a node_token that Validate cannot classify,
 // so a wiki node backed by a locally opened Office file only reveals itself
-// after get_node runs in Execute. The export must be refused there, before any
+// after node_by_token runs in Execute. The export must be refused there, before any
 // export_tasks request goes out — the create stub is registered so an
 // unexpected call would surface as a passing export instead of a rejection.
 func TestWorkbookExport_LocalOfficeBehindWikiNodeRejected(t *testing.T) {
 	getNode := &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "success",
 			"data": map[string]interface{}{

--- a/shortcuts/slides/helpers.go
+++ b/shortcuts/slides/helpers.go
@@ -13,6 +13,13 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
+const slidesWikiNodeByTokenPath = "/open-apis/wiki/v2/spaces/node_by_token"
+
+type slidesWikiNode struct {
+	ObjType  string
+	ObjToken string
+}
+
 // presentationRef holds a parsed --presentation input.
 //
 // Slides shortcuts accept three input shapes:
@@ -75,7 +82,7 @@ func tokenAfterPathPrefix(path, prefix string) (string, bool) {
 }
 
 // resolvePresentationID resolves a parsed ref into an xml_presentation_id.
-// Slides refs pass through; wiki refs are looked up via wiki.spaces.get_node and
+// Slides refs pass through; wiki refs are looked up via wiki.spaces.node_by_token and
 // must resolve to obj_type=slides.
 func resolvePresentationID(runtime *common.RuntimeContext, ref presentationRef) (string, error) {
 	switch ref.Kind {
@@ -84,23 +91,25 @@ func resolvePresentationID(runtime *common.RuntimeContext, ref presentationRef) 
 	case "wiki":
 		data, err := runtime.CallAPITyped(
 			"GET",
-			"/open-apis/wiki/v2/spaces/get_node",
+			slidesWikiNodeByTokenPath,
 			map[string]interface{}{"token": ref.Token},
 			nil,
 		)
 		if err != nil {
-			return "", err
+			return "", slidesWikiNodeLookupProblem(err)
 		}
-		node := common.GetMap(data, "node")
-		objType := common.GetString(node, "obj_type")
-		objToken := common.GetString(node, "obj_token")
-		if objType == "" || objToken == "" {
-			return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data")
+		nodeData := common.GetMap(data, "node")
+		node := slidesWikiNode{
+			ObjType:  common.GetString(nodeData, "obj_type"),
+			ObjToken: common.GetString(nodeData, "obj_token"),
 		}
-		if objType != "slides" {
-			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but slides shortcuts require a slides presentation", objType).WithParam("--presentation")
+		if node.ObjType == "" || node.ObjToken == "" {
+			return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node_by_token returned incomplete node data")
 		}
-		return objToken, nil
+		if node.ObjType != "slides" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but slides shortcuts require a slides presentation", node.ObjType).WithParam("--presentation")
+		}
+		return node.ObjToken, nil
 	default:
 		// Unreachable: ref.Kind is set only by parsePresentationRef, which
 		// emits exclusively "slides" or "wiki". A hit here means an internal
@@ -108,6 +117,20 @@ func resolvePresentationID(runtime *common.RuntimeContext, ref presentationRef) 
 		// not bad user input — classify as internal, not validation.
 		return "", errs.NewInternalError(errs.SubtypeUnknown, "unsupported presentation ref kind %q", ref.Kind)
 	}
+}
+
+func slidesWikiNodeLookupProblem(err error) error {
+	if problem, ok := errs.ProblemOf(err); ok {
+		switch problem.Code {
+		case 131012:
+			problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+		case 131013, 131016:
+			problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+		case 131014:
+			problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+		}
+	}
+	return err
 }
 
 // imgSrcPlaceholderRegex matches `src="@<path>"` or `src='@<path>'` inside <img> tags.

--- a/shortcuts/slides/slides_add_slide.go
+++ b/shortcuts/slides/slides_add_slide.go
@@ -115,7 +115,7 @@ var SlidesAddSlide = common.Shortcut{
 		if ref.Kind == "wiki" {
 			presentationID = unresolvedSlidesTokenPlaceholder
 			dry.Desc(fmt.Sprintf("%d-step orchestration: resolve wiki → add page", total)).
-				GET("/open-apis/wiki/v2/spaces/get_node").
+				GET(slidesWikiNodeByTokenPath).
 				Desc(fmt.Sprintf("[%d/%d] Resolve wiki node to slides presentation", step, total)).
 				Params(map[string]interface{}{"token": ref.Token})
 			step++

--- a/shortcuts/slides/slides_add_slide_test.go
+++ b/shortcuts/slides/slides_add_slide_test.go
@@ -274,7 +274,7 @@ func TestAddSlideResolvesWikiURL(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -420,7 +420,7 @@ func TestAddSlideDryRunPlansWikiResolution(t *testing.T) {
 	if len(steps) != 2 {
 		t.Fatalf("planned %d calls, want resolve then add: %#v", len(steps), steps)
 	}
-	resolve := assertDryRunStep(t, steps, 0, "GET", "/open-apis/wiki/v2/spaces/get_node")
+	resolve := assertDryRunStep(t, steps, 0, "GET", "/open-apis/wiki/v2/spaces/node_by_token")
 	resolveParams, _ := resolve["params"].(map[string]interface{})
 	if resolveParams["token"] != "wikcnTOKEN" {
 		t.Fatalf("resolve token = %v, want wikcnTOKEN", resolveParams["token"])

--- a/shortcuts/slides/slides_delete_slide.go
+++ b/shortcuts/slides/slides_delete_slide.go
@@ -74,7 +74,7 @@ var SlidesDeleteSlide = common.Shortcut{
 			total = 2
 			presentationID = "<resolved_slides_token>"
 			dry.Desc("2-step orchestration: resolve wiki → delete page").
-				GET("/open-apis/wiki/v2/spaces/get_node").
+				GET(slidesWikiNodeByTokenPath).
 				Desc("[1/2] Resolve wiki node to slides presentation").
 				Params(map[string]interface{}{"token": ref.Token})
 			step = 2

--- a/shortcuts/slides/slides_delete_slide_test.go
+++ b/shortcuts/slides/slides_delete_slide_test.go
@@ -141,7 +141,7 @@ func TestDeleteSlideResolvesWikiURL(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -178,7 +178,7 @@ func TestDeleteSlideRejectsNonSlidesWiki(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -199,7 +199,7 @@ func TestDeleteSlideRejectsNonSlidesWiki(t *testing.T) {
 		t.Fatal("expected an error when the wiki node is not a slides deck")
 	}
 	// Tagged --presentation, not --slide-id: the wrong input is the URL. No
-	// cause — the mismatch is read off a successful get_node response.
+	// cause — the mismatch is read off a successful node_by_token response.
 	assertValidationProblem(t, err, "--presentation", nil)
 	if !strings.Contains(err.Error(), "docx") {
 		t.Fatalf("err = %v, want mention of the resolved obj_type", err)
@@ -265,7 +265,7 @@ func TestDeleteSlideDryRunPlansWikiResolution(t *testing.T) {
 	if len(steps) != 2 {
 		t.Fatalf("planned %d calls, want resolve then delete: %#v", len(steps), steps)
 	}
-	resolve := assertDryRunStep(t, steps, 0, "GET", "/open-apis/wiki/v2/spaces/get_node")
+	resolve := assertDryRunStep(t, steps, 0, "GET", "/open-apis/wiki/v2/spaces/node_by_token")
 	resolveParams, _ := resolve["params"].(map[string]interface{})
 	if resolveParams["token"] != "wikcnTOKEN" {
 		t.Fatalf("resolve token = %v, want wikcnTOKEN", resolveParams["token"])

--- a/shortcuts/slides/slides_history.go
+++ b/shortcuts/slides/slides_history.go
@@ -91,7 +91,7 @@ func newSlidesHistoryDryRun(ref presentationRef, desc string) (*common.DryRunAPI
 	if ref.Kind == "wiki" {
 		presentationID = "<resolved_slides_token>"
 		dry.Desc("2-step orchestration: resolve wiki then " + desc).
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET(slidesWikiNodeByTokenPath).
 			Desc("[1] Resolve wiki node to slides presentation").
 			Params(map[string]interface{}{"token": ref.Token})
 	} else {

--- a/shortcuts/slides/slides_history_test.go
+++ b/shortcuts/slides/slides_history_test.go
@@ -190,7 +190,7 @@ func TestSlidesHistoryDryRunWithWikiPresentation(t *testing.T) {
 	if len(dry.API) != 2 {
 		t.Fatalf("api calls = %d, want 2: %#v", len(dry.API), dry.API)
 	}
-	if got, want := dry.API[0].URL, "/open-apis/wiki/v2/spaces/get_node"; got != want {
+	if got, want := dry.API[0].URL, "/open-apis/wiki/v2/spaces/node_by_token"; got != want {
 		t.Fatalf("wiki dry-run URL = %q, want %q", got, want)
 	}
 	if got := dry.API[0].Params["token"]; got != "wikcn123" {
@@ -347,7 +347,7 @@ func TestSlidesHistoryExecuteResolvesWikiPresentation(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{

--- a/shortcuts/slides/slides_media_parent_type_test.go
+++ b/shortcuts/slides/slides_media_parent_type_test.go
@@ -134,7 +134,7 @@ func mustJSONArray(t *testing.T, pages ...string) string {
 }
 
 // uploadStepBody finds the planned upload_all call and returns its body. Wiki
-// refs put a get_node step first, so the upload is not at a fixed index.
+// refs put a node_by_token step first, so the upload is not at a fixed index.
 func uploadStepBody(t *testing.T, steps []map[string]interface{}) map[string]interface{} {
 	t.Helper()
 

--- a/shortcuts/slides/slides_media_upload.go
+++ b/shortcuts/slides/slides_media_upload.go
@@ -49,7 +49,7 @@ func slidesMediaParentType(presentationToken string) string {
 
 // unresolvedSlidesTokenPlaceholder is what a dry-run shows in place of a
 // presentation token it cannot know: the caller passed a wiki reference, and
-// resolving it needs the get_node call a preview must not make.
+// resolving it needs the node_by_token call a preview must not make.
 const unresolvedSlidesTokenPlaceholder = "<resolved_slides_token>"
 
 // slidesDryRunParentType returns the parent_type a dry-run should preview for
@@ -114,7 +114,7 @@ var SlidesMediaUpload = common.Shortcut{
 			uploadNode = unresolvedSlidesTokenPlaceholder
 			stepBase = 2
 			dry.Desc("2-step orchestration: resolve wiki → upload media").
-				GET("/open-apis/wiki/v2/spaces/get_node").
+				GET(slidesWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to slides presentation").
 				Params(map[string]interface{}{"token": ref.Token})
 		} else {

--- a/shortcuts/slides/slides_media_upload_test.go
+++ b/shortcuts/slides/slides_media_upload_test.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"mime"
 	"mime/multipart"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -116,7 +118,7 @@ func TestSlidesMediaUploadFromSlidesURL(t *testing.T) {
 	}
 }
 
-// TestSlidesMediaUploadFromWikiURL verifies wiki URL → get_node lookup is performed
+// TestSlidesMediaUploadFromWikiURL verifies wiki URL → node_by_token lookup is performed
 // and the resolved obj_token is used as parent_node.
 func TestSlidesMediaUploadFromWikiURL(t *testing.T) {
 	dir := t.TempDir()
@@ -128,7 +130,7 @@ func TestSlidesMediaUploadFromWikiURL(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -173,7 +175,7 @@ func TestSlidesMediaUploadWikiWrongType(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -196,6 +198,53 @@ func TestSlidesMediaUploadWikiWrongType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "docx") {
 		t.Fatalf("err = %v, want mention of resolved obj_type", err)
+	}
+}
+
+func TestSlidesMediaUploadClassifiesNodeByTokenErrors(t *testing.T) {
+	const wikiToken = "wikcn_lookup_error"
+	for _, tt := range []struct {
+		code    int
+		subtype errs.Subtype
+	}{
+		{code: 131012, subtype: errs.SubtypeNotFound},
+		{code: 131013, subtype: errs.SubtypeInvalidParameters},
+		{code: 131014, subtype: errs.SubtypeFailedPrecondition},
+		{code: 131016, subtype: errs.SubtypeInvalidParameters},
+	} {
+		t.Run(fmt.Sprint(tt.code), func(t *testing.T) {
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+			f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
+			reg.Register(&httpmock.Stub{
+				Method:  "GET",
+				URL:     "/open-apis/wiki/v2/spaces/node_by_token",
+				Headers: http.Header{"X-Tt-Logid": []string{"slides-wiki-lookup-log"}},
+				Body:    map[string]interface{}{"code": tt.code, "msg": "lookup rejected"},
+				OnMatch: func(req *http.Request) {
+					if got := req.URL.Query().Get("token"); got != wikiToken {
+						t.Errorf("lookup token = %q, want %q", got, wikiToken)
+					}
+				},
+			})
+
+			err := runSlidesShortcut(t, f, stdout, SlidesMediaUpload, []string{
+				"+media-upload",
+				"--file", "missing.png",
+				"--presentation", "https://x.feishu.cn/wiki/" + wikiToken,
+				"--as", "user",
+			})
+			problem, ok := errs.ProblemOf(err)
+			if !ok || problem.Category != errs.CategoryAPI || problem.Subtype != tt.subtype || problem.Code != tt.code || problem.Retryable {
+				t.Fatalf("error = %#v (%v), want terminal api/%s/%d", problem, err, tt.subtype, tt.code)
+			}
+			if problem.LogID != "slides-wiki-lookup-log" || !strings.Contains(problem.Message, "lookup rejected") {
+				t.Fatalf("upstream metadata not preserved: %#v", problem)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("unexpected success output: %s", stdout)
+			}
+		})
 	}
 }
 

--- a/shortcuts/slides/slides_replace_slide.go
+++ b/shortcuts/slides/slides_replace_slide.go
@@ -113,7 +113,7 @@ var SlidesReplaceSlide = common.Shortcut{
 		if ref.Kind == "wiki" {
 			presentationID = "<resolved_slides_token>"
 			dry.Desc("2-step orchestration: resolve wiki → replace slide parts").
-				GET("/open-apis/wiki/v2/spaces/get_node").
+				GET(slidesWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to slides presentation").
 				Params(map[string]interface{}{"token": ref.Token})
 		} else {

--- a/shortcuts/slides/slides_replace_slide_test.go
+++ b/shortcuts/slides/slides_replace_slide_test.go
@@ -510,7 +510,7 @@ func TestReplaceSlideWikiResolution(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{

--- a/shortcuts/slides/slides_screenshot.go
+++ b/shortcuts/slides/slides_screenshot.go
@@ -136,7 +136,7 @@ var SlidesScreenshot = common.Shortcut{
 		if ref.Kind == "wiki" {
 			presentationID = "<resolved_slides_token>"
 			dry.Desc("2-step orchestration: resolve wiki → fetch slide screenshot(s)").
-				GET("/open-apis/wiki/v2/spaces/get_node").
+				GET(slidesWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to slides presentation").
 				Params(map[string]interface{}{"token": ref.Token})
 		} else {

--- a/shortcuts/slides/slides_update_slide.go
+++ b/shortcuts/slides/slides_update_slide.go
@@ -164,7 +164,7 @@ func updateSlideDryRun(_ context.Context, runtime *common.RuntimeContext) *commo
 	if ref.Kind == "wiki" {
 		presentationID = unresolvedSlidesTokenPlaceholder
 		dry.Desc(fmt.Sprintf("%d-step orchestration: resolve wiki → replace slide", total)).
-			GET("/open-apis/wiki/v2/spaces/get_node").
+			GET(slidesWikiNodeByTokenPath).
 			Desc(fmt.Sprintf("[%d/%d] Resolve wiki node to slides presentation", step, total)).
 			Params(map[string]interface{}{"token": ref.Token})
 		step++

--- a/shortcuts/slides/slides_xml_get.go
+++ b/shortcuts/slides/slides_xml_get.go
@@ -82,7 +82,7 @@ var SlidesXMLGet = common.Shortcut{
 		if ref.Kind == "wiki" {
 			presentationID = "<resolved_slides_token>"
 			dry.Desc("2-step orchestration: resolve wiki → fetch presentation XML").
-				GET("/open-apis/wiki/v2/spaces/get_node").
+				GET(slidesWikiNodeByTokenPath).
 				Desc("[1] Resolve wiki node to slides presentation").
 				Params(map[string]interface{}{"token": ref.Token})
 		} else {

--- a/shortcuts/slides/slides_xml_get_test.go
+++ b/shortcuts/slides/slides_xml_get_test.go
@@ -319,7 +319,7 @@ func TestSlidesXMLGetResolvesWikiPresentation(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, slidesTestConfig(t, ""))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		URL:    "/open-apis/wiki/v2/spaces/node_by_token",
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{

--- a/skills/lark-slides/references/cli/lark-slides-add-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-add-slide.md
@@ -28,7 +28,7 @@ lark-cli slides +add-slide --as user \
   --slide @cover.xml \
   --before-slide-id "$SID"
 
-# wiki 链接（CLI 自动 wiki.spaces.get_node 解析，并校验 obj_type=slides）
+# wiki 链接（CLI 自动通过 node_by_token 接口解析，并校验 obj_type=slides）
 lark-cli slides +add-slide --as user \
   --presentation "https://xxx.feishu.cn/wiki/wikcnXXXXXX" \
   --slide @page3.xml

--- a/skills/lark-slides/references/cli/lark-slides-media-upload.md
+++ b/skills/lark-slides/references/cli/lark-slides-media-upload.md
@@ -15,7 +15,7 @@ lark-cli slides +media-upload --as user \
   --file ./chart.png \
   --presentation "https://xxx.feishu.cn/slides/slidesXXXXXXXXXXXXXXXXXXXXXX"
 
-# 传 wiki URL（CLI 自动 wiki.spaces.get_node 解析为真实 token，校验 obj_type=slides）
+# 传 wiki URL（CLI 自动通过 node_by_token 接口解析真实 token，校验 obj_type=slides）
 lark-cli slides +media-upload --as user \
   --file ./pic.png \
   --presentation "https://xxx.feishu.cn/wiki/wikcnXXXXXX"

--- a/skills/lark-slides/references/cli/lark-slides-replace-slide.md
+++ b/skills/lark-slides/references/cli/lark-slides-replace-slide.md
@@ -32,7 +32,7 @@ lark-cli slides +replace-slide --as user \
 cat parts.json | lark-cli slides +replace-slide --as user \
   --presentation $PRES_ID --slide-id $SID --parts -
 
-# wiki URL 直接传（CLI 自动 get_node → 拿真实 xml_presentation_id）
+# wiki URL 直接传（CLI 自动通过 node_by_token 拿真实 xml_presentation_id）
 lark-cli slides +replace-slide --as user \
   --presentation "https://xxx.feishu.cn/wiki/wikcnXXXXXX" --slide-id pfG \
   --parts '[{"action":"block_insert","insertion":"<shape type=\"rect\" width=\"100\" height=\"100\"/>"}]'

--- a/tests/cli_e2e/sheets/sheets_image_upload_dryrun_test.go
+++ b/tests/cli_e2e/sheets/sheets_image_upload_dryrun_test.go
@@ -24,7 +24,7 @@ import (
 // office/native split fans out to.
 //
 // The wiki rows carry an office-shaped node_token on purpose. A preview cannot
-// know what a wiki node resolves to — that needs the get_node call a dry-run
+// know what a wiki node resolves to — that needs the node_by_token call a dry-run
 // must not make — so it must not read the office/native split out of the
 // node_token it happens to be holding. Those rows show the same token as a
 // /wiki/ URL and as a raw spreadsheet token and expect different answers, which

--- a/tests/cli_e2e/slides/slides_image_upload_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_image_upload_dryrun_test.go
@@ -61,7 +61,7 @@ func TestSlides_ImageUploadDryRunParentType(t *testing.T) {
 		wantParentNode string
 		wantParentType string
 		// uploadStep is the index of the upload_all call in data.api. A wiki ref
-		// plans get_node first, so its upload is not the leading step.
+		// plans node_by_token first, so its upload is not the leading step.
 		uploadStep string
 	}{
 		{
@@ -179,7 +179,7 @@ func TestSlides_ImageUploadDryRunParentType(t *testing.T) {
 
 			out := result.Stdout
 			// The upload precedes the page XML that references its file_token,
-			// and follows the get_node that names the deck to upload into.
+			// and follows the node_by_token call that names the deck to upload into.
 			require.Equal(t, "POST", clie2e.DryRunGet(out, "api."+tt.uploadStep+".method").String(),
 				"data.api.%s must be the drive upload; stdout:\n%s", tt.uploadStep, out)
 			require.Equal(t, "/open-apis/drive/v1/medias/upload_all",

--- a/tests/cli_e2e/slides/slides_slide_add_delete_dryrun_test.go
+++ b/tests/cli_e2e/slides/slides_slide_add_delete_dryrun_test.go
@@ -138,7 +138,7 @@ func TestSlidesDeleteSlideWikiDryRunE2E(t *testing.T) {
 	result.AssertExitCode(t, 0)
 
 	require.Equal(t, "GET", gjson.Get(result.Stdout, "data.api.0.method").String(), result.Stdout)
-	require.Equal(t, "/open-apis/wiki/v2/spaces/get_node", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
+	require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", gjson.Get(result.Stdout, "data.api.0.url").String(), result.Stdout)
 	require.Equal(t, "wikcnE2ETOKEN", gjson.Get(result.Stdout, "data.api.0.params.token").String(), result.Stdout)
 	require.Equal(t, "DELETE", gjson.Get(result.Stdout, "data.api.1.method").String(), result.Stdout)
 }


### PR DESCRIPTION
## Summary

Migrate Sheets and Slides Wiki URL resolution from `wiki/v2/spaces/get_node` to `wiki/v2/spaces/node_by_token`. The commands continue to validate `obj_type=sheet` or `obj_type=slides`, preserve their conditional scope behavior, and pass the resolved `obj_token` to downstream APIs.

## Changes

- Switch the shared Sheets and Slides Wiki resolvers and Slides dry-run requests to `node_by_token`.
- Project the new API response into typed node structs and classify its endpoint-specific error codes.
- Update unit tests, dry-run E2E coverage, and affected Slides skill references.

## Test Plan

- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] Sheets and Slides dry-run E2E tests
- [x] Package tests for `./shortcuts/sheets` and `./shortcuts/slides`

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wiki URLs for spreadsheet and presentation shortcuts now resolve through the updated wiki node lookup flow.
  - Wiki references with incomplete or unsupported node data receive clearer validation errors.
  - Wiki lookup failures are classified into more specific, actionable error types.

- **Documentation**
  - Updated CLI guidance for wiki links across slide-related commands to reflect the current resolution process.

- **Tests**
  - Added coverage for wiki lookup errors, incomplete node data, and updated dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->