### PR TITLE
fix(ci): handle Unicode paths in E2E domain selection

### DIFF
--- a/scripts/e2e_domains.js
+++ b/scripts/e2e_domains.js
@@ -74,7 +74,10 @@ function readChangedFiles() {
   const baseRef = process.env.GITHUB_BASE_REF || "main";
   try {
     execFileSync("git", ["rev-parse", "--verify", `origin/${baseRef}`], { stdio: "ignore" });
-    return execLines("git", ["diff", "--name-only", `origin/${baseRef}...HEAD`]).map(normalizeRepoPath);
+    return execFileSync("git", ["diff", "--name-only", "-z", `origin/${baseRef}...HEAD`], { encoding: "utf8" })
+      .split("\0")
+      .map(normalizeRepoPath)
+      .filter(Boolean);
   } catch {
     return null;
   }

--- a/scripts/e2e_domains.test.js
+++ b/scripts/e2e_domains.test.js
@@ -101,3 +101,45 @@ test("falls back to full when a mapped path has no e2e package", () => {
   assert.equal(output.mode, "full");
   assert.match(output.reason, /unmapped CLI E2E domain path/);
 });
+
+test("reads quoted Git paths without changing filenames", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-domains-git-"));
+  const git = (...args) => execFileSync("git", [
+    "-c", "user.name=Test",
+    "-c", "user.email=test@example.com",
+    "-c", "commit.gpgsign=false",
+    ...args,
+  ], { cwd: dir, stdio: "ignore" });
+  const files = ["docs/使用指南.md", "docs/usage notes.md"];
+
+  try {
+    git("init", "-q");
+    git("config", "core.quotepath", "true");
+    git("commit", "--allow-empty", "-qm", "base");
+    git("update-ref", "refs/remotes/origin/main", "HEAD");
+    fs.mkdirSync(path.join(dir, "docs"));
+    for (const file of files) {
+      fs.writeFileSync(path.join(dir, file), "example\n");
+    }
+    git("add", "docs");
+    git("commit", "-qm", "docs");
+
+    const raw = execFileSync(process.execPath, [
+      "-e", "console.log(JSON.stringify(require(process.argv[1]).readChangedFiles()))",
+      scriptPath,
+    ], {
+      cwd: dir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        E2E_DOMAINS_ROOT: dir,
+        E2E_DOMAIN_CHANGED_FILES: "",
+        GITHUB_EVENT_NAME: "pull_request",
+        GITHUB_BASE_REF: "main",
+      },
+    });
+    assert.deepEqual(JSON.parse(raw).sort(), files.sort());
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

With Git's default `core.quotepath=true`, a filename such as `docs/使用指南.md` is C-quoted in `git diff --name-only`. The E2E selector treats the quotes and escapes as part of the path, so a documentation-only change can incorrectly trigger all E2E domains.

## Changes

- Request NUL-delimited filenames from Git and split on NUL before applying the existing path normalization.
- Add a regression test using a real temporary Git repository with Unicode and space-containing filenames.

## Test Plan

- Confirmed the new regression test fails before the implementation change because the Unicode path is escaped and quoted.
- `make script-test` passes, including all 166 Node tests and the shell script checks.
- `git diff --check` passes.

## Related Issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of changed files with spaces, special characters, and Unicode in their names.
  - Preserved accurate file paths during change detection and filtering.

- **Tests**
  - Added coverage for quoted Git paths containing spaces and Unicode characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->