### PR TITLE
fix(base): migrate wiki lookup to node_by_token

### DIFF
--- a/shortcuts/base/base_resolve.go
+++ b/shortcuts/base/base_resolve.go
@@ -17,6 +17,7 @@ import (
 const (
 	baseURLResolveHintGeneric = "Provide a /base/, /app/, /wiki/, or /record/ URL, or use base +title-resolve --title if you only know the Base title."
 	baseTitleResolveHint      = "choose one candidate, then use +base-block-list to list tables, dashboards, workflows, and other Base blocks"
+	baseWikiNodeByTokenPath   = "/open-apis/wiki/v2/spaces/node_by_token"
 	nextStepBaseBlockList     = "use +base-block-list to list tables, dashboards, workflows, and other Base blocks"
 	nextStepRecordList        = "use +record-list to list records in the resolved table"
 	nextStepBaseApp           = "use +app-get with app_token; there is no +app-list, so list apps in a workspace with +workspace-entity-list --type baseapp"
@@ -74,11 +75,11 @@ var BaseURLResolve = common.Shortcut{
 			selectedBlockID := strings.TrimSpace(parsed.Query().Get("table"))
 			if selectedBlockID == "" {
 				return dry.
-					GET("/open-apis/wiki/v2/spaces/get_node").
+					GET(baseWikiNodeByTokenPath).
 					Params(map[string]interface{}{"token": firstPathSegmentAfter(parsed.Path, "/wiki/")})
 			}
 			dry.Desc("2-step: resolve the Wiki node to a Base, then identify the selected Base block")
-			dry.GET("/open-apis/wiki/v2/spaces/get_node").
+			dry.GET(baseWikiNodeByTokenPath).
 				Desc("[1] Resolve the Wiki node to its underlying Base").
 				Params(map[string]interface{}{"token": firstPathSegmentAfter(parsed.Path, "/wiki/")})
 			dry.POST("/open-apis/base/v3/bases/:base_token/blocks/list").
@@ -320,32 +321,55 @@ func applyResolvedTableSelection(out map[string]interface{}, selection baseURLSe
 	}
 }
 
+type baseWikiNode struct {
+	ObjType  string
+	ObjToken string
+	Title    string
+}
+
 func resolveWikiBaseURL(runtime *common.RuntimeContext, u *url.URL) (map[string]interface{}, error) {
 	token := firstPathSegmentAfter(u.Path, "/wiki/")
-	data, err := runtime.CallAPITyped("GET", "/open-apis/wiki/v2/spaces/get_node", map[string]interface{}{"token": token}, nil)
+	data, err := runtime.CallAPITyped("GET", baseWikiNodeByTokenPath, map[string]interface{}{"token": token}, nil)
 	if err != nil {
-		return nil, err
+		return nil, baseWikiNodeLookupProblem(err)
 	}
-	node := common.GetMap(data, "node")
-	objType := strings.TrimSpace(common.GetString(node, "obj_type"))
-	if objType != "bitable" {
+	nodeData := common.GetMap(data, "node")
+	node := baseWikiNode{
+		ObjType:  strings.TrimSpace(common.GetString(nodeData, "obj_type")),
+		ObjToken: strings.TrimSpace(common.GetString(nodeData, "obj_token")),
+		Title:    common.GetString(nodeData, "title"),
+	}
+	if node.ObjType != "bitable" {
 		return nil, resolveValidationError(
-			fmt.Sprintf("This Wiki URL resolves to %s, not Base.", valueOrUnknown(objType)),
+			fmt.Sprintf("This Wiki URL resolves to %s, not Base.", valueOrUnknown(node.ObjType)),
 			"Use the corresponding skill for that resource, or provide a Base URL.",
 		)
 	}
-	baseToken := strings.TrimSpace(common.GetString(node, "obj_token"))
-	if baseToken == "" {
+	if node.ObjToken == "" {
 		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki node response is missing obj_token")
 	}
 	return map[string]interface{}{
 		"input_type":      "wiki_url",
 		"resource_type":   "bitable",
 		"wiki_node_token": token,
-		"base_token":      baseToken,
-		"title":           common.GetString(node, "title"),
+		"base_token":      node.ObjToken,
+		"title":           node.Title,
 		"hint":            resolveHint("", nil),
 	}, nil
+}
+
+func baseWikiNodeLookupProblem(err error) error {
+	if problem, ok := errs.ProblemOf(err); ok {
+		switch problem.Code {
+		case 131012:
+			problem.Subtype, problem.Retryable = errs.SubtypeNotFound, false
+		case 131013, 131016:
+			problem.Subtype, problem.Retryable = errs.SubtypeInvalidParameters, false
+		case 131014:
+			problem.Subtype, problem.Retryable = errs.SubtypeFailedPrecondition, false
+		}
+	}
+	return err
 }
 
 func resolveRecordShareURL(runtime *common.RuntimeContext, u *url.URL) (map[string]interface{}, error) {

--- a/shortcuts/base/base_resolve_test.go
+++ b/shortcuts/base/base_resolve_test.go
@@ -4,6 +4,8 @@
 package base
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -388,7 +390,7 @@ func TestBaseURLResolveWikiURL(t *testing.T) {
 		factory, stdout, reg := newExecuteFactory(t)
 		reg.Register(&httpmock.Stub{
 			Method: "GET",
-			URL:    "/open-apis/wiki/v2/spaces/get_node?token=wikdoc",
+			URL:    baseWikiNodeByTokenPath + "?token=wikdoc",
 			Body: map[string]interface{}{
 				"code": 0,
 				"data": map[string]interface{}{
@@ -404,12 +406,52 @@ func TestBaseURLResolveWikiURL(t *testing.T) {
 			t.Fatalf("err=%v, want non-Base validation error", err)
 		}
 	})
+
+	t.Run("classifies node_by_token errors", func(t *testing.T) {
+		for _, failure := range []struct {
+			code    int
+			subtype errs.Subtype
+		}{
+			{131012, errs.SubtypeNotFound},
+			{131013, errs.SubtypeInvalidParameters},
+			{131014, errs.SubtypeFailedPrecondition},
+			{131016, errs.SubtypeInvalidParameters},
+		} {
+			t.Run(fmt.Sprintf("code_%d", failure.code), func(t *testing.T) {
+				factory, stdout, reg := newExecuteFactory(t)
+				lookup := &httpmock.Stub{
+					Method:  "GET",
+					URL:     baseWikiNodeByTokenPath + "?token=wik123",
+					Headers: http.Header{"X-Tt-Logid": []string{"base-wiki-lookup-log"}},
+					Body:    map[string]interface{}{"code": failure.code, "msg": "lookup rejected"},
+				}
+				reg.Register(lookup)
+
+				err := runShortcutWithAuthTypes(t, BaseURLResolve, authTypes(), []string{
+					"+url-resolve", "--url", "https://example.larkoffice.com/wiki/wik123", "--as", "user",
+				}, factory, stdout)
+				problem, ok := errs.ProblemOf(err)
+				if !ok || problem.Category != errs.CategoryAPI || problem.Subtype != failure.subtype || problem.Code != failure.code || problem.Retryable {
+					t.Fatalf("error = %#v (%v), want terminal api/%s/%d", problem, err, failure.subtype, failure.code)
+				}
+				if problem.LogID != "base-wiki-lookup-log" || !strings.Contains(problem.Message, "lookup rejected") {
+					t.Fatalf("upstream metadata not preserved: %#v", problem)
+				}
+				if len(lookup.CapturedBodies) != 1 {
+					t.Fatalf("lookup calls = %d, want 1", len(lookup.CapturedBodies))
+				}
+				if stdout.Len() != 0 {
+					t.Fatalf("unexpected success output: %s", stdout)
+				}
+			})
+		}
+	})
 }
 
 func wikiBaseNodeStub(wikiToken, baseToken, title string) *httpmock.Stub {
 	return &httpmock.Stub{
 		Method: "GET",
-		URL:    "/open-apis/wiki/v2/spaces/get_node?token=" + wikiToken,
+		URL:    baseWikiNodeByTokenPath + "?token=" + wikiToken,
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -420,6 +462,39 @@ func wikiBaseNodeStub(wikiToken, baseToken, title string) *httpmock.Stub {
 				},
 			},
 		},
+	}
+}
+
+func TestBaseWikiNodeLookupProblemPreservesCause(t *testing.T) {
+	for _, failure := range []struct {
+		code    int
+		subtype errs.Subtype
+	}{
+		{131012, errs.SubtypeNotFound},
+		{131013, errs.SubtypeInvalidParameters},
+		{131014, errs.SubtypeFailedPrecondition},
+		{131016, errs.SubtypeInvalidParameters},
+	} {
+		t.Run(fmt.Sprintf("code_%d", failure.code), func(t *testing.T) {
+			cause := errors.New("upstream sentinel")
+			upstream := errs.NewAPIError(errs.SubtypeUnknown, "lookup rejected").
+				WithCode(failure.code).
+				WithRetryable().
+				WithLogID("base-wiki-lookup-log").
+				WithCause(cause)
+
+			got := baseWikiNodeLookupProblem(upstream)
+			if !errors.Is(got, cause) {
+				t.Fatalf("errors.Is(got, cause) = false, want preserved cause")
+			}
+			problem, ok := errs.ProblemOf(got)
+			if !ok || problem.Subtype != failure.subtype || problem.Code != failure.code || problem.Retryable {
+				t.Fatalf("error = %#v (%v), want terminal api/%s/%d", problem, got, failure.subtype, failure.code)
+			}
+			if problem.LogID != "base-wiki-lookup-log" {
+				t.Fatalf("log_id = %q, want preserved upstream log ID", problem.LogID)
+			}
+		})
 	}
 }
 

--- a/tests/cli_e2e/base/base_url_resolve_dryrun_test.go
+++ b/tests/cli_e2e/base/base_url_resolve_dryrun_test.go
@@ -35,6 +35,29 @@ func TestBaseURLResolveSelectedBlockDryRun(t *testing.T) {
 	require.Equal(t, "blk_selected", clie2e.DryRunGet(result.Stdout, "selected_block_id").String(), result.Stdout)
 }
 
+func TestBaseURLResolveWikiDryRun(t *testing.T) {
+	setBaseDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"base", "+url-resolve",
+			"--url", "https://example.larkoffice.com/wiki/wik_x",
+			"--dry-run",
+		},
+		BinaryPath: "../../../lark-cli",
+		DefaultAs:  "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, "api.0.method").String(), result.Stdout)
+	require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", clie2e.DryRunGet(result.Stdout, "api.0.url").String(), result.Stdout)
+	require.Equal(t, "wik_x", clie2e.DryRunGet(result.Stdout, "api.0.params.token").String(), result.Stdout)
+}
+
 func TestBaseURLResolveWikiSelectedBlockDryRun(t *testing.T) {
 	setBaseDryRunConfigEnv(t)
 
@@ -54,7 +77,7 @@ func TestBaseURLResolveWikiSelectedBlockDryRun(t *testing.T) {
 	result.AssertExitCode(t, 0)
 
 	require.Equal(t, "GET", clie2e.DryRunGet(result.Stdout, "api.0.method").String(), result.Stdout)
-	require.Equal(t, "/open-apis/wiki/v2/spaces/get_node", clie2e.DryRunGet(result.Stdout, "api.0.url").String(), result.Stdout)
+	require.Equal(t, "/open-apis/wiki/v2/spaces/node_by_token", clie2e.DryRunGet(result.Stdout, "api.0.url").String(), result.Stdout)
 	require.Equal(t, "wik_x", clie2e.DryRunGet(result.Stdout, "api.0.params.token").String(), result.Stdout)
 	require.Equal(t, "POST", clie2e.DryRunGet(result.Stdout, "api.1.method").String(), result.Stdout)
 	require.Equal(t, "/open-apis/base/v3/bases/%3Cobj_token%20from%20step%201%3E/blocks/list", clie2e.DryRunGet(result.Stdout, "api.1.url").String(), result.Stdout)


### PR DESCRIPTION
## Summary

Migrate the Wiki URL lookup in `base +url-resolve` from `wiki/v2/spaces/get_node` to `wiki/v2/spaces/node_by_token`. The resolver continues to require `obj_type=bitable` and returns the same Base token, title, and selected block coordinates.

## Changes

- Switch live and dry-run Wiki resolution to `node_by_token` while preserving the existing request token and output contract.
- Project the new API response into a typed node shape and classify its endpoint-specific terminal errors.
- Update unit tests and add dry-run E2E coverage for both one-step and selected-block Wiki URL flows.

## Test Plan

- [x] `make unit-test`
- [x] `make vet`
- [x] `make fmt-check`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] `go test ./shortcuts/base -race -count=1`
- [x] Base dry-run E2E tests
- [x] Diff-scoped golangci-lint and repository lint checks

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wiki URL resolution by using the correct node lookup endpoint.
  * Added clearer handling for Wiki API errors, including error classification and retryability.
  * Updated dry-run output and behavior for Wiki URLs without table parameters.

* **Tests**
  * Added coverage for Wiki URL dry-run resolution.
  * Added coverage for Wiki node lookup error scenarios, including error details and classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->