### PR TITLE
fix(mail): complete rule reorder requests

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -370,7 +370,7 @@ var MailRuleReorder = common.Shortcut{
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule ID order. Missing current rules are appended in their existing relative order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1631,10 +1631,7 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
-			return nil, err
-		}
-		return ids, nil
+		return completeRuleTargetOrder(ids, currentIDs)
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1653,23 +1650,29 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 	}
 }
 
-func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
-	}
-	want := make(map[string]int, len(current))
+func completeRuleTargetOrder(target, current []string) ([]string, error) {
+	want := make(map[string]struct{}, len(current))
 	for _, id := range current {
-		want[id]++
+		want[id] = struct{}{}
 	}
+	seen := make(map[string]struct{}, len(target))
+	out := make([]string, 0, len(current))
 	for _, id := range target {
-		want[id]--
+		if _, ok := seen[id]; ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
+		}
+		if _, ok := want[id]; !ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains unknown rule id %s; run +rule-list first and submit current rule ids", id)
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+	for _, id := range current {
+		if _, ok := seen[id]; !ok {
+			out = append(out, id)
 		}
 	}
-	return nil
+	return out, nil
 }
 
 func normalizeRuleIDs(ids []string) []string {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1526,9 +1526,10 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name string
-		args []string
-		want string
+		name      string
+		args      []string
+		want      string
+		wantParam string
 	}{
 		{
 			name: "no mode",
@@ -1546,19 +1547,22 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			want: "move mode requires exactly one",
 		},
 		{
-			name: "move missing rule",
-			args: []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
-			want: "is not in current rule order",
+			name:      "move missing rule",
+			args:      []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
+			want:      "is not in current rule order",
+			wantParam: "--move-rule-id",
 		},
 		{
-			name: "unknown full order rule",
-			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "unknown rule id z",
+			name:      "unknown full order rule",
+			args:      []string{"+rule-reorder", "--rule-ids", "a,z"},
+			want:      "unknown rule id z",
+			wantParam: "--rule-ids",
 		},
 		{
-			name: "duplicate full order rule",
-			args: []string{"+rule-reorder", "--rule-ids", "a,a"},
-			want: "duplicate rule id a",
+			name:      "duplicate full order rule",
+			args:      []string{"+rule-reorder", "--rule-ids", "a,a"},
+			want:      "duplicate rule id a",
+			wantParam: "--rule-ids",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1574,7 +1578,13 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			if !errors.As(err, &validationErr) {
 				t.Fatalf("error type = %T, want *errs.ValidationError: %v", err, err)
 			}
-			if validationErr.Param == "" && len(validationErr.Params) == 0 {
+			if validationErr.Param != tc.wantParam {
+				t.Fatalf("validation error param = %q, want %q", validationErr.Param, tc.wantParam)
+			}
+			if tc.wantParam == "" && len(validationErr.Params) != 0 {
+				t.Fatalf("validation error params = %#v, want none", validationErr.Params)
+			}
+			if tc.wantParam != "" && validationErr.Param == "" && len(validationErr.Params) == 0 {
 				t.Fatalf("validation error missing parameter contract: %#v", validationErr)
 			}
 			if !strings.Contains(err.Error(), tc.want) {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1165,6 +1165,27 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
 	})
 
+	t.Run("partial order appends missing current rules", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+			mailRuleTestRawRule("d", "D"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b,d")
+	})
+
 	t.Run("move to bottom", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
@@ -1488,11 +1509,14 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 }
 
 func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+	if got, err := completeRuleTargetOrder([]string{"a"}, []string{"a", "b"}); err != nil || strings.Join(got, ",") != "a,b" {
+		t.Fatalf("completeRuleTargetOrder partial = %v, %v; want a,b", got, err)
 	}
-	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected duplicate mismatch error")
+	if _, err := completeRuleTargetOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected duplicate rule id error")
+	}
+	if _, err := completeRuleTargetOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected unknown rule id error")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1527,14 +1551,19 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			want: "is not in current rule order",
 		},
 		{
-			name: "full mismatch",
+			name: "unknown full order rule",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
+			want: "unknown rule id z",
+		},
+		{
+			name: "duplicate full order rule",
+			args: []string{"+rule-reorder", "--rule-ids", "a,a"},
+			want: "duplicate rule id a",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "unknown rule id") || strings.Contains(tc.want, "duplicate rule id") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1570,6 +1570,13 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected reorder error")
 			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error type = %T, want *errs.ValidationError: %v", err, err)
+			}
+			if validationErr.Param == "" && len(validationErr.Params) == 0 {
+				t.Fatalf("validation error missing parameter contract: %#v", validationErr)
+			}
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}


### PR DESCRIPTION
Updates the mail rule reorder shortcut so it completes a partial user-provided rule order with the current mailbox rule IDs before calling the reorder API. Adds focused unit coverage for complete, partial, unknown, and duplicate rule ID inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `+rule-reorder` shortcut now accepts partial rule ID lists.
  * Rules omitted from the list are automatically appended in their existing order, making it easier to move selected rules without specifying the complete list.
  * Duplicate or unknown rule IDs are rejected with clear validation errors identifying the affected input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->