### PR TITLE
fix(base): preserve unsupported record values in NDJSON exports

### DIFF
--- a/shortcuts/base/record_export_test.go
+++ b/shortcuts/base/record_export_test.go
@@ -17,7 +17,67 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
 )
+
+func TestRecordReadsNDJSONPreserveButtonAndUnknownColumns(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		shortcut common.Shortcut
+		method   string
+		path     string
+		args     []string
+	}{
+		{"list", BaseRecordList, "GET", "/records?", []string{"--limit", "1"}},
+		{"search", BaseRecordSearch, "POST", "/records/search", []string{"--keyword", "Alice", "--search-field", "Name", "--limit", "1"}},
+		{"get", BaseRecordGet, "POST", "/records/batch_get", []string{"--record-id", "rec_1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			withBaseWorkingDir(t, dir)
+			factory, stdout, registry := newExecuteFactory(t)
+			registry.Register(&httpmock.Stub{
+				Method: tc.method, URL: tc.path,
+				Body: map[string]any{"code": 0, "data": map[string]any{
+					"timezone":        "UTC",
+					"fields":          []any{"Name", "Button", "Score", "Future"},
+					"field_id_list":   []any{"fld_name", "fld_button", "fld_score", "fld_future"},
+					"field_type_list": []any{"text", "button", "number", "future_type"},
+					"record_id_list":  []any{"rec_1"},
+					"data":            []any{[]any{"Alice", nil, 42, map[string]any{"items": []any{false, nil}}}},
+					"has_more":        false,
+				}},
+			})
+			args := append([]string{"+record-" + tc.name, "--base-token", "app_x", "--table-id", "tbl_x", "--output", "buttons.ndjson"}, tc.args...)
+			if err := runShortcut(t, tc.shortcut, args, factory, stdout); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(filepath.Join(dir, "buttons.ndjson"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var row map[string]any
+			if err := json.Unmarshal(data, &row); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(row, map[string]any{"record_id": "rec_1", "Name": "Alice", "Button": nil, "Score": float64(42), "Future": map[string]any{"items": []any{false, nil}}}) {
+				t.Fatalf("row = %#v", row)
+			}
+			var manifest map[string]any
+			if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+				t.Fatal(err)
+			}
+			button := manifest["columns"].(map[string]any)["Button"].(map[string]any)
+			if button["field_type"] != "button" || button["physical_type"] != "null" {
+				t.Fatalf("button column = %#v", button)
+			}
+			future := manifest["columns"].(map[string]any)["Future"].(map[string]any)
+			if future["field_type"] != "not_support" || future["physical_type"] != "json" {
+				t.Fatalf("future column = %#v", future)
+			}
+		})
+	}
+}
 
 func TestRecordListNDJSONOutputInfersFormatAndNormalizesValues(t *testing.T) {
 	dir := t.TempDir()

--- a/shortcuts/base/recordexport/README.md
+++ b/shortcuts/base/recordexport/README.md
@@ -1,0 +1,17 @@
+# Record export contract
+
+The NDJSON exporter validates matrix dimensions and preserves column alignment.
+Known Base v3 field types use their declared cell shape: array fields normalize
+null to `[]`, checkboxes normalize null to `false`, and timestamps normalize to
+RFC3339. Buttons have no record value and export as null with physical type `null`.
+
+Unknown field types export with manifest `field_type: "not_support"` and
+`physical_type: "json"`. Their decoded JSON values pass through without cell
+normalization, including null, booleans, numbers, arrays, and nested objects.
+The same passthrough applies when the API explicitly returns `not_support`.
+This preserves JSON values, not original whitespace or object key order.
+Fallback columns report null counts without assuming a string or array shape.
+
+The original API field types remain in the source schema so a type change
+between pages still fails the export, even if both types map to `not_support`.
+Malformed matrices and invalid cells of known types remain errors.

--- a/shortcuts/base/recordexport/dataset.go
+++ b/shortcuts/base/recordexport/dataset.go
@@ -22,6 +22,8 @@ const RecordIDColumnName = "record_id"
 type ValueKind string
 
 const (
+	KindJSON    ValueKind = "json"
+	KindNull    ValueKind = "null"
 	KindString  ValueKind = "string"
 	KindNumber  ValueKind = "number"
 	KindBoolean ValueKind = "boolean"
@@ -39,7 +41,12 @@ type fieldTypeSpec struct {
 // remain decoded JSON values; the CLI does not construct Go structs for cells.
 func specForFieldType(fieldType string) (fieldTypeSpec, bool) {
 	switch fieldType {
-	case "text", "formula", "lookup", "auto_number", "datetime", "created_at", "updated_at", "not_support":
+	case "button":
+		// Buttons trigger actions; the read API exposes their cells as null.
+		return fieldTypeSpec{kind: KindNull, physicalType: "null"}, true
+	case "not_support":
+		return fieldTypeSpec{kind: KindJSON, physicalType: "json"}, true
+	case "text", "formula", "lookup", "auto_number", "datetime", "created_at", "updated_at":
 		return fieldTypeSpec{kind: KindString, physicalType: "string|null"}, true
 	case "number":
 		return fieldTypeSpec{kind: KindNumber, physicalType: "number|null"}, true
@@ -174,11 +181,13 @@ func ParseMatrix(data map[string]any) (Page, error) {
 	}}
 	exportSourceIndexes := make([]int, 0, len(fields))
 	for index := range fields {
-		column, err := sourceColumn(fields[index], fieldIDs[index], fieldTypes[index])
-		if err != nil {
-			return Page{}, err
-		}
+		column := Column{Name: fields[index], FieldID: fieldIDs[index], FieldType: fieldTypes[index]}
 		sourceColumns = append(sourceColumns, column)
+		// Retain the wire type above for cross-page schema checks; expose unknown
+		// types as not_support without dropping or rewriting their JSON values.
+		if _, known := specForFieldType(column.FieldType); !known {
+			column.FieldType = "not_support"
+		}
 		// The system join key intentionally wins over a same-named Base field.
 		if column.Name == RecordIDColumnName {
 			continue
@@ -282,17 +291,10 @@ func (d *Dataset) AppendPage(page Page) error {
 	return nil
 }
 
-func sourceColumn(name, fieldID, fieldType string) (Column, error) {
-	if _, ok := specForFieldType(fieldType); !ok {
-		return Column{}, &MatrixError{Reason: fmt.Sprintf("field %q has unsupported field type %q", name, fieldType)}
-	}
-	return Column{Name: name, FieldID: fieldID, FieldType: fieldType}, nil
-}
-
 func normalizeCell(column Column, value any, timezone string) (any, error) {
 	spec, ok := specForFieldType(column.FieldType)
-	if !ok {
-		return nil, newDetailErrorf("unsupported field type %q", column.FieldType)
+	if !ok || spec.kind == KindJSON {
+		return value, nil
 	}
 	if spec.repeated {
 		if value == nil {
@@ -323,6 +325,8 @@ func normalizeCell(column Column, value any, timezone string) (any, error) {
 		return nil, nil
 	}
 	switch spec.kind {
+	case KindNull:
+		return nil, newDetailErrorf("expected null, got %T", value)
 	case KindString:
 		text, ok := value.(string)
 		if !ok {

--- a/shortcuts/base/recordexport/dataset_test.go
+++ b/shortcuts/base/recordexport/dataset_test.go
@@ -6,9 +6,143 @@ package recordexport
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+// Cover the Base v3 read field types, including read-only fields and the
+// not_support fallback. UI variants use these wire types, not their UI names.
+func TestReadFieldTypesRoundTripNDJSON(t *testing.T) {
+	for _, tc := range []struct {
+		fieldType string
+		value     any
+	}{
+		{"text", "hello"}, {"number", json.Number("12.5")},
+		{"select", []any{"Todo"}}, {"checkbox", true},
+		{"user", []any{map[string]any{"id": "ou_user"}}},
+		{"group_chat", []any{map[string]any{"id": "oc_chat"}}},
+		{"link", []any{map[string]any{"id": "rec_link"}}},
+		{"attachment", []any{map[string]any{"file_token": "file_x", "name": "sample.txt"}}},
+		{"location", map[string]any{"lng": json.Number("1"), "lat": json.Number("2")}},
+		{"formula", "calculated"}, {"lookup", "looked up"}, {"auto_number", "001"},
+		{"datetime", "2026-08-04T12:30:00+08:00"},
+		{"created_at", "2026-08-04T12:30:00+08:00"},
+		{"updated_at", "2026-08-04T12:30:00+08:00"},
+		{"created_by", []any{map[string]any{"id": "ou_creator"}}},
+		{"updated_by", []any{map[string]any{"id": "ou_updater"}}},
+		{"button", nil}, {"not_support", nil},
+	} {
+		t.Run(tc.fieldType, func(t *testing.T) {
+			page, err := ParseMatrix(matrixFixture("Value", "fld_value", tc.fieldType, "rec_1", tc.value))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			if err := WriteNDJSON(&output, page.Dataset); err != nil {
+				t.Fatal(err)
+			}
+			decoder := json.NewDecoder(&output)
+			decoder.UseNumber()
+			var row map[string]any
+			if err := decoder.Decode(&row); err != nil {
+				t.Fatal(err)
+			}
+			value, exists := row["Value"]
+			if !exists || !reflect.DeepEqual(value, tc.value) || row["record_id"] != "rec_1" {
+				t.Fatalf("exported row = %#v, want value %#v", row, tc.value)
+			}
+		})
+	}
+}
+
+func TestButtonColumnManifestAndEmptyPage(t *testing.T) {
+	fixture := matrixFixture("Button", "fld_button", "button", "rec_1", nil)
+	page, err := ParseMatrix(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := BuildManifest(page.Dataset, ManifestOptions{})
+	column := manifest.Columns["Button"]
+	if column.FieldType != "button" || column.PhysicalType != "null" || column.Stats.NullCount == nil || *column.Stats.NullCount != 1 || column.Stats.MaxLength != nil {
+		t.Fatalf("button manifest = %#v", column)
+	}
+	fixture["record_id_list"], fixture["data"] = []any{}, []any{}
+	empty, err := ParseMatrix(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := page.Dataset.AppendPage(empty); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseMatrixRejectsInvalidButton(t *testing.T) {
+	for _, tc := range []struct {
+		fieldType string
+		value     any
+	}{
+		{"button", "Run"}, {"button", false}, {"button", map[string]any{}},
+	} {
+		_, err := ParseMatrix(matrixFixture("Value", "fld_value", tc.fieldType, "rec_1", tc.value))
+		var matrixErr *MatrixError
+		if !errors.As(err, &matrixErr) {
+			t.Fatalf("type %s value %#v: error = %v, want MatrixError", tc.fieldType, tc.value, err)
+		}
+	}
+}
+
+func TestUnknownFieldTypesPreserveRawJSON(t *testing.T) {
+	for _, fieldType := range []string{"future_type", "not_support"} {
+		t.Run(fieldType, func(t *testing.T) {
+			values := []any{nil, false, json.Number("9007199254740993"), "text", []any{}, []any{nil, true, "mixed"}, map[string]any{"nested": []any{json.Number("1.25"), nil}}}
+			fixture := matrixFixture("Future", "fld_future", fieldType, "rec_1", nil)
+			ids, rows := []any{}, []any{}
+			for _, value := range values {
+				ids = append(ids, "rec_1")
+				rows = append(rows, []any{value})
+			}
+			fixture["record_id_list"], fixture["data"] = ids, rows
+			page, err := ParseMatrix(fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if page.Dataset.SourceColumns[0].FieldType != fieldType {
+				t.Fatal("lost wire type")
+			}
+			manifest := BuildManifest(page.Dataset, ManifestOptions{})
+			column := manifest.Columns["Future"]
+			if column.FieldType != "not_support" || column.PhysicalType != "json" || column.Stats.NullCount == nil || *column.Stats.NullCount != 1 || column.Stats.MaxLength != nil {
+				t.Fatalf("fallback manifest = %#v", column)
+			}
+			var output bytes.Buffer
+			if err := WriteNDJSON(&output, page.Dataset); err != nil {
+				t.Fatal(err)
+			}
+			decoder := json.NewDecoder(&output)
+			decoder.UseNumber()
+			for _, want := range values {
+				var row map[string]any
+				if err := decoder.Decode(&row); err != nil {
+					t.Fatal(err)
+				}
+				got, exists := row["Future"]
+				if !exists || !reflect.DeepEqual(got, want) {
+					t.Fatalf("got %#v, want %#v", row, want)
+				}
+			}
+			other, err := ParseMatrix(matrixFixture("Future", "fld_future", "another_future_type", "rec_2", nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var schemaErr *SchemaChangedError
+			if err := page.Dataset.AppendPage(other); !errors.As(err, &schemaErr) {
+				t.Fatalf("schema change error = %v", err)
+			}
+		})
+	}
+}
 
 func TestParseMatrixNormalizesTypedRows(t *testing.T) {
 	page, err := ParseMatrix(map[string]any{

--- a/shortcuts/base/recordexport/manifest.go
+++ b/shortcuts/base/recordexport/manifest.go
@@ -255,7 +255,7 @@ func buildColumnStats(records []Record, columnIndex int, column Column) ColumnSt
 		}
 		return ColumnStats{TrueCount: &trueCount}
 
-	case "location":
+	case "location", "button", "not_support":
 		nullCount := 0
 		for _, record := range records {
 			if columnIndex >= len(record.Values) || record.Values[columnIndex] == nil {


### PR DESCRIPTION
## Summary

NDJSON record reads failed when a table included a button field because the exporter rejected field types outside its local type table. Recognize buttons explicitly and preserve values from future field types instead of rejecting the entire export.

## Changes

- Export button cells as null with physical type `null`.
- Map unknown field types to manifest `field_type: "not_support"` and `physical_type: "json"`; preserve decoded JSON values, including null, arrays, nested objects, and large numbers. Apply the same passthrough to explicit `not_support` fields.
- Preserve known-field normalization, matrix validation, and original source types for cross-page schema checks.
- Add coverage for all 19 current wire field types, fallback values, schema changes, and list/search/get artifact output; document the export contract.

## Test Plan

- [x] Base package tests pass, including race-enabled tests in `make unit-test`.
- [x] `make build`, `make vet`, `make fmt-check`, and `make quality-gate` pass. Quality gate reports existing guidance warnings.
- [x] `go mod tidy` leaves module files unchanged.
- [x] Record list/search/get dry-run E2E tests pass.
- [x] Manual read-only NDJSON export from a table with a button succeeds; button values remain null.
- [ ] Full `make unit-test`: the unrelated `TestLockGlobalConfigSerializesWriters` fails under the full run; its isolated race-enabled rerun passes. All other packages pass.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Record exports now preserve null button values.
  - Unsupported and unknown field types retain their original JSON values in NDJSON exports.
  - Export manifests provide consistent type and null-value information for button and unsupported fields.
  - Record exports continue across pages while validating schema consistency.

- **Documentation**
  - Added documentation describing export behavior, supported field types, null handling, JSON preservation, and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->