### PR TITLE
fix(mail): complete mail rule reorder ids

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -364,13 +364,13 @@ var MailRuleDisable = makeRuleToggleShortcut("+rule-disable", false)
 var MailRuleReorder = common.Shortcut{
 	Service:     "mail",
 	Command:     "+rule-reorder",
-	Description: "Reorder mailbox rules by full rule_id list or by moving one rule before/after/top/bottom.",
+	Description: "Reorder mailbox rules by rule_id list, auto-completing omitted rules in current order, or by moving one rule before/after/top/bottom.",
 	Risk:        "write",
 	Scopes:      []string{"mail:user_mailbox.rule:write"},
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule ID order. Omitted current rules are appended in their existing relative order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1630,12 +1630,11 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
+	if len(currentIDs) == 0 {
+		return nil, mailValidationError("cannot reorder mail rules because the current rule list is empty")
+	}
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		target, err := completeRuleTargetOrder(ids, currentIDs)
-		if err != nil {
-			return nil, err
-		}
-		return target, nil
+		return completeRuleTargetOrder(ids, currentIDs)
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1655,34 +1654,35 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 }
 
 func completeRuleTargetOrder(explicit, current []string) ([]string, error) {
-	if len(current) == 0 {
-		return nil, mailValidationParamError("--rule-ids", "current rule order is empty; run +rule-list first")
-	}
 	currentSet := make(map[string]struct{}, len(current))
 	for _, id := range current {
+		if _, exists := currentSet[id]; exists {
+			return nil, mailValidationParamError("--rule-ids", "cannot reorder mail rules because current rule list contains duplicate id %s", id)
+		}
 		currentSet[id] = struct{}{}
 	}
+
 	seen := make(map[string]struct{}, len(explicit))
-	target := make([]string, 0, len(current))
+	out := make([]string, 0, len(current))
 	for _, id := range explicit {
-		if _, ok := seen[id]; ok {
+		if _, duplicate := seen[id]; duplicate {
 			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
 		}
-		if _, ok := currentSet[id]; !ok {
+		if _, exists := currentSet[id]; !exists {
 			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains unknown rule id %s; run +rule-list first", id)
 		}
 		seen[id] = struct{}{}
-		target = append(target, id)
+		out = append(out, id)
 	}
 	for _, id := range current {
-		if _, ok := seen[id]; !ok {
-			target = append(target, id)
+		if _, specified := seen[id]; !specified {
+			out = append(out, id)
 		}
 	}
-	if len(target) != len(current) {
-		return nil, mailValidationParamError("--rule-ids", "failed to build complete rule order (got %d, want %d)", len(target), len(current))
+	if len(out) != len(current) {
+		return nil, mailValidationParamError("--rule-ids", "unable to construct complete rule order (got %d, want %d)", len(out), len(current))
 	}
-	return target, nil
+	return out, nil
 }
 
 func validateFullRuleOrder(target, current []string) error {

--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -1631,10 +1631,11 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
+		target, err := completeRuleTargetOrder(ids, currentIDs)
+		if err != nil {
 			return nil, err
 		}
-		return ids, nil
+		return target, nil
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1651,6 +1652,37 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 	default:
 		return insertRelative(order, moveID, strings.TrimSpace(rt.Str("after-rule-id")), true)
 	}
+}
+
+func completeRuleTargetOrder(explicit, current []string) ([]string, error) {
+	if len(current) == 0 {
+		return nil, mailValidationParamError("--rule-ids", "current rule order is empty; run +rule-list first")
+	}
+	currentSet := make(map[string]struct{}, len(current))
+	for _, id := range current {
+		currentSet[id] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(explicit))
+	target := make([]string, 0, len(current))
+	for _, id := range explicit {
+		if _, ok := seen[id]; ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
+		}
+		if _, ok := currentSet[id]; !ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains unknown rule id %s; run +rule-list first", id)
+		}
+		seen[id] = struct{}{}
+		target = append(target, id)
+	}
+	for _, id := range current {
+		if _, ok := seen[id]; !ok {
+			target = append(target, id)
+		}
+	}
+	if len(target) != len(current) {
+		return nil, mailValidationParamError("--rule-ids", "failed to build complete rule order (got %d, want %d)", len(target), len(current))
+	}
+	return target, nil
 }
 
 func validateFullRuleOrder(target, current []string) error {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1165,7 +1165,7 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
 	})
 
-	t.Run("partial order appends unspecified current rules", func(t *testing.T) {
+	t.Run("partial order appends omitted rules in current order", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
 			mailRuleTestRawRule("a", "A"),
@@ -1245,6 +1245,28 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		}
 		assertRuleIDsBody(t, post.CapturedBody, "b,c,a")
 	})
+}
+
+func TestMailRuleReorderListFailureDoesNotPost(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	post := &httpmock.Stub{
+		Method:   "POST",
+		URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Optional: true,
+		Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+	}
+	reg.Register(post)
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a,b", "--format", "json"}, f, stdout)
+	if err == nil {
+		t.Fatal("expected list failure")
+	}
+	if !strings.Contains(err.Error(), "list mail rules before reorder failed") {
+		t.Fatalf("error = %v, want list failure context", err)
+	}
+	if len(post.CapturedBodies) != 0 {
+		t.Fatalf("POST reorder should not be sent when list fails, captured %d request(s)", len(post.CapturedBodies))
+	}
 }
 
 func TestMailRuleUpdateReplacesUnknownConditionCollection(t *testing.T) {
@@ -1515,6 +1537,18 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
 		t.Fatal("expected duplicate mismatch error")
 	}
+	if got, err := completeRuleTargetOrder([]string{"b"}, []string{"a", "b", "c"}); err != nil || strings.Join(got, ",") != "b,a,c" {
+		t.Fatalf("completeRuleTargetOrder partial = %v, %v; want b,a,c", got, err)
+	}
+	if err := validateFullRuleOrder([]string{"b"}, []string{"a", "b", "c"}); err == nil {
+		t.Fatal("validateFullRuleOrder should still reject partial lists")
+	}
+	if _, err := completeRuleTargetOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected duplicate explicit id error")
+	}
+	if _, err := completeRuleTargetOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected unknown explicit id error")
+	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
 	}
@@ -1548,28 +1582,23 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			want: "is not in current rule order",
 		},
 		{
-			name: "full mismatch",
+			name: "unknown explicit rule id",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
 			want: "unknown rule id z",
 		},
 		{
-			name: "duplicate rule id",
+			name: "duplicate explicit rule id",
 			args: []string{"+rule-reorder", "--rule-ids", "a,a"},
 			want: "duplicate rule id a",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "unknown rule id") || strings.Contains(tc.want, "duplicate rule id") {
+			if strings.Contains(tc.want, "current rule order") ||
+				strings.Contains(tc.want, "unknown rule id") ||
+				strings.Contains(tc.want, "duplicate rule id") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
-			post := &httpmock.Stub{
-				Method:   "POST",
-				URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
-				Optional: true,
-				Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
-			}
-			reg.Register(post)
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)
 			if err == nil {
 				t.Fatal("expected reorder error")
@@ -1577,40 +1606,7 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
-			if len(post.CapturedBodies) != 0 {
-				t.Fatalf("POST should not be sent on invalid reorder input, captured %d request(s)", len(post.CapturedBodies))
-			}
 		})
-	}
-}
-
-func TestMailRuleReorderListFailureDoesNotPost(t *testing.T) {
-	f, stdout, _, reg := mailShortcutTestFactory(t)
-	reg.Register(&httpmock.Stub{
-		Method: "GET",
-		URL:    "open-apis/mail/v1/user_mailboxes/me/rules",
-		Body: map[string]interface{}{
-			"code": 999,
-			"msg":  "list unavailable",
-		},
-	})
-	post := &httpmock.Stub{
-		Method:   "POST",
-		URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
-		Optional: true,
-		Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
-	}
-	reg.Register(post)
-
-	err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
-	if err == nil {
-		t.Fatal("expected list failure")
-	}
-	if !strings.Contains(err.Error(), "list mail rules before reorder failed") {
-		t.Fatalf("error = %v, want decorated list failure", err)
-	}
-	if len(post.CapturedBodies) != 0 {
-		t.Fatalf("POST should not be sent when list fails, captured %d request(s)", len(post.CapturedBodies))
 	}
 }
 

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1165,6 +1165,27 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
 	})
 
+	t.Run("partial order appends unspecified current rules", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+			mailRuleTestRawRule("d", "D"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b,d")
+	})
+
 	t.Run("move to bottom", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
@@ -1529,14 +1550,26 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 		{
 			name: "full mismatch",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
+			want: "unknown rule id z",
+		},
+		{
+			name: "duplicate rule id",
+			args: []string{"+rule-reorder", "--rule-ids", "a,a"},
+			want: "duplicate rule id a",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "unknown rule id") || strings.Contains(tc.want, "duplicate rule id") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
+			post := &httpmock.Stub{
+				Method:   "POST",
+				URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+				Optional: true,
+				Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+			}
+			reg.Register(post)
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)
 			if err == nil {
 				t.Fatal("expected reorder error")
@@ -1544,7 +1577,40 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
+			if len(post.CapturedBodies) != 0 {
+				t.Fatalf("POST should not be sent on invalid reorder input, captured %d request(s)", len(post.CapturedBodies))
+			}
 		})
+	}
+}
+
+func TestMailRuleReorderListFailureDoesNotPost(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "list unavailable",
+		},
+	})
+	post := &httpmock.Stub{
+		Method:   "POST",
+		URL:      "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Optional: true,
+		Body:     map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+	}
+	reg.Register(post)
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "a", "--format", "json"}, f, stdout)
+	if err == nil {
+		t.Fatal("expected list failure")
+	}
+	if !strings.Contains(err.Error(), "list mail rules before reorder failed") {
+		t.Fatalf("error = %v, want decorated list failure", err)
+	}
+	if len(post.CapturedBodies) != 0 {
+		t.Fatalf("POST should not be sent when list fails, captured %d request(s)", len(post.CapturedBodies))
 	}
 }
 


### PR DESCRIPTION
## Summary
- complete partial +rule-reorder --rule-ids input by fetching current mail rule order first
- preserve explicitly requested order and append unspecified rules in existing order
- fail clearly without POSTing reorder when the current list cannot be loaded or input contains unknown/duplicate IDs

## Tests
- go test ./shortcuts/mail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail rules can now be reordered using a partial list of rule IDs; unspecified rules retain their existing relative order.
  * Updated command guidance explains that omitted rule IDs are automatically appended in their current order.

* **Bug Fixes**
  * Invalid rule IDs and duplicate IDs are rejected before changes are submitted.
  * Reordering no longer submits changes when validation or rule-list retrieval fails.
  * Errors from failed rule-list retrieval now provide clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->