### PR TITLE
docs(skills): use wiki node shortcut in guidance

### DIFF
--- a/skill-template/domains/base.md
+++ b/skill-template/domains/base.md
@@ -47,15 +47,15 @@
 
 ### 处理流程
 
-1. **使用 `wiki.spaces.get_node` 查询节点信息**
+1. **使用 `wiki +node-get` 查询节点信息**
    ```bash
-   lark-cli wiki spaces.get_node --params '{"token":"&lt;wiki_token&gt;"}'
+   lark-cli wiki +node-get --node-token 'https://xxx.feishu.cn/wiki/<wiki_token>' --format json
    ```
 
 2. **从返回结果中提取关键信息**
-   - `node.obj_type`：文档类型（docx/doc/sheet/bitable/slides/file/mindnote）
-   - `node.obj_token`：**真实的文档 token**（用于后续操作）
-   - `node.title`：文档标题
+   - `data.obj_type`：文档类型（docx/doc/sheet/bitable/slides/file/mindnote）
+   - `data.obj_token`：**真实的文档 token**（用于后续操作）
+   - `data.title`：文档标题
 
 3. **根据 `obj_type` 选择后续命令**
 
@@ -70,25 +70,27 @@
    | `mindnote` | 思维导图 | `drive.*` |
 
 4. **把 wiki 解析出的 `obj_token` 当成 Base token 使用**
-   - 当 `obj_type=bitable` 时，`node.obj_token` 就是后续 `base` 命令应使用的真实 token
+   - 当 `obj_type=bitable` 时，`data.obj_token` 就是后续 `base` 命令应使用的真实 token
    - 不要把 `wiki_token` 直接塞给 `--base-token`
 
 5. **如果已经报了 token 错，再回退检查 wiki**
    - 如果命令返回 `param baseToken is invalid`、`base_token invalid`、`not found`，并且输入来自 `/wiki/...`，优先怀疑“把 wiki token 当成了 base token”
-   - 重新执行 `wiki.spaces.get_node`
-   - 确认 `obj_type=bitable` 后，用 `node.obj_token` 重试 `lark-cli base ...`
+   - 重新执行 `wiki +node-get`
+   - 确认 `data.obj_type=bitable` 后，用 `data.obj_token` 重试 `lark-cli base ...`
 
 ### 查询示例
 
 ```bash
 # 查询 wiki 节点
-lark-cli wiki spaces.get_node --params '{"token":"Pgrrwvr***********UnRb"}'
+lark-cli wiki +node-get --node-token 'https://xxx.feishu.cn/wiki/Pgrrwvr***********UnRb' --format json
 ```
 
-返回结果示例：
+返回结果中的路由关键字段示例（`data` 中的其他节点字段省略）：
 ```json
 {
-  "node": {
+  "ok": true,
+  "identity": "user",
+  "data": {
     "obj_type": "docx",
     "obj_token": "UAJh***********ccaE9nic",
     "title": "ai friendly 测试 - 1 副本",
@@ -107,7 +109,7 @@ lark-cli wiki spaces.get_node --params '{"token":"Pgrrwvr***********UnRb"}'
 | 1254066 | 人员字段错误 | `[{ "id": "ou_xxx" }]` |
 | 1254045 | 字段名不存在 | 检查字段名（含空格、大小写） |
 | 1254015 | 字段值类型不匹配 | 先 list 字段，再按类型构造 |
-| `param baseToken is invalid` / `base_token invalid` | 把 wiki token、workspace token 或其他 token 当成了 `base_token` | 如果输入来自 `/wiki/...`，先查 `wiki.spaces.get_node`；当 `obj_type=bitable` 时，用 `node.obj_token` 作为 `base_token` 重试，不要改走 `bitable/v1` |
+| `param baseToken is invalid` / `base_token invalid` | 把 wiki token、workspace token 或其他 token 当成了 `base_token` | 如果输入来自 `/wiki/...`，先用 `wiki +node-get` 查询；当 `data.obj_type=bitable` 时，用 `data.obj_token` 作为 `base_token` 重试，不要改走 `bitable/v1` |
 | 1254104 | 批量超 200 条 | 分批调用 |
 | 1254291 | 并发写冲突 | 串行写入 + 批次间延迟 |
 

--- a/skill-template/domains/doc.md
+++ b/skill-template/domains/doc.md
@@ -21,15 +21,15 @@
 
 #### 处理流程
 
-1. **使用 `wiki.spaces.get_node` 查询节点信息**
+1. **使用 `wiki +node-get` 查询节点信息**
    ```bash
-   lark-cli wiki spaces get_node --params '{"token":"wiki_token"}'
+   lark-cli wiki +node-get --node-token 'https://xxx.feishu.cn/wiki/<wiki_token>' --format json
    ```
 
 2. **从返回结果中提取关键信息**
-   - `node.obj_type`：文档类型（docx/doc/sheet/bitable/slides/file/mindnote）
-   - `node.obj_token`：**真实的文档 token**（用于后续操作）
-   - `node.title`：文档标题
+   - `data.obj_type`：文档类型（docx/doc/sheet/bitable/slides/file/mindnote）
+   - `data.obj_token`：**真实的文档 token**（用于后续操作）
+   - `data.title`：文档标题
 
 3. **根据 `obj_type` 使用对应的 API**
 
@@ -47,13 +47,15 @@
 
 ```bash
 # 查询 wiki 节点
-lark-cli wiki spaces get_node --params '{"token":"wiki_token"}'
+lark-cli wiki +node-get --node-token 'https://xxx.feishu.cn/wiki/<wiki_token>' --format json
 ```
 
-返回结果示例：
+返回结果中的路由关键字段示例（`data` 中的其他节点字段省略）：
 ```json
 {
-   "node": {
+   "ok": true,
+   "identity": "user",
+   "data": {
       "obj_type": "docx",
       "obj_token": "xxxx",
       "title": "标题",

--- a/skill-template/domains/drive.md
+++ b/skill-template/domains/drive.md
@@ -44,17 +44,17 @@ lark-cli drive +inspect --url 'https://xxx.feishu.cn/wiki/wikcnXXX'
 
 返回结果包含 `type`（底层文档类型）、`token`（真实 file_token）、`title`、`url` 等字段，直接用于后续操作。
 
-**手动方式：使用 `wiki.spaces.get_node` 查询节点信息**
+**节点详情方式：使用 `wiki +node-get` 查询节点信息**
 
-1. **使用 `wiki.spaces.get_node` 查询节点信息**
+1. **使用 `wiki +node-get` 查询节点信息**
    ```bash
-   lark-cli wiki spaces get_node --params '{"token":"wiki_token"}'
+   lark-cli wiki +node-get --node-token 'https://xxx.feishu.cn/wiki/<wiki_token>' --format json
    ```
 
 2. **从返回结果中提取关键信息**
-   - `node.obj_type`：文档类型（docx/doc/sheet/bitable/slides/file/mindnote）
-   - `node.obj_token`：**真实的文档 token**（用于后续操作）
-   - `node.title`：文档标题
+   - `data.obj_type`：文档类型（docx/doc/sheet/bitable/slides/file/mindnote）
+   - `data.obj_token`：**真实的文档 token**（用于后续操作）
+   - `data.title`：文档标题
 
 3. **根据 `obj_type` 使用对应的 API**
 
@@ -72,13 +72,15 @@ lark-cli drive +inspect --url 'https://xxx.feishu.cn/wiki/wikcnXXX'
 
 ```bash
 # 查询 wiki 节点
-lark-cli wiki spaces get_node --params '{"token":"wiki_token"}'
+lark-cli wiki +node-get --node-token 'https://xxx.feishu.cn/wiki/<wiki_token>' --format json
 ```
 
-返回结果示例：
+返回结果中的路由关键字段示例（`data` 中的其他节点字段省略）：
 ```json
 {
-  "node": {
+  "ok": true,
+  "identity": "user",
+  "data": {
     "obj_type": "docx",
     "obj_token": "xxxx",
     "title": "标题",

--- a/skill-template/domains/wiki.md
+++ b/skill-template/domains/wiki.md
@@ -8,14 +8,14 @@
 
 - 用户要**整理 / 盘点 / 归类 / 重构知识库、个人文档库、文档库目录或 Wiki 节点结构**，或要生成整理方案、目标目录树、移动计划时，不要只使用 Wiki 节点 API。必须先阅读 [`../lark-drive/references/lark-drive-workflow-knowledge-organize.md`](../lark-drive/references/lark-drive-workflow-knowledge-organize.md)，该 workflow 负责 Drive / Wiki / 个人文档库的统一入口解析、资源盘点、分类计划、写前确认和结果验证。
 - 用户要把**已有 Wiki 节点移出知识库，放到 Drive 文件夹或“我的空间”根目录**：使用 `wiki +move-to-drive`，不要使用 `wiki +move` 或 `drive +move`。执行前确认源节点与目标位置。
-- 用户给的是知识库 URL（`.../wiki/<token>`），且后续要查成员/加成员/删成员：先调用 `lark-cli wiki spaces get_node --params '{"token":"<wiki_token>"}'` 获取 `space_id`，后续成员接口统一使用 `space_id`。
+- 用户给的是知识库 URL（`.../wiki/<token>`），且后续要查成员/加成员/删成员：先确定下游成员操作的身份（默认 `user`；用户明确要求应用 / bot 视角时用 `bot`），再调用 `lark-cli wiki +node-get --node-token '<wiki_url>' --as user --format json`，从 `data.space_id` 获取空间 ID；下游使用 bot 时将示例中的身份改为 `--as bot`。节点解析与后续成员操作必须使用相同身份。
 - 用户要**删除**知识空间（`wiki +delete-space`）但只给了名称或 URL：**不能**把名称 / URL 原样传给 `--space-id`，必须先解析出真实 `space_id`。解析方式：
-  - URL（`.../wiki/<token>`）：`lark-cli wiki spaces get_node --params '{"token":"<wiki_token>"}' --format json`，读 `data.node.space_id`。
+  - URL（`.../wiki/<token>`）：先确定后续 `wiki +delete-space` 的身份（默认 `user`；明确要求 bot 视角时用 `bot`），再调用 `lark-cli wiki +node-get --node-token '<wiki_url>' --as user --format json`，读取 `data.space_id`；下游使用 bot 时将示例中的身份改为 `--as bot`。解析和删除必须使用相同身份。
   - 只知名称：`lark-cli wiki spaces list --format json`，边翻页边收集 items 并按 `name` 精确匹配；**一旦任一页累计到至少 1 条精确匹配就停止翻页**。只有当翻完所有页（`has_more=false`）仍无精确匹配时，才对已收集的全量 items 做宽松匹配（`name` trim 空格、大小写不敏感、子串包含）。
   - **关键安全约束**：无论精确还是模糊，**无论命中 1 条还是多条，发起删除前都必须把候选（`name` + `space_id` + `description` + `space_type`）列给用户，由用户明确选定一个 `space_id` 再执行**。不要因为"只命中一条"就自动执行删除。
   - 命中 0 条：停下来问用户是名称拼错了还是调用方无权限；**不要**自行改名字重试。
   - 用户明确选定后再执行 `lark-cli wiki +delete-space --space-id <ID> --yes`（高风险写操作，必须显式 `--yes`）。
-  - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki spaces get_node` 解析出 `data.node.space_id` 再传。
+  - 反例：不要把 wiki URL / 名称直接当 `--space-id`（如 `--space-id "https://.../wiki/<wiki_token>"`）；务必先用 `wiki +node-get` 解析出 `data.space_id` 再传。
 - 用户要在知识库中创建新节点，优先使用 `lark-cli wiki +node-create`。
 - 用户说“给知识库添加成员/管理员”：先把目标解析成“用户 / 群 / 部门 / 应用”四类之一，再决定 `--member-type`，不要先调 `wiki +member-add` 再根据报错反推类型。
 - 用户说“部门 + bot”：这是已知不支持路径。不要继续尝试 `wiki +member-add --as bot`；直接提示必须改成 `--as user`，或明确告知当前要求无法完成。

--- a/skills/lark-drive/references/lark-drive-inspect.md
+++ b/skills/lark-drive/references/lark-drive-inspect.md
@@ -46,7 +46,7 @@ JSON 输出包含以下字段：
 
 - `--url` 为必填参数
 - 当 `--url` 是 bare token（非完整 URL）时，`--type` 也是必填的
-- wiki URL 会自动调用 `get_node` API 解包，输出中 `type` 和 `token` 是底层文档的类型和 token
+- wiki URL 会自动调用 `node_by_token` API 解包，输出中 `type` 和 `token` 是底层文档的类型和 token
 - `+inspect` 只用于识别/消歧；如果任务已能通过 URL 路径形态完成路由判断，不必把它作为所有 Drive 操作的通用前置步骤
 - `+inspect` 失败后不要自动切到写接口继续尝试，先按错误提示处理权限、scope 或链接问题
 - 支持 `--dry-run` 查看将调用的 API 步骤

--- a/skills/lark-shared/references/lark-wiki-token-routing.md
+++ b/skills/lark-shared/references/lark-wiki-token-routing.md
@@ -12,22 +12,22 @@ lark-cli drive +inspect --url 'https://xxx.feishu.cn/wiki/<wiki_token>'
 
 输出中的 `type` 是底层对象类型，`token` 是后续命令应使用的 canonical token。`wiki_node` 字段保留节点侧信息，如 `space_id`、`node_token`、`obj_token`、`obj_type`。
 
-## 手动方式
+## 节点详情方式
 
-如果不能使用 shortcut，再调用 Wiki 节点接口：
+如果后续操作需要 Wiki 节点侧的字段，使用 `wiki +node-get`：
 
 ```bash
-lark-cli wiki spaces get_node --params '{"token":"<wiki_token>"}'
+lark-cli wiki +node-get --node-token 'https://xxx.feishu.cn/wiki/<wiki_token>' --format json
 ```
 
 从返回值中读取：
 
 | 字段 | 含义 |
 |------|------|
-| `node.obj_type` | 底层对象类型，如 `docx`、`doc`、`sheet`、`bitable`、`slides`、`file`、`mindnote` |
-| `node.obj_token` | 底层对象 token，用于对应业务 skill 或原生 API |
-| `node.node_token` / `token` | Wiki 节点 token，用于 Wiki 节点层级操作 |
-| `node.space_id` | 所属知识空间 |
+| `data.obj_type` | 底层对象类型，如 `docx`、`doc`、`sheet`、`bitable`、`slides`、`file`、`mindnote` |
+| `data.obj_token` | 底层对象 token，用于对应业务 skill 或原生 API |
+| `data.node_token` | Wiki 节点 token，用于 Wiki 节点层级操作 |
+| `data.space_id` | 所属知识空间 |
 
 ## 路由
 

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -49,7 +49,7 @@ metadata:
 
 Shortcut 是对常用操作的高级封装（`lark-cli wiki +<verb> [flags]`）。有 Shortcut 的操作优先使用。
 
-获取或解析 Wiki 节点统一优先使用 `wiki +node-get`，包括只为获取 `space_id`、`node_token`、`obj_token` 或 `obj_type` 的中间步骤。只有当前 CLI 不提供该 shortcut，或任务明确需要 shortcut 未输出的原始响应字段时，才回退到 `wiki spaces get_node`；回退前先运行 `lark-cli schema wiki.spaces.get_node`。
+获取或解析 Wiki 节点统一使用 `wiki +node-get`，包括只为获取 `space_id`、`node_token`、`obj_token` 或 `obj_type` 的中间步骤。
 
 | Shortcut | 说明 |
 |----------|------|
@@ -95,7 +95,6 @@ lark-cli wiki <resource> <method> [flags]  # 调用 API
 
 - `create` — 创建知识空间
 - `get` — 获取知识空间信息
-- `get_node` — 获取知识空间节点信息
 - `list` — 获取知识空间列表
 
 ### members


### PR DESCRIPTION
## Summary

Skill guidance still directed agents to the raw `wiki spaces get_node` command, which calls the legacy Wiki node endpoint. This change routes node lookups through `wiki +node-get` and updates the documented output paths to match the shortcut envelope.

## Changes

- Replace legacy Wiki node lookup commands in shipped skills and reusable skill templates with `wiki +node-get`.
- Update examples from `data.node.*` to the shortcut's `data.*` fields and identify abbreviated response examples.
- Update `drive +inspect` guidance to name the `node_by_token` API used by the shortcut.

## Test Plan

- [x] `node scripts/skill-format-check/index.js`
- [x] `go test ./internal/skillscheck ./shortcuts/wiki -count=1`
- [x] `QUALITY_GATE_CHANGED_FROM=origin/main make quality-gate`
- [x] Verified `wiki +node-get --dry-run` calls `/open-apis/wiki/v2/spaces/node_by_token`

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Wiki node lookup guidance to use `wiki +node-get` with full Wiki URLs.
  - Revised examples and response-field references to match the current `data.*` response format.
  - Updated Wiki URL routing, space identification, deletion, and Drive inspection instructions.
  - Clarified that the same identity must be used for node resolution and follow-up operations.
  - Removed fallback guidance for the legacy Wiki node lookup method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->