### PR TITLE
fix(minutes): enforce deterministic search ordering

### DIFF
--- a/shortcuts/minutes/minutes_search.go
+++ b/shortcuts/minutes/minutes_search.go
@@ -137,6 +137,9 @@ func buildMinutesSearchBody(runtime *common.RuntimeContext, startTime, endTime s
 		body["filter"] = filter
 	}
 
+	// Force a deterministic ordering for paginated minutes search results.
+	body["sorter"] = "create_time_desc"
+
 	return body, nil
 }
 

--- a/shortcuts/minutes/minutes_search_test.go
+++ b/shortcuts/minutes/minutes_search_test.go
@@ -150,6 +150,9 @@ func TestBuildMinutesSearchParams(t *testing.T) {
 	if body["query"] != "budget" {
 		t.Fatalf("body.query = %v, want budget", body["query"])
 	}
+	if got, _ := body["sorter"].(string); got != "create_time_desc" {
+		t.Fatalf("body.sorter = %q, want create_time_desc", got)
+	}
 	filter, _ := body["filter"].(map[string]interface{})
 	if filter == nil {
 		t.Fatalf("body.filter = nil, want filter object")


### PR DESCRIPTION
## Summary

Ensure Minutes search results have a deterministic server-side order across paginated requests.

## Changes

- send `sorter=create_time_desc` with `minutes +search` requests
- add a request-body regression assertion

## Test Plan

- [x] `go test ./shortcuts/minutes -count=1`
- [x] `go vet ./shortcuts/minutes`
- [x] `git diff --check`

## Related Issues

- Supersedes #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Minute search results are now consistently ordered by creation time, from newest to oldest.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->