### PR TITLE
fix(docs): preserve text around inline attachments

### DIFF
--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -131,6 +131,8 @@ func prepareDocsV2WriteInput(runtime *common.RuntimeContext, input docsV2WriteIn
 	return prepareDocsV2WriteInputForFormat(runtime, runtime.Str("doc-format"), input)
 }
 
+// prepareDocsV2WriteInputForFormat resolves resource references through the
+// invocation runtime and normalizes content before a DocsAI write or preview.
 func prepareDocsV2WriteInputForFormat(runtime *common.RuntimeContext, format string, input docsV2WriteInput) (docsV2WriteInput, error) {
 	refMap := cloneReferenceMapObject(input.ReferenceMap)
 	html5RefMap, err := html5ReferenceMapFromObject(refMap)

--- a/shortcuts/doc/html5_block_resources.go
+++ b/shortcuts/doc/html5_block_resources.go
@@ -154,6 +154,7 @@ func prepareDocsV2WriteInputForFormat(runtime *common.RuntimeContext, format str
 		return docsV2WriteInput{}, err
 	}
 	refMap = mergeHTML5ReferenceMap(refMap, html5RefMap)
+	content = prepareInlineDocAttachments(format, content)
 	return docsV2WriteInput{
 		Content:        content,
 		ReferenceMap:   refMap,

--- a/shortcuts/doc/inline_doc_attachments.go
+++ b/shortcuts/doc/inline_doc_attachments.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import "strings"
+
+type inlineAttachmentElement struct {
+	name string
+	end  int
+}
+
+// prepareInlineDocAttachments isolates each paragraph attachment from following
+// text. DocsAI otherwise accepts the XML but drops siblings after <source>.
+// Insert spans in the original bytes so attributes, entities and namespaces are
+// not reserialized. Other resource formats keep their existing preparation path.
+func prepareInlineDocAttachments(format, content string) string {
+	if strings.TrimSpace(format) == "markdown" || !strings.Contains(content, "<source") {
+		return content
+	}
+	var out strings.Builder
+	var stack []inlineAttachmentElement
+	written := 0
+	for offset := 0; offset < len(content); {
+		relative := strings.IndexByte(content[offset:], '<')
+		if relative < 0 {
+			break
+		}
+		start := offset + relative
+		if end, ok := inlineAttachmentInertEnd(content, start); ok {
+			offset = end
+			continue
+		}
+		end := findXMLStartTagEnd(content, start)
+		if end < 0 {
+			return content
+		}
+		raw := content[start+1 : end-1]
+		closing := strings.HasPrefix(raw, "/")
+		name := strings.TrimPrefix(raw, "/")
+		if boundary := strings.IndexAny(name, " \t\r\n/"); boundary >= 0 {
+			name = name[:boundary]
+		}
+		if closing {
+			if name == "br" || name == "hr" || name == "img" || name == "col" {
+				offset = end
+				continue
+			}
+			if len(stack) == 0 || stack[len(stack)-1].name != name {
+				return content
+			}
+			stack = stack[:len(stack)-1]
+			offset = end
+			continue
+		}
+		selfClosing := strings.HasSuffix(strings.TrimSpace(raw), "/")
+		if name == "source" {
+			if !selfClosing {
+				closeAt := end
+				for closeAt < len(content) {
+					if isXMLSpace(content[closeAt]) {
+						closeAt++
+						continue
+					}
+					if strings.HasPrefix(content[closeAt:], "<!--") || strings.HasPrefix(content[closeAt:], "<![CDATA[") {
+						if inertEnd, ok := inlineAttachmentInertEnd(content, closeAt); ok {
+							closeAt = inertEnd
+							continue
+						}
+					}
+					break
+				}
+				closeEnd := findXMLStartTagEnd(content, closeAt)
+				if closeEnd < 0 || !strings.HasPrefix(content[closeAt:], "</") ||
+					strings.TrimSpace(content[closeAt+2:closeEnd-1]) != "source" {
+					return content
+				}
+				end = closeEnd
+			}
+			if inlineAttachmentInParagraph(stack) && !inlineAttachmentHasOwnSpan(content, start, end, stack) {
+				out.WriteString(content[written:start])
+				out.WriteString("<span>")
+				out.WriteString(content[start:end])
+				out.WriteString("</span>")
+				written = end
+			}
+		} else if !selfClosing && name != "br" && name != "hr" && name != "img" && name != "col" {
+			stack = append(stack, inlineAttachmentElement{name: name, end: end})
+		}
+		offset = end
+	}
+	if len(stack) != 0 || written == 0 {
+		return content
+	}
+	out.WriteString(content[written:])
+	return out.String()
+}
+
+// inlineAttachmentInParagraph excludes card/preview figures even when nested
+// under a paragraph; their sources already have a block resource boundary.
+func inlineAttachmentInParagraph(stack []inlineAttachmentElement) bool {
+	for i := len(stack) - 1; i >= 0; i-- {
+		if stack[i].name == "figure" {
+			return false
+		}
+		if stack[i].name == "p" {
+			return true
+		}
+	}
+	return false
+}
+
+// inlineAttachmentHasOwnSpan keeps preparation idempotent without treating a
+// span containing additional siblings as an attachment boundary.
+func inlineAttachmentHasOwnSpan(content string, start, end int, stack []inlineAttachmentElement) bool {
+	return len(stack) > 0 && stack[len(stack)-1].name == "span" &&
+		stack[len(stack)-1].end == start && strings.HasPrefix(content[end:], "</span>")
+}
+
+// inlineAttachmentInertEnd skips literal markup and embedded resource bodies.
+// Those bodies may contain non-XML DSL, including examples of <p>/<source>.
+func inlineAttachmentInertEnd(content string, start int) (int, bool) {
+	for _, delimiters := range [][2]string{{"<!--", "-->"}, {"<![CDATA[", "]]>"}, {"<?", "?>"}} {
+		if strings.HasPrefix(content[start:], delimiters[0]) {
+			if end := strings.Index(content[start+len(delimiters[0]):], delimiters[1]); end >= 0 {
+				return start + len(delimiters[0]) + end + len(delimiters[1]), true
+			}
+			return len(content), true
+		}
+	}
+	if end, ok := findMarkdownRawHTMLInertEnd(content, start); ok {
+		return end, true
+	}
+	for _, name := range []string{"code", "whiteboard", "html5-block"} {
+		nameEnd := start + 1 + len(name)
+		if nameEnd >= len(content) || content[start+1:nameEnd] != name || !isLocalDocResourceHTMLTagBoundary(content[nameEnd]) {
+			continue
+		}
+		end := findXMLStartTagEnd(content, start)
+		if end < 0 {
+			return len(content), true
+		}
+		if strings.HasSuffix(strings.TrimSpace(content[start:end]), "/>") {
+			return end, true
+		}
+		closing := "</" + name
+		for end < len(content) {
+			relative := strings.Index(content[end:], closing)
+			if relative < 0 {
+				break
+			}
+			closeStart := end + relative
+			boundary := closeStart + len(closing)
+			if boundary < len(content) && isLocalDocResourceHTMLTagBoundary(content[boundary]) {
+				if closeEnd := findXMLStartTagEnd(content, closeStart); closeEnd >= 0 {
+					return closeEnd, true
+				}
+				break
+			}
+			end = boundary
+		}
+		return len(content), true
+	}
+	return 0, false
+}

--- a/shortcuts/doc/inline_doc_attachments_test.go
+++ b/shortcuts/doc/inline_doc_attachments_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+func TestPrepareInlineDocAttachments(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, input, want string
+	}{
+		{
+			name:  "text after attachment",
+			input: `<p>before <source token="file_a"/> after</p>`,
+			want:  `<p>before <span><source token="file_a"/></span> after</p>`,
+		},
+		{
+			name:  "multiple attachments and styled text",
+			input: `<p>before <source token="file_a"/> <b>between</b> <source token="file_b"/> after</p>`,
+			want:  `<p>before <span><source token="file_a"/></span> <b>between</b> <span><source token="file_b"/></span> after</p>`,
+		},
+		{
+			name:  "paired source and exact input bytes",
+			input: `<p align='right'>中 &amp; 文 <source token='file_a' name='A &amp; B' x:future='&quot; >' xmlns:x='urn:test'></source> 尾</p>`,
+			want:  `<p align='right'>中 &amp; 文 <span><source token='file_a' name='A &amp; B' x:future='&quot; >' xmlns:x='urn:test'></source></span> 尾</p>`,
+		},
+		{
+			name:  "paired source whitespace and line breaks",
+			input: "<p>before<br></br><source token=\"file_a\">\n</source > after</p>",
+			want:  "<p>before<br></br><span><source token=\"file_a\">\n</source ></span> after</p>",
+		},
+		{
+			name:  "nested style containing siblings",
+			input: `<p><span text-color="red">before <source token="file_a"/> after</span> tail</p>`,
+			want:  `<p><span text-color="red">before <span><source token="file_a"/></span> after</span> tail</p>`,
+		},
+		{
+			name:  "existing own styled span",
+			input: `<p>before <span text-color="red"><source token="file_a"/></span> after</p>`,
+		},
+		{
+			name:  "paragraph in table",
+			input: `<table><tr><td><p>A<source token="file_a"/>B</p></td></tr></table>`,
+			want:  `<table><tr><td><p>A<span><source token="file_a"/></span>B</p></td></tr></table>`,
+		},
+		{
+			name:  "figures and standalone sources",
+			input: `<source token="file_a"/><figure view-type="Card"><source token="file_b"/></figure><p>A<figure><source token="file_c"/></figure>B</p>`,
+		},
+		{
+			name:  "literal and embedded markup",
+			input: `<!-- <p><source token="comment"/></p> --><![CDATA[<p><source token="cdata"/></p>]]><pre><code><p><source token="code"/></p></code></pre><whiteboard type="svg"><svg><p><source token="board"/></p></svg></whiteboard><html5-block><p><source token="html"/></p></html5-block><p>A<source token="file_a"/>B</p>`,
+			want:  `<!-- <p><source token="comment"/></p> --><![CDATA[<p><source token="cdata"/></p>]]><pre><code><p><source token="code"/></p></code></pre><whiteboard type="svg"><svg><p><source token="board"/></p></svg></whiteboard><html5-block><p><source token="html"/></p></html5-block><p>A<span><source token="file_a"/></span>B</p>`,
+		},
+		{
+			name:  "inline code and escaped example",
+			input: `<p><code><source token="literal"/></code>&lt;source/&gt; <source token="file_a"/> tail</p>`,
+			want:  `<p><code><source token="literal"/></code>&lt;source/&gt; <span><source token="file_a"/></span> tail</p>`,
+		},
+		{
+			name:  "whitespace in opaque closing tag",
+			input: `<p>A<source token="file_a"/>B<code>x</code ></p>`,
+			want:  `<p>A<span><source token="file_a"/></span>B<code>x</code ></p>`,
+		},
+		{
+			name:  "empty paired attachment markup",
+			input: `<p>A<source token="file_a"><!-- marker --><![CDATA[]]></source>B</p>`,
+			want:  `<p>A<span><source token="file_a"><!-- marker --><![CDATA[]]></source></span>B</p>`,
+		},
+		{
+			name:  "namespaced tags are unrelated",
+			input: `<x:p xmlns:x="urn:test"><source token="file_a"/></x:p><p><x:source token="file_b"/></p>`,
+		},
+		{
+			name:  "malformed XML retains existing validation behavior",
+			input: `<p><source token="file_a"/> tail`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := tt.want
+			if want == "" {
+				want = tt.input
+			}
+			got := prepareInlineDocAttachments("xml", tt.input)
+			if got != want {
+				t.Fatalf("prepared XML = %q, want %q", got, want)
+			}
+			if again := prepareInlineDocAttachments("xml", got); again != got {
+				t.Fatalf("preparation is not idempotent: %q != %q", again, got)
+			}
+			if markdown := prepareInlineDocAttachments("markdown", tt.input); markdown != tt.input {
+				t.Fatalf("Markdown changed: %q", markdown)
+			}
+		})
+	}
+}
+
+func TestDocsWritePreparesInlineAttachmentsBeforeAPI(t *testing.T) {
+	const input = `<p>before <source token="file_a"/> between <source token="file_b"/> after</p>`
+	const want = `<p>before <span><source token="file_a"/></span> between <span><source token="file_b"/></span> after</p>`
+	for _, operation := range []string{"create", "update"} {
+		t.Run(operation, func(t *testing.T) {
+			f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("inline-attachments-"+operation))
+			method, path := "POST", "/open-apis/docs_ai/v1/documents"
+			shortcut := DocsCreate
+			args := []string{"+create", "--content", input, "--as", "user"}
+			if operation == "update" {
+				method, path = "PUT", path+"/doxcn_inline"
+				shortcut = DocsUpdate
+				args = []string{"+update", "--doc", "doxcn_inline", "--command", "append", "--content", input, "--as", "user"}
+			}
+			stub := registerDocsAIStub(reg, method, path, map[string]interface{}{
+				"result":   "success",
+				"document": map[string]interface{}{"document_id": "doxcn_inline", "revision_id": 1},
+			})
+			if err := mountAndRunDocs(t, shortcut, args, f, stdout); err != nil {
+				t.Fatalf("command failed: %v", err)
+			}
+			if got := decodeRequestBody(t, stub.CapturedBody)["content"]; got != want {
+				t.Fatalf("API content = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestDocsPreparedInlineLocalAttachmentRetainsResourceBinding(t *testing.T) {
+	runtime := newLocalDocResourceTestRuntime(t, map[string]string{"report.txt": "fixture"})
+	input, err := prepareDocsV2WriteInputForFormat(runtime, "xml", docsV2WriteInput{
+		Content: `<p>before <source path="@report.txt" name="report.txt"/> after</p>`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(input.LocalResources) != 1 || input.LocalResources[0].Kind != localDocResourceFile {
+		t.Fatalf("resources = %#v", input.LocalResources)
+	}
+	if !strings.Contains(input.Content, `<span><source path="`+input.LocalResources[0].Marker+`" name="report.txt"/></span> after`) {
+		t.Fatalf("prepared local attachment = %q", input.Content)
+	}
+}

--- a/shortcuts/doc/inline_doc_attachments_test.go
+++ b/shortcuts/doc/inline_doc_attachments_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/larksuite/cli/internal/cmdutil"
 )
 
+// TestPrepareInlineDocAttachments verifies attachment isolation without changing
+// surrounding XML bytes, literal markup, or repeated preparation results.
 func TestPrepareInlineDocAttachments(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -102,6 +104,8 @@ func TestPrepareInlineDocAttachments(t *testing.T) {
 	}
 }
 
+// TestDocsWritePreparesInlineAttachmentsBeforeAPI checks the actual create and
+// update requests so removing the shared preparation step fails the regression.
 func TestDocsWritePreparesInlineAttachmentsBeforeAPI(t *testing.T) {
 	const input = `<p>before <source token="file_a"/> between <source token="file_b"/> after</p>`
 	const want = `<p>before <span><source token="file_a"/></span> between <span><source token="file_b"/></span> after</p>`
@@ -130,6 +134,8 @@ func TestDocsWritePreparesInlineAttachmentsBeforeAPI(t *testing.T) {
 	}
 }
 
+// TestDocsPreparedInlineLocalAttachmentRetainsResourceBinding ensures the span
+// repair retains the marker needed to upload and bind a local attachment.
 func TestDocsPreparedInlineLocalAttachmentRetainsResourceBinding(t *testing.T) {
 	runtime := newLocalDocResourceTestRuntime(t, map[string]string{"report.txt": "fixture"})
 	input, err := prepareDocsV2WriteInputForFormat(runtime, "xml", docsV2WriteInput{

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -13,6 +13,7 @@
 - `<pre lang="go" caption="示例"><code>fmt.Println(&quot;hello&quot;)</code></pre>`：代码必须放在 `<code>` 内，禁止直接放在 `<pre>` 下；`caption` 可省略。
 - `<img path="@./photo.png"/>`：上传当前工作目录内的本地图片。也可用 `<img href="URL"/>` 上传公开 HTTP(S) 网络图片，或用 `<img src="token"/>` 复制原始图片；三者任选一个，可选 `width`、`height`、`caption`、`name`。使用 `href` 时，CLI 会将远程图片转为本地资源并完成上传；响应须为 PNG、JPEG、GIF 或 WebP，单图不超过 20MiB。内部网络图片须先下载到本地再使用 `path`。
 - `<source path="@./report.pdf" name="报告.pdf"/>`：上传本地附件；也可使用 `<source token="token" name="xx"/>` 复制已有附件。可独立使用、放入 `<p>` 作为行内附件，或写成 `<figure view-type="Card|Preview"><source/></figure>`；
+- XML 写入时，CLI 自动为 `<p>` 内的每个行内附件添加独立的 `<span>`，保留附件后方的文字和其他附件；已有独立 `<span>` 不重复包装。独立附件和 `<figure>` 中的附件不变。
 - `<checkbox done="true|false">todo</checkbox>`
 - `p, h1-h9, li, checkbox, title` 支持可选属性 `align`，可选值为 `left`、`center`、`right`，例如 `<p align="center">居中正文</p>`。
 

--- a/tests/cli_e2e/docs/docs_inline_attachments_workflow_test.go
+++ b/tests/cli_e2e/docs/docs_inline_attachments_workflow_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestDocs_InlineAttachmentsWorkflowAsUser verifies the server keeps text and
+// both inline files, including the existing local-file upload/binding workflow.
+func TestDocs_InlineAttachmentsWorkflowAsUser(t *testing.T) {
+	clie2e.SkipWithoutUserToken(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+	skipWithoutInlineAttachmentCleanupScope(t, ctx)
+	workDir := t.TempDir()
+	writeLocalResourceFixture(t, workDir, "inline-a.txt", []byte("inline attachment A\n"))
+	writeLocalResourceFixture(t, workDir, "inline-b.txt", []byte("inline attachment B\n"))
+	created, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+create", "--title", "lark-cli inline attachments " + clie2e.GenerateSuffix(),
+			"--content", `<p>created before <source path="@inline-a.txt"/> created between <source path="@inline-b.txt"/> created after</p>`,
+		},
+		DefaultAs: "user", WorkDir: workDir,
+	})
+	require.NoError(t, err)
+	docToken := gjson.Get(created.Stdout, "data.document.document_id").String()
+	if docToken != "" {
+		t.Cleanup(func() {
+			cleanupCtx, cleanupCancel := clie2e.CleanupContext()
+			defer cleanupCancel()
+			result, cleanupErr := drive.DeleteDriveResourceAndVerify(cleanupCtx, docToken, "docx", "user")
+			clie2e.ReportCleanupFailure(t, "delete inline attachment test document", result, cleanupErr)
+		})
+	}
+	created.AssertExitCode(t, 0)
+	require.NotEmpty(t, docToken)
+	assertBoundLocalResourceBlocks(t, created.Stdout, 0, 2)
+	assertInlineAttachmentParagraph(t, ctx, docToken, "created")
+	var tokens []string
+	for _, block := range gjson.Get(created.Stdout, "data.document.new_blocks").Array() {
+		if block.Get("block_type").String() == "file" {
+			tokens = append(tokens, block.Get("block_token").String())
+		}
+	}
+	require.Len(t, tokens, 2)
+	updated, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+update", "--doc", docToken, "--command", "append",
+			"--content", fmt.Sprintf(`<p>updated before <source token="%s"/> updated between <source token="%s"/> updated after</p>`, tokens[0], tokens[1]),
+		},
+		DefaultAs: "user", WorkDir: workDir,
+	})
+	require.NoError(t, err)
+	updated.AssertExitCode(t, 0)
+	assertInlineAttachmentParagraph(t, ctx, docToken, "updated")
+}
+
+// This workflow must be able to delete its document even when an assertion
+// fails. An environment token without known grants is not a cleanable fixture.
+func skipWithoutInlineAttachmentCleanupScope(t *testing.T, ctx context.Context) {
+	t.Helper()
+	status, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"auth", "status", "--json"}, DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	status.AssertExitCode(t, 0)
+	for _, scope := range strings.Fields(gjson.Get(status.Stdout, "identities.user.scope").String()) {
+		if scope == "drive:drive" || scope == "space:document:delete" {
+			return
+		}
+	}
+	t.Skip("inline attachment workflow requires a user profile with known drive:drive or space:document:delete grants for cleanup")
+}
+
+// assertInlineAttachmentParagraph checks source placement within one paragraph,
+// rather than accepting matching text from unrelated blocks elsewhere in a doc.
+func assertInlineAttachmentParagraph(t *testing.T, ctx context.Context, docToken, prefix string) {
+	t.Helper()
+	paragraphs := regexp.MustCompile(`(?s)<p\b[^>]*>.*?</p>`)
+	var content string
+	require.Eventually(t, func() bool {
+		var err error
+		content, err = fetchDocsContent(ctx, docToken, "xml", "full", "user")
+		if err != nil {
+			return false
+		}
+		for _, paragraph := range paragraphs.FindAllString(content, -1) {
+			before := strings.Index(paragraph, prefix+" before")
+			middle := strings.Index(paragraph, prefix+" between")
+			after := strings.Index(paragraph, prefix+" after")
+			if before < 0 || middle <= before || after <= middle || strings.Count(paragraph, "<source ") != 2 {
+				continue
+			}
+			return strings.Contains(paragraph[before:middle], "<source ") && strings.Contains(paragraph[middle:after], "<source ")
+		}
+		return false
+	}, 20*time.Second, 500*time.Millisecond, "inline attachment paragraph was not preserved")
+}

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -76,6 +76,21 @@ func TestDocs_DryRunDefaultsToV2OpenAPI(t *testing.T) {
 			wantContains: []string{"/open-apis/docs_ai/v1/documents/doxcnDryRunE2E"},
 		},
 		{
+			name: "create inline attachments",
+			args: []string{
+				"docs", "+create", "--content", `<p>before <source token="file_a"/> after</p>`, "--dry-run",
+			},
+			wantBody: map[string]any{"content": `<p>before <span><source token="file_a"/></span> after</p>`},
+		},
+		{
+			name: "update inline attachments",
+			args: []string{
+				"docs", "+update", "--doc", "doxcnDryRunE2E", "--command", "append",
+				"--content", `<p>before <source token="file_a"/> between <source token="file_b"/> after</p>`, "--dry-run",
+			},
+			wantBody: map[string]any{"content": `<p>before <span><source token="file_a"/></span> between <span><source token="file_b"/></span> after</p>`},
+		},
+		{
 			name: "update reference-map",
 			args: []string{
 				"docs", "+update",

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// TestDocs_DryRunDefaultsToV2OpenAPI checks the default DocsAI endpoint and the
+// prepared request body using placeholder credentials and no live API calls.
 func TestDocs_DryRunDefaultsToV2OpenAPI(t *testing.T) {
 	// Fake creds are enough — dry-run short-circuits before any real API call.
 	t.Setenv("LARKSUITE_CLI_APP_ID", "app")


### PR DESCRIPTION
## Summary

XML writes containing `<p>before <source token="file_a"/> after</p>` can return `success` while losing the text after the inline attachment. A second attachment and the text between attachments can disappear as well. This change preserves those siblings by isolating each paragraph attachment in its own neutral `<span>` before the DocsAI request.

## Changes

- Apply the repair in shared XML write preparation used by create, update, and script flows, including local-file resource binding.
- Insert wrapper bytes without reserializing the original XML. Keep block/card attachments, literal markup, Markdown, and already isolated attachments unchanged.
- Add request-level and dry-run regressions, a cleanable live workflow with a deletion-scope prerequisite, and a short XML reference note.

## Test Plan

- [x] Full `shortcuts/doc/...` tests, CLI dry-run E2E, `make vet`, `make fmt-check`, and canonical `make build`.
- [x] Reverting only the shared preparation call through a Go overlay makes the create/update request regression tests fail.
- [x] Manual live create with two local attachments and append using their tokens; XML readback confirms both attachments and all before/between/after text in the same paragraph. The temporary document's content was cleared; deleting the document itself was unavailable because the test application lacks the deletion scope.
- [x] `go mod tidy` leaves module files unchanged; pinned golangci-lint, source-contract lint, lint module tests, license check, skill formatting, and committed-diff quality gate pass.
- [x] Full `make unit-test` on `b059697` with Go 1.23.0 on macOS arm64: 129 packages passed, using a short isolated `TMPDIR` and process-local Git configuration. Earlier temporary-directory cleanup failures were not reproduced in this run. GitHub-hosted Actions still await maintainer approval; this is local validation.

## Related Issues

- None. Whiteboard XML cloning is a separate server-side behavior and is outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline document attachments in XML content are automatically wrapped in spans while preserving surrounding text, attributes, and attachment order.
  * Create, update, and dry-run document workflows now handle inline attachments consistently.
  * Standalone attachments and attachments inside figures remain unchanged.

* **Documentation**
  * Added guidance on automatic inline attachment handling when writing XML content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->