### PR TITLE
Complete mail rule reorder inputs

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -370,7 +370,7 @@ var MailRuleReorder = common.Shortcut{
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule ID order. Omitted current rules are appended in their existing order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1631,10 +1631,7 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
-			return nil, err
-		}
-		return ids, nil
+		return completeRuleTargetOrder(ids, currentIDs)
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1654,22 +1651,33 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 }
 
 func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
-	}
-	want := make(map[string]int, len(current))
+	_, err := completeRuleTargetOrder(target, current)
+	return err
+}
+
+func completeRuleTargetOrder(target, current []string) ([]string, error) {
+	currentSet := make(map[string]struct{}, len(current))
 	for _, id := range current {
-		want[id]++
+		currentSet[id] = struct{}{}
 	}
+	seen := make(map[string]struct{}, len(target))
+	out := make([]string, 0, len(current))
 	for _, id := range target {
-		want[id]--
+		if _, ok := currentSet[id]; !ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains unknown rule id %s; run +rule-list first to inspect current rule ids", id)
+		}
+		if _, ok := seen[id]; ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+	for _, id := range current {
+		if _, ok := seen[id]; !ok {
+			out = append(out, id)
 		}
 	}
-	return nil
+	return out, nil
 }
 
 func normalizeRuleIDs(ids []string) []string {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1145,6 +1145,27 @@ func TestMailRuleListFilterUsesTextTable(t *testing.T) {
 }
 
 func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
+	t.Run("partial order completes with omitted rules", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+			mailRuleTestRawRule("d", "D"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b,d")
+	})
+
 	t.Run("full order", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
@@ -1223,6 +1244,67 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 			t.Fatalf("run +rule-reorder after error = %v", err)
 		}
 		assertRuleIDsBody(t, post.CapturedBody, "b,c,a")
+	})
+}
+
+func TestMailRuleReorderPreservesOmittedRulesWhenPartialOrderContainsTail(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(mailRuleListStub(
+		mailRuleTestRawRule("a", "A"),
+		mailRuleTestRawRule("b", "B"),
+		mailRuleTestRawRule("c", "C"),
+		mailRuleTestRawRule("d", "D"),
+	))
+	post := &httpmock.Stub{
+		Method: "POST",
+		URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+	}
+	reg.Register(post)
+
+	if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "d,b", "--format", "json"}, f, stdout); err != nil {
+		t.Fatalf("run +rule-reorder partial tail error = %v", err)
+	}
+	assertRuleIDsBody(t, post.CapturedBody, "d,b,a,c")
+}
+
+func TestMailRuleReorderPropagatesListAndReorderErrors(t *testing.T) {
+	t.Run("list error", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(&httpmock.Stub{
+			Method: "GET",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules",
+			Body:   map[string]interface{}{"code": 999, "msg": "list failed"},
+		})
+
+		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
+		if err == nil {
+			t.Fatal("expected list error")
+		}
+		if !strings.Contains(err.Error(), "list mail rules before reorder failed") {
+			t.Fatalf("error = %v, want list context", err)
+		}
+	})
+
+	t.Run("reorder error", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+		))
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 999, "msg": "reorder failed"},
+		})
+
+		err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "b", "--format", "json"}, f, stdout)
+		if err == nil {
+			t.Fatal("expected reorder error")
+		}
+		if !strings.Contains(err.Error(), "reorder mail rules failed") {
+			t.Fatalf("error = %v, want reorder context", err)
+		}
 	})
 }
 
@@ -1488,11 +1570,11 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 }
 
 func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+	if err := validateFullRuleOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected unknown rule id error")
 	}
 	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected duplicate mismatch error")
+		t.Fatal("expected duplicate rule id error")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1529,12 +1611,12 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 		{
 			name: "full mismatch",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
+			want: "unknown rule id",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "unknown rule id") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)


### PR DESCRIPTION
Mail receive-rule reordering now expands partial user input into a complete ordered rule ID list before calling the reorder API. This preserves omitted rules in their existing relative order while keeping full-list input behavior unchanged.

- Fetch the current receive-rule list before reorder operations.
- Merge user-provided IDs with omitted existing rule IDs before calling reorder.
- Add unit coverage for partial reorder input, full-list passthrough, omitted-rule preservation, and list/reorder error propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Mail rules can now be reordered using a partial list of rule IDs; omitted rules remain in their existing order.
  * Invalid or duplicate rule IDs continue to be rejected.
* **Bug Fixes**
  * Improved handling and reporting of errors when retrieving or reordering mail rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->