### PR TITLE
fix: complete mail rule reorder ids

### DIFF
--- a/shortcuts/mail/mail_rules.go
+++ b/shortcuts/mail/mail_rules.go
@@ -370,7 +370,7 @@ var MailRuleReorder = common.Shortcut{
 	AuthTypes:   mailRuleAuthTypes,
 	HasFormat:   true,
 	Flags: append([]common.Flag{}, append(mailRuleCommonFlags,
-		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Full target rule ID order. Must contain every current rule exactly once."},
+		common.Flag{Name: "rule-ids", Type: "string_slice", Desc: "Target rule ID order. Missing current rules are appended in current order."},
 		common.Flag{Name: "move-rule-id", Desc: "Rule ID to move in the current order."},
 		common.Flag{Name: "before-rule-id", Desc: "Place --move-rule-id before this rule."},
 		common.Flag{Name: "after-rule-id", Desc: "Place --move-rule-id after this rule."},
@@ -1631,10 +1631,11 @@ func validateRuleReorderFlags(rt *common.RuntimeContext) error {
 func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope) ([]string, error) {
 	currentIDs := envelopeRuleIDs(current)
 	if ids := normalizeRuleIDs(rt.StrSlice("rule-ids")); len(ids) > 0 {
-		if err := validateFullRuleOrder(ids, currentIDs); err != nil {
+		order, err := completeRuleOrder(ids, currentIDs)
+		if err != nil {
 			return nil, err
 		}
-		return ids, nil
+		return order, nil
 	}
 	moveID := strings.TrimSpace(rt.Str("move-rule-id"))
 	order := removeString(currentIDs, moveID)
@@ -1653,23 +1654,29 @@ func buildRuleTargetOrder(rt *common.RuntimeContext, current []mailRuleEnvelope)
 	}
 }
 
-func validateFullRuleOrder(target, current []string) error {
-	if len(target) != len(current) {
-		return mailValidationParamError("--rule-ids", "--rule-ids must contain every current rule id exactly once (got %d, want %d)", len(target), len(current))
-	}
-	want := make(map[string]int, len(current))
+func completeRuleOrder(target, current []string) ([]string, error) {
+	currentSet := make(map[string]struct{}, len(current))
 	for _, id := range current {
-		want[id]++
+		currentSet[id] = struct{}{}
 	}
+	seen := make(map[string]struct{}, len(target))
+	out := make([]string, 0, len(current))
 	for _, id := range target {
-		want[id]--
+		if _, ok := seen[id]; ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains duplicate rule id %s", id)
+		}
+		seen[id] = struct{}{}
+		if _, ok := currentSet[id]; !ok {
+			return nil, mailValidationParamError("--rule-ids", "--rule-ids contains unknown rule id %s; run +rule-list first", id)
+		}
+		out = append(out, id)
 	}
-	for id, count := range want {
-		if count != 0 {
-			return mailValidationParamError("--rule-ids", "--rule-ids mismatch for %s; run +rule-list first and submit the complete order", id)
+	for _, id := range current {
+		if _, ok := seen[id]; !ok {
+			out = append(out, id)
 		}
 	}
-	return nil
+	return out, nil
 }
 
 func normalizeRuleIDs(ids []string) []string {

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1518,9 +1518,13 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 	}
 	if _, err := completeRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
 		t.Fatal("expected duplicate mismatch error")
+	} else {
+		assertMailRuleValidationError(t, err, "--rule-ids", "duplicate rule id", nil)
 	}
 	if _, err := completeRuleOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil {
 		t.Fatal("expected unknown rule id error")
+	} else {
+		assertMailRuleValidationError(t, err, "--rule-ids", "unknown rule id", nil)
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1530,9 +1534,10 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name string
-		args []string
-		want string
+		name  string
+		args  []string
+		want  string
+		param string
 	}{
 		{
 			name: "no mode",
@@ -1550,14 +1555,16 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			want: "move mode requires exactly one",
 		},
 		{
-			name: "move missing rule",
-			args: []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
-			want: "is not in current rule order",
+			name:  "move missing rule",
+			args:  []string{"+rule-reorder", "--move-rule-id", "z", "--to-top"},
+			want:  "is not in current rule order",
+			param: "--move-rule-id",
 		},
 		{
-			name: "full mismatch",
-			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "unknown rule id",
+			name:  "full mismatch",
+			args:  []string{"+rule-reorder", "--rule-ids", "a,z"},
+			want:  "unknown rule id",
+			param: "--rule-ids",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1569,10 +1576,38 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected reorder error")
 			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("error = %v, want %q", err, tc.want)
-			}
+			assertMailRuleValidationError(t, err, tc.param, tc.want, nil)
 		})
+	}
+}
+
+func assertMailRuleValidationError(t *testing.T, err error, wantParam, wantMessage string, wantCause error) {
+	t.Helper()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryValidation {
+		t.Fatalf("category = %q, want %q", p.Category, errs.CategoryValidation)
+	}
+	if p.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("subtype = %q, want %q", p.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if validationErr.Param != wantParam {
+		t.Fatalf("param = %q, want %q", validationErr.Param, wantParam)
+	}
+	if !strings.Contains(validationErr.Message, wantMessage) {
+		t.Fatalf("message = %q, want substring %q", validationErr.Message, wantMessage)
+	}
+	if wantCause != nil && !errors.Is(err, wantCause) {
+		t.Fatalf("cause %v not preserved in %v", wantCause, err)
+	}
+	if wantCause == nil && errors.Unwrap(err) != nil {
+		t.Fatalf("unexpected cause preserved in %v", err)
 	}
 }
 

--- a/shortcuts/mail/mail_rules_test.go
+++ b/shortcuts/mail/mail_rules_test.go
@@ -1165,6 +1165,27 @@ func TestMailRuleReorderShortcutPostsFullAndMoveOrders(t *testing.T) {
 		assertRuleIDsBody(t, post.CapturedBody, "c,b,a")
 	})
 
+	t.Run("partial order appends missing current rules", func(t *testing.T) {
+		f, stdout, _, reg := mailShortcutTestFactory(t)
+		reg.Register(mailRuleListStub(
+			mailRuleTestRawRule("a", "A"),
+			mailRuleTestRawRule("b", "B"),
+			mailRuleTestRawRule("c", "C"),
+			mailRuleTestRawRule("d", "D"),
+		))
+		post := &httpmock.Stub{
+			Method: "POST",
+			URL:    "open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+			Body:   map[string]interface{}{"code": 0, "data": map[string]interface{}{}},
+		}
+		reg.Register(post)
+
+		if err := runMountedMailShortcut(t, MailRuleReorder, []string{"+rule-reorder", "--rule-ids", "c,a", "--format", "json"}, f, stdout); err != nil {
+			t.Fatalf("run +rule-reorder partial order error = %v", err)
+		}
+		assertRuleIDsBody(t, post.CapturedBody, "c,a,b,d")
+	})
+
 	t.Run("move to bottom", func(t *testing.T) {
 		f, stdout, _, reg := mailShortcutTestFactory(t)
 		reg.Register(mailRuleListStub(
@@ -1488,11 +1509,18 @@ func TestMailRuleScalarHelpersCoverFallbacks(t *testing.T) {
 }
 
 func TestMailRuleOrderValidationErrors(t *testing.T) {
-	if err := validateFullRuleOrder([]string{"a"}, []string{"a", "b"}); err == nil {
-		t.Fatal("expected length mismatch error")
+	order, err := completeRuleOrder([]string{"a"}, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("completeRuleOrder() incomplete target error = %v", err)
 	}
-	if err := validateFullRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
+	if got := strings.Join(order, ","); got != "a,b" {
+		t.Fatalf("completeRuleOrder() = %s, want a,b", got)
+	}
+	if _, err := completeRuleOrder([]string{"a", "a"}, []string{"a", "b"}); err == nil {
 		t.Fatal("expected duplicate mismatch error")
+	}
+	if _, err := completeRuleOrder([]string{"a", "z"}, []string{"a", "b"}); err == nil {
+		t.Fatal("expected unknown rule id error")
 	}
 	if _, err := insertRelative([]string{"a", "b"}, "c", "", true); err == nil {
 		t.Fatal("expected missing target error")
@@ -1529,12 +1557,12 @@ func TestMailRuleOrderValidationErrors(t *testing.T) {
 		{
 			name: "full mismatch",
 			args: []string{"+rule-reorder", "--rule-ids", "a,z"},
-			want: "mismatch",
+			want: "unknown rule id",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, stdout, _, reg := mailShortcutTestFactory(t)
-			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "mismatch") {
+			if strings.Contains(tc.want, "current rule order") || strings.Contains(tc.want, "unknown rule id") {
 				reg.Register(mailRuleListStub(mailRuleTestRawRule("a", "A"), mailRuleTestRawRule("b", "B")))
 			}
 			err := runMountedMailShortcut(t, MailRuleReorder, append(tc.args, "--format", "json"), f, stdout)


### PR DESCRIPTION
## Summary
Fix mail receive rule reordering so `+rule-reorder --rule-ids` no longer sends a partial list to the backend. The shortcut now lists current rules first, validates the user-provided IDs, and appends any missing current rule IDs in existing order before calling reorder.

## Changes
- Allow `--rule-ids` to express a partial target order and complete it from the current rule list.
- Preserve duplicate and unknown rule ID validation.
- Add regression coverage for partial order completion.

## Test Plan
- [x] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

Command run:
- `go test ./shortcuts/mail -run 'TestMailRule(ReorderShortcutPostsFullAndMoveOrders|OrderValidationErrors)|TestRuleReorderComputesMoveTarget' -count=1`

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mail rules can now be reordered using a partial list of rule IDs. Any omitted existing rules remain in their current relative order and are appended automatically.
  - The `--rule-ids` option now explains this partial-order behavior more clearly.

- **Bug Fixes**
  - Reorder validation now clearly rejects duplicate or unknown rule IDs while preserving the existing full-order behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->